### PR TITLE
Bump scc 2.1.0 to avoid yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5566,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96560eea317a9cc4e0bb1f6a2c93c09a19b8c4fc5cb3fcc0ec1c094cd783e2"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
 ]
@@ -5651,9 +5651,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "0.2.0"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"


### PR DESCRIPTION
Fixing 

```
> cargo audit
...
Crate:     scc
Version:   2.1.0
Warning:   yanked
Dependency tree:
scc 2.1.0
└── serial_test 3.2.0
    └── issues 0.0.0
        ├── storage 0.2.0
        │   └── qdrant 1.15.5-dev
        ├── qdrant 1.15.5-dev
        └── collection 0.4.2
            ├── storage 0.2.0
            ├── qdrant 1.15.5-dev
            └── collection 0.4.2
```

It is just a test dependency but better keep things clean as always.            