### PR TITLE
Add function for `indexed_only` decision

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12166,7 +12166,7 @@
             "type": "boolean",
             "nullable": true
           },
-          "index_only_excluded_vectors": {
+          "indexed_only_excluded_vectors": {
             "type": "object",
             "additionalProperties": {
               "type": "integer",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12165,6 +12165,15 @@
           "async_scorer": {
             "type": "boolean",
             "nullable": true
+          },
+          "index_only_excluded_vectors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "nullable": true
           }
         }
       },

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -71,6 +71,7 @@ impl DummyShard {
             segments: None,
             optimizations: Default::default(),
             async_scorer: None,
+            index_only_excluded_vectors: None,
         }
     }
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -71,7 +71,7 @@ impl DummyShard {
             segments: None,
             optimizations: Default::default(),
             async_scorer: None,
-            index_only_excluded_vectors: None,
+            indexed_only_excluded_vectors: None,
         }
     }
 

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -178,7 +178,7 @@ fn get_index_only_excluded_vectors(
                 .vector_names()
                 .into_iter()
                 .filter_map(move |vector_name| {
-                    let segment_config = &segment_guard.config().vector_data[&vector_name];
+                    let segment_config = segment_guard.config().vector_data.get(&vector_name)?;
 
                     // Skip segments that have an index.
                     if segment_config.index.is_indexed() {

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -1,10 +1,16 @@
+use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 
 use common::types::{DetailsLevel, TelemetryDetail};
-use segment::types::SizeStats;
+use segment::common::BYTES_IN_KB;
+use segment::common::operation_time_statistics::OperationDurationStatistics;
+use segment::types::{SizeStats, VectorNameBuf};
 use segment::vector_storage::common::get_async_scorer;
+use shard::segment_holder::SegmentHolder;
 
+use crate::config::CollectionConfigInternal;
 use crate::operations::types::OptimizersStatus;
+use crate::optimizers_builder::DEFAULT_INDEXING_THRESHOLD_KB;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::telemetry::{LocalShardTelemetry, OptimizerTelemetry};
 
@@ -12,29 +18,38 @@ impl LocalShard {
     pub async fn get_telemetry_data(&self, detail: TelemetryDetail) -> LocalShardTelemetry {
         let segments = self.segments.clone();
 
-        let segments = tokio::task::spawn_blocking(move || {
-            let segments = segments.read(); // blocking sync lock
+        let segments_data = if detail.level < DetailsLevel::Level4 {
+            Ok((vec![], HashMap::default()))
+        } else {
+            let locked_collection_config = self.collection_config.clone();
 
-            if detail.level >= DetailsLevel::Level4 {
-                segments
+            tokio::task::spawn_blocking(move || {
+                // blocking sync lock
+                let segments_guard = segments.read();
+
+                let segments_telemetry = segments_guard
                     .iter()
                     .map(|(_id, segment)| segment.get().read().get_telemetry_data(detail))
-                    .collect()
-            } else {
-                vec![]
-            }
-        })
-        .await;
+                    .collect();
 
-        if let Err(err) = &segments {
+                let collection_config = locked_collection_config.blocking_read();
+                let index_only_excluded_vectors =
+                    get_index_only_excluded_vectors(&segments_guard, &collection_config);
+
+                (segments_telemetry, index_only_excluded_vectors)
+            })
+            .await
+        };
+
+        if let Err(err) = &segments_data {
             log::error!("Failed to get telemetry: {err}");
         }
 
-        let segments = segments.unwrap_or_default();
+        let (segments, index_only_excluded_vectors) = segments_data.unwrap_or_default();
 
         let total_optimized_points = self.total_optimized_points.load(Ordering::Relaxed);
 
-        let optimizations = self
+        let optimizations: OperationDurationStatistics = self
             .optimizers
             .iter()
             .map(|optimizer| {
@@ -70,10 +85,12 @@ impl LocalShard {
             optimizations: OptimizerTelemetry {
                 status,
                 optimizations,
-                log: (detail.level >= DetailsLevel::Level4 || detail.optimizer_logs)
+                log: (detail.level >= DetailsLevel::Level4)
                     .then(|| self.optimizers_log.lock().to_telemetry()),
             },
             async_scorer: Some(get_async_scorer()),
+            index_only_excluded_vectors: (!index_only_excluded_vectors.is_empty())
+                .then_some(index_only_excluded_vectors),
         }
     }
 
@@ -132,4 +149,62 @@ impl LocalShard {
 
         stats.unwrap_or_default()
     }
+}
+
+/// Returns vectors which will be excluded from requests with `index-only` enabled.
+fn get_index_only_excluded_vectors(
+    segment_holder: &SegmentHolder,
+    collection_config: &CollectionConfigInternal,
+) -> HashMap<VectorNameBuf, usize> {
+    let indexing_threshold = collection_config
+        .optimizer_config
+        .indexing_threshold
+        .unwrap_or(DEFAULT_INDEXING_THRESHOLD_KB);
+
+    // Threshold in kilobytes below which we allow full-search.
+    let search_optimized_threshold_bytes = indexing_threshold.max(collection_config.hnsw_config.full_scan_threshold)
+        // convert KB to bytes
+        * BYTES_IN_KB;
+
+    segment_holder
+        .iter()
+        .flat_map(|(_, segment)| {
+            let segment_guard = segment.get().read();
+
+            // Get a map of vector-name=>vector-storage-size for unindexed vectors in this segment.
+            segment_guard
+                .vector_names()
+                .into_iter()
+                .filter_map(move |vector_name| {
+                    let segment_config = &segment_guard.config().vector_data[&vector_name];
+
+                    // Skip segments that have an index.
+                    if segment_config.index.is_indexed() {
+                        return None;
+                    }
+
+                    let vector_storage_size =
+                        segment_guard.available_vectors_size_in_bytes(&vector_name);
+
+                    if let Err(err) = vector_storage_size {
+                        log::error!("Failed to get vector size from segment: {err:?}");
+                        return None;
+                    }
+
+                    let points = segment_guard.available_point_count();
+                    Some((vector_name, vector_storage_size.unwrap(), points))
+                })
+        })
+        .filter(|(_, vector_size_bytes, _)| {
+            // Filter out only large segments that do not support full-scan, as smaller segments can
+            // be searched quickly without using an index and are included in index-only searches.
+            *vector_size_bytes > search_optimized_threshold_bytes
+        })
+        .fold(
+            HashMap::<VectorNameBuf, usize>::default(),
+            |mut acc, (name, _, point_count)| {
+                *acc.entry(name).or_insert(0) += point_count;
+                acc
+            },
+        )
 }

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -151,7 +151,9 @@ impl LocalShard {
     }
 }
 
-/// Returns vectors which will be excluded from requests with `index-only` enabled.
+/// Returns the number of vectors which will be excluded from requests with `indexed_only` enabled.
+///
+/// This effectively counts vectors in large unindexed segments.
 fn get_index_only_excluded_vectors(
     segment_holder: &SegmentHolder,
     collection_config: &CollectionConfigInternal,

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -191,14 +191,16 @@ fn get_index_only_excluded_vectors(
 
                     let vector_storage_size =
                         segment_guard.available_vectors_size_in_bytes(&vector_name);
-
-                    if let Err(err) = vector_storage_size {
-                        log::error!("Failed to get vector size from segment: {err:?}");
-                        return None;
-                    }
+                    let vector_storage_size = match vector_storage_size {
+                        Ok(size) => size,
+                        Err(err) => {
+                            log::error!("Failed to get vector size from segment: {err:?}");
+                            return None;
+                        }
+                    };
 
                     let points = segment_guard.available_point_count();
-                    Some((vector_name, vector_storage_size.unwrap(), points))
+                    Some((vector_name, vector_storage_size, points))
                 })
         })
         .fold(

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -33,10 +33,10 @@ impl LocalShard {
                     .collect();
 
                 let collection_config = locked_collection_config.blocking_read();
-                let index_only_excluded_vectors =
+                let indexed_only_excluded_vectors =
                     get_index_only_excluded_vectors(&segments_guard, &collection_config);
 
-                (segments_telemetry, index_only_excluded_vectors)
+                (segments_telemetry, indexed_only_excluded_vectors)
             })
             .await
         };
@@ -89,7 +89,7 @@ impl LocalShard {
                     .then(|| self.optimizers_log.lock().to_telemetry()),
             },
             async_scorer: Some(get_async_scorer()),
-            index_only_excluded_vectors: (!index_only_excluded_vectors.is_empty())
+            indexed_only_excluded_vectors: (!index_only_excluded_vectors.is_empty())
                 .then_some(index_only_excluded_vectors),
         }
     }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -65,6 +65,8 @@ pub struct LocalShardTelemetry {
     pub optimizations: OptimizerTelemetry,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub async_scorer: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_only_excluded_vectors: Option<HashMap<String, usize>>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize, Default)]

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -66,7 +66,7 @@ pub struct LocalShardTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub async_scorer: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub index_only_excluded_vectors: Option<HashMap<String, usize>>,
+    pub indexed_only_excluded_vectors: Option<HashMap<String, usize>>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize, Default)]

