### PR TITLE
Bump MSRV to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.89"
 default-run = "qdrant"
 
 [lints]


### PR DESCRIPTION
Bump the minimum supported Rust version to 1.89.

We need at least this function because we use [`_mm256_popcnt_epi64`](https://doc.rust-lang.org/core/arch/x86/fn._mm256_popcnt_epi64.html) here:

https://github.com/qdrant/qdrant/blob/793b261016fc9c45559bae2e3d0bb323384141e7/lib/quantization/src/encoded_vectors_binary.rs#L1066

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?