### PR TITLE
rollback pyvector implementation

### DIFF
--- a/lib/edge/python/examples/qdrant-edge.py
+++ b/lib/edge/python/examples/qdrant-edge.py
@@ -75,6 +75,21 @@ shard.update(UpdateOperation.upsert_points([
     ),
 ]))
 
+print("---- Some other points ----")
+
+some_other_points = [
+    Point(10, [[1,2,3], [3, 4, 5]], {}),
+    Point(11, {
+        "sparse": SparseVector(indices=[0, 2], values=[1.0, 3.0])
+    }, {}),
+]
+
+
+# Test points conversion into internal representation and back
+for point in some_other_points:
+    print(f"Point: {point.id}, vector: {point.vector}, payload: {point.payload}")
+
+
 print("---- Search ----")
 
 points = shard.search(SearchRequest(

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -28,9 +28,9 @@ mod qdrant_edge {
     #[pymodule_export]
     use super::search::{PyScoredPoint, PySearchParams, PySearchRequest};
     #[pymodule_export]
-    use super::types::{PyRecord, PySparseVector};
+    use super::types::{PyPoint, PyRecord, PySparseVector};
     #[pymodule_export]
-    use super::update::{PyPoint, PyUpdateOperation};
+    use super::update::PyUpdateOperation;
 }
 
 #[pyclass(name = "Shard")]

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -5,9 +5,8 @@ use pyo3::IntoPyObjectExt as _;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use segment::data_types::vectors::NamedQuery;
-use segment::types::*;
 use shard::query::query_enum::QueryEnum;
-use shard::search::*;
+use shard::search::CoreSearchRequest;
 
 use crate::*;
 
@@ -223,8 +222,8 @@ impl PyScoredPoint {
     }
 
     #[getter]
-    pub fn vector(&self) -> Option<&PyVectorInternal> {
-        self.0.vector.as_ref().map(PyVectorInternal::from_ref)
+    pub fn vector(&self) -> Option<PyVector> {
+        self.0.vector.clone().map(PyVector::from)
     }
 
     #[getter]

--- a/lib/edge/python/src/types/mod.rs
+++ b/lib/edge/python/src/types/mod.rs
@@ -1,9 +1,11 @@
 pub mod payload;
+pub mod point;
 pub mod point_id;
 pub mod record;
 pub mod vector;
 
 pub use payload::*;
+pub use point::*;
 pub use point_id::*;
 pub use record::*;
 pub use vector::*;

--- a/lib/edge/python/src/types/point.rs
+++ b/lib/edge/python/src/types/point.rs
@@ -1,0 +1,39 @@
+use derive_more::Into;
+use pyo3::prelude::*;
+use segment::types::{Payload, PointIdType};
+use shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
+
+use crate::{PyPayload, PyPointId, PyVector};
+
+#[pyclass(name = "Point")]
+#[derive(Clone, Debug, Into)]
+pub struct PyPoint(PointStructPersisted);
+
+#[pymethods]
+impl PyPoint {
+    #[new]
+    pub fn new(id: PyPointId, vector: PyVector, payload: Option<PyPayload>) -> Result<Self, PyErr> {
+        let point = PointStructPersisted {
+            id: PointIdType::from(id),
+            vector: VectorStructPersisted::from(vector),
+            payload: payload.map(Payload::from),
+        };
+
+        Ok(Self(point))
+    }
+
+    #[getter]
+    pub fn id(&self) -> PyPointId {
+        PyPointId(self.0.id)
+    }
+
+    #[getter]
+    pub fn vector(&self) -> PyVector {
+        PyVector::from(self.0.vector.clone())
+    }
+
+    #[getter]
+    pub fn payload(&self) -> Option<&PyPayload> {
+        self.0.payload.as_ref().map(PyPayload::from_ref)
+    }
+}

--- a/lib/edge/python/src/types/record.rs
+++ b/lib/edge/python/src/types/record.rs
@@ -27,8 +27,8 @@ impl PyRecord {
     }
 
     #[getter]
-    pub fn vector(&self) -> Option<&PyVectorInternal> {
-        self.0.vector.as_ref().map(PyVectorInternal::from_ref)
+    pub fn vector(&self) -> Option<PyVector> {
+        self.0.vector.clone().map(PyVector::from)
     }
 
     #[getter]

--- a/lib/edge/python/src/types/vector.rs
+++ b/lib/edge/python/src/types/vector.rs
@@ -1,84 +1,32 @@
 use std::collections::HashMap;
-use std::mem;
 
 use derive_more::Into;
-use pyo3::IntoPyObjectExt as _;
-use pyo3::prelude::*;
-use segment::data_types::vectors::{DenseVector, VectorStructInternal};
+use pyo3::{FromPyObject, IntoPyObject, PyResult, pyclass, pymethods};
+use segment::data_types::vectors::{DenseVector, VectorInternal, VectorStructInternal};
 use segment::types::VectorNameBuf;
 use shard::operations::point_ops::{VectorPersisted, VectorStructPersisted};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::{DimId, DimWeight};
 
-#[derive(Clone, Debug, Into)]
-pub struct PyVector(VectorStructPersisted);
-
-impl<'py> FromPyObject<'py> for PyVector {
-    fn extract_bound(vector: &Bound<'py, PyAny>) -> PyResult<Self> {
-        #[derive(FromPyObject)]
-        enum Helper {
-            Single(DenseVector),
-            Multi(Vec<DenseVector>),
-            Named(HashMap<VectorNameBuf, PyNamedVector>),
-        }
-
-        let vector = match vector.extract()? {
-            Helper::Single(single) => VectorStructPersisted::Single(single),
-            Helper::Multi(multi) => VectorStructPersisted::MultiDense(multi),
-            Helper::Named(named) => {
-                let named = PyNamedVector::into_rust_map(named);
-                VectorStructPersisted::Named(named)
-            }
-        };
-
-        Ok(Self(vector))
-    }
+#[derive(Clone, Debug, IntoPyObject, FromPyObject)]
+pub enum PyVector {
+    // Put Int first so ints don't get parsed as floats (since f64 can extract from ints).
+    Single(DenseVector),
+    MultiDense(Vec<DenseVector>),
+    Named(HashMap<VectorNameBuf, PyVectorType>),
 }
 
-#[derive(Clone, Debug, Into)]
-#[repr(transparent)]
-struct PyNamedVector(VectorPersisted);
-
-impl PyNamedVector {
-    pub fn into_rust_map(
-        vectors: HashMap<VectorNameBuf, Self>,
-    ) -> HashMap<VectorNameBuf, VectorPersisted> {
-        unsafe { mem::transmute(vectors) }
-    }
-}
-
-impl<'py> FromPyObject<'py> for PyNamedVector {
-    fn extract_bound(vector: &Bound<'py, PyAny>) -> PyResult<Self> {
-        #[derive(FromPyObject)]
-        enum Helper {
-            Dense(DenseVector),
-            MultiDense(Vec<DenseVector>),
-            Sparse(PySparseVector),
-        }
-
-        let vector = match vector.extract()? {
-            Helper::Dense(dense) => VectorPersisted::Dense(dense),
-            Helper::MultiDense(multi) => VectorPersisted::MultiDense(multi),
-            Helper::Sparse(sparse) => {
-                let sparse = PySparseVector::into_rust(sparse);
-                VectorPersisted::Sparse(sparse)
-            }
-        };
-
-        Ok(Self(vector))
-    }
+#[derive(Clone, Debug, IntoPyObject, FromPyObject)]
+pub enum PyVectorType {
+    // Put Int first so ints don't get parsed as floats (since f64 can extract from ints).
+    Dense(DenseVector),
+    MultiDense(Vec<DenseVector>),
+    Sparse(PySparseVector),
 }
 
 #[pyclass(name = "SparseVector")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PySparseVector(SparseVector);
-
-impl PySparseVector {
-    pub fn into_rust(self) -> SparseVector {
-        unsafe { mem::transmute(self) }
-    }
-}
 
 #[pymethods]
 impl PySparseVector {
@@ -89,45 +37,97 @@ impl PySparseVector {
 
     #[getter]
     pub fn indices(&self) -> &[DimId] {
-        &self.0.indices
+        self.0.indices.as_slice()
     }
 
     #[getter]
     pub fn values(&self) -> &[DimWeight] {
-        &self.0.values
+        self.0.values.as_slice()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "SparseVector(indices={:?}, values={:?})",
+            self.indices(),
+            self.values()
+        ))
     }
 }
 
-#[derive(Clone, Debug, Into)]
-#[repr(transparent)]
-pub struct PyVectorInternal(pub VectorStructInternal);
-
-impl PyVectorInternal {
-    pub fn from_ref(vector: &VectorStructInternal) -> &Self {
-        unsafe { mem::transmute(vector) }
+impl From<VectorStructPersisted> for PyVector {
+    fn from(value: VectorStructPersisted) -> Self {
+        match value {
+            VectorStructPersisted::Single(dense) => PyVector::Single(dense),
+            VectorStructPersisted::MultiDense(multi) => PyVector::MultiDense(multi),
+            VectorStructPersisted::Named(named) => PyVector::Named(
+                named
+                    .into_iter()
+                    .map(|(k, v)| (k, PyVectorType::from(v)))
+                    .collect::<HashMap<_, _>>(),
+            ),
+        }
     }
 }
 
-impl<'py> IntoPyObject<'py> for PyVectorInternal {
-    type Target = PyAny;
-    type Output = Bound<'py, Self::Target>;
-    type Error = PyErr; // Infallible
-
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        IntoPyObject::into_pyobject(&self, py)
+impl From<VectorPersisted> for PyVectorType {
+    fn from(value: VectorPersisted) -> Self {
+        match value {
+            VectorPersisted::Dense(dense) => PyVectorType::Dense(dense),
+            VectorPersisted::MultiDense(multi) => PyVectorType::MultiDense(multi),
+            VectorPersisted::Sparse(sparse) => PyVectorType::Sparse(PySparseVector(sparse)),
+        }
     }
 }
 
-impl<'py> IntoPyObject<'py> for &PyVectorInternal {
-    type Target = PyAny;
-    type Output = Bound<'py, Self::Target>;
-    type Error = PyErr; // Infallible
+impl From<PyVector> for VectorStructPersisted {
+    fn from(value: PyVector) -> Self {
+        match value {
+            PyVector::Single(dense) => VectorStructPersisted::Single(dense),
+            PyVector::MultiDense(multi) => VectorStructPersisted::MultiDense(multi),
+            PyVector::Named(named) => VectorStructPersisted::Named(
+                named
+                    .into_iter()
+                    .map(|(k, v)| (k, VectorPersisted::from(v)))
+                    .collect::<HashMap<_, _>>(),
+            ),
+        }
+    }
+}
+impl From<PyVectorType> for VectorPersisted {
+    fn from(value: PyVectorType) -> Self {
+        match value {
+            PyVectorType::Dense(dense) => VectorPersisted::Dense(dense),
+            PyVectorType::MultiDense(multi) => VectorPersisted::MultiDense(multi),
+            PyVectorType::Sparse(sparse) => VectorPersisted::Sparse(sparse.0),
+        }
+    }
+}
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        match &self.0 {
-            VectorStructInternal::Single(single) => single.into_bound_py_any(py),
-            VectorStructInternal::MultiDense(_multi) => todo!(),
-            VectorStructInternal::Named(_named) => todo!(),
+impl From<VectorStructInternal> for PyVector {
+    fn from(value: VectorStructInternal) -> Self {
+        match value {
+            VectorStructInternal::Single(dense) => PyVector::Single(dense),
+            VectorStructInternal::MultiDense(multi) => {
+                PyVector::MultiDense(multi.into_multi_vectors())
+            }
+            VectorStructInternal::Named(named) => PyVector::Named(
+                named
+                    .into_iter()
+                    .map(|(k, v)| (k, PyVectorType::from(v)))
+                    .collect::<HashMap<_, _>>(),
+            ),
+        }
+    }
+}
+
+impl From<VectorInternal> for PyVectorType {
+    fn from(value: VectorInternal) -> Self {
+        match value {
+            VectorInternal::Dense(dense) => PyVectorType::Dense(dense),
+            VectorInternal::MultiDense(multi) => {
+                PyVectorType::MultiDense(multi.into_multi_vectors())
+            }
+            VectorInternal::Sparse(sparse) => PyVectorType::Sparse(PySparseVector(sparse)),
         }
     }
 }

--- a/lib/edge/python/src/update.rs
+++ b/lib/edge/python/src/update.rs
@@ -23,21 +23,3 @@ impl PyUpdateOperation {
         Self(operation)
     }
 }
-
-#[pyclass(name = "Point")]
-#[derive(Clone, Debug, Into)]
-pub struct PyPoint(PointStructPersisted);
-
-#[pymethods]
-impl PyPoint {
-    #[new]
-    pub fn new(id: PyPointId, vector: PyVector, payload: Option<PyPayload>) -> Result<Self, PyErr> {
-        let point = PointStructPersisted {
-            id: PointIdType::from(id),
-            vector: VectorStructPersisted::from(vector),
-            payload: payload.map(Payload::from),
-        };
-
-        Ok(Self(point))
-    }
-}


### PR DESCRIPTION
Current version of `PyVector` didn't have `into_pyobject` for multivecotr and named vectors implemented.

After few attempts to implement those missing implementations I gave up.

I am falling back to previously discarded implementation from https://github.com/qdrant/qdrant/pull/7376 which had all options implemented, even assuming it have slight performance suboptimality.

FYI @ffuugoo, I am going to merge this without a review, as it is blocking progress on update operations and I would like to close this topic to not spend any more time on it.