### PR TITLE
feat(groups): add offset pagination to grouped queries (REST/gRPC/internal)

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14081,7 +14081,7 @@
           "offset": {
             "description": "Offset of the group to start returning results from. Default is 0.",
             "type": "integer",
-            "format": "uint32",
+            "format": "uint64",
             "minimum": 0,
             "default": 0
           }
@@ -14286,7 +14286,7 @@
           "offset": {
             "description": "Offset of the group to start returning results from. Default is 0.",
             "type": "integer",
-            "format": "uint32",
+            "format": "uint64",
             "minimum": 0,
             "default": 0
           }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14081,7 +14081,7 @@
           "offset": {
             "description": "Offset of the group to start returning results from. Default is 0.",
             "type": "integer",
-            "format": "uint64",
+            "format": "uint32",
             "minimum": 0,
             "default": 0
           }
@@ -14286,7 +14286,7 @@
           "offset": {
             "description": "Offset of the group to start returning results from. Default is 0.",
             "type": "integer",
-            "format": "uint64",
+            "format": "uint32",
             "minimum": 0,
             "default": 0
           }

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14077,6 +14077,13 @@
                 "nullable": true
               }
             ]
+          },
+          "offset": {
+            "description": "Offset of the group to start returning results from. Default is 0.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "default": 0
           }
         }
       },
@@ -14275,6 +14282,13 @@
                 "nullable": true
               }
             ]
+          },
+          "offset": {
+            "description": "Offset of the group to start returning results from. Default is 0.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "default": 0
           }
         }
       },
@@ -15690,6 +15704,14 @@
                 "nullable": true
               }
             ]
