### PR TITLE
Add avx512vl and avx512vpopcntdq in telemetry

### DIFF
--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -135,6 +135,12 @@ fn get_system_data() -> RunningEnvironmentTelemetry {
         if std::arch::is_x86_feature_detected!("avx512f") {
             cpu_flags.push("avx512f");
         }
+        if std::arch::is_x86_feature_detected!("avx512vl") {
+            cpu_flags.push("avx512vl");
+        }
+        if std::arch::is_x86_feature_detected!("avx512vpopcntdq") {
+            cpu_flags.push("avx512vpopcntdq");
+        }
     }
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {


### PR DESCRIPTION
Depends on #7052

In #7052 we use new x86 features because of avx512 usage. This PR adds them into telemetry for consistency and debugging purposes.