### PR TITLE
Add comment on why we do/don't share deleted points in proxies

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -650,6 +650,9 @@ pub trait SegmentOptimizer {
             let mut proxy = ProxySegment::new(
                 sg.clone(),
                 tmp_segment.clone(),
+                // In this case, all proxies share their set of deleted points
+                // We can share deletes because they're all propagated to the same optimized
+                // segment, and we unproxy all at the same time
                 Arc::clone(&proxy_deleted_points),
                 Arc::clone(&proxy_index_changes),
             );

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1098,6 +1098,9 @@ impl SegmentHolder {
             let mut proxy = ProxySegment::new(
                 segment.clone(),
                 tmp_segment.clone(),
+                // In this case, each proxy has their own set of deleted points
+                // We cannot share deletes because they're propagated to different wrapped
+                // segments, and we unproxy at different times
                 LockedRmSet::default(),
                 LockedIndexChanges::default(),
             );


### PR DESCRIPTION
Addition alongside <https://github.com/qdrant/qdrant/pull/7208>.

We create proxy segments in two places, and the set of deleted points is set up differently:
1. proxies for optimization: does share pending deletes across proxies
2. proxies for snapshot: does **not** share pending deletes across proxies

In my opinion it is correct that both are implemented differently. This PR adds two comments to emphasize this difference.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?