### PR TITLE
Fix: config mismatch optimizer trigger loop

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -186,8 +186,10 @@ impl ConfigMismatchOptimizer {
                                         .unwrap_or(false);
                                     // If segment is unindexed, only appendable quantization is applied.
                                     // So that we check if any config is appendable to avoid infinity loop here.
-                                    let unindexed_changed = vector_data_quantization_appendable
-                                        || target_quantization_appendable;
+                                    let unindexed_changed = common::flags::feature_flags()
+                                        .appendable_quantization
+                                        && (vector_data_quantization_appendable
+                                            || target_quantization_appendable);
                                     (vector_data.quantization_config.is_some()
                                         != target_quantization.is_some())
                                         && (vector_data.index.is_indexed() || unindexed_changed)


### PR DESCRIPTION
After merging #7145, I've started seeing never-ending attempts to rebuild a segment when both following conditions met:
- `appendable_quantization` feature flag is disabled
- binary quantization is enabled

Log:
```
2025-09-09T21:06:51.217475Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [45]
2025-09-09T21:06:51.217892Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
2025-09-09T21:06:51.312801Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [47]
2025-09-09T21:06:51.313369Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
2025-09-09T21:06:51.407156Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [49]
2025-09-09T21:06:51.407788Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
2025-09-09T21:06:51.506105Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [51]
2025-09-09T21:06:51.506630Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
2025-09-09T21:06:51.601657Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [53]
2025-09-09T21:06:51.602088Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
2025-09-09T21:06:51.694458Z DEBUG collection::update_handler: Optimizer 'config mismatch' running on segments: [55]
2025-09-09T21:06:51.694903Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 2577080176640, needed for optimization: 155648
```

# Investigation

The rebuild-triggering condition in question after #7145:
https://github.com/qdrant/qdrant/blob/c075b28f1f4e3c470bb4f8db656044926d1123a0/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs#L189-L193

Same condition before #7145:
https://github.com/qdrant/qdrant/blob/6cb54ca380355bd34065545c3f9de4e1bdcc5116/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs#L179-L181
Note: newly added `target_quantization_appendable` value (equals to `true`; it is taken from the collection config) is the cause.

---

When `appendable_quantization` feature flag is set, the condition above shouldn't triggered at all because of the following part (called when creating a temporary segment):
https://github.com/qdrant/qdrant/blob/c075b28f1f4e3c470bb4f8db656044926d1123a0/lib/collection/src/config.rs#L499-L502