### PR TITLE
Use `bytemuck` to safely transmute between `edge-py` wrapper types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,7 @@ name = "edge-py"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "bytemuck",
  "derive_more 2.0.1",
  "edge",
  "ordered-float 5.1.0",

--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -18,6 +18,7 @@ shard = { path = "../../shard" }
 sparse = { path = "../../sparse" }
 
 ahash = { workspace = true }
+bytemuck = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 ordered-float = { workspace = true }

--- a/lib/edge/python/src/config.rs
+++ b/lib/edge/python/src/config.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
+use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use pyo3::prelude::*;
 use segment::types::*;
 
 #[pyclass(name = "SegmentConfig")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
+#[repr(transparent)]
 pub struct PySegmentConfig(SegmentConfig);
 
 #[pymethods]
@@ -37,7 +39,8 @@ impl PySegmentConfig {
 }
 
 #[pyclass(name = "VectorDataConfig")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
+#[repr(transparent)]
 pub struct PyVectorDataConfig(VectorDataConfig);
 
 #[pymethods]

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -6,6 +6,7 @@ pub mod update;
 
 use std::path::PathBuf;
 
+use bytemuck::TransparentWrapperAlloc as _;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use segment::common::operation_error::OperationError;
@@ -75,13 +76,13 @@ impl PyShard {
 
     pub fn query(&self, query: PyQueryRequest) -> Result<Vec<Vec<Vec<PyScoredPoint>>>> {
         let points = self.0.query(query.into())?;
-        let points = PyScoredPoint::from_rust_vec3(points);
+        let points = PyScoredPoint::wrap_query_resp(points);
         Ok(points)
     }
 
     pub fn search(&self, search: PySearchRequest) -> Result<Vec<PyScoredPoint>> {
         let points = self.0.search(search.into())?;
-        let points = PyScoredPoint::from_rust_vec(points);
+        let points = PyScoredPoint::wrap_vec(points);
         Ok(points)
     }
 
@@ -91,13 +92,13 @@ impl PyShard {
         with_payload: Option<PyWithPayload>,
         with_vector: Option<PyWithVector>,
     ) -> Result<Vec<PyRecord>> {
-        let point_ids = PyPointId::into_rust_vec(point_ids);
+        let point_ids = PyPointId::peel_vec(point_ids);
         let points = self.0.retrieve(
             &point_ids,
             with_payload.map(WithPayloadInterface::from),
             with_vector.map(WithVector::from),
         )?;
-        let points = PyRecord::from_rust_vec(points);
+        let points = PyRecord::wrap_vec(points);
         Ok(points)
     }
 }

--- a/lib/edge/python/src/query.rs
+++ b/lib/edge/python/src/query.rs
@@ -1,5 +1,4 @@
-use std::mem;
-
+use bytemuck::{TransparentWrapper, TransparentWrapperAlloc as _};
 use derive_more::Into;
 use ordered_float::OrderedFloat;
 use pyo3::IntoPyObjectExt;
@@ -16,7 +15,6 @@ use super::*;
 
 #[pyclass(name = "QueryRequest")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyQueryRequest(ShardQueryRequest);
 
 #[pymethods]