--- a/lib/collection/src/telemetry.rs
+++ b/lib/collection/src/telemetry.rs
@@ -66,6 +66,15 @@ impl CollectionTelemetry {
             .filter(|log| log.status == TrackerStatus::Optimizing)
             .count()
     }
+
+    pub fn count_points(&self) -> usize {
+        self.shards
+            .iter()
+            .flatten()
+            .filter_map(|shard| shard.local.as_ref())
+            .map(|local_shard| local_shard.num_points.unwrap_or(0))
+            .sum()
+    }
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema)]

--- a/lib/common/common/src/types.rs
+++ b/lib/common/common/src/types.rs
@@ -33,7 +33,6 @@ impl PartialOrd for ScoredPointOffset {
 pub struct TelemetryDetail {
     pub level: DetailsLevel,
     pub histograms: bool,
-    pub optimizer_logs: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -70,7 +69,6 @@ impl Default for TelemetryDetail {
         TelemetryDetail {
             level: DetailsLevel::Level0,
             histograms: false,
-            optimizer_logs: false,
         }
     }
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -241,6 +241,15 @@ pub trait SegmentEntry: SnapshotEntry {
     /// Size of all available vectors in storage
     fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize>;
 
+    /// Whether to include the vectors with the given name vector in `indexed_only` searches
+    fn in_indexed_only_search(
+        &self,
+        vector_name: &VectorName,
+        search_optimized_threshold_kb: usize,
+        filter: Option<&Filter>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool>;
+
     /// Max value from all `available_vectors_size_in_bytes`
     fn max_available_vectors_size_in_bytes(&self) -> OperationResult<usize> {
         self.vector_names()

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -462,6 +462,21 @@ impl SegmentEntry for Segment {
         Ok(size)
     }
 
+    fn in_indexed_only_search(
+        &self,
+        vector_name: &VectorName,
+        search_optimized_threshold_kb: usize,
+        filter: Option<&Filter>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        check_vector_name(vector_name, &self.segment_config)?;
+        let include = self.vector_data[vector_name]
+            .vector_index
+            .borrow()
+            .in_indexed_only_search(search_optimized_threshold_kb, filter, hw_counter);
+        Ok(include)
+    }
+
     fn estimate_point_count<'a>(
         &'a self,
         filter: Option<&'a Filter>,

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -540,10 +540,26 @@ impl SegmentEntry for ProxySegment {
         filter: Option<&Filter>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
+        // If the proxy segment has no deleted points, direct call to wrapped segment
+        if self.deleted_points.is_empty() {
+            return self.wrapped_segment.get().read().in_indexed_only_search(
+                vector_name,
+                search_optimized_threshold_kb,
+                filter,
+                hw_counter,
+            );
+        }
+
+        // Incorporate deleted point count in decision
+        let wrapped_filter = Self::add_deleted_points_condition_to_filter(
+            filter,
+            self.deleted_points.keys().copied(),
+        );
+
         self.wrapped_segment.get().read().in_indexed_only_search(
             vector_name,
             search_optimized_threshold_kb,
-            filter,
+            Some(&wrapped_filter),
             hw_counter,
         )
     }

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -533,6 +533,21 @@ impl SegmentEntry for ProxySegment {
         }
     }
 
+    fn in_indexed_only_search(
+        &self,
+        vector_name: &VectorName,
+        search_optimized_threshold_kb: usize,
+        filter: Option<&Filter>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        self.wrapped_segment.get().read().in_indexed_only_search(
+            vector_name,
+            search_optimized_threshold_kb,
+            filter,
+            hw_counter,
+        )
+    }
+
     fn estimate_point_count<'a>(
         &'a self,
         filter: Option<&'a Filter>,

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -540,28 +540,36 @@ impl SegmentEntry for ProxySegment {
         filter: Option<&Filter>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        // If the proxy segment has no deleted points, direct call to wrapped segment
-        if self.deleted_points.is_empty() {
-            return self.wrapped_segment.get().read().in_indexed_only_search(
-                vector_name,
-                search_optimized_threshold_kb,
-                filter,
-                hw_counter,
-            );
-        }
-
-        // Incorporate deleted point count in decision
-        let wrapped_filter = Self::add_deleted_points_condition_to_filter(
-            filter,
-            self.deleted_points.keys().copied(),
-        );
-
         self.wrapped_segment.get().read().in_indexed_only_search(
             vector_name,
             search_optimized_threshold_kb,
-            Some(&wrapped_filter),
+            filter,
             hw_counter,
         )
+
+        // TODO(timvisee): enable indexed_only handling with proxies
+        // // If the proxy segment has no deleted points, direct call to wrapped segment
+        // if self.deleted_points.is_empty() {
+        //     return self.wrapped_segment.get().read().in_indexed_only_search(
+        //         vector_name,
+        //         search_optimized_threshold_kb,
+        //         filter,
+        //         hw_counter,
+        //     );
+        // }
+
+        // // Incorporate deleted point count in decision
+        // let wrapped_filter = Self::add_deleted_points_condition_to_filter(
+        //     filter,
+        //     self.deleted_points.keys().copied(),
+        // );
+
+        // self.wrapped_segment.get().read().in_indexed_only_search(
+        //     vector_name,
+        //     search_optimized_threshold_kb,
+        //     Some(&wrapped_filter),
+        //     hw_counter,
+        // )
     }
 
     fn estimate_point_count<'a>(

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -46,7 +46,6 @@ fn telemetry(
         let detail = TelemetryDetail {
             level: details_level,
             histograms: false,
-            optimizer_logs: false,
         };
         let telemetry_collector = telemetry_collector.lock().await;
         let telemetry_data = telemetry_collector.prepare_data(&access, detail).await;
@@ -80,9 +79,8 @@ async fn metrics(
         .prepare_data(
             &access,
             TelemetryDetail {
-                level: DetailsLevel::Level3,
+                level: DetailsLevel::Level4,
                 histograms: true,
-                optimizer_logs: true,
             },
         )
         .await;

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -232,7 +232,7 @@ impl MetricsProvider for CollectionsTelemetry {
 
         if !indexed_only_excluded.is_empty() {
             metrics.push(metric_family(
-                "collection_index_only_excluded",
+                "collection_index_only_excluded_points",
                 "amount of points excluded in indexed_only requests",
                 MetricType::GAUGE,
                 indexed_only_excluded,

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -175,7 +175,12 @@ impl MetricsProvider for CollectionsTelemetry {
             vec![gauge(vector_count as f64, &[])],
         ));
 
+        // Optimizers
         let mut total_optimizations_running = 0;
+
+        // Points & Vectors per collection
+        let mut vectors_per_collection = vec![];
+        let mut points_per_collection = vec![];
 
         for collection in self.collections.iter().flatten() {
             let collection = match collection {
@@ -186,6 +191,16 @@ impl MetricsProvider for CollectionsTelemetry {
             };
 
             total_optimizations_running += collection.count_optimizers_running();
+
+            points_per_collection.push(gauge(
+                collection.count_points() as f64,
+                &[("id", &collection.id)],
+            ));
+
+            vectors_per_collection.push(gauge(
+                collection.count_vectors() as f64,
+                &[("id", &collection.id)],
+            ));
         }
 
         metrics.push(metric_family(
@@ -193,6 +208,20 @@ impl MetricsProvider for CollectionsTelemetry {
             "number of currently running optimization processes",
             MetricType::GAUGE,
             vec![gauge(total_optimizations_running as f64, &[])],
+        ));
+
+        metrics.push(metric_family(
+            "collection_points",
+            "approximate amount of points per collection",
+            MetricType::GAUGE,
+            points_per_collection,
+        ));
+
+        metrics.push(metric_family(
+            "collection_vectors",
+            "approximate amount of vectors per collection",
+            MetricType::GAUGE,
+            vectors_per_collection,
         ));
     }
 }

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -212,7 +212,7 @@ impl MetricsProvider for CollectionsTelemetry {
                 .iter()
                 .flatten()
                 .filter_map(|shard| shard.local.as_ref())
-                .filter_map(|local| local.index_only_excluded_vectors.as_ref())
+                .filter_map(|local| local.indexed_only_excluded_vectors.as_ref())
                 .flatten()
                 .fold(
                     HashMap::<&str, usize>::default(),
@@ -232,7 +232,7 @@ impl MetricsProvider for CollectionsTelemetry {
 
         if !indexed_only_excluded.is_empty() {
             metrics.push(metric_family(
-                "collection_index_only_excluded_points",
+                "collection_indexed_only_excluded_points",
                 "amount of points excluded in indexed_only requests",
                 MetricType::GAUGE,
                 indexed_only_excluded,

--- a/src/common/telemetry_reporting.rs
+++ b/src/common/telemetry_reporting.rs
@@ -12,7 +12,6 @@ use super::telemetry::TelemetryCollector;
 const DETAIL: TelemetryDetail = TelemetryDetail {
     level: DetailsLevel::Level2,
     histograms: false,
-    optimizer_logs: false,
 };
 const REPORTING_INTERVAL: Duration = Duration::from_secs(60 * 60); // One hour
 


### PR DESCRIPTION
Improves <https://github.com/qdrant/qdrant/pull/7307>

Add a `in_indexed_only_search()` function to segments and their indices. Allow us to use just this function to decide how `indexed_only` behaves.

This specifically improves the way we list excluded points for <https://github.com/qdrant/qdrant/pull/7307> by keeping the `indexed_only` decision within segments.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?