### PR TITLE
feat: add read-only mode (--read-only) for Qdrant

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run integration tests
         run: poetry --project tests run bash ./tests/integration-tests.sh
         shell: bash
+      - name: Run read-only integration tests
+        run: poetry --project tests run bash ./tests/integration-tests.sh readonly
+        shell: bash
 
   integration-tests-consensus:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -262,6 +262,13 @@ service:
   # Check user HTTPS client certificate against CA file specified in tls config
   verify_https_client_certificate: false
 
+  # Enable read-only mode for this instance.
+  # In read-only mode, all write operations will be rejected with 403 Forbidden.
+  # This mode assumes that all changes have been applied and flushed to storage in advance,
+  # so WAL reading is skipped. Distributed deployment cannot be run in read-only mode.
+  # Default: false
+  # read_only_mode: false
+
   # Set an api-key.
   # If set, all requests must include a header with the api-key.
   # example header: `api-key: <API-KEY>`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,6 +34,14 @@ docker run -p 6333:6333 \
     qdrant/qdrant
 ```
 
+For read-only deployments, you can use the CLI flag:
+
+```bash
+docker run -p 6333:6333 \
+    -v $(pwd)/path/to/data:/qdrant/storage \
+    qdrant/qdrant --read-only
+```
+
 * `/qdrant/storage` - is the place where Qdrant persists all your data.
 Make sure to mount it as a volume, otherwise docker will drop it with the container.
 - `/qdrant/snapshots` - is the place where Qdrant stores [snapshots](https://qdrant.tech/documentation/concepts/snapshots/)
@@ -83,6 +91,29 @@ To run Qdrant on local development environment you need to install below:
 
     ./target/release/qdrant
     ```
