### PR TITLE
Do not merge threadpool experiment

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -21,9 +21,9 @@ cluster:
   resharding_enabled: true
 
 storage:
-  performance:
-    # Number of parallel threads used for search operations. If 0 - auto selection.
-    max_search_threads: 4
+#  performance:
+#    # Number of parallel threads used for search operations. If 0 - auto selection.
+#    max_search_threads: 4
 
   optimizers:
     # Minimum interval between forced flushes.

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -290,7 +290,8 @@ impl SegmentsSearcher {
             (segments, search)
         };
 
-        let (all_search_results_per_segment, further_results): (Vec<_>, Vec<_>) = search.await??.into_iter().unzip();
+        let (all_search_results_per_segment, further_results): (Vec<_>, Vec<_>) =
+            search.await??.into_iter().unzip();
 
         debug_assert!(all_search_results_per_segment.len() == locked_segments.len());
 


### PR DESCRIPTION
An exaple of using different threading layout for segment search.

Current dev:

- Assigns search in each segment to independent thread

This PR:

- Assign search in all segments to a single thread

Intuition:

Maybe if segments are small, the overhead for moving tasks to different threads is greated than benefit of threading?

Does the intuition work? **No**