### PR TITLE
Allow payload operations on dummy shard

### DIFF
--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -106,13 +106,17 @@ impl ShardOperation for DummyShard {
         _: HwMeasurementAcc,
     ) -> CollectionResult<UpdateResult> {
         match &op.operation {
-            // Allow (and ignore) field operations here as they'll be applied again when the shard is recovered
+            CollectionUpdateOperations::PointOperation(_) => self.dummy(),
+            CollectionUpdateOperations::VectorOperation(_) => self.dummy(),
+            CollectionUpdateOperations::PayloadOperation(_) => self.dummy(),
+
+            // Allow (and ignore) field index operations. Field index schema is stored in collection
+            // config, and indices will be created (if needed) when dummy shard is recovered.
             CollectionUpdateOperations::FieldIndexOperation(_) => Ok(UpdateResult {
                 operation_id: None,
                 status: UpdateStatus::Acknowledged,
                 clock_tag: None,
             }),
-            _ => self.dummy(),
         }
     }
 


### PR DESCRIPTION
Payload ops are applied as consensus operations, which leads to crash loop on dummy shards.

[We rebuild payload indices when loading `LocalShard`](https://github.com/qdrant/qdrant/blob/dev/lib/collection/src/shards/local_shard/mod.rs#L362-L366), and to switch from `DummyShard` to `LocalShard` we ***have to*** load the `LocalShard` from disk, so it should be safe-enough to allow dummy shards to "ignore" payload operations.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
