### PR TITLE
Change score of query-less prefetch to 1.0

### DIFF
--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -125,7 +125,7 @@ impl LocalShard {
             .map(|record| ScoredPoint {
                 id: record.id,
                 version: 0,
-                score: 0.0,
+                score: 1.0,
                 payload: record.payload,
                 vector: record.vector,
                 shard_key: record.shard_key,


### PR DESCRIPTION
There is a use-case where a filter is to be used as a primary source, and then use vector search as fallback. With this PR,  assuming cosine similarity which has output of 0-1, a query like this can be made.

```json
{
  "prefetch": [
    {
      "filter": { "must": { "key": "description", "match": { "text": ... } } }, // full-text filter
    },
    { 
      "query": ..., // vector query
    }
  ],
  "query": { "formula": { "sum": ["$score[0]", "$score[1]"] } }
}
```

This way, results from the full-text filter will rank higher, but if the filter does not have enough results, we'll still have results from vector search.

Alternatively, something that can be done without this PR is to use the condition within the formula query again. But this method will check the same condition twice, and has a worse DX.
```json
{
  "prefetch": [
    {
      "filter": { "must": { "key": "description", "match": { "text": ... } } }, // full-text filter
    },
    { 
      "query": ..., // vector query
    }
  ],
  "query": { "formula": { 
    "sum": [
      { "key": "description", "match": { "text": ... } }, // same condition again
      "$score[1]", 
    ]
  }
}
```