### PR TITLE
use mutex to ensure sequential segment flushed + await on drop

### DIFF
--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -611,6 +611,7 @@ fn create_segment(
         initial_version,
         version,
         persisted_version: Arc::new(Mutex::new(version)),
+        is_alive_flush_lock: Arc::new(Mutex::new(true)),
         current_path: segment_path.to_owned(),
         version_tracker: Default::default(),
         id_tracker,


### PR DESCRIPTION
Fixes

```
2025-10-17T11:12:20.503980Z ERROR collection::update_handler: Failed to flush: Service runtime error: Failed to flush id_tracker mapping: Service runtime error: IO Error: failed to open file `./storage/collections/benchmark/0/segments/1a570d1b-07c5-4c40-8adf-d7a8ada7030d/mutable_id_tracker.mappings`: No such file or directory (os error 2)
```

introduced in https://github.com/qdrant/qdrant/pull/7388
