### PR TITLE
non appendable proxies

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -744,10 +744,8 @@ pub trait SegmentOptimizer {
         );
 
         if let Some(cow_segment_id) = cow_segment_id_opt {
-            debug_assert!(
-                write_segments_guard.get(cow_segment_id).is_some(),
-                "temporary CoW segment must exist"
-            );
+            // Temp segment might be taken into another parallel optimization
+            // so it is not necessary exist by this time
             write_segments_guard.remove_segment_if_not_needed(cow_segment_id)?;
         }
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -375,19 +375,18 @@ pub trait SegmentOptimizer {
         restored_segment_ids
     }
 
-    /// Unwraps proxy, adds temp segment into collection
+    /// Unwraps proxy, puts wrapped segment back into local shard
     ///
     /// # Arguments
     ///
     /// * `segments` - all registered segments of the collection
     /// * `proxy_ids` - currently used proxies
-    /// * `temp_segment` - currently used temporary segment
     ///
     /// # Result
     ///
-    /// Rolls back optimization state.
-    /// All processed changes will still be there, but the collection should be returned into state
-    /// before optimization.
+    /// Drops any optimized state, and rolls back the segments to before optimizing. All new
+    /// changes since optimizing remain available as they were written to other appendable
+    /// segments.
     fn handle_cancellation(
         &self,
         segments: &LockedSegmentHolder,
@@ -747,7 +746,7 @@ pub trait SegmentOptimizer {
         if let Some(cow_segment_id) = cow_segment_id_opt {
             debug_assert!(
                 write_segments_guard.get(cow_segment_id).is_some(),
-                "temporary COW segment must exist"
+                "temporary CoW segment must exist"
             );
             write_segments_guard.remove_segment_if_not_needed(cow_segment_id)?;
         }

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -17,7 +17,6 @@ use shard::retrieve::retrieve_blocking::retrieve_blocking;
 use shard::update::{delete_points, set_payload, upsert_points};
 use tempfile::Builder;
 
-use super::holders::proxy_segment;
 use crate::collection_manager::fixtures::{build_segment_1, build_segment_2, empty_segment};
 use crate::collection_manager::holders::proxy_segment::ProxySegment;
 use crate::collection_manager::holders::segment_holder::{
@@ -32,11 +31,7 @@ fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId) -> SegmentId {
 
     let optimizing_segment = write_segments.get(sid).unwrap().clone();
 
-    let proxy = ProxySegment::new(
-        optimizing_segment,
-        proxy_segment::LockedRmSet::default(),
-        proxy_segment::LockedIndexChanges::default(),
-    );
+    let proxy = ProxySegment::new(optimizing_segment);
 
     let (new_id, _replaced_segments) = write_segments.swap_new(proxy, &[sid]);
     new_id
@@ -397,19 +392,12 @@ fn test_proxy_shared_updates() {
         .set_payload(10, idx2, &old_payload, &None, &hw_counter)
         .unwrap();
 
-    let deleted_points = proxy_segment::LockedRmSet::default();
-    let changed_indexes = proxy_segment::LockedIndexChanges::default();
-
     let locked_segment_1 = LockedSegment::new(segment1);
     let locked_segment_2 = LockedSegment::new(segment2);
 
-    let proxy_segment_1 = ProxySegment::new(
-        locked_segment_1,
-        Arc::clone(&deleted_points),
-        Arc::clone(&changed_indexes),
-    );
+    let proxy_segment_1 = ProxySegment::new(locked_segment_1);
 
-    let proxy_segment_2 = ProxySegment::new(locked_segment_2, deleted_points, changed_indexes);
+    let proxy_segment_2 = ProxySegment::new(locked_segment_2);
 
     let mut holder = SegmentHolder::default();
 
@@ -539,19 +527,13 @@ fn test_proxy_shared_updates_same_version() {
         .set_payload(10, idx2, &old_payload, &None, &hw_counter)
         .unwrap();
 
-    let deleted_points = proxy_segment::LockedRmSet::default();
-    let changed_indexes = proxy_segment::LockedIndexChanges::default();
 
     let locked_segment_1 = LockedSegment::new(segment1);
     let locked_segment_2 = LockedSegment::new(segment2);
 
-    let proxy_segment_1 = ProxySegment::new(
-        locked_segment_1,
-        Arc::clone(&deleted_points),
-        Arc::clone(&changed_indexes),
-    );
+    let proxy_segment_1 = ProxySegment::new(locked_segment_1);
 
-    let proxy_segment_2 = ProxySegment::new(locked_segment_2, deleted_points, changed_indexes);
+    let proxy_segment_2 = ProxySegment::new(locked_segment_2);
 
     let mut holder = SegmentHolder::default();
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -527,7 +527,6 @@ fn test_proxy_shared_updates_same_version() {
         .set_payload(10, idx2, &old_payload, &None, &hw_counter)
         .unwrap();
 
-
     let locked_segment_1 = LockedSegment::new(segment1);
     let locked_segment_2 = LockedSegment::new(segment2);
 

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -28,16 +27,13 @@ use crate::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
 
 mod test_search_aggregation;
 
-fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId, path: &Path) -> SegmentId {
+fn wrap_proxy(segments: LockedSegmentHolder, sid: SegmentId) -> SegmentId {
     let mut write_segments = segments.write();
-
-    let temp_segment: LockedSegment = empty_segment(path).into();
 
     let optimizing_segment = write_segments.get(sid).unwrap().clone();
 
     let proxy = ProxySegment::new(
         optimizing_segment,
-        temp_segment,
         proxy_segment::LockedRmSet::default(),
         proxy_segment::LockedIndexChanges::default(),
     );
@@ -61,7 +57,7 @@ fn test_update_proxy_segments() {
 
     let segments = Arc::new(RwLock::new(holder));
 
-    let _proxy_id = wrap_proxy(segments.clone(), sid1, dir.path());
+    let _proxy_id = wrap_proxy(segments.clone(), sid1);
 
     let vectors = vec![
         only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
@@ -114,11 +110,11 @@ fn test_move_points_to_copy_on_write() {
     let mut holder = SegmentHolder::default();
 
     let sid1 = holder.add_new(segment1);
-    let _sid2 = holder.add_new(segment2);
+    let sid2 = holder.add_new(segment2);
 
     let segments = Arc::new(RwLock::new(holder));
 
-    let proxy_id = wrap_proxy(segments.clone(), sid1, dir.path());
+    let proxy_id = wrap_proxy(segments.clone(), sid1);
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -135,6 +131,8 @@ fn test_move_points_to_copy_on_write() {
         },
     ];
 
+    // Points should be marked as deleted in proxy segment
+    // and moved to another appendable segment (segment2)
     upsert_points(&segments.read(), 1001, &points, &hw_counter).unwrap();
 
     let points = vec![
@@ -161,33 +159,33 @@ fn test_move_points_to_copy_on_write() {
 
     let read_proxy = locked_proxy.read();
 
-    let copy_on_write_segment = match read_proxy.write_segment.clone() {
-        LockedSegment::Original(locked_segment) => locked_segment,
-        LockedSegment::Proxy(_) => panic!("wrong type"),
-    };
+    let num_deleted_points_in_proxy = read_proxy.deleted_point_count();
 
-    let copy_on_write_segment_read = copy_on_write_segment.read();
+    assert_eq!(
+        num_deleted_points_in_proxy, 3,
+        "3 points should be deleted in proxy"
+    );
 
-    let copy_on_write_points = copy_on_write_segment_read.iter_points().collect_vec();
+    // Copy-on-write segment should contain all 3 points
 
-    let id_mapper = copy_on_write_segment_read.id_tracker.clone();
+    let cow_segment = segments_write.get(sid2).unwrap();
 
-    eprintln!("copy_on_write_points = {copy_on_write_points:#?}");
+    let cow_segment_read = cow_segment.get().read();
 
-    for idx in copy_on_write_points {
-        let internal = id_mapper.borrow().internal_id(idx).unwrap();
-        eprintln!("{idx} -> {internal}");
-    }
+    let cow_points: HashSet<_> = cow_segment_read.iter_points().collect();
 
-    let id_tracker = copy_on_write_segment_read.id_tracker.clone();
-    let internal_ids = id_tracker.borrow().iter_ids().collect_vec();
-
-    eprintln!("internal_ids = {internal_ids:#?}");
-
-    for idx in internal_ids {
-        let external = id_mapper.borrow().external_id(idx).unwrap();
-        eprintln!("{idx} -> {external}");
-    }
+    assert!(
+        cow_points.contains(&1.into()),
+        "Point 1 should be in copy-on-write segment"
+    );
+    assert!(
+        cow_points.contains(&2.into()),
+        "Point 2 should be in copy-on-write segment"
+    );
+    assert!(
+        cow_points.contains(&3.into()),
+        "Point 3 should be in copy-on-write segment"
+    );
 }
 
 #[test]
@@ -365,6 +363,7 @@ fn test_proxy_shared_updates() {
     let old_payload = payload_json! {"size": vec!["small"]};
     let new_payload = payload_json! {"size": vec!["big"]};
 
+    // Appendable segment that should serve as a copy-on-write segment for both proxies
     let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
     let idx1 = PointIdType::from(1);
@@ -406,22 +405,17 @@ fn test_proxy_shared_updates() {
 
     let proxy_segment_1 = ProxySegment::new(
         locked_segment_1,
-        write_segment.clone(),
         Arc::clone(&deleted_points),
         Arc::clone(&changed_indexes),
     );
 
-    let proxy_segment_2 = ProxySegment::new(
-        locked_segment_2,
-        write_segment.clone(),
-        deleted_points,
-        changed_indexes,
-    );
+    let proxy_segment_2 = ProxySegment::new(locked_segment_2, deleted_points, changed_indexes);
 
     let mut holder = SegmentHolder::default();
 
     let proxy_1_id = holder.add_new(proxy_segment_1);
     let proxy_2_id = holder.add_new(proxy_segment_2);
+    let write_segment_id = holder.add_new(write_segment);
 
     let payload = payload_json! {"color": vec!["yellow"]};
 
@@ -432,7 +426,7 @@ fn test_proxy_shared_updates() {
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {
         assert!(
-            holder
+            !holder
                 .get(proxy_1_id)
                 .unwrap()
                 .get()
@@ -440,8 +434,16 @@ fn test_proxy_shared_updates() {
                 .has_point(point_id),
         );
         assert!(
-            holder
+            !holder
                 .get(proxy_2_id)
+                .unwrap()
+                .get()
+                .read()
+                .has_point(point_id),
+        );
+        assert!(
+            holder
+                .get(write_segment_id)
                 .unwrap()
                 .get()
                 .read()
@@ -545,22 +547,17 @@ fn test_proxy_shared_updates_same_version() {
 
     let proxy_segment_1 = ProxySegment::new(
         locked_segment_1,
-        write_segment.clone(),
         Arc::clone(&deleted_points),
         Arc::clone(&changed_indexes),
     );
 
-    let proxy_segment_2 = ProxySegment::new(
-        locked_segment_2,
-        write_segment.clone(),
-        deleted_points,
-        changed_indexes,
-    );
+    let proxy_segment_2 = ProxySegment::new(locked_segment_2, deleted_points, changed_indexes);
 
     let mut holder = SegmentHolder::default();
 
     let proxy_1_id = holder.add_new(proxy_segment_1);
     let proxy_2_id = holder.add_new(proxy_segment_2);
+    let write_segment_id = holder.add_new(write_segment);
 
     let payload = payload_json! {"color": "yellow"};
 
@@ -571,7 +568,7 @@ fn test_proxy_shared_updates_same_version() {
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {
         assert!(
-            holder
+            !holder
                 .get(proxy_1_id)
                 .unwrap()
                 .get()
@@ -579,8 +576,16 @@ fn test_proxy_shared_updates_same_version() {
                 .has_point(point_id),
         );
         assert!(
-            holder
+            !holder
                 .get(proxy_2_id)
+                .unwrap()
+                .get()
+                .read()
+                .has_point(point_id),
+        );
+        assert!(
+            holder
+                .get(write_segment_id)
                 .unwrap()
                 .get()
                 .read()

--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -272,7 +272,7 @@ where
 
     // Proxy all segments
     log::trace!("Proxying all shard segments to apply function");
-    let (mut proxies, tmp_segment, mut segments_lock) = SegmentHolder::proxy_all_segments(
+    let (mut proxies, tmp_segment_id, mut segments_lock) = SegmentHolder::proxy_all_segments(
         segments_lock,
         segments_path,
         segment_config,
@@ -338,7 +338,7 @@ where
     // Always do this to prevent leaving proxy segments behind
     log::trace!("Unproxying all shard segments after function is applied");
     let _update_guard = update_lock.blocking_write();
-    SegmentHolder::unproxy_all_segments(segments_lock, proxies, tmp_segment)?;
+    SegmentHolder::unproxy_all_segments(segments_lock, proxies, tmp_segment_id)?;
 
     result
 }

--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
@@ -221,8 +220,6 @@ pub fn snapshot_all_segments(
     // Snapshotting may take long-running read locks on segments blocking incoming writes, do
     // this through proxied segments to allow writes to continue.
 
-    let mut snapshotted_segments = HashSet::<String>::new();
-
     proxy_all_segments_and_apply(
         segments,
         segments_path,
@@ -230,13 +227,7 @@ pub fn snapshot_all_segments(
         payload_index_schema,
         |segment| {
             let read_segment = segment.read();
-            read_segment.take_snapshot(
-                temp_dir,
-                tar,
-                format,
-                manifest,
-                &mut snapshotted_segments,
-            )?;
+            read_segment.take_snapshot(temp_dir, tar, format, manifest)?;
             Ok(())
         },
         update_lock,

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -266,6 +266,10 @@ impl<'a> NamedVectors<'a> {
             .insert(CowKey::Owned(name), CowVector::from(vector));
     }
 
+    pub fn remove_ref(&mut self, key: &VectorName) {
+        self.map.remove(key);
+    }
+
     pub fn insert_ref(&mut self, name: &'a VectorName, vector: VectorRef<'a>) {
         self.map
             .insert(CowKey::Borrowed(name), CowVector::from(vector));

--- a/lib/segment/src/data_types/tiny_map.rs
+++ b/lib/segment/src/data_types/tiny_map.rs
@@ -102,8 +102,12 @@ where
             .map(|(_, v)| v)
     }
 
-    pub fn remove(&mut self, key: &K) -> Option<V> {
-        let found = self.list.iter().position(|(k, _)| k == key);
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: borrow::Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        let found = self.list.iter().position(|(k, _)| k.borrow() == key);
         match found {
             Some(i) => {
                 let (_, v) = self.list.remove(i);

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -31,6 +31,8 @@ pub trait SegmentEntry: SnapshotEntry {
     /// Get current update version of the segment
     fn version(&self) -> SeqNumberType;
 
+    fn is_proxy(&self) -> bool;
+
     /// Get version of specified point
     ///
     /// Returns `None` if point does not exist or is soft-deleted.

--- a/lib/segment/src/entry/snapshot_entry.rs
+++ b/lib/segment/src/entry/snapshot_entry.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::Path;
 
 use common::tar_ext;
@@ -12,14 +11,12 @@ pub trait SnapshotEntry {
     ///
     /// Creates a tar archive of the segment directory into `snapshot_dir_path`.
     /// Uses `temp_path` to prepare files to archive.
-    /// The `snapshotted_segments` set is used to avoid writing the same snapshot twice.
     fn take_snapshot(
         &self,
         temp_path: &Path,
         tar: &tar_ext::BuilderExt,
         format: SnapshotFormat,
         manifest: Option<&SnapshotManifest>,
-        snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()>;
 
     fn collect_snapshot_manifest(&self, manifest: &mut SnapshotManifest) -> OperationResult<()>;

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -39,6 +39,10 @@ impl SegmentEntry for Segment {
         self.version.unwrap_or(0)
     }
 
+    fn is_proxy(&self) -> bool {
+        false
+    }
+
     fn point_version(&self, point_id: PointIdType) -> Option<SeqNumberType> {
         let id_tracker = self.id_tracker.borrow();
         id_tracker

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -30,17 +30,10 @@ impl SnapshotEntry for Segment {
         tar: &tar_ext::BuilderExt,
         format: SnapshotFormat,
         manifest: Option<&SnapshotManifest>,
-        snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()> {
         let segment_id = self.segment_id()?;
 
         log::debug!("Taking snapshot of segment {segment_id}");
-
-        if !snapshotted_segments.insert(segment_id.to_string()) {
-            // Already snapshotted.
-            log::debug!("Segment {segment_id} is already snapshotted!");
-            return Ok(());
-        }
 
         // force flush segment to capture latest state
         self.flush(true, true)?;

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -209,7 +208,7 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
     let tar =
         tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), &tar, format, None, &mut HashSet::new())
+        .take_snapshot(temp_dir.path(), &tar, format, None)
         .unwrap();
     tar.blocking_finish().unwrap();
 

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 
 use common::budget::ResourcePermit;
@@ -165,7 +165,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
     let tar =
         tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
     segment
-        .take_snapshot(temp_dir.path(), &tar, format, None, &mut HashSet::new())
+        .take_snapshot(temp_dir.path(), &tar, format, None)
         .unwrap();
     tar.blocking_finish().unwrap();
 

--- a/lib/shard/src/locked_segment.rs
+++ b/lib/shard/src/locked_segment.rs
@@ -57,6 +57,13 @@ impl LockedSegment {
         }
     }
 
+    pub fn is_original(&self) -> bool {
+        match self {
+            LockedSegment::Original(_) => true,
+            LockedSegment::Proxy(_) => false,
+        }
+    }
+
     /// Consume the LockedSegment and drop the underlying segment data.
     /// Operation fails if the segment is used by other thread for longer than `timeout`.
     pub fn drop_data(self) -> OperationResult<()> {

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -34,8 +34,8 @@ pub struct ProxySegment {
     deleted_points: DeletedPoints,
     wrapped_config: SegmentConfig,
 
-    /// Keeps track if the wrapped segment has pending changes
-    /// If so, we can't discard WAL for newer than version of wrapped segment
+    /// Version of the last change in this proxy, considering point deletes and payload index
+    /// changes. Defaults to the version of the wrapped segment.
     version: SeqNumberType,
 }
 

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -4,8 +4,6 @@ pub mod snapshot_entry;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashMap;
-
 use ahash::AHashMap;
 use bitvec::prelude::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -266,7 +264,7 @@ pub struct ProxyDeletedPoint {
 
 #[derive(Debug, Default)]
 pub struct ProxyIndexChanges {
-    changes: HashMap<PayloadKeyType, ProxyIndexChange>,
+    changes: AHashMap<PayloadKeyType, ProxyIndexChange>,
 }
 
 impl ProxyIndexChanges {

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -42,9 +42,7 @@ pub struct ProxySegment {
 }
 
 impl ProxySegment {
-    pub fn new(
-        segment: LockedSegment,
-    ) -> Self {
+    pub fn new(segment: LockedSegment) -> Self {
         let deleted_mask = match &segment {
             LockedSegment::Original(raw_segment) => {
                 let raw_segment_guard = raw_segment.read();

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -14,7 +14,6 @@ use common::types::PointOffsetType;
 use itertools::Itertools as _;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use segment::common::operation_error::OperationResult;
-use segment::entry::entry_point::SegmentEntry;
 use segment::types::*;
 
 use crate::locked_segment::LockedSegment;
@@ -28,7 +27,6 @@ pub type LockedIndexChanges = Arc<RwLock<ProxyIndexChanges>>;
 /// It writes all changed records into a temporary `write_segment` and keeps track on changed points
 #[derive(Debug)]
 pub struct ProxySegment {
-    pub write_segment: LockedSegment,
     pub wrapped_segment: LockedSegment,
     /// Internal mask of deleted points, specific to the wrapped segment
     /// Present if the wrapped segment is a plain segment
@@ -40,12 +38,15 @@ pub struct ProxySegment {
     /// because the set is shared among all proxy segments
     deleted_points: LockedRmSet,
     wrapped_config: SegmentConfig,
+
+    /// Keeps track if the wrapped segment has pending changes
+    /// If so, we can't discard WAL for newer than version of wrapped segment
+    version: SeqNumberType,
 }
 
 impl ProxySegment {
     pub fn new(
         segment: LockedSegment,
-        write_segment: LockedSegment,
         deleted_points: LockedRmSet,
         changed_indexes: LockedIndexChanges,
     ) -> Self {
@@ -60,24 +61,30 @@ impl ProxySegment {
                 None
             }
         };
-        let wrapped_config = segment.get().read().config().clone();
+
+        let (wrapped_config, version) = {
+            let read_segment = segment.get().read();
+            (read_segment.config().clone(), read_segment.version())
+        };
+
         ProxySegment {
-            write_segment,
             wrapped_segment: segment,
             deleted_mask,
             changed_indexes,
             deleted_points,
             wrapped_config,
+            version,
         }
     }
 
     /// Ensure that write segment have same indexes as wrapped segment
     pub fn replicate_field_indexes(
-        &mut self,
+        &self,
         op_num: SeqNumberType,
         hw_counter: &HardwareCounterCell,
+        segment_to_update: &LockedSegment,
     ) -> OperationResult<()> {
-        let existing_indexes = self.write_segment.get().read().get_indexed_fields();
+        let existing_indexes = segment_to_update.get().read().get_indexed_fields();
         let expected_indexes = self.wrapped_segment.get().read().get_indexed_fields();
 
         // Add missing indexes
@@ -86,12 +93,12 @@ impl ProxySegment {
 
             if existing_schema != Some(expected_schema) {
                 if existing_schema.is_some() {
-                    self.write_segment
+                    segment_to_update
                         .get()
                         .write()
                         .delete_field_index(op_num, expected_field)?;
                 }
-                self.write_segment.get().write().create_field_index(
+                segment_to_update.get().write().create_field_index(
                     op_num,
                     expected_field,
                     Some(expected_schema),
@@ -103,7 +110,7 @@ impl ProxySegment {
         // Remove extra indexes
         for existing_field in existing_indexes.keys() {
             if !expected_indexes.contains_key(existing_field) {
-                self.write_segment
+                segment_to_update
                     .get()
                     .write()
                     .delete_field_index(op_num, existing_field)?;
@@ -127,91 +134,6 @@ impl ProxySegment {
             }
             _ => false,
         }
-    }
-
-    fn move_if_exists(
-        &mut self,
-        op_num: SeqNumberType,
-        point_id: PointIdType,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<bool> {
-        let deleted_points_guard = self.deleted_points.upgradable_read();
-
-        let (point_offset, local_version) = {
-            let (wrapped_segment, point_offset): (
-                Arc<RwLock<dyn SegmentEntry>>,
-                Option<PointOffsetType>,
-            ) = match &self.wrapped_segment {
-                LockedSegment::Original(raw_segment) => {
-                    let point_offset = raw_segment.read().get_internal_id(point_id);
-                    (raw_segment.clone(), point_offset)
-                }
-                LockedSegment::Proxy(sub_proxy) => (sub_proxy.clone(), None),
-            };
-
-            let wrapped_segment_guard = wrapped_segment.read();
-
-            // Since `deleted_points` are shared between multiple ProxySegments,
-            // It is possible that some other Proxy moved its point with different version already
-            // If this is the case, there are multiple scenarios:
-            // - Local point doesn't exist or already removed locally -> do nothing
-            // - Already moved version is higher than the current one -> mark local as removed
-            // - Already moved version is less than what we have in current proxy -> overwrite
-
-            // Point doesn't exist in wrapped segment - do nothing
-            let Some(local_version) = wrapped_segment_guard.point_version(point_id) else {
-                return Ok(false);
-            };
-
-            // Equal or higher point version is already moved into write segment - delete from
-            // wrapped segment and do not move it again
-            if deleted_points_guard
-                .get(&point_id)
-                .is_some_and(|&deleted| deleted.local_version >= local_version)
-            {
-                drop(deleted_points_guard);
-                self.set_deleted_offset(point_offset);
-                return Ok(false);
-            }
-
-            let (all_vectors, payload) = (
-                wrapped_segment_guard.all_vectors(point_id, hw_counter)?,
-                wrapped_segment_guard.payload(point_id, hw_counter)?,
-            );
-
-            {
-                let segment_arc = self.write_segment.get();
-                let mut write_segment = segment_arc.write();
-
-                write_segment.upsert_point(op_num, point_id, all_vectors, hw_counter)?;
-                if !payload.is_empty() {
-                    write_segment.set_full_payload(op_num, point_id, &payload, hw_counter)?;
-                }
-            }
-
-            (point_offset, local_version)
-        };
-
-        {
-            let mut deleted_points_write = RwLockUpgradableReadGuard::upgrade(deleted_points_guard);
-            let prev = deleted_points_write.insert(
-                point_id,
-                ProxyDeletedPoint {
-                    local_version,
-                    operation_version: op_num,
-                },
-            );
-            if let Some(prev) = prev {
-                debug_assert!(
-                    prev.operation_version < op_num,
-                    "Overriding deleted flag {prev:?} with older op_num:{op_num}",
-                )
-            }
-        }
-
-        self.set_deleted_offset(point_offset);
-
-        Ok(true)
     }
 
     fn add_deleted_points_condition_to_filter(

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -229,6 +229,12 @@ impl SegmentEntry for ProxySegment {
         point_id: PointIdType,
         _vector_name: &VectorName,
     ) -> OperationResult<bool> {
+        // Print current stack trace for easier debugging of unexpected calls
+
+        println!("Stack trace for delete_vector call:");
+        let backtrace = std::backtrace::Backtrace::capture();
+        println!("{backtrace}");
+
         Err(OperationError::service_error(format!(
             "Delete vector is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -488,11 +488,8 @@ impl SegmentEntry for ProxySegment {
     }
 
     fn has_point(&self, point_id: PointIdType) -> bool {
-        if self.deleted_points.contains_key(&point_id) {
-            false
-        } else {
-            self.wrapped_segment.get().read().has_point(point_id)
-        }
+        !self.deleted_points.contains_key(&point_id)
+            && self.wrapped_segment.get().read().has_point(point_id)
     }
 
     fn is_empty(&self) -> bool {

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -150,8 +150,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Upsert is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id,
+            "Upsert is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -220,8 +219,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Update vectors is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id,
+            "Update vectors is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -232,8 +230,7 @@ impl SegmentEntry for ProxySegment {
         _vector_name: &VectorName,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Delete vector is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id
+            "Delete vector is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -245,8 +242,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Set full payload is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id,
+            "Set full payload is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -259,8 +255,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Set payload is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id
+            "Set payload is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -272,8 +267,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Delete payload is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id
+            "Delete payload is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 
@@ -284,8 +278,7 @@ impl SegmentEntry for ProxySegment {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         Err(OperationError::service_error(format!(
-            "Clear payload is disabled for proxy segments: operation {} on point {}",
-            op_num, point_id
+            "Clear payload is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
     }
 

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
-use segment::common::operation_error::{OperationResult, SegmentFailedState};
+use segment::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
 use segment::data_types::build_index_result::BuildFieldIndexResult;
 use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
@@ -23,18 +23,10 @@ use super::{ProxyDeletedPoint, ProxyIndexChange, ProxySegment};
 use crate::locked_segment::LockedSegment;
 impl SegmentEntry for ProxySegment {
     fn version(&self) -> SeqNumberType {
-        cmp::max(
-            self.wrapped_segment.get().read().version(),
-            self.write_segment.get().read().version(),
-        )
+        cmp::max(self.wrapped_segment.get().read().version(), self.version)
     }
 
     fn point_version(&self, point_id: PointIdType) -> Option<SeqNumberType> {
-        // Use write segment version if present, we assume it's always higher
-        if let Some(version) = self.write_segment.get().read().point_version(point_id) {
-            return Some(version);
-        }
-
         // Use wrapped segment version, if absent we have no version at all
         let wrapped_version = self.wrapped_segment.get().read().point_version(point_id)?;
 
@@ -71,7 +63,7 @@ impl SegmentEntry for ProxySegment {
         // We need to prevent them from being found by search request
         // That is why we need to pass additional filter for deleted points
         let do_update_filter = !deleted_points.is_empty();
-        let mut wrapped_results = if do_update_filter {
+        let wrapped_results = if do_update_filter {
             // If we are wrapping a segment with deleted points,
             // we can make this hack of replacing deleted_points of the wrapped_segment
             // with our proxied deleted_points, do avoid additional filter creation
@@ -120,19 +112,6 @@ impl SegmentEntry for ProxySegment {
                 query_context,
             )?
         };
-        let mut write_results = self.write_segment.get().read().search_batch(
-            vector_name,
-            vectors,
-            with_payload,
-            with_vector,
-            filter,
-            top,
-            params,
-            query_context,
-        )?;
-        for (index, write_result) in write_results.iter_mut().enumerate() {
-            wrapped_results[index].append(write_result)
-        }
         Ok(wrapped_results)
     }
 
@@ -142,57 +121,49 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPoint>> {
         // Run rescore in wrapped segment
-        let mut wrapped_results = self
+        let wrapped_results = self
             .wrapped_segment
             .get()
             .read()
             .rescore_with_formula(formula_ctx.clone(), hw_counter)?;
 
-        // Run rescore in write segment
-        let mut write_results = self
-            .write_segment
-            .get()
-            .read()
-            .rescore_with_formula(formula_ctx, hw_counter)?;
-
-        {
+        let result = {
             let deleted_points = self.deleted_points.read();
             if deleted_points.is_empty() {
-                // Just join both results, they will be deduplicated and top-k'd later
-                write_results.append(&mut wrapped_results);
+                wrapped_results
             } else {
-                for wrapped_result in wrapped_results {
-                    if !deleted_points.contains_key(&wrapped_result.id) {
-                        write_results.push(wrapped_result);
-                    }
-                }
+                wrapped_results
+                    .into_iter()
+                    .filter(|point| !deleted_points.contains_key(&point.id))
+                    .collect()
             }
-        }
+        };
 
-        Ok(write_results)
+        Ok(result)
     }
 
     fn upsert_point(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vectors: NamedVectors,
-        hw_counter: &HardwareCounterCell,
+        _vectors: NamedVectors,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment
-            .get()
-            .write()
-            .upsert_point(op_num, point_id, vectors, hw_counter)
+        Err(OperationError::service_error(format!(
+            "Upsert is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id,
+        )))
     }
 
     fn delete_point(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let mut was_deleted = false;
+
+        self.version = cmp::max(self.version, op_num);
 
         let point_offset = match &self.wrapped_segment {
             LockedSegment::Original(raw_segment) => {
@@ -238,98 +209,84 @@ impl SegmentEntry for ProxySegment {
 
         self.set_deleted_offset(point_offset);
 
-        let was_deleted_in_writable = self
-            .write_segment
-            .get()
-            .write()
-            .delete_point(op_num, point_id, hw_counter)?;
-
-        Ok(was_deleted || was_deleted_in_writable)
+        Ok(was_deleted)
     }
 
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vectors: NamedVectors,
-        hw_counter: &HardwareCounterCell,
+        _vectors: NamedVectors,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment
-            .get()
-            .write()
-            .update_vectors(op_num, point_id, vectors, hw_counter)
+        Err(OperationError::service_error(format!(
+            "Update vectors is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id,
+        )))
     }
 
     fn delete_vector(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        vector_name: &VectorName,
+        _vector_name: &VectorName,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, &HardwareCounterCell::disposable())?;
-        self.write_segment
-            .get()
-            .write()
-            .delete_vector(op_num, point_id, vector_name)
+        Err(OperationError::service_error(format!(
+            "Delete vector is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id
+        )))
     }
 
     fn set_full_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        full_payload: &Payload,
-        hw_counter: &HardwareCounterCell,
+        _full_payload: &Payload,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment.get().write().set_full_payload(
-            op_num,
-            point_id,
-            full_payload,
-            hw_counter,
-        )
+        Err(OperationError::service_error(format!(
+            "Set full payload is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id,
+        )))
     }
 
     fn set_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        payload: &Payload,
-        key: &Option<JsonPath>,
-        hw_counter: &HardwareCounterCell,
+        _payload: &Payload,
+        _key: &Option<JsonPath>,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment
-            .get()
-            .write()
-            .set_payload(op_num, point_id, payload, key, hw_counter)
+        Err(OperationError::service_error(format!(
+            "Set payload is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id
+        )))
     }
 
     fn delete_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        key: PayloadKeyTypeRef,
-        hw_counter: &HardwareCounterCell,
+        _key: PayloadKeyTypeRef,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment
-            .get()
-            .write()
-            .delete_payload(op_num, point_id, key, hw_counter)
+        Err(OperationError::service_error(format!(
+            "Delete payload is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id
+        )))
     }
 
     fn clear_payload(
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        self.move_if_exists(op_num, point_id, hw_counter)?;
-        self.write_segment
-            .get()
-            .write()
-            .clear_payload(op_num, point_id, hw_counter)
+        Err(OperationError::service_error(format!(
+            "Clear payload is disabled for proxy segments: operation {} on point {}",
+            op_num, point_id
+        )))
     }
 
     fn vector(
@@ -339,18 +296,8 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<VectorInternal>> {
         if self.deleted_points.read().contains_key(&point_id) {
-            self.write_segment
-                .get()
-                .read()
-                .vector(vector_name, point_id, hw_counter)
+            Ok(None)
         } else {
-            {
-                let write_segment = self.write_segment.get();
-                let segment_guard = write_segment.read();
-                if segment_guard.has_point(point_id) {
-                    return segment_guard.vector(vector_name, point_id, hw_counter);
-                }
-            }
             self.wrapped_segment
                 .get()
                 .read()
@@ -391,18 +338,8 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         if self.deleted_points.read().contains_key(&point_id) {
-            self.write_segment
-                .get()
-                .read()
-                .payload(point_id, hw_counter)
+            Ok(Payload::default())
         } else {
-            {
-                let write_segment = self.write_segment.get();
-                let segment_guard = write_segment.read();
-                if segment_guard.has_point(point_id) {
-                    return segment_guard.payload(point_id, hw_counter);
-                }
-            }
             self.wrapped_segment
                 .get()
                 .read()
@@ -426,7 +363,7 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> Vec<PointIdType> {
         let deleted_points = self.deleted_points.read();
-        let mut read_points = if deleted_points.is_empty() {
+        if deleted_points.is_empty() {
             self.wrapped_segment
                 .get()
                 .read()
@@ -443,16 +380,7 @@ impl SegmentEntry for ProxySegment {
                 is_stopped,
                 hw_counter,
             )
-        };
-        let mut write_segment_points = self
-            .write_segment
-            .get()
-            .read()
-            .read_filtered(offset, limit, filter, is_stopped, hw_counter);
-        read_points.append(&mut write_segment_points);
-        read_points.sort_unstable();
-        read_points.dedup();
-        read_points
+        }
     }
 
     fn read_ordered_filtered<'a>(
@@ -464,7 +392,7 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
         let deleted_points = self.deleted_points.read();
-        let mut read_points = if deleted_points.is_empty() {
+        let read_points = if deleted_points.is_empty() {
             self.wrapped_segment
                 .get()
                 .read()
@@ -482,14 +410,6 @@ impl SegmentEntry for ProxySegment {
                 hw_counter,
             )?
         };
-        let mut write_segment_points = self
-            .write_segment
-            .get()
-            .read()
-            .read_ordered_filtered(limit, filter, order_by, is_stopped, hw_counter)?;
-        read_points.append(&mut write_segment_points);
-        read_points.sort_unstable();
-        read_points.dedup();
         Ok(read_points)
     }
 
@@ -501,7 +421,7 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> Vec<PointIdType> {
         let deleted_points = self.deleted_points.read();
-        let mut read_points = if deleted_points.is_empty() {
+        if deleted_points.is_empty() {
             self.wrapped_segment
                 .get()
                 .read()
@@ -517,30 +437,21 @@ impl SegmentEntry for ProxySegment {
                 is_stopped,
                 hw_counter,
             )
-        };
-        let mut write_segment_points = self
-            .write_segment
-            .get()
-            .read()
-            .read_random_filtered(limit, filter, is_stopped, hw_counter);
-        read_points.append(&mut write_segment_points);
-        read_points.sort_unstable();
-        read_points.dedup();
-        read_points
+        }
     }
 
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType> {
         let deleted_points = self.deleted_points.read();
-        let mut read_points = self.wrapped_segment.get().read().read_range(from, to);
-        if !deleted_points.is_empty() {
-            read_points.retain(|idx| !deleted_points.contains_key(idx))
+        let read_points = self.wrapped_segment.get().read().read_range(from, to);
+        if deleted_points.is_empty() {
+            read_points
+        } else {
+            read_points
+                .into_iter()
+                .filter(|idx| !deleted_points.contains_key(idx))
+                .collect()
         }
-        let mut write_segment_points = self.write_segment.get().read().read_range(from, to);
-        read_points.append(&mut write_segment_points);
-        read_points.sort_unstable();
-        read_points.dedup();
-        read_points
     }
 
     fn unique_values(
@@ -550,19 +461,11 @@ impl SegmentEntry for ProxySegment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<BTreeSet<FacetValue>> {
-        let mut values = self
+        let values = self
             .wrapped_segment
             .get()
             .read()
             .unique_values(key, filter, is_stopped, hw_counter)?;
-
-        values.extend(
-            self.write_segment
-                .get()
-                .read()
-                .unique_values(key, filter, is_stopped, hw_counter)?,
-        );
-
         Ok(values)
     }
 
@@ -573,7 +476,7 @@ impl SegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
         let deleted_points = self.deleted_points.read();
-        let mut hits = if deleted_points.is_empty() {
+        let hits = if deleted_points.is_empty() {
             self.wrapped_segment
                 .get()
                 .read()
@@ -593,43 +496,29 @@ impl SegmentEntry for ProxySegment {
                 .facet(&new_request, is_stopped, hw_counter)?
         };
 
-        let write_segment_hits = self
-            .write_segment
-            .get()
-            .read()
-            .facet(request, is_stopped, hw_counter)?;
-
-        write_segment_hits
-            .into_iter()
-            .for_each(|(facet_value, count)| {
-                *hits.entry(facet_value).or_insert(0) += count;
-            });
-
         Ok(hits)
     }
 
     fn has_point(&self, point_id: PointIdType) -> bool {
         if self.deleted_points.read().contains_key(&point_id) {
-            self.write_segment.get().read().has_point(point_id)
+            false
         } else {
-            self.write_segment.get().read().has_point(point_id)
-                || self.wrapped_segment.get().read().has_point(point_id)
+            self.wrapped_segment.get().read().has_point(point_id)
         }
     }
 
     fn is_empty(&self) -> bool {
-        self.wrapped_segment.get().read().is_empty() && self.write_segment.get().read().is_empty()
+        self.wrapped_segment.get().read().is_empty()
     }
 
     fn available_point_count(&self) -> usize {
         let deleted_points_count = self.deleted_points.read().len();
         let wrapped_segment_count = self.wrapped_segment.get().read().available_point_count();
-        let write_segment_count = self.write_segment.get().read().available_point_count();
-        (wrapped_segment_count + write_segment_count).saturating_sub(deleted_points_count)
+        wrapped_segment_count.saturating_sub(deleted_points_count)
     }
 
     fn deleted_point_count(&self) -> usize {
-        self.write_segment.get().read().deleted_point_count()
+        self.wrapped_segment.get().read().deleted_point_count() + self.deleted_points.read().len()
     }
 
     fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize> {
@@ -639,20 +528,14 @@ impl SegmentEntry for ProxySegment {
         let wrapped_count = wrapped_segment_guard.available_point_count();
         drop(wrapped_segment_guard);
 
-        let write_segment = self.write_segment.get();
-        let write_segment_guard = write_segment.read();
-        let write_size = write_segment_guard.available_vectors_size_in_bytes(vector_name)?;
-        let write_count = write_segment_guard.available_point_count();
-        drop(write_segment_guard);
-
-        let stored_points = wrapped_count + write_count;
+        let stored_points = wrapped_count;
         // because we don't know the exact size of deleted vectors, we assume that they are the same avg size as the wrapped ones
         if stored_points > 0 {
             let deleted_points_count = self.deleted_points.read().len();
             let available_points = stored_points.saturating_sub(deleted_points_count);
             Ok(
-                ((wrapped_size as u128 + write_size as u128) * available_points as u128
-                    / stored_points as u128) as usize,
+                ((wrapped_size as u128) * available_points as u128 / stored_points as u128)
+                    as usize,
             )
         } else {
             Ok(0)
@@ -675,12 +558,6 @@ impl SegmentEntry for ProxySegment {
             )
         };
 
-        let write_segment_est = self
-            .write_segment
-            .get()
-            .read()
-            .estimate_point_count(filter, hw_counter);
-
         let expected_deleted_count = if total_wrapped_size > 0 {
             (wrapped_segment_est.exp as f64
                 * (deleted_point_count as f64 / total_wrapped_size as f64)) as usize
@@ -688,20 +565,18 @@ impl SegmentEntry for ProxySegment {
             0
         };
 
-        let primary_clauses =
-            if wrapped_segment_est.primary_clauses == write_segment_est.primary_clauses {
-                wrapped_segment_est.primary_clauses
-            } else {
-                vec![]
-            };
+        let CardinalityEstimation {
+            primary_clauses,
+            min,
+            exp,
+            max,
+        } = wrapped_segment_est;
 
         CardinalityEstimation {
             primary_clauses,
-            min: wrapped_segment_est.min.saturating_sub(deleted_point_count)
-                + write_segment_est.min,
-            exp: (wrapped_segment_est.exp + write_segment_est.exp)
-                .saturating_sub(expected_deleted_count),
-            max: wrapped_segment_est.max + write_segment_est.max,
+            min: min.saturating_sub(deleted_point_count),
+            exp: exp.saturating_sub(expected_deleted_count),
+            max,
         }
     }
 
@@ -716,14 +591,14 @@ impl SegmentEntry for ProxySegment {
 
     fn info(&self) -> SegmentInfo {
         let wrapped_info = self.wrapped_segment.get().read().info();
-        let write_info = self.write_segment.get().read().size_info(); // Only fields set by `size_info()` needed!
 
         let vector_name_count =
             self.config().vector_data.len() + self.config().sparse_vector_data.len();
         let deleted_points_count = self.deleted_points.read().len();
 
         // This is a best estimate
-        let num_vectors = (wrapped_info.num_vectors + write_info.num_vectors)
+        let num_vectors = wrapped_info
+            .num_vectors
             .saturating_sub(deleted_points_count * vector_name_count);
 
         let num_indexed_vectors = if wrapped_info.segment_type == SegmentType::Indexed {
@@ -734,27 +609,19 @@ impl SegmentEntry for ProxySegment {
             0
         };
 
-        let mut vector_data = wrapped_info.vector_data;
-
-        for (key, info) in write_info.vector_data {
-            vector_data
-                .entry(key)
-                .and_modify(|wrapped_info| {
-                    wrapped_info.num_vectors += info.num_vectors;
-                })
-                .or_insert(info);
-        }
+        let vector_data = wrapped_info.vector_data;
 
         SegmentInfo {
             segment_type: SegmentType::Special,
             num_vectors,
             num_indexed_vectors,
             num_points: self.available_point_count(),
-            num_deleted_vectors: write_info.num_deleted_vectors,
+            num_deleted_vectors: wrapped_info.num_deleted_vectors
+                + deleted_points_count * vector_name_count,
             vectors_size_bytes: wrapped_info.vectors_size_bytes, //  + write_info.vectors_size_bytes,
             payloads_size_bytes: wrapped_info.payloads_size_bytes,
-            ram_usage_bytes: wrapped_info.ram_usage_bytes + write_info.ram_usage_bytes,
-            disk_usage_bytes: wrapped_info.disk_usage_bytes + write_info.disk_usage_bytes,
+            ram_usage_bytes: wrapped_info.ram_usage_bytes,
+            disk_usage_bytes: wrapped_info.disk_usage_bytes,
             is_appendable: false,
             index_schema: wrapped_info.index_schema,
             vector_data,
@@ -766,67 +633,15 @@ impl SegmentEntry for ProxySegment {
     }
 
     fn is_appendable(&self) -> bool {
-        true
+        false
     }
 
     fn flush(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType> {
-        let changed_indexes_guard = self.changed_indexes.read();
-        let deleted_points_guard = self.deleted_points.read();
+        let wrapped_segment = self.wrapped_segment.get();
+        let wrapped_segment_guard = wrapped_segment.read();
+        let persisted_version = wrapped_segment_guard.flush(sync, force)?;
 
-        let (wrapped_version, wrapped_persisted_version) = {
-            let wrapped_segment = self.wrapped_segment.get();
-            let wrapped_segment_guard = wrapped_segment.read();
-            let persisted_version = wrapped_segment_guard.flush(sync, force)?;
-            let version = wrapped_segment_guard.version();
-            (version, persisted_version)
-        };
-
-        // In case there are no updates happened to the proxy, this value can be
-        // - either higher than wrapped segment (in case new updates were written to proxy as an appendable segment)
-        // - or lower than wrapped segment (in case no updates were written to proxy, so the version is 0)
-        let write_persisted_version = self.write_segment.get().read().flush(sync, force)?;
-
-        // As soon as anything is written to the proxy, the max version of the proxy if fixed to
-        // minimal of both versions. So we should never ack operation, which does copy-on-write.
-        let is_all_empty = changed_indexes_guard.is_empty() && deleted_points_guard.is_empty();
-
-        let flushed_version = if is_all_empty {
-            // It might happen, that wrapped segment still has some data which is not flushed
-            // Because we are going async flush and call to `.flush` doesn't guarantee that all data is already persisted
-            // If this happens, we can't ack WAL based on write segment and should wait for wrapped segment to be flushed
-
-            let wrapped_full_persisted = wrapped_persisted_version >= wrapped_version;
-
-            if wrapped_full_persisted {
-                debug_assert!(wrapped_persisted_version == wrapped_version);
-                debug_assert!(
-                    write_persisted_version == 0
-                        || write_persisted_version >= wrapped_persisted_version
-                );
-                // This is the case, if **wrapped segment is fully persisted and will not be changed anymore**
-                // Examples:
-                // write_persisted_version = 0, wrapped_persisted_version = 10 -> flushed_version = 10
-                // write_persisted_version = 15, wrapped_persisted_version = 10 -> flushed_version = 15
-                // write_persisted_version = 7, wrapped_persisted_version = 10 -> flushed_version = 10 // should never happen
-                cmp::max(write_persisted_version, wrapped_persisted_version)
-            } else {
-                // This is the case, if wrapped segment is not fully persisted yet
-                // We should wait for it to be fully persisted.
-                // At the same time "write_segment_version" can be either higher than wrapped_version
-                // Or it can be 0, if no updates were written to proxy
-                // In both cases it should be fine to return minimal of both.
-                // Even if for the short of first period we would think that accepted version goes back to 0,
-                // it shouldn't be a problem for was, as it will just stop ack WAL changes.
-                // Examples:
-                // write_persisted_version = 0, wrapped_persisted_version = 10 -> flushed_version = 0
-                // write_persisted_version = 15, wrapped_persisted_version = 10 -> flushed_version = 10
-                cmp::min(write_persisted_version, wrapped_persisted_version)
-            }
-        } else {
-            cmp::min(write_persisted_version, wrapped_persisted_version)
-        };
-
-        Ok(flushed_version)
+        Ok(persisted_version)
     }
 
     fn drop_data(self) -> OperationResult<()> {
@@ -842,15 +657,14 @@ impl SegmentEntry for ProxySegment {
             return Ok(false);
         }
 
+        self.version = cmp::max(self.version, op_num);
+
         // Store index change to later propagate to optimized/wrapped segment
         self.changed_indexes
             .write()
             .insert(key.clone(), ProxyIndexChange::Delete(op_num));
 
-        self.write_segment
-            .get()
-            .write()
-            .delete_field_index(op_num, key)
+        Ok(true)
     }
 
     fn delete_field_index_if_incompatible(
@@ -863,32 +677,31 @@ impl SegmentEntry for ProxySegment {
             return Ok(false);
         }
 
+        self.version = cmp::max(self.version, op_num);
+
         self.changed_indexes.write().insert(
             key.clone(),
             ProxyIndexChange::DeleteIfIncompatible(op_num, field_schema.clone()),
         );
 
-        self.write_segment
-            .get()
-            .write()
-            .delete_field_index_if_incompatible(op_num, key, field_schema)
+        Ok(true)
     }
 
     fn build_field_index(
         &self,
         op_num: SeqNumberType,
-        key: PayloadKeyTypeRef,
+        _key: PayloadKeyTypeRef,
         field_type: &PayloadFieldSchema,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<BuildFieldIndexResult> {
         if self.version() > op_num {
             return Ok(BuildFieldIndexResult::SkippedByVersion);
         }
 
-        self.write_segment
-            .get()
-            .read()
-            .build_field_index(op_num, key, field_type, hw_counter)
+        Ok(BuildFieldIndexResult::Built {
+            indexes: vec![], // No actual index is built in proxy segment, they will be created later
+            schema: field_type.clone(),
+        })
     }
 
     fn apply_field_index(
@@ -896,20 +709,13 @@ impl SegmentEntry for ProxySegment {
         op_num: SeqNumberType,
         key: PayloadKeyType,
         field_schema: PayloadFieldSchema,
-        field_index: Vec<FieldIndex>,
+        _field_index: Vec<FieldIndex>,
     ) -> OperationResult<bool> {
         if self.version() > op_num {
             return Ok(false);
         }
 
-        if !self.write_segment.get().write().apply_field_index(
-            op_num,
-            key.clone(),
-            field_schema.clone(),
-            field_index,
-        )? {
-            return Ok(false);
-        };
+        self.version = cmp::max(self.version, op_num);
 
         // Store index change to later propagate to optimized/wrapped segment
         self.changed_indexes
@@ -944,11 +750,11 @@ impl SegmentEntry for ProxySegment {
     }
 
     fn check_error(&self) -> Option<SegmentFailedState> {
-        self.write_segment.get().read().check_error()
+        self.wrapped_segment.get().read().check_error()
     }
 
     fn vector_names(&self) -> HashSet<VectorNameBuf> {
-        self.write_segment.get().read().vector_names()
+        self.wrapped_segment.get().read().vector_names()
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -626,6 +626,12 @@ impl SegmentEntry for ProxySegment {
         let wrapped_segment_guard = wrapped_segment.read();
         let persisted_version = wrapped_segment_guard.flush(sync, force)?;
 
+        debug_assert_eq!(
+            persisted_version,
+            wrapped_segment_guard.version(),
+            "wrapped segment must be flushed upto the current wrapped segment version",
+        );
+
         Ok(persisted_version)
     }
 

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -230,11 +230,6 @@ impl SegmentEntry for ProxySegment {
         _vector_name: &VectorName,
     ) -> OperationResult<bool> {
         // Print current stack trace for easier debugging of unexpected calls
-
-        println!("Stack trace for delete_vector call:");
-        let backtrace = std::backtrace::Backtrace::capture();
-        println!("{backtrace}");
-
         Err(OperationError::service_error(format!(
             "Delete vector is disabled for proxy segments: operation {op_num} on point {point_id}",
         )))
@@ -632,9 +627,8 @@ impl SegmentEntry for ProxySegment {
         let wrapped_segment_guard = wrapped_segment.read();
         let persisted_version = wrapped_segment_guard.flush(sync, force)?;
 
-        debug_assert_eq!(
-            persisted_version,
-            wrapped_segment_guard.version(),
+        debug_assert!(
+            !sync || (persisted_version == wrapped_segment_guard.version()),
             "wrapped segment must be flushed upto the current wrapped segment version",
         );
 

--- a/lib/shard/src/proxy_segment/snapshot_entry.rs
+++ b/lib/shard/src/proxy_segment/snapshot_entry.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::Path;
 
 use common::tar_ext;
@@ -16,38 +15,20 @@ impl SnapshotEntry for ProxySegment {
         tar: &tar_ext::BuilderExt,
         format: SnapshotFormat,
         manifest: Option<&SnapshotManifest>,
-        snapshotted_segments: &mut HashSet<String>,
     ) -> OperationResult<()> {
         log::info!("Taking a snapshot of a proxy segment");
 
         // Snapshot wrapped segment data into the temporary dir
-        self.wrapped_segment.get().read().take_snapshot(
-            temp_path,
-            tar,
-            format,
-            manifest,
-            snapshotted_segments,
-        )?;
-
-        // Snapshot write_segment
-        self.write_segment.get().read().take_snapshot(
-            temp_path,
-            tar,
-            format,
-            manifest,
-            snapshotted_segments,
-        )?;
+        self.wrapped_segment
+            .get()
+            .read()
+            .take_snapshot(temp_path, tar, format, manifest)?;
 
         Ok(())
     }
 
     fn collect_snapshot_manifest(&self, manifest: &mut SnapshotManifest) -> OperationResult<()> {
         self.wrapped_segment
-            .get()
-            .read()
-            .collect_snapshot_manifest(manifest)?;
-
-        self.write_segment
             .get()
             .read()
             .collect_snapshot_manifest(manifest)?;

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -7,10 +6,9 @@ use fs_err::File;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::query_context::QueryContext;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, QueryVector, only_default_vector};
-use segment::entry::SnapshotEntry as _;
-use segment::payload_json;
+use segment::entry::{SegmentEntry, SnapshotEntry as _};
 use segment::types::{FieldCondition, PayloadSchemaType};
-use tempfile::{Builder, TempDir};
+use tempfile::Builder;
 
 use super::*;
 use crate::fixtures::*;
@@ -48,92 +46,30 @@ impl ProxySegment {
 }
 
 #[test]
-fn test_writing() {
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let original_segment = LockedSegment::new(build_segment_1(dir.path()));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
-
-    let mut proxy_segment = ProxySegment::new(
-        original_segment,
-        write_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
-
-    let hw_counter = HardwareCounterCell::new();
-
-    let vec4 = vec![1.1, 1.0, 0.0, 1.0];
-    proxy_segment
-        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
-        .unwrap();
-    let vec6 = vec![1.0, 1.0, 0.5, 1.0];
-    proxy_segment
-        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
-        .unwrap();
-    proxy_segment
-        .delete_point(102, 1.into(), &hw_counter)
-        .unwrap();
-
-    let query_vector = [1.0, 1.0, 1.0, 1.0].into();
-    let search_result = proxy_segment
-        .search(
-            DEFAULT_VECTOR_NAME,
-            &query_vector,
-            &WithPayload::default(),
-            &false.into(),
-            None,
-            10,
-            None,
-        )
-        .unwrap();
-
-    eprintln!("search_result = {search_result:#?}");
-
-    let mut seen_points: HashSet<PointIdType> = Default::default();
-    for res in search_result {
-        if seen_points.contains(&res.id) {
-            panic!("point {} appears multiple times", res.id);
-        }
-        seen_points.insert(res.id);
-    }
-
-    assert!(seen_points.contains(&4.into()));
-    assert!(seen_points.contains(&6.into()));
-    assert!(!seen_points.contains(&1.into()));
-
-    assert!(!proxy_segment.write_segment.get().read().has_point(2.into()));
-
-    let payload_key = "color".parse().unwrap();
-    proxy_segment
-        .delete_payload(103, 2.into(), &payload_key, &hw_counter)
-        .unwrap();
-
-    assert!(proxy_segment.write_segment.get().read().has_point(2.into()))
-}
-
-#[test]
 fn test_search_batch_equivalence_single() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(build_segment_1(dir.path()));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec4 = vec![1.1, 1.0, 0.0, 1.0];
+    original_segment
+        .get()
+        .write()
+        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
+        .unwrap();
+    let vec6 = vec![1.0, 1.0, 0.5, 1.0];
+    original_segment
+        .get()
+        .write()
+        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
+        .unwrap();
 
     let mut proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
 
-    let hw_counter = HardwareCounterCell::new();
-
-    let vec4 = vec![1.1, 1.0, 0.0, 1.0];
-    proxy_segment
-        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_counter)
-        .unwrap();
-    let vec6 = vec![1.0, 1.0, 0.5, 1.0];
-    proxy_segment
-        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
-        .unwrap();
     proxy_segment
         .delete_point(102, 1.into(), &hw_counter)
         .unwrap();
@@ -181,11 +117,9 @@ fn test_search_batch_equivalence_single() {
 fn test_search_batch_equivalence_single_random() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
     let proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
@@ -231,11 +165,9 @@ fn test_search_batch_equivalence_single_random() {
 fn test_search_batch_equivalence_multi_random() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
     let proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
@@ -286,12 +218,9 @@ fn test_search_batch_equivalence_multi_random() {
     assert_eq!(all_single_results, search_batch_result)
 }
 
-fn wrap_proxy(dir: &TempDir, original_segment: LockedSegment) -> ProxySegment {
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
-
+fn wrap_proxy(original_segment: LockedSegment) -> ProxySegment {
     ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     )
@@ -326,7 +255,7 @@ fn test_read_filter() {
         &hw_counter,
     );
 
-    let mut proxy_segment = wrap_proxy(&dir, original_segment);
+    let mut proxy_segment = wrap_proxy(original_segment);
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -352,21 +281,12 @@ fn test_read_range() {
         .read()
         .read_range(None, Some(10.into()));
 
-    let mut proxy_segment = wrap_proxy(&dir, original_segment);
+    let mut proxy_segment = wrap_proxy(original_segment);
 
     let hw_cell = HardwareCounterCell::new();
 
     proxy_segment.delete_point(100, 2.into(), &hw_cell).unwrap();
 
-    proxy_segment
-        .set_payload(
-            101,
-            3.into(),
-            &payload_json! { "color": vec!["red".to_owned()] },
-            &None,
-            &hw_cell,
-        )
-        .unwrap();
     let proxy_res = proxy_segment.read_range(None, Some(10.into()));
 
     assert_eq!(original_points.len() - 1, proxy_res.len());
@@ -389,16 +309,17 @@ fn test_sync_indexes() {
         )
         .unwrap();
 
-    let mut proxy_segment = ProxySegment::new(
+    let proxy_segment = ProxySegment::new(
         original_segment.clone(),
-        write_segment.clone(),
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
 
     let hw_cell = HardwareCounterCell::new();
 
-    proxy_segment.replicate_field_indexes(0, &hw_cell).unwrap();
+    proxy_segment
+        .replicate_field_indexes(0, &hw_cell, &write_segment)
+        .unwrap();
 
     assert!(
         write_segment
@@ -425,7 +346,9 @@ fn test_sync_indexes() {
         .delete_field_index(12, &"color".parse().unwrap())
         .unwrap();
 
-    proxy_segment.replicate_field_indexes(0, &hw_cell).unwrap();
+    proxy_segment
+        .replicate_field_indexes(0, &hw_cell, &write_segment)
+        .unwrap();
 
     assert!(
         write_segment
@@ -448,7 +371,6 @@ fn test_take_snapshot() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(build_segment_1(dir.path()));
     let original_segment_2 = LockedSegment::new(build_segment_2(dir.path()));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
     let deleted_points = LockedRmSet::default();
     let changed_indexes = LockedIndexChanges::default();
@@ -457,64 +379,32 @@ fn test_take_snapshot() {
 
     let mut proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment.clone(),
         Arc::clone(&deleted_points),
         Arc::clone(&changed_indexes),
     );
 
-    let mut proxy_segment2 = ProxySegment::new(
-        original_segment_2,
-        write_segment,
-        deleted_points,
-        changed_indexes,
-    );
+    let proxy_segment2 = ProxySegment::new(original_segment_2, deleted_points, changed_indexes);
 
-    let vec4 = vec![1.1, 1.0, 0.0, 1.0];
-    proxy_segment
-        .upsert_point(100, 4.into(), only_default_vector(&vec4), &hw_cell)
-        .unwrap();
-    let vec6 = vec![1.0, 1.0, 0.5, 1.0];
-    proxy_segment
-        .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_cell)
-        .unwrap();
     proxy_segment.delete_point(102, 1.into(), &hw_cell).unwrap();
-
-    proxy_segment2
-        .upsert_point(201, 11.into(), only_default_vector(&vec6), &hw_cell)
-        .unwrap();
 
     let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
     eprintln!("Snapshot into {:?}", snapshot_file.path());
     let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
-    let mut snapshotted_segments = HashSet::new();
     proxy_segment
-        .take_snapshot(
-            temp_dir.path(),
-            &tar,
-            SnapshotFormat::Regular,
-            None,
-            &mut snapshotted_segments,
-        )
+        .take_snapshot(temp_dir.path(), &tar, SnapshotFormat::Regular, None)
         .unwrap();
     proxy_segment2
-        .take_snapshot(
-            temp_dir2.path(),
-            &tar,
-            SnapshotFormat::Regular,
-            None,
-            &mut snapshotted_segments,
-        )
+        .take_snapshot(temp_dir2.path(), &tar, SnapshotFormat::Regular, None)
         .unwrap();
     tar.blocking_finish().unwrap();
 
-    // validate that 3 archives were created:
-    // wrapped_segment1, wrapped_segment2 & shared write_segment
+    // validate that 2 archives were created:
+    // wrapped_segment1, wrapped_segment2
     let mut tar = tar::Archive::new(File::open(snapshot_file.path()).unwrap());
     let archive_count = tar.entries_with_seek().unwrap().count();
-    assert_eq!(archive_count, 3);
-    assert_eq!(snapshotted_segments.len(), 3);
+    assert_eq!(archive_count, 2);
 
     let mut tar = tar::Archive::new(File::open(snapshot_file.path()).unwrap());
     for entry in tar.entries_with_seek().unwrap() {
@@ -529,13 +419,11 @@ fn test_take_snapshot() {
 fn test_point_vector_count() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(build_segment_1(dir.path()));
-    let write_segment = LockedSegment::new(empty_segment(dir.path()));
 
     let hw_cell = HardwareCounterCell::new();
 
     let mut proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
@@ -570,7 +458,6 @@ fn test_point_vector_count() {
 
 #[test]
 fn test_point_vector_count_multivec() {
-    use segment::segment_constructor::build_segment;
     use segment::segment_constructor::simple_segment_constructor::{
         VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment,
     };
@@ -581,7 +468,6 @@ fn test_point_vector_count_multivec() {
     let dim = 1;
 
     let mut original_segment = build_multivec_segment(dir.path(), dim, dim, Distance::Dot).unwrap();
-    let write_segment = build_segment(dir.path(), &original_segment.segment_config, true).unwrap();
 
     let hw_cell = HardwareCounterCell::new();
 
@@ -609,11 +495,9 @@ fn test_point_vector_count_multivec() {
         .unwrap();
 
     let original_segment = LockedSegment::new(original_segment);
-    let write_segment = LockedSegment::new(write_segment);
 
     let mut proxy_segment = ProxySegment::new(
         original_segment,
-        write_segment,
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
@@ -710,108 +594,26 @@ fn test_proxy_segment_flush() {
         .unwrap();
 
     let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
-    let locked_write_segment = LockedSegment::new(empty_segment(tmp_dir.path()));
 
     let mut proxy_segment = ProxySegment::new(
         locked_wrapped_segment.clone(),
-        locked_write_segment.clone(),
         LockedRmSet::default(),
         LockedIndexChanges::default(),
     );
 
-    // Unwrapped `LockedSegment`s for convenient access
-    let LockedSegment::Original(wrapped_segment) = locked_wrapped_segment else {
-        unreachable!();
-    };
-
-    let LockedSegment::Original(write_segment) = locked_write_segment else {
-        unreachable!()
-    };
-
-    // - `wrapped_segment` has unflushed data
-    // - `write_segment` has no data
-    // - `proxy_segment` has no in-memory data
-    // - flush `proxy_segment`, ensure:
-    //   - `wrapped_segment` is flushed
-    //   - `ProxySegment::flush` returns `wrapped_segment`'s persisted version
-
-    let flushed_version = proxy_segment.flush(true, false).unwrap();
-    let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
-    assert_eq!(Some(flushed_version), wrapped_segment_persisted_version);
-
-    // - `wrapped_segment` has unflushed data
-    // - `write_segment` has unflushed data
-    // - `proxy_segment` has no in-memory data
-    // - flush `proxy_segment`, ensure:
-    //   - `wrapped_segment` is flushed
-    //   - `write_segment` is flushed
-    //   - `ProxySegment::flush` returns `write_segment`'s persisted version
-
-    let current_version = proxy_segment.version();
-
-    let hw_cell = HardwareCounterCell::new();
-
-    wrapped_segment
-        .write()
-        .upsert_point(
-            current_version + 1,
-            42.into(),
-            only_default_vector(&[4.0, 2.0, 0.0, 0.0]),
-            &hw_cell,
-        )
-        .unwrap();
+    let flushed_version_1 = proxy_segment.flush(true, false).unwrap();
 
     proxy_segment
-        .upsert_point(
-            current_version + 2,
-            69.into(),
-            only_default_vector(&[6.0, 9.0, 0.0, 0.0]),
-            &hw_cell,
-        )
+        .delete_point(100, 2.into(), &HardwareCounterCell::new())
         .unwrap();
 
-    let flushed_version = proxy_segment.flush(true, false).unwrap();
-    let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
-    let write_segment_persisted_version = *write_segment.read().persisted_version.lock();
+    let flushed_version_2 = proxy_segment.flush(true, false).unwrap();
 
-    assert_eq!(wrapped_segment_persisted_version, Some(current_version + 1));
-    assert_eq!(write_segment_persisted_version, Some(current_version + 2));
-    assert_eq!(Some(flushed_version), write_segment_persisted_version);
+    assert_eq!(flushed_version_2, flushed_version_1);
 
-    // - `wrapped_segment` has unflushed data
-    // - `write_segment` has unflushed data
-    // - `proxy_segment` has in-memory data
-    // - flush `proxy_segment`, ensure:
-    //   - `wrapped_segment` is flushed
-    //   - `write_segment` is flushed
-    //   - `ProxySegment::flush` returns `wrapped_segment`'s persisted version
+    let version_after_delete = proxy_segment.version();
 
-    let current_version = proxy_segment.version();
-
-    wrapped_segment
-        .write()
-        .upsert_point(
-            current_version + 1,
-            666.into(),
-            only_default_vector(&[6.0, 6.0, 6.0, 0.0]),
-            &hw_cell,
-        )
-        .unwrap();
-
-    proxy_segment
-        .upsert_point(
-            current_version + 2,
-            42.into(),
-            only_default_vector(&[0.0, 0.0, 4.0, 2.0]),
-            &hw_cell,
-        )
-        .unwrap();
-
-    let flushed_version = proxy_segment.flush(true, false).unwrap();
-    let wrapped_segment_persisted_version = *wrapped_segment.read().persisted_version.lock();
-    let write_segment_persisted_version = *write_segment.read().persisted_version.lock();
-
-    assert_eq!(wrapped_segment_persisted_version, Some(current_version + 1));
-    assert_eq!(write_segment_persisted_version, Some(current_version + 2));
-    assert_eq!(Some(flushed_version), wrapped_segment_persisted_version);
+    // We can never fully persist proxy segment, as list of deleted points is always in-memory only.
+    // So we have to keep WAL for deleted points.
+    assert!(version_after_delete > flushed_version_2);
 }

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -64,11 +64,7 @@ fn test_search_batch_equivalence_single() {
         .upsert_point(101, 6.into(), only_default_vector(&vec6), &hw_counter)
         .unwrap();
 
-    let mut proxy_segment = ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let mut proxy_segment = ProxySegment::new(original_segment);
 
     proxy_segment
         .delete_point(102, 1.into(), &hw_counter)
@@ -118,11 +114,7 @@ fn test_search_batch_equivalence_single_random() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
 
-    let proxy_segment = ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let proxy_segment = ProxySegment::new(original_segment);
 
     let query_vector = [1.0, 1.0, 1.0, 1.0].into();
     let search_result = proxy_segment
@@ -166,11 +158,7 @@ fn test_search_batch_equivalence_multi_random() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(random_segment(dir.path(), 100, 200, 4));
 
-    let proxy_segment = ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let proxy_segment = ProxySegment::new(original_segment);
 
     let q1 = [1.0, 1.0, 1.0, 0.1];
     let q2 = [1.0, 1.0, 0.1, 0.1];
@@ -219,11 +207,7 @@ fn test_search_batch_equivalence_multi_random() {
 }
 
 fn wrap_proxy(original_segment: LockedSegment) -> ProxySegment {
-    ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    )
+    ProxySegment::new(original_segment)
 }
 
 #[test]
@@ -309,11 +293,7 @@ fn test_sync_indexes() {
         )
         .unwrap();
 
-    let proxy_segment = ProxySegment::new(
-        original_segment.clone(),
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let proxy_segment = ProxySegment::new(original_segment.clone());
 
     let hw_cell = HardwareCounterCell::new();
 
@@ -372,18 +352,11 @@ fn test_take_snapshot() {
     let original_segment = LockedSegment::new(build_segment_1(dir.path()));
     let original_segment_2 = LockedSegment::new(build_segment_2(dir.path()));
 
-    let deleted_points = LockedRmSet::default();
-    let changed_indexes = LockedIndexChanges::default();
-
     let hw_cell = HardwareCounterCell::new();
 
-    let mut proxy_segment = ProxySegment::new(
-        original_segment,
-        Arc::clone(&deleted_points),
-        Arc::clone(&changed_indexes),
-    );
+    let mut proxy_segment = ProxySegment::new(original_segment);
 
-    let proxy_segment2 = ProxySegment::new(original_segment_2, deleted_points, changed_indexes);
+    let proxy_segment2 = ProxySegment::new(original_segment_2);
 
     proxy_segment.delete_point(102, 1.into(), &hw_cell).unwrap();
 
@@ -422,11 +395,7 @@ fn test_point_vector_count() {
 
     let hw_cell = HardwareCounterCell::new();
 
-    let mut proxy_segment = ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let mut proxy_segment = ProxySegment::new(original_segment);
 
     // We have 5 points by default, assert counts
     let segment_info = proxy_segment.info();
@@ -496,11 +465,7 @@ fn test_point_vector_count_multivec() {
 
     let original_segment = LockedSegment::new(original_segment);
 
-    let mut proxy_segment = ProxySegment::new(
-        original_segment,
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let mut proxy_segment = ProxySegment::new(original_segment);
 
     // Assert counts from original segment
     let segment_info = proxy_segment.info();
@@ -595,11 +560,7 @@ fn test_proxy_segment_flush() {
 
     let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
 
-    let mut proxy_segment = ProxySegment::new(
-        locked_wrapped_segment.clone(),
-        LockedRmSet::default(),
-        LockedIndexChanges::default(),
-    );
+    let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
 
     let flushed_version_1 = proxy_segment.flush(true, false).unwrap();
 

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -415,14 +415,6 @@ fn test_point_vector_count() {
     let segment_info = proxy_segment.info();
     assert_eq!(segment_info.num_points, 4);
     assert_eq!(segment_info.num_vectors, 4);
-
-    // Delete vector of point 2, vector count should now be zero
-    proxy_segment
-        .delete_vector(103, 2.into(), DEFAULT_VECTOR_NAME)
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 4);
-    assert_eq!(segment_info.num_vectors, 3);
 }
 
 #[test]
@@ -472,83 +464,17 @@ fn test_point_vector_count_multivec() {
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 4);
 
-    // Insert point ID 8 and 10 partially, assert counts
-    proxy_segment
-        .upsert_point(
-            102,
-            8.into(),
-            NamedVectors::from_pairs([(VECTOR1_NAME.into(), vec![0.0])]),
-            &hw_cell,
-        )
-        .unwrap();
-    proxy_segment
-        .upsert_point(
-            103,
-            10.into(),
-            NamedVectors::from_pairs([(VECTOR2_NAME.into(), vec![1.0])]),
-            &hw_cell,
-        )
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 4);
-    assert_eq!(segment_info.num_vectors, 6);
-
     // Delete nonexistent point, counts should remain the same
     proxy_segment.delete_point(104, 1.into(), &hw_cell).unwrap();
     let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 4);
-    assert_eq!(segment_info.num_vectors, 6);
+    assert_eq!(segment_info.num_points, 2);
+    assert_eq!(segment_info.num_vectors, 4);
 
     // Delete point 4, counts should decrease by 1
     proxy_segment.delete_point(105, 4.into(), &hw_cell).unwrap();
     let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 3);
-    assert_eq!(segment_info.num_vectors, 4);
-
-    // Delete vector 'a' of point 6, vector count should decrease by 1
-    proxy_segment
-        .delete_vector(106, 6.into(), VECTOR1_NAME)
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 3);
-    assert_eq!(segment_info.num_vectors, 3);
-
-    // Deleting it again shouldn't chain anything
-    proxy_segment
-        .delete_vector(107, 6.into(), VECTOR1_NAME)
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 3);
-    assert_eq!(segment_info.num_vectors, 3);
-
-    // Replace vector 'a' for point 8, counts should remain the same
-    proxy_segment
-        .upsert_point(
-            108,
-            8.into(),
-            NamedVectors::from_pairs([(VECTOR1_NAME.into(), vec![0.0])]),
-            &hw_cell,
-        )
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 3);
-    assert_eq!(segment_info.num_vectors, 3);
-
-    // Replace both vectors for point 8, adding a new vector
-    proxy_segment
-        .upsert_point(
-            109,
-            8.into(),
-            NamedVectors::from_pairs([
-                (VECTOR1_NAME.into(), vec![0.0]),
-                (VECTOR2_NAME.into(), vec![0.0]),
-            ]),
-            &hw_cell,
-        )
-        .unwrap();
-    let segment_info = proxy_segment.info();
-    assert_eq!(segment_info.num_points, 3);
-    assert_eq!(segment_info.num_vectors, 4);
+    assert_eq!(segment_info.num_points, 1);
+    assert_eq!(segment_info.num_vectors, 2);
 }
 
 #[test]

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -219,7 +219,10 @@ impl SegmentHolder {
                 LockedSegment::Original(_) => {}
             }
         }
-        debug_assert!(write_segments.get(tmp_segment_id).is_some(), "temp segment must exist");
+        debug_assert!(
+            write_segments.get(tmp_segment_id).is_some(),
+            "temp segment must exist"
+        );
         // Remove temporary appendable segment, if we don't need it anymore
         write_segments.remove_segment_if_not_needed(tmp_segment_id)?;
 

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -219,10 +219,12 @@ impl SegmentHolder {
                 LockedSegment::Original(_) => {}
             }
         }
+
         debug_assert!(
             write_segments.get(tmp_segment_id).is_some(),
-            "temp segment must exist"
+            "temp segment must exist",
         );
+
         // Remove temporary appendable segment, if we don't need it anymore
         write_segments.remove_segment_if_not_needed(tmp_segment_id)?;
 

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -742,7 +742,7 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
     match (&outer_proxies[0].1, &outer_proxies[1].1) {
         (LockedSegment::Proxy(first), LockedSegment::Proxy(second)) => {
             assert_eq!(
-                first.read().get_deleted_points().read().deref(),
+                first.read().get_deleted_points(),
                 &AHashMap::from_iter([(
                     pid,
                     ProxyDeletedPoint {
@@ -754,7 +754,7 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
                 )]),
             );
             assert_eq!(
-                second.read().get_deleted_points().read().deref(),
+                second.read().get_deleted_points(),
                 &AHashMap::from_iter([(
                     pid,
                     ProxyDeletedPoint {

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -728,12 +728,22 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
 
     // Both the outer and inner tmp segment must have point
     assert_eq!(
-        outer_tmp_segment.get().read().point_version(pid),
+        outer_segments_lock
+            .get(outer_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
         Some(300),
         "shared outer tmp segment has point version 300 from latest upsert",
     );
     assert_eq!(
-        inner_tmp_segment.get().read().point_version(pid),
+        outer_segments_lock
+            .get(inner_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
         Some(100),
         "shared inner tmp segment has point version 100 from first upsert",
     );
@@ -780,7 +790,12 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
 
     // Delete propagation at unproxy deleted version 210 from shared inner tmp segment which had version 100
     assert!(
-        !inner_tmp_segment.get().read().has_point(pid),
+        !outer_segments_lock
+            .get(inner_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .has_point(pid),
         "inner tmp segment must not have point",
     );
 
@@ -806,12 +821,22 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
         "last outer proxy has point version 300 through shared outer tmp segment",
     );
     assert_eq!(
-        outer_tmp_segment.get().read().point_version(pid),
+        outer_segments_lock
+            .get(outer_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
         Some(300),
         "outer tmp segment has point version 300",
     );
     assert_eq!(
-        inner_tmp_segment.get().read().point_version(pid),
+        outer_segments_lock
+            .get(inner_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
         Some(400),
         "inner tmp segment has point version 400 from latest upsert",
     );
@@ -840,8 +865,15 @@ fn test_proxy_propagate_older_delete_to_wrapped() {
         Some(400),
         "last outer proxy has point version 300 through shared outer tmp segment",
     );
+
     assert_eq!(
-        inner_tmp_segment.get().read().point_version(pid),
+        holder
+            .read()
+            .get(inner_tmp_segment)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(pid),
         Some(400),
         "inner tmp segment has point version 400 from latest upsert",
     );

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use rand::Rng;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal, only_default_vector};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal};
 use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
@@ -12,7 +12,6 @@ use tempfile::Builder;
 
 use super::*;
 use crate::fixtures::*;
-use crate::proxy_segment::ProxyDeletedPoint;
 
 #[test]
 fn test_add_and_swap() {
@@ -528,7 +527,9 @@ fn test_double_proxies() {
 
     let mut holder = SegmentHolder::default();
 
-    let _sid1 = holder.add_new(segment1);
+    let locked_segment1 = LockedSegment::from(segment1);
+
+    let _sid1 = holder.add_new_locked(locked_segment1.clone());
 
     let holder = Arc::new(RwLock::new(holder));
 
@@ -572,18 +573,31 @@ fn test_double_proxies() {
         SegmentHolder::proxy_all_segments(inner_segments_lock, segments_dir.path(), None, schema)
             .unwrap();
 
-    // Writing to outer proxy segment
-    outer_proxies[0]
-        .1
-        .get()
-        .write()
-        .upsert_point(
-            100,
-            1.into(),
-            only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
-            &hw_counter,
-        )
-        .unwrap();
+    let mut has_point = false;
+    for (_proxy_id, proxy) in &outer_proxies {
+        let proxy_read = proxy.get().read();
+
+        if proxy_read.has_point(2.into()) {
+            has_point = true;
+            let payload = proxy_read.payload(2.into(), &hw_counter).unwrap();
+
+            assert!(
+                payload.0.get("color").is_some(),
+                "Payload should be readable in double proxy"
+            );
+            drop(proxy_read);
+
+            proxy
+                .get()
+                .write()
+                .delete_point(11, 2.into(), &hw_counter)
+                .unwrap();
+
+            break;
+        }
+    }
+
+    assert!(has_point, "Point should be present in double proxy");
 
     // Unproxy once
     SegmentHolder::unproxy_all_segments(outer_segments_lock, outer_proxies, outer_tmp_segment)
@@ -603,321 +617,15 @@ fn test_double_proxies() {
     let diff: HashSet<_> = after_segment_ids.difference(&before_segment_ids).collect();
     assert_eq!(
         diff.len(),
-        1,
-        "There should be one new segment after unproxying"
-    );
-}
-
-/// Test proxy propagating older delete to wrapped segment is sound
-///
-/// A specific scenario that asserts the delete propagation logic is sound. It tries to propagate
-/// an older delete version to a wrapped segment that already has a newer point version. It
-/// previously had a faulty debug assertion in place that triggers in this case.
-///
-/// This scenario is possible if:
-/// - there are at least two layers of two proxies
-/// - one of the outer proxies is unproxied half way
-/// - a new point version is upserted through the unproxied segment (now being the inner proxy)
-///
-/// See: <https://github.com/qdrant/qdrant/pull/7208>
-#[test]
-fn test_proxy_propagate_older_delete_to_wrapped() {
-    let hw_counter = HardwareCounterCell::disposable();
-
-    let pid = ExtendedPointId::from(1);
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let segment1 = empty_segment(dir.path());
-    let segment2 = empty_segment(dir.path());
-
-    let mut holder = SegmentHolder::default();
-
-    let sid1 = holder.add_new(segment1);
-    let sid2 = holder.add_new(segment2);
-
-    let holder = Arc::new(RwLock::new(holder));
-
-    let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
-    let payload_schema_file = dir.path().join("payload.schema");
-    let schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
-        Arc::new(SaveOnDisk::load_or_init_default(payload_schema_file).unwrap());
-
-    // Create inner proxies, we have two of them
-    let (inner_proxies, inner_tmp_segment, inner_segments_lock) =
-        SegmentHolder::proxy_all_segments(
-            holder.upgradable_read(),
-            segments_dir.path(),
-            None,
-            schema.clone(),
-        )
-        .unwrap();
-    assert_eq!(inner_proxies.len(), 2);
-
-    // Insert version 100 in first inner proxy
-    inner_proxies[0]
-        .1
-        .get()
-        .write()
-        .upsert_point(
-            100,
-            pid,
-            only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
-            &hw_counter,
-        )
-        .unwrap();
-
-    // Create outer proxies, we have two of them
-    let (mut outer_proxies, outer_tmp_segment, mut outer_segments_lock) =
-        SegmentHolder::proxy_all_segments(inner_segments_lock, segments_dir.path(), None, schema)
-            .unwrap();
-    assert_eq!(outer_proxies.len(), 2);
-
-    // Insert version 200 then delete version 210 in first outer proxy
-    outer_proxies[0]
-        .1
-        .get()
-        .write()
-        .upsert_point(
-            200,
-            pid,
-            only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
-            &hw_counter,
-        )
-        .unwrap();
-    outer_proxies[0]
-        .1
-        .get()
-        .write()
-        .delete_point(210, pid, &hw_counter)
-        .unwrap();
-
-    // First outer proxy has point deleted, second outer proxy still has it
-    assert!(
-        !outer_proxies[0].1.get().read().has_point(pid),
-        "first proxy must not have point",
-    );
-    assert_eq!(
-        outer_proxies[1].1.get().read().point_version(pid),
-        Some(100),
-        "second outer proxy must have point version 100 through shared inner tmp segment",
+        0,
+        "There should be no new segment after unproxying"
     );
 
-    // Insert version 300 in second outer proxy
-    outer_proxies[1]
-        .1
-        .get()
-        .write()
-        .upsert_point(
-            300,
-            pid,
-            only_default_vector(&[1.0, 1.0, 1.0, 1.0]),
-            &hw_counter,
-        )
-        .unwrap();
+    let has_point_1 = locked_segment1.get().read().has_point(1.into()); // Deleted in inner proxy
+    let has_point_2 = locked_segment1.get().read().has_point(2.into()); // Deleted in outer proxy
+    let has_point_3 = locked_segment1.get().read().has_point(3.into()); // Not deleted
 
-    // Both outer proxies must have point
-    assert_eq!(
-        outer_proxies[0].1.get().read().point_version(pid),
-        Some(300),
-        "second outer proxy must have point version 300, latest upsert through shared outer tmp segment",
-    );
-    assert_eq!(
-        outer_proxies[1].1.get().read().point_version(pid),
-        Some(300),
-        "second outer proxy must have point version 300, latest upsert through shared outer tmp segment",
-    );
-
-    // Both the outer and inner tmp segment must have point
-    assert_eq!(
-        outer_segments_lock
-            .get(outer_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(300),
-        "shared outer tmp segment has point version 300 from latest upsert",
-    );
-    assert_eq!(
-        outer_segments_lock
-            .get(inner_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(100),
-        "shared inner tmp segment has point version 100 from first upsert",
-    );
-
-    // Assert both outer proxies have delete markers we expect
-    match (&outer_proxies[0].1, &outer_proxies[1].1) {
-        (LockedSegment::Proxy(first), LockedSegment::Proxy(second)) => {
-            assert_eq!(
-                first.read().get_deleted_points(),
-                &AHashMap::from_iter([(
-                    pid,
-                    ProxyDeletedPoint {
-                        // Delete version 210 in first outer proxy
-                        operation_version: 210,
-                        // Delete version 210 in first outer proxy
-                        local_version: 210,
-                    }
-                )]),
-            );
-            assert_eq!(
-                second.read().get_deleted_points(),
-                &AHashMap::from_iter([(
-                    pid,
-                    ProxyDeletedPoint {
-                        // Initial upsert version 100 through shared inner tmp segment
-                        local_version: 100,
-                        // Latest upsert version 300 did CoW to shared outer tmp segment
-                        operation_version: 300,
-                    }
-                )]),
-            );
-        }
-        _ => unreachable!(),
-    }
-
-    // Unproxy only first outer proxy
-    // Happens in `proxy_all_segments_and_apply` function that immediately tries to unproxy
-    // proxy segments it has applied an operation on, without waiting until all proxy segments
-    // have applied the operation.
-    let (unproxy_id, unproxy_segment) = outer_proxies.remove(0);
-    outer_segments_lock =
-        SegmentHolder::try_unproxy_segment(outer_segments_lock, unproxy_id, unproxy_segment)
-            .expect("should always succeed");
-
-    // Delete propagation at unproxy deleted version 210 from shared inner tmp segment which had version 100
-    assert!(
-        !outer_segments_lock
-            .get(inner_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .has_point(pid),
-        "inner tmp segment must not have point",
-    );
-
-    // Insert point version 400 into now unproxied segment (which now became the first inner proxy)
-    outer_segments_lock
-        .get(unproxy_id)
-        .unwrap()
-        .get()
-        .write()
-        .upsert_point(
-            400,
-            pid,
-            only_default_vector(&[1.0, 1.0, 1.0, 1.0]),
-            &hw_counter,
-        )
-        .unwrap();
-
-    // Last outer proxy still views point version 300
-    // Shared inner tmp segment has point version 400 from latest upsert
-    assert_eq!(
-        outer_proxies[0].1.get().read().point_version(pid),
-        Some(300),
-        "last outer proxy has point version 300 through shared outer tmp segment",
-    );
-    assert_eq!(
-        outer_segments_lock
-            .get(outer_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(300),
-        "outer tmp segment has point version 300",
-    );
-    assert_eq!(
-        outer_segments_lock
-            .get(inner_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(400),
-        "inner tmp segment has point version 400 from latest upsert",
-    );
-
-    // Unproxy last outer proxy
-    //
-    // The proxy will propagate its queued deletes to wrapped segment:
-    // It will try to delete point version 300, but it's wrapped segment already has point version
-    // 400 which is shared through the inner tmp segment. Because the delete version is older, it
-    // will not delete the newer point.
-    // The faulty debug assertion assumed the wrapped segment could not change and therefore delete
-    // version must always be newer. This is not true, because if the wrapped segment is also a
-    // proxy it can share state with other segments. If these other segments receive updates, the
-    // wrapped segment might view newer point versions.
-    SegmentHolder::unproxy_all_segments(outer_segments_lock, outer_proxies, outer_tmp_segment)
-        .unwrap();
-
-    // Inner proxies and shared inner tmp segment all see point version 400
-    assert_eq!(
-        inner_proxies[0].1.get().read().point_version(pid),
-        Some(400),
-        "last outer proxy has point version 300 through shared outer tmp segment",
-    );
-    assert_eq!(
-        inner_proxies[1].1.get().read().point_version(pid),
-        Some(400),
-        "last outer proxy has point version 300 through shared outer tmp segment",
-    );
-
-    assert_eq!(
-        holder
-            .read()
-            .get(inner_tmp_segment)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(400),
-        "inner tmp segment has point version 400 from latest upsert",
-    );
-
-    // Unproxy inner proxies
-    // Note: in our current codebase we don't unproxy like this twice
-    eprintln!("\n\n\nUNPROXY INNER PROXIES");
-    SegmentHolder::unproxy_all_segments(holder.upgradable_read(), inner_proxies, inner_tmp_segment)
-        .unwrap();
-
-    // Original segments should not have point, newly added tmp segment does have the point
-    assert_eq!(
-        holder.read().len(),
-        4,
-        "segment holder must have 4 segments, 2 original plus 2 temporary",
-    );
-    assert!(
-        !holder.read().get(sid1).unwrap().get().read().has_point(pid),
-        "first original segment must not have the point",
-    );
-    assert!(
-        !holder.read().get(sid2).unwrap().get().read().has_point(pid),
-        "second original segment must not have the point",
-    );
-    assert_eq!(
-        holder
-            .read()
-            .get(sid2 + 1)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(300),
-        "outer tmp segment still has point version 300",
-    );
-    assert_eq!(
-        holder
-            .read()
-            .get(sid2 + 2)
-            .unwrap()
-            .get()
-            .read()
-            .point_version(pid),
-        Some(400),
-        "inner tmp segment must have latest point version 400",
-    );
+    assert!(!has_point_1, "Point 1 should be deleted");
+    assert!(!has_point_2, "Point 2 should be deleted");
+    assert!(has_point_3, "Point 3 should be present");
 }


### PR DESCRIPTION
Current architecture assumes, that proxy segments are appendable by default and do internal copy-on-write into write segment whenever somehing needs to be changed. This architecture have acient roots and there are no clear reasons why it was designed like this in the first place, but the whole engine was designed around it and it kinda worked, untill we tried to integrate snapshots, which required double proxies. That's where it stated to fall apart with no clear way of reparing. So why appendable proxies are bad?

- Appendable proxies require internal CoW machanism, which duplicates shard-level CoW.
- Appendable proxies used shared write segment and shared delted points, which while technically sound for one level proxifying, introduced a huge amount of mental complexity and made it very hard to reason about the system in general.
- Shared CoW segments "hacked" the immutability guarantee - most parts of the code assumed that if segment is read-locked -- the data doesn't change. Which was not the case if CoW segment was changes by soem other proxy.

This PR does:

- Makes proxy segment non-appendable
- Removes proxy-level CoW
- Removes proxy update operations
- Changes the logic of handling extra segment on proxifying/de-proxifying
  - New appendable segment is added to the holder only if it is needed
  - On the finilization, empty segment is removed from the holder
- Changes/removes a bunch of tests which are now obsolete

