### PR TITLE
Various metrics tweaks

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -671,9 +671,7 @@ impl OperationDurationMetricsBuilder {
 
     /// Build metrics and add them to the provided vector.
     pub fn build(self, global_prefix: Option<&str>, prefix: &str, metrics: &mut Vec<MetricFamily>) {
-        let prefix = global_prefix
-            .map(|global_prefix| format!("{global_prefix}{prefix}_"))
-            .unwrap_or_else(|| prefix.to_string());
+        let prefix = format!("{}{prefix}_", global_prefix.unwrap_or(""));
 
         if !self.total.is_empty() {
             metrics.push(metric_family(


### PR DESCRIPTION
Various `/metrics` tweaks

Changes include:
- fix missing `_` separator in gRPC metrics
- change page fault gauges to counters (these are monotonic)
- remove `_total` suffix from vector count, make consistent with point count
- rename `procfs` metrics to 'process', e.g:
  - `qdrant_procfs_mmap_count` -> `qdrant_process_mmap_count`
  - `qdrant_procfs_major_page_faults` -> `qdrant_process_major_page_faults_total`
- merge soft/hard limit for file descriptors into one metric
- changed other metrics to better follow convention

Please see each individual commit for a better view in all exact changes.

A snippet of some metrics:

```bash
# HELP qdrant_active_replicas_min minimum number of active replicas across all shards
# TYPE qdrant_active_replicas_min gauge
qdrant_active_replicas_min 1
# HELP qdrant_active_replicas_max maximum number of active replicas across all shards
# TYPE qdrant_active_replicas_max gauge
qdrant_active_replicas_max 1
# HELP qdrant_optimizer_running_processes number of currently running optimization processes
# TYPE qdrant_optimizer_running_processes gauge
qdrant_optimizer_running_processes 0
# HELP qdrant_collection_points approximate amount of points per collection
# TYPE qdrant_collection_points gauge
qdrant_collection_points{id="benchmark"} 100000
qdrant_collection_points{id="test"} 123
# HELP qdrant_collection_vectors amount of vectors grouped by vector name
# TYPE qdrant_collection_vectors gauge
qdrant_collection_vectors{collection="benchmark",vector=""} 100000
qdrant_collection_vectors{collection="test",vector=""} 123
# HELP qdrant_dead_replicas total amount of shard replicas in non-active state
# TYPE qdrant_dead_replicas gauge
qdrant_dead_replicas 0
# HELP qdrant_process_open_mmaps count of open mmaps
# TYPE qdrant_process_open_mmaps gauge
qdrant_process_open_mmaps 831
# HELP qdrant_process_open_fds count of currently open file descriptors
# TYPE qdrant_process_open_fds gauge
qdrant_process_open_fds 122
# HELP qdrant_process_max_fds limit for open file descriptors
# TYPE qdrant_process_max_fds gauge
qdrant_process_max_fds 1024
# HELP qdrant_process_minor_page_faults_total count of minor page faults which didn't cause a disk access
# TYPE qdrant_process_minor_page_faults_total counter
qdrant_process_minor_page_faults_total 0
# HELP qdrant_process_major_page_faults_total count of disk accesses caused by a mmap page fault
# TYPE qdrant_process_major_page_faults_total counter
qdrant_process_major_page_faults_total 0
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?