### PR TITLE
Unit test with proxy that propagates older delete to wrapped segment

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -672,6 +672,18 @@ pub trait SegmentOptimizer {
             let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
             let mut proxy_ids = Vec::new();
             for (mut proxy, idx) in proxies.into_iter().zip(ids.iter().cloned()) {
+                // During optimization, we expect that logical point data in the wrapped segment is
+                // not changed at all. But this would be possible if we wrap another proxy segment,
+                // because it can share state through it's write segment. To prevent this we assert
+                // here that we only wrap non-proxy segments.
+                // Also helps to ensure the delete propagation behavior in
+                // `optimize_segment_propagate_changes` remains  sound.
+                // See: <https://github.com/qdrant/qdrant/pull/7208>
+                debug_assert!(
+                    matches!(proxy.wrapped_segment, LockedSegment::Original(_)),
+                    "during optimization, wrapped segment in a proxy segment must not be another proxy segment",
+                );
+
                 // replicate_field_indexes for the second time,
                 // because optimized segments could have been changed.
                 // The probability is small, though,
@@ -839,8 +851,11 @@ pub trait SegmentOptimizer {
             .iter()
             .filter(|&(point_id, _version)| !already_remove_points.contains(point_id));
         for (&point_id, &versions) in points_diff {
-            // Delete points here with their operation version, that'll bump the optimized
-            // segment version and will ensure we flush the new changes
+            // In this specific case we're sure logical point data in the wrapped segment is not
+            // changed at all. We ensure this with an assertion at time of proxying, which makes
+            // sure we only wrap original segments. Because we're sure logical data doesn't change,
+            // we also know pending deletes are always newer. Here we assert that's actually the
+            // case.
             debug_assert!(
                 versions.operation_version
                     >= optimized_segment.point_version(point_id).unwrap_or(0),

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -320,10 +320,15 @@ impl ProxySegment {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn get_deleted_points(&self) -> &LockedRmSet {
+        &self.deleted_points
+    }
 }
 
 /// Point persion information of points to delete from a wrapped proxy segment.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ProxyDeletedPoint {
     /// Version the point had in the wrapped segment when the delete was scheduled.
     /// We use it to determine if some other proxy segment should move the point again with

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -295,13 +295,12 @@ impl ProxySegment {
             if !deleted_points.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (point_id, versions) in deleted_points.iter() {
-                        // Delete points here with their operation version, that'll bump the optimized
-                        // segment version and will ensure we flush the new changes
-                        debug_assert!(
-                            versions.operation_version
-                                >= wrapped_segment.point_version(*point_id).unwrap_or(0),
-                            "proxied point deletes should have newer version than point in segment",
-                        );
+                        // Note:
+                        // Queued deletes may have an older version than what is currently in the
+                        // wrapped segment. Such deletes are ignored because the point in the
+                        // wrapped segment is considered to be newer. This is possible because
+                        // different proxy segments can share state through a common write segment.
+                        // See: <https://github.com/qdrant/qdrant/pull/7208>
                         wrapped_segment.delete_point(
                             versions.operation_version,
                             *point_id,

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -677,6 +677,8 @@ fn test_double_proxies() {
 /// - there are at least two layers of two proxies
 /// - one of the outer proxies is unproxied half way
 /// - a new point version is upserted through the unproxied segment (now being the inner proxy)
+///
+/// See: <https://github.com/qdrant/qdrant/pull/7208>
 #[test]
 fn test_proxy_propagate_older_delete_to_wrapped() {
     let hw_counter = HardwareCounterCell::disposable();

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -13,6 +13,7 @@ use tempfile::Builder;
 
 use super::*;
 use crate::fixtures::*;
+use crate::proxy_segment::ProxyDeletedPoint;
 
 #[test]
 fn test_add_and_swap() {
@@ -663,5 +664,286 @@ fn test_double_proxies() {
         diff.len(),
         1,
         "There should be one new segment after unproxying"
+    );
+}
+
+/// Test proxy propagating older delete to wrapped segment is sound
+///
+/// A specific scenario that asserts the delete propagation logic is sound. It tries to propagate
+/// an older delete version to a wrapped segment that already has a newer point version. It
+/// previously had a faulty debug assertion in place that triggers in this case.
+///
+/// This scenario is possible if:
+/// - there are at least two layers of two proxies
+/// - one of the outer proxies is unproxied half way
+/// - a new point version is upserted through the unproxied segment (now being the inner proxy)
+#[test]
+fn test_proxy_propagate_older_delete_to_wrapped() {
+    let hw_counter = HardwareCounterCell::disposable();
+
+    let pid = ExtendedPointId::from(1);
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment1 = empty_segment(dir.path());
+    let segment2 = empty_segment(dir.path());
+
+    let mut holder = SegmentHolder::default();
+
+    let sid1 = holder.add_new(segment1);
+    let sid2 = holder.add_new(segment2);
+
+    let holder = Arc::new(RwLock::new(holder));
+
+    let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+    let payload_schema_file = dir.path().join("payload.schema");
+    let schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_schema_file).unwrap());
+
+    // Create inner proxies, we have two of them
+    let (inner_proxies, inner_tmp_segment, inner_segments_lock) =
+        SegmentHolder::proxy_all_segments(
+            holder.upgradable_read(),
+            segments_dir.path(),
+            None,
+            schema.clone(),
+        )
+        .unwrap();
+    assert_eq!(inner_proxies.len(), 2);
+
+    // Insert version 100 in first inner proxy
+    inner_proxies[0]
+        .1
+        .get()
+        .write()
+        .upsert_point(
+            100,
+            pid,
+            only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    // Create outer proxies, we have two of them
+    let (mut outer_proxies, outer_tmp_segment, mut outer_segments_lock) =
+        SegmentHolder::proxy_all_segments(inner_segments_lock, segments_dir.path(), None, schema)
+            .unwrap();
+    assert_eq!(outer_proxies.len(), 2);
+
+    // Insert version 200 then delete version 210 in first outer proxy
+    outer_proxies[0]
+        .1
+        .get()
+        .write()
+        .upsert_point(
+            200,
+            pid,
+            only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    outer_proxies[0]
+        .1
+        .get()
+        .write()
+        .delete_point(210, pid, &hw_counter)
+        .unwrap();
+
+    // First outer proxy has point deleted, second outer proxy still has it
+    assert!(
+        !outer_proxies[0].1.get().read().has_point(pid),
+        "first proxy must not have point 1",
+    );
+    assert_eq!(
+        outer_proxies[1].1.get().read().point_version(pid),
+        Some(100),
+        "second outer proxy must have point version 100 through shared inner tmp segment",
+    );
+
+    // Insert version 300 in second outer proxy
+    outer_proxies[1]
+        .1
+        .get()
+        .write()
+        .upsert_point(
+            300,
+            pid,
+            only_default_vector(&[1.0, 1.0, 1.0, 1.0]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    // Both outer proxies must have point
+    assert_eq!(
+        outer_proxies[0].1.get().read().point_version(pid),
+        Some(300),
+        "second outer proxy must have point version 300, latest upsert through shared outer tmp segment",
+    );
+    assert_eq!(
+        outer_proxies[1].1.get().read().point_version(pid),
+        Some(300),
+        "second outer proxy must have point version 300, latest upsert through shared outer tmp segment",
+    );
+
+    // Both the outer and inner tmp segment must have point
+    assert_eq!(
+        outer_tmp_segment.get().read().point_version(pid),
+        Some(300),
+        "shared outer tmp segment has point version 300 from latest upsert",
+    );
+    assert_eq!(
+        inner_tmp_segment.get().read().point_version(pid),
+        Some(100),
+        "shared inner tmp segment has point version 100 from first upsert",
+    );
+
+    // Assert both outer proxies have delete markers we expect
+    match (&outer_proxies[0].1, &outer_proxies[1].1) {
+        (LockedSegment::Proxy(first), LockedSegment::Proxy(second)) => {
+            assert_eq!(
+                first.read().get_deleted_points().read().deref(),
+                &AHashMap::from_iter([(
+                    pid,
+                    ProxyDeletedPoint {
+                        // Delete version 210 in first outer proxy
+                        operation_version: 210,
+                        // Delete version 210 in first outer proxy
+                        local_version: 210,
+                    }
+                )]),
+            );
+            assert_eq!(
+                second.read().get_deleted_points().read().deref(),
+                &AHashMap::from_iter([(
+                    pid,
+                    ProxyDeletedPoint {
+                        // Initial upsert version 100 through shared inner tmp segment
+                        local_version: 100,
+                        // Latest upsert version 300 did CoW to shared outer tmp segment
+                        operation_version: 300,
+                    }
+                )]),
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    // Unproxy only first outer proxy
+    // Happens in `proxy_all_segments_and_apply` function that immediately tries to unproxy
+    // proxy segments it has applied an operation on, without waiting until all proxy segments
+    // have applied the operation.
+    let (unproxy_id, unproxy_segment) = outer_proxies.remove(0);
+    outer_segments_lock =
+        SegmentHolder::try_unproxy_segment(outer_segments_lock, unproxy_id, unproxy_segment)
+            .expect("should always succeed");
+
+    // Delete propagation at unproxy deleted version 210 from shared inner tmp segment which had version 100
+    assert!(
+        !inner_tmp_segment.get().read().has_point(pid),
+        "inner tmp segment must not have point",
+    );
+
+    // Insert point version 400 into now unproxied segment (which now became the first inner proxy)
+    outer_segments_lock
+        .get(unproxy_id)
+        .unwrap()
+        .get()
+        .write()
+        .upsert_point(
+            400,
+            pid,
+            only_default_vector(&[1.0, 1.0, 1.0, 1.0]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    // Last outer proxy still views point version 300
+    // Shared inner tmp segment has point version 400 from latest upsert
+    // TODO: should last outer proxy also see point version 400!?
+    assert_eq!(
+        outer_proxies[0].1.get().read().point_version(pid),
+        Some(300),
+        "last outer proxy has point version 300 through shared outer tmp segment",
+    );
+    assert_eq!(
+        outer_tmp_segment.get().read().point_version(pid),
+        Some(300),
+        "outer tmp segment has point version 300",
+    );
+    assert_eq!(
+        inner_tmp_segment.get().read().point_version(pid),
+        Some(400),
+        "inner tmp segment has point version 400 from latest upsert",
+    );
+
+    // Unproxy last outer proxy
+    //
+    // The proxy will propagate its queued deletes to wrapped segment:
+    // It will try to delete point version 300, but it's wrapped segment already has point version
+    // 400 which is shared through the inner tmp segment. Because the delete version is older, it
+    // will not delete the newer point.
+    // The faulty debug assertion assumed the wrapped segment could not change and therefore delete
+    // version must always be newer. This is not true, because if the wrapped segment is also a
+    // proxy it can share state with other segments. If these other segments receive updates, the
+    // wrapped segment might view newer point versions.
+    SegmentHolder::unproxy_all_segments(outer_segments_lock, outer_proxies, outer_tmp_segment)
+        .unwrap();
+
+    // Inner proxies and shared inner tmp segment all see point version 400
+    assert_eq!(
+        inner_proxies[0].1.get().read().point_version(pid),
+        Some(400),
+        "last outer proxy has point version 300 through shared outer tmp segment",
+    );
+    assert_eq!(
+        inner_proxies[1].1.get().read().point_version(pid),
+        Some(400),
+        "last outer proxy has point version 300 through shared outer tmp segment",
+    );
+    assert_eq!(
+        inner_tmp_segment.get().read().point_version(pid),
+        Some(400),
+        "inner tmp segment has point version 400 from latest upsert",
+    );
+
+    // Unproxy inner proxies
+    // Note: in our current codebase we don't unproxy like this twice
+    eprintln!("\n\n\nUNPROXY INNER PROXIES");
+    SegmentHolder::unproxy_all_segments(holder.upgradable_read(), inner_proxies, inner_tmp_segment)
+        .unwrap();
+
+    // Original segments should not have point, newly added tmp segment does have the point
+    assert_eq!(
+        holder.read().len(),
+        4,
+        "segment holder must have 4 segments, 2 original plus 2 temporary",
+    );
+    assert!(
+        !holder.read().get(sid1).unwrap().get().read().has_point(pid),
+        "first original segment must not have the point",
+    );
+    assert!(
+        !holder.read().get(sid2).unwrap().get().read().has_point(pid),
+        "second original segment must not have the point",
+    );
+    assert_eq!(
+        holder
+            .read()
+            .get(sid2 + 1)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
+        Some(300),
+        "outer tmp segment still has point version 300",
+    );
+    assert_eq!(
+        holder
+            .read()
+            .get(sid2 + 2)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
+        Some(400),
+        "inner tmp segment must have latest point version 400",
     );
 }

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -752,7 +752,7 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
     // First outer proxy has point deleted, second outer proxy still has it
     assert!(
         !outer_proxies[0].1.get().read().has_point(pid),
-        "first proxy must not have point 1",
+        "first proxy must not have point",
     );
     assert_eq!(
         outer_proxies[1].1.get().read().point_version(pid),
@@ -859,7 +859,6 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
 
     // Last outer proxy still views point version 300
     // Shared inner tmp segment has point version 400 from latest upsert
-    // TODO: should last outer proxy also see point version 400!?
     assert_eq!(
         outer_proxies[0].1.get().read().point_version(pid),
         Some(300),


### PR DESCRIPTION
Add a unit test to assert a proxy segment propagating an older delete to a wrapped segment with a newer point is sound. It proves that this situation is possible in specific circumstances.

This eliminates a faulty debug assertion:
https://github.com/qdrant/qdrant/blob/60e0c07b0ab4cbd1eec053542b9db85441b4c4ae/lib/shard/src/proxy_segment/mod.rs#L298-L304

The debug assertion assumed that the logical point data in a wrapped segment of a proxy cannot change. But that is not true. If the wrapped segment is also a proxy, it may share logical state with other segments through it's write segment.

It means the following is required to make this happen:
- there must be two layers of two proxies
- one of the outer proxies is unproxied half way
- a point is updated through the unproxied segment (now being the inner proxy)

We have the same debug assertion in the optimizer [here](https://github.com/qdrant/qdrant/blob/5235d8643552c3106e4e91b522a5b20d5b86b689/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs#L842-L848). But that one is sound, because the optimizer never proxies a proxy, and so we can't have this shared state in a wrapped segment. I've added an extra debug assertion to ensure we don't do that.

Other examples triggering this debug assertion:
- https://github.com/qdrant/qdrant/pull/7074

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?