### PR TITLE
Fixup remaining PeerId anonymization

### DIFF
--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
-use segment::common::anonymize::{Anonymize, anonymize_collection_with_u64_hashable_key};
+use segment::common::anonymize::{Anonymize, anonymize_collection_values};
 use segment::common::operation_time_statistics::OperationDurationStatistics;
 use segment::telemetry::SegmentTelemetry;
 use segment::types::ShardKey;
@@ -19,7 +19,7 @@ pub struct ReplicaSetTelemetry {
     pub key: Option<ShardKey>,
     pub local: Option<LocalShardTelemetry>,
     pub remote: Vec<RemoteShardTelemetry>,
-    #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
+    #[anonymize(with = anonymize_collection_values)]
     pub replicate_states: HashMap<PeerId, ReplicaState>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partial_snapshot: Option<PartialSnapshotTelemetry>,

--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -93,22 +93,19 @@ where
         .collect()
 }
 
-pub fn hash_u64(value: u64) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
-}
-
-pub fn anonymize_collection_with_u64_hashable_key<C, V>(collection: &C) -> C
+/// Anonymize the values of a collection wrapped into an [`Option`], but keeps the keys intact.
+///
+/// Similar to [`anonymize_collection_values`].
+pub fn anonymize_collection_values_opt<C, K, V>(collection_opt: &Option<C>) -> Option<C>
 where
-    for<'a> &'a C: IntoIterator<Item = (&'a u64, &'a V)>,
-    C: FromIterator<(u64, V)>,
+    for<'a> &'a C: IntoIterator<Item = (&'a K, &'a V)>,
+    C: FromIterator<(K, V)>,
+    K: Clone,
     V: Anonymize,
 {
-    collection
-        .into_iter()
-        .map(|(k, v)| (hash_u64(*k), v.anonymize()))
-        .collect()
+    collection_opt
+        .as_ref()
+        .map(|c| anonymize_collection_values(c))
 }
 
 impl Anonymize for String {

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -15,7 +15,7 @@ use collection::shards::shard::PeerId;
 use collection::shards::transfer::ShardTransferMethod;
 use memory::madvise;
 use schemars::JsonSchema;
-use segment::common::anonymize::{Anonymize, anonymize_collection_with_u64_hashable_key};
+use segment::common::anonymize::{Anonymize, anonymize_collection_values};
 use segment::data_types::collection_defaults::CollectionConfigDefaults;
 use segment::types::{HnswConfig, HnswGlobalConfig};
 use serde::{Deserialize, Serialize};
@@ -213,7 +213,7 @@ pub struct ClusterInfo {
     #[anonymize(false)]
     pub peer_id: PeerId,
     /// Peers composition of the cluster with main information
-    #[anonymize(with = anonymize_collection_with_u64_hashable_key)]
+    #[anonymize(with = anonymize_collection_values)]
     pub peers: HashMap<PeerId, PeerInfo>,
     /// Status of the Raft consensus
     pub raft_info: RaftInfo,

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -4,7 +4,7 @@ use collection::operations::types::PeerMetadata;
 use collection::shards::shard::PeerId;
 use common::types::{DetailsLevel, TelemetryDetail};
 use schemars::JsonSchema;
-use segment::common::anonymize::Anonymize;
+use segment::common::anonymize::{Anonymize, anonymize_collection_values_opt};
 use serde::Serialize;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::{Access, AccessRequirements};
@@ -60,7 +60,7 @@ pub struct ClusterStatusTelemetry {
     pub pending_operations: usize,
     pub role: Option<StateRole>,
     pub is_voter: bool,
-    #[anonymize(value = None)]
+    #[anonymize(false)]
     pub peer_id: Option<PeerId>,
     pub consensus_thread_status: ConsensusThreadStatus,
 }
@@ -73,7 +73,7 @@ pub struct ClusterTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<ClusterConfigTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[anonymize(false)]
+    #[anonymize(with = anonymize_collection_values_opt)]
     pub peers: Option<HashMap<PeerId, PeerInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]


### PR DESCRIPTION
This PR makes anonymization of `PeerId` and `ReplicaState` consistent:
- Disable `PeerId` anonymization in `ReplicaSetTelemetry`, `ClusterInfo`, `ClusterStatusTelemetry` to match changes in #7177. 
- Enable `ReplicaState` anonymization in `ClusterTelemetry` to match other places that anonymize `ClusterTelemetry`.

Past PRs that affect `PeerId` anonymization: #6390, #7177.

I've used this ast-grep rule to find all structs that contain `PeerId`/`PeerInfo`.
```yaml
id: struct-with-peerid-or-peerinfo
language: rust
rule:
  kind: struct_item
  has:
    kind: type_identifier
    regex: "^PeerId|PeerInfo$"
    stopBy: end
  follows:
    kind: attribute_item
    has:
      kind: identifier
      regex: "^Anonymize$"
      stopBy: end
```