### PR TITLE
Broken async. flush for snapshot

### DIFF
--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -36,7 +36,7 @@ impl SnapshotEntry for Segment {
         log::debug!("Taking snapshot of segment {segment_id}");
 
         // force flush segment to capture latest state
-        self.flush(true, true)?;
+        self.flush(false, true)?;
 
         let include_files = match manifest {
             None => HashSet::new(),


### PR DESCRIPTION
```
cargo nextest run --workspace --profile ci --locked --no-default-features contin

   Starting 1 test across 24 binaries (1282 tests skipped)
  TRY 1 FAIL [   7.391s] collection::integration continuous_snapshot_test::test_continuous_snapshot
  stdout ───

    running 1 test
    test continuous_snapshot_test::test_continuous_snapshot ... FAILED

    failures:

    failures:
        continuous_snapshot_test::test_continuous_snapshot

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 40 filtered out; finished in 7.38s

  stderr ───

    thread 'continuous_snapshot_test::test_continuous_snapshot' panicked at lib/collection/tests/integration/continuous_snapshot_test.rs:254:31:
    snapshot_task error: Service internal error: failed to create snapshot: Service internal error: Applying function to a proxied shard segment 9470 failed: Service runtime error: failed to add id tracker file /tmp/test_collectioncCFcH5/0/segments/e2ce18e6-6af3-463c-8b66-a615f70fffa8/mutable_id_tracker.versions into snapshot: lseek(SEEK_DATA) went beyond the end of the file. Did the file change while appending?
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    [2025-10-10T09:31:51Z ERROR segment::segment::segment_ops] Segment "/tmp/test_collectioncCFcH5/0/segments/52ab61d7-87ba-48ca-99ab-c00a259baaf0" operation error: Service runtime error: failed to open file `/tmp/test_collectioncCFcH5/0/segments/52ab61d7-87ba-48ca-99ab-c00a259baaf0/vector_storage/vectors/chunk_0.tmp`: No such file or directory (os error 2)
    [2025-10-10T09:31:51Z ERROR collection::collection_manager::collection_updater] Update operation failed: Service internal error: failed to open file `/tmp/test_collectioncCFcH5/0/segments/52ab61d7-87ba-48ca-99ab-c00a259baaf0/vector_storage/vectors/chunk_0.tmp`: No such file or directory (os error 2)
    [2025-10-10T09:31:51Z ERROR collection::update_handler] Optimization error: Service internal error: No such file or directory (os error 2) at path "/tmp/test_collectioncCFcH5/0/temp_segments/segment_builder_a9At2K/.atomicwriteJhNr81"

    thread 'tokio-runtime-worker' panicked at lib/collection/src/update_handler.rs:456:41:
    Optimization error: Service internal error: No such file or directory (os error 2) at path "/tmp/test_collectioncCFcH5/0/temp_segments/segment_builder_a9At2K/.atomicwriteJhNr81"

   DELAY 2/2 by   2.000s collection::integration continuous_snapshot_test::test_continuous_snapshot
   RETRY 2/2 [         ] collection::integration continuous_snapshot_test::test_continuous_snapshot
  Cancelling due to interrupt: 1 test still running
   TRY 2 INT [   0.798s] collection::integration continuous_snapshot_test::test_continuous_snapshot
────────────
     Summary [  10.200s] 1 test run: 0 passed, 1 failed, 1282 skipped
error: test run failed
```