### PR TITLE
DiffConfig: replace serde-based impl with explicit impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "log",
- "merge",
  "object_store",
  "ordered-float 5.0.0",
  "parking_lot",
@@ -3615,28 +3614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merge"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
-dependencies = [
- "merge_derive",
- "num-traits",
-]
-
-[[package]]
-name = "merge_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5801,7 +5778,6 @@ dependencies = [
  "macros",
  "memmap2",
  "memory",
- "merge",
  "ndarray",
  "ndarray-npy",
  "nom 8.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,6 @@ byteorder = "1.5.0"
 thiserror = "2.0.16"
 bitvec = "1.0.1"
 smallvec = { version = "1.15.1", features = ["write"] }
-merge = "0.1.0"
 dashmap = "6.1"
 walkdir = "2.5.0"
 

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -57,7 +57,6 @@ futures = { workspace = true }
 atomicwrites = { workspace = true}
 log = { workspace = true }
 env_logger = "0.11"
-merge = { workspace = true }
 async-trait = "0.1.89"
 arc-swap = "1.7.1"
 tonic = { workspace = true }

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -34,7 +34,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         {
             let mut config = self.collection_config.write().await;
-            config.params = config.params.update(params_diff)?;
+            config.params = config.params.update(&params_diff);
         }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
@@ -51,7 +51,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         {
             let mut config = self.collection_config.write().await;
-            config.hnsw_config = config.hnsw_config.update(hnsw_config_diff)?;
+            config.hnsw_config = config.hnsw_config.update(&hnsw_config_diff);
         }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
@@ -104,7 +104,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         {
             let mut config = self.collection_config.write().await;
-            config.optimizer_config = config.optimizer_config.update(optimizer_config_diff)?;
+            config.optimizer_config = config.optimizer_config.update(&optimizer_config_diff);
         }
         self.collection_config.read().await.save(&self.path)?;
         Ok(())
