### PR TITLE
Fix missing gRPC api validations points selection

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -191,6 +191,7 @@ fn configure_validation(builder: Builder) -> Builder {
         ], &[])
         // Service: points.proto
         .validates(&[
+            ("PointsSelector.points_selector_one_of", ""),
             ("UpsertPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("UpsertPoints.points", ""),
             ("UpsertPoints.update_filter", ""),
@@ -200,11 +201,15 @@ fn configure_validation(builder: Builder) -> Builder {
             ("UpdatePointVectors.update_filter", ""),
             ("DeletePointVectors.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("DeletePointVectors.vector_names", "length(min = 1, message = \"must specify vector names to delete\")"),
+            ("DeletePointVectors.points_selector", ""),
             ("PointVectors.vectors", ""),
             ("GetPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("SetPayloadPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
+            ("SetPayloadPoints.points_selector", ""),
             ("DeletePayloadPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
+            ("DeletePayloadPoints.points_selector", ""),
             ("ClearPayloadPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
+            ("ClearPayloadPoints.points", ""),
             ("UpdateBatchPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("UpdateBatchPoints.operations", "length(min = 1)"),
             ("CreateFieldIndexCollection.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -4496,6 +4496,7 @@ pub struct DeletePointVectors {
     pub wait: ::core::option::Option<bool>,
     /// Affected points
     #[prost(message, optional, tag = "3")]
+    #[validate(nested)]
     pub points_selector: ::core::option::Option<PointsSelector>,
     /// List of vector names to delete
     #[prost(message, optional, tag = "4")]
@@ -4527,6 +4528,7 @@ pub struct SetPayloadPoints {
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     /// Affected points
     #[prost(message, optional, tag = "5")]
+    #[validate(nested)]
     pub points_selector: ::core::option::Option<PointsSelector>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
@@ -4558,6 +4560,7 @@ pub struct DeletePayloadPoints {
     pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Affected points
     #[prost(message, optional, tag = "5")]
+    #[validate(nested)]
     pub points_selector: ::core::option::Option<PointsSelector>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
@@ -4583,6 +4586,7 @@ pub struct ClearPayloadPoints {
     pub wait: ::core::option::Option<bool>,
     /// Affected points
     #[prost(message, optional, tag = "3")]
+    #[validate(nested)]
     pub points: ::core::option::Option<PointsSelector>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
@@ -6862,11 +6866,13 @@ pub struct ValuesCount {
     #[prost(uint64, optional, tag = "4")]
     pub lte: ::core::option::Option<u64>,
 }
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsSelector {
     #[prost(oneof = "points_selector::PointsSelectorOneOf", tags = "1, 2")]
+    #[validate(nested)]
     pub points_selector_one_of: ::core::option::Option<
         points_selector::PointsSelectorOneOf,
     >,

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -478,6 +478,15 @@ impl Validate for super::qdrant::IntegerIndexParams {
     }
 }
 
+impl Validate for super::qdrant::points_selector::PointsSelectorOneOf {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        match self {
+            grpc::points_selector::PointsSelectorOneOf::Points(_) => Ok(()),
+            grpc::points_selector::PointsSelectorOneOf::Filter(filter) => filter.validate(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use validator::Validate;


### PR DESCRIPTION
The filter within the `PointsSelector` in gRPC should be validated.

Backported from https://github.com/qdrant/qdrant/pull/7216