### PR TITLE
Final metrics tweaks for Qdrant 1.16.0

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -174,27 +174,29 @@ impl MetricsProvider for CollectionsTelemetry {
             prefix,
         ));
 
+        let num_collections = self.collections.as_ref().map_or(0, |c| c.len());
+
         // Optimizers
-        let mut total_optimizations_running = vec![];
+        let mut total_optimizations_running = Vec::with_capacity(num_collections);
 
         // Min/Max/Expected/Active replicas over all shards.
         let mut total_min_active_replicas = usize::MAX;
         let mut total_max_active_replicas = 0;
 
         // Points per collection
-        let mut points_per_collection = vec![];
+        let mut points_per_collection = Vec::with_capacity(num_collections);
 
         // Vectors excluded from index-only requests.
-        let mut indexed_only_excluded = vec![];
+        let mut indexed_only_excluded = Vec::with_capacity(num_collections);
 
         let mut total_dead_replicas = 0;
 
         // Snapshot metrics
-        let mut snapshots_creation_running = vec![];
-        let mut snapshots_recovery_running = vec![];
-        let mut snapshots_created_total = vec![];
+        let mut snapshots_creation_running = Vec::with_capacity(num_collections);
+        let mut snapshots_recovery_running = Vec::with_capacity(num_collections);
+        let mut snapshots_created_total = Vec::with_capacity(num_collections);
 
-        let mut vector_count_by_name = vec![];
+        let mut vector_count_by_name = Vec::with_capacity(num_collections);
 
         for collection in self.collections.iter().flatten() {
             let collection = match collection {


### PR DESCRIPTION
Here I make and propose some final changes to our current metrics for the release of Qdrant 1.16.0.

Specifically this does:

1. re-adds `collections_vector_total` metric (for backwards compatibility)
2. namespaces new replica metrics with `collection_` (to best follow my interpretation of [recommendations](https://prometheus.io/docs/practices/naming/#metric-names)):
    - `active_replicas_{min,max}` -> `collection_active_replicas_{min,max}`
    - `dead_replicas` -> `collection_dead_replicas`
3. count `collection_running_optimizations` per collection, as I think that's much more interesting in practice

We keep the new `qdrant_` prefix disabled for all metrics to not break existing deployments. Users have control over the prefix if they ever want to enable it for their deployment.

Please see this PR as a request for comment. If we're happy with this final result, we can merge.

Here is a dump of all metrics: https://gist.github.com/timvisee/6a3e7968bcfc63b3cc1471788ca9ccbc

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
5. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
6. [x] Have you checked your code using `cargo clippy --all --all-features` command?