+
+Qdrant supports a read-only mode that can be enabled in two ways:
+
+1. Via CLI flag:
+    ```shell
+    ./target/release/qdrant --read-only
+    ```
+
+2. Via configuration file:**
+    Add or uncomment the following in your config file:
+    ```yaml
+    service:
+      read_only_mode: true
+    ```
+
+In read-only mode:
+- All write operations (create, update, delete) are rejected with 403 Forbidden
+- Only search and read operations are allowed
+- WAL reading is skipped for better performance
+- Cannot be used with distributed deployments
+
+This mode is useful for creating read-only replicas, maintenance scenarios, or when you need to ensure no modifications are made to the data.
+
 - Install Python dependencies for testing
     ```shell
     poetry -C tests install --sync

--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -35,6 +35,7 @@ pub struct SharedStorageConfig {
     pub snapshots_config: SnapshotsConfig,
     pub hnsw_global_config: HnswGlobalConfig,
     pub search_thread_count: usize,
+    pub read_only_mode: bool,
 }
 
 impl Default for SharedStorageConfig {
@@ -54,6 +55,7 @@ impl Default for SharedStorageConfig {
             snapshots_config: default::Default::default(),
             hnsw_global_config: HnswGlobalConfig::default(),
             search_thread_count: common::defaults::search_thread_count(common::cpu::get_num_cpus()),
+            read_only_mode: false,
         }
     }
 }
@@ -75,6 +77,7 @@ impl SharedStorageConfig {
         snapshots_config: SnapshotsConfig,
         hnsw_global_config: HnswGlobalConfig,
         search_thread_count: usize,
+        read_only_mode: bool,
     ) -> Self {
         let update_queue_size = update_queue_size.unwrap_or(match node_type {
             NodeType::Normal => DEFAULT_UPDATE_QUEUE_SIZE,
@@ -95,6 +98,7 @@ impl SharedStorageConfig {
             snapshots_config,
             hnsw_global_config,
             search_thread_count,
+            read_only_mode,
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -421,6 +421,8 @@ impl LocalShard {
             )?;
         }
 
+        let read_only_mode = shared_storage_config.read_only_mode;
+
         let local_shard = LocalShard::new(
             segment_holder,
             collection_config,
@@ -436,8 +438,15 @@ impl LocalShard {
         )
         .await;
 
-        // Apply outstanding operations from WAL
-        local_shard.load_from_wal(collection_id).await?;
+        // Apply outstanding operations from WAL (skip in read-only mode)
+        if !read_only_mode {
+            local_shard.load_from_wal(collection_id).await?;
+        } else {
+            log::info!(
+                "Skipping WAL loading in read-only mode for shard at {}",
+                shard_path.display()
+            );
+        }
 
         Ok(local_shard)
     }

--- a/lib/storage/src/types.rs
+++ b/lib/storage/src/types.rs
@@ -111,6 +111,11 @@ pub struct StorageConfig {
     /// Maximum number of collections to allow in the cluster.
     #[serde(default)]
     pub max_collections: Option<usize>,
+    /// If true, enables read-only mode for this instance.
+    /// In read-only mode, all write operations will be rejected with 403 Forbidden.
+    /// This assumes that all changes have been applied and flushed to storage in advance.
+    #[serde(default)]
+    pub read_only_mode: bool,
 }
 
 impl StorageConfig {
@@ -132,6 +137,7 @@ impl StorageConfig {
             self.snapshots_config.clone(),
             self.hnsw_global_config.clone(),
             common::defaults::search_thread_count(self.performance.max_search_threads),
+            self.read_only_mode,
         )
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -41,6 +41,10 @@ pub struct ServiceConfig {
     #[serde(default)]
     pub hide_jwt_dashboard: Option<bool>,
 
+    /// Read-only mode flag - set internally via CLI, not configurable via config file
+    #[serde(skip)]
+    pub read_only_mode: bool,
+
     /// Directory where static files are served from.
     /// For example, the Web-UI should be placed here.
     #[serde(default)]

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -205,7 +205,7 @@ pub fn init(
                         )
                         .clone(),
                 )
-                .map(auth::AuthLayer::new)
+                .map(|auth_keys| auth::AuthLayer::new(auth_keys, settings.service.read_only_mode))
             })
             .into_inner();
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -22,6 +22,12 @@ if [ "$MODE" == "distributed" ]; then
   export QDRANT__CLUSTER__ENABLED="true"
   # Run in background
   $QDRANT_EXECUTABLE --uri "http://127.0.0.1:6335" &
+elif [ "$MODE" == "readonly" ]; then
+  QDRANT_HOST='localhost:6337'
+  export QDRANT__SERVICE__HTTP_PORT="6337"
+  export QDRANT__SERVICE__GRPC_PORT="6338"
+  # Run in background
+  $QDRANT_EXECUTABLE &
 else
   # Run in background
   $QDRANT_EXECUTABLE &
@@ -60,16 +66,21 @@ if [ "$MODE" == "distributed" ]; then
   sleep 10
 fi
 
-pytest tests/openapi --durations=10
+if [ "$MODE" == "readonly" ]; then
+  export PID=$PID
+  ./tests/readonly_filesystem_test.sh
+else
+  pytest tests/openapi --durations=10
 
-./tests/basic_api_test.sh
+  ./tests/basic_api_test.sh
 
-./tests/basic_sparse_test.sh
+  ./tests/basic_sparse_test.sh
 
-./tests/basic_grpc_test.sh
+  ./tests/basic_grpc_test.sh
 
-./tests/basic_sparse_grpc_test.sh
+  ./tests/basic_sparse_grpc_test.sh
 
-./tests/basic_multivector_grpc_test.sh
+  ./tests/basic_multivector_grpc_test.sh
 
-./tests/basic_query_grpc_test.sh
+  ./tests/basic_query_grpc_test.sh
+fi

--- a/tests/readonly_filesystem_test.sh
+++ b/tests/readonly_filesystem_test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# This test checks that Qdrant works correctly when running in read-only mode
+
+set -ex
+
+QDRANT_HOST=${QDRANT_HOST:-'localhost:6337'}
+QDRANT_EXECUTABLE="./target/debug/qdrant"
+
+qdrant_host_headers=()
+
+if [ -n "${QDRANT_HOST_HEADERS}" ]; then
+  while read h; do
+    qdrant_host_headers+=("-H" "$h")
+  done <<<  $(echo "${QDRANT_HOST_HEADERS}" | jq -r 'to_entries|map("\(.key): \(.value)")[]')
+fi
+
+# cleanup collection if it exists
+curl -X DELETE "http://$QDRANT_HOST/collections/test_collection" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  -s || true
+
+# create collection
+curl -X PUT "http://$QDRANT_HOST/collections/test_collection" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s \
+  --data-raw '{
+      "vectors": {
+        "size": 4,
+        "distance": "Dot"
+      }
+  }' | jq
+
+curl -X PUT "http://$QDRANT_HOST/collections/test_collection/points?wait=true" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s \
+  --data-raw '{
+      "points": [
+          {
+              "id": 1,
+              "vector": [0.1, 0.2, 0.3, 0.4],
+              "payload": {"city": "Berlin", "test": "readonly_lifecycle"}
+          },
+          {
+              "id": 2,
+              "vector": [0.5, 0.6, 0.7, 0.8],
+              "payload": {"city": "Paris", "test": "readonly_lifecycle"}
+          }
+      ]
+  }' | jq
+
+TEST_COLLECTION="test_collection"
+EXPECTED_COUNT="2"
+
+# kill the current server
+if [ -n "$PID" ]; then
+    kill -9 $PID || true
+fi
+
+# start server in read-only mode with proper environment variables
+echo "Starting server in read-only mode..."
+export QDRANT__SERVICE__HTTP_PORT="6337"
+export QDRANT__SERVICE__GRPC_PORT="6338"
+$QDRANT_EXECUTABLE --read-only &
+READONLY_PID=$!
+
+cleanup() {
+  kill -9 $READONLY_PID
+}
+
+trap cleanup EXIT
+
+until curl --output /dev/null --silent --get --fail http://$QDRANT_HOST/collections; do
+  printf 'waiting for server to start...'
+  sleep 5
+done
+
+# check that our collection still exists
+curl -X GET "http://$QDRANT_HOST/collections/$TEST_COLLECTION" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s | jq
+
+# verify our points are still there
+echo "Verifying points persisted..."
+READONLY_POINT_COUNT=$(curl -X POST "http://$QDRANT_HOST/collections/$TEST_COLLECTION/points/count" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s \
+  --data-raw '{"exact": true}' | jq -r '.result.count')
+
+if [ "$READONLY_POINT_COUNT" != "$EXPECTED_COUNT" ]; then
+    echo "expected $EXPECTED_COUNT persisted points, got $READONLY_POINT_COUNT"
+    exit 1
+fi
+
+# test that read operations work
+curl -X POST "http://$QDRANT_HOST/collections/$TEST_COLLECTION/points/scroll" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --fail -s \
+  --data-raw '{
+      "limit": 10,
+      "with_payload": true,
+      "with_vector": true
+  }' | jq
+
+# test that write operations are forbidden 
+echo "Testing point insertion (should fail with 403)..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "http://$QDRANT_HOST/collections/$TEST_COLLECTION/points" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --data-raw '{
+      "points": [
+          {
+              "id": 999,
+              "vector": [0.9, 0.8, 0.7, 0.6],
+              "payload": {"city": "Tokyo", "test": "should_fail"}
+          }
+      ]
+  }')
+
+if [ "$HTTP_CODE" != "403" ]; then
+    echo "expected 403 Forbidden for point insertion, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://$QDRANT_HOST/collections/$TEST_COLLECTION/points/delete" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --data-raw '{
+      "points": [1]
+  }')
+
+if [ "$HTTP_CODE" != "403" ]; then
+    echo "expected 403 Forbidden for point deletion, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "http://$QDRANT_HOST/collections/new_readonly_collection" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}" \
+  --data-raw '{
+      "vectors": {
+        "size": 4,
+        "distance": "Dot"
+      }
+  }')
+
+if [ "$HTTP_CODE" != "403" ]; then
+    echo "expected 403 Forbidden for collection creation, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://$QDRANT_HOST/collections/$TEST_COLLECTION" \
+  -H 'Content-Type: application/json' "${qdrant_host_headers[@]}")
+
+if [ "$HTTP_CODE" != "403" ]; then
+    echo "expected 403 Forbidden for collection deletion, got HTTP $HTTP_CODE"
+    exit 1
+fi


### PR DESCRIPTION
### Description

- CLI argument `--read-only`
- Configuration file option
- Authentication middleware that converts access to read-only
- WAL loading skip in read-only mode
- Validation preventing distributed + read-only combination
- Integration tests that verify read operations work and write operations return 403
- Documentation updates

fixes https://github.com/qdrant/qdrant/issues/3321
/claim https://github.com/qdrant/qdrant/issues/3321

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
