### PR TITLE
Try fixing Dependabot

### DIFF
--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-edge = { path = "../../edge" } # ".." does not play with with Dependabot
+edge = { path = "../../edge" } # ".." does not play well with Dependabot
 segment = { path = "../../segment", default-features = false }
 shard = { path = "../../shard" }
 sparse = { path = "../../sparse" }


### PR DESCRIPTION
Dependabot for `cargo` seems to be [broken](https://github.com/qdrant/qdrant/actions/workflows/dependabot/dependabot-updates) more or less since the introduction of the `edge` crate.

The error is a bit cryptic:

```
updater | 2025/11/03 18:45:02 ERROR <job_1142349536> Error processing tikv-jemalloc-ctl (Errno::EACCES)
2025/11/03 18:45:02 ERROR <job_1142349536> Permission denied @ rb_sysopen - /Cargo.toml
2025/11/03 18:45:02 ERROR <job_1142349536> /home/dependabot/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb:317:in 'IO.write'
```


I can't run it locally so I am guessing the path to the `Cargo.toml` is not built properly in the specific case of the nested `edge-py` crate.

This PR tries to normalize the path to help Dependabot.

The change will be validated by tomorrow's update run.
