### PR TITLE
Test continuous snapshot data loss

### DIFF
--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -193,12 +193,12 @@ async fn test_continuous_snapshot() {
                     assert_eq!(set_result.status, UpdateStatus::Completed);
                 }
 
-                // Retrieve one point at a time again with payload
+                // Retrieve one point at a time again with payload & vector
                 for i in 0..points_count {
                     let retrieve_point = PointRequestInternal {
                         ids: vec![i.into()],
                         with_payload: Some(true.into()),
-                        with_vector: WithVector::Bool(false),
+                        with_vector: WithVector::Bool(true),
                     };
                     let hw_counter = HwMeasurementAcc::disposable();
                     let retrieve_result = collection
@@ -211,6 +211,8 @@ async fn test_continuous_snapshot() {
                         )
                         .await?;
                     assert_eq!(retrieve_result.len(), 1);
+                    assert!(retrieve_result[0].vector.is_some(), "missing vector");
+                    assert!(retrieve_result[0].payload.is_some(), "missing payload");
                 }
             }
             CollectionResult::Ok(())

--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -125,8 +125,8 @@ async fn test_continuous_snapshot() {
                     )
                     .await?;
 
+                // Insert one point at a time
                 for i in 0..points_count {
-                    // Insert one point at a time
                     let point = PointStructPersisted {
                         id: i.into(),
                         vector: VectorStructPersisted::Single(vec![i as f32, 0.0, 0.0, 0.0]),
@@ -191,6 +191,26 @@ async fn test_continuous_snapshot() {
                         )
                         .await?;
                     assert_eq!(set_result.status, UpdateStatus::Completed);
+                }
+
+                // Retrieve one point at a time again with payload
+                for i in 0..points_count {
+                    let retrieve_point = PointRequestInternal {
+                        ids: vec![i.into()],
+                        with_payload: Some(true.into()),
+                        with_vector: WithVector::Bool(false),
+                    };
+                    let hw_counter = HwMeasurementAcc::disposable();
+                    let retrieve_result = collection
+                        .retrieve(
+                            retrieve_point,
+                            None,
+                            &ShardSelectorInternal::All,
+                            None,
+                            hw_counter,
+                        )
+                        .await?;
+                    assert_eq!(retrieve_result.len(), 1);
                 }
             }
             CollectionResult::Ok(())


### PR DESCRIPTION
This test used to be broken with:

```
RUST_LOG=debug cargo nextest run -p collection test_continuous_snapshot --nocapture

...
[2025-09-25T09:37:08Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment af3cee4d-a4a5-4474-a344-749a12aca0ba
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment c496b4a2-e09e-42c9-97ba-f15e5f362061
[2025-09-25T09:37:08Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment 5387da80-1800-4d41-ae7e-d81437068c1e
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment c496b4a2-e09e-42c9-97ba-f15e5f362061
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Segment c496b4a2-e09e-42c9-97ba-f15e5f362061 is already snapshotted!
[2025-09-25T09:37:08Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment 7497eab1-38e7-42bf-86ab-db21a3fe4e12
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment c496b4a2-e09e-42c9-97ba-f15e5f362061
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Segment c496b4a2-e09e-42c9-97ba-f15e5f362061 is already snapshotted!
[2025-09-25T09:37:08Z DEBUG collection::shards::replica_set::execute_read_operation] Read operation failed: Service internal error: No version for point 0
[2025-09-25T09:37:08Z DEBUG collection::update_handler] Optimizer 'merge' running on segments: [1692, 1693, 1694]
[2025-09-25T09:37:08Z DEBUG collection::collection_manager::optimizers::segment_optimizer] Available space: 27.23 GiB, needed for optimization: 1.33 MiB
[2025-09-25T09:37:08Z DEBUG collection::common::sha_256] Computing checksum for file: "/tmp/temp_dirEg6kVn/test-0-2025-09-25-09-37-08.snapshot-arc-J3NO0Y"
[2025-09-25T09:37:08Z INFO  collection::collection::snapshots] Creating collection snapshot test-0-2025-09-25-09-37-08.snapshot into "/tmp/test_snapshotsi2ngdD/test-0-2025-09-25-09-37-08.snapshot"
[2025-09-25T09:37:08Z DEBUG shard::proxy_segment] Double proxy segment creation
[2025-09-25T09:37:08Z DEBUG shard::proxy_segment] Double proxy segment creation
[2025-09-25T09:37:08Z DEBUG shard::proxy_segment] Double proxy segment creation
[2025-09-25T09:37:08Z INFO  shard::proxy_segment::snapshot_entry] Taking a snapshot of a proxy segment
[2025-09-25T09:37:08Z DEBUG segment::segment::snapshot] Taking snapshot of segment 9a4bc3fd-87a9-41f1-8137-fd43d5a4b84a

thread 'continuous_snapshot_test::test_continuous_snapshot' panicked at lib/collection/tests/integration/continuous_snapshot_test.rs:244:31:
points_task error: Service internal error: 1 of 1 read operations failed:
  Service internal error: No version for point 0
```  

It is now fixed after reworking how proxy segments work in https://github.com/qdrant/qdrant/pull/7345

The PR can now be merged to act as non regression test.
