### PR TITLE
Downgrade cargo-chef base image to fix runtime error on NVIDIA GPU image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} tonistiigi/xx AS xx
 
 # Note: using bookworm base image to match GPU runtime image, otherwise we're
 # seeing runtime errors due to libc version mismatch.
+# See: <https://github.com/qdrant/qdrant/pull/7334>
 FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.90-bookworm  AS chef
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} tonistiigi/xx AS xx
 # Utilizing Docker layer caching with `cargo-chef`.
 #
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
-FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.90.0 AS chef
+
+# Note: using bookworm base image to match GPU runtime image, otherwise we're
+# seeing runtime errors due to libc version mismatch.
+FROM --platform=${BUILDPLATFORM:-linux/amd64} lukemathwalker/cargo-chef:latest-rust-1.90-bookworm  AS chef
 
 
 FROM chef AS planner


### PR DESCRIPTION
Downgrade the cargo-chef image we're using for building Qdrant. This is needed to fix runtime errors in our NVIDIA GPU image.

More specifically, the changed image still uses Rust 1.90 but switches to an older base image. It now uses Debian bookworm, which shares its libc (amongst others) version with the NVIDIA GPU runtime image.

Sadly, no new [NVIDIA image](https://hub.docker.com/layers/nvidia/opengl/1.2-glvnd-devel-ubuntu22.04/images/sha256-c030a21588ddb89c245c8a2a24d6e68772cfa5939d312bab19f0833b90e9620a) is available and so changing the build image is necessary.

Running the GPU image before this fix:

```bash
$ docker run --gpus=all qdrant/qdrant:v1.15.5-gpu-nvidia
./qdrant: /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./qdrant)
./qdrant: /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./qdrant)
./qdrant: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./qdrant)
./qdrant: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by ./qdrant)
```

Running it after this fix:

```bash
$ docker run --gpus=all a788c24957d30fd11aabecd8da4821830ff2fffd5cd2675c992e823a3df61fe5
           _                 _
  __ _  __| |_ __ __ _ _ __ | |_
 / _` |/ _` | '__/ _` | '_ \| __|
| (_| | (_| | | | (_| | | | | |_
 \__, |\__,_|_|  \__,_|_| |_|\__|
    |_|

Version: 1.15.5
Access web UI at http://localhost:6333/dashboard

2025-09-30T08:57:29.007947Z  WARN qdrant: There is a potential issue with the filesystem for storage path ./storage. Details: Container filesystem detected - storage might be lost with container re-creation
2025-09-30T08:57:29.007983Z  INFO storage::content_manager::consensus::persistent: Initializing new raft state at ./storage/raft_state.json
2025-09-30T08:57:29.015812Z  INFO qdrant: Distributed mode disabled
2025-09-30T08:57:29.015832Z  INFO qdrant: Telemetry reporting enabled, id: 3f4fa91c-82b5-4d0e-ba52-1a99a5377522
...
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?