### PR TITLE
Access vector_data without risk of panicking

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1853,9 +1853,7 @@ impl SparseVectorsConfig {
                 .sparse_vectors
                 .as_ref()
                 .and_then(|v| v.get(vector_name).map(|_| ()))
-                .ok_or_else(|| OperationError::VectorNameNotExists {
-                    received_name: vector_name.clone(),
-                })?;
+                .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
         }
         Ok(())
     }

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -172,9 +172,7 @@ fn get_vector_config_or_error<'a>(
     segment_config
         .vector_data
         .get(vector_name)
-        .ok_or_else(|| OperationError::VectorNameNotExists {
-            received_name: vector_name.to_owned(),
-        })
+        .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))
 }
 
 /// Get the sparse vector config for the given name, or return a name error.
@@ -187,9 +185,7 @@ fn get_sparse_vector_config_or_error<'a>(
     segment_config
         .sparse_vector_data
         .get(vector_name)
-        .ok_or_else(|| OperationError::VectorNameNotExists {
-            received_name: vector_name.to_owned(),
-        })
+        .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))
 }
 
 /// Check if the given dense vector data is compatible with the given configuration.

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -107,6 +107,12 @@ impl OperationError {
             description: description.into(),
         }
     }
+
+    pub fn vector_name_not_exists(vector_name: impl Into<String>) -> OperationError {
+        OperationError::VectorNameNotExists {
+            received_name: vector_name.into(),
+        }
+    }
 }
 
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -67,11 +67,10 @@ impl SegmentEntry for Segment {
         query_context: &SegmentQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
         check_query_vectors(vector_name, query_vectors, &self.segment_config)?;
-        let vector_data = &self.vector_data.get(vector_name).ok_or_else(|| {
-            OperationError::VectorNameNotExists {
-                received_name: vector_name.to_owned(),
-            }
-        })?;
+        let vector_data = &self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
         let vector_query_context = query_context.get_vector_context(vector_name);
         let internal_results = vector_data.vector_index.borrow().search(
             query_vectors,
@@ -198,11 +197,10 @@ impl SegmentEntry for Segment {
             }),
             Some(internal_id) => {
                 self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
-                    let vector_data = segment.vector_data.get(vector_name).ok_or_else(|| {
-                        OperationError::VectorNameNotExists {
-                            received_name: vector_name.to_owned(),
-                        }
-                    })?;
+                    let vector_data = segment
+                        .vector_data
+                        .get(vector_name)
+                        .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
                     let mut vector_storage = vector_data.vector_storage.borrow_mut();
                     let is_deleted = vector_storage.delete_vector(internal_id)?;
 
@@ -457,11 +455,10 @@ impl SegmentEntry for Segment {
 
     fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize> {
         check_vector_name(vector_name, &self.segment_config)?;
-        let vector_data = self.vector_data.get(vector_name).ok_or_else(|| {
-            OperationError::VectorNameNotExists {
-                received_name: vector_name.to_owned(),
-            }
-        })?;
+        let vector_data = self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
         let size = vector_data
             .vector_index
             .borrow()

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -385,11 +385,10 @@ impl Segment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<VectorInternal>> {
         check_vector_name(vector_name, &self.segment_config)?;
-        let vector_data = &self.vector_data.get(vector_name).ok_or_else(|| {
-            OperationError::VectorNameNotExists {
-                received_name: vector_name.to_owned(),
-            }
-        })?;
+        let vector_data = &self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
         let vector_storage = vector_data.vector_storage.borrow();
         let is_vector_deleted = vector_storage.is_deleted_vector(point_offset);
         if !is_vector_deleted && !self.id_tracker.borrow().is_deleted_point(point_offset) {
@@ -627,9 +626,7 @@ impl Segment {
         Ok(self
             .vector_data
             .get(vector_name)
-            .ok_or_else(|| OperationError::VectorNameNotExists {
-                received_name: vector_name.to_owned(),
-            })?
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?
             .vector_storage
             .borrow()
             .available_vector_count())


### PR DESCRIPTION
When accessing `vector_data`, always use `.get()` rather than `[]` to not risk panicking.

Semi-related: https://github.com/qdrant/qdrant/pull/7463#discussion_r2472120665

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?