### PR TITLE
[WIP/RFC] feat: add /collections/{name}/points/average_vector

### DIFF
--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -467,6 +467,16 @@ message RecommendBatchPoints {
   optional uint64 timeout = 4; // If set, overrides global timeout setting for this request. Unit is seconds.
 }
 
+message AverageVectorPoints {
+  string collection_name = 1; // Name of the collection
+  repeated VectorExample examples = 2; // List of point IDs or vectors to average
+  optional string using = 3; // Define which vector to use, if not specified - use default vector
+  optional LookupLocation lookup_from = 4; // Name of the collection to use for points lookup, if not specified - use current collection
+  optional ReadConsistency read_consistency = 5; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 6; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 7; // Specify in which shards to look for the points, if not specified - look in all shards
+}
+
 message RecommendPointGroups {
   string collection_name = 1; // Name of the collection
   repeated PointId positive = 2; // Look for vectors closest to the vectors from these points
@@ -995,6 +1005,12 @@ message GetResponse {
 
 message RecommendResponse {
   repeated ScoredPoint result = 1;
+  double time = 2; // Time spent to process
+  optional Usage usage = 3;
+}
+
+message AverageVectorResponse {
+  Vector vector = 1; // The computed average vector
   double time = 2; // Time spent to process
   optional Usage usage = 3;
 }

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -22,6 +22,7 @@ service PointsInternal {
   rpc Scroll (ScrollPointsInternal) returns (ScrollResponse) {}
   rpc Count (CountPointsInternal) returns (CountResponse) {}
   rpc Recommend (RecommendPointsInternal) returns (RecommendResponse) {}
+  rpc AverageVector (AverageVectorPointsInternal) returns (AverageVectorResponse) {}
   rpc Get (GetPointsInternal) returns (GetResponse) {}
   rpc QueryBatch (QueryBatchPointsInternal) returns (QueryBatchResponseInternal) {}
   rpc Facet(FacetCountsInternal) returns (FacetResponseInternal) {}
@@ -224,6 +225,11 @@ message ScrollPointsInternal {
 
 message RecommendPointsInternal {
   RecommendPoints recommend_points = 1;
+  optional uint32 shard_id = 2;
+}
+
+message AverageVectorPointsInternal {
+  AverageVectorPoints average_vector_points = 1;
   optional uint32 shard_id = 2;
 }
 

--- a/lib/api/src/grpc/proto/points_service.proto
+++ b/lib/api/src/grpc/proto/points_service.proto
@@ -79,6 +79,10 @@ service Points {
   */
   rpc RecommendGroups (RecommendPointGroups) returns (RecommendGroupsResponse) {}
   /*
+  Compute the average vector from a list of point IDs or vectors
+  */
+  rpc AverageVector (AverageVectorPoints) returns (AverageVectorResponse) {}
+  /*
   Use context and a target to find the most similar points to the target, constrained by the context.
 
   When using only the context (without a target), a special search - called context search - is performed where

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1330,6 +1330,13 @@ pub struct FacetResponse {
     pub hits: Vec<FacetValueHit>,
 }
 
+/// Response containing the computed average vector
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AverageVectorResponse {
+    /// The computed average vector
+    pub vector: VectorOutput,
+}
+
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct PointStruct {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -740,6 +740,27 @@ pub struct RecommendGroupsRequestInternal {
     pub group_request: BaseGroupRequest,
 }
 
+/// Request to compute average vector from a list of examples
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AverageVectorRequest {
+    /// List of point IDs or raw vectors to average
+    #[validate(nested)]
+    pub examples: Vec<RecommendExample>,
+
+    /// Name of the vector field to use (for named vectors)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub using: Option<UsingVector>,
+
+    /// If provided, resolve point IDs from this collection instead of the current one
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lookup_from: Option<LookupLocation>,
+
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard_key: Option<ShardKeySelector>,
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
 pub struct ContextExamplePair {
     #[validate(nested)]

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -1,7 +1,9 @@
 use segment::types::Filter;
 
 use super::StrictModeVerification;
-use crate::operations::types::{RecommendGroupsRequestInternal, RecommendRequestInternal};
+use crate::operations::types::{
+    AverageVectorRequest, RecommendGroupsRequestInternal, RecommendRequestInternal,
+};
 
 impl StrictModeVerification for RecommendRequestInternal {
     fn query_limit(&self) -> Option<usize> {
@@ -44,5 +46,27 @@ impl StrictModeVerification for RecommendGroupsRequestInternal {
 
     fn request_search_params(&self) -> Option<&segment::types::SearchParams> {
         self.params.as_ref()
+    }
+}
+
+impl StrictModeVerification for AverageVectorRequest {
+    fn query_limit(&self) -> Option<usize> {
+        None // No limit for average vector computation
+    }
+
+    fn indexed_filter_read(&self) -> Option<&Filter> {
+        None // No filtering for average vector
+    }
+
+    fn indexed_filter_write(&self) -> Option<&Filter> {
+        None
+    }
+
+    fn request_exact(&self) -> Option<bool> {
+        None
+    }
+
+    fn request_search_params(&self) -> Option<&segment::types::SearchParams> {
+        None
     }
 }

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -30,7 +30,7 @@ use crate::operations::types::{
     RecommendRequestInternal, UsingVector,
 };
 
-fn avg_vectors<'a>(
+pub fn avg_vectors<'a>(
     vectors: impl IntoIterator<Item = VectorRef<'a>>,
 ) -> CollectionResult<VectorInternal> {
     let mut avg_dense = DenseVector::default();

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -4,17 +4,18 @@ use std::time::{Duration, Instant};
 use api::grpc::Usage;
 use api::grpc::qdrant::points_server::Points;
 use api::grpc::qdrant::{
-    ClearPayloadPoints, CountPoints, CountResponse, CreateFieldIndexCollection,
-    DeleteFieldIndexCollection, DeletePayloadPoints, DeletePointVectors, DeletePoints,
-    DiscoverBatchPoints, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse, FacetCounts,
-    FacetResponse, GetPoints, GetResponse, PointsOperationResponse, QueryBatchPoints,
-    QueryBatchResponse, QueryGroupsResponse, QueryPointGroups, QueryPoints, QueryResponse,
-    RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse, RecommendPointGroups,
-    RecommendPoints, RecommendResponse, ScrollPoints, ScrollResponse, SearchBatchPoints,
-    SearchBatchResponse, SearchGroupsResponse, SearchMatrixOffsets, SearchMatrixOffsetsResponse,
-    SearchMatrixPairs, SearchMatrixPairsResponse, SearchMatrixPoints, SearchPointGroups,
-    SearchPoints, SearchResponse, SetPayloadPoints, UpdateBatchPoints, UpdateBatchResponse,
-    UpdatePointVectors, UpsertPoints,
+    AverageVectorPoints, AverageVectorResponse, ClearPayloadPoints, CountPoints, CountResponse,
+    CreateFieldIndexCollection, DeleteFieldIndexCollection, DeletePayloadPoints,
+    DeletePointVectors, DeletePoints, DiscoverBatchPoints, DiscoverBatchResponse, DiscoverPoints,
+    DiscoverResponse, FacetCounts, FacetResponse, GetPoints, GetResponse,
+    PointsOperationResponse, QueryBatchPoints, QueryBatchResponse, QueryGroupsResponse,
+    QueryPointGroups, QueryPoints, QueryResponse, RecommendBatchPoints, RecommendBatchResponse,
+    RecommendGroupsResponse, RecommendPointGroups, RecommendPoints, RecommendResponse,
+    ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse,
+    SearchMatrixOffsets, SearchMatrixOffsetsResponse, SearchMatrixPairs,
+    SearchMatrixPairsResponse, SearchMatrixPoints, SearchPointGroups, SearchPoints,
+    SearchResponse, SetPayloadPoints, UpdateBatchPoints, UpdateBatchResponse, UpdatePointVectors,
+    UpsertPoints,
 };
 use collection::operations::types::CoreSearchRequest;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -730,5 +731,15 @@ impl Points for PointsService {
         };
 
         Ok(Response::new(offsets_response))
+    }
+
+    async fn average_vector(
+        &self,
+        _request: Request<AverageVectorPoints>,
+    ) -> Result<Response<AverageVectorResponse>, Status> {
+        // TODO: Implement gRPC handler for average_vector
+        Err(Status::unimplemented(
+            "AverageVector gRPC endpoint is not yet implemented. Please use the REST API endpoint instead.",
+        ))
     }
 }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 use api::grpc::HardwareUsage;
 use api::grpc::qdrant::points_internal_server::PointsInternal;
 use api::grpc::qdrant::{
-    ClearPayloadPointsInternal, CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
+    AverageVectorPointsInternal, AverageVectorResponse, ClearPayloadPointsInternal,
+    CoreSearchBatchPointsInternal, CountPointsInternal, CountResponse,
     CreateFieldIndexCollectionInternal, DeleteFieldIndexCollectionInternal,
     DeletePayloadPointsInternal, DeletePointsInternal, DeleteVectorsInternal, FacetCountsInternal,
     FacetResponseInternal, GetPointsInternal, GetResponse, IntermediateResult,
@@ -832,6 +833,16 @@ impl PointsInternal for PointsInternalService {
             request_inner.collection_name.clone(),
         );
         facet_counts_internal(self.toc.as_ref(), request_inner, hw_data).await
+    }
+
+    async fn average_vector(
+        &self,
+        _request: Request<AverageVectorPointsInternal>,
+    ) -> Result<Response<AverageVectorResponse>, Status> {
+        // TODO: Implement gRPC handler for average_vector
+        Err(Status::unimplemented(
+            "AverageVector gRPC endpoint is not yet implemented. Please use the REST API endpoint instead.",
+        ))
     }
 }
 


### PR DESCRIPTION
Allows quickly retrieving the average vector from existing points, e.g. to enable custom recommendation search.

Example use case: for https://github.com/qdrant/qdrant/issues/4235, get the average of the positive and negative examples, and apply custom weights with the Rocchio algorithm.

Still needs work but what do you think, worth adding?

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
