### PR TITLE
In metrics, only show cumulative number of page faults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,6 +5159,7 @@ dependencies = [
  "memory",
  "mockito",
  "murmur3",
+ "nix 0.29.0",
  "ordered-float 5.1.0",
  "parking_lot",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ sealed_test = "1.1.0"
 
 tempfile = { workspace = true }
 rusty-hook = "^0.11.2"
+nix = { workspace = true, features = ["process"] }
 
 mockito = "1.7"
 


### PR DESCRIPTION
In metrics, only expose a cumulative number of minor and major page faults. Remove the metrics for page faults in joined children:

```bash
# HELP qdrant_procfs_minor_page_faults_total count of minor page faults which didn't cause a 
# TYPE qdrant_procfs_minor_page_faults_total counter
qdrant_procfs_minor_page_faults_total 180664
# HELP qdrant_procfs_major_page_faults_total count of disk accesses caused by a mmap page 
# TYPE qdrant_procfs_major_page_faults_total counter
qdrant_procfs_major_page_faults_total 0
```

In my opinion, we should **only** expose the above two. I see no point in reporting separate values for children. In fact, it is currently incorrectly implemented, more on that later.

In practice we're only interested in the cumulative number of page faults that happen during the life time of the Qdrant process, in the process itself and in all its children. If the number grows faster than we expect, the cluster may need attention.

The minor/major metric needs to be a sum of:

1. page faults in the current PID
2. plus, page faults in all current child processes
3. plus, historic page faults from all joined child processes

~Actually, Qdrant currently does not even spawn any child processes at all. It means that the child metrics will always be 0 at this time.~ (Might be wrong of this, but the fact remains that we currently don't report it correctly)

But, to make our reporting more future proof I still recommend to implement it properly. For point two we'd have to iterate over all child processes recursively and fetch its page fault stats (left a TODO). Point three is a different number and we've already implemented this.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?