### PR TITLE
Fix missing API validation for MinShould

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -268,6 +268,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("Filter.must_not", ""),
             ("NestedCondition.filter", ""),
             ("Condition.condition_one_of", ""),
+            ("Filter.min_should", ""),
+            ("MinShould.conditions", ""),
             ("PointStruct.vectors", ""),
             ("Vectors.vectors_options", ""),
             ("NamedVectors.vectors", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6589,13 +6589,16 @@ pub struct Filter {
     pub must_not: ::prost::alloc::vec::Vec<Condition>,
     /// At least minimum amount of given conditions should match
     #[prost(message, optional, tag = "4")]
+    #[validate(nested)]
     pub min_should: ::core::option::Option<MinShould>,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MinShould {
     #[prost(message, repeated, tag = "1")]
+    #[validate(nested)]
     pub conditions: ::prost::alloc::vec::Vec<Condition>,
     #[prost(uint64, tag = "2")]
     pub min_count: u64,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3250,6 +3250,7 @@ pub struct WithPayload {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct MinShould {
+    #[validate(nested)]
     pub conditions: Vec<Condition>,
     pub min_count: usize,
 }


### PR DESCRIPTION
The `Conditions` when using a `MinShould` are currently not validated (REST & gRPC).

Backported from https://github.com/qdrant/qdrant/pull/7216