### PR TITLE
Chain nested locks for proxy segments

### DIFF
--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -241,8 +241,8 @@ fn test_upsert_points_in_smallest_segment() {
 
     // Segment 1 and 2 are over capacity, we expect to have the new points in segment 3
     {
-        let segment3 = segments.read().get(sid3).unwrap().get_cloned();
-        let segment3_read = segment3.read();
+        let segment3 = segments.read();
+        let segment3_read = segment3.get(sid3).unwrap().get().read();
         for point_id in 1000..1010 {
             assert!(segment3_read.has_point(point_id.into()));
         }

--- a/lib/shard/src/locked_segment.rs
+++ b/lib/shard/src/locked_segment.rs
@@ -57,16 +57,6 @@ impl LockedSegment {
         }
     }
 
-    /// Get cloned Arc to the locked segment
-    ///
-    /// Use [`get()`] if possible.
-    pub fn get_cloned(&self) -> Arc<RwLock<dyn SegmentEntry>> {
-        match self {
-            LockedSegment::Original(segment) => segment.clone(),
-            LockedSegment::Proxy(proxy) => proxy.clone(),
-        }
-    }
-
     /// Consume the LockedSegment and drop the underlying segment data.
     /// Operation fails if the segment is used by other thread for longer than `timeout`.
     pub fn drop_data(self) -> OperationResult<()> {


### PR DESCRIPTION
Keep the chain of locks on the proxy segment for the integrity of the access.