### PR TITLE
Fix corruption due to concurrent update during snapshot

### DIFF
--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -104,7 +104,7 @@ async fn test_continuous_snapshot() {
     let stop_flag = Arc::new(AtomicBool::new(false));
 
     // Continuously insert the same point
-    let points_count = 1;
+    let points_count = 3;
     let points_task = {
         let collection = Arc::clone(&collection);
         let stop_flag = Arc::clone(&stop_flag);


### PR DESCRIPTION
This PR fixes the non-atomic copy on write by forcing the serialization of all updates.

During snapshot, a single write segment is shared by all proxy segments.

At the end of the segments snapshot process, deletes are propagated to the wrapped segments.

This happens concurrently with user update operations which are serialized through an update channel.

As demonstrated by the test `test_continuous_snapshot`, it is possible that the delete propagation happens right in between of the CoW for the `set_payload` operation.

```rust
 fn set_payload(
        &mut self,
        op_num: SeqNumberType,
        point_id: PointIdType,
        payload: &Payload,
        key: &Option<JsonPath>,
        hw_counter: &HardwareCounterCell,
    ) -> OperationResult<bool> {
        self.move_if_exists(op_num, point_id, hw_counter)?;
        // NOT ATOMIC - write segment can be updated from another proxy segment
        self.write_segment
            .get()
            .write()
            .set_payload(op_num, point_id, payload, key, hw_counter)
    }
```

This PR introduces a new update lock at the level of the segment holder to ensure that the snapshot process does not interfere with on-going client updates.