### PR TITLE
Add `repr(C)` attribute to type used in MmapSlice

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -28,6 +28,7 @@ const OFFSETS_DIR_PATH: &str = "offsets";
 const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
 pub struct MultivectorMmapOffset {
     offset: u32,
     count: u32,


### PR DESCRIPTION
Similar to <https://github.com/qdrant/qdrant/pull/7415>

Add `#[repr(C)]` attribute to `MultivectorMmapOffset`.

Used [here](https://github.com/qdrant/qdrant/blob/1e4a39a5a077640d2c5c69c0527e0bb82a4e3884/lib/segment/src/vector_storage/vector_storage_base.rs#L300) for example, indirectly used in `MmapSlice`.

With this we cover all types that are used in this way.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?