### PR TITLE
refactor matrix api to use query instead of deprecated search

### DIFF
--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -133,7 +133,6 @@ impl GroupRequest {
             group_by: self.group_by,
             group_size: self.group_size,
             groups: self.limit,
-            with_lookup: self.with_lookup,
         })
     }
 }

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -3,7 +3,6 @@ use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
 use segment::types::{PointIdType, ScoredPoint};
 
-use crate::lookup::WithLookup;
 use crate::operations::types::PointGroup;
 use crate::operations::universal_query::shard_query::ShardQueryRequest;
 
@@ -56,9 +55,6 @@ pub struct QueryGroupRequest {
 
     /// Limit of groups to return
     pub groups: usize,
-
-    /// Options for specifying how to use the group id to lookup points in another collection
-    pub with_lookup: Option<WithLookup>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`do_core_search_batch`, which was used in search matrix API is going to be deprecated and removed. This PR replaces matrix internals with query API and makes some small fixes along the way