### PR TITLE
HNSW: use new graph format during search

### DIFF
--- a/lib/common/common/src/cow.rs
+++ b/lib/common/common/src/cow.rs
@@ -1,0 +1,54 @@
+//! [`std::borrow::Cow`]-like enums.
+//!
+//! # Comparison table
+//!
+//! | Type                 | Borrowed | Owned                   |
+//! | -------------------- | -------- | ----------------------- |
+//! | [`Cow<'a, T>`]       | `&'a T`  | `<T as ToOwned>::Owned` |
+//! | [`BoxCow<'a, T>`]    | `&'a T`  | `Box<T>`                |
+//! | [`SimpleCow<'a, T>`] | `&'a T`  | `T`                     |
+//!
+//! [`Cow<'a, T>`]: std::borrow::Cow
+
+use std::ops::Deref;
+
+pub enum BoxCow<'a, T: ?Sized> {
+    Borrowed(&'a T),
+    Owned(Box<T>),
+}
+
+impl<'a, T: ?Sized> BoxCow<'a, T> {
+    pub fn as_borrowed(&'a self) -> Self {
+        match self {
+            BoxCow::Borrowed(v) => BoxCow::Borrowed(v),
+            BoxCow::Owned(v) => BoxCow::Borrowed(v.as_ref()),
+        }
+    }
+}
+
+impl<T: ?Sized> Deref for BoxCow<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            BoxCow::Borrowed(t) => t,
+            BoxCow::Owned(t) => t,
+        }
+    }
+}
+
+pub enum SimpleCow<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<T> Deref for SimpleCow<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            SimpleCow::Borrowed(v) => v,
+            SimpleCow::Owned(v) => v,
+        }
+    }
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bitpacking_ordered;
 pub mod budget;
 pub mod bytes;
 pub mod counter;
+pub mod cow;
 pub mod cpu;
 pub mod defaults;
 pub mod delta_pack;

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use bitvec::prelude::BitSlice;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::cow::SimpleCow;
 use sparse::common::types::{DimId, DimWeight};
 
 use crate::data_types::tiny_map;
@@ -186,22 +186,6 @@ pub struct VectorQueryContext<'a> {
     deleted_points: Option<&'a BitSlice>,
 
     hardware_counter: HardwareCounterCell,
-}
-
-pub enum SimpleCow<'a, T> {
-    Borrowed(&'a T),
-    Owned(T),
-}
-
-impl<T> Deref for SimpleCow<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            SimpleCow::Borrowed(value) => value,
-            SimpleCow::Owned(value) => value,
-        }
-    }
 }
 
 impl VectorQueryContext<'_> {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -17,9 +17,11 @@ use crate::common::operation_error::{
 };
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::graph_links::{GraphLinksFormatParam, serialize_graph_links};
-use crate::index::hnsw_index::point_scorer::{FilteredScorer, ScorerFilters};
+use crate::index::hnsw_index::point_scorer::{FilteredBytesScorer, FilteredScorer, ScorerFilters};
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
+use crate::vector_storage::RawScorer;
+use crate::vector_storage::query_scorer::QueryScorerBytes;
 
 pub type LinkContainer = Vec<PointOffsetType>;
 pub type LayersContainer = Vec<LinkContainer>;
@@ -188,13 +190,158 @@ pub trait GraphLayersBase {
     }
 }
 
