### PR TITLE
Add unified raft version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,7 @@ murmur3 = { git = "https://github.com/stusmall/murmur3", rev = "2c39087" }
 tempfile = { workspace = true }
 
 # Consensus related crates
-raft = { version = "0.7.0", features = [
-    "prost-codec",
-], default-features = false }
+raft = { workspace = true }
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_debug",
@@ -238,6 +236,7 @@ prost = "0.12.6"
 prost-build = { version = "0.12.6", features = ["cleanup-markdown"] }
 prost-wkt-types = "0.5"
 prost-for-raft = { package = "prost", version = "=0.11.9" } # version of prost used by raft
+raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 rand = "0.9.2"
 reqwest = { version = "0.12.23", default-features = false, features = [
     "json",

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -42,7 +42,7 @@ semver = { workspace = true }
 
 # Consensus related
 atomicwrites = { workspace = true }
-raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
+raft = { workspace = true }
 prost-for-raft = { workspace = true }
 protobuf = "2.28.0" # version of protobuf used by raft
 serde_cbor = { workspace = true }


### PR DESCRIPTION
A modified version of `raft` has been added, as the same version is used in the root project and in `storage`.