### PR TITLE
Tone down optimizer logging

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -160,11 +160,13 @@ pub trait SegmentOptimizer {
 
         match (space_available, space_needed) {
             (Some(space_available), Some(space_needed)) => {
-                log::debug!(
-                    "Available space: {}, needed for optimization: {}",
-                    bytes_to_human(space_available as usize),
-                    bytes_to_human(space_needed as usize),
-                );
+                if space_needed > 0 {
+                    log::debug!(
+                        "Available space: {}, needed for optimization: {}",
+                        bytes_to_human(space_available as usize),
+                        bytes_to_human(space_needed as usize),
+                    );
+                }
                 if space_available < space_needed {
                     return Err(CollectionError::service_error(format!(
                         "Not enough space available for optimization, needed: {}, available: {}",


### PR DESCRIPTION
This debug log is a bit too verbose when the space required is 0 bytes.

```
2025-09-30T13:21:37.089921Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.090006Z DEBUG collection::update_handler: Optimizer 'vacuum' running on segments: [225]
2025-09-30T13:21:37.090113Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 2.42 MiB
2025-09-30T13:21:37.149219Z DEBUG collection::update_handler: Optimizer 'vacuum' running on segments: [225]
2025-09-30T13:21:37.201201Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.201268Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.206480Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [784, 783, 780]
2025-09-30T13:21:37.206853Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 242.63 MiB
2025-09-30T13:21:37.213618Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [784, 783, 780]
2025-09-30T13:21:37.273329Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [784, 783, 780]
2025-09-30T13:21:37.326263Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.326338Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.524476Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [231, 229, 228, 230]
2025-09-30T13:21:37.524854Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 1.51 MiB
2025-09-30T13:21:37.525736Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [231, 229, 228, 230]
2025-09-30T13:21:37.527440Z DEBUG collection::update_handler: Optimizer 'merge' running on segments: [231, 229, 228, 230]
2025-09-30T13:21:37.624289Z DEBUG segment::index::hnsw_index::hnsw: building HNSW for 20000 vectors with 8 CPUs
2025-09-30T13:21:37.625969Z DEBUG segment::index::hnsw_index::hnsw: Finish main graph in time 221ns
2025-09-30T13:21:37.625986Z DEBUG segment::index::hnsw_index::hnsw: skip building additional HNSW links
2025-09-30T13:21:37.648820Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
2025-09-30T13:21:37.648868Z DEBUG collection::collection_manager::optimizers::segment_optimizer: Available space: 1.03 TiB, needed for optimization: 0 B
```