### PR TITLE
Issue #7379 Enhancing Timeout Configuration for High-Concurrency Local Deployments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -233,8 +233,11 @@ storage:
 
 service:
   # Optional: Connection keep-alive timeout in seconds.
-  # If not set, Actix/gRPC default (5 seconds) will be used.
-  # keep_alive_sec: 5
+  # If not set, Actix default (5 seconds) will be used.
+  # http_keep_alive_sec: 5
+  # If not set, gRPC default (20 seconds) will be used.
+  # grpc_keep_alive_interval_sec: 40
+  # grpc_keep_alive_timeout_sec: 20
   # Maximum size of POST data in a single request in megabytes
   max_request_size_mb: 32
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -175,7 +175,7 @@ pub fn init(
             app
         })
         .workers(max_web_workers(&settings));
-        if let Some(keep_alive) = settings.service.keep_alive_sec {
+        if let Some(keep_alive) = settings.service.http_keep_alive_sec {
             log::info!("Applying actix keep-alive interval: {keep_alive}s");
             server = server.keep_alive(Duration::from_secs(keep_alive));
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -44,8 +44,15 @@ pub struct ServiceConfig {
 
     #[serde(default)]
     #[validate(range(min = 1))]
-    pub keep_alive_sec: Option<u64>,
+    pub http_keep_alive_sec: Option<u64>,
 
+    #[serde(default)]
+    #[validate(range(min = 1))]
+    pub grpc_keep_alive_interval_sec: Option<u64>,
+
+    #[serde(default)]
+    #[validate(range(min = 1))]
+    pub grpc_keep_alive_timeout_sec: Option<u64>,
     /// Directory where static files are served from.
     /// For example, the Web-UI should be placed here.
     #[serde(default)]

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -185,12 +185,25 @@ pub fn init(
 
         let mut server = Server::builder();
 
-        if let Some(keep_alive) = settings.service.keep_alive_sec {
-            log::info!("Applying gRPC keep-alive interval: {keep_alive}s");
+        if let (Some(interval), Some(timeout)) = (
+            settings.service.grpc_keep_alive_interval_sec,
+            settings.service.grpc_keep_alive_timeout_sec,
+        ) {
+            log::info!("Applying gRPC keep-alive: interval = {interval}s, timeout = {timeout}s");
+
             server = server
-                .http2_keepalive_interval(Some(Duration::from_secs(keep_alive * 2)))
-                .http2_keepalive_timeout(Some(Duration::from_secs(keep_alive)));
+                .http2_keepalive_interval(Some(Duration::from_secs(interval)))
+                .http2_keepalive_timeout(Some(Duration::from_secs(timeout)));
+        } else if settings.service.grpc_keep_alive_interval_sec.is_some()
+            || settings.service.grpc_keep_alive_timeout_sec.is_some()
+        {
+            log::warn!(
+                "gRPC keep-alive is partially configured. \
+         Both grpc_keep_alive_interval_sec and grpc_keep_alive_timeout_sec must be set. \
+         Ignoring gRPC keep-alive configuration."
+            );
         }
+
         if settings.service.enable_tls {
             log::info!("TLS enabled for gRPC API (TTL not supported)");
 
@@ -309,13 +322,6 @@ pub fn init_internal(
                 // versus an internal error that is very hard to handle.
                 // More info: <https://github.com/qdrant/qdrant/issues/1907>
                 .http2_max_pending_accept_reset_streams(Some(1024));
-
-            if let Some(keep_alive) = settings.service.keep_alive_sec {
-                log::info!("Applying internal gRPC keep-alive interval: {keep_alive}s");
-                server = server
-                    .http2_keepalive_interval(Some(Duration::from_secs(keep_alive * 2)))
-                    .http2_keepalive_timeout(Some(Duration::from_secs(keep_alive)));
-            }
 
             if let Some(config) = tls_config {
                 log::info!("TLS enabled for internal gRPC API (TTL not supported)");


### PR DESCRIPTION
## Resolving #7379 

I ran qdrant in a docker container and benchmarked it by adding artificial latency for the container to reproduce the mentioned scenario.

These code changes make `keep alive time` and `request timeout` configurable.

After making the changes and increasing the values, I saw significant improvement while benchmarking.

