### PR TITLE
[WIP] Continuous snapshot data loss

### DIFF
--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -104,7 +104,7 @@ async fn test_continuous_snapshot() {
     let stop_flag = Arc::new(AtomicBool::new(false));
 
     // Continuously insert the same point
-    let points_count = 1;
+    let points_count = 3;
     let points_task = {
         let collection = Arc::clone(&collection);
         let stop_flag = Arc::clone(&stop_flag);


### PR DESCRIPTION
```
RUST_LOG=debug cargo nextest run --all continuous --nocapture

────────────
 Nextest run ID 8c335d13-b250-42b7-9da4-32c74ff69005 with nextest profile: default
    Starting 1 test across 22 binaries (1350 tests skipped)
       START             collection::integration continuous_snapshot_test::test_continuous_snapshot

running 1 test
[2025-09-23T14:10:41Z INFO  wal] Wal { path: "/tmp/test_collectionf8Rfmt/0/wal", segment-count: 1, entries: [0, 0)  }: opened
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-23-14-10-41.snapshot into "/tmp/test_snapshotstnfDIe/test-0-2025-09-23-14-10-41.snapshot"
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-23T14:10:41Z WARN  collection::collection_manager::collection_updater] Update operation declined: No point with id 2 found
[2025-09-23T14:10:41Z WARN  collection::shards::replica_set::update] Failed to update shard test:0 on peer 0, error: No point with id 2 found

thread 'continuous_snapshot_test::test_continuous_snapshot' panicked at lib/collection/tests/integration/continuous_snapshot_test.rs:224:31:
points_task error: No point with id 2 found
```
