### PR TITLE
Improve segment ordering in segment holder

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -402,6 +402,10 @@ pub enum SegmentFlushOrdering {
 }
 
 impl SegmentFlushOrdering {
+    pub fn is_appendable(self) -> bool {
+        matches!(self, SegmentFlushOrdering::Appendable)
+    }
+
     pub fn proxy(self) -> Self {
         match self {
             SegmentFlushOrdering::Appendable => SegmentFlushOrdering::ProxyWithAppendable,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -90,11 +90,18 @@ pub type LockedSegmentHolder = Arc<RwLock<SegmentHolder>>;
 impl SegmentHolder {
     /// Iterate over all segments with their IDs
     ///
-    /// Appendable first, then non-appendable.
+    /// Ordered by flush ordering, then by segment ID.
     pub fn iter(&self) -> impl Iterator<Item = (&SegmentId, &LockedSegment)> {
         self.segments
             .iter()
             .map(|(_, segment_id, segment)| (segment_id, segment))
+    }
+
+    /// Iterate over all segment IDs
+    ///
+    /// Ordered by flush ordering, then by segment ID.
+    pub fn iter_ids(&self) -> impl Iterator<Item = SegmentId> {
+        self.segments.iter().map(|(_, segment_id, _)| *segment_id)
     }
 
     pub fn len(&self) -> usize {
@@ -353,11 +360,11 @@ impl SegmentHolder {
             .fetch_max(op_num, Ordering::Relaxed);
     }
 
+    /// All segment IDs
+    ///
+    /// Ordered by flush ordering, then by segment ID.
     pub fn segment_ids(&self) -> Vec<SegmentId> {
-        self.segments
-            .iter()
-            .map(|(_, segment_id, _)| *segment_id)
-            .collect()
+        self.iter_ids().collect()
     }
 
     /// Get a random appendable segment

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -179,6 +179,17 @@ impl SegmentHolder {
     }
 
     pub fn remove(&mut self, remove_ids: &[SegmentId]) -> Vec<LockedSegment> {
+        // Removing a single ID is common enough to have a special optimized case for it
+        if remove_ids.len() == 1 {
+            return self
+                .segments
+                .iter()
+                .position(|(_, segment_id, _)| *segment_id == remove_ids[0])
+                .map(|index| self.segments.remove(index).2)
+                .into_iter()
+                .collect();
+        }
+
         self.segments
             .extract_if(.., |(_, segment_id, _)| remove_ids.contains(segment_id))
             .map(|(_, _, segment)| segment)

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -55,18 +55,7 @@ impl SegmentHolder {
         )?;
 
         // List all segments we want to snapshot
-        let mut segment_ids = segments_lock.segment_ids();
-
-        // Re-sort segments for flush ordering, required to guarantee data consistency
-        // TODO: sort in a better place to not lock each segment
-        segment_ids.sort_by_cached_key(|segment_id| {
-            segments_lock
-                .get(*segment_id)
-                .unwrap()
-                .get()
-                .read()
-                .flush_ordering()
-        });
+        let segment_ids = segments_lock.segment_ids();
 
         // Create proxy for all segments
         let mut new_proxies = Vec::with_capacity(segment_ids.len());


### PR DESCRIPTION
Improves <https://github.com/qdrant/qdrant/pull/7381>, as per <https://github.com/qdrant/qdrant/pull/7381#discussion_r2435767399>

Rework the segment holder and use a single list of segments. The segments are sorted by flush ordering, then by segment ID. Ordering is guaranteed to be maintained.

This unifies ordering of segments across our code base, and removes some sorts that now became unnecessary.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
