### PR TITLE
In optimizer, show bytes available/needed in human readable format

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use common::budget::{ResourceBudget, ResourcePermit};
+use common::bytes::bytes_to_human;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::disk::dir_disk_size;
 use io::storage_version::StorageVersion;
@@ -159,18 +160,22 @@ pub trait SegmentOptimizer {
         match (space_available, space_needed) {
             (Some(space_available), Some(space_needed)) => {
                 log::debug!(
-                    "Available space: {space_available}, needed for optimization: {space_needed}",
+                    "Available space: {}, needed for optimization: {}",
+                    bytes_to_human(space_available),
+                    bytes_to_human(space_needed),
                 );
                 if space_available < space_needed {
                     return Err(CollectionError::service_error(format!(
-                        "Not enough space available for optimization, needed: {space_needed}, available: {space_available}"
+                        "Not enough space available for optimization, needed: {}, available: {}"
+                        bytes_to_human(space_needed),
+                        bytes_to_human(space_available),
                     )));
                 }
             }
             _ => {
                 log::warn!(
                     "Could not estimate available storage space in `{}`; will try optimizing anyway",
-                    self.name()
+                    self.name(),
                 );
             }
         }

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -161,14 +161,14 @@ pub trait SegmentOptimizer {
             (Some(space_available), Some(space_needed)) => {
                 log::debug!(
                     "Available space: {}, needed for optimization: {}",
-                    bytes_to_human(space_available),
-                    bytes_to_human(space_needed),
+                    bytes_to_human(space_available as usize),
+                    bytes_to_human(space_needed as usize),
                 );
                 if space_available < space_needed {
                     return Err(CollectionError::service_error(format!(
-                        "Not enough space available for optimization, needed: {}, available: {}"
-                        bytes_to_human(space_needed),
-                        bytes_to_human(space_available),
+                        "Not enough space available for optimization, needed: {}, available: {}",
+                        bytes_to_human(space_needed as usize),
+                        bytes_to_human(space_available as usize),
                     )));
                 }
             }


### PR DESCRIPTION
The optimizer logs how many bytes are needed/available.

This now formats it in human readable format:

From:

```log
Available space: 122273390592, needed for optimization: 347267072
```

To:

```log
Available space: 122.27 GiB, needed for optimization: 347.26 MiB
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?