### PR TITLE
rate limit slow request warning queue

### DIFF
--- a/lib/collection/src/profiling/slow_requests_collector.rs
+++ b/lib/collection/src/profiling/slow_requests_collector.rs
@@ -79,17 +79,14 @@ impl RequestsCollector {
                 .unwrap_or_else(|_| 0);
 
             // Atomically update if enough time has passed
-            let updated = LAST_SEND_WARN.fetch_update(
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-                |prev| {
+            let updated =
+                LAST_SEND_WARN.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
                     if now.saturating_sub(prev) >= WARN_INTERVAL_SECS {
                         Some(now)
                     } else {
                         None
                     }
-                }
-            );
+                });
 
             if updated.is_err() {
                 return;


### PR DESCRIPTION
I wasn't able to reproduce it even under 512 parallel search threads, but some users reported this message being spammy