@@ -35,7 +33,7 @@ impl PyQueryRequest {
         with_payload: PyWithPayload,
     ) -> Self {
         Self(ShardQueryRequest {
-            prefetches: PyPrefetch::into_rust_vec(prefetches),
+            prefetches: PyPrefetch::peel_vec(prefetches),
             query: query.map(ScoringQuery::from),
             filter: filter.map(Filter::from),
             score_threshold: score_threshold.map(OrderedFloat),
@@ -49,16 +47,9 @@ impl PyQueryRequest {
 }
 
 #[pyclass(name = "Prefetch")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyPrefetch(ShardPrefetch);
-
-impl PyPrefetch {
-    pub fn into_rust_vec(prefetches: Vec<Self>) -> Vec<ShardPrefetch> {
-        // `PyPrefetch` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(prefetches) }
-    }
-}
 
 #[pymethods]
 impl PyPrefetch {
@@ -72,7 +63,7 @@ impl PyPrefetch {
         score_threshold: Option<f32>,
     ) -> Self {
         Self(ShardPrefetch {
-            prefetches: PyPrefetch::into_rust_vec(prefetches),
+            prefetches: PyPrefetch::peel_vec(prefetches),
             query: query.map(ScoringQuery::from),
             limit,
             params: params.map(SearchParams::from),
@@ -83,7 +74,6 @@ impl PyPrefetch {
 }
 
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyScoringQuery(ScoringQuery);
 
 impl<'py> FromPyObject<'py> for PyScoringQuery {
@@ -123,16 +113,9 @@ impl<'py> FromPyObject<'py> for PyScoringQuery {
 }
 
 #[pyclass(name = "Fusion")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyFusion(FusionInternal);
-
-impl PyFusion {
-    pub fn from_ref(fusion: &FusionInternal) -> &Self {
-        // `PyFusion` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(fusion) }
-    }
-}
 
 #[pymethods]
 impl PyFusion {
@@ -147,7 +130,6 @@ impl PyFusion {
 
 #[pyclass(name = "OrderBy")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyOrderBy(OrderBy);
 
 #[pymethods]
@@ -194,7 +176,6 @@ impl From<PyDirection> for Direction {
 }
 
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyStartFrom(StartFrom);
 
 impl<'py> FromPyObject<'py> for PyStartFrom {
@@ -278,7 +259,6 @@ impl From<PySample> for SampleInternal {
 
 #[pyclass(name = "Mmr")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyMmr(MmrInternal);
 
 #[pymethods]

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use bytemuck::{TransparentWrapper, TransparentWrapperAlloc as _};
 use derive_more::Into;
 use ordered_float::OrderedFloat;
 use pyo3::IntoPyObjectExt as _;
@@ -167,9 +168,7 @@ impl<'py> FromPyObject<'py> for PyWithPayload {
 
         let with_payload = match with_payload.extract()? {
             Helper::Bool(bool) => WithPayloadInterface::Bool(bool),
-            Helper::Fields(fields) => {
-                WithPayloadInterface::Fields(PyJsonPath::into_rust_vec(fields))
-            }
+            Helper::Fields(fields) => WithPayloadInterface::Fields(PyJsonPath::peel_vec(fields)),
             Helper::Selector(selector) => {
                 WithPayloadInterface::Selector(PayloadSelector::from(selector))
             }
@@ -198,37 +197,30 @@ impl<'py> IntoPyObject<'py> for &PyWithPayload {
         match &self.0 {
             WithPayloadInterface::Bool(bool) => bool.into_bound_py_any(py),
             WithPayloadInterface::Fields(fields) => {
-                PyJsonPath::from_slice(fields).into_bound_py_any(py)
+                PyJsonPath::wrap_slice(fields).into_bound_py_any(py)
             }
-            WithPayloadInterface::Selector(selector) => PyPayloadSelector::from_ref(selector)
+            WithPayloadInterface::Selector(selector) => PyPayloadSelector::wrap_ref(selector)
                 .clone()
                 .into_bound_py_any(py),
         }
     }
 }
 
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyPayloadSelector(PayloadSelector);
-
-impl PyPayloadSelector {
-    pub fn from_ref(selector: &PayloadSelector) -> &Self {
-        // `PyPayloadSelector` has transparent representation, so transmuting references is safe
-        unsafe { mem::transmute(selector) }
-    }
-}
 
 impl FromPyObject<'_> for PyPayloadSelector {
     fn extract_bound(selector: &Bound<'_, PyAny>) -> PyResult<Self> {
         let selector = match selector.extract()? {
             PyPayloadSelectorInterface::Include(keys) => {
                 PayloadSelector::Include(PayloadSelectorInclude {
-                    include: PyJsonPath::into_rust_vec(keys),
+                    include: PyJsonPath::peel_vec(keys),
                 })
             }
             PyPayloadSelectorInterface::Exclude(keys) => {
                 PayloadSelector::Exclude(PayloadSelectorExclude {
-                    exclude: PyJsonPath::into_rust_vec(keys),
+                    exclude: PyJsonPath::peel_vec(keys),
                 })
             }
         };
@@ -245,10 +237,10 @@ impl<'py> IntoPyObject<'py> for PyPayloadSelector {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let selector = match self.0 {
             PayloadSelector::Include(PayloadSelectorInclude { include }) => {
-                PyPayloadSelectorInterface::Include(PyJsonPath::from_rust_vec(include))
+                PyPayloadSelectorInterface::Include(PyJsonPath::wrap_vec(include))
             }
             PayloadSelector::Exclude(PayloadSelectorExclude { exclude }) => {
-                PyPayloadSelectorInterface::Exclude(PyJsonPath::from_rust_vec(exclude))
+                PyPayloadSelectorInterface::Exclude(PyJsonPath::wrap_vec(exclude))
             }
         };
 
@@ -264,19 +256,16 @@ pub enum PyPayloadSelectorInterface {
 }
 
 #[pyclass(name = "ScoredPoint")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyScoredPoint(pub ScoredPoint);
 
 impl PyScoredPoint {
-    pub fn from_rust_vec(points: Vec<ScoredPoint>) -> Vec<Self> {
-        // `PyScoredPoint` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(points) }
-    }
-
-    pub fn from_rust_vec3(points: Vec<Vec<Vec<ScoredPoint>>>) -> Vec<Vec<Vec<Self>>> {
-        // `PyScoredPoint` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(points) }
+    pub fn wrap_query_resp(resp: Vec<Vec<Vec<ScoredPoint>>>) -> Vec<Vec<Vec<PyScoredPoint>>>
+    where
+        Self: TransparentWrapper<ScoredPoint>,
+    {
+        unsafe { mem::transmute(resp) }
     }
 }
 
@@ -304,6 +293,6 @@ impl PyScoredPoint {
 
     #[getter]
     pub fn payload(&self) -> Option<&PyPayload> {
-        self.0.payload.as_ref().map(PyPayload::from_ref)
+        self.0.payload.as_ref().map(PyPayload::wrap_ref)
     }
 }

--- a/lib/edge/python/src/types/filter/condition.rs
+++ b/lib/edge/python/src/types/filter/condition.rs
@@ -89,7 +89,7 @@ impl PyHasIdCondition {
     #[new]
     pub fn new(point_ids: ahash::HashSet<PyPointId>) -> Result<Self, PyErr> {
         Ok(Self(HasIdCondition {
-            has_id: MaybeArc::NoArc(ahash::AHashSet::from(PyPointId::into_rust_set(point_ids))),
+            has_id: MaybeArc::NoArc(ahash::AHashSet::from(PyPointId::peel_set(point_ids))),
         }))
     }
 }

--- a/lib/edge/python/src/types/filter/field_condition.rs
+++ b/lib/edge/python/src/types/filter/field_condition.rs
@@ -15,7 +15,6 @@ use crate::types::range::PyRangeInterface;
 
 #[pyclass(name = "FieldCondition")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyFieldCondition(pub FieldCondition);
 
 #[pymethods]

--- a/lib/edge/python/src/types/filter/min_should.rs
+++ b/lib/edge/python/src/types/filter/min_should.rs
@@ -6,7 +6,6 @@ use crate::types::filter::condition::PyCondition;
 
 #[pyclass(name = "MinShould")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyMinShould(pub MinShould);
 
 #[pymethods]

--- a/lib/edge/python/src/types/filter/mod.rs
+++ b/lib/edge/python/src/types/filter/mod.rs
@@ -22,7 +22,6 @@ pub use self::value_count::*;
 
 #[pyclass(name = "Filter")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyFilter(pub Filter);
 
 #[pymethods]

--- a/lib/edge/python/src/types/json_path.rs
+++ b/lib/edge/python/src/types/json_path.rs
@@ -1,32 +1,16 @@
 use std::convert::Infallible;
 use std::str::FromStr as _;
 
+use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 use segment::json_path::JsonPath;
 
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyJsonPath(pub JsonPath);
-
-impl PyJsonPath {
-    pub fn from_slice(paths: &[JsonPath]) -> &[Self] {
-        // `PyJsonPath` has transparent representation, so transmuting slices is safe
-        unsafe { std::mem::transmute(paths) }
-    }
-
-    pub fn from_rust_vec(paths: Vec<JsonPath>) -> Vec<Self> {
-        // `PyJsonPath` has transparent representation, so transmuting is safe
-        unsafe { std::mem::transmute(paths) }
-    }
-
-    pub fn into_rust_vec(paths: Vec<Self>) -> Vec<JsonPath> {
-        // `PyJsonPath` has transparent representation, so transmuting is safe
-        unsafe { std::mem::transmute(paths) }
-    }
-}
 
 impl<'py> FromPyObject<'py> for PyJsonPath {
     fn extract_bound(json_path: &Bound<'py, PyAny>) -> PyResult<Self> {

--- a/lib/edge/python/src/types/payload.rs
+++ b/lib/edge/python/src/types/payload.rs
@@ -1,21 +1,13 @@
-use std::mem;
-
+use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use pyo3::prelude::*;
 use segment::types::*;
 
 use super::value::*;
 
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyPayload(pub Payload);
-
-impl PyPayload {
-    pub fn from_ref(payload: &Payload) -> &Self {
-        // `PyPayload` has transparent representation, so we can safely transmute references
-        unsafe { mem::transmute(payload) }
-    }
-}
 
 impl<'py> FromPyObject<'py> for PyPayload {
     fn extract_bound(payload: &Bound<'py, PyAny>) -> PyResult<Self> {

--- a/lib/edge/python/src/types/point.rs
+++ b/lib/edge/python/src/types/point.rs
@@ -1,3 +1,4 @@
+use bytemuck::TransparentWrapper as _;
 use derive_more::Into;
 use pyo3::prelude::*;
 use segment::types::{Payload, PointIdType};
@@ -34,6 +35,6 @@ impl PyPoint {
 
     #[getter]
     pub fn payload(&self) -> Option<&PyPayload> {
-        self.0.payload.as_ref().map(PyPayload::from_ref)
+        self.0.payload.as_ref().map(PyPayload::wrap_ref)
     }
 }

--- a/lib/edge/python/src/types/point_id.rs
+++ b/lib/edge/python/src/types/point_id.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use pyo3::IntoPyObjectExt as _;
 use pyo3::exceptions::PyValueError;
@@ -7,19 +8,16 @@ use pyo3::prelude::*;
 use segment::types::PointIdType;
 use uuid::Uuid;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Into)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyPointId(pub PointIdType);
 
 impl PyPointId {
-    pub fn into_rust_vec(point_ids: Vec<PyPointId>) -> Vec<PointIdType> {
-        // `PyPointId` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(point_ids) }
-    }
-
-    pub fn into_rust_set(point_ids: ahash::HashSet<PyPointId>) -> ahash::HashSet<PointIdType> {
-        // `PyPointId` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(point_ids) }
+    pub fn peel_set(set: ahash::HashSet<Self>) -> ahash::HashSet<PointIdType>
+    where
+        Self: TransparentWrapper<PointIdType>,
+    {
+        unsafe { mem::transmute(set) }
     }
 }
 

--- a/lib/edge/python/src/types/point_vectors.rs
+++ b/lib/edge/python/src/types/point_vectors.rs
@@ -8,7 +8,6 @@ use crate::types::{PyPointId, PyVector};
 
 #[pyclass(name = "PointVectors")]
 #[derive(Clone, Debug, Into)]
-#[repr(transparent)]
 pub struct PyPointVectors(pub PointVectorsPersisted);
 
 #[pymethods]

--- a/lib/edge/python/src/types/record.rs
+++ b/lib/edge/python/src/types/record.rs
@@ -1,5 +1,4 @@
-use std::mem;
-
+use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use pyo3::prelude::*;
 use segment::data_types::order_by::OrderValue;
@@ -8,16 +7,9 @@ use shard::retrieve::record_internal::RecordInternal;
 use crate::*;
 
 #[pyclass(name = "Record")]
-#[derive(Clone, Debug, Into)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyRecord(pub RecordInternal);
-
-impl PyRecord {
-    pub fn from_rust_vec(records: Vec<RecordInternal>) -> Vec<Self> {
-        // `PyRecord` has transparent representation, so transmuting is safe
-        unsafe { mem::transmute(records) }
-    }
-}
 
 #[pymethods]
 impl PyRecord {
@@ -33,7 +25,7 @@ impl PyRecord {
 
     #[getter]
     pub fn payload(&self) -> Option<&PyPayload> {
-        self.0.payload.as_ref().map(PyPayload::from_ref)
+        self.0.payload.as_ref().map(PyPayload::wrap_ref)
     }
 
     #[getter]

--- a/lib/edge/python/src/update.rs
+++ b/lib/edge/python/src/update.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use bytemuck::TransparentWrapperAlloc as _;
 use derive_more::Into;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -52,7 +53,7 @@ impl PyUpdateOperation {
 
     #[staticmethod]
     pub fn delete_points(ids: Vec<PyPointId>) -> Self {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
 
         let operation =
             CollectionUpdateOperations::PointOperation(point_ops::PointOperations::DeletePoints {
@@ -111,7 +112,7 @@ impl PyUpdateOperation {
 
     #[staticmethod]
     pub fn delete_vectors(ids: Vec<PyPointId>, vector_names: Vec<VectorNameBuf>) -> Self {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
         let operation = CollectionUpdateOperations::VectorOperation(
             vector_ops::VectorOperations::DeleteVectors(
                 PointIdsList::from(point_ids),
@@ -137,7 +138,7 @@ impl PyUpdateOperation {
         payload: PyPayload,
         key: Option<String>,
     ) -> Result<Self, PyErr> {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
         let payload = Payload::from(payload);
 
         let key = key
@@ -184,7 +185,7 @@ impl PyUpdateOperation {
     #[staticmethod]
     #[pyo3(signature = (ids, keys))]
     pub fn delete_payload(ids: Vec<PyPointId>, keys: Vec<String>) -> Result<Self, PyErr> {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
 
         let keys: Vec<_> = keys
             .into_iter()
@@ -222,7 +223,7 @@ impl PyUpdateOperation {
 
     #[staticmethod]
     pub fn clear_payload(ids: Vec<PyPointId>) -> Self {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
         let operation =
             CollectionUpdateOperations::PayloadOperation(payload_ops::PayloadOps::ClearPayload {
                 points: point_ids,
@@ -246,7 +247,7 @@ impl PyUpdateOperation {
         payload: PyPayload,
         key: Option<String>,
     ) -> Result<Self, PyErr> {
-        let point_ids = PyPointId::into_rust_vec(ids);
+        let point_ids = PyPointId::peel_vec(ids);
         let payload = Payload::from(payload);
 
         let key = key


### PR DESCRIPTION
No more `unsafe { mem::transmute(smth) }`

Based on #7481.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
