### PR TITLE
Use first WAL index instead of last in shard snapshot transfer

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -414,7 +414,13 @@ impl Inner {
         wal_keep_from: Arc<AtomicU64>,
         progress: Arc<ParkingMutex<TransferTaskProgress>>,
     ) -> Self {
-        let start_from = wrapped_shard.wal.wal.lock().await.last_index() + 1;
+        // If nothing else is specified, we need to keep all WAL entries, which might be
+        // potentially not yet applied(persisted) with in the storage.
+        //
+        // We assume, that snapshot made from this point forward is guaranteed to have all
+        // previous updates applied, as they are already acknowledged in the WAL, and it is
+        // equivalent to killing the node right now and trying to recover from the snapshot.
+        let start_from = wrapped_shard.wal.wal.lock().await.first_index();
         Self::new_from_version(
             wrapped_shard,
             remote_shard,


### PR DESCRIPTION
instead of last WAL index, we need to use first one as there are no guarantees that last WAL entries will make it into snapshot.

Should fix: https://github.com/qdrant/qdrant/issues/7335

Potential downsides:

- We will post-transfer more operations, maybe with duplicates. This means that potentially WAL delta will be compromized for some interval.


