### PR TITLE
extra cloud params for web-ui customization

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11687,6 +11687,7 @@
       "AppBuildTelemetry": {
         "type": "object",
         "required": [
+          "cloud_params",
           "name",
           "startup",
           "version"
@@ -11749,6 +11750,9 @@
           "startup": {
             "type": "string",
             "format": "date-time"
+          },
+          "cloud_params": {
+            "$ref": "#/components/schemas/CloudParams"
           }
         }
       },
@@ -11921,6 +11925,34 @@
         "properties": {
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "CloudParams": {
+        "type": "object",
+        "properties": {
+          "is_cloud": {
+            "description": "Indicates if current qdrant instance is running in cloud",
+            "default": null,
+            "type": "boolean",
+            "nullable": true
+          },
+          "is_free": {
+            "default": null,
+            "type": "boolean",
+            "nullable": true
+          },
+          "cluster_name": {
+            "description": "Cluster name to display",
+            "default": null,
+            "type": "string",
+            "nullable": true
+          },
+          "backlink": {
+            "description": "Link to cluster page",
+            "default": null,
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11687,7 +11687,6 @@
       "AppBuildTelemetry": {
         "type": "object",
         "required": [
-          "cloud_params",
           "name",
           "startup",
           "version"
@@ -11752,7 +11751,14 @@
             "format": "date-time"
           },
           "cloud_params": {
-            "$ref": "#/components/schemas/CloudParams"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CloudParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -66,18 +66,6 @@ pub struct CloudParams {
     pub backlink: Option<String>,
 }
 
-impl CloudParams {
-    fn is_empty(&self) -> bool {
-        let Self {
-            is_cloud,
-            is_free,
-            cluster_name,
-            backlink,
-        } = self;
-        is_cloud.is_none() && is_free.is_none() && cluster_name.is_none() && backlink.is_none()
-    }
-}
-
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
 pub struct AppBuildTelemetry {
     #[anonymize(false)]
@@ -98,8 +86,8 @@ pub struct AppBuildTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_jwt_dashboard: Option<bool>,
     pub startup: DateTime<Utc>,
-    #[serde(skip_serializing_if = "CloudParams::is_empty")]
-    pub cloud_params: CloudParams,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloud_params: Option<CloudParams>,
 }
 
 impl AppBuildTelemetry {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,7 @@ use validator::Validate;
 
 use crate::common::debugger::DebuggerConfig;
 use crate::common::inference::config::InferenceConfig;
+use crate::common::telemetry_ops::app_telemetry::CloudParams;
 use crate::tracing;
 
 const MAX_PEER_ID: u64 = (1 << 53) - 1;
@@ -224,6 +225,8 @@ pub struct Settings {
     pub gpu: Option<GpuConfig>,
     #[serde(default)]
     pub feature_flags: FeatureFlags,
+    /// Extra parameters configured in cloud, propagated to telemetry
+    pub cloud_params: CloudParams,
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -226,7 +226,8 @@ pub struct Settings {
     #[serde(default)]
     pub feature_flags: FeatureFlags,
     /// Extra parameters configured in cloud, propagated to telemetry
-    pub cloud_params: CloudParams,
+    #[serde(default)]
+    pub cloud_params: Option<CloudParams>,
 }
 
 impl Settings {


### PR DESCRIPTION
This PR adds some internal Settings (and associated ENV parameteres) to be propagated into web-ui from cloud.

For example:

```
QDRANT__CLOUD_PARAMS__BACKLINK='https://cloud.qdrant.io/accounts/db3db48e-678f-463a-bf87-52ddc33ee788/clusters/61768340-a723-4a60-ab07-bbf74275ee0d/overview'
```

Would allow web-ui to render navigation link back to qdrant cloud. 

Unfortunately, not all planned parameters are suitable for transferring over ENV, as ENV can only be changed on cluster restart (e.g. cluster name,  user name, available upgrade), so we would need to find other ways to get this information

