### PR TITLE
Fix scroll lock ordering

### DIFF
--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -153,8 +153,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable) = segments.read().split_segments();
         let scroll_lock = self.scroll_read_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
 
         let read_filtered = |segment: LockedSegment, hw_counter: HardwareCounterCell| {
             let filter = filter.cloned();
@@ -238,8 +238,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable) = segments.read().split_segments();
         let scroll_lock = self.scroll_read_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
 
         let read_ordered_filtered = |segment: LockedSegment, hw_counter: &HardwareCounterCell| {
             let is_stopped = stopping_guard.get_is_stopped();
@@ -337,8 +337,8 @@ impl LocalShard {
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
-        let (non_appendable, appendable) = segments.read().split_segments();
         let scroll_lock = self.scroll_read_lock.read().await;
+        let (non_appendable, appendable) = segments.read().split_segments();
 
         let read_filtered = |segment: LockedSegment, hw_counter: &HardwareCounterCell| {
             let is_stopped = stopping_guard.get_is_stopped();


### PR DESCRIPTION
Always take the scroll lock and segment locks in the same order. 

The update path takes the scroll lock in the opposite order as the read paths.

https://github.com/qdrant/qdrant/blob/dev/lib/collection/src/collection_manager/collection_updater.rs#L55-L70

Now it is always

1. scroll_lock
2. segments lock
3. segment lock