### PR TITLE
Better immutable ID tracker load errors

### DIFF
--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -101,6 +101,12 @@ impl OperationError {
             description: description.into(),
         }
     }
+
+    pub fn inconsistent_storage(description: impl Into<String>) -> OperationError {
+        OperationError::InconsistentStorage {
+            description: description.into(),
+        }
+    }
 }
 
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -157,16 +157,22 @@ impl ImmutableIdTracker {
                 });
             }
             Some(ExternalIdType::Number) => {
-                let num = reader.read_u64::<FileEndianess>()?;
+                let num = reader.read_u64::<FileEndianess>().map_err(|err| {
+                    OperationError::inconsistent_storage(format!("Immutable ID tracker failed to read numeric point ID from file, assuming malformed storage: {err}"))
+                })?;
                 PointIdType::NumId(num)
             }
             Some(ExternalIdType::Uuid) => {
-                let uuid_u128 = reader.read_u128::<FileEndianess>()?;
+                let uuid_u128 = reader.read_u128::<FileEndianess>().map_err(|err| {
+                    OperationError::inconsistent_storage(format!("Immutable ID tracker failed to read UUID point ID from file, assuming malformed storage: {err}"))
+                })?;
                 PointIdType::Uuid(Uuid::from_u128_le(uuid_u128))
             }
         };
 
-        let internal_id = reader.read_u32::<FileEndianess>()? as PointOffsetType;
+        let internal_id = reader.read_u32::<FileEndianess>().map_err(|err| {
+            OperationError::inconsistent_storage(format!("Immutable ID tracker failed to read internal point ID from file, assuming malformed storage: {err}"))
+        })? as PointOffsetType;
         Ok((internal_id, external_id))
     }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -151,10 +151,9 @@ impl ImmutableIdTracker {
 
         let external_id = match ExternalIdType::from_byte(point_id_type) {
             None => {
-                return Err(OperationError::InconsistentStorage {
-                    description: "Invalid byte read when deserializing Immutable id tracker"
-                        .to_string(),
-                });
+                return Err(OperationError::inconsistent_storage(
+                    "Invalid byte read when deserializing Immutable id tracker",
+                ));
             }
             Some(ExternalIdType::Number) => {
                 let num = reader.read_u64::<FileEndianess>().map_err(|err| {


### PR DESCRIPTION
This improves error reporting if loading mappings for the immutable ID tracker fails. While this doesn't resolve the load issue, it helps us pinpoint to the place of failure much quicker.

Before, our error looked like this:

```
IO error: failed to fill whole buffer
```

Now it looks like this:

```
Inconsistent storage: Immutable ID tracker failed to read next mapping, reading entry 46001/46077, assuming malformed storage: Inconsistent storage: failed to read numeric point ID from file: failed to fill whole buffer
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?