### PR TITLE
Use `Path` instead of `str` in `ConsensusWal::new`

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -26,8 +26,8 @@ pub struct ConsensusOpWal {
 }
 
 impl ConsensusOpWal {
-    pub fn new(storage_path: &str) -> Self {
-        let collections_meta_wal_path = Path::new(storage_path).join(COLLECTIONS_META_WAL_DIR);
+    pub fn new(storage_path: &Path) -> Self {
+        let collections_meta_wal_path = storage_path.join(COLLECTIONS_META_WAL_DIR);
 
         fs::create_dir_all(&collections_meta_wal_path)
             .expect("Can't create consensus WAL directory");
@@ -453,7 +453,7 @@ mod tests {
 
         let temp_dir = tempfile::tempdir().unwrap();
 
-        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(temp_dir.path());
         wal.append_entries(entries_orig).unwrap();
         wal.append_entries(entries_new.clone()).unwrap();
 
@@ -542,7 +542,7 @@ mod tests {
         ];
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(temp_dir.path());
 
         // append original entries
         wal.append_entries(entries_orig).unwrap();
@@ -560,7 +560,7 @@ mod tests {
 
         // drop wal to check persistence
         drop(wal);
-        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(temp_dir.path());
 
         // append overlapping entries
         wal.append_entries(entries_new).unwrap();
@@ -579,7 +579,7 @@ mod tests {
 
         // drop wal to check persistence
         drop(wal);
-        let wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let wal = ConsensusOpWal::new(temp_dir.path());
         assert_eq!(wal.wal.num_segments(), 1);
         assert_eq!(wal.wal.num_entries(), 4);
         assert_eq!(wal.index_offset().unwrap().wal_to_raft_offset, 1);
@@ -627,7 +627,7 @@ mod tests {
         }];
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(temp_dir.path());
 
         // append original entries
         wal.append_entries(entries_orig).unwrap();
@@ -645,7 +645,7 @@ mod tests {
 
         // drop wal to check persistence
         drop(wal);
-        let mut wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(temp_dir.path());
 
         // append overlapping entries
         wal.append_entries(entries_new).unwrap();
@@ -663,7 +663,7 @@ mod tests {
 
         // drop wal to check persistence
         drop(wal);
-        let wal = ConsensusOpWal::new(temp_dir.path().to_str().unwrap());
+        let wal = ConsensusOpWal::new(temp_dir.path());
         assert_eq!(wal.wal.num_segments(), 1);
         assert_eq!(wal.wal.num_entries(), 3);
         assert_eq!(wal.index_offset().unwrap().wal_to_raft_offset, 1);

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
 use std::ops::Deref;
+use std::path::Path;
 use std::str;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -107,7 +108,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         persistent_state: Persistent,
         toc: Arc<C>,
         propose_sender: OperationSender,
-        storage_path: &str,
+        storage_path: &Path,
     ) -> Self {
         Self {
             persistent: RwLock::new(persistent_state),
@@ -1188,7 +1189,7 @@ mod tests {
     #[test]
     fn correct_entry_with_offset() {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let mut wal = ConsensusOpWal::new(dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(dir.path());
         wal.append_entries(vec![Entry {
             index: 4,
             ..Default::default()
@@ -1210,7 +1211,7 @@ mod tests {
     #[test]
     fn at_least_1_entry() {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let mut wal = ConsensusOpWal::new(dir.path().to_str().unwrap());
+        let mut wal = ConsensusOpWal::new(dir.path());
         wal.append_entries(vec![
             Entry {
                 index: 4,
@@ -1269,7 +1270,7 @@ mod tests {
             persistent,
             Arc::new(NoCollections),
             OperationSender::new(sender),
-            path.to_str().unwrap(),
+            path,
         );
         let mem_storage = MemStorage::new();
         mem_storage.wl().append(entries.as_ref()).unwrap();
@@ -1374,7 +1375,7 @@ mod tests {
 
     fn empty_wal() -> (tempfile::TempDir, ConsensusOpWal) {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let wal = ConsensusOpWal::new(dir.path().to_str().unwrap());
+        let wal = ConsensusOpWal::new(dir.path());
         (dir, wal)
     }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1412,6 +1412,7 @@ fn is_heartbeat(message: &RaftMessage) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::sync::Arc;
     use std::thread;
 
@@ -1471,7 +1472,7 @@ mod tests {
             persistent_state,
             toc_arc.clone(),
             operation_sender,
-            storage_path,
+            Path::new(storage_path),
         )
         .into();
         let dispatcher =

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod tracing;
 
 use std::fs::create_dir_all;
 use std::io::Error;
+use std::path::Path;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
@@ -395,7 +396,7 @@ fn main() -> anyhow::Result<()> {
             persistent_consensus_state,
             toc_arc.clone(),
             propose_operation_sender.unwrap(),
-            storage_path,
+            Path::new(storage_path),
         )
         .into();
         let is_new_deployment = consensus_state.is_new_deployment();

--- a/src/wal_inspector.rs
+++ b/src/wal_inspector.rs
@@ -24,7 +24,7 @@ fn main() {
 
 fn print_consensus_wal(wal_path: &Path) {
     // must live within a folder named `collections_meta_wal`
-    let wal = ConsensusOpWal::new(wal_path.to_str().unwrap());
+    let wal = ConsensusOpWal::new(wal_path);
     println!("==========================");
     let first_index = wal.first_entry().unwrap();
     println!("First entry: {first_index:?}");


### PR DESCRIPTION
Small refactoring. Using `str` is silly.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
