### PR TITLE
smaller update batch size

### DIFF
--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -166,7 +166,7 @@ pub fn process_field_index_operation(
     }
 }
 
-/// No not insert more than this number of points in a single update operation chunk
+/// Do not insert more than this number of points in a single update operation chunk
 /// This is needed to avoid locking segments for too long, so that
 /// parallel read operations are not starved.
 const UPDATE_OP_CHUNK_SIZE: usize = 32;


### PR DESCRIPTION
Noticed in benchmark, that update of 1k+ poitns at a sime could increase latency of the scroll operation to 2 seconds. 
Ususally this is unacceptable performance, so we have to make update batches smaller.

- **make update batch smaller to prevent long blocks**
- **limit vector update operations as well**
- **limit update chunk for point upsertion**
