### PR TITLE
Allow partial recovery of dummy shard

### DIFF
--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -49,7 +49,7 @@ impl DummyShard {
     }
 
     pub fn snapshot_manifest(&self) -> CollectionResult<SnapshotManifest> {
-        self.dummy()
+        Ok(SnapshotManifest::default())
     }
 
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {


### PR DESCRIPTION
This allows to recover "dummy" shards with partial snapshots.

This does **zero** additional validation, so it's easy to destroy the shard with an invalid/incompatible partial snapshot. But it should work as long as partial snapshot is "full".

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
