### PR TITLE
Configurable max number of payload indexes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -231,6 +231,10 @@ storage:
   # If null - no limit.
   max_collections: null
 
+  # Maximum number of payload indexes allowed to be created across all collections
+  # If null - no limit.
+  max_payload_indexes: null
+
 service:
   # Maximum size of POST data in a single request in megabytes
   max_request_size_mb: 32

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -563,6 +563,11 @@ impl Collection {
         }
     }
 
+    /// Get the count of payload indexes in this collection
+    pub fn payload_index_count(&self) -> usize {
+        self.payload_index_schema.read().schema.len()
+    }
+
     pub async fn remove_shards_at_peer(&self, peer_id: PeerId) -> CollectionResult<()> {
         // Abort resharding, if shards are removed from peer driving resharding
         // (which *usually* means the *peer* is being removed from consensus)

--- a/lib/storage/src/content_manager/toc/telemetry.rs
+++ b/lib/storage/src/content_manager/toc/telemetry.rs
@@ -37,4 +37,19 @@ impl TableOfContent {
     pub fn max_collections(&self) -> Option<usize> {
         self.storage_config.max_collections
     }
+
+    pub fn max_payload_indexes(&self) -> Option<usize> {
+        self.storage_config.max_payload_indexes
+    }
+
+    /// Count total number of payload indexes across all collections
+    pub async fn count_total_payload_indexes(&self, access: &Access) -> usize {
+        let mut total = 0;
+        for collection_pass in self.all_collections(access).await {
+            if let Ok(collection) = self.get_collection(&collection_pass).await {
+                total += collection.payload_index_count();
+            }
+        }
+        total
+    }
 }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -111,6 +111,9 @@ pub struct StorageConfig {
     /// Maximum number of collections to allow in the cluster.
     #[serde(default)]
     pub max_collections: Option<usize>,
+    /// Maximum number of payload indexes to allow across all collections.
+    #[serde(default)]
+    pub max_payload_indexes: Option<usize>,
 }
 
 impl StorageConfig {

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -73,6 +73,7 @@ fn test_alias_operation() {
         shard_transfer_method: None,
         collection: None,
         max_collections: None,
+        max_payload_indexes: None,
     };
 
     let search_runtime = Runtime::new().unwrap();


### PR DESCRIPTION
Adds a `QDRANT__STORAGE__MAX_PAYLOAD_INDEXES` setting to limit the total amount of payload indices across collections