### PR TITLE
Fix panic in metrics API

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -349,13 +349,15 @@ impl MetricsProvider for CollectionsTelemetry {
             prefix,
         ));
 
-        metrics.push(metric_family(
-            "collection_points",
-            "approximate amount of points per collection",
-            MetricType::GAUGE,
-            points_per_collection,
-            prefix,
-        ));
+        if !points_per_collection.is_empty() {
+            metrics.push(metric_family(
+                "collection_points",
+                "approximate amount of points per collection",
+                MetricType::GAUGE,
+                points_per_collection,
+                prefix,
+            ));
+        }
 
         metrics.push(metric_family(
             "dead_shards_total",


### PR DESCRIPTION
Fixes a panic in metrics API caused by an empty list, in case no collections exist.

I tried to find a way to prevent these issues in future but there is no low hanging fruit here.
I'll look into it and make a separate PR for this in case there is a good solution.