### PR TITLE
Fix deadlock on Actix RT in Cluster Info

### DIFF
--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -481,6 +481,7 @@ impl SegmentsSearcher {
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<BTreeSet<PointIdType>> {
         let stopping_guard = StoppingGuard::new();
+        // cloning filter spawning task
         let filter = filter.cloned();
         runtime_handle
             .spawn_blocking(move || {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use segment::data_types::facets::{FacetParams, FacetResponse};
@@ -358,12 +357,14 @@ impl ForwardProxyShard {
         self.wrapped_shard.update_tracker()
     }
 
-    pub fn estimate_cardinality(
+    pub async fn estimate_cardinality(
         &self,
         filter: Option<&Filter>,
-        hw_counter: &HardwareCounterCell,
+        hw_measurement_acc: &HwMeasurementAcc,
     ) -> CollectionResult<CardinalityEstimation> {
-        self.wrapped_shard.estimate_cardinality(filter, hw_counter)
+        self.wrapped_shard
+            .estimate_cardinality(filter, hw_measurement_acc)
+            .await
     }
 }
 

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -215,11 +215,9 @@ impl ShardOperation for LocalShard {
             })??;
             all_points.len()
         } else {
-            self.estimate_cardinality(
-                request.filter.as_ref(),
-                &hw_measurement_acc.get_counter_cell(),
-            )?
-            .exp
+            self.estimate_cardinality(request.filter.as_ref(), &hw_measurement_acc)
+                .await?
+                .exp
         };
         Ok(CountResult { count: total_count })
     }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::types::TelemetryDetail;
 use parking_lot::Mutex as ParkingMutex;
@@ -238,14 +237,15 @@ impl QueueProxyShard {
         (queue_proxy.wrapped_shard, queue_proxy.remote_shard)
     }
 
-    pub fn estimate_cardinality(
+    pub async fn estimate_cardinality(
         &self,
         filter: Option<&Filter>,
-        hw_counter: &HardwareCounterCell,
+        hw_measurement_acc: &HwMeasurementAcc,
     ) -> CollectionResult<CardinalityEstimation> {
         self.inner_unchecked()
             .wrapped_shard
-            .estimate_cardinality(filter, hw_counter)
+            .estimate_cardinality(filter, hw_measurement_acc)
+            .await
     }
 }
 

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -845,20 +845,20 @@ impl ShardReplicaSet {
     /// - cost_fn: the cost of the operation called lazily
     ///
     /// Returns an error if the rate limit is exceeded.
-    fn check_write_rate_limiter<F>(
+    async fn check_write_rate_limiter<F>(
         &self,
         hw_measurement_acc: &HwMeasurementAcc,
         cost_fn: F,
     ) -> CollectionResult<()>
     where
-        F: FnOnce() -> usize,
+        F: AsyncFnOnce() -> usize,
     {
         // Do not rate limit internal operation tagged with disposable measurement
         if hw_measurement_acc.is_disposable() {
             return Ok(());
         }
         if let Some(rate_limiter) = &self.write_rate_limiter {
-            let cost = cost_fn();
+            let cost = cost_fn().await;
             rate_limiter
                 .lock()
                 .try_consume(cost as f64)


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/7265

When the Actix runtime runs on a single thread, it can be starved by blocking the running thread on a sync lock.

This happens when calling the cluster info API while:
- have long running streaming snapshot going out holding read lock
- a segment lock (not segment holder lock)
- a pending write to the same segment
- request cluster info that blocks actix runtime with blocking read lock

I was able to reproduce the issue by adapting the existing deadlock test by interleaving calls to the cluster info API.

```
Thread 8 (Thread 0x7b408ebff6c0 (LWP 313205) "actix-rt|system"):
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x000060f10badea19 in parking_lot_core::thread_parker::imp::ThreadParker::futex_wait () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/thread_parker/linux.rs:112
#2  0x000060f10bade84c in <parking_lot_core::thread_parker::imp::ThreadParker as parking_lot_core::thread_parker::ThreadParkerT>::park () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/thread_parker/linux.rs:66
#3  0x000060f10badaf2d in parking_lot_core::parking_lot::park::{{closure}} () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:635
#4  0x000060f10bada2af in with_thread_data<parking_lot_core::parking_lot::ParkResult, parking_lot_core::parking_lot::park::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#1}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#2}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>>> () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:207
#5  park<parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#1}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#2}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>> () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:600
#6  0x000060f10bae575b in parking_lot::raw_rwlock::RawRwLock::lock_common () at src/raw_rwlock.rs:1123
#7  0x000060f10bae445e in parking_lot::raw_rwlock::RawRwLock::lock_shared_slow () at src/raw_rwlock.rs:723
#8  0x000060f107975872 in lock_shared () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot-0.12.4/src/raw_rwlock.rs:109
#9  0x000060f1078bb2a3 in lock_api::rwlock::RwLock<R,T>::read () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.13/src/rwlock.rs:468
#10 0x000060f1071d101b in collection::shards::local_shard::LocalShard::estimate_cardinality::{{closure}} () at lib/collection/src/shards/local_shard/mod.rs:1004
#11 0x000060f10731baff in core::iter::adapters::map::map_fold::{{closure}} () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:88
#12 0x000060f107305baf in core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:294
#13 0x000060f106e9da2d in core::iter::traits::iterator::Iterator::fold () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2602
#14 0x000060f106a3156a in <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::fold () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/chain.rs:123
#15 0x000060f1072fee52 in <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:128
#16 0x000060f10729229a in collection::shards::local_shard::LocalShard::estimate_cardinality () at lib/collection/src/shards/local_shard/mod.rs:1007
#17 0x000060f106c935ea in {async_block#0} () at lib/collection/src/shards/local_shard/shard_ops.rs:218
#18 0x000060f106b8afd9 in poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<collection::operations::types::CountResult, collection::operations::types::CollectionError>> + core::marker::Send), alloc::alloc::Global>> () at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124
#19 0x000060f10600dbe0 in {async_fn#0} () at lib/collection/src/shards/replica_set/read_ops.rs:186
#20 0x000060f10462376b in {async_fn#0} () at lib/collection/src/collection/collection_ops.rs:368
#21 0x000060f1049f08aa in {async_fn#0} () at src/common/collections.rs:195
#22 0x000060f1053d6e3c in {async_block#0}<collection::operations::types::CollectionClusterInfo, qdrant::common::collections::do_get_collection_cluster::{async_fn_env#0}> () at src/actix/helpers.rs:146
#23 0x000060f1053e2fea in {async_fn#0}<collection::operations::types::CollectionClusterInfo, qdrant::actix::helpers::time::{async_fn#0}::{async_block_env#0}<collection::operations::types::CollectionClusterInfo, qdrant::common::collections::do_get_collection_cluster::{async_fn_env#0}>> () at src/actix/helpers.rs:186
#24 0x000060f1053d2a38 in {async_fn#0}<collection::operations::types::CollectionClusterInfo, qdrant::common::collections::do_get_collection_cluster::{async_fn_env#0}> () at src/actix/helpers.rs:146
#25 0x000060f104d17799 in {async_fn#0} () at src/actix/api/collections_api.rs:209

Thread 4 (Thread 0x7b408bfff6c0 (LWP 313219) "update-24"):
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x000060f10badea19 in parking_lot_core::thread_parker::imp::ThreadParker::futex_wait () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/thread_parker/linux.rs:112
#2  0x000060f10bade84c in <parking_lot_core::thread_parker::imp::ThreadParker as parking_lot_core::thread_parker::ThreadParkerT>::park () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/thread_parker/linux.rs:66
#3  0x000060f10baddef9 in parking_lot_core::parking_lot::park::{{closure}} () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:635
#4  0x000060f10bada604 in with_thread_data<parking_lot_core::parking_lot::ParkResult, parking_lot_core::parking_lot::park::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}>> () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:207
#5  park<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}> () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.11/src/parking_lot.rs:600
#6  0x000060f10bae5431 in wait_for_readers () at src/raw_rwlock.rs:1022
#7  0x000060f10bae4283 in parking_lot::raw_rwlock::RawRwLock::lock_exclusive_slow () at src/raw_rwlock.rs:647
#8  0x000060f107975982 in <parking_lot::raw_rwlock::RawRwLock as lock_api::rwlock::RawRwLock>::lock_exclusive () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot-0.12.4/src/raw_rwlock.rs:73
#9  0x000060f1078bb3b3 in lock_api::rwlock::RwLock<R,T>::write () at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.13/src/rwlock.rs:500
#10 0x000060f1078cae0b in apply_points<bool, shard::update::upsert_points::{closure_env#3}<core::slice::iter::Iter<shard::operations::point_ops::PointStructPersisted>>, shard::segment_holder::{impl#2}::apply_points_with_conditional_move::{closure_env#0}<shard::update::upsert_points::{closure_env#1}<core::slice::iter::Iter<shard::operations::point_ops::PointStructPersisted>>, shard::update::upsert_points::{closure_env#3}<core::slice::iter::Iter<shard::operations::point_ops::PointStructPersisted>>, shard::update::upsert_points::{closure_env#2}<core::slice::iter::Iter<shard::operations::point_ops::PointStructPersisted>>>> () at lib/shard/src/segment_holder/mod.rs:579
``` 

The fix is to make the underlying `estimate_cardinality` used by the cluster info non-blocking by offloading it to a dedicated blocking thread.

There is a bit of refactoring:
- making `estimate_cardinality` async
- using the thread-safe `HwMeasurementAcc` instead of `HardwareCounterCell`
- cloning the `Filter` to be able to spawn a task :see_no_evil: 