### PR TITLE
Add more Optimizer data in metrics

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12746,8 +12746,8 @@
         "type": "object",
         "required": [
           "optimizations",
-          "status",
-          "triggers"
+          "runs",
+          "status"
         ],
         "properties": {
           "status": {
@@ -12763,8 +12763,8 @@
             },
             "nullable": true
           },
-          "triggers": {
-            "$ref": "#/components/schemas/OptimizerTriggers"
+          "runs": {
+            "$ref": "#/components/schemas/OptimizerRunCounters"
           }
         }
       },
@@ -12843,7 +12843,7 @@
           }
         ]
       },
-      "OptimizerTriggers": {
+      "OptimizerRunCounters": {
         "type": "object",
         "required": [
           "config_mismatch",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12746,7 +12746,8 @@
         "type": "object",
         "required": [
           "optimizations",
-          "status"
+          "status",
+          "triggers"
         ],
         "properties": {
           "status": {
@@ -12761,6 +12762,9 @@
               "$ref": "#/components/schemas/TrackerTelemetry"
             },
             "nullable": true
+          },
+          "triggers": {
+            "$ref": "#/components/schemas/OptimizerTriggers"
           }
         }
       },
@@ -12838,6 +12842,37 @@
             "additionalProperties": false
           }
         ]
