### PR TITLE
Use `fs_err::exists` and `fs_err::tokio::try_exists`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -56,7 +56,7 @@ disallowed-methods = [
   { path = "std::path::Path::read_dir", replacement = "fs_err::read_dir" },
   { path = "std::path::Path::read_link", replacement = "fs_err::read_link" },
   { path = "std::path::Path::symlink_metadata", replacement = "fs_err::symlink_metadata" },
-  { path = "std::path::Path::try_exists", replacement = "fs_err::PathExt::fs_err_try_exists" },
+  { path = "std::path::Path::try_exists", replacement = "fs_err::exists" },
   { path = "tokio::fs::File::create", replacement = "fs_err::tokio::File::create" },
   { path = "tokio::fs::File::create_new", replacement = "fs_err::tokio::File::create_new" },
   { path = "tokio::fs::File::from_std", replacement = "fs_err::tokio::File::from_std" },
@@ -89,8 +89,6 @@ disallowed-methods = [
   { path = "tokio::fs::symlink_dir", replacement = "fs_err::tokio::symlink_dir", allow-invalid = true },
   { path = "tokio::fs::symlink_file", replacement = "fs_err::tokio::symlink_file", allow-invalid = true },
   { path = "tokio::fs::symlink_metadata", replacement = "fs_err::tokio::symlink_metadata" },
+  { path = "tokio::fs::try_exists", replacement = "fs_err::tokio::try_exists" },
   { path = "tokio::fs::write", replacement = "fs_err::tokio::write" },
-
-  # The following is not yet available in fs_err
-  # { path = "tokio::fs::try_exists", replacement = "fs_err::tokio::try_exists" },
 ]

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -446,7 +446,7 @@ impl Collection {
 
                 let shard_flag = shard_initializing_flag_path(&collection_path, shard_id);
 
-                if tokio::fs::try_exists(&shard_flag).await.is_ok() {
+                if tokio_fs::try_exists(&shard_flag).await.is_ok() {
                     // We can delete initializing flag without waiting for transfer to finish
                     // because if transfer fails in between, Qdrant will retry it.
                     tokio_fs::remove_file(&shard_flag).await?;

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -635,7 +635,7 @@ impl ShardHolder {
             // Check if shard is fully initialized on disk
             // The initialization flag should be absent for a well-formed replica set
             let initializing_flag = shard_initializing_flag_path(collection_path, shard_id);
-            let is_dirty_shard = tokio::fs::try_exists(&initializing_flag)
+            let is_dirty_shard = tokio_fs::try_exists(&initializing_flag)
                 .await
                 .unwrap_or(false);
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -8,7 +8,6 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use fs_err as fs;
-use fs_err::PathExt;
 use io::storage_version::{StorageVersion as _, VERSION_FILE};
 use itertools::Itertools;
 use semver::Version;
@@ -117,7 +116,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             (config, inverted_index, indices_tracker)
         } else {
             Self::try_load(path).or_else(|e| {
-                if path.fs_err_try_exists().unwrap_or(true) {
+                if fs::exists(path).unwrap_or(true) {
                     log::warn!("Failed to load {path:?}, rebuilding: {e}");
 
                     // Drop index completely.


### PR DESCRIPTION
Followup for #7319.

[fs-err 3.13](https://github.com/andrewhickman/fs-err/blob/3758b0c2684d7d3939ab520e085e0097ad0c1ed5/CHANGELOG.md#313) added two new wrappers that previously were missing. This PR switches to them.