+          },
+          "offset": {
+            "description": "Offset of the group to start returning results from. Default is 0.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "default": 0,
+            "nullable": true
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2835,6 +2835,7 @@ impl TryFrom<SearchPointGroups> for rest::SearchGroupsRequestInternal {
             with_vectors,
             group_by,
             group_size,
+            offset,
             read_consistency,
             with_lookup,
             timeout,
@@ -2890,6 +2891,7 @@ impl TryFrom<SearchPointGroups> for rest::SearchGroupsRequestInternal {
                 group_by: json::json_path_from_proto(&group_by)?,
                 limit,
                 group_size,
+                offset,
                 with_lookup: with_lookup
                     .map(rest::WithLookupInterface::try_from)
                     .transpose()?,

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -381,7 +381,7 @@ message SearchPointGroups {
   optional uint64 timeout = 14; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 15; // Specify in which shards to look for the points, if not specified - look in all shards
   optional SparseIndices sparse_indices = 16;
-  optional uint64 offset = 17; // Offset of the first group to return
+  optional uint32 offset = 17; // Offset of the first group to return
 }
 
 enum Direction {
@@ -490,7 +490,7 @@ message RecommendPointGroups {
   repeated Vector negative_vectors = 19; // Try to avoid vectors like this
   optional uint64 timeout = 20; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 21; // Specify in which shards to look for the points, if not specified - look in all shards
-  optional uint64 offset = 22; // Offset of the first group to return
+  optional uint32 offset = 22; // Offset of the first group to return
 }
 
 message TargetVector {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -381,6 +381,7 @@ message SearchPointGroups {
   optional uint64 timeout = 14; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 15; // Specify in which shards to look for the points, if not specified - look in all shards
   optional SparseIndices sparse_indices = 16;
+  optional uint32 offset = 17; // Offset of the first group to return
 }
 
 enum Direction {
@@ -489,6 +490,7 @@ message RecommendPointGroups {
   repeated Vector negative_vectors = 19; // Try to avoid vectors like this
   optional uint64 timeout = 20; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 21; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional uint32 offset = 22; // Offset of the first group to return
 }
 
 message TargetVector {
@@ -743,6 +745,7 @@ message QueryPointGroups {
   optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
   optional uint64 timeout = 16; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 17; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional uint64 offset = 18; // Offset of the first group to return
 }
 
 message FacetCounts {

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -381,7 +381,7 @@ message SearchPointGroups {
   optional uint64 timeout = 14; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 15; // Specify in which shards to look for the points, if not specified - look in all shards
   optional SparseIndices sparse_indices = 16;
-  optional uint32 offset = 17; // Offset of the first group to return
+  optional uint64 offset = 17; // Offset of the first group to return
 }
 
 enum Direction {
@@ -490,7 +490,7 @@ message RecommendPointGroups {
   repeated Vector negative_vectors = 19; // Try to avoid vectors like this
   optional uint64 timeout = 20; // If set, overrides global timeout setting for this request. Unit is seconds.
   optional ShardKeySelector shard_key_selector = 21; // Specify in which shards to look for the points, if not specified - look in all shards
-  optional uint32 offset = 22; // Offset of the first group to return
+  optional uint64 offset = 22; // Offset of the first group to return
 }
 
 message TargetVector {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5023,8 +5023,8 @@ pub struct SearchPointGroups {
     #[prost(message, optional, tag = "16")]
     pub sparse_indices: ::core::option::Option<SparseIndices>,
     /// Offset of the first group to return
-    #[prost(uint64, optional, tag = "17")]
-    pub offset: ::core::option::Option<u64>,
+    #[prost(uint32, optional, tag = "17")]
+    pub offset: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -5287,8 +5287,8 @@ pub struct RecommendPointGroups {
     #[prost(message, optional, tag = "21")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// Offset of the first group to return
-    #[prost(uint64, optional, tag = "22")]
-    pub offset: ::core::option::Option<u64>,
+    #[prost(uint32, optional, tag = "22")]
+    pub offset: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5023,8 +5023,8 @@ pub struct SearchPointGroups {
     #[prost(message, optional, tag = "16")]
     pub sparse_indices: ::core::option::Option<SparseIndices>,
     /// Offset of the first group to return
-    #[prost(uint32, optional, tag = "17")]
-    pub offset: ::core::option::Option<u32>,
+    #[prost(uint64, optional, tag = "17")]
+    pub offset: ::core::option::Option<u64>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -5287,8 +5287,8 @@ pub struct RecommendPointGroups {
     #[prost(message, optional, tag = "21")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     /// Offset of the first group to return
-    #[prost(uint32, optional, tag = "22")]
-    pub offset: ::core::option::Option<u32>,
+    #[prost(uint64, optional, tag = "22")]
+    pub offset: ::core::option::Option<u64>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5022,6 +5022,9 @@ pub struct SearchPointGroups {
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
     #[prost(message, optional, tag = "16")]
     pub sparse_indices: ::core::option::Option<SparseIndices>,
+    /// Offset of the first group to return
+    #[prost(uint32, optional, tag = "17")]
+    pub offset: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -5283,6 +5286,9 @@ pub struct RecommendPointGroups {
     /// Specify in which shards to look for the points, if not specified - look in all shards
     #[prost(message, optional, tag = "21")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    /// Offset of the first group to return
+    #[prost(uint32, optional, tag = "22")]
+    pub offset: ::core::option::Option<u32>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -5935,6 +5941,9 @@ pub struct QueryPointGroups {
     /// Specify in which shards to look for the points, if not specified - look in all shards
     #[prost(message, optional, tag = "17")]
     pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    /// Offset of the first group to return
+    #[prost(uint64, optional, tag = "18")]
+    pub offset: ::core::option::Option<u64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1062,7 +1062,7 @@ pub struct LookupLocation {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn default_group_offset_u32() -> Option<u32> {
+fn default_group_offset_u64() -> Option<u64> {
     Some(0)
 }
 
@@ -1088,9 +1088,9 @@ pub struct BaseGroupRequest {
     pub limit: u32,
 
     /// Offset of the group to start returning results from.
-    #[serde(default = "default_group_offset_u32")]
-    #[schemars(default = "default_group_offset_u32")]
-    pub offset: Option<u32>,
+    #[serde(default = "default_group_offset_u64")]
+    #[schemars(default = "default_group_offset_u64")]
+    pub offset: Option<u64>,
 
     /// Look for points in another collection using the group ids
     pub with_lookup: Option<WithLookupInterface>,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1061,10 +1061,12 @@ pub struct LookupLocation {
     pub shard_key: Option<ShardKeySelector>,
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn default_group_offset_u32() -> Option<u32> {
     Some(0)
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn default_group_offset_usize() -> Option<usize> {
     Some(0)
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1062,7 +1062,7 @@ pub struct LookupLocation {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn default_group_offset_u64() -> Option<u64> {
+fn default_group_offset_u32() -> Option<u32> {
     Some(0)
 }
 
@@ -1088,9 +1088,9 @@ pub struct BaseGroupRequest {
     pub limit: u32,
 
     /// Offset of the group to start returning results from.
-    #[serde(default = "default_group_offset_u64")]
-    #[schemars(default = "default_group_offset_u64")]
-    pub offset: Option<u64>,
+    #[serde(default = "default_group_offset_u32")]
+    #[schemars(default = "default_group_offset_u32")]
+    pub offset: Option<u32>,
 
     /// Look for points in another collection using the group ids
     pub with_lookup: Option<WithLookupInterface>,

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1061,6 +1061,14 @@ pub struct LookupLocation {
     pub shard_key: Option<ShardKeySelector>,
 }
 
+fn default_group_offset_u32() -> Option<u32> {
+    Some(0)
+}
+
+fn default_group_offset_usize() -> Option<usize> {
+    Some(0)
+}
+
 #[derive(Validate, Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct BaseGroupRequest {
     /// Payload field to group by, must be a string or number field.
@@ -1076,6 +1084,11 @@ pub struct BaseGroupRequest {
     /// Maximum amount of groups to return
     #[validate(range(min = 1))]
     pub limit: u32,
+
+    /// Offset of the group to start returning results from.
+    #[serde(default = "default_group_offset_u32")]
+    #[schemars(default = "default_group_offset_u32")]
+    pub offset: Option<u32>,
 
     /// Look for points in another collection using the group ids
     pub with_lookup: Option<WithLookupInterface>,
@@ -1163,6 +1176,12 @@ pub struct QueryBaseGroupRequest {
     /// Maximum amount of groups to return. Default is 10.
     #[validate(range(min = 1))]
     pub limit: Option<usize>,
+
+    /// Offset of the group to start returning results from. Default is 0.
+    #[validate(range(min = 0))]
+    #[serde(default = "default_group_offset_usize")]
+    #[schemars(default = "default_group_offset_usize")]
+    pub offset: Option<usize>,
 
     /// Look for points in another collection using the group ids
     pub with_lookup: Option<WithLookupInterface>,

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -55,6 +55,9 @@ pub struct QueryGroupRequest {
 
     /// Limit of groups to return
     pub groups: usize,
+
+    /// Offset of groups to skip
+    pub offset: usize,
 }
 
 #[cfg(test)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1313,6 +1313,7 @@ impl TryFrom<api::grpc::qdrant::RecommendPointGroups> for RecommendGroupsRequest
                 group_by: json_path_from_proto(&value.group_by)?,
                 limit: value.limit,
                 group_size: value.group_size,
+                offset: value.offset,
                 with_lookup: value.with_lookup.map(|l| l.try_into()).transpose()?,
             },
         })

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -81,6 +81,7 @@ pub struct CollectionQueryGroupsRequest {
     pub group_by: JsonPath,
     pub group_size: usize,
     pub limit: usize,
+    pub offset: usize,
     pub with_lookup: Option<WithLookup>,
 }
 

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -266,7 +266,7 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit * self.group_size)
+        Some((self.limit + self.offset) * self.group_size)
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/tests/sparse_vectors_validation_tests.rs
+++ b/lib/collection/src/tests/sparse_vectors_validation_tests.rs
@@ -100,6 +100,7 @@ fn validate_error_sparse_vector_search_groups_request_internal() {
             group_by: "sparse".parse().unwrap(),
             group_size: 5,
             limit: 5,
+            offset: None,
             with_lookup: None,
         },
     });

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -944,6 +944,7 @@ mod tests_ops {
             group_by: "path".parse().unwrap(),
             group_size: 100,
             limit: 100,
+            offset: 0,
             with_lookup: Some(WithLookup {
                 collection_name: "col2".to_string(),
                 with_payload: Some(WithPayloadInterface::Bool(true)),

--- a/src/common/inference/batch_processing.rs
+++ b/src/common/inference/batch_processing.rs
@@ -350,6 +350,7 @@ mod tests {
                 group_by: "test".parse().unwrap(),
                 group_size: None,
                 limit: None,
+                offset: None,
                 with_lookup: None,
             },
         };

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -42,6 +42,7 @@ pub async fn convert_query_point_groups_from_grpc(
         limit,
         group_size,
         group_by,
+        offset,
         with_lookup,
         read_consistency: _,
         timeout: _,
@@ -97,6 +98,9 @@ pub async fn convert_query_point_groups_from_grpc(
         limit: limit
             .map(|l| l as usize)
             .unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
+        offset: offset
+            .map(|o| o as usize)
+            .unwrap_or(CollectionQueryRequest::DEFAULT_OFFSET),
         params: params.map(From::from),
         with_lookup: with_lookup.map(TryFrom::try_from).transpose()?,
     };

--- a/src/common/inference/query_requests_rest.rs
+++ b/src/common/inference/query_requests_rest.rs
@@ -78,6 +78,9 @@ pub async fn convert_query_groups_request_from_rest(
         limit: group_request
             .limit
             .unwrap_or(CollectionQueryRequest::DEFAULT_LIMIT),
+        offset: group_request
+            .offset
+            .unwrap_or(CollectionQueryRequest::DEFAULT_OFFSET),
         group_by: group_request.group_by,
         group_size: group_request
             .group_size


### PR DESCRIPTION
Introduce offset for grouped queries to enable forward pagination over groups.

Default offset to 0. Propagate through REST, gRPC, and internal execution.

Apply offset after establishing a deterministic global order of groups to prevent overlap/flakiness.
Ordering tuple: (score DESC, group_id ASC, best_point_id ASC[, shard_id ASC]).

Compute enough candidates to cover the requested window (offset + limit groups).
If the implementation gathers point candidates as an intermediate step, clarify: “internally we fetch up to (offset + limit) * group_size points before grouping.”

Extend tests and conversions to carry offset through REST/gRPC paths.

Fixes #7117.

API / Schema:

REST: add optional offset to QueryBaseGroupRequest / BaseGroupRequest (default 0).

gRPC: add offset to corresponding messages.

Backward-compatible: omitting offset keeps prior behavior.