+      },
+      "OptimizerTriggers": {
+        "type": "object",
+        "required": [
+          "config_mismatch",
+          "index",
+          "merge",
+          "vacuum"
+        ],
+        "properties": {
+          "vacuum": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "merge": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "index": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "config_mismatch": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        }
       },
       "RemoteShardTelemetry": {
         "type": "object",

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -272,7 +272,10 @@ impl SegmentOptimizer for ConfigMismatchOptimizer {
     }
 
     fn increment_run_counter(&self) {
-        self.telemetry_aggregator.triggers.lock().config_mismatch += 1;
+        self.telemetry_aggregator
+            .run_counters
+            .lock()
+            .config_mismatch += 1;
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -280,7 +280,7 @@ impl SegmentOptimizer for IndexingOptimizer {
     }
 
     fn increment_run_counter(&self) {
-        self.telemetry_aggregator.triggers.lock().index += 1;
+        self.telemetry_aggregator.run_counters.lock().index += 1;
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -153,7 +153,7 @@ impl SegmentOptimizer for MergeOptimizer {
     }
 
     fn increment_run_counter(&self) {
-        self.telemetry_aggregator.triggers.lock().merge += 1;
+        self.telemetry_aggregator.run_counters.lock().merge += 1;
     }
 }
 

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -5,9 +5,11 @@ use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
+use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use serde::{Deserialize, Serialize};
 
 use super::holders::segment_holder::SegmentId;
+use crate::shards::telemetry::OptimizerTriggers;
 
 pub mod config_mismatch_optimizer;
 pub mod indexing_optimizer;
@@ -180,4 +182,25 @@ pub enum TrackerStatus {
     Cancelled(String),
     #[anonymize(false)]
     Error(String),
+}
+
+#[derive(Debug)]
+pub struct OptimizerTelemetryCounter {
+    pub durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
+    pub triggers: Arc<Mutex<OptimizerTriggers>>,
+}
+
+impl OptimizerTelemetryCounter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for OptimizerTelemetryCounter {
+    fn default() -> Self {
+        Self {
+            durations_aggregator: OperationDurationsAggregator::new(),
+            triggers: Arc::new(Mutex::new(OptimizerTriggers::default())),
+        }
+    }
 }

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -9,7 +9,7 @@ use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use serde::{Deserialize, Serialize};
 
 use super::holders::segment_holder::SegmentId;
-use crate::shards::telemetry::OptimizerTriggers;
+use crate::shards::telemetry::OptimizerRunCounters;
 
 pub mod config_mismatch_optimizer;
 pub mod indexing_optimizer;
@@ -187,7 +187,7 @@ pub enum TrackerStatus {
 #[derive(Debug)]
 pub struct OptimizerTelemetryCounter {
     pub durations_aggregator: Arc<Mutex<OperationDurationsAggregator>>,
-    pub triggers: Arc<Mutex<OptimizerTriggers>>,
+    pub run_counters: Arc<Mutex<OptimizerRunCounters>>,
 }
 
 impl OptimizerTelemetryCounter {
@@ -200,7 +200,7 @@ impl Default for OptimizerTelemetryCounter {
     fn default() -> Self {
         Self {
             durations_aggregator: OperationDurationsAggregator::new(),
-            triggers: Arc::new(Mutex::new(OptimizerTriggers::default())),
+            run_counters: Arc::new(Mutex::new(OptimizerRunCounters::default())),
         }
     }
 }

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -211,7 +211,7 @@ impl SegmentOptimizer for VacuumOptimizer {
     }
 
     fn increment_run_counter(&self) {
-        self.telemetry_aggregator.triggers.lock().vacuum += 1;
+        self.telemetry_aggregator.run_counters.lock().vacuum += 1;
     }
 }
 

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -70,7 +70,7 @@ impl LocalShard {
             optimizations: OptimizerTelemetry {
                 status,
                 optimizations,
-                log: (detail.level >= DetailsLevel::Level4)
+                log: (detail.level >= DetailsLevel::Level3)
                     .then(|| self.optimizers_log.lock().to_telemetry()),
             },
             async_scorer: Some(get_async_scorer()),

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -46,10 +46,10 @@ impl LocalShard {
             })
             .fold(Default::default(), |total, stats| total + stats);
 
-        let optimizer_triggers = self
+        let optimizer_runs = self
             .optimizers
             .iter()
-            .map(|optimizer| *optimizer.get_telemetry_counter().triggers.lock())
+            .map(|optimizer| *optimizer.get_telemetry_counter().run_counters.lock())
             .fold(Default::default(), |total, stats| total + stats);
 
         let status = self.get_optimization_status().await;
@@ -79,7 +79,7 @@ impl LocalShard {
                 optimizations,
                 log: (detail.level >= DetailsLevel::Level4 || detail.optimizer_logs)
                     .then(|| self.optimizers_log.lock().to_telemetry()),
-                triggers: optimizer_triggers,
+                runs: optimizer_runs,
             },
             async_scorer: Some(get_async_scorer()),
         }

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -77,7 +77,7 @@ impl LocalShard {
             optimizations: OptimizerTelemetry {
                 status,
                 optimizations,
-                log: (detail.level >= DetailsLevel::Level4)
+                log: (detail.level >= DetailsLevel::Level4 || detail.optimizer_logs)
                     .then(|| self.optimizers_log.lock().to_telemetry()),
                 triggers: optimizer_triggers,
             },

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Add;
 
 use schemars::JsonSchema;
 use segment::common::anonymize::{Anonymize, anonymize_collection_values};
@@ -73,6 +74,28 @@ pub struct OptimizerTelemetry {
     pub optimizations: OperationDurationStatistics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Vec<TrackerTelemetry>>,
+    pub triggers: OptimizerTriggers,
+}
+
+#[derive(Serialize, Clone, Copy, Debug, JsonSchema, Anonymize, Default)]
+pub struct OptimizerTriggers {
+    pub vacuum: usize,
+    pub merge: usize,
+    pub index: usize,
+    pub config_mismatch: usize,
+}
+
+impl Add for OptimizerTriggers {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            vacuum: self.vacuum + rhs.vacuum,
+            merge: self.merge + rhs.merge,
+            index: self.index + rhs.index,
+            config_mismatch: self.config_mismatch + rhs.config_mismatch,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, JsonSchema, Anonymize)]

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -74,18 +74,18 @@ pub struct OptimizerTelemetry {
     pub optimizations: OperationDurationStatistics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Vec<TrackerTelemetry>>,
-    pub triggers: OptimizerTriggers,
+    pub runs: OptimizerRunCounters,
 }
 
 #[derive(Serialize, Clone, Copy, Debug, JsonSchema, Anonymize, Default)]
-pub struct OptimizerTriggers {
+pub struct OptimizerRunCounters {
     pub vacuum: usize,
     pub merge: usize,
     pub index: usize,
     pub config_mismatch: usize,
 }
 
-impl Add for OptimizerTriggers {
+impl Add for OptimizerRunCounters {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -364,9 +364,6 @@ impl UpdateHandler {
                     &nonoptimal_segment_ids
                 );
 
-                // Optimizer has been triggered, so we need to increment the trigger-counter.
-                optimizer.increment_run_counter();
-
                 // Determine how many Resources we prefer for optimization task, acquire permit for it
                 // And use same amount of IO threads as CPUs
                 let max_indexing_threads = optimizer.hnsw_config().max_indexing_threads;
@@ -396,6 +393,9 @@ impl UpdateHandler {
                     // Notify scheduler that resource budget is explicitly changed
                     permit_callback(false);
                 });
+
+                // Optimizer has been started, so we need to increment the run-counter.
+                optimizer.increment_run_counter();
 
                 let optimizer = optimizer.clone();
                 let optimizers_log = optimizers_log.clone();

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -364,6 +364,9 @@ impl UpdateHandler {
                     &nonoptimal_segment_ids
                 );
 
+                // Optimizer has been triggered, so we need to increment the trigger-counter.
+                optimizer.increment_run_counter();
+
                 // Determine how many Resources we prefer for optimization task, acquire permit for it
                 // And use same amount of IO threads as CPUs
                 let max_indexing_threads = optimizer.hnsw_config().max_indexing_threads;

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -33,6 +33,7 @@ impl PartialOrd for ScoredPointOffset {
 pub struct TelemetryDetail {
     pub level: DetailsLevel,
     pub histograms: bool,
+    pub optimizer_logs: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -69,6 +70,7 @@ impl Default for TelemetryDetail {
         TelemetryDetail {
             level: DetailsLevel::Level0,
             histograms: false,
+            optimizer_logs: false,
         }
     }
 }

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -46,6 +46,7 @@ fn telemetry(
         let detail = TelemetryDetail {
             level: details_level,
             histograms: false,
+            optimizer_logs: false,
         };
         let telemetry_collector = telemetry_collector.lock().await;
         let telemetry_data = telemetry_collector.prepare_data(&access, detail).await;
@@ -81,6 +82,7 @@ async fn metrics(
             TelemetryDetail {
                 level: DetailsLevel::Level3,
                 histograms: true,
+                optimizer_logs: true,
             },
         )
         .await;

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -1,6 +1,6 @@
 use api::rest::models::HardwareUsage;
 use collection::collection_manager::optimizers::TrackerStatus;
-use collection::shards::telemetry::OptimizerTriggers;
+use collection::shards::telemetry::OptimizerRunCounters;
 use prometheus::TextEncoder;
 use prometheus::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
 use segment::common::operation_time_statistics::OperationDurationStatistics;
@@ -205,8 +205,10 @@ impl MetricsProvider for CollectionsTelemetry {
                 .iter()
                 .flatten()
                 .filter_map(|i| i.local.as_ref())
-                .map(|i| i.optimizations.triggers)
-                .fold(OptimizerTriggers::default(), |total, state| total + state);
+                .map(|i| i.optimizations.runs)
+                .fold(OptimizerRunCounters::default(), |total, state| {
+                    total + state
+                });
 
             let mut add_optimizer_metric = |name: &str, value: usize| {
                 if value > 0 {
@@ -217,7 +219,7 @@ impl MetricsProvider for CollectionsTelemetry {
                 }
             };
 
-            let OptimizerTriggers {
+            let OptimizerRunCounters {
                 vacuum,
                 merge,
                 index,
@@ -232,8 +234,8 @@ impl MetricsProvider for CollectionsTelemetry {
 
         if !optimizer_counter_metrics.is_empty() {
             metrics.push(metric_family(
-                "collections_optimizer_trigger_count",
-                "number of optimization triggers per optimizer",
+                "collections_optimizer_run_count",
+                "number of optimization runs per optimizer",
                 MetricType::COUNTER,
                 optimizer_counter_metrics,
             ));

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -217,10 +217,17 @@ impl MetricsProvider for CollectionsTelemetry {
                 }
             };
 
-            add_optimizer_metric("config-mismatch", optimizer_triggers.config_mismatch);
-            add_optimizer_metric("index", optimizer_triggers.index);
-            add_optimizer_metric("merge", optimizer_triggers.merge);
-            add_optimizer_metric("vacuum", optimizer_triggers.vacuum);
+            let OptimizerTriggers {
+                vacuum,
+                merge,
+                index,
+                config_mismatch,
+            } = optimizer_triggers;
+
+            add_optimizer_metric("config-mismatch", config_mismatch);
+            add_optimizer_metric("index", index);
+            add_optimizer_metric("merge", merge);
+            add_optimizer_metric("vacuum", vacuum);
         }
 
         if !optimizer_counter_metrics.is_empty() {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -207,12 +207,14 @@ impl MetricsProvider for CollectionsTelemetry {
                 })
                 .collect();
 
-            metrics.push(metric_family(
-                "collections_optimizer_trigger_count",
-                "number of optimization triggers per optimizer",
-                MetricType::COUNTER,
-                counter_metrics,
-            ));
+            if !counter_metrics.is_empty() {
+                metrics.push(metric_family(
+                    "collections_optimizer_trigger_count",
+                    "number of optimization triggers per optimizer",
+                    MetricType::COUNTER,
+                    counter_metrics,
+                ));
+            }
         }
     }
 }

--- a/src/common/telemetry_reporting.rs
+++ b/src/common/telemetry_reporting.rs
@@ -12,6 +12,7 @@ use super::telemetry::TelemetryCollector;
 const DETAIL: TelemetryDetail = TelemetryDetail {
     level: DetailsLevel::Level2,
     histograms: false,
+    optimizer_logs: false,
 };
 const REPORTING_INTERVAL: Duration = Duration::from_secs(60 * 60); // One hour
 


### PR DESCRIPTION
Adds 2 new metrics, `collections_optimizer_trigger_count` and `optimizer_total_processes_running`, to the metrics API. The first one measures the amount of triggers of our optimizers on per (local) collection level.
The second one measures the total amount of optimization processes running on all local-shards of the given node.

```
# HELP collections_optimizer_run_count number of optimization triggers per optimizer
# TYPE collections_optimizer_run_count counter
collections_optimizer_run_count{id="benchmark",optimizer="merge"} 1
collections_optimizer_run_count{id="benchmark",optimizer="index"} 4
```

and 

```
# HELP optimizer_total_processes_running number of optimization processes running in total
# TYPE optimizer_total_processes_running gauge
optimizer_total_processes_running 1
````