### PR TITLE
In snasphot transfer, queue WAL operations from last acknowledged

### DIFF
--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -499,4 +499,15 @@ impl ShardReplicaSet {
 
         local_shard.wal_version().await
     }
+
+    pub async fn wal_acknowledged_version(&self) -> CollectionResult<Option<u64>> {
+        let local_shard_read = self.local.read().await;
+        let Some(local_shard) = local_shard_read.deref() else {
+            return Err(CollectionError::service_error(
+                "Cannot get WAL acknowleged version, shard replica set does not have local shard",
+            ));
+        };
+
+        local_shard.wal_acknowledged_version().await
+    }
 }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -300,6 +300,30 @@ impl Shard {
         }
     }
 
+    pub async fn wal_acknowledged_version(&self) -> CollectionResult<Option<u64>> {
+        match self {
+            Self::Local(local_shard) => {
+                local_shard
+                    .wal
+                    .wal_acknowledged_version()
+                    .await
+                    .map_err(|err| {
+                        CollectionError::service_error(format!(
+                            "Cannot get WAL acknowledged version on {}: {err}",
+                            self.variant_name(),
+                        ))
+                    })
+            }
+
+            Self::Proxy(_) | Self::ForwardProxy(_) | Self::QueueProxy(_) | Self::Dummy(_) => {
+                Err(CollectionError::service_error(format!(
+                    "Cannot get WAL acknowledged version on {}",
+                    self.variant_name(),
+                )))
+            }
+        }
+    }
+
     pub async fn estimate_cardinality(
         &self,
         filter: Option<&Filter>,

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -118,6 +118,15 @@ impl RecoverableWal {
         )
     }
 
+    pub async fn wal_acknowledged_version(&self) -> Result<Option<u64>, WalDeltaError> {
+        let wal = self.wal.lock().await;
+        if wal.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(wal.first_index()))
+        }
+    }
+
     pub async fn wal_version(&self) -> Result<Option<u64>, WalDeltaError> {
         let wal = self.wal.lock().await;
         if wal.is_empty() {


### PR DESCRIPTION
Improves <https://github.com/qdrant/qdrant/pull/7341> based on [this](https://github.com/qdrant/qdrant/pull/7341#issuecomment-3370505121) comment.

I'd argue that this is the better implementation of <https://github.com/qdrant/qdrant/pull/7341>. Please see my motivation [here](https://github.com/qdrant/qdrant/pull/7341#issuecomment-3370505121).

I also argue this is better than <https://github.com/qdrant/qdrant/pull/7342> because this is cheaper. Snapshots are already very expensive, flushing them makes this worse. We already have a background task that is supposed to take care of this.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?