### PR TITLE
Add num points/vectors to metrics API

### DIFF
--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -66,6 +66,15 @@ impl CollectionTelemetry {
             .filter(|log| log.status == TrackerStatus::Optimizing)
             .count()
     }
+
+    pub fn count_points(&self) -> usize {
+        self.shards
+            .iter()
+            .flatten()
+            .filter_map(|shard| shard.local.as_ref())
+            .map(|local_shard| local_shard.num_points.unwrap_or(0))
+            .sum()
+    }
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]


### PR DESCRIPTION
Depends on  #7301

Add per-collection point and vector approximations to /metrics API:

```
# HELP collection_points approximate amount of points per collection
# TYPE collection_points gauge
collection_points{id="benchmark"} 100000
collection_points{id="1234"} 100000

# HELP collection_vectors approximate amount of vectors per collection
# TYPE collection_vectors gauge
collection_vectors{id="benchmark"} 100000
collection_vectors{id="1234"} 100000
```