### PR TITLE
Draft: flush segments in two stages

### DIFF
--- a/lib/collection/src/shards/local_shard/testing.rs
+++ b/lib/collection/src/shards/local_shard/testing.rs
@@ -12,7 +12,7 @@ impl LocalShard {
                 LockedSegment::Original(raw_segment_lock) => {
                     let raw_segment = raw_segment_lock.read();
 
-                    raw_segment.id_tracker.borrow().mapping_flusher()().unwrap();
+                    raw_segment.id_tracker.borrow().flush_mappings().unwrap();
                 }
                 LockedSegment::Proxy(_) => {} // Skipping
             }

--- a/lib/gridstore/benches/bustle_bench/payload_storage.rs
+++ b/lib/gridstore/benches/bustle_bench/payload_storage.rs
@@ -59,7 +59,6 @@ impl SequentialCollectionHandle for PayloadStorage {
     }
 
     fn flush(&self) -> bool {
-        let (stage_1_flusher, stage_2_flusher) = self.flusher();
-        stage_1_flusher().is_ok() && stage_2_flusher().is_ok()
+        self.flush_all().is_ok()
     }
 }

--- a/lib/gridstore/benches/bustle_bench/payload_storage.rs
+++ b/lib/gridstore/benches/bustle_bench/payload_storage.rs
@@ -59,6 +59,7 @@ impl SequentialCollectionHandle for PayloadStorage {
     }
 
     fn flush(&self) -> bool {
-        self.flusher()().is_ok()
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        stage_1_flusher().is_ok() && stage_2_flusher().is_ok()
     }
 }

--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -37,7 +37,7 @@ pub fn flush_bench(c: &mut Criterion) {
                     // Benchmark the flush operation after accumulating updates
                     let instant = Instant::now();
 
-                    storage.flusher()().unwrap();
+                    storage.flush().unwrap();
 
                     total_elapsed += instant.elapsed();
                 }
@@ -76,7 +76,7 @@ pub fn flush_bench(c: &mut Criterion) {
                     // Benchmark the flush operation after accumulating updates
                     let instant = Instant::now();
 
-                    storage.flusher()().unwrap();
+                    storage.flush().unwrap();
 
                     total_elapsed += instant.elapsed();
                 }

--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -37,7 +37,7 @@ pub fn flush_bench(c: &mut Criterion) {
                     // Benchmark the flush operation after accumulating updates
                     let instant = Instant::now();
 
-                    storage.flush().unwrap();
+                    storage.flush_all().unwrap();
 
                     total_elapsed += instant.elapsed();
                 }
@@ -76,7 +76,7 @@ pub fn flush_bench(c: &mut Criterion) {
                     // Benchmark the flush operation after accumulating updates
                     let instant = Instant::now();
 
-                    storage.flush().unwrap();
+                    storage.flush_all().unwrap();
 
                     total_elapsed += instant.elapsed();
                 }

--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -66,12 +66,12 @@ pub fn real_data_data_bench(c: &mut Criterion) {
 
     // insert data once & flush
     append_csv_data(&mut storage, &csv_path);
-    storage.flush().unwrap();
+    storage.flush_all().unwrap();
 
     assert_eq!(storage.max_point_id(), expected_point_count);
 
     // flush to get a consistent bitmask
-    storage.flush().unwrap();
+    storage.flush_all().unwrap();
 
     // sanity check of storage size
     let storage_size = storage.get_storage_size_bytes();
@@ -98,7 +98,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     // append the same data again to increase storage size
     for _ in 0..10 {
         append_csv_data(&mut storage, &csv_path);
-        storage.flush().unwrap();
+        storage.flush_all().unwrap();
     }
 
     let inflated_storage_size = storage.get_storage_size_bytes();
@@ -117,7 +117,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     }
 
     // flush to get a consistent bitmask
-    storage.flush().unwrap();
+    storage.flush_all().unwrap();
 
     c.bench_function("compute storage size (large sparse)", |b| {
         b.iter(|| black_box(storage.get_storage_size_bytes()));
@@ -128,7 +128,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
             append_csv_data(&mut storage, &csv_path);
             // do not always flush to build up pending updates
             if rng.random_bool(0.3) {
-                storage.flush().unwrap();
+                storage.flush_all().unwrap();
             }
         });
     });

--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -66,12 +66,12 @@ pub fn real_data_data_bench(c: &mut Criterion) {
 
     // insert data once & flush
     append_csv_data(&mut storage, &csv_path);
-    storage.flusher()().unwrap();
+    storage.flush().unwrap();
 
     assert_eq!(storage.max_point_id(), expected_point_count);
 
     // flush to get a consistent bitmask
-    storage.flusher()().unwrap();
+    storage.flush().unwrap();
 
     // sanity check of storage size
     let storage_size = storage.get_storage_size_bytes();
@@ -98,7 +98,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     // append the same data again to increase storage size
     for _ in 0..10 {
         append_csv_data(&mut storage, &csv_path);
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
     }
 
     let inflated_storage_size = storage.get_storage_size_bytes();
@@ -117,7 +117,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     }
 
     // flush to get a consistent bitmask
-    storage.flusher()().unwrap();
+    storage.flush().unwrap();
 
     c.bench_function("compute storage size (large sparse)", |b| {
         b.iter(|| black_box(storage.get_storage_size_bytes()));
@@ -128,7 +128,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
             append_csv_data(&mut storage, &csv_path);
             // do not always flush to build up pending updates
             if rng.random_bool(0.3) {
-                storage.flusher()().unwrap();
+                storage.flush().unwrap();
             }
         });
     });

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use fs_err as fs;
@@ -589,18 +590,43 @@ impl<V> Gridstore<V> {
         value_size.div_ceil(block_size).try_into().unwrap()
     }
 
+    /// Immediately persist all pending changes
+    #[allow(dead_code)]
+    pub fn flush(&self) -> std::result::Result<(), mmap_type::Error> {
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        stage_1_flusher()?;
+        stage_2_flusher()
+    }
+
     /// Create flusher that durably persists all pending changes when invoked
