### PR TITLE
Fix consensus test port race condition

### DIFF
--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -33,6 +33,8 @@ class PeerProcess:
 
     def kill(self):
         self.proc.kill()
+        self.proc.wait()
+
         # remove allocated ports from the dictionary
         # so they can be used afterwards
         del busy_ports[self.http_port]


### PR DESCRIPTION
Do not release the port before the process is really gone otherwise it can be wrongly reused.

E.g.

```
2025-11-14T10:39:20.156573Z ERROR qdrant::startup: Panic occurred in file src/tonic/mod.rs at line 358:
called `Result::unwrap()` on an `Err` value: tonic::transport::Error(Transport, hyper::Error(Listen, Os { code: 98, kind: AddrInUse, message: "Address already in use" }))
```