### PR TITLE
Report max system wide mmap count in metrics

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -810,6 +810,7 @@ fn label_pair(name: &str, value: &str) -> LabelPair {
 #[cfg(target_os = "linux")]
 struct ProcFsMetrics {
     mmap_count: usize,
+    system_mmap_limit: u64,
     open_fds: usize,
     max_fds_soft: u64,
     max_fds_hard: u64,
@@ -843,6 +844,7 @@ impl ProcFsMetrics {
 
         Ok(Self {
             mmap_count: current_process.maps()?.len(),
+            system_mmap_limit: procfs::sys::vm::max_map_count()?,
             open_fds: current_process.fd_count()?,
             max_fds_soft,
             max_fds_hard,
@@ -862,6 +864,14 @@ impl MetricsProvider for ProcFsMetrics {
             "count of open mmaps",
             MetricType::GAUGE,
             vec![gauge(self.mmap_count as f64, &[])],
+            prefix,
+        ));
+
+        metrics.push(metric_family(
+            "system_max_mmaps",
+            "system wide limit of open mmaps",
+            MetricType::GAUGE,
+            vec![gauge(self.system_mmap_limit as f64, &[])],
             prefix,
         ));
 


### PR DESCRIPTION
This adds the first:

```bash
# HELP qdrant_system_max_mmaps system wide limit of open mmaps
# TYPE qdrant_system_max_mmaps gauge
qdrant_system_max_mmaps 1048576
# HELP qdrant_process_open_mmaps count of open mmaps
# TYPE qdrant_process_open_mmaps gauge
qdrant_process_open_mmaps 668
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?