### PR TITLE
Don't return failure when writing to `Partial` replicas for tenant promotion

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1034,6 +1034,20 @@ impl ShardReplicaSet {
         is_active_or_resharding && !self.is_locally_disabled(peer_id)
     }
 
+    fn are_all_partial(&self) -> bool {
+        if self.replica_state.read().peers().is_empty() {
+            return false;
+        }
+
+        // todo: Check if we have custom sharding mode enabled. It's a must
+
+        self.replica_state
+            .read()
+            .peers()
+            .values()
+            .all(|state| matches!(state, ReplicaState::Partial))
+    }
+
     fn peer_is_initializing(&self, peer_id: PeerId) -> bool {
         let is_initializing = matches!(self.peer_state(peer_id), Some(ReplicaState::Initializing));
         is_initializing && !self.is_locally_disabled(peer_id)

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1036,13 +1036,13 @@ impl ShardReplicaSet {
 
     /// Is the current replica set used for tenant promotion
     fn is_tenant_promotion(&self) -> bool {
-        // If there's only on peer and it's in Partial state, it's a promotion
-        // since we don't support promotion with multiple destination replicas
+        // No custom sharding means no promotion
         if self.shard_key.is_none() {
-            // No custom sharding means no promotion
             return false;
         }
 
+        // If there's only on peer and it's in Partial state, it's a promotion
+        // since we don't support promotion with multiple destination replicas
         let peers = self.replica_state.read().peers();
         peers.len() == 1 && matches!(peers.values().next(), Some(ReplicaState::Partial))
     }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -514,7 +514,8 @@ impl ShardReplicaSet {
         if !successes
             .iter()
             .any(|&(peer_id, _)| self.peer_is_active_or_resharding(peer_id))
-            && !self.are_all_partial() // All replicas are partial only when creating new shard key for tenant promotion
+            && !self.are_all_partial()
+        // All replicas are partial only when creating new shard key for tenant promotion
         {
             return Err(CollectionError::service_error(format!(
                 // throws error

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -514,8 +514,10 @@ impl ShardReplicaSet {
         if !successes
             .iter()
             .any(|&(peer_id, _)| self.peer_is_active_or_resharding(peer_id))
+            && !self.are_all_partial() // All replicas are partial only when creating new shard key for tenant promotion
         {
             return Err(CollectionError::service_error(format!(
+                // throws error
                 "Failed to apply operation to at least one `Active` replica. \
                  Consistency of this update is not guaranteed. Please retry. {failure_error}",
             )));

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -517,7 +517,6 @@ impl ShardReplicaSet {
             && !self.is_tenant_promotion()
         {
             return Err(CollectionError::service_error(format!(
-                // throws error
                 "Failed to apply operation to at least one `Active` replica. \
                  Consistency of this update is not guaranteed. Please retry. {failure_error}",
             )));

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -514,8 +514,7 @@ impl ShardReplicaSet {
         if !successes
             .iter()
             .any(|&(peer_id, _)| self.peer_is_active_or_resharding(peer_id))
-            && !self.are_all_partial()
-        // All replicas are partial only when creating new shard key for tenant promotion
+            && !self.is_tenant_promotion()
         {
             return Err(CollectionError::service_error(format!(
                 // throws error

--- a/tests/consensus_tests/custom_sharding.py
+++ b/tests/consensus_tests/custom_sharding.py
@@ -1,0 +1,59 @@
+from .utils import *
+from .fixtures import *
+
+DEFAULT_COLLECTION_NAME = "test_collection"
+
+
+def create_collection_with_custom_sharding(
+        peer_url,
+        collection=DEFAULT_COLLECTION_NAME,
+        shard_number=1,
+        replication_factor=1,
+        write_consistency_factor=1,
+        timeout=10
+):
+    create_collection(
+        peer_url,
+        collection=collection,
+        shard_number=shard_number,
+        replication_factor=replication_factor,
+        write_consistency_factor=write_consistency_factor,
+        timeout=timeout,
+        sharding_method="custom",
+    )
+
+
+def create_shard(
+        peer_url,
+        collection,
+        shard_key,
+        shard_number=1,
+        replication_factor=1,
+        placement=None,
+        initial_state=None,
+        timeout=10
+):
+    r_batch = requests.put(
+        f"{peer_url}/collections/{collection}/shards?timeout={timeout}", json={
+            "shard_key": shard_key,
+            "shards_number": shard_number,
+            "replication_factor": replication_factor,
+            "placement": placement,
+            "initial_state": initial_state,
+        })
+    assert_http_ok(r_batch)
+
+
+def delete_shard(
+        peer_url,
+        collection,
+        shard_key,
+        timeout=10
+):
+    r_batch = requests.post(
+        f"{peer_url}/collections/{collection}/shards/delete?timeout={timeout}",
+        json={
+            "shard_key": shard_key,
+        }
+    )
+    assert_http_ok(r_batch)

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -93,7 +93,9 @@ def upsert_random_points(
     shard_key=None,
     num_cities=None,
     headers={},
+    extra_payload=None,
 ):
+    extra_payload = extra_payload or {}
 
     def get_vector():
         # Create points in first peer's collection
@@ -115,7 +117,10 @@ def upsert_random_points(
                     {
                         "id": i + offset,
                         "vector": get_vector(),
-                        "payload": {"city": random.choice(CITIES[:num_cities]) if num_cities is not None else random.choice(CITIES)},
+                        "payload": {
+                            **extra_payload,
+                            "city": random.choice(CITIES[:num_cities]) if num_cities is not None else random.choice(CITIES)
+                        },
                     }
                     for i in range(size)
                 ],

--- a/tests/consensus_tests/test_custom_sharding.py
+++ b/tests/consensus_tests/test_custom_sharding.py
@@ -1,8 +1,8 @@
 import concurrent.futures
 import pathlib
 import threading
-import time
 
+from .custom_sharding import create_collection_with_custom_sharding, create_shard, delete_shard
 from .fixtures import *
 from .utils import *
 
@@ -11,66 +11,6 @@ N_SHARDS = 1
 N_REPLICAS = 1
 
 COLLECTION_NAME = "test_collection"
-
-
-def create_collection_with_custom_sharding(
-        peer_url,
-        collection=COLLECTION_NAME,
-        shard_number=1,
-        replication_factor=1,
-        write_consistency_factor=1,
-        timeout=10
-):
-    # Create collection in peer_url
-    r_batch = requests.put(
-        f"{peer_url}/collections/{collection}?timeout={timeout}", json={
-            "vectors": {
-                "size": 4,
-                "distance": "Dot"
-            },
-            "shard_number": shard_number,
-            "replication_factor": replication_factor,
-            "write_consistency_factor": write_consistency_factor,
-            "sharding_method": "custom",
-        })
-    assert_http_ok(r_batch)
-
-
-def create_shard(
-        peer_url,
-        collection,
-        shard_key,
-        shard_number=1,
-        replication_factor=1,
-        placement=None,
-        initial_state=None,
-        timeout=10
-):
-    r_batch = requests.put(
-        f"{peer_url}/collections/{collection}/shards?timeout={timeout}", json={
-            "shard_key": shard_key,
-            "shards_number": shard_number,
-            "replication_factor": replication_factor,
-            "placement": placement,
-            "initial_state": initial_state,
-        })
-    assert_http_ok(r_batch)
-
-
-def delete_shard(
-        peer_url,
-        collection,
-        shard_key,
-        timeout=10
-):
-    r_batch = requests.post(
-        f"{peer_url}/collections/{collection}/shards/delete?timeout={timeout}",
-        json={
-            "shard_key": shard_key,
-        }
-    )
-    assert_http_ok(r_batch)
-
 
 def test_shard_consistency(tmp_path: pathlib.Path):
     assert_project_root()

--- a/tests/consensus_tests/test_tenant_promotion.py
+++ b/tests/consensus_tests/test_tenant_promotion.py
@@ -1,0 +1,168 @@
+import concurrent.futures
+import pathlib
+import threading
+import time
+
+from .custom_sharding import create_collection_with_custom_sharding, create_shard
+from .fixtures import *
+from .utils import *
+
+COLLECTION_NAME = "tenant_collection"
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICAS = 1
+
+
+def match_results(results1: List[dict], results2: List[dict]):
+    # Compare ids and payloads of search results
+    if len(results1) != len(results2):
+        return False, f"Results length differ: {len(results1)} != {len(results2)}"
+
+    for idx, (r1, r2) in enumerate(zip(results1, results2)):
+        if r1['id'] != r2['id']:
+            return False, f"Result IDs differ: {r1['id']} != {r2['id']} at index {idx}"
+        if r1.get('payload') != r2.get('payload'):
+            return False, f"Result payloads differ for ID {r1['id']}: {r1.get('payload')} != {r2.get('payload')}, at index {idx}"
+
+    return True, ""
+
+
+def search_points(peer_url):
+    query_vector = [0.1, 0.2, 0.3, 0.4]
+    resp = requests.post(
+        f"{peer_url}/collections/{COLLECTION_NAME}/points/search",
+        json={
+            "vector": query_vector,
+            "top": 5,
+            "filter": {
+                "must": [
+                    {
+                        "key": "tenant",
+                        "match": {
+                            "value": "tenant1"
+                        }
+                    }
+                ]
+            },
+            "shard_key": {
+                "fallback": "default",
+                "target": "tenant1"
+            }
+        }
+    )
+    assert_http_ok(resp)
+
+    results = resp.json()["result"]
+    return results
+
+
+def test_tenant_promotion_simple(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    create_collection_with_custom_sharding(peer_api_uris[0], collection=COLLECTION_NAME, shard_number=N_SHARDS,
+                                           replication_factor=N_REPLICAS)
+
+    create_shard(
+        peer_url=peer_api_uris[0],
+        collection=COLLECTION_NAME,
+        shard_key="default",
+        shard_number=N_SHARDS,
+        replication_factor=N_REPLICAS,
+        # initial_state="Partial",
+    )
+
+    n_points = 1_000
+    upsert_random_points(
+        peer_api_uris[0],
+        n_points,
+        collection_name=COLLECTION_NAME,
+        shard_key={
+            "fallback": "default",
+            "target": "tenant1"
+        },
+        extra_payload={
+            "tenant": "tenant1"
+        }
+    )
+
+    n_points = 100
+    upsert_random_points(
+        peer_api_uris[0],
+        n_points,
+        collection_name=COLLECTION_NAME,
+        shard_key={
+            "fallback": "default",
+            "target": "tenant2"
+        },
+        extra_payload={
+            "tenant": "tenant2"
+        }
+    )
+
+    # Search point with shard key and filter
+    results = search_points(peer_api_uris[0])
+    assert len(results) > 0, "No results found for tenant1"
+
+    create_shard(
+        peer_url=peer_api_uris[0],
+        collection=COLLECTION_NAME,
+        shard_key="tenant1",
+        shard_number=N_SHARDS,
+        replication_factor=N_REPLICAS,
+        initial_state="Partial",
+    )
+
+    # With new shard we should get the same results
+    result2 = search_points(peer_api_uris[0])
+    match, msg = match_results(results, result2)
+    assert match, f"Results differ after tenant1 shard creation: {msg}"
+
+    n_points = 100
+    upsert_random_points(
+        peer_api_uris[0],
+        n_points,
+        collection_name=COLLECTION_NAME,
+        shard_key={
+            "fallback": "default",
+            "target": "tenant1"
+        },
+        extra_payload={
+            "tenant": "tenant1"
+        }
+    )
+
+    results = search_points(peer_api_uris[0])
+
+    # Promote to dedicated shard
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster",
+        json={
+            "replicate_points": {
+                "filter": {
+                    "must": {
+                        "key": "tenant",
+                        "match": {
+                            "value": "tenant1"
+                        }
+                    }
+                },
+                "from_shard_key": "default",
+                "to_shard_key": "tenant1"
+            }
+        }
+    )
+    assert_http_ok(resp)
+
+    results2 = search_points(peer_api_uris[0])
+    match, msg = match_results(results, results2)
+    assert match, f"Results differ after tenant1 promotion start: {msg}"
+
+    # Wait all transfers complete
+    wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
+
+    results3 = search_points(peer_api_uris[0])
+    match, msg = match_results(results, results3)
+    assert match, f"Results differ after tenant1 promotion complete: {msg}"

--- a/tests/consensus_tests/test_tenant_promotion.py
+++ b/tests/consensus_tests/test_tenant_promotion.py
@@ -166,3 +166,24 @@ def test_tenant_promotion_simple(tmp_path: pathlib.Path):
     results3 = search_points(peer_api_uris[0])
     match, msg = match_results(results, results3)
     assert match, f"Results differ after tenant1 promotion complete: {msg}"
+
+    # Delete records from the old shard
+    resp = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/delete?wait=true",
+        json={
+            "filter": {
+                "must": {
+                    "key": "tenant",
+                    "match": {
+                        "value": "tenant1"
+                    }
+                }
+            },
+            "shard_key": "default"
+        }
+    )
+    assert_http_ok(resp)
+
+    results4 = search_points(peer_api_uris[0])
+    match, msg = match_results(results, results4)
+    assert match, f"Results differ after tenant1 deletion from old shard: {msg}"

--- a/tests/consensus_tests/test_tenant_promotion.py
+++ b/tests/consensus_tests/test_tenant_promotion.py
@@ -60,7 +60,7 @@ def search_points(peer_url):
 def test_tenant_promotion_simple(tmp_path: pathlib.Path):
     assert_project_root()
 
-    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, port_seed=6000)
 
     create_collection_with_custom_sharding(peer_api_uris[0], collection=COLLECTION_NAME, shard_number=N_SHARDS,
                                            replication_factor=N_REPLICAS)
@@ -71,7 +71,6 @@ def test_tenant_promotion_simple(tmp_path: pathlib.Path):
         shard_key="default",
         shard_number=N_SHARDS,
         replication_factor=N_REPLICAS,
-        # initial_state="Partial",
     )
 
     n_points = 1_000


### PR DESCRIPTION
If you have collection with something like this:

```json
{
    "result": {
        "peer_id": 283000563180723,
        "shard_count": 2,
        "local_shards": [
            {
                "shard_id": 1,
                "shard_key": "default",
                "points_count": 1000,
                "state": "Active"
            },
            {
                "shard_id": 2,
                "shard_key": "tenant1",
                "points_count": 0,
                "state": "Partial"
            }
        ],
        "remote_shards": [],
        "shard_transfers": []
    },
    "status": "ok",
    "time": 0.000541685
}
```

Using shard fallback for writes will return error response because it internally tries to write to both shard keys. This happens because `tenant1` has only `Partial` replicas (i.e. no `Active` replicas)

```http
PUT /collections/benchmark/points
{
  "points": [
    {
      "id": 1,
      "payload": {"org": "tenant1"},
      "vector": [0.1, 0.2, 0.3, 0.4]
    }
  ],
  "shard_key": {
    "target": "tenant1",
    "fallback": "default"
  }
}
```

```console
{'status': {'error': 'Service internal error: Failed to apply operation to at least one `Active` replica. Consistency of this update is not guaranteed. Please retry. '}, 'time': 0.191400375, 'usage': {'hardware': {'cpu': 0, 'payload_io_read': 0, 'payload_io_write': 0, 'payload_index_io_read': 0, 'payload_index_io_write': 0, 'vector_io_read': 0, 'vector_io_write': 0}, 'inference': None}}
```

The write succeeds anyways in this case but we return an error which can be confusing for the user.