### PR TITLE
Fix Tokio race condition in benchmarks

### DIFF
--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -221,6 +221,10 @@ fn batch_search_bench(c: &mut Criterion) {
     }
 
     group.finish();
+
+    search_runtime.block_on(async {
+        shard.stop_gracefully().await;
+    });
 }
 
 fn batch_rrf_query_bench(c: &mut Criterion) {
@@ -284,6 +288,10 @@ fn batch_rrf_query_bench(c: &mut Criterion) {
     }
 
     group.finish();
+
+    search_runtime.block_on(async {
+        shard.stop_gracefully().await;
+    });
 }
 
 fn batch_rescore_bench(c: &mut Criterion) {
@@ -337,6 +345,10 @@ fn batch_rescore_bench(c: &mut Criterion) {
     }
 
     group.finish();
+
+    search_runtime.block_on(async {
+        shard.stop_gracefully().await;
+    });
 }
 
 criterion_group! {

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -209,6 +209,10 @@ fn batch_search_bench(c: &mut Criterion) {
     }
 
     group.finish();
+
+    search_runtime.block_on(async {
+        shard.stop_gracefully().await;
+    });
 }
 
 criterion_group! {


### PR DESCRIPTION
Shutdown `shard` explicitly at the end of benchmark to avoid error

```
A Tokio 1.x context was found, but it is being shutdown.
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
