### PR TITLE
Use AHash for ShardId HashMap

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
+use ahash::AHashMap;
 use cancel::{CancellationToken, DropGuard};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use parking_lot::RwLock;
@@ -35,7 +36,7 @@ const CLEAN_BATCH_SIZE: usize = 5_000;
 /// completes. Once it completes it does not have to be run again on restart.
 #[derive(Default)]
 pub(super) struct ShardCleanTasks {
-    tasks: Arc<RwLock<HashMap<ShardId, ShardCleanTask>>>,
+    tasks: Arc<RwLock<AHashMap<ShardId, ShardCleanTask>>>,
 }
 
 impl ShardCleanTasks {
@@ -172,7 +173,7 @@ impl ShardCleanTasks {
     ///
     /// Only includes shards we've triggered cleaning for. On restart, or when invalidating shards,
     /// items are removed from the list.
-    pub fn statuses(&self) -> HashMap<ShardId, ShardCleanStatus> {
+    pub fn statuses(&self) -> AHashMap<ShardId, ShardCleanStatus> {
         self.tasks
             .read()
             .iter()

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 
 use crate::collection::Collection;
@@ -184,10 +185,10 @@ impl Collection {
 
     async fn apply_shard_info(
         &self,
-        shards: HashMap<ShardId, ShardInfo>,
+        shards: AHashMap<ShardId, ShardInfo>,
         shards_key_mapping: ShardKeyMapping,
     ) -> CollectionResult<()> {
-        let mut extra_shards: HashMap<ShardId, ShardReplicaSet> = HashMap::new();
+        let mut extra_shards: AHashMap<ShardId, ShardReplicaSet> = AHashMap::new();
 
         let shard_ids = shards.keys().copied().collect::<HashSet<_>>();
 

--- a/lib/collection/src/collection_state.rs
+++ b/lib/collection/src/collection_state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::collection::payload_index_schema::PayloadIndexSchema;
@@ -18,7 +19,7 @@ pub struct ShardInfo {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct State {
     pub config: CollectionConfigInternal,
-    pub shards: HashMap<ShardId, ShardInfo>,
+    pub shards: AHashMap<ShardId, ShardInfo>,
     pub resharding: Option<ReshardState>,
     #[serde(default)]
     pub transfers: HashSet<ShardTransfer>,

--- a/lib/collection/src/operations/mod.rs
+++ b/lib/collection/src/operations/mod.rs
@@ -22,8 +22,7 @@ pub mod query_enum {
     pub use shard::query::query_enum::QueryEnum;
 }
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use segment::types::ExtendedPointId;
 pub use shard::operations::*;
 
@@ -99,7 +98,7 @@ where
     I: IntoIterator<Item = O>,
     F: Fn(&O) -> ExtendedPointId,
 {
-    let mut op_vec_by_shard: HashMap<ShardId, Vec<O>> = HashMap::new();
+    let mut op_vec_by_shard: AHashMap<ShardId, Vec<O>> = AHashMap::new();
     for operation in iter {
         for shard_id in point_to_shards(&id_extractor(&operation), ring) {
             op_vec_by_shard

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use ahash::AHashMap;
 use api::rest::ShardKeySelector;
 use itertools::izip;
 use schemars::JsonSchema;
@@ -129,7 +130,7 @@ impl SplitByShard for ConditionalInsertOperationInternal {
 impl SplitByShard for BatchPersisted {
     fn split_by_shard(self, ring: &HashRingRouter) -> OperationToShard<Self> {
         let batch = self;
-        let mut batch_by_shard: HashMap<ShardId, BatchPersisted> = HashMap::new();
+        let mut batch_by_shard: AHashMap<ShardId, BatchPersisted> = AHashMap::new();
         let BatchPersisted {
             ids,
             vectors,

--- a/lib/collection/src/shards/collection_shard_distribution.rs
+++ b/lib/collection/src/shards/collection_shard_distribution.rs
@@ -1,11 +1,13 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+
+use ahash::AHashMap;
 
 use crate::collection_state::ShardInfo;
 use crate::shards::shard::{PeerId, ShardId};
 
 #[derive(Debug, Clone)]
 pub struct CollectionShardDistribution {
-    pub shards: HashMap<ShardId, HashSet<PeerId>>,
+    pub shards: AHashMap<ShardId, HashSet<PeerId>>,
 }
 
 impl CollectionShardDistribution {
@@ -17,7 +19,7 @@ impl CollectionShardDistribution {
         }
     }
 
-    pub fn from_shards_info(shards_info: HashMap<ShardId, ShardInfo>) -> Self {
+    pub fn from_shards_info(shards_info: AHashMap<ShardId, ShardInfo>) -> Self {
         Self {
             shards: shards_info
                 .into_iter()

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops;
 
+use ahash::AHashMap;
 use itertools::Itertools;
 use segment::types::ShardKey;
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,7 @@ impl ops::DerefMut for ShardKeyMapping {
 
 impl ShardKeyMapping {
     /// Get an inverse mapping, all shard IDs and their key
-    pub fn shard_id_to_shard_key(&self) -> HashMap<ShardId, ShardKey> {
+    pub fn shard_id_to_shard_key(&self) -> AHashMap<ShardId, ShardKey> {
         self.shard_key_to_shard_ids
             .iter()
             .flat_map(|(shard_key, shard_ids)| {

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -1,7 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use api::rest::OrderByInterface;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -68,7 +69,7 @@ async fn fixture() -> Collection {
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
 
     let collection_name = "test".to_string();
-    let shards: HashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
+    let shards: AHashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
         .map(|i| (i, HashSet::from([PEER_ID])))
         .collect();
 

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -1,7 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use rand::{Rng, rng};
@@ -66,7 +67,7 @@ async fn fixture() -> Collection {
     let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
 
     let collection_name = "test".to_string();
-    let shards: HashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
+    let shards: AHashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
         .map(|i| (i, HashSet::from([PEER_ID])))
         .collect();
 

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -1,7 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common::budget::ResourceBudget;
 use segment::types::Distance;
 use tempfile::Builder;
@@ -63,7 +64,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
 
     let collection_name = "test".to_string();
     let collection_name_rec = "test_rec".to_string();
-    let mut shards = HashMap::new();
+    let mut shards = AHashMap::new();
     shards.insert(0, HashSet::from([1]));
     shards.insert(1, HashSet::from([1]));
     shards.insert(2, HashSet::from([10_000])); // remote shard


### PR DESCRIPTION
We have good experiences using `AHash` for `u32` keys in terms of performance.

This PR applies the same migration to `HashMap<ShardId, _>`.

This change was prompted by seeing the standard hashing showing up in profiling when splitting operations by shards.