-pub trait GraphLayersWithVectors {
+pub trait GraphLayersWithVectors: GraphLayersBase {
+    /// Returns `true` if the current graph format contains vectors.
+    fn has_vectors(&self) -> bool;
+
     /// # Panics
     ///
     /// Panics when using a format that does not support vectors.
-    fn for_each_link_with_vector<'a, F>(&'a self, point_id: PointOffsetType, level: usize, f: F)
-    where
-        F: FnMut(PointOffsetType, &'a [u8]);
+    /// Check with [`Self::has_vectors()`] before calling this method.
+    fn links_with_vectors(
+        &self,
+        point_id: PointOffsetType,
+        level: usize,
+    ) -> (&[u8], impl Iterator<Item = (PointOffsetType, &[u8])> + '_);
+
+    /// Similar to [`GraphLayersBase::_search_on_level`].
+    #[allow(clippy::too_many_arguments)]
+    fn _search_on_level_with_vectors(
+        &self,
+        links_searcher: &mut SearchContext,
+        base_searcher: &mut SearchContext,
+        level: usize,
+        visited_list: &mut VisitedListHandle,
+        links_scorer: &FilteredBytesScorer,
+        base_scorer: &dyn QueryScorerBytes,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<()> {
+        let limit = self.get_m(level);
+        let mut points: Vec<(PointOffsetType, &[u8])> = Vec::with_capacity(2 * limit);
+
+        while let Some(candidate) = links_searcher.candidates.pop() {
+            check_process_stopped(is_stopped)?;
+
+            if candidate.score < links_searcher.lower_bound() {
+                let (base_vector, _) = self.links_with_vectors(candidate.idx, level);
+                base_searcher.process_candidate(ScoredPointOffset {
+                    idx: candidate.idx,
+                    score: base_scorer.score_bytes(base_vector),
+                });
+                break;
+            }
+
+            points.clear();
+            let (base_vector, links_iter) = self.links_with_vectors(candidate.idx, level);
+            links_iter.for_each(|(link, link_vector)| {
+                if !visited_list.check(link) {
+                    points.push((link, link_vector));
+                }
+            });
+            base_searcher.process_candidate(ScoredPointOffset {
+                idx: candidate.idx,
+                score: base_scorer.score_bytes(base_vector),
+            });
+
+            links_scorer
+                .score_points(&mut points, limit)
+                .for_each(|score_point| {
+                    links_searcher.process_candidate(score_point);
+                    visited_list.check_and_update_visited(score_point.idx);
+                });
+        }
+
+        Ok(())
+    }
+
+    /// Similar to [`GraphLayersBase::search_on_level`].
+    fn search_on_level_with_vectors(
+        &self,
+        level_entry: ScoredPointOffset,
+        level: usize,
+        ef: usize,
+        links_scorer: &FilteredBytesScorer,
+        base_scorer: &dyn QueryScorerBytes,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<FixedLengthPriorityQueue<ScoredPointOffset>> {
+        let mut visited_list = self.get_visited_list_from_pool();
+        visited_list.check_and_update_visited(level_entry.idx);
+        let mut links_search_context = SearchContext::new(ef);
+        let mut base_search_context = SearchContext::new(ef);
+        links_search_context.process_candidate(level_entry);
+
+        self._search_on_level_with_vectors(
+            &mut links_search_context,
+            &mut base_search_context,
+            level,
+            &mut visited_list,
+            links_scorer,
+            base_scorer,
+            is_stopped,
+        )?;
+        Ok(base_search_context.nearest)
+    }
+
+    /// Similar to [`GraphLayersBase::search_entry`].
+    fn search_entry_with_vectors(
+        &self,
+        entry_point: PointOffsetType,
+        top_level: usize,
+        target_level: usize,
+        links_scorer_raw: &dyn RawScorer,
+        links_scorer: &FilteredBytesScorer,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<ScoredPointOffset> {
+        let mut links_buffer = Vec::new();
+        let mut current_point = ScoredPointOffset {
+            idx: entry_point,
+            score: links_scorer_raw.score_point(entry_point),
+        };
+        for level in rev_range(top_level, target_level) {
+            check_process_stopped(is_stopped)?;
+            current_point = self.search_entry_on_level_with_vectors(
+                current_point,
+                level,
+                links_scorer,
+                &mut links_buffer,
+            );
+        }
+        Ok(current_point)
+    }
+
+    /// Similar to [`GraphLayersBase::search_entry_on_level`].
+    fn search_entry_on_level_with_vectors<'a>(
+        &'a self,
+        entry_point: ScoredPointOffset,
+        level: usize,
+        links_scorer: &FilteredBytesScorer,
+        links: &mut Vec<(PointOffsetType, &'a [u8])>,
+    ) -> ScoredPointOffset {
+        let limit = self.get_m(level);
+
+        links.clear();
+        links.reserve(limit);
+
+        let mut changed = true;
+        let mut current_point = entry_point;
+        while changed {
+            changed = false;
+
+            links.clear();
+            let (_, links_iter) = self.links_with_vectors(current_point.idx, level);
+            links_iter.for_each(|(link, vector)| links.push((link, vector)));
+
+            links_scorer
+                .score_points(links, limit)
+                .for_each(|score_point| {
+                    if score_point.score > current_point.score {
+                        changed = true;
+                        current_point = score_point;
+                    }
+                });
+        }
+        current_point
+    }
 }
 
 impl GraphLayersBase for GraphLayers {
@@ -215,14 +362,16 @@ impl GraphLayersBase for GraphLayers {
 }
 
 impl GraphLayersWithVectors for GraphLayers {
-    fn for_each_link_with_vector<'a, F>(&'a self, point_id: PointOffsetType, level: usize, mut f: F)
-    where
-        F: FnMut(PointOffsetType, &'a [u8]),
-    {
-        self.links
-            .links_with_vectors(point_id, level)
-            .1
-            .for_each(|(point_id, vector)| f(point_id, vector));
+    fn has_vectors(&self) -> bool {
+        self.links.format().is_with_vectors()
+    }
+
+    fn links_with_vectors(
+        &self,
+        point_id: PointOffsetType,
+        level: usize,
+    ) -> (&[u8], impl Iterator<Item = (PointOffsetType, &[u8])> + '_) {
+        self.links.links_with_vectors(point_id, level)
     }
 }
 
@@ -284,6 +433,41 @@ impl GraphLayers {
             0,
             max(top, ef),
             &mut points_scorer,
+            is_stopped,
+        )?;
+        Ok(nearest.into_iter_sorted().take(top).collect_vec())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn search_with_vectors(
+        &self,
+        top: usize,
+        ef: usize,
+        links_scorer: &FilteredScorer,
+        links_scorer_bytes: &FilteredBytesScorer,
+        base_scorer: &dyn QueryScorerBytes,
+        custom_entry_points: Option<&[PointOffsetType]>,
+        is_stopped: &AtomicBool,
+    ) -> CancellableResult<Vec<ScoredPointOffset>> {
+        let Some(entry_point) = self.get_entry_point(links_scorer.filters(), custom_entry_points)
+        else {
+            return Ok(Vec::default());
+        };
+
+        let zero_level_entry = self.search_entry_with_vectors(
+            entry_point.point_id,
+            entry_point.level,
+            0,
+            links_scorer.raw_scorer(),
+            links_scorer_bytes,
+            is_stopped,
+        )?;
+        let nearest = self.search_on_level_with_vectors(
+            zero_level_entry,
+            0,
+            max(top, ef),
+            links_scorer_bytes,
+            base_scorer,
             is_stopped,
         )?;
         Ok(nearest.into_iter_sorted().take(top).collect_vec())

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -394,7 +394,7 @@ impl GraphLayersBuilder {
         let entry_point_opt = self
             .entry_points
             .lock()
-            .get_entry_point(|point_id| points_scorer.check_vector(point_id));
+            .get_entry_point(|point_id| points_scorer.filters().check_vector(point_id));
         if let Some(entry_point) = entry_point_opt {
             let mut level_entry = if entry_point.level > level {
                 // The entry point is higher than a new point
@@ -435,7 +435,7 @@ impl GraphLayersBuilder {
         self.entry_points
             .lock()
             .new_point(point_id, level, |point_id| {
-                points_scorer.check_vector(point_id)
+                points_scorer.filters().check_vector(point_id)
             });
     }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -9,6 +9,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use bitvec::prelude::BitSlice;
 use bitvec::vec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::cow::BoxCow;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
 use common::ext::BitSliceExt as _;
@@ -47,7 +48,7 @@ use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersWithVectors
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::graph_layers_healer::GraphLayersHealer;
 use crate::index::hnsw_index::graph_links::StorageGraphLinksVectors;
-use crate::index::hnsw_index::point_scorer::{BoxCow, FilteredScorer};
+use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -846,7 +847,7 @@ impl HNSWIndex {
                     block_point_id,
                     vector_storage,
                     quantized_vectors.as_ref(),
-                    Some(BoxCow::Boxed(block_condition_checker)),
+                    Some(BoxCow::Owned(block_condition_checker)),
                     id_tracker.deleted_point_bitslice(),
                     hardware_counter,
                 )
@@ -1212,7 +1213,7 @@ impl HNSWIndex {
             vector.to_owned(),
             vector_storage,
             quantization_enabled.then_some(quantized_storage).flatten(),
-            filter_context.map(BoxCow::Boxed),
+            filter_context.map(BoxCow::Owned),
             deleted_points,
             hardware_counter,
         )

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,8 +1,8 @@
-use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
 
 use bitvec::slice::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::cow::BoxCow;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
@@ -300,30 +300,5 @@ impl<'a> FilteredScorer<'a> {
         }
 
         Ok(pq.into_sorted_vec())
-    }
-}
-
-pub enum BoxCow<'a, T: ?Sized> {
-    Borrowed(&'a T),
-    Boxed(Box<T>),
-}
-
-impl<'a, T: ?Sized> BoxCow<'a, T> {
-    pub fn as_borrowed(&'a self) -> Self {
-        match self {
-            BoxCow::Borrowed(t) => BoxCow::Borrowed(t),
-            BoxCow::Boxed(t) => BoxCow::Borrowed(t.as_ref()),
-        }
-    }
-}
-
-impl<T: ?Sized> Deref for BoxCow<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            BoxCow::Borrowed(t) => t,
-            BoxCow::Boxed(t) => t,
-        }
     }
 }

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -184,6 +184,10 @@ impl<'a> FilteredScorer<'a> {
         }
     }
 
+    pub fn raw_scorer(&self) -> &dyn RawScorer {
+        self.raw_scorer.as_ref()
+    }
+
     pub fn filters(&self) -> &ScorerFilters<'a> {
         &self.filters
     }

--- a/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_compact_graph_layer.rs
@@ -23,7 +23,7 @@ fn search_in_builder(
 ) -> Vec<ScoredPointOffset> {
     let Some(entry_point) = builder
         .get_entry_points()
-        .get_entry_point(|point_id| points_scorer.check_vector(point_id))
+        .get_entry_point(|point_id| points_scorer.filters().check_vector(point_id))
     else {
         return vec![];
     };

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -3,8 +3,9 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::typelevel::False;
+use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
+use zerocopy::FromBytes;
 
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{DenseVector, TypedDenseVector};
@@ -120,8 +121,8 @@ impl<
         unimplemented!("Custom scorer can compare against multiple vectors, not just one")
     }
 
-    type SupportsBytes = False;
-    fn score_bytes(&self, enabled: Self::SupportsBytes, _: &[u8]) -> ScoreType {
-        match enabled {}
+    type SupportsBytes = True;
+    fn score_bytes(&self, _enabled: Self::SupportsBytes, bytes: &[u8]) -> ScoreType {
+        self.score(<[TElement]>::ref_from_bytes(bytes).unwrap())
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -3,8 +3,9 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::typelevel::False;
+use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
+use zerocopy::FromBytes;
 
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{TypedDenseVector, VectorElementType};
@@ -103,8 +104,8 @@ impl<
         TMetric::similarity(v1, v2)
     }
 
-    type SupportsBytes = False;
-    fn score_bytes(&self, enabled: Self::SupportsBytes, _: &[u8]) -> ScoreType {
-        match enabled {}
+    type SupportsBytes = True;
+    fn score_bytes(&self, _enabled: Self::SupportsBytes, bytes: &[u8]) -> ScoreType {
+        self.score(<[TElement]>::ref_from_bytes(bytes).unwrap())
     }
 }


### PR DESCRIPTION
~~Based on #7171, ignore first three commits during the review.~~

This PR:
1. Adds new method `GraphLayers::links_with_vectors` that uses both quantized and non-quantized vectors stored in the file format implemented in #7171.
2. Uses this new method in `HNSWIndex::search_with_graph`.