### PR TITLE
Add trigger reason to optimizer telemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "qdrant"
 workspace = true
 
 [features]
-default = ["rocksdb"]
+default = []
 service_debug = ["parking_lot/deadlock_detection"]
 tracing = [
     "api/tracing",

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -28,6 +28,7 @@ use crate::collection_manager::holders::proxy_segment::{self, ProxyIndexChange, 
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
+use crate::collection_manager::optimizers::TriggerReason;
 use crate::config::CollectionParams;
 use crate::operations::config_diff::DiffConfig;
 use crate::operations::types::{CollectionError, CollectionResult};
@@ -74,12 +75,14 @@ pub trait SegmentOptimizer {
     /// Get thresholds configuration for the current optimizer
     fn threshold_config(&self) -> &OptimizerThresholds;
 
-    /// Checks if segment optimization is required
+    /// Checks if segment optimization is required.
+    ///
+    /// This function may also return a reason indicating why the returned segment(s) should be indexed.
     fn check_condition(
         &self,
         segments: LockedSegmentHolder,
         excluded_ids: &HashSet<SegmentId>,
-    ) -> Vec<SegmentId>;
+    ) -> (Vec<SegmentId>, Option<TriggerReason>);
 
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator>;
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -343,7 +343,7 @@ impl UpdateHandler {
                     break 'outer;
                 }
 
-                let nonoptimal_segment_ids =
+                let (nonoptimal_segment_ids, trigger_reason) =
                     optimizer.check_condition(segments.clone(), &scheduled_segment_ids);
                 if nonoptimal_segment_ids.is_empty() {
                     break;
@@ -401,7 +401,11 @@ impl UpdateHandler {
                         let segments = segments.clone();
                         move |stopped| {
                             // Track optimizer status
-                            let tracker = Tracker::start(optimizer.as_ref().name(), nsi.clone());
+                            let tracker = Tracker::start(
+                                optimizer.as_ref().name(),
+                                nsi.clone(),
+                                trigger_reason,
+                            );
                             let tracker_handle = tracker.handle();
                             optimizers_log.lock().register(tracker);
 
@@ -536,7 +540,7 @@ impl UpdateHandler {
 
         let excluded_ids = HashSet::<_>::default();
         let has_suboptimal_optimizers = self.optimizers.iter().any(|optimizer| {
-            let nonoptimal_segment_ids =
+            let (nonoptimal_segment_ids, _reasons) =
                 optimizer.check_condition(self.segments.clone(), &excluded_ids);
             !nonoptimal_segment_ids.is_empty()
         });

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 workspace = true
 
 [features]
-default = ["rocksdb"]
+default = []
 testing = ["common/testing", "sparse/testing", "gpu/testing", "quantization/testing"]
 gpu = ["gpu/gpu"]
 rocksdb = ["dep:rocksdb"]


### PR DESCRIPTION
This PR adds a new field, `trigger_reason`, to the optimizer logs in telemetry.
In a future PR, this data will be used to calculate statistics on how often optimizers are triggered and for what reasons, which will be exposed in our `/metrics` API.

```json
{
  "name": "indexing",
  "segment_ids": [13],
  "status": "done",
  "start_at": "2025-09-18T09:44:20.107724473Z",
  "end_at": "2025-09-18T09:44:32.481401239Z",
  "trigger_reason": "to_index"
}
```