### PR TITLE
Improve snapshot transfer tests

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -561,6 +561,7 @@ impl Inner {
     ///
     /// Providing `None` will release this limitation.
     fn set_wal_keep_from(&self, version: Option<u64>) {
+        log::trace!("set_wal_keep_from {version:?}");
         let version = version.unwrap_or(u64::MAX);
         self.wal_keep_from.store(version, Ordering::Relaxed);
     }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -633,6 +633,7 @@ impl SegmentEntry for Segment {
             }
             (Some(version), Some(persisted_version)) => {
                 if !force && version == persisted_version {
+                    log::trace!("not flushing because version == persisted_version");
                     // Segment is already flushed
                     return Ok(persisted_version);
                 }

--- a/tests/consensus_tests/test_snapshot_consistency.py
+++ b/tests/consensus_tests/test_snapshot_consistency.py
@@ -28,29 +28,6 @@ def run_update_points_in_background(peer_url, collection_name, init_offset=0, th
     p.start()
     return p
 
-def check_data_consistency(data):
-
-    assert(len(data) > 1)
-
-    for i in range(len(data) - 1):
-        j = i + 1
-
-        data_i = data[i]
-        data_j = data[j]
-
-        if data_i != data_j:
-            ids_i = set(x.id for x in data_i)
-            ids_j = set(x.id for x in data_j)
-
-            diff = ids_i - ids_j
-
-            if len(diff) < 100:
-                print(f"Diff between {i} and {j}: {diff}")
-            else:
-                print(f"Diff len between {i} and {j}: {len(diff)}")
-
-            assert False, "Data on all nodes should be consistent"
-
 
 # Test data consistency across nodes when creating snapshots.
 #
@@ -103,5 +80,5 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path):
             }
         )
         assert_http_ok(r)
-        data.append(r.json()["result"])
+        data.append(r.json()["result"]["points"])
     check_data_consistency(data)


### PR DESCRIPTION
This branch is the result of refurbishing the learning from hunting down an inconsistency in the shard transfer.

Some changes are I believe a net improvements and should be kept to make the next debugging session easier.

The changes are:
- enable trace logging during tests to gather more info by default
- check data consistency on count failure
- add a few more trace logging
- document trick to slow down qdrant nodes with CPU quotas
- remove sleep