### PR TITLE
Limit concurrent calls to `load_segment`

### DIFF
--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -13,6 +13,9 @@ lazy_static! {
     pub static ref QDRANT_VERSION: Version = Version::parse(QDRANT_VERSION_STRING).expect("malformed version string");
 }
 
+/// Maximum number of segments to load concurrently when loading a collection.
+pub const MAX_CONCURRENT_SEGMENT_LOADS: usize = 8;
+
 /// Number of retries for confirming a consensus operation.
 pub const CONSENSUS_CONFIRM_RETRIES: usize = 3;
 


### PR DESCRIPTION
# Problem

The `load_segment()` function is executed in parallel per segment.

https://github.com/qdrant/qdrant/blob/8235a76fde322cb7cc2c8fb4030693a2aae8a6df/lib/collection/src/shards/local_shard/mod.rs#L335-L338

Inside `load_segment()`, the migration to from RocksDB is performed (gated by a feature flag for now).

https://github.com/qdrant/qdrant/blob/8235a76fde322cb7cc2c8fb4030693a2aae8a6df/lib/segment/src/segment_constructor/segment_constructor_base.rs#L751-L761

That means with 100 segments we'll get 100 parallel migrations once we enable these feature flags.

# Solution

This PR implements the the following limit:

```rust
/// Maximum number of segments to load concurrently when loading a collection.
pub const MAX_CONCURRENT_SEGMENT_LOADS: usize = 8;
```