-    pub fn flusher(&self) -> Flusher {
-        let pending_updates = self.tracker.read().pending_updates.clone();
+    pub fn flusher(&self) -> (Flusher, Flusher) {
+        let (pending_updates, pending_deletes) = self
+            .tracker
+            .read()
+            .pending_updates
+            .clone()
+            .into_iter()
+            .map(|(point_offset, updates)| (point_offset, updates.into_update_deletes()))
+            .fold(
+                (AHashMap::new(), AHashMap::new()),
+                |(mut all_updates, mut all_deletes), (offset, (update, deletes))| {
+                    if let Some(update) = update {
+                        all_updates.insert(offset, update);
+                    }
+                    if let Some(deletes) = deletes {
+                        all_deletes.insert(offset, deletes);
+                    }
+                    (all_updates, all_deletes)
+                },
+            );
 
         let pages = Arc::downgrade(&self.pages);
         let tracker = Arc::downgrade(&self.tracker);
         let bitmask = Arc::downgrade(&self.bitmask);
         let block_size_bytes = self.config.block_size_bytes;
-
         let is_alive_flush_lock = self.is_alive_flush_lock.clone();
 
-        Box::new(move || {
+        let stage_1_flusher = Box::new(move || {
             // Keep the guard till the end of the flush to prevent concurrent flushes
             let is_alive_flush_guard = is_alive_flush_lock.lock();
 
@@ -616,15 +642,20 @@ impl<V> Gridstore<V> {
             };
 
             let mut bitmask_guard = bitmask.upgradable_read();
+
+            // Flush new used blocks and pages
             bitmask_guard.flush()?;
             for page in pages.read().iter() {
                 page.flush()?;
             }
 
+            // Only write mappings for new blocks
+            // Mappings we overwrite will be returned, we can safely mark them as free in the first flush stage
             let old_pointers = tracker.write().write_pending_and_flush(pending_updates)?;
             if old_pointers.is_empty() {
                 return Ok(());
             }
+
             // Update all free blocks in the bitmask
             bitmask_guard.with_upgraded(|guard| {
                 for (page_id, pointer_group) in
@@ -632,7 +663,7 @@ impl<V> Gridstore<V> {
                 {
                     let local_ranges = pointer_group.map(|pointer| {
                         let start = pointer.block_offset;
-                        let end = pointer.block_offset
+                        let end = start
                             + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
                         start as usize..end as usize
                     });
@@ -642,6 +673,62 @@ impl<V> Gridstore<V> {
             bitmask_guard.flush()?;
 
             Ok(())
+        });
+
+        let tracker = Arc::downgrade(&self.tracker);
+        let bitmask = Arc::downgrade(&self.bitmask);
+        let is_alive_flush_lock = self.is_alive_flush_lock.clone();
+
+        let stage_2_flusher = Box::new(move || {
+            // Keep the guard till the end of the flush to prevent concurrent flushes
+            let is_alive_flush_guard = is_alive_flush_lock.lock();
+
+            if !*is_alive_flush_guard {
+                // Segment is cleared, skip flush
+                return Ok(());
+            }
+
+            let (Some(tracker), Some(bitmask)) = (tracker.upgrade(), bitmask.upgrade()) else {
+                log::debug!("Aborted flushing on a dropped Gridstore instance");
+                return Ok(());
+            };
+
+            let mut bitmask_guard = bitmask.upgradable_read();
+
+            // Only write mappings for deleted blocks
+            let old_pointers = tracker.write().write_pending_and_flush(pending_deletes)?;
+            if old_pointers.is_empty() {
+                return Ok(());
+            }
+
+            // Update all free blocks in the bitmask
+            bitmask_guard.with_upgraded(|guard| {
+                for (page_id, pointer_group) in
+                    &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
+                {
+                    let local_ranges = pointer_group.map(|pointer| {
+                        let start = pointer.block_offset;
+                        let end = start
+                            + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
+                        start as usize..end as usize
+                    });
+                    guard.mark_blocks_batch(page_id, local_ranges, false);
+                }
+            });
+            bitmask_guard.flush()?;
+
+            Ok(())
+        });
+
+        (stage_1_flusher, stage_2_flusher)
+    }
+
+    #[cfg(test)]
+    pub fn flusher_all(&self) -> Flusher {
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        Box::new(move || {
+            stage_1_flusher()?;
+            stage_2_flusher()
         })
     }
 
@@ -685,7 +772,7 @@ mod tests {
     use crate::config::{
         DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS,
     };
-    use crate::fixtures::{HM_FIELDS, Payload, empty_storage, empty_storage_sized, random_payload};
+    use crate::fixtures::{empty_storage, empty_storage_sized, random_payload, Payload, HM_FIELDS};
 
     #[test]
     fn test_empty_payload_storage() {
@@ -840,7 +927,7 @@ mod tests {
         // get payload again
         let stored_payload = storage.get_value::<false>(0, &hw_counter);
         assert!(stored_payload.is_none());
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
         assert_eq!(storage.get_storage_size_bytes(), 0);
     }
 
@@ -878,7 +965,7 @@ mod tests {
 
         put_payload(&mut storage, "updated again", 2);
 
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
 
         // First block offset should be available again, so we can reuse it
         put_payload(&mut storage, "updated after flush", 0);
@@ -1014,7 +1101,7 @@ mod tests {
                         );
                     } else {
                         log::debug!("op:{i} Scheduling flush in {delay:?}");
-                        let flusher = storage.flusher();
+                        let flusher = storage.flusher_all();
                         *flush_lock_guard = true;
                         drop(flush_lock_guard);
                         let flush_lock = has_flusher_lock.clone();
@@ -1060,7 +1147,7 @@ mod tests {
         }
 
         // flush data
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
 
         let before_size = storage.get_storage_size_bytes();
         // drop storage
@@ -1159,7 +1246,7 @@ mod tests {
             assert_eq!(stored_payload.unwrap(), payload);
 
             // flush storage before dropping
-            storage.flusher()().unwrap();
+            storage.flush().unwrap();
         }
 
         // reopen storage
@@ -1202,7 +1289,7 @@ mod tests {
                     .unwrap();
                 point_offset += 1;
             }
-            storage.flusher()().unwrap();
+            storage.flush().unwrap();
             point_offset
         }
 
@@ -1259,7 +1346,7 @@ mod tests {
         storage_double_pass_is_consistent(&storage, 0);
 
         // drop storage
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
         drop(storage);
 
         // reopen storage
@@ -1337,7 +1424,7 @@ mod tests {
                 .unwrap();
         }
 
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
         println!("{last_point_id}");
 
         assert_eq!(storage.pages.read().len(), 4);
@@ -1397,7 +1484,7 @@ mod tests {
         put_payload(&mut storage, "value 2", 1);
         assert_eq!(get_payload(&storage), "value 2");
 
-        let flusher = storage.flusher();
+        let flusher = storage.flusher_all();
 
         put_payload(&mut storage, "value 3", 2);
         assert_eq!(get_payload(&storage), "value 3");
@@ -1406,7 +1493,7 @@ mod tests {
         drop(flusher);
         assert_eq!(get_payload(&storage), "value 3");
 
-        let flusher = storage.flusher();
+        let flusher = storage.flusher_all();
 
         put_payload(&mut storage, "value 4", 3);
         assert_eq!(get_payload(&storage), "value 4");
@@ -1488,7 +1575,7 @@ mod tests {
         put_payload(&mut storage, "value 2", 1);
         assert_eq!(get_payload(&storage).unwrap(), "value 2");
 
-        let flusher = storage.flusher();
+        let flusher = storage.flusher_all();
 
         put_payload(&mut storage, "value 3", 2);
         assert_eq!(get_payload(&storage).unwrap(), "value 3");
@@ -1505,7 +1592,7 @@ mod tests {
         let mut storage = Gridstore::<Payload>::open(path.clone()).unwrap();
         assert_eq!(storage.pages.read().len(), 1);
 
-        let flusher = storage.flusher();
+        let flusher = storage.flusher_all();
 
         // On reopen, later updates and the delete were not flushed, expect to read value 2
         assert_eq!(get_payload(&storage).unwrap(), "value 2");
@@ -1515,8 +1602,8 @@ mod tests {
         storage.delete_value(0);
         assert!(get_payload(&storage).is_none());
 
-        storage.flusher()().unwrap();
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
+        storage.flush().unwrap();
         assert!(get_payload(&storage).is_none());
 
         // Reopen gridstore
@@ -1536,7 +1623,7 @@ mod tests {
             "expect 1 pending update",
         );
 
-        storage.flusher()().unwrap();
+        storage.flush().unwrap();
 
         assert_eq!(
             storage.tracker.read().pending_updates.len(),
@@ -1555,17 +1642,17 @@ mod tests {
         put_payload(&mut storage, "value 5", 1);
         assert_eq!(get_payload(&storage).unwrap(), "value 5");
 
-        let flusher_1_value_5 = storage.flusher();
+        let flusher_1_value_5 = storage.flusher_all();
 
         storage.delete_value(0);
         assert!(get_payload(&storage).is_none());
 
-        let flusher_2_delete = storage.flusher();
+        let flusher_2_delete = storage.flusher_all();
 
         put_payload(&mut storage, "value 6", 3);
         assert_eq!(get_payload(&storage).unwrap(), "value 6");
 
-        let flusher_3_value_6 = storage.flusher();
+        let flusher_3_value_6 = storage.flusher_all();
 
         put_payload(&mut storage, "value 7", 4);
         assert_eq!(get_payload(&storage).unwrap(), "value 7");
@@ -1646,7 +1733,7 @@ mod tests {
             put_payload(&mut storage, i, "value x");
         }
 
-        let flusher = storage.flusher();
+        let flusher = storage.flusher_all();
 
         // Clone arcs to keep storage alive after clear
         // Necessary for this test to allow the flusher task to still upgrade its weak arcs when we

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -170,7 +170,10 @@ impl PointerUpdates {
     ///
     /// Returns if the structure is empty after this operation
     fn drain_persisted(&mut self, persisted: &Self) -> bool {
-        debug_assert!(self.has_last_change, "should drain from updates that have last change");
+        debug_assert!(
+            self.has_last_change,
+            "should drain from updates that have last change"
+        );
         debug_assert!(!self.is_empty(), "must have at least one pointer");
         debug_assert!(
             !persisted.is_empty(),

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -53,15 +53,36 @@ impl ValuePointer {
 /// come in between preparing the flusher and executing it. After we've written to disk, we remove (drain),
 /// the now persisted changes from these pointer updates. With this mechanism we write each update to
 /// disk exactly once.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) struct PointerUpdates {
     /// Pointer to write in tracker when persisting
     current: Option<ValuePointer>,
+
     /// List of pointers to free in bitmask when persisting
     to_free: SmallVec<[ValuePointer; 1]>,
+
+    /// Whether this updates struct contains the last change for this pointer
+    ///
+    /// Using [`into_update_deletes`] will split this structure in two, one for any update and the
+    /// other for deletes.
+    ///
+    /// When writing a pointer to disk, we only write the very last known state. It either exist
+    /// and we write the pointer, or it doesn't and we clear the pointer. This flag tells us
+    /// whether this structure holds the last known change. Or more specifically, if we only hold
+    /// deletes it tells us whether we can clear the pointer for the current point offset on disk.
+    has_last_change: bool,
 }
 
 impl PointerUpdates {
+    /// Construct new empty updates structure, assume this is the latest
+    pub fn new() -> Self {
+        Self {
+            current: None,
+            to_free: SmallVec::new(),
+            has_last_change: true,
+        }
+    }
+
     /// Mark this pointer as set
     ///
     /// It will mark the pointer as used on disk on flush, and will free all previous pending
@@ -115,6 +136,26 @@ impl PointerUpdates {
         );
     }
 
+    /// Split this pointer update structure into two
+    ///
+    /// A structure that only updates the pointer, and a structure that only deletes pointers.
+    pub fn into_update_deletes(mut self) -> (Option<Self>, Option<Self>) {
+        let to_free = std::mem::take(&mut self.to_free);
+
+        // We only have an update if a current pointer is set
+        let update = Some(self).filter(|u| !u.is_empty());
+
+        // We only have deletes if any pointers are pending free
+        let deletes = (!to_free.is_empty()).then(|| PointerUpdates {
+            current: None,
+            to_free,
+            // We only have the last changes if there is no update
+            has_last_change: update.is_none(),
+        });
+
+        (update, deletes)
+    }
+
     /// Pointer is empty if there is no set nor unsets
     fn is_empty(&self) -> bool {
         self.current.is_none() && self.to_free.is_empty()
@@ -129,6 +170,7 @@ impl PointerUpdates {
     ///
     /// Returns if the structure is empty after this operation
     fn drain_persisted(&mut self, persisted: &Self) -> bool {
+        debug_assert!(self.has_last_change, "should drain from updates that have last change");
         debug_assert!(!self.is_empty(), "must have at least one pointer");
         debug_assert!(
             !persisted.is_empty(),
@@ -137,13 +179,14 @@ impl PointerUpdates {
 
         // Shortcut: we persisted everything if both are equal, we can empty this structure
         if self == persisted {
-            *self = Self::default();
+            *self = Self::new();
             return true;
         }
 
         let Self {
             current: previous_current,
             to_free: freed,
+            has_last_change: _,
         } = persisted;
 
         // Remove self set if persisted
@@ -263,8 +306,12 @@ impl Tracker {
 
                     self.persist_pointer(point_offset, Some(new_pointer));
                 }
-                // Write to empty the pointer
-                None => self.persist_pointer(point_offset, None),
+
+                // If last known update for this point offset, clear pointer on disk
+                None if updates.has_last_change => {
+                    self.persist_pointer(point_offset, None);
+                }
+                None => {}
             }
 
             // Mark all old pointers for removal to free its blocks
@@ -393,7 +440,7 @@ impl Tracker {
     pub fn set(&mut self, point_offset: PointOffset, value_pointer: ValuePointer) {
         self.pending_updates
             .entry(point_offset)
-            .or_default()
+            .or_insert_with(PointerUpdates::new)
             .set(value_pointer);
         self.next_pointer_offset = self.next_pointer_offset.max(point_offset + 1);
     }
@@ -405,7 +452,7 @@ impl Tracker {
         if let Some(pointer) = pointer_opt {
             self.pending_updates
                 .entry(point_offset)
-                .or_default()
+                .or_insert_with(PointerUpdates::new)
                 .unset(pointer);
         }
 
@@ -422,6 +469,7 @@ mod tests {
     use std::path::PathBuf;
 
     use rstest::rstest;
+    use smallvec::SmallVec;
     use tempfile::Builder;
 
     use super::{PointerUpdates, Tracker, ValuePointer};
@@ -613,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_value_pointer_drain() {
-        let mut updates = PointerUpdates::default();
+        let mut updates = PointerUpdates::new();
         updates.set(ValuePointer::new(1, 1, 1));
 
         // When all updates are persisted, drop the entry
@@ -695,7 +743,7 @@ mod tests {
         // - latest: true
         // - history: [block_offset:2]
 
-        let mut updates = PointerUpdates::default();
+        let mut updates = PointerUpdates::new();
 
         // Put and delete block offset 1
         updates.set(ValuePointer::new(1, 1, 1));
@@ -712,10 +760,10 @@ mod tests {
         assert!(!do_drop, "must not drop entry");
 
         // Pending updates must only have set for block offset 2
-        let expected = {
-            let mut expected = PointerUpdates::default();
-            expected.set(ValuePointer::new(1, 2, 1));
-            expected
+        let expected = PointerUpdates {
+            current: Some(ValuePointer::new(1, 2, 1)),
+            to_free: SmallVec::new(),
+            has_last_change: true,
         };
         assert_eq!(
             updates, expected,

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -123,7 +123,7 @@ fn range_filtering(c: &mut Criterion) {
     });
 
     // flush data
-    index.flusher()().unwrap();
+    index.flush_all().unwrap();
     drop(index);
 
     // reload as IMMUTABLE index

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -149,8 +149,8 @@ impl IdTracker for FixtureIdTracker {
         self.deleted_count
     }
 
-    fn mapping_flusher(&self) -> Flusher {
-        Box::new(|| Ok(()))
+    fn mapping_flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
     fn versions_flusher(&self) -> Flusher {

--- a/lib/segment/src/fixtures/payload_context_fixture.rs
+++ b/lib/segment/src/fixtures/payload_context_fixture.rs
@@ -153,8 +153,8 @@ impl IdTracker for FixtureIdTracker {
         (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
-    fn versions_flusher(&self) -> Flusher {
-        Box::new(|| Ok(()))
+    fn versions_flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
     fn is_deleted_point(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -104,8 +104,24 @@ pub trait IdTracker: fmt::Debug {
     /// Flush id mapping to disk
     fn mapping_flusher(&self) -> (Flusher, Flusher);
 
+    /// Flush id mapping to disk
+    fn flush_mappings(&self) -> OperationResult<()> {
+        let (stage_1_flush, stage_2_flush) = self.mapping_flusher();
+        stage_1_flush()?;
+        stage_2_flush()?;
+        Ok(())
+    }
+
     /// Flush points versions to disk
     fn versions_flusher(&self) -> (Flusher, Flusher);
+
+    /// Flush points versions to disk
+    fn flush_versions(&self) -> OperationResult<()> {
+        let (stage_1_flush, stage_2_flush) = self.versions_flusher();
+        stage_1_flush()?;
+        stage_2_flush()?;
+        Ok(())
+    }
 
     /// Number of total points
     ///

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -102,7 +102,7 @@ pub trait IdTracker: fmt::Debug {
     fn iter_random(&self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + '_>;
 
     /// Flush id mapping to disk
-    fn mapping_flusher(&self) -> Flusher;
+    fn mapping_flusher(&self) -> (Flusher, Flusher);
 
     /// Flush points versions to disk
     fn versions_flusher(&self) -> Flusher;
@@ -369,7 +369,7 @@ impl IdTracker for IdTrackerEnum {
         }
     }
 
-    fn mapping_flusher(&self) -> Flusher {
+    fn mapping_flusher(&self) -> (Flusher, Flusher) {
         match self {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -105,7 +105,7 @@ pub trait IdTracker: fmt::Debug {
     fn mapping_flusher(&self) -> (Flusher, Flusher);
 
     /// Flush points versions to disk
-    fn versions_flusher(&self) -> Flusher;
+    fn versions_flusher(&self) -> (Flusher, Flusher);
 
     /// Number of total points
     ///
@@ -379,7 +379,7 @@ impl IdTracker for IdTrackerEnum {
         }
     }
 
-    fn versions_flusher(&self) -> Flusher {
+    fn versions_flusher(&self) -> (Flusher, Flusher) {
         match self {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.versions_flusher(),

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -655,8 +655,8 @@ pub(super) mod test {
                 }
             }
 
-            id_tracker.mapping_flusher()().unwrap();
-            id_tracker.versions_flusher()().unwrap();
+            id_tracker.flush_mappings().unwrap();
+            id_tracker.flush_versions().unwrap();
 
             (dropped_points, custom_version)
         };
@@ -741,8 +741,8 @@ pub(super) mod test {
                 .expect("Point to delete exists.");
             assert!(!id_tracker.is_deleted_point(intetrnal_id));
             id_tracker.drop(point_to_delete).unwrap();
-            id_tracker.mapping_flusher()().unwrap();
-            id_tracker.versions_flusher()().unwrap();
+            id_tracker.flush_mappings().unwrap();
+            id_tracker.flush_versions().unwrap();
             id_tracker.mappings
         };
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -468,8 +468,11 @@ impl IdTracker for ImmutableIdTracker {
     }
 
     /// Creates a flusher function, that writes the points versions to disk.
-    fn versions_flusher(&self) -> Flusher {
-        self.internal_to_version_wrapper.flusher()
+    fn versions_flusher(&self) -> (Flusher, Flusher) {
+        (
+            self.internal_to_version_wrapper.flusher(),
+            Box::new(|| Ok(())),
+        )
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -462,9 +462,9 @@ impl IdTracker for ImmutableIdTracker {
     }
 
     /// Creates a flusher function, that writes the deleted points bitvec to disk.
-    fn mapping_flusher(&self) -> Flusher {
+    fn mapping_flusher(&self) -> (Flusher, Flusher) {
         // Only flush deletions because mappings are immutable
-        self.deleted_wrapper.flusher()
+        (Box::new(|| Ok(())), self.deleted_wrapper.flusher())
     }
 
     /// Creates a flusher function, that writes the points versions to disk.

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -116,9 +116,9 @@ impl IdTracker for InMemoryIdTracker {
     }
 
     /// Creates a flusher function, that writes the deleted points bitvec to disk.
-    fn mapping_flusher(&self) -> Flusher {
+    fn mapping_flusher(&self) -> (Flusher, Flusher) {
         debug_assert!(false, "InMemoryIdTracker should not be flushed");
-        Box::new(|| Ok(()))
+        (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
     /// Creates a flusher function, that writes the points versions to disk.

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -122,9 +122,9 @@ impl IdTracker for InMemoryIdTracker {
     }
 
     /// Creates a flusher function, that writes the points versions to disk.
-    fn versions_flusher(&self) -> Flusher {
+    fn versions_flusher(&self) -> (Flusher, Flusher) {
         debug_assert!(false, "InMemoryIdTracker should not be flushed");
-        Box::new(|| Ok(()))
+        (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -951,8 +951,8 @@ pub(super) mod tests {
                 }
             }
 
-            id_tracker.mapping_flusher()().unwrap();
-            id_tracker.versions_flusher()().unwrap();
+            id_tracker.flush_mappings().unwrap();
+            id_tracker.flush_versions().unwrap();
 
             (dropped_points, custom_version)
         };
@@ -1037,8 +1037,8 @@ pub(super) mod tests {
                 .expect("Point to delete exists.");
             assert!(!id_tracker.is_deleted_point(intetrnal_id));
             id_tracker.drop(point_to_delete).unwrap();
-            id_tracker.mapping_flusher()().unwrap();
-            id_tracker.versions_flusher()().unwrap();
+            id_tracker.flush_mappings().unwrap();
+            id_tracker.flush_versions().unwrap();
             id_tracker.mappings
         };
 
@@ -1266,8 +1266,12 @@ pub(super) mod tests {
                 .unwrap()
         }
 
-        id_tracker.mapping_flusher()().expect("failed to flush ID tracker mappings");
-        id_tracker.versions_flusher()().expect("failed to flush ID tracker versions");
+        id_tracker
+            .flush_mappings()
+            .expect("failed to flush ID tracker mappings");
+        id_tracker
+            .flush_versions()
+            .expect("failed to flush ID tracker versions");
 
         id_tracker
     }
@@ -1395,8 +1399,8 @@ pub(super) mod tests {
         check_trackers(&simple_id_tracker, &mutable_id_tracker);
 
         // Persist and reload mutable tracker and test again
-        mutable_id_tracker.mapping_flusher()().unwrap();
-        mutable_id_tracker.versions_flusher()().unwrap();
+        mutable_id_tracker.flush_mappings().unwrap();
+        mutable_id_tracker.flush_versions().unwrap();
         drop(mutable_id_tracker);
         let mutable_id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
 

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -274,8 +274,8 @@ impl IdTracker for SimpleIdTracker {
     /// Creates a flusher function, that persists the removed points in the mapping database
     /// and flushes the mapping to disk.
     /// This function should be called _before_ flushing the version database.
-    fn mapping_flusher(&self) -> Flusher {
-        self.mapping_db_wrapper.flusher()
+    fn mapping_flusher(&self) -> (Flusher, Flusher) {
+        (self.mapping_db_wrapper.flusher(), Box::new(|| Ok(())))
     }
 
     /// Creates a flusher function, that persists the removed points in the version database

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -281,13 +281,8 @@ impl IdTracker for SimpleIdTracker {
     /// Creates a flusher function, that persists the removed points in the version database
     /// and flushes the version database to disk.
     /// This function should be called _after_ flushing the mapping database.
-    fn versions_flusher(&self) -> Flusher {
-        let (stage_1, stage_2) = self.versions_db_wrapper.flusher();
-        Box::new(move || {
-            stage_1()?;
-            stage_2()?;
-            Ok(())
-        })
+    fn versions_flusher(&self) -> (Flusher, Flusher) {
+        self.versions_db_wrapper.flusher()
     }
 
     fn is_deleted_point(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -7,6 +7,7 @@ use simple_bool_index::SimpleBoolIndex;
 use super::facet_index::FacetIndex;
 use super::map_index::IdIter;
 use super::{PayloadFieldIndex, ValueIndexer};
+use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::payload_config::{IndexMutability, StorageType};
@@ -169,7 +170,7 @@ impl PayloadFieldIndex for BoolIndex {
         }
     }
 
-    fn flusher(&self) -> crate::common::Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             #[cfg(feature = "rocksdb")]
             BoolIndex::Simple(index) => index.flusher(),
@@ -433,7 +434,7 @@ mod tests {
                 index.add_point(i as u32, &[&value], &hw_counter).unwrap();
             });
 
-        index.flusher()().unwrap();
+        index.flush_all().unwrap();
 
         drop(index);
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -7,6 +7,7 @@ use fs_err as fs;
 use roaring::RoaringBitmap;
 
 use super::BoolIndex;
+use crate::common::Flusher;
 use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -318,7 +319,7 @@ impl PayloadFieldIndex for MutableBoolIndex {
         Ok(())
     }
 
-    fn flusher(&self) -> crate::common::Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         let Self {
             base_dir: _,
             indexed_count: _,
@@ -334,11 +335,13 @@ impl PayloadFieldIndex for MutableBoolIndex {
         let trues_flusher = trues_flags.flusher();
         let falses_flusher = falses_flags.flusher();
 
-        Box::new(move || {
+        let stage_2_flusher = Box::new(move || {
             trues_flusher()?;
             falses_flusher()?;
             Ok(())
-        })
+        });
+
+        (Box::new(|| Ok(())), stage_2_flusher)
     }
 
     fn files(&self) -> Vec<std::path::PathBuf> {

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 
 use self::memory::{BoolMemory, BooleanItem};
 use super::BoolIndex;
+use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::rocksdb_buffered_delete_wrapper::DatabaseColumnScheduledDeleteWrapper;
 use crate::common::rocksdb_wrapper::DatabaseColumnWrapper;
@@ -337,7 +338,7 @@ impl PayloadFieldIndex for SimpleBoolIndex {
         self.db_wrapper.remove_column_family()
     }
 
-    fn flusher(&self) -> crate::common::Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         self.db_wrapper.flusher()
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -44,7 +44,15 @@ pub trait PayloadFieldIndex {
     fn wipe(self) -> OperationResult<()>;
 
     /// Return function that flushes all pending updates to disk.
-    fn flusher(&self) -> Flusher;
+    fn flusher(&self) -> (Flusher, Flusher);
+
+    /// Immediately flush all pending updates and deletes to disk.
+    fn flush_all(&self) -> OperationResult<()> {
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        stage_1_flusher()?;
+        stage_2_flusher()?;
+        Ok(())
+    }
 
     fn files(&self) -> Vec<PathBuf>;
 
@@ -233,7 +241,7 @@ impl FieldIndex {
         self.get_payload_field_index().count_indexed_points()
     }
 
-    pub fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> (Flusher, Flusher) {
         self.get_payload_field_index().flusher()
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -141,7 +141,7 @@ impl ImmutableFullTextIndex {
         }
     }
 
-    pub fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> (Flusher, Flusher) {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(ref db_wrapper) => db_wrapper.flusher(),

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -364,8 +364,8 @@ impl MmapInvertedIndex {
         ]
     }
 
-    pub fn flusher(&self) -> Flusher {
-        self.storage.deleted_points.flusher()
+    pub fn flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), self.storage.deleted_points.flusher())
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -70,7 +70,7 @@ impl MmapFullTextIndex {
         self.inverted_index.remove(id);
     }
 
-    pub fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> (Flusher, Flusher) {
         self.inverted_index.flusher()
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -241,7 +241,7 @@ fn build_random_index(
         index.remove_point(200).unwrap();
         index.remove_point(250).unwrap();
 
-        index.flusher()().expect("failed to flush deletions");
+        index.flush_all().expect("failed to flush deletions");
     }
 
     // Reopen the index if requested

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -566,7 +566,7 @@ impl PayloadFieldIndex for FullTextIndex {
         }
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             Self::Mutable(index) => index.flusher(),
             Self::Immutable(index) => index.flusher(),
@@ -723,7 +723,7 @@ impl FieldIndexBuilderTrait for FullTextGridstoreIndexBuilder {
                 "FullTextIndexGridstoreBuilder: index must be initialized to finalize",
             ));
         };
-        index.flusher()()?;
+        index.flush_all()?;
         Ok(index)
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -282,7 +282,7 @@ impl ImmutableGeoMapIndex {
         }
     }
 
-    pub fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> (Flusher, Flusher) {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(ref db_wrapper) => db_wrapper.flusher(),

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -375,8 +375,8 @@ impl MmapGeoMapIndex {
         files
     }
 
-    pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+    pub fn flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), self.storage.deleted.flusher())
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -660,7 +660,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexGridstoreBuilder {
                 "GeoMapIndexGridstoreBuilder: index must be initialized to finalize",
             ));
         };
-        index.flusher()()?;
+        index.flush_all()?;
         Ok(index)
     }
 }
@@ -678,7 +678,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         }
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             GeoMapIndex::Mutable(index) => index.flusher(),
             GeoMapIndex::Immutable(index) => index.flusher(),
@@ -1498,7 +1498,7 @@ mod tests {
             let mut index = builder.finalize().unwrap();
 
             index.remove_point(1).unwrap();
-            index.flusher()().unwrap();
+            index.flush_all().unwrap();
 
             assert_eq!(index.points_count(), 1);
             if index_type != IndexType::Mmap {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index.rs
@@ -281,9 +281,14 @@ impl MutableGeoMapIndex {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(store) => {
-                let storage_flusher = store.flusher();
+                let (stage_1_flusher, stage_2_flusher) = store.flusher();
                 Box::new(move || {
-                    storage_flusher().map_err(|err| {
+                    stage_1_flusher().map_err(|err| {
+                        OperationError::service_error(format!(
+                            "Failed to flush mutable geo index gridstore: {err}"
+                        ))
+                    })?;
+                    stage_2_flusher().map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable geo index gridstore: {err}"
                         ))

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -408,7 +408,7 @@ where
     }
 
     #[inline]
-    pub(super) fn flusher(&self) -> Flusher {
+    pub(super) fn flusher(&self) -> (Flusher, Flusher) {
         match self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(ref db_wrapper) => db_wrapper.flusher(),

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -146,8 +146,8 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         })
     }
 
-    pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+    pub fn flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), self.storage.deleted.flusher())
     }
 
     pub fn wipe(self) -> OperationResult<()> {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -279,7 +279,7 @@ where
         format!("{field}_map")
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             MapIndex::Mutable(index) => index.flusher(),
             MapIndex::Immutable(index) => index.flusher(),
@@ -718,7 +718,7 @@ where
                 "MapIndexGridstoreBuilder: index must be initialized to finalize",
             ));
         };
-        index.flusher()()?;
+        index.flush_all()?;
         Ok(index)
     }
 }
@@ -732,7 +732,7 @@ impl PayloadFieldIndex for MapIndex<str> {
         self.wipe()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         MapIndex::flusher(self)
     }
 
@@ -880,7 +880,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
         self.wipe()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         MapIndex::flusher(self)
     }
 
@@ -1069,7 +1069,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         self.wipe()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         MapIndex::flusher(self)
     }
 

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -333,24 +333,29 @@ where
     }
 
     #[inline]
-    pub(super) fn flusher(&self) -> Flusher {
+    pub(super) fn flusher(&self) -> (Flusher, Flusher) {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(store) => {
                 let (stage_1_flusher, stage_2_flusher) = store.flusher();
-                Box::new(move || {
+
+                let stage_1_flusher = Box::new(move || {
                     stage_1_flusher().map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable map index gridstore: {err}"
                         ))
-                    })?;
+                    })
+                });
+                let stage_2_flusher = Box::new(move || {
                     stage_2_flusher().map_err(|err| {
                         OperationError::service_error(format!(
-                            "Failed to flush mutable map index gridstore: {err}"
+                            "Failed to flush mutable map index gridstore deletes: {err}"
                         ))
                     })
-                })
+                });
+
+                (stage_1_flusher, stage_2_flusher)
             }
         }
     }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -338,9 +338,14 @@ where
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(store) => {
-                let storage_flusher = store.flusher();
+                let (stage_1_flusher, stage_2_flusher) = store.flusher();
                 Box::new(move || {
-                    storage_flusher().map_err(|err| {
+                    stage_1_flusher().map_err(|err| {
+                        OperationError::service_error(format!(
+                            "Failed to flush mutable map index gridstore: {err}"
+                        ))
+                    })?;
+                    stage_2_flusher().map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable map index gridstore: {err}"
                         ))

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -229,15 +229,17 @@ impl PayloadFieldIndex for MutableNullIndex {
         Ok(())
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         let flush_has_values = self.storage.has_values_flags.flusher();
         let flush_is_null = self.storage.is_null_flags.flusher();
 
-        Box::new(move || {
+        let stage_2_flusher = Box::new(move || {
             flush_has_values()?;
             flush_is_null()?;
             Ok(())
-        })
+        });
+
+        (Box::new(|| Ok(())), stage_2_flusher)
     }
 
     fn files(&self) -> Vec<PathBuf> {
@@ -385,7 +387,7 @@ impl FieldIndexBuilderTrait for MutableNullIndexBuilder {
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
         // Flush any remaining buffered updates
-        self.0.flusher()()?;
+        self.0.flush_all()?;
         Ok(self.0)
     }
 }
@@ -527,7 +529,7 @@ mod tests {
         }
 
         // Manually flush via flusher
-        index.flusher()().unwrap();
+        index.flush_all().unwrap();
 
         // Verify data is in bitmaps
         for i in 0..10 {

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -273,7 +273,7 @@ where
     }
 
     #[inline]
-    pub(super) fn flusher(&self) -> Flusher {
+    pub(super) fn flusher(&self) -> (Flusher, Flusher) {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -227,8 +227,8 @@ impl<T: Encodable + Numericable + Default + MmapValue> MmapNumericIndex<T> {
         files
     }
 
-    pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+    pub fn flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), self.storage.deleted.flusher())
     }
 
     pub fn check_values_any(

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -242,7 +242,7 @@ where
         }
     }
 
-    pub fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             NumericIndexInner::Mutable(index) => index.flusher(),
             NumericIndexInner::Immutable(index) => index.flusher(),
@@ -690,7 +690,7 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        self.0.inner.flusher()()?;
+        self.0.inner.flush_all()?;
         Ok(self.0)
     }
 }
@@ -735,7 +735,7 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        self.index.inner.flusher()()?;
+        self.index.inner.flush_all()?;
         drop(self.index);
         let inner: NumericIndexInner<T> =
             NumericIndexInner::new_rocksdb(self.db, &self.field, false, false)?
@@ -869,7 +869,7 @@ where
                 "NumericIndexGridstoreBuilder: index must be initialized to finalize",
             ));
         };
-        index.inner.flusher()()?;
+        index.inner.flush_all()?;
         Ok(index)
     }
 }
@@ -891,7 +891,7 @@ where
         }
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         NumericIndexInner::flusher(self)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -410,24 +410,29 @@ where
     }
 
     #[inline]
-    pub(super) fn flusher(&self) -> Flusher {
+    pub(super) fn flusher(&self) -> (Flusher, Flusher) {
         match &self.storage {
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(store) => {
                 let (stage_1_flusher, stage_2_flusher) = store.flusher();
-                Box::new(move || {
+
+                let stage_1_flusher = Box::new(move || {
                     stage_1_flusher().map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable numeric index gridstore: {err}"
                         ))
-                    })?;
+                    })
+                });
+                let stage_2_flusher = Box::new(move || {
                     stage_2_flusher().map_err(|err| {
                         OperationError::service_error(format!(
-                            "Failed to flush mutable numeric index gridstore: {err}"
+                            "Failed to flush mutable numeric index gridstore deletes: {err}"
                         ))
                     })
-                })
+                });
+
+                (stage_1_flusher, stage_2_flusher)
             }
         }
     }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index.rs
@@ -415,9 +415,14 @@ where
             #[cfg(feature = "rocksdb")]
             Storage::RocksDb(db_wrapper) => db_wrapper.flusher(),
             Storage::Gridstore(store) => {
-                let storage_flusher = store.flusher();
+                let (stage_1_flusher, stage_2_flusher) = store.flusher();
                 Box::new(move || {
-                    storage_flusher().map_err(|err| {
+                    stage_1_flusher().map_err(|err| {
+                        OperationError::service_error(format!(
+                            "Failed to flush mutable numeric index gridstore: {err}"
+                        ))
+                    })?;
+                    stage_2_flusher().map_err(|err| {
                         OperationError::service_error(format!(
                             "Failed to flush mutable numeric index gridstore: {err}"
                         ))

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -155,7 +155,15 @@ pub trait PayloadIndex {
     ) -> OperationResult<Option<Payload>>;
 
     /// Return function that forces persistence of current storage state.
-    fn flusher(&self) -> Flusher;
+    fn flusher(&self) -> (Flusher, Flusher);
+
+    /// Immediately flush all pending changes and deletes to the disk.
+    fn flush_all(&self) -> OperationResult<()> {
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        stage_1_flusher()?;
+        stage_2_flusher()?;
+        Ok(())
+    }
 
     #[cfg(feature = "rocksdb")]
     fn take_database_snapshot(&self, path: &std::path::Path) -> OperationResult<()>;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -252,7 +252,7 @@ impl PayloadIndex for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         unreachable!()
     }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -1104,20 +1104,26 @@ impl PayloadIndex for StructPayloadIndex {
         self.payload.borrow_mut().clear(point_id, hw_counter)
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         // Most field indices have either 2 or 3 indices (including null), we also have an extra
         // payload storage flusher. Overallocate to save potential reallocations.
-        let mut flushers = Vec::with_capacity(self.field_indexes.len() * 3 + 1);
+        let mut flushers = (
+            Vec::with_capacity(self.field_indexes.len() * 3 + 1),
+            Vec::with_capacity(self.field_indexes.len() * 3 + 1),
+        );
 
         for field_indexes in self.field_indexes.values() {
             for index in field_indexes {
-                flushers.push(index.flusher());
+                flushers.extend([index.flusher()]);
             }
         }
-        flushers.push(self.payload.borrow().flusher());
 
-        Box::new(move || {
-            for flusher in flushers {
+        flushers.extend([self.payload.borrow().flusher()]);
+
+        let (stage_1_flushers, stage_2_flushers) = flushers;
+
+        let stage_1_flusher = Box::new(move || {
+            for flusher in stage_1_flushers {
                 match flusher() {
                     Ok(_) => {}
                     Err(OperationError::RocksDbColumnFamilyNotFound { name }) => {
@@ -1141,7 +1147,36 @@ impl PayloadIndex for StructPayloadIndex {
                 }
             }
             Ok(())
-        })
+        });
+
+        let stage_2_flusher = Box::new(move || {
+            for flusher in stage_2_flushers {
+                match flusher() {
+                    Ok(_) => {}
+                    Err(OperationError::RocksDbColumnFamilyNotFound { name }) => {
+                        // It is possible, that the index was removed during the flush by user or another thread.
+                        // In this case, non-existing column family is not an error, but an expected behavior.
+
+                        // Still we want to log this event, for potential debugging.
+                        log::warn!(
+                            "Flush: RocksDB cf_handle error: Cannot find column family {name}. Assume index is removed.",
+                        );
+                        debug_assert!(
+                            false,
+                            "Missing column family should not happen during testing",
+                        );
+                    }
+                    Err(err) => {
+                        return Err(OperationError::service_error(format!(
+                            "Failed to flush payload_index deletes: {err}",
+                        )));
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        (stage_1_flusher, stage_2_flusher)
     }
 
     #[cfg(feature = "rocksdb")]

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -105,8 +105,8 @@ impl PayloadStorage for InMemoryPayloadStorage {
         Ok(())
     }
 
-    fn flusher(&self) -> Flusher {
-        Box::new(|| Ok(()))
+    fn flusher(&self) -> (Flusher, Flusher) {
+        (Box::new(|| Ok(())), Box::new(|| Ok(())))
     }
 
     fn iter<F>(&self, mut callback: F, _hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -183,7 +183,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
         self.db_wrapper.recreate_column_family()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         self.db_wrapper.flusher()
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -68,7 +68,15 @@ pub trait PayloadStorage {
     fn clear_all(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()>;
 
     /// Return function that forces persistence of current storage state.
-    fn flusher(&self) -> Flusher;
+    fn flusher(&self) -> (Flusher, Flusher);
+
+    /// Immediately flush all pending updates and deletes to disk.
+    fn flush_all(&self) -> OperationResult<()> {
+        let (stage_1_flusher, stage_2_flusher) = self.flusher();
+        stage_1_flusher()?;
+        stage_2_flusher()?;
+        Ok(())
+    }
 
     /// Iterate over all stored payload and apply the provided callback.
     /// Stop iteration if callback returns false or error.

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -200,7 +200,7 @@ impl PayloadStorage for PayloadStorageEnum {
         }
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         match self {
             #[cfg(feature = "testing")]
             PayloadStorageEnum::InMemoryPayloadStorage(s) => s.flusher(),
@@ -470,7 +470,7 @@ mod tests {
         assert_eq!(storage.get_storage_size_bytes().unwrap(), 0);
 
         // needs a flush to impact the storage size
-        storage.flusher()().unwrap();
+        storage.flush_all().unwrap();
         // large value contains initial cost of infra (SSTable, etc.), not stable across different OS
         let storage_size = storage.get_storage_size_bytes().unwrap();
         assert!(
@@ -483,7 +483,7 @@ mod tests {
             storage.overwrite(point_id, &payload, &hw_counter).unwrap();
         }
 
-        storage.flusher()().unwrap();
+        storage.flush_all().unwrap();
         // loose assertion because value not stable across different OS
         let storage_size = storage.get_storage_size_bytes().unwrap();
         assert!(

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -112,7 +112,7 @@ impl PayloadStorage for SimplePayloadStorage {
         self.db_wrapper.recreate_column_family()
     }
 
-    fn flusher(&self) -> Flusher {
+    fn flusher(&self) -> (Flusher, Flusher) {
         self.db_wrapper.flusher()
     }
 

--- a/lib/segment/src/payload_storage/tests.rs
+++ b/lib/segment/src/payload_storage/tests.rs
@@ -119,7 +119,7 @@ fn test_trait_impl<S: PayloadStorage>(open: impl Fn(&Path) -> S) {
     eprintln!("storage is correct before drop");
 
     // flush, drop, and reopen
-    storage.flusher()().unwrap();
+    storage.flush_all().unwrap();
     drop(storage);
     let storage = open(dir.path());
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -619,7 +619,7 @@ impl SegmentEntry for Segment {
         }
     }
 
-    fn flusher(&self, force: bool) -> Option<Flusher> {
+    fn flusher(&self, force: bool) -> Option<(Flusher, Flusher)> {
         let current_persisted_version: Option<SeqNumberType> = *self.persisted_version.lock();
 
         match (self.version, current_persisted_version) {
@@ -703,7 +703,7 @@ impl SegmentEntry for Segment {
 
         let is_alive_flush_lock = self.is_alive_flush_lock.clone();
 
-        let flush_op = move || {
+        let stage_1_updates = move || {
             // Keep the guard till the end of the flush to prevent concurrent flushes
             let is_alive_flush_guard = is_alive_flush_lock.lock();
 
@@ -741,6 +741,10 @@ impl SegmentEntry for Segment {
                 OperationError::service_error(format!("Failed to flush id_tracker versions: {err}"))
             })?;
 
+            Ok(())
+        };
+
+        let stage_2_deletes = move || {
             let mut current_persisted_version_guard = persisted_version.lock();
             let persisted_version_value_opt = *current_persisted_version_guard;
 
@@ -762,7 +766,7 @@ impl SegmentEntry for Segment {
             Ok(())
         };
 
-        Some(Box::new(flush_op))
+        Some((Box::new(stage_1_updates), Box::new(stage_2_deletes)))
     }
 
     fn drop_data(self) -> OperationResult<()> {

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -516,13 +516,8 @@ impl SegmentBuilder {
                 IdTrackerEnum::RocksDbIdTracker(_) => id_tracker,
             };
 
-            let (mapping_stage_1, mapping_stage_2) = id_tracker.mapping_flusher();
-            let (version_stage_1, version_stage_2) = id_tracker.versions_flusher();
-            mapping_stage_1()?;
-            version_stage_1()?;
-            mapping_stage_2()?;
-            version_stage_2()?;
-
+            id_tracker.flush_mappings()?;
+            id_tracker.flush_versions()?;
             let id_tracker_arc = Arc::new(AtomicRefCell::new(id_tracker));
 
             let mut quantized_vectors = Self::update_quantization(

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -517,9 +517,12 @@ impl SegmentBuilder {
             };
 
             let (mapping_stage_1, mapping_stage_2) = id_tracker.mapping_flusher();
+            let (version_stage_1, version_stage_2) = id_tracker.versions_flusher();
             mapping_stage_1()?;
+            version_stage_1()?;
             mapping_stage_2()?;
-            id_tracker.versions_flusher()()?;
+            version_stage_2()?;
+
             let id_tracker_arc = Arc::new(AtomicRefCell::new(id_tracker));
 
             let mut quantized_vectors = Self::update_quantization(

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -497,7 +497,7 @@ impl SegmentBuilder {
 
             let appendable_flag = segment_config.is_appendable();
 
-            payload_storage.flusher()()?;
+            payload_storage.flush_all()?;
             let payload_storage_arc = Arc::new(AtomicRefCell::new(payload_storage));
 
             let id_tracker = match id_tracker {
@@ -580,7 +580,7 @@ impl SegmentBuilder {
             }
             drop(progress_payload_index);
 
-            payload_index.flusher()()?;
+            payload_index.flush_all()?;
             let payload_index_arc = Arc::new(AtomicRefCell::new(payload_index));
 
             // Try to lock GPU device.

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -516,7 +516,9 @@ impl SegmentBuilder {
                 IdTrackerEnum::RocksDbIdTracker(_) => id_tracker,
             };
 
-            id_tracker.mapping_flusher()()?;
+            let (mapping_stage_1, mapping_stage_2) = id_tracker.mapping_flusher();
+            mapping_stage_1()?;
+            mapping_stage_2()?;
             id_tracker.versions_flusher()()?;
             let id_tracker_arc = Arc::new(AtomicRefCell::new(id_tracker));
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -941,12 +941,8 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
         }
 
         // Flush mappings and versions
-        let (mapping_stage_1, mapping_stage_2) = new_id_tracker.mapping_flusher();
-        let (version_stage_1, version_stage_2) = new_id_tracker.versions_flusher();
-        mapping_stage_1()?;
-        version_stage_1()?;
-        mapping_stage_2()?;
-        version_stage_2()?;
+        new_id_tracker.flush_mappings()?;
+        new_id_tracker.flush_versions()?;
 
         Ok(new_id_tracker)
     }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -1442,7 +1442,7 @@ pub fn migrate_rocksdb_payload_storage_to_mmap(
         )?;
 
         // Flush new storage
-        new_storage.flusher()()?;
+        new_storage.flush_all()?;
 
         Ok(new_storage)
     }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -941,7 +941,9 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
         }
 
         // Flush mappings and versions
-        new_id_tracker.mapping_flusher()()?;
+        let (mapping_stage_1, mapping_stage_2) = new_id_tracker.mapping_flusher();
+        mapping_stage_1()?;
+        mapping_stage_2()?;
         new_id_tracker.versions_flusher()()?;
 
         Ok(new_id_tracker)

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -942,9 +942,11 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
 
         // Flush mappings and versions
         let (mapping_stage_1, mapping_stage_2) = new_id_tracker.mapping_flusher();
+        let (version_stage_1, version_stage_2) = new_id_tracker.versions_flusher();
         mapping_stage_1()?;
+        version_stage_1()?;
         mapping_stage_2()?;
-        new_id_tracker.versions_flusher()()?;
+        version_stage_2()?;
 
         Ok(new_id_tracker)
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -265,16 +265,20 @@ impl VectorStorage for MmapSparseVectorStorage {
     }
 
     fn flusher(&self) -> crate::common::Flusher {
-        let storage_flusher = self.storage.flusher();
+        let (storage_stage_1_flusher, storage_stage_2_flusher) = self.storage.flusher();
         let deleted_flags_flusher = self.deleted.flusher();
         Box::new(move || {
             deleted_flags_flusher()?;
-            storage_flusher().map_err(|err| {
+            storage_stage_1_flusher().map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to flush mmap sparse vector gridstore: {err}"
                 ))
             })?;
-            Ok(())
+            storage_stage_2_flusher().map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to flush mmap sparse vector gridstore: {err}"
+                ))
+            })
         })
     }
 

--- a/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/simple_sparse_vector_storage.rs
@@ -247,7 +247,12 @@ impl VectorStorage for SimpleSparseVectorStorage {
     }
 
     fn flusher(&self) -> Flusher {
-        self.db_wrapper.flusher()
+        let (stage_1, stage_2) = self.db_wrapper.flusher();
+        Box::new(move || {
+            stage_1()?;
+            stage_2()?;
+            Ok(())
+        })
     }
 
     fn files(&self) -> Vec<std::path::PathBuf> {

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -636,7 +636,7 @@ impl SegmentEntry for ProxySegment {
             .proxy()
     }
 
-    fn flusher(&self, force: bool) -> Option<Flusher> {
+    fn flusher(&self, force: bool) -> Option<(Flusher, Flusher)> {
         let wrapped_segment = self.wrapped_segment.get();
         let wrapped_segment_guard = wrapped_segment.read();
         wrapped_segment_guard.flusher(force)

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -74,37 +74,29 @@ impl SegmentHolder {
         // as it is exclusive
         let mut background_flush_lock = self.lock_flushing()?;
 
-        if sync {
-            let mut stage_2_flushers = Vec::with_capacity(segment_reads.len());
-
-            for read_segment in segment_reads.iter() {
-                if let Some((stage_1_flusher, stage_2_flusher)) = read_segment.flusher(force) {
-                    stage_2_flushers.push(stage_2_flusher);
-                    stage_1_flusher()?;
-                }
+        // Collect flusher closures for all segments
+        // TODO: try to release segment read locks early here!
+        let (stage_1_flushers, stage_2_flushers): (Vec<_>, Vec<_>) = segment_reads
+            .iter()
+            .filter_map(|read_segment| read_segment.flusher(force))
+            .unzip();
+        let flush_all = move || -> OperationResult<_> {
+            for stage_1_flusher in stage_1_flushers {
+                stage_1_flusher()?;
             }
-
             for stage_2_flusher in stage_2_flushers {
                 stage_2_flusher()?;
             }
-        } else {
-            let (stage_1_flushers, stage_2_flushers): (Vec<_>, Vec<_>) = segment_reads
-                .iter()
-                .filter_map(|read_segment| read_segment.flusher(force))
-                .collect();
+            Ok(())
+        };
 
+        if sync {
+            flush_all()?;
+        } else {
             *background_flush_lock = Some(
                 std::thread::Builder::new()
                     .name("background_flush".to_string())
-                    .spawn(move || {
-                        for stage_1_flusher in stage_1_flushers {
-                            stage_1_flusher()?;
-                        }
-                        for stage_2_flusher in stage_2_flushers {
-                            stage_2_flusher()?;
-                        }
-                        Ok(())
-                    })
+                    .spawn(flush_all)
                     .unwrap(),
             );
         }

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -88,8 +88,9 @@ impl SegmentHolder {
                 std::thread::Builder::new()
                     .name("background_flush".to_string())
                     .spawn(move || {
-                        for flusher in flushers {
-                            flusher()?;
+                        for (stage_1_updates, stage_2_deletes) in flushers {
+                            stage_1_updates()?;
+                            stage_2_deletes()?;
                         }
                         Ok(())
                     })


### PR DESCRIPTION
_WIP_

Flush all segments in two stages:
1. inserts and updates
2. deletes

This is a naive implementation that allows us to test this idea. If it works out, we can polish it further.

We've seen a variety of issues where points did go missing. Almost all of them are related to us deleting them on disk too early. Segments have a strong dependency with each other in terms of flushing order to ensure data consistency.

The rough idea of this change is to always flush deletes as very last step. This will hopefully prevent all such issues. We rely on the WAL to repair all cases where we might have partially flushed.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
4. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
5. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
