### PR TITLE
Bump Pyo3 to 0.27.1 for Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5037,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
  "indoc",
  "libc",
@@ -5055,18 +5055,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -5074,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -5086,9 +5086,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-edge = { path = "../../edge" } # ".." does not play well with Dependabot
+edge = { path = ".." }
 segment = { path = "../../segment", default-features = false }
 shard = { path = "../../shard" }
 sparse = { path = "../../sparse" }
@@ -30,5 +30,5 @@ version = "2.0"
 features = ["into"]
 
 [dependencies.pyo3]
-version = "0.26"
+version = "0.27.1"
 features = ["uuid"]

--- a/lib/edge/python/src/query.rs
+++ b/lib/edge/python/src/query.rs
@@ -76,8 +76,10 @@ impl PyPrefetch {
 #[derive(Clone, Debug, Into)]
 pub struct PyScoringQuery(ScoringQuery);
 
-impl<'py> FromPyObject<'py> for PyScoringQuery {
-    fn extract_bound(query: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyScoringQuery {
+    type Error = PyErr;
+
+    fn extract(query: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             Vector(PyQuery),
@@ -178,8 +180,10 @@ impl From<PyDirection> for Direction {
 #[derive(Clone, Debug, Into)]
 pub struct PyStartFrom(StartFrom);
 
-impl<'py> FromPyObject<'py> for PyStartFrom {
-    fn extract_bound(start_from: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyStartFrom {
+    type Error = PyErr;
+
+    fn extract(start_from: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             Integer(IntPayloadType),

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -97,8 +97,9 @@ impl PyAcornSearchParams {
 #[derive(Clone, Debug, Into)]
 pub struct PyWithVector(WithVector);
 
-impl<'py> FromPyObject<'py> for PyWithVector {
-    fn extract_bound(with_vector: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyWithVector {
+    type Error = PyErr;
+    fn extract(with_vector: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             Bool(bool),
@@ -147,8 +148,9 @@ impl<'py> IntoPyObject<'py> for &PyWithVector {
 #[derive(Clone, Debug, Into)]
 pub struct PyWithPayload(WithPayloadInterface);
 
-impl<'py> FromPyObject<'py> for PyWithPayload {
-    fn extract_bound(with_payload: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyWithPayload {
+    type Error = PyErr;
+    fn extract(with_payload: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             Bool(bool),
@@ -208,8 +210,9 @@ impl<'py> IntoPyObject<'py> for &PyWithPayload {
 #[repr(transparent)]
 pub struct PyPayloadSelector(PayloadSelector);
 
-impl FromPyObject<'_> for PyPayloadSelector {
-    fn extract_bound(selector: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyPayloadSelector {
+    type Error = PyErr;
+    fn extract(selector: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let selector = match selector.extract()? {
             PyPayloadSelectorInterface::Include(keys) => {
                 PayloadSelector::Include(PayloadSelectorInclude {

--- a/lib/edge/python/src/types/filter/condition.rs
+++ b/lib/edge/python/src/types/filter/condition.rs
@@ -11,8 +11,9 @@ use crate::types::*;
 #[repr(transparent)]
 pub struct PyCondition(pub Condition);
 
-impl FromPyObject<'_> for PyCondition {
-    fn extract_bound(condition: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyCondition {
+    type Error = PyErr;
+    fn extract(condition: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         #[expect(clippy::large_enum_variant)]
         enum Helper {

--- a/lib/edge/python/src/types/formula.rs
+++ b/lib/edge/python/src/types/formula.rs
@@ -35,8 +35,9 @@ impl PyFormula {
 #[repr(transparent)]
 pub struct PyExpression(ExpressionInternal);
 
-impl<'py> FromPyObject<'py> for PyExpression {
-    fn extract_bound(helper: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyExpression {
+    type Error = PyErr;
+    fn extract(helper: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let expr = match helper.extract()? {
             PyExpressionInterface::Constant(val) => ExpressionInternal::Constant(val),
             PyExpressionInterface::Variable(var) => ExpressionInternal::Variable(var),

--- a/lib/edge/python/src/types/json_path.rs
+++ b/lib/edge/python/src/types/json_path.rs
@@ -12,8 +12,9 @@ use segment::json_path::JsonPath;
 #[repr(transparent)]
 pub struct PyJsonPath(pub JsonPath);
 
-impl<'py> FromPyObject<'py> for PyJsonPath {
-    fn extract_bound(json_path: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyJsonPath {
+    type Error = PyErr;
+    fn extract(json_path: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let json_path: String = json_path.extract()?;
         let json_path = JsonPath::from_str(&json_path)
             .map_err(|_| PyValueError::new_err(format!("invalid JSON path {json_path}")))?;

--- a/lib/edge/python/src/types/payload.rs
+++ b/lib/edge/python/src/types/payload.rs
@@ -9,9 +9,10 @@ use super::value::*;
 #[repr(transparent)]
 pub struct PyPayload(pub Payload);
 
-impl<'py> FromPyObject<'py> for PyPayload {
-    fn extract_bound(payload: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let payload = value_map_from_py(payload)?;
+impl<'py> FromPyObject<'_, 'py> for PyPayload {
+    type Error = PyErr;
+    fn extract(payload: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        let payload = value_map_from_py(&payload)?;
         Ok(Self(Payload(payload)))
     }
 }

--- a/lib/edge/python/src/types/point_id.rs
+++ b/lib/edge/python/src/types/point_id.rs
@@ -21,8 +21,9 @@ impl PyPointId {
     }
 }
 
-impl<'py> FromPyObject<'py> for PyPointId {
-    fn extract_bound(point_id: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyPointId {
+    type Error = PyErr;
+    fn extract(point_id: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             NumId(u64),

--- a/lib/edge/python/src/types/query/mod.rs
+++ b/lib/edge/python/src/types/query/mod.rs
@@ -11,8 +11,9 @@ use crate::types::*;
 #[derive(Clone, Debug, Into)]
 pub struct PyQuery(QueryEnum);
 
-impl FromPyObject<'_> for PyQuery {
-    fn extract_bound(query: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyQuery {
+    type Error = PyErr;
+    fn extract(query: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let query = match query.extract()? {
             PyQueryInterface::Nearest { query, using } => QueryEnum::Nearest(NamedQuery {
                 query: VectorInternal::try_from(query)?,

--- a/lib/edge/python/src/types/value.rs
+++ b/lib/edge/python/src/types/value.rs
@@ -21,8 +21,9 @@ impl PyValue {
     }
 }
 
-impl<'py> FromPyObject<'py> for PyValue {
-    fn extract_bound(value: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for PyValue {
+    type Error = PyErr;
+    fn extract(value: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         #[derive(FromPyObject)]
         enum Helper {
             Bool(bool),


### PR DESCRIPTION
Decided to handle this migration to [0.27.1](https://github.com/PyO3/pyo3/releases/tag/v0.27.0) after setting up Edge locally.

Migration guide required https://pyo3.rs/v0.27.0/migration.html#from-026-to-027