### PR TITLE
Limit the timeout parameter for all requests to 1h

### DIFF
--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::collections::BTreeMap;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
@@ -153,6 +154,8 @@ pub fn try_record_from_grpc(
     })
 }
 
+const HOURS_IN_SECONDS: u64 = 60 * 60;
+
 #[allow(clippy::type_complexity)]
 pub fn try_discover_request_from_grpc(
     value: api::grpc::qdrant::DiscoverPoints,
@@ -222,7 +225,9 @@ pub fn try_discover_request_from_grpc(
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
-    let timeout = timeout.map(Duration::from_secs);
+    let timeout = timeout
+        .map(|i| cmp::min(i, HOURS_IN_SECONDS))
+        .map(Duration::from_secs);
 
     Ok((
         request,

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -154,7 +154,7 @@ pub fn try_record_from_grpc(
     })
 }
 
-const HOURS_IN_SECONDS: u64 = 60 * 60;
+const HOUR_IN_SECONDS: u64 = 60 * 60;
 
 #[allow(clippy::type_complexity)]
 pub fn try_discover_request_from_grpc(
@@ -226,7 +226,7 @@ pub fn try_discover_request_from_grpc(
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let timeout = timeout
-        .map(|i| cmp::min(i, HOURS_IN_SECONDS))
+        .map(|i| cmp::min(i, HOUR_IN_SECONDS))
         .map(Duration::from_secs);
 
     Ok((

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -154,7 +154,7 @@ pub fn try_record_from_grpc(
     })
 }
 
-const HOUR_IN_SECONDS: u64 = 60 * 60;
+const HOUR_AS_SECONDS: u64 = 60 * 60;
 
 #[allow(clippy::type_complexity)]
 pub fn try_discover_request_from_grpc(
@@ -226,7 +226,7 @@ pub fn try_discover_request_from_grpc(
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let timeout = timeout
-        .map(|i| cmp::min(i, HOUR_IN_SECONDS))
+        .map(|i| cmp::min(i, HOUR_AS_SECONDS))
         .map(Duration::from_secs);
 
     Ok((

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -9,6 +9,7 @@ mod search;
 mod update;
 
 use std::fmt::Display;
+use std::time::Duration;
 
 use itertools::Itertools;
 use segment::json_path::JsonPath;
@@ -202,10 +203,14 @@ fn check_filter_limits(
 }
 
 pub fn check_timeout(
-    timeout: usize,
+    timeout: Duration,
     strict_mode_config: &StrictModeConfig,
 ) -> CollectionResult<()> {
-    check_limit_opt(Some(timeout), strict_mode_config.max_timeout, "timeout")
+    check_limit_opt(
+        Some(timeout.as_secs()),
+        strict_mode_config.max_timeout.map(|i| i as u64),
+        "timeout",
+    )
 }
 
 pub(crate) fn check_bool_opt(

--- a/lib/storage/src/content_manager/collection_verification.rs
+++ b/lib/storage/src/content_manager/collection_verification.rs
@@ -1,5 +1,6 @@
 use std::iter;
 use std::sync::Arc;
+use std::time::Duration;
 
 use collection::operations::verification::{
     StrictModeVerification, VerificationPass, check_timeout, new_unchecked_verification_pass,
@@ -16,7 +17,7 @@ use crate::rbac::{Access, AccessRequirements};
 ///       This method should only be used if you only have `TableOfContent` without `Dispatcher`, like in internal API.
 pub async fn check_strict_mode_toc_batch<'a, I>(
     requests: impl Iterator<Item = &'a I>,
-    timeout: Option<usize>,
+    timeout: Option<Duration>,
     collection_name: &str,
     toc: &TableOfContent,
     access: &Access,
@@ -50,7 +51,7 @@ where
 
 pub async fn check_strict_mode_batch<'a, I>(
     requests: impl Iterator<Item = &'a I>,
-    timeout: Option<usize>,
+    timeout: Option<Duration>,
     collection_name: &str,
     dispatcher: &Dispatcher,
     access: &Access,
@@ -64,7 +65,7 @@ where
 
 pub async fn check_strict_mode(
     request: &impl StrictModeVerification,
-    timeout: Option<usize>,
+    timeout: Option<Duration>,
     collection_name: &str,
     dispatcher: &Dispatcher,
     access: &Access,
@@ -85,7 +86,7 @@ pub async fn check_strict_mode(
 ///       This method should only be used if you only have `TableOfContent` without `Dispatcher`, like in internal API.
 pub async fn check_strict_mode_toc(
     request: &impl StrictModeVerification,
-    timeout: Option<usize>,
+    timeout: Option<Duration>,
     collection_name: &str,
     toc: &TableOfContent,
     access: &Access,
@@ -94,7 +95,7 @@ pub async fn check_strict_mode_toc(
 }
 
 pub async fn check_strict_mode_timeout(
-    timeout: Option<usize>,
+    timeout: Option<Duration>,
     collection_name: &str,
     dispatcher: &Dispatcher,
     access: &Access,

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -16,13 +16,12 @@ use crate::actix::auth::ActixAccess;
 use crate::actix::helpers;
 
 mod request_params {
-    use std::cmp;
     use std::time::Duration;
 
     use serde::Deserialize;
     use validator::Validate;
 
-    use crate::actix::api::read_params::HOUR_IN_SECONDS;
+    use crate::common::helpers::limit_and_convert_timeout_opt;
 
     #[derive(Debug, Deserialize, Validate)]
     pub(super) struct QueryParams {
@@ -36,9 +35,7 @@ mod request_params {
     impl QueryParams {
         /// Returns the passed timeout, limited to 1h.
         pub fn timeout(&self) -> Option<Duration> {
-            self.timeout
-                .map(|timeout| cmp::min(timeout, HOUR_IN_SECONDS))
-                .map(Duration::from_secs)
+            limit_and_convert_timeout_opt(self.timeout)
         }
 
         pub fn force(&self) -> bool {

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -17,13 +17,12 @@ use crate::actix::helpers::{self, process_response};
 use crate::common::collections::*;
 
 pub(crate) mod request_params {
-    use std::cmp;
     use std::time::Duration;
 
     use serde::Deserialize;
     use validator::Validate;
 
-    use crate::actix::api::read_params::HOUR_IN_SECONDS;
+    use crate::common::helpers::limit_and_convert_timeout_opt;
 
     #[derive(Debug, Deserialize, Validate)]
     pub struct WaitTimeout {
@@ -34,9 +33,7 @@ pub(crate) mod request_params {
     impl WaitTimeout {
         /// Returns the timeout, limited to 1h.
         pub fn timeout(&self) -> Option<Duration> {
-            self.timeout
-                .map(|i| cmp::min(i, HOUR_IN_SECONDS))
-                .map(Duration::from_secs)
+            limit_and_convert_timeout_opt(self.timeout)
         }
     }
 }
@@ -264,7 +261,7 @@ mod tests {
     use actix_web::web::Query;
 
     use super::WaitTimeout;
-    use crate::actix::api::read_params::HOUR_IN_SECONDS;
+    use crate::common::helpers::HOUR_AS_SECONDS;
 
     #[test]
     fn timeout_is_deserialized() {
@@ -275,7 +272,7 @@ mod tests {
         let timeout: WaitTimeout = Query::from_query("timeout=9999").unwrap().0;
         assert_eq!(
             timeout.timeout(),
-            Some(Duration::from_secs(HOUR_IN_SECONDS))
+            Some(Duration::from_secs(HOUR_AS_SECONDS))
         );
     }
 }

--- a/src/actix/api/count_api.rs
+++ b/src/actix/api/count_api.rs
@@ -29,7 +29,7 @@ async fn count_points(
 
     let pass = match check_strict_mode(
         &count_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/discovery_api.rs
+++ b/src/actix/api/discovery_api.rs
@@ -32,7 +32,7 @@ async fn discover_points(
 
     let pass = match check_strict_mode(
         &discover_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -92,7 +92,7 @@ async fn discover_batch_points(
 
     let pass = match check_strict_mode_batch(
         request.searches.iter().map(|i| &i.discover_request),
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/facet_api.rs
+++ b/src/actix/api/facet_api.rs
@@ -32,7 +32,7 @@ async fn facet(
 
     let pass = match check_strict_mode(
         &facet_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/local_shard_api.rs
+++ b/src/actix/api/local_shard_api.rs
@@ -221,13 +221,12 @@ async fn count_points(
 }
 
 mod request_params {
-    use std::cmp;
     use std::num::NonZeroU64;
     use std::time::Duration;
 
     use serde::Deserialize;
 
-    use crate::actix::api::read_params::HOUR_IN_SECONDS;
+    use crate::common::helpers::limit_and_convert_timeout_opt;
 
     #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize)]
     pub struct CleanParams {
@@ -241,9 +240,7 @@ mod request_params {
     impl CleanParams {
         /// Returns the passed timeout, limited to 1h.
         pub fn timeout(&self) -> Option<Duration> {
-            self.timeout
-                .map(|timeout| cmp::min(timeout.get(), HOUR_IN_SECONDS))
-                .map(Duration::from_secs)
+            limit_and_convert_timeout_opt(self.timeout.map(|i| i.get()))
         }
     }
 }

--- a/src/actix/api/query_api.rs
+++ b/src/actix/api/query_api.rs
@@ -64,7 +64,7 @@ async fn query_points(
 
         let pass = check_strict_mode(
             &request,
-            params.timeout_as_secs(),
+            params.timeout(),
             &collection.name,
             &dispatcher,
             &access,
@@ -151,7 +151,7 @@ async fn query_points_batch(
 
         let pass = check_strict_mode_batch(
             batch.iter().map(|i| &i.0),
-            params.timeout_as_secs(),
+            params.timeout(),
             &collection.name,
             &dispatcher,
             &access,
@@ -228,7 +228,7 @@ async fn query_points_groups(
 
         let pass = check_strict_mode(
             &request,
-            params.timeout_as_secs(),
+            params.timeout(),
             &collection.name,
             &dispatcher,
             &access,

--- a/src/actix/api/read_params.rs
+++ b/src/actix/api/read_params.rs
@@ -24,8 +24,8 @@ impl ReadParams {
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
             // Limit the timeout to 1 hour.
-            .map(|num| cmp::min(num.get(), HOUR_IN_SECONDS) as usize)
-            .map(|secs| Duration::from_secs(secs as u64))
+            .map(|num| cmp::min(num.get(), HOUR_IN_SECONDS))
+            .map(|secs| Duration::from_secs(secs))
     }
 }
 

--- a/src/actix/api/read_params.rs
+++ b/src/actix/api/read_params.rs
@@ -25,7 +25,7 @@ impl ReadParams {
         self.timeout
             // Limit the timeout to 1 hour.
             .map(|num| cmp::min(num.get(), HOUR_IN_SECONDS))
-            .map(|secs| Duration::from_secs(secs))
+            .map(Duration::from_secs)
     }
 }
 

--- a/src/actix/api/read_params.rs
+++ b/src/actix/api/read_params.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::num::NonZeroU64;
 use std::time::Duration;
 
@@ -7,8 +6,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use validator::Validate;
 
-/// 1 Hour in seconds.
-pub const HOUR_IN_SECONDS: u64 = 60 * 60;
+use crate::common::helpers::limit_and_convert_timeout_opt;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize, JsonSchema, Validate)]
 pub struct ReadParams {
@@ -22,10 +20,7 @@ pub struct ReadParams {
 impl ReadParams {
     /// Returns the timeout passed as parameter and limit it to max 1 hour.
     pub fn timeout(&self) -> Option<Duration> {
-        self.timeout
-            // Limit the timeout to 1 hour.
-            .map(|num| cmp::min(num.get(), HOUR_IN_SECONDS))
-            .map(Duration::from_secs)
+        limit_and_convert_timeout_opt(self.timeout.map(|i| i.get()))
     }
 }
 

--- a/src/actix/api/recommend_api.rs
+++ b/src/actix/api/recommend_api.rs
@@ -41,7 +41,7 @@ async fn recommend_points(
 
     let pass = match check_strict_mode(
         &recommend_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -132,7 +132,7 @@ async fn recommend_batch_points(
 ) -> impl Responder {
     let pass = match check_strict_mode_batch(
         request.searches.iter().map(|i| &i.recommend_request),
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -192,7 +192,7 @@ async fn recommend_point_groups(
 
     let pass = match check_strict_mode(
         &recommend_group_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/retrieve_api.rs
+++ b/src/actix/api/retrieve_api.rs
@@ -76,17 +76,13 @@ async fn get_point(
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let pass = match check_strict_mode_timeout(
-        params.timeout_as_secs(),
-        &collection.name,
-        &dispatcher,
-        &access,
-    )
-    .await
-    {
-        Ok(p) => p,
-        Err(err) => return process_response_error(err, Instant::now(), None),
-    };
+    let pass =
+        match check_strict_mode_timeout(params.timeout(), &collection.name, &dispatcher, &access)
+            .await
+        {
+            Ok(p) => p,
+            Err(err) => return process_response_error(err, Instant::now(), None),
+        };
 
     let Ok(point_id) = point.id.parse::<PointIdType>() else {
         let err = StorageError::BadInput {
@@ -132,17 +128,13 @@ async fn get_points(
     service_config: web::Data<ServiceConfig>,
     ActixAccess(access): ActixAccess,
 ) -> impl Responder {
-    let pass = match check_strict_mode_timeout(
-        params.timeout_as_secs(),
-        &collection.name,
-        &dispatcher,
-        &access,
-    )
-    .await
-    {
-        Ok(p) => p,
-        Err(err) => return process_response_error(err, Instant::now(), None),
-    };
+    let pass =
+        match check_strict_mode_timeout(params.timeout(), &collection.name, &dispatcher, &access)
+            .await
+        {
+            Ok(p) => p,
+            Err(err) => return process_response_error(err, Instant::now(), None),
+        };
 
     let PointRequest {
         point_request,
@@ -199,7 +191,7 @@ async fn scroll_points(
 
     let pass = match check_strict_mode(
         &scroll_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/search_api.rs
+++ b/src/actix/api/search_api.rs
@@ -40,7 +40,7 @@ async fn search_points(
 
     let pass = match check_strict_mode(
         &search_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -116,7 +116,7 @@ async fn batch_search_points(
 
     let pass = match check_strict_mode_batch(
         requests.iter().map(|i| &i.0),
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -177,7 +177,7 @@ async fn search_point_groups(
 
     let pass = match check_strict_mode(
         &search_group_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -232,7 +232,7 @@ async fn search_points_matrix_pairs(
 
     let pass = match check_strict_mode(
         &search_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,
@@ -288,7 +288,7 @@ async fn search_points_matrix_offsets(
 
     let pass = match check_strict_mode(
         &search_request,
-        params.timeout_as_secs(),
+        params.timeout(),
         &collection.name,
         &dispatcher,
         &access,

--- a/src/actix/api/shards_api.rs
+++ b/src/actix/api/shards_api.rs
@@ -9,7 +9,7 @@ use storage::dispatcher::Dispatcher;
 use tokio::time::Instant;
 
 use crate::actix::api::CollectionPath;
-use crate::actix::api::collections_api::WaitTimeout;
+use crate::actix::api::collections_api::request_params::WaitTimeout;
 use crate::actix::auth::ActixAccess;
 use crate::actix::helpers::{self, process_response};
 use crate::common::collections::{do_get_collection_shard_keys, do_update_collection_cluster};

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,6 +1,7 @@
-use std::cmp::max;
+use std::cmp::{self, max};
 use std::io;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use fs_err as fs;
 use tokio::runtime;
@@ -103,6 +104,19 @@ fn load_ca_certificate(tls_config: &TlsConfig) -> io::Result<Certificate> {
 
 pub fn tonic_error_to_io_error(err: tonic::transport::Error) -> io::Error {
     io::Error::other(err)
+}
+
+/// 1 hour as seconds.
+pub const HOUR_AS_SECONDS: u64 = 60 * 60;
+
+/// Limits the given timeout to 1h and returns it as `Duration`.
+pub fn limit_and_convert_timeout_opt(timeout: Option<u64>) -> Option<Duration> {
+    timeout.map(limit_and_convert_timeout)
+}
+
+/// Limits the given timeout to 1h and returns it as `Duration`.
+pub fn limit_and_convert_timeout(timeout: u64) -> Duration {
+    Duration::from_secs(cmp::min(timeout, HOUR_AS_SECONDS))
 }
 
 #[cfg(test)]

--- a/src/common/strict_mode.rs
+++ b/src/common/strict_mode.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use collection::operations::verification::StrictModeVerification;
 use storage::content_manager::collection_verification::{
@@ -15,7 +16,7 @@ pub trait CheckedTocProvider {
         &self,
         request: &impl StrictModeVerification,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError>;
 
@@ -24,7 +25,7 @@ pub trait CheckedTocProvider {
         requests: &[I],
         conv: impl Fn(&I) -> &R,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError>
     where
@@ -48,7 +49,7 @@ impl CheckedTocProvider for UncheckedTocProvider<'_> {
         &self,
         _request: &impl StrictModeVerification,
         _collection_name: &str,
-        _timeout: Option<usize>,
+        _timeout: Option<Duration>,
         _access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError> {
         // No checks here
@@ -60,7 +61,7 @@ impl CheckedTocProvider for UncheckedTocProvider<'_> {
         _requests: &[I],
         _conv: impl Fn(&I) -> &R,
         _collection_name: &str,
-        _timeout: Option<usize>,
+        _timeout: Option<Duration>,
         _access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError>
     where
@@ -88,7 +89,7 @@ impl CheckedTocProvider for StrictModeCheckedTocProvider<'_> {
         &self,
         request: &impl StrictModeVerification,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError> {
         let pass =
@@ -101,7 +102,7 @@ impl CheckedTocProvider for StrictModeCheckedTocProvider<'_> {
         requests: &[I],
         conv: impl Fn(&I) -> &R,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError>
     where
@@ -138,7 +139,7 @@ impl CheckedTocProvider for StrictModeCheckedInternalTocProvider<'_> {
         &self,
         request: &impl StrictModeVerification,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError> {
         check_strict_mode_toc(request, timeout, collection_name, self.toc, access).await?;
@@ -150,7 +151,7 @@ impl CheckedTocProvider for StrictModeCheckedInternalTocProvider<'_> {
         requests: &[I],
         conv: impl Fn(&I) -> &R,
         collection_name: &str,
-        timeout: Option<usize>,
+        timeout: Option<Duration>,
         access: &Access,
     ) -> Result<&Arc<TableOfContent>, StorageError>
     where

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -816,7 +816,7 @@ pub async fn do_create_index(
     // Check strict mode before submitting consensus operation
     let pass = check_strict_mode(
         &operation,
-        wait_timeout.map(|d| d.as_secs() as usize),
+        wait_timeout,
         &collection_name,
         &dispatcher,
         &access,

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -340,6 +340,7 @@ impl Collections for CollectionsService {
 }
 
 trait WithTimeout {
+    // Returns the passed timeout, limited to 1h.
     fn wait_timeout(&self) -> Option<Duration>;
 }
 
@@ -347,7 +348,9 @@ macro_rules! impl_with_timeout {
     ($operation:ty) => {
         impl WithTimeout for $operation {
             fn wait_timeout(&self) -> Option<Duration> {
-                self.timeout.map(Duration::from_secs)
+                self.timeout
+                    .map(|i| std::cmp::min(i, crate::actix::api::read_params::HOUR_IN_SECONDS))
+                    .map(Duration::from_secs)
             }
         }
     };

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use api::grpc::qdrant::collections_internal_server::CollectionsInternal;
 use api::grpc::qdrant::{
@@ -13,6 +13,7 @@ use tonic::{Request, Response, Status};
 
 use super::validate_and_log;
 use crate::tonic::api::collections_common::get;
+use crate::tonic::api::limit_timeout;
 
 const FULL_ACCESS: Access = Access::full("Internal API");
 
@@ -96,7 +97,8 @@ impl CollectionsInternal for CollectionsInternalService {
             timeout,
         } = request;
         let state = state.try_into()?;
-        let timeout = Duration::from_secs(timeout);
+
+        let timeout = limit_timeout(timeout);
 
         let collection_read = self
             .toc

--- a/src/tonic/api/collections_internal_api.rs
+++ b/src/tonic/api/collections_internal_api.rs
@@ -12,8 +12,8 @@ use storage::rbac::{Access, AccessRequirements, CollectionPass};
 use tonic::{Request, Response, Status};
 
 use super::validate_and_log;
+use crate::common::helpers::limit_and_convert_timeout;
 use crate::tonic::api::collections_common::get;
-use crate::tonic::api::limit_timeout;
 
 const FULL_ACCESS: Access = Access::full("Internal API");
 
@@ -98,7 +98,7 @@ impl CollectionsInternal for CollectionsInternalService {
         } = request;
         let state = state.try_into()?;
 
-        let timeout = limit_timeout(timeout);
+        let timeout = limit_and_convert_timeout(timeout);
 
         let collection_read = self
             .toc

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -9,9 +9,13 @@ mod collections_common;
 mod query_common;
 mod update_common;
 
+use std::time::Duration;
+
 use collection::operations::validation;
 use tonic::Status;
 use validator::Validate;
+
+use crate::actix::api::read_params::HOUR_IN_SECONDS;
 
 /// Validate the given request and fail on error.
 ///
@@ -27,6 +31,16 @@ fn validate_and_log(request: &impl Validate) {
     if let Err(ref err) = request.validate() {
         validation::warn_validation_errors("Internal gRPC", err);
     }
+}
+
+/// Converts the given `seconds` into `Duration` and limits it to 1h.
+pub(crate) fn limit_timeout(seconds: u64) -> Duration {
+    Duration::from_secs(std::cmp::min(seconds, HOUR_IN_SECONDS))
+}
+
+/// Converts the given `seconds` into `Duration` and limits it to 1h.
+pub(crate) fn limit_timeout_opt(seconds: Option<u64>) -> Option<Duration> {
+    seconds.map(limit_timeout)
 }
 
 #[cfg(test)]

--- a/src/tonic/api/mod.rs
+++ b/src/tonic/api/mod.rs
@@ -9,13 +9,9 @@ mod collections_common;
 mod query_common;
 mod update_common;
 
-use std::time::Duration;
-
 use collection::operations::validation;
 use tonic::Status;
 use validator::Validate;
-
-use crate::actix::api::read_params::HOUR_IN_SECONDS;
 
 /// Validate the given request and fail on error.
 ///
@@ -31,16 +27,6 @@ fn validate_and_log(request: &impl Validate) {
     if let Err(ref err) = request.validate() {
         validation::warn_validation_errors("Internal gRPC", err);
     }
-}
-
-/// Converts the given `seconds` into `Duration` and limits it to 1h.
-pub(crate) fn limit_timeout(seconds: u64) -> Duration {
-    Duration::from_secs(std::cmp::min(seconds, HOUR_IN_SECONDS))
-}
-
-/// Converts the given `seconds` into `Duration` and limits it to 1h.
-pub(crate) fn limit_timeout_opt(seconds: Option<u64>) -> Option<Duration> {
-    seconds.map(limit_timeout)
 }
 
 #[cfg(test)]

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use api::grpc::Usage;
 use api::grpc::qdrant::points_server::Points;
@@ -30,6 +30,7 @@ use crate::common::inference::token::extract_token;
 use crate::common::strict_mode::*;
 use crate::common::update::InternalUpdateParams;
 use crate::settings::ServiceConfig;
+use crate::tonic::api::limit_timeout_opt;
 use crate::tonic::auth::extract_access;
 
 pub struct PointsService {
@@ -376,7 +377,7 @@ impl Points for PointsService {
             timeout,
         } = request.into_inner();
 
-        let timeout = timeout.map(Duration::from_secs);
+        let timeout = limit_timeout_opt(timeout);
 
         let mut requests = Vec::new();
 
@@ -484,13 +485,15 @@ impl Points for PointsService {
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
 
+        let timeout = limit_timeout_opt(timeout);
+
         let res = recommend_batch(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             &collection_name,
             recommend_points,
             read_consistency,
             access,
-            timeout.map(Duration::from_secs),
+            timeout,
             hw_metrics,
         )
         .await?;
@@ -553,13 +556,14 @@ impl Points for PointsService {
 
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
+        let timeout = limit_timeout_opt(timeout);
         let res = discover_batch(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             &collection_name,
             discover_points,
             read_consistency,
             access,
-            timeout.map(Duration::from_secs),
+            timeout,
             hw_metrics,
         )
         .await?;
@@ -634,7 +638,9 @@ impl Points for PointsService {
             read_consistency,
             timeout,
         } = request;
-        let timeout = timeout.map(Duration::from_secs);
+
+        let timeout = limit_timeout_opt(timeout);
+
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
         let res = query_batch(

--- a/src/tonic/api/points_api.rs
+++ b/src/tonic/api/points_api.rs
@@ -25,12 +25,12 @@ use tonic::{Request, Response, Status};
 use super::query_common::*;
 use super::update_common::*;
 use super::validate;
+use crate::common::helpers::limit_and_convert_timeout_opt;
 use crate::common::inference::params::InferenceParams;
 use crate::common::inference::token::extract_token;
 use crate::common::strict_mode::*;
 use crate::common::update::InternalUpdateParams;
 use crate::settings::ServiceConfig;
-use crate::tonic::api::limit_timeout_opt;
 use crate::tonic::auth::extract_access;
 
 pub struct PointsService {
@@ -377,7 +377,7 @@ impl Points for PointsService {
             timeout,
         } = request.into_inner();
 
-        let timeout = limit_timeout_opt(timeout);
+        let timeout = limit_and_convert_timeout_opt(timeout);
 
         let mut requests = Vec::new();
 
@@ -485,7 +485,7 @@ impl Points for PointsService {
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
 
-        let timeout = limit_timeout_opt(timeout);
+        let timeout = limit_and_convert_timeout_opt(timeout);
 
         let res = recommend_batch(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
@@ -556,7 +556,7 @@ impl Points for PointsService {
 
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
-        let timeout = limit_timeout_opt(timeout);
+        let timeout = limit_and_convert_timeout_opt(timeout);
         let res = discover_batch(
             StrictModeCheckedTocProvider::new(&self.dispatcher),
             &collection_name,
@@ -599,10 +599,10 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let inference_token = extract_token(&request);
-        let inference_params = InferenceParams::new(
-            inference_token,
-            request.get_ref().timeout.map(Duration::from_secs),
-        );
+
+        let timeout = limit_and_convert_timeout_opt(request.get_ref().timeout);
+        let inference_params = InferenceParams::new(inference_token, timeout);
+
         let collection_name = request.get_ref().collection_name.clone();
         let hw_metrics = self.get_request_collection_hw_usage_counter(collection_name, None);
 
@@ -626,20 +626,17 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let inference_token = extract_token(&request);
-        let inference_params = InferenceParams::new(
-            inference_token,
-            request.get_ref().timeout.map(Duration::from_secs),
-        );
+
+        let timeout = limit_and_convert_timeout_opt(request.get_ref().timeout);
+        let inference_params = InferenceParams::new(inference_token, timeout);
 
         let request = request.into_inner();
         let QueryBatchPoints {
             collection_name,
             query_points,
             read_consistency,
-            timeout,
+            timeout: _,
         } = request;
-
-        let timeout = limit_timeout_opt(timeout);
 
         let hw_metrics =
             self.get_request_collection_hw_usage_counter(collection_name.clone(), None);
@@ -665,10 +662,10 @@ impl Points for PointsService {
         validate(request.get_ref())?;
         let access = extract_access(&mut request);
         let inference_token = extract_token(&request);
-        let inference_params = InferenceParams::new(
-            inference_token,
-            request.get_ref().timeout.map(Duration::from_secs),
-        );
+
+        let timeout = limit_and_convert_timeout_opt(request.get_ref().timeout);
+        let inference_params = InferenceParams::new(inference_token, timeout);
+
         let collection_name = request.get_ref().collection_name.clone();
         let hw_metrics = self.get_request_collection_hw_usage_counter(collection_name, None);
 

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -32,12 +32,12 @@ use tonic::{Request, Response, Status};
 use super::query_common::*;
 use super::update_common::*;
 use super::validate_and_log;
+use crate::common::helpers::limit_and_convert_timeout_opt;
 use crate::common::inference::params::InferenceParams;
 use crate::common::inference::token::extract_token;
 use crate::common::strict_mode::*;
 use crate::common::update::InternalUpdateParams;
 use crate::settings::ServiceConfig;
-use crate::tonic::api::{limit_timeout, limit_timeout_opt};
 
 const FULL_ACCESS: Access = Access::full("Internal API");
 
@@ -339,8 +339,6 @@ pub async fn query_batch_internal(
     timeout: Option<Duration>,
     request_hw_data: RequestHwCounter,
 ) -> Result<Response<QueryBatchResponseInternal>, Status> {
-    let timeout = timeout.map(|i| limit_timeout(i.as_secs()));
-
     let batch_requests: Vec<_> = query_points
         .into_iter()
         .map(ShardQueryRequest::try_from)
@@ -405,7 +403,7 @@ async fn facet_counts_internal(
         timeout,
     } = request;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let shard_selection = ShardSelectorInternal::ShardId(shard_id);
 
@@ -651,7 +649,7 @@ impl PointsInternal for PointsInternalService {
             timeout,
         } = request.into_inner();
 
-        let timeout = limit_timeout_opt(timeout);
+        let timeout = limit_and_convert_timeout_opt(timeout);
 
         // Individual `read_consistency` values are ignored by `core_search_batch`...
         //
@@ -821,7 +819,7 @@ impl PointsInternal for PointsInternalService {
             timeout,
         } = request.into_inner();
 
-        let timeout = limit_timeout_opt(timeout);
+        let timeout = limit_and_convert_timeout_opt(timeout);
 
         let hw_data =
             self.get_request_collection_hw_usage_counter_for_internal(collection_name.clone());

--- a/src/tonic/api/query_common.rs
+++ b/src/tonic/api/query_common.rs
@@ -33,13 +33,13 @@ use storage::content_manager::toc::request_hw_counter::RequestHwCounter;
 use storage::rbac::Access;
 use tonic::{Response, Status};
 
+use crate::common::helpers::limit_and_convert_timeout_opt;
 use crate::common::inference::params::InferenceParams;
 use crate::common::inference::query_requests_grpc::{
     convert_query_point_groups_from_grpc, convert_query_points_from_grpc,
 };
 use crate::common::query::*;
 use crate::common::strict_mode::*;
-use crate::tonic::api::limit_timeout_opt;
 
 pub(crate) fn convert_shard_selector_for_read(
     shard_id_selector: Option<ShardId>,
@@ -84,7 +84,7 @@ pub async fn search(
         sparse_indices,
     } = search_points;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let vector_internal =
         VectorInternal::from_vector_and_indices(vector, sparse_indices.map(|v| v.data));
@@ -259,7 +259,7 @@ pub async fn search_groups(
         ..
     } = search_point_groups;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let toc = toc_provider
         .check_strict_mode(&search_groups_request, &collection_name, timeout, &access)
@@ -304,7 +304,7 @@ pub async fn recommend(
     let collection_name = recommend_points.collection_name.clone();
     let read_consistency = recommend_points.read_consistency.clone();
     let shard_key_selector = recommend_points.shard_key_selector.clone();
-    let timeout = limit_timeout_opt(recommend_points.timeout);
+    let timeout = limit_and_convert_timeout_opt(recommend_points.timeout);
 
     let request =
         collection::operations::types::RecommendRequestInternal::try_from(recommend_points)?;
@@ -408,7 +408,7 @@ pub async fn recommend_groups(
         ..
     } = recommend_point_groups;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let toc = toc_provider
         .check_strict_mode(
@@ -559,7 +559,7 @@ pub async fn scroll(
         timeout,
     } = scroll_points;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let scroll_request = ScrollRequestInternal {
         offset: offset.map(|o| o.try_into()).transpose()?,
@@ -630,7 +630,7 @@ pub async fn count(
         timeout,
     } = count_points;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let count_request = collection::operations::types::CountRequestInternal {
         filter: filter.map(|f| f.try_into()).transpose()?,
@@ -685,7 +685,7 @@ pub async fn get(
         timeout,
     } = get_points;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let point_request = PointRequestInternal {
         ids: ids
@@ -744,7 +744,7 @@ pub async fn query(
         .map(TryFrom::try_from)
         .transpose()?;
     let collection_name = query_points.collection_name.clone();
-    let timeout = limit_timeout_opt(query_points.timeout);
+    let timeout = limit_and_convert_timeout_opt(query_points.timeout);
     let (request, inference_usage) =
         convert_query_points_from_grpc(query_points, inference_params).await?;
 
@@ -850,7 +850,7 @@ pub async fn query_groups(
         .clone()
         .map(TryFrom::try_from)
         .transpose()?;
-    let timeout = limit_timeout_opt(query_points.timeout);
+    let timeout = limit_and_convert_timeout_opt(query_points.timeout);
     let collection_name = query_points.collection_name.clone();
     let (request, inference_usage) =
         convert_query_point_groups_from_grpc(query_points, inference_params).await?;
@@ -902,7 +902,7 @@ pub async fn facet(
         timeout,
     } = facet_counts;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let facet_request = FacetParams {
         key: json_path_from_proto(&key)?,
@@ -964,7 +964,7 @@ pub async fn search_points_matrix(
         timeout,
     } = search_matrix_points;
 
-    let timeout = limit_timeout_opt(timeout);
+    let timeout = limit_and_convert_timeout_opt(timeout);
 
     let search_matrix_request = CollectionSearchMatrixRequest {
         filter: filter.map(TryInto::try_into).transpose()?,

--- a/src/tonic/api/query_common.rs
+++ b/src/tonic/api/query_common.rs
@@ -39,6 +39,7 @@ use crate::common::inference::query_requests_grpc::{
 };
 use crate::common::query::*;
 use crate::common::strict_mode::*;
+use crate::tonic::api::limit_timeout_opt;
 
 pub(crate) fn convert_shard_selector_for_read(
     shard_id_selector: Option<ShardId>,
@@ -83,6 +84,8 @@ pub async fn search(
         sparse_indices,
     } = search_points;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let vector_internal =
         VectorInternal::from_vector_and_indices(vector, sparse_indices.map(|v| v.data));
 
@@ -107,12 +110,7 @@ pub async fn search(
     };
 
     let toc = toc_provider
-        .check_strict_mode(
-            &search_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&search_request, &collection_name, timeout, &access)
         .await?;
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
@@ -125,7 +123,7 @@ pub async fn search(
         read_consistency,
         shard_selector,
         access,
-        timeout.map(Duration::from_secs),
+        timeout,
         hw_measurement_acc.get_counter(),
     )
     .await?;
@@ -152,13 +150,7 @@ pub async fn core_search_batch(
     request_hw_counter: RequestHwCounter,
 ) -> Result<Response<SearchBatchResponse>, Status> {
     let toc = toc_provider
-        .check_strict_mode_batch(
-            &requests,
-            |i| &i.0,
-            collection_name,
-            timeout.map(|i| i.as_secs() as usize),
-            &access,
-        )
+        .check_strict_mode_batch(&requests, |i| &i.0, collection_name, timeout, &access)
         .await?;
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
@@ -267,13 +259,10 @@ pub async fn search_groups(
         ..
     } = search_point_groups;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let toc = toc_provider
-        .check_strict_mode(
-            &search_groups_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&search_groups_request, &collection_name, timeout, &access)
         .await?;
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
@@ -288,7 +277,7 @@ pub async fn search_groups(
         read_consistency,
         shard_selector,
         access,
-        timeout.map(Duration::from_secs),
+        timeout,
         request_hw_counter.get_counter(),
     )
     .await?;
@@ -315,23 +304,17 @@ pub async fn recommend(
     let collection_name = recommend_points.collection_name.clone();
     let read_consistency = recommend_points.read_consistency.clone();
     let shard_key_selector = recommend_points.shard_key_selector.clone();
-    let timeout = recommend_points.timeout;
+    let timeout = limit_timeout_opt(recommend_points.timeout);
 
     let request =
         collection::operations::types::RecommendRequestInternal::try_from(recommend_points)?;
 
     let toc = toc_provider
-        .check_strict_mode(
-            &request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&request, &collection_name, timeout, &access)
         .await?;
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector)?;
-    let timeout = timeout.map(Duration::from_secs);
 
     let timing = Instant::now();
     let recommended_points = toc
@@ -378,13 +361,7 @@ pub async fn recommend_batch(
     }
 
     let toc = toc_provider
-        .check_strict_mode_batch(
-            &requests,
-            |i| &i.0,
-            collection_name,
-            timeout.map(|i| i.as_secs() as usize),
-            &access,
-        )
+        .check_strict_mode_batch(&requests, |i| &i.0, collection_name, timeout, &access)
         .await?;
 
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
@@ -431,11 +408,13 @@ pub async fn recommend_groups(
         ..
     } = recommend_point_groups;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let toc = toc_provider
         .check_strict_mode(
             &recommend_groups_request,
             &collection_name,
-            timeout.map(|i| i as usize),
+            timeout,
             &access,
         )
         .await?;
@@ -452,7 +431,7 @@ pub async fn recommend_groups(
         read_consistency,
         shard_selector,
         access,
-        timeout.map(Duration::from_secs),
+        timeout,
         request_hw_counter.get_counter(),
     )
     .await?;
@@ -479,12 +458,7 @@ pub async fn discover(
         try_discover_request_from_grpc(discover_points)?;
 
     let toc = toc_provider
-        .check_strict_mode(
-            &request,
-            &collection_name,
-            timeout.map(|i| i.as_secs() as usize),
-            &access,
-        )
+        .check_strict_mode(&request, &collection_name, timeout, &access)
         .await?;
 
     let timing = Instant::now();
@@ -536,13 +510,7 @@ pub async fn discover_batch(
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let toc = toc_provider
-        .check_strict_mode_batch(
-            &requests,
-            |i| &i.0,
-            collection_name,
-            timeout.map(|i| i.as_secs() as usize),
-            &access,
-        )
+        .check_strict_mode_batch(&requests, |i| &i.0, collection_name, timeout, &access)
         .await?;
 
     let timing = Instant::now();
@@ -591,6 +559,8 @@ pub async fn scroll(
         timeout,
     } = scroll_points;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let scroll_request = ScrollRequestInternal {
         offset: offset.map(|o| o.try_into()).transpose()?,
         limit: limit.map(|l| l as usize),
@@ -606,15 +576,9 @@ pub async fn scroll(
     };
 
     let toc = toc_provider
-        .check_strict_mode(
-            &scroll_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&scroll_request, &collection_name, timeout, &access)
         .await?;
 
-    let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector)?;
@@ -666,21 +630,17 @@ pub async fn count(
         timeout,
     } = count_points;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let count_request = collection::operations::types::CountRequestInternal {
         filter: filter.map(|f| f.try_into()).transpose()?,
         exact: exact.unwrap_or_else(default_exact_count),
     };
 
     let toc = toc_provider
-        .check_strict_mode(
-            &count_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            access,
-        )
+        .check_strict_mode(&count_request, &collection_name, timeout, access)
         .await?;
 
-    let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let shard_selector = convert_shard_selector_for_read(shard_selection, shard_key_selector)?;
@@ -725,6 +685,8 @@ pub async fn get(
         timeout,
     } = get_points;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let point_request = PointRequestInternal {
         ids: ids
             .into_iter()
@@ -742,15 +704,8 @@ pub async fn get(
     let timing = Instant::now();
 
     let toc = toc_provider
-        .check_strict_mode(
-            &point_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&point_request, &collection_name, timeout, &access)
         .await?;
-
-    let timeout = timeout.map(Duration::from_secs);
 
     let records = do_get_points(
         toc,
@@ -789,20 +744,13 @@ pub async fn query(
         .map(TryFrom::try_from)
         .transpose()?;
     let collection_name = query_points.collection_name.clone();
-    let timeout = query_points.timeout;
+    let timeout = limit_timeout_opt(query_points.timeout);
     let (request, inference_usage) =
         convert_query_points_from_grpc(query_points, inference_params).await?;
 
     let toc = toc_provider
-        .check_strict_mode(
-            &request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&request, &collection_name, timeout, &access)
         .await?;
-
-    let timeout = timeout.map(Duration::from_secs);
 
     let timing = Instant::now();
     let scored_points = do_query_points(
@@ -854,13 +802,7 @@ pub async fn query_batch(
     }
 
     let toc = toc_provider
-        .check_strict_mode_batch(
-            &requests,
-            |i| &i.0,
-            collection_name,
-            timeout.map(|i| i.as_secs() as usize),
-            &access,
-        )
+        .check_strict_mode_batch(&requests, |i| &i.0, collection_name, timeout, &access)
         .await?;
 
     let timing = Instant::now();
@@ -908,21 +850,15 @@ pub async fn query_groups(
         .clone()
         .map(TryFrom::try_from)
         .transpose()?;
-    let timeout = query_points.timeout;
+    let timeout = limit_timeout_opt(query_points.timeout);
     let collection_name = query_points.collection_name.clone();
     let (request, inference_usage) =
         convert_query_point_groups_from_grpc(query_points, inference_params).await?;
 
     let toc = toc_provider
-        .check_strict_mode(
-            &request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&request, &collection_name, timeout, &access)
         .await?;
 
-    let timeout = timeout.map(Duration::from_secs);
     let timing = Instant::now();
 
     let groups_result = do_query_point_groups(
@@ -966,6 +902,8 @@ pub async fn facet(
         timeout,
     } = facet_counts;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let facet_request = FacetParams {
         key: json_path_from_proto(&key)?,
         filter: filter.map(TryInto::try_into).transpose()?,
@@ -978,15 +916,9 @@ pub async fn facet(
     };
 
     let toc = toc_provider
-        .check_strict_mode(
-            &facet_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&facet_request, &collection_name, timeout, &access)
         .await?;
 
-    let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector)?;
@@ -1032,6 +964,8 @@ pub async fn search_points_matrix(
         timeout,
     } = search_matrix_points;
 
+    let timeout = limit_timeout_opt(timeout);
+
     let search_matrix_request = CollectionSearchMatrixRequest {
         filter: filter.map(TryInto::try_into).transpose()?,
         sample_size: sample
@@ -1048,15 +982,9 @@ pub async fn search_points_matrix(
     };
 
     let toc = toc_provider
-        .check_strict_mode(
-            &search_matrix_request,
-            &collection_name,
-            timeout.map(|i| i as usize),
-            &access,
-        )
+        .check_strict_mode(&search_matrix_request, &collection_name, timeout, &access)
         .await?;
 
-    let timeout = timeout.map(Duration::from_secs);
     let read_consistency = ReadConsistency::try_from_optional(read_consistency)?;
 
     let shard_selector = convert_shard_selector_for_read(None, shard_key_selector)?;


### PR DESCRIPTION

- Limit timeout to 1h for both rest and grpc endpoints.
- use `Duration` instead of `u64` in strict mode for better consistency and cleaner code