### PR TITLE
Introduce fallback shard key for read and write requests

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8045,6 +8045,9 @@
             "items": {
               "$ref": "#/components/schemas/ShardKey"
             }
+          },
+          {
+            "$ref": "#/components/schemas/ShardKeyWithFallback"
           }
         ]
       },
@@ -8061,6 +8064,21 @@
             "example": 12
           }
         ]
+      },
+      "ShardKeyWithFallback": {
+        "type": "object",
+        "required": [
+          "fallback",
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/ShardKey"
+          },
+          "fallback": {
+            "$ref": "#/components/schemas/ShardKey"
+          }
+        }
       },
       "ExtendedPointId": {
         "description": "Type, used for specifying point ID in user interface",

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -394,12 +394,19 @@ pub struct Batch {
     pub payloads: Option<Vec<Option<Payload>>>,
 }
 
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
+pub struct ShardKeyWithFallback {
+    pub target: ShardKey,
+    pub fallback: ShardKey,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq, Hash)]
 #[serde(untagged)]
 #[serde(expecting = "Expected a string or an integer")]
 pub enum ShardKeySelector {
     ShardKey(ShardKey),
     ShardKeys(Vec<ShardKey>),
+    ShardKeyWithFallback(ShardKeyWithFallback),
     // ToDo: select by pattern
 }
 

--- a/lib/collection/src/operations/shard_selector_internal.rs
+++ b/lib/collection/src/operations/shard_selector_internal.rs
@@ -1,4 +1,4 @@
-use api::rest::ShardKeySelector;
+use api::rest::{ShardKeySelector, ShardKeyWithFallback};
 use segment::types::ShardKey;
 
 use crate::shards::shard::ShardId;
@@ -13,6 +13,8 @@ pub enum ShardSelectorInternal {
     ShardKey(ShardKey),
     /// Select multiple shard keys
     ShardKeys(Vec<ShardKey>),
+    /// Select shard key with a fallback shard
+    ShardKeyWithFallback(ShardKeyWithFallback),
     /// ShardId
     ShardId(ShardId),
 }
@@ -43,6 +45,9 @@ impl From<ShardKeySelector> for ShardSelectorInternal {
         match selector {
             ShardKeySelector::ShardKey(key) => ShardSelectorInternal::ShardKey(key),
             ShardKeySelector::ShardKeys(keys) => ShardSelectorInternal::ShardKeys(keys),
+            ShardKeySelector::ShardKeyWithFallback(key_with_fallback) => {
+                ShardSelectorInternal::ShardKeyWithFallback(key_with_fallback)
+            }
         }
     }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -570,7 +570,6 @@ impl ShardHolder {
                 }
             }
             ShardSelectorInternal::ShardKeyWithFallback(key) => {
-
                 let shard_key_to_ids_mapping = self.get_shard_key_to_ids_mapping();
 
                 let (shard_ids, used_shard_key) = shard_key_to_ids_mapping
@@ -590,7 +589,7 @@ impl ShardHolder {
 
                 for shard_id in shard_ids {
                     if let Some(replica_set) = self.shards.get(&shard_id) {
-                        res.push((replica_set, Some(&used_shard_key)));
+                        res.push((replica_set, Some(used_shard_key)));
                     } else {
                         debug_assert!(false, "Shard id {shard_id} not found")
                     }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -569,6 +569,33 @@ impl ShardHolder {
                     }
                 }
             }
+            ShardSelectorInternal::ShardKeyWithFallback(key) => {
+
+                let shard_key_to_ids_mapping = self.get_shard_key_to_ids_mapping();
+
+                let (shard_ids, used_shard_key) = shard_key_to_ids_mapping
+                    .get(&key.target)
+                    .map(|shard_ids| (shard_ids.clone(), &key.target))
+                    .or_else(|| {
+                        shard_key_to_ids_mapping
+                            .get(&key.fallback)
+                            .map(|shard_ids| (shard_ids.clone(), &key.fallback))
+                    })
+                    .ok_or_else(|| {
+                        CollectionError::bad_request(format!(
+                            "Neither target shard key {} nor fallback shard key {} exist",
+                            key.target, key.fallback
+                        ))
+                    })?;
+
+                for shard_id in shard_ids {
+                    if let Some(replica_set) = self.shards.get(&shard_id) {
+                        res.push((replica_set, Some(&used_shard_key)));
+                    } else {
+                        debug_assert!(false, "Shard id {shard_id} not found")
+                    }
+                }
+            }
             ShardSelectorInternal::ShardId(shard_id) => {
                 if let Some(replica_set) = self.shards.get(shard_id) {
                     res.push((replica_set, self.shard_id_to_key_mapping.get(shard_id)));

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -600,6 +600,31 @@ impl TableOfContent {
                 .await?
             }
 
+            ShardSelectorInternal::ShardKeyWithFallback(key) => {
+                let shard_keys = if collection.get_shard_keys().await.contains(&key.target) {
+                    // ToDo: Only send to target shard key shard IDs if they are active?
+                    vec![key.target]
+                } else if collection.get_shard_keys().await.contains(&key.fallback) {
+                    vec![key.fallback]
+                } else {
+                    return Err(StorageError::bad_input(format!(
+                        "Neither target shard key '{}' nor fallback shard key '{}' are present in the collection",
+                        key.target, key.fallback
+                    )));
+                };
+
+                // ToDo: If there's an ongoing transfer from fallback to target, we should push updates to both
+
+                Self::_update_shard_keys(
+                    &collection,
+                    shard_keys,
+                    operation.operation,
+                    wait,
+                    ordering,
+                    hw_measurement_acc.clone(),
+                )
+                .await?
+            }
             ShardSelectorInternal::ShardId(shard_selection) => {
                 collection
                     .update_from_peer(


### PR DESCRIPTION
Replacement of https://github.com/qdrant/qdrant/pull/7067 and https://github.com/qdrant/qdrant/pull/7069 since we decided to define fallback shard key on request level. Specifying it on a request level gives more control to the user and allows better scaling since now they can have multiple fallback shards.

```http
PUT /collections/tenant/points
{
  "points": [
    {
      "id": 1,
      "payload": {
        "tenant": "tenant-123"
      },
      "vector": {}
    }
  ],
  "shard_key": {
    "target": "tenant-123",
    "fallback": "default"
  }
}
```