@@ -186,7 +186,7 @@ impl Collection {
         {
             let mut config = self.collection_config.write().await;
             if let Some(current_config) = config.strict_mode_config.as_mut() {
-                *current_config = current_config.update(strict_mode_diff)?;
+                *current_config = current_config.update(&strict_mode_diff);
             } else {
                 config.strict_mode_config = Some(strict_mode_diff);
             }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -132,7 +132,7 @@ impl Collection {
             let mut effective_optimizers_config = collection_config.optimizer_config.clone();
             if let Some(optimizers_overwrite) = optimizers_overwrite.clone() {
                 effective_optimizers_config =
-                    effective_optimizers_config.update(optimizers_overwrite)?;
+                    effective_optimizers_config.update(&optimizers_overwrite);
             }
 
             let shard_key = shard_key_mapping
@@ -253,9 +253,7 @@ impl Collection {
         let mut effective_optimizers_config = collection_config.optimizer_config.clone();
 
         if let Some(optimizers_overwrite) = optimizers_overwrite.clone() {
-            effective_optimizers_config = effective_optimizers_config
-                .update(optimizers_overwrite)
-                .expect("Can not apply optimizer overwrite");
+            effective_optimizers_config = effective_optimizers_config.update(&optimizers_overwrite);
         }
 
         let shared_collection_config = Arc::new(RwLock::new(collection_config.clone()));
@@ -847,7 +845,7 @@ impl Collection {
         let config = self.collection_config.read().await;
 
         if let Some(optimizers_overwrite) = self.optimizers_overwrite.clone() {
-            Ok(config.optimizer_config.update(optimizers_overwrite)?)
+            Ok(config.optimizer_config.update(&optimizers_overwrite))
         } else {
             Ok(config.optimizer_config.clone())
         }

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -116,7 +116,9 @@ impl ConfigMismatchOptimizer {
                                         self.collection_params
                                             .vectors
                                             .get_params(vector_name)
-                                            .and_then(|vector_params| vector_params.hnsw_config),
+                                            .and_then(|vector_params| {
+                                                vector_params.hnsw_config.as_ref()
+                                            }),
                                     );
                                     if effective_hnsw.mismatch_requires_rebuild(&target_hnsw) {
                                         return true;
@@ -577,12 +579,12 @@ mod tests {
             .for_each(|segment| {
                 assert_eq!(
                     segment.config().vector_data[VECTOR1_NAME].index,
-                    Indexes::Hnsw(hnsw_config_collection.update(hnsw_config_vector1).unwrap()),
+                    Indexes::Hnsw(hnsw_config_collection.update(&hnsw_config_vector1)),
                     "HNSW config of vector1 is not what we expect",
                 );
                 assert_eq!(
                     segment.config().vector_data[VECTOR2_NAME].index,
-                    Indexes::Hnsw(hnsw_config_collection.update(hnsw_config_vector2).unwrap()),
+                    Indexes::Hnsw(hnsw_config_collection.update(&hnsw_config_vector2)),
                     "HNSW config of vector2 is not what we expect",
                 );
             });

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -254,7 +254,7 @@ pub trait SegmentOptimizer {
                     .vectors
                     .get_params(vector_name)
                     .and_then(|params| params.hnsw_config);
-                let vector_hnsw = collection_hnsw.update_opt(param_hnsw);
+                let vector_hnsw = collection_hnsw.update_opt(param_hnsw.as_ref());
                 config.index = Indexes::Hnsw(vector_hnsw);
 
                 // Assign quantization config

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -281,7 +281,9 @@ impl CollectionConfigInternal {
         let mut warnings = Vec::new();
 
         for (vector_name, vector_config) in self.params.vectors.params_iter() {
-            let vector_hnsw = self.hnsw_config.update_opt(vector_config.hnsw_config);
+            let vector_hnsw = self
+                .hnsw_config
+                .update_opt(vector_config.hnsw_config.as_ref());
 
             let vector_quantization =
                 vector_config.quantization_config.is_some() || self.quantization_config.is_some();
@@ -449,7 +451,7 @@ impl CollectionParams {
 
             if let Some(hnsw_diff) = hnsw_config {
                 if let Some(existing_hnsw) = &vector_params.hnsw_config {
-                    vector_params.hnsw_config = Some(existing_hnsw.update(hnsw_diff)?);
+                    vector_params.hnsw_config = Some(existing_hnsw.update(&hnsw_diff));
                 } else {
                     vector_params.hnsw_config = Some(hnsw_diff);
                 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -50,7 +50,7 @@ use tonic::codegen::http::uri::InvalidUri;
 use uuid::Uuid;
 use validator::{Validate, ValidationError, ValidationErrors};
 
-use super::{ClockTag, config_diff};
+use super::ClockTag;
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::config_diff::{HnswConfigDiff, QuantizationConfigDiff};
@@ -1534,10 +1534,7 @@ pub fn validate_nonzerou64_range_min_1_max_65536(
 
 /// Is considered empty if `None` or if diff has no field specified
 fn is_hnsw_diff_empty(hnsw_config: &Option<HnswConfigDiff>) -> bool {
-    hnsw_config
-        .as_ref()
-        .and_then(|config| config_diff::is_empty(config).ok())
-        .unwrap_or(true)
+    hnsw_config.is_none() || *hnsw_config == Some(HnswConfigDiff::default())
 }
 
 /// If used, include weight modification, which will be applied to sparse vectors at query time:

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -18,7 +18,6 @@ use common::validation::validate_range_generic;
 use common::{defaults, save_on_disk};
 use io::file_operations::FileStorageError;
 use issues::IssueRecord;
-use merge::Merge;
 use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
@@ -1870,9 +1869,7 @@ impl From<&segment::types::VectorDataConfig> for VectorParamsBase {
     }
 }
 
-#[derive(
-    Debug, Hash, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Merge,
-)]
+#[derive(Debug, Hash, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct VectorParamsDiff {
     /// Update params for HNSW index. If empty object - it will be unset.

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -123,7 +123,6 @@ tracing = { workspace = true, optional = true }
 macro_rules_attribute = "0.2.2"
 nom = "8.0.0"
 half = { workspace = true }
-merge = { workspace = true }
 roaring = { version = "0.11.2" }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -17,7 +17,6 @@ use fnv::FnvBuildHasher;
 use geo::{Contains, Coord, Distance as GeoDistance, Haversine, LineString, Point, Polygon};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use merge::Merge;
 use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -866,9 +865,7 @@ impl From<BinaryQuantizationConfig> for QuantizationConfig {
     }
 }
 
-#[derive(
-    Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Merge, Hash,
-)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
 pub struct StrictModeSparse {
     /// Max length of sparse vector
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -882,14 +879,6 @@ pub struct StrictModeSparseConfig {
     #[validate(nested)]
     #[serde(flatten)]
     pub config: BTreeMap<VectorNameBuf, StrictModeSparse>,
-}
-
-impl Merge for StrictModeSparseConfig {
-    fn merge(&mut self, other: Self) {
-        for (key, value) in other.config {
-            self.config.entry(key).or_default().merge(value);
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, PartialEq, Default)]
@@ -927,9 +916,7 @@ impl From<StrictModeSparse> for StrictModeSparseOutput {
     }
 }
 
-#[derive(
-    Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Merge, Hash,
-)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Hash)]
 pub struct StrictModeMultivector {
     /// Max number of vectors in a multivector
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -943,15 +930,6 @@ pub struct StrictModeMultivectorConfig {
     #[validate(nested)]
     #[serde(flatten)]
     pub config: BTreeMap<VectorNameBuf, StrictModeMultivector>,
-}
-
-impl Merge for StrictModeMultivectorConfig {
-    fn merge(&mut self, other: Self) {
-        for (key, value) in other.config {
-            // overwrite value if key exists
-            self.config.entry(key).or_default().merge(value);
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Clone, PartialEq, Default)]
@@ -989,7 +967,7 @@ impl From<StrictModeMultivector> for StrictModeMultivectorOutput {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default, Merge)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Default)]
 pub struct StrictModeConfig {
     // Global
     /// Whether strict mode is enabled for a collection or not.

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -164,14 +164,17 @@ impl TableOfContent {
             )?,
             read_fan_out_factor: None,
         };
-        let wal_config = self.storage_config.wal.update_opt(wal_config_diff);
+        let wal_config = self.storage_config.wal.update_opt(wal_config_diff.as_ref());
 
         let optimizer_config = self
             .storage_config
             .optimizers
-            .update_opt(optimizers_config_diff);
+            .update_opt(optimizers_config_diff.as_ref());
 
-        let hnsw_config = self.storage_config.hnsw_index.update_opt(hnsw_config_diff);
+        let hnsw_config = self
+            .storage_config
+            .hnsw_index
+            .update_opt(hnsw_config_diff.as_ref());
 
         let quantization_config = match quantization_config {
             None => self
@@ -190,7 +193,7 @@ impl TableOfContent {
                     .as_ref()
                     .and_then(|i| i.strict_mode.clone())
                     .unwrap_or_default();
-                Some(default_config.update(diff)?)
+                Some(default_config.update(&diff))
             }
             None => self
                 .storage_config


### PR DESCRIPTION
This PR replaces serde-based `DiffConfig` implementation with explicit implementation. Depends on #7293.

# Issue

In `dev`, we have this type coercion that copies fields from `*ConfigDiff` structs into `*Config` structs:
```rust
/// Hacky way to update configuration structures with diff-updates.
/// Intended to only be used in non critical for speed places.
/// TODO: replace with proc macro
pub fn update_config<T: DeserializeOwned + Serialize, Y: DeserializeOwned + Serialize + Merge>(
    config: &T,
    update: Y,
) -> CollectionResult<T> {
    let mut config_values = serde_json::to_value(config)?;
    let diff_values = serde_json::to_value(&update)?;
    merge_level_0(&mut config_values, diff_values);
    let res = serde_json::from_value(config_values)?;
    Ok(res)
}
```

It's hacky indeed. It's error-prone: missing/wrong field names not caught by a compiler). And it's makes the code hard to explore: rust-analyzer "find usages" feature will newer help you find out that `HnswConfig::copy_vectors` can be populated through `HnswConfigDiff::copy_vectors`.

# Solution

This PR replaces this coercion-via-json with a few hand-rolled implementations of `impl DiffConfig` and `impl From`. Additionally, `DiffConfig` trait methods are infallible now (as there no JSON serialization/serialization errors possible).

# Discarded approaches

- Q: What about generating `*ConfigDiff` from `*Config` definition?
  A: I decided to keep them explicitly hand-rolled as these structures have some subtle differences, e.g., see the following diff. While it's possible encode these differences via proc macro and attributes, I find it less maintainable. And probably `macro_rules` give better LSP experience than proc macros.

  ```diff
  -pub struct OptimizersConfig {
  +pub struct OptimizersConfigDiff {
       …
       /// Max number of threads (jobs) for running optimizations per shard.
       /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
  -    /// If "auto" - have no limit and choose dynamically to saturate CPU.
  +    /// If null - have no limit and choose dynamically to saturate CPU.
       /// If 0 - no optimization threads, optimizations will be disabled.
       #[serde(default)]
  -    pub max_optimization_threads: Option<usize>,
  +    pub max_optimization_threads: Option<MaxOptimizationThreads>,
   }
  ```
- Previous version of this PR were using macro_rules.
  <details><summary>old description</summary>

  This PR replaces this coercion-via-json with a `impl_diff_config` that macro that produces the conversion boilerplate. Any missing field will result in a compile error; and "find usages" on `HnswConfig` fields will find this definition. Additionally, `DiffConfig` trait methods are infallible now (as there no JSON serialization/serialization errors possible). Also, the macro syntax mimics real Rust syntax, thus `rustfmt` will format it correctly.
  
  ```rust
  impl_diff_config!(
      {
          impl DiffConfig<HnswConfigDiff> for HnswConfig {}
          impl DiffConfig<HnswConfigDiff> for HnswConfigDiff {}
          impl From<HnswConfig> for HnswConfigDiff {}
      },
      common_fields(
          m,
          ef_construct,
          full_scan_threshold,
          max_indexing_threads,
          on_disk,
          payload_m,
          copy_vectors,
      ),
      config_only_fields()
  );
  ```
  
  </details>