### PR TITLE
Fix flaky partial snapshot test

### DIFF
--- a/tests/consensus_tests/test_partial_snapshot.py
+++ b/tests/consensus_tests/test_partial_snapshot.py
@@ -259,6 +259,9 @@ def bootstrap_collection(peer_url, shards = 1, bootstrap_points = 0):
     if bootstrap_points > 0:
         upsert(peer_url, bootstrap_points)
 
+    # Don't let asynchronous optimizations mess with our tests
+    wait_collection_green(peer_url, COLLECTION)
+
 def recover_collection(peer_url: str, recover_from_url: str):
     snapshot_url = create_collection_snapshot(recover_from_url)
     recover_collection_snapshot(peer_url, snapshot_url)


### PR DESCRIPTION
Fixes:

```bash
================================================================= FAILURES =================================================================
_______________________________________________________ test_partial_snapshot_empty ________________________________________________________

    def test_partial_snapshot_empty(tmp_path: pathlib.Path):
        # ...

        # Ensure that both replicas are in sync (because of collection snapshot) and new partial snapshots are empty
        resp = create_partial_snapshot(write_peer, shard = 0, manifest = get_snapshot_manifest(read_peer))
>       assert resp.status_code == 304
E       assert 200 == 304
E        +  where 200 = <Response [200]>.status_code

tests/consensus_tests/test_partial_snapshot.py:143: AssertionError
========================================================= short test summary info ==========================================================
FAILED tests/consensus_tests/test_partial_snapshot.py::test_partial_snapshot_empty - assert 200 == 304
============================================================ 1 failed in 11.55s ============================================================
```

Adjust partial snapshot test bootstrapping to wait for a green collection status. This way we are sure there is no asynchronous optimization task messing with our tests.

Before this change, `pytest tests/consensus_tests/test_partial_snapshot.py::test_partial_snapshot_empty` reliably fails for me if I change the number of points to 10k [here](https://github.com/qdrant/qdrant/blob/c5f7385762350ee481c3e35c3ad85b51b1ff78cc/tests/consensus_tests/test_partial_snapshot.py#L135).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?