### PR TITLE
Fix shard snapshots IO error, proxy first then flush

### DIFF
--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -272,8 +272,6 @@ where
 {
     let segments_lock = segments.upgradable_read();
 
-    segments_lock.flush_all(true, true)?;
-
     // Proxy all segments
     log::trace!("Proxying all shard segments to apply function");
     let (mut proxies, tmp_segment_id, mut segments_lock) = SegmentHolder::proxy_all_segments(
@@ -282,6 +280,9 @@ where
         segment_config,
         payload_index_schema,
     )?;
+
+    // Flush all pending changes of each segment, now wrapped segments won't change anymore
+    segments_lock.flush_all(true, true)?;
 
     // Apply provided function
     log::trace!("Applying function on all proxied shard segments");


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/7404>

When taking a shard snapshot, we proxy all segments and flush them.

It is important that we proxy first, and then flush. Proxying ensures that the segments won't change anymore. After that we can flush the last changes that were still pending.

If we do it the other way around, new changes might land in the segments after flush but before we proxy them. The background flush task might trigger another flush during the snapshot process, which conflicts on file IO.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?