### PR TITLE
Fix missing REST API validation for point batch update

### DIFF
--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -71,6 +71,7 @@ impl InternalUpdateParams {
 
 #[derive(Deserialize, Serialize, JsonSchema, Validate)]
 pub struct UpdateOperations {
+    #[validate(nested)]
     pub operations: Vec<UpdateOperation>,
 }
 

--- a/tests/openapi/test_batch_update_multivec.py
+++ b/tests/openapi/test_batch_update_multivec.py
@@ -45,7 +45,7 @@ def test_batch_update_validation(collection_name):
                         {
                             "id": 7,
                             "vector": {
-                                "image": [1.0, 0.0, 9.0],
+                                "image": [1.0, 0.0, 9.0, 1.0],
                             },
                             "payload": {},
                         },


### PR DESCRIPTION
The validation is completely missing on the point batch update operations.

The new test fails without the fix.

Backported from https://github.com/qdrant/qdrant/pull/7216