### PR TITLE
Fix missing version debug log

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -201,9 +201,7 @@ pub trait IdTracker: fmt::Debug {
         for external_id in to_remove {
             self.drop(external_id)?;
             #[cfg(debug_assertions)]
-            {
-                log::debug!("dropped mapping for point {external_id} without version");
-            }
+            log::debug!("dropped mapping for point {external_id} without version");
         }
         Ok(to_return)
     }


### PR DESCRIPTION
This `DEBUG` log appears often during crash testing, decided to finally fix it!