### PR TITLE
parallel scroll

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -102,7 +102,7 @@ mod tests {
         build_segment_1, build_segment_2, build_test_holder,
     };
     use crate::collection_manager::holders::segment_holder::LockedSegment::Original;
-    use crate::collection_manager::segments_searcher::SegmentsSearcher;
+    use crate::collection_manager::segments_retriever::SegmentsRetriever;
     use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
     use crate::operations::point_ops::{
         PointOperations, PointStructPersisted, VectorStructPersisted,
@@ -189,7 +189,7 @@ mod tests {
         assert!(matches!(res, Ok(1)));
 
         let segments = Arc::new(segments);
-        let records = SegmentsSearcher::retrieve_blocking(
+        let records = SegmentsRetriever::retrieve_blocking(
             segments.clone(),
             &[1.into(), 2.into(), 500.into()],
             &WithPayload::from(true),
@@ -226,7 +226,7 @@ mod tests {
         )
         .unwrap();
 
-        let records = SegmentsSearcher::retrieve_blocking(
+        let records = SegmentsRetriever::retrieve_blocking(
             segments,
             &[1.into(), 2.into(), 500.into()],
             &WithPayload::from(true),
@@ -269,7 +269,7 @@ mod tests {
         .unwrap();
 
         let segments = Arc::new(segments);
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments.clone(),
             &points,
             &WithPayload::from(true),
@@ -306,7 +306,7 @@ mod tests {
         )
         .unwrap();
 
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments.clone(),
             &[3.into()],
             &WithPayload::from(true),
@@ -323,7 +323,7 @@ mod tests {
 
         // Test clear payload
 
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments.clone(),
             &[2.into()],
             &WithPayload::from(true),
@@ -347,7 +347,7 @@ mod tests {
             &hw_counter,
         )
         .unwrap();
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments,
             &[2.into()],
             &WithPayload::from(true),
@@ -419,7 +419,7 @@ mod tests {
         )
         .unwrap();
 
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments.clone(),
             &points,
             &WithPayload::from(true),
@@ -482,7 +482,7 @@ mod tests {
         )
         .unwrap();
 
-        let res = SegmentsSearcher::retrieve_blocking(
+        let res = SegmentsRetriever::retrieve_blocking(
             segments,
             &points,
             &WithPayload::from(true),

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -81,16 +81,6 @@ impl CollectionUpdater {
 mod tests {
     use std::sync::Arc;
 
-    use super::*;
-    use crate::collection_manager::fixtures::{
-        build_segment_1, build_segment_2, build_test_holder,
-    };
-    use crate::collection_manager::holders::segment_holder::LockedSegment::Original;
-    use crate::collection_manager::segments_retriever::SegmentsRetriever;
-    use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
-    use crate::operations::point_ops::{
-        PointOperations, PointStructPersisted, VectorStructPersisted,
-    };
     use common::counter::hardware_accumulator::HwMeasurementAcc;
     use itertools::Itertools;
     use parking_lot::RwLockUpgradableReadGuard;
@@ -106,6 +96,17 @@ mod tests {
     use shard::update::upsert_points;
     use tempfile::Builder;
     use tokio::runtime::Handle;
+
+    use super::*;
+    use crate::collection_manager::fixtures::{
+        build_segment_1, build_segment_2, build_test_holder,
+    };
+    use crate::collection_manager::holders::segment_holder::LockedSegment::Original;
+    use crate::collection_manager::segments_retriever::SegmentsRetriever;
+    use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
+    use crate::operations::point_ops::{
+        PointOperations, PointStructPersisted, VectorStructPersisted,
+    };
 
     #[test]
     fn test_sync_ops() {

--- a/lib/collection/src/collection_manager/mod.rs
+++ b/lib/collection/src/collection_manager/mod.rs
@@ -3,6 +3,8 @@ pub mod holders;
 pub mod optimizers;
 pub mod segments_searcher;
 
+pub mod segments_retriever;
+
 pub mod probabilistic_search_sampling;
 mod search_result_aggregator;
 

--- a/lib/collection/src/collection_manager/segments_retriever.rs
+++ b/lib/collection/src/collection_manager/segments_retriever.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeSet;
+use std::collections::hash_map::Entry;
+use std::sync::atomic::AtomicBool;
+
+use ahash::AHashMap;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::common::operation_error::OperationError;
+use segment::data_types::named_vectors::NamedVectors;
+use segment::data_types::vectors::VectorStructInternal;
+use segment::types::{Filter, PointIdType, SeqNumberType, WithPayload, WithVector};
+use shard::segment_holder::LockedSegmentHolder;
+use tokio::runtime::Handle;
+
+use crate::common::stopping_guard::StoppingGuard;
+use crate::operations::types::{CollectionResult, RecordInternal};
+
+#[derive(Default)]
+pub struct SegmentsRetriever;
+
+impl SegmentsRetriever {
+    /// Retrieve records for the given points ids from the segments
+    /// - if payload is enabled, payload will be fetched
+    /// - if vector is enabled, vector will be fetched
+    ///
+    /// The points ids can contain duplicates, the records will be fetched only once
+    ///
+    /// If an id is not found in the segments, it won't be included in the output.
+    pub async fn retrieve(
+        segments: LockedSegmentHolder,
+        points: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        runtime_handle: &Handle,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
+        let stopping_guard = StoppingGuard::new();
+        runtime_handle
+            .spawn_blocking({
+                let segments = segments.clone();
+                let points = points.to_vec();
+                let with_payload = with_payload.clone();
+                let with_vector = with_vector.clone();
+                let is_stopped = stopping_guard.get_is_stopped();
+                // TODO create one Task per segment level retrieve
+                move || {
+                    Self::retrieve_blocking(
+                        segments,
+                        &points,
+                        &with_payload,
+                        &with_vector,
+                        &is_stopped,
+                        hw_measurement_acc,
+                    )
+                }
+            })
+            .await?
+    }
+
+    pub fn retrieve_blocking(
+        segments: LockedSegmentHolder,
+        points: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        is_stopped: &AtomicBool,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
+        let mut point_version: AHashMap<PointIdType, SeqNumberType> = Default::default();
+        let mut point_records: AHashMap<PointIdType, RecordInternal> = Default::default();
+
+        let hw_counter = hw_measurement_acc.get_counter_cell();
+
+        segments
+            .read()
+            .read_points(points, is_stopped, |id, segment| {
+                let version = segment.point_version(id).ok_or_else(|| {
+                    OperationError::service_error(format!("No version for point {id}"))
+                })?;
+
+                // If we already have the latest point version, keep that and continue
+                let version_entry = point_version.entry(id);
+                if matches!(&version_entry, Entry::Occupied(entry) if *entry.get() >= version) {
+                    return Ok(true);
+                }
+
+                point_records.insert(
+                    id,
+                    RecordInternal {
+                        id,
+                        payload: if with_payload.enable {
+                            if let Some(selector) = &with_payload.payload_selector {
+                                Some(selector.process(segment.payload(id, &hw_counter)?))
+                            } else {
+                                Some(segment.payload(id, &hw_counter)?)
+                            }
+                        } else {
+                            None
+                        },
+                        vector: {
+                            match with_vector {
+                                WithVector::Bool(true) => {
+                                    let vectors = segment.all_vectors(id, &hw_counter)?;
+                                    Some(VectorStructInternal::from(vectors))
+                                }
+                                WithVector::Bool(false) => None,
+                                WithVector::Selector(vector_names) => {
+                                    let mut selected_vectors = NamedVectors::default();
+                                    for vector_name in vector_names {
+                                        if let Some(vector) =
+                                            segment.vector(vector_name, id, &hw_counter)?
+                                        {
+                                            selected_vectors.insert(vector_name.clone(), vector);
+                                        }
+                                    }
+                                    Some(VectorStructInternal::from(selected_vectors))
+                                }
+                            }
+                        },
+                        shard_key: None,
+                        order_value: None,
+                    },
+                );
+                *version_entry.or_default() = version;
+
+                Ok(true)
+            })?;
+
+        Ok(point_records)
+    }
+
+    pub async fn read_filtered(
+        segments: LockedSegmentHolder,
+        filter: Option<&Filter>,
+        runtime_handle: &Handle,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<BTreeSet<PointIdType>> {
+        let stopping_guard = StoppingGuard::new();
+        let filter = filter.cloned();
+        runtime_handle
+            .spawn_blocking(move || {
+                let is_stopped = stopping_guard.get_is_stopped();
+                let segments = segments.read();
+                let hw_counter = hw_measurement_acc.get_counter_cell();
+                let all_points: BTreeSet<_> = segments
+                    .non_appendable_then_appendable_segments()
+                    .flat_map(|segment| {
+                        segment.get().read().read_filtered(
+                            None,
+                            None,
+                            filter.as_ref(),
+                            &is_stopped,
+                            &hw_counter,
+                        )
+                    })
+                    .collect();
+                Ok(all_points)
+            })
+            .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection_manager::fixtures::build_test_holder;
+
+    #[test]
+    fn test_retrieve() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let segment_holder = build_test_holder(dir.path());
+        let records = SegmentsRetriever::retrieve_blocking(
+            Arc::new(segment_holder),
+            &[1.into(), 2.into(), 3.into()],
+            &WithPayload::from(true),
+            &true.into(),
+            &AtomicBool::new(false),
+            HwMeasurementAcc::new(),
+        )
+        .unwrap();
+        assert_eq!(records.len(), 3);
+    }
+}

--- a/lib/collection/src/collection_manager/segments_retriever.rs
+++ b/lib/collection/src/collection_manager/segments_retriever.rs
@@ -3,8 +3,6 @@ use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::common::stopping_guard::StoppingGuard;
-use crate::operations::types::{CollectionResult, RecordInternal, RecordInternalVersioned};
 use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -18,6 +16,9 @@ use segment::types::{Filter, PointIdType, WithPayload, WithVector};
 use shard::locked_segment::LockedSegment;
 use shard::segment_holder::LockedSegmentHolder;
 use tokio::runtime::Handle;
+
+use crate::common::stopping_guard::StoppingGuard;
+use crate::operations::types::{CollectionResult, RecordInternal, RecordInternalVersioned};
 
 #[derive(Default)]
 pub struct SegmentsRetriever;

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -1,7 +1,4 @@
-use std::collections::BTreeSet;
-use std::collections::hash_map::Entry;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -11,12 +8,11 @@ use futures::{FutureExt, TryStreamExt};
 use itertools::Itertools;
 use ordered_float::Float;
 use segment::common::operation_error::OperationError;
-use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::vectors::{QueryVector, VectorStructInternal};
+use segment::data_types::vectors::QueryVector;
 use segment::types::{
-    Filter, Indexes, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SeqNumberType,
-    VectorName, WithPayload, WithPayloadInterface, WithVector,
+    Filter, Indexes, ScoredPoint, SearchParams, SegmentConfig, VectorName, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use tinyvec::TinyVec;
 use tokio::runtime::Handle;
@@ -29,9 +25,7 @@ use crate::collection_manager::search_result_aggregator::BatchResultAggregator;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::config::CollectionConfigInternal;
 use crate::operations::query_enum::QueryEnum;
-use crate::operations::types::{
-    CollectionResult, CoreSearchRequestBatch, Modifier, RecordInternal,
-};
+use crate::operations::types::{CollectionResult, CoreSearchRequestBatch, Modifier};
 use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
 
 type BatchOffset = usize;
@@ -365,146 +359,6 @@ impl SegmentsSearcher {
         Ok(top_scores)
     }
 
-    /// Retrieve records for the given points ids from the segments
-    /// - if payload is enabled, payload will be fetched
-    /// - if vector is enabled, vector will be fetched
-    ///
-    /// The points ids can contain duplicates, the records will be fetched only once
-    ///
-    /// If an id is not found in the segments, it won't be included in the output.
-    pub async fn retrieve(
-        segments: LockedSegmentHolder,
-        points: &[PointIdType],
-        with_payload: &WithPayload,
-        with_vector: &WithVector,
-        runtime_handle: &Handle,
-        hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
-        let stopping_guard = StoppingGuard::new();
-        runtime_handle
-            .spawn_blocking({
-                let segments = segments.clone();
-                let points = points.to_vec();
-                let with_payload = with_payload.clone();
-                let with_vector = with_vector.clone();
-                let is_stopped = stopping_guard.get_is_stopped();
-                // TODO create one Task per segment level retrieve
-                move || {
-                    Self::retrieve_blocking(
-                        segments,
-                        &points,
-                        &with_payload,
-                        &with_vector,
-                        &is_stopped,
-                        hw_measurement_acc,
-                    )
-                }
-            })
-            .await?
-    }
-
-    pub fn retrieve_blocking(
-        segments: LockedSegmentHolder,
-        points: &[PointIdType],
-        with_payload: &WithPayload,
-        with_vector: &WithVector,
-        is_stopped: &AtomicBool,
-        hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<AHashMap<PointIdType, RecordInternal>> {
-        let mut point_version: AHashMap<PointIdType, SeqNumberType> = Default::default();
-        let mut point_records: AHashMap<PointIdType, RecordInternal> = Default::default();
-
-        let hw_counter = hw_measurement_acc.get_counter_cell();
-
-        segments
-            .read()
-            .read_points(points, is_stopped, |id, segment| {
-                let version = segment.point_version(id).ok_or_else(|| {
-                    OperationError::service_error(format!("No version for point {id}"))
-                })?;
-
-                // If we already have the latest point version, keep that and continue
-                let version_entry = point_version.entry(id);
-                if matches!(&version_entry, Entry::Occupied(entry) if *entry.get() >= version) {
-                    return Ok(true);
-                }
-
-                point_records.insert(
-                    id,
-                    RecordInternal {
-                        id,
-                        payload: if with_payload.enable {
-                            if let Some(selector) = &with_payload.payload_selector {
-                                Some(selector.process(segment.payload(id, &hw_counter)?))
-                            } else {
-                                Some(segment.payload(id, &hw_counter)?)
-                            }
-                        } else {
-                            None
-                        },
-                        vector: {
-                            match with_vector {
-                                WithVector::Bool(true) => {
-                                    let vectors = segment.all_vectors(id, &hw_counter)?;
-                                    Some(VectorStructInternal::from(vectors))
-                                }
-                                WithVector::Bool(false) => None,
-                                WithVector::Selector(vector_names) => {
-                                    let mut selected_vectors = NamedVectors::default();
-                                    for vector_name in vector_names {
-                                        if let Some(vector) =
-                                            segment.vector(vector_name, id, &hw_counter)?
-                                        {
-                                            selected_vectors.insert(vector_name.clone(), vector);
-                                        }
-                                    }
-                                    Some(VectorStructInternal::from(selected_vectors))
-                                }
-                            }
-                        },
-                        shard_key: None,
-                        order_value: None,
-                    },
-                );
-                *version_entry.or_default() = version;
-
-                Ok(true)
-            })?;
-
-        Ok(point_records)
-    }
-
-    pub async fn read_filtered(
-        segments: LockedSegmentHolder,
-        filter: Option<&Filter>,
-        runtime_handle: &Handle,
-        hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<BTreeSet<PointIdType>> {
-        let stopping_guard = StoppingGuard::new();
-        // cloning filter spawning task
-        let filter = filter.cloned();
-        runtime_handle
-            .spawn_blocking(move || {
-                let is_stopped = stopping_guard.get_is_stopped();
-                let segments = segments.read();
-                let hw_counter = hw_measurement_acc.get_counter_cell();
-                let all_points: BTreeSet<_> = segments
-                    .non_appendable_then_appendable_segments()
-                    .flat_map(|segment| {
-                        segment.get().read().read_filtered(
-                            None,
-                            None,
-                            filter.as_ref(),
-                            &is_stopped,
-                            &hw_counter,
-                        )
-                    })
-                    .collect();
-                Ok(all_points)
-            })
-            .await?
-    }
-
     /// Rescore results with a formula that can reference payload values.
     ///
     /// Aggregates rescores from the segments.
@@ -774,7 +628,7 @@ mod tests {
     use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
     use segment::fixtures::index_fixtures::random_vector;
     use segment::index::VectorIndexEnum;
-    use segment::types::{Condition, HasIdCondition};
+    use segment::types::{Condition, HasIdCondition, PointIdType};
     use tempfile::Builder;
 
     use super::*;
@@ -958,22 +812,6 @@ mod tests {
                 assert_eq!(no_sampling.score, sampling.score); // different IDs may have same scores
             }
         }
-    }
-
-    #[test]
-    fn test_retrieve() {
-        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let segment_holder = build_test_holder(dir.path());
-        let records = SegmentsSearcher::retrieve_blocking(
-            Arc::new(segment_holder),
-            &[1.into(), 2.into(), 3.into()],
-            &WithPayload::from(true),
-            &true.into(),
-            &AtomicBool::new(false),
-            HwMeasurementAcc::new(),
-        )
-        .unwrap();
-        assert_eq!(records.len(), 3);
     }
 
     #[test]

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -22,7 +22,7 @@ use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
 };
-use crate::collection_manager::segments_searcher::SegmentsSearcher;
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
 use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
 use crate::operations::types::RecordInternal;
 
@@ -292,7 +292,7 @@ fn test_delete_all_point_versions() {
     let segments = Arc::new(RwLock::new(holder));
 
     // We should be able to retrieve point 123
-    let retrieved = SegmentsSearcher::retrieve_blocking(
+    let retrieved = SegmentsRetriever::retrieve_blocking(
         segments.clone(),
         &[point_id],
         &WithPayload::from(false),
@@ -337,7 +337,7 @@ fn test_delete_all_point_versions() {
 
     // We must not be able to retrieve point 123
     // Note: before the bug fix we could retrieve the point again from segment 1
-    let retrieved = SegmentsSearcher::retrieve_blocking(
+    let retrieved = SegmentsRetriever::retrieve_blocking(
         segments.clone(),
         &[point_id],
         &WithPayload::from(false),
@@ -456,7 +456,7 @@ fn test_proxy_shared_updates() {
     let with_payload = WithPayload::from(true);
     let with_vector = WithVector::from(true);
 
-    let result = SegmentsSearcher::retrieve_blocking(
+    let result = SegmentsRetriever::retrieve_blocking(
         locked_holder.clone(),
         &ids,
         &with_payload,
@@ -595,7 +595,7 @@ fn test_proxy_shared_updates_same_version() {
     let with_payload = WithPayload::from(true);
     let with_vector = WithVector::from(true);
 
-    let result = SegmentsSearcher::retrieve_blocking(
+    let result = SegmentsRetriever::retrieve_blocking(
         locked_holder.clone(),
         &ids,
         &with_payload,

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -3,15 +3,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use super::holders::proxy_segment;
-use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
-use crate::collection_manager::holders::proxy_segment::ProxySegment;
-use crate::collection_manager::holders::segment_holder::{
-    LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
-};
-use crate::collection_manager::segments_retriever::SegmentsRetriever;
-use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
-use crate::operations::types::RecordInternal;
 use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -25,6 +16,16 @@ use segment::types::{ExtendedPointId, PayloadContainer, PointIdType, WithPayload
 use shard::update::{delete_points, set_payload, upsert_points};
 use tempfile::Builder;
 use tokio::runtime::Handle;
+
+use super::holders::proxy_segment;
+use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
+use crate::collection_manager::holders::proxy_segment::ProxySegment;
+use crate::collection_manager::holders::segment_holder::{
+    LockedSegment, LockedSegmentHolder, SegmentHolder, SegmentId,
+};
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
+use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
+use crate::operations::types::RecordInternal;
 
 mod test_search_aggregation;
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -141,6 +141,11 @@ pub struct RecordInternal {
     pub order_value: Option<OrderValue>,
 }
 
+pub struct RecordInternalVersioned {
+    pub record: RecordInternal,
+    pub version: SeqNumberType,
+}
+
 /// Warn: panics if the vector is empty
 impl TryFrom<RecordInternal> for PointStructPersisted {
     type Error = String;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -55,7 +55,7 @@ use crate::collection_manager::holders::segment_holder::{
     LockedSegment, LockedSegmentHolder, SegmentHolder,
 };
 use crate::collection_manager::optimizers::TrackerLog;
-use crate::collection_manager::segments_searcher::SegmentsSearcher;
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
 use crate::common::file_utils::{move_dir, move_file};
 use crate::config::CollectionConfigInternal;
 use crate::operations::OperationWithClockTag;
@@ -1029,7 +1029,7 @@ impl LocalShard {
         hw_counter: HwMeasurementAcc,
     ) -> CollectionResult<BTreeSet<PointIdType>> {
         let segments = self.segments.clone();
-        SegmentsSearcher::read_filtered(segments, filter, runtime_handle, hw_counter).await
+        SegmentsRetriever::read_filtered(segments, filter, runtime_handle, hw_counter).await
     }
 
     pub async fn local_shard_status(&self) -> (ShardStatus, OptimizersStatus) {

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -15,7 +15,7 @@ use tokio::time::error::Elapsed;
 
 use super::LocalShard;
 use crate::collection::mmr::mmr_from_points_with_vector;
-use crate::collection_manager::segments_searcher::SegmentsSearcher;
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
 use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, CoreSearchRequestBatch,
     QueryScrollRequestInternal, ScrollOrder,
@@ -126,7 +126,7 @@ impl LocalShard {
         // Collect retrieved records into a hashmap for fast lookup
         let records_map = tokio::time::timeout(
             timeout,
-            SegmentsSearcher::retrieve(
+            SegmentsRetriever::retrieve(
                 self.segments.clone(),
                 &point_ids,
                 &(&with_payload).into(),

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -18,7 +18,7 @@ use tokio::time::error::Elapsed;
 
 use super::LocalShard;
 use crate::collection_manager::holders::segment_holder::LockedSegment;
-use crate::collection_manager::segments_searcher::SegmentsSearcher;
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
 use crate::common::stopping_guard::StoppingGuard;
 use crate::operations::types::{
     CollectionError, CollectionResult, QueryScrollRequestInternal, RecordInternal, ScrollOrder,
@@ -198,7 +198,7 @@ impl LocalShard {
         let timeout = timeout.saturating_sub(start.elapsed());
         let mut records_map = tokio::time::timeout(
             timeout,
-            SegmentsSearcher::retrieve(
+            SegmentsRetriever::retrieve(
                 segments,
                 &point_ids,
                 &with_payload,
@@ -294,7 +294,7 @@ impl LocalShard {
         // Fetch with the requested vector and payload
         let records_map = tokio::time::timeout(
             timeout,
-            SegmentsSearcher::retrieve(
+            SegmentsRetriever::retrieve(
                 segments,
                 &point_ids,
                 &with_payload,
@@ -434,7 +434,7 @@ impl LocalShard {
         let timeout = timeout.saturating_sub(start.elapsed());
         let records_map = tokio::time::timeout(
             timeout,
-            SegmentsSearcher::retrieve(
+            SegmentsRetriever::retrieve(
                 segments,
                 &selected_points,
                 &with_payload,

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::time::error::Elapsed;
 
-use crate::collection_manager::segments_searcher::SegmentsSearcher;
+use crate::collection_manager::segments_retriever::SegmentsRetriever;
 use crate::operations::OperationWithClockTag;
 use crate::operations::types::{
     CollectionError, CollectionInfo, CollectionResult, CoreSearchRequestBatch,
@@ -238,7 +238,7 @@ impl ShardOperation for LocalShard {
         let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let records_map = tokio::time::timeout(
             timeout,
-            SegmentsSearcher::retrieve(
+            SegmentsRetriever::retrieve(
                 self.segments.clone(),
                 &request.ids,
                 with_payload,


### PR DESCRIPTION
Current implementation of scroll works in 2 stages:

1. It reads point ids from all segments in parallel and merges them into final list of IDs
2. It retrieves payload & vectors from segments according to resolved list. 

The second stage, however, is done sequntially.

This PR changes the second stage to parallel read. In theory it should better utilize IOPS, especially in case of large limits (100+). And improve shard transfer performance.

WARN: 

The current version tries to read points in non-appendable -> appendable sequence. This PR removes it, as it looks like this pattern is not required:

1. It doesn't actually prevent what it was designed to prevent
2. We have another mechanism, which guarantees that there will be no updates during scroll requests - `scroll_lock`, as we rely on scroll operation for many internal processes

Main changes are in this PR: https://github.com/qdrant/qdrant/commit/d2910df472ec03b6c72f9f694d4412dc10cbca7e

