### PR TITLE
Adjust log warning about trying to read lock a segment

### DIFF
--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -607,7 +607,7 @@ impl SegmentHolder {
             interval = interval.saturating_mul(2);
             if interval.as_secs() >= 10 {
                 log::warn!(
-                    "Trying to read-lock a segments is taking a long time. This could be a deadlock and may block new updates.",
+                    "Trying to read-lock a segment is taking a long time. This could be a deadlock and may block new updates.",
                 );
             }
         }


### PR DESCRIPTION
The log message is wrong. It only tries to lock a single segment, not all of them.

I'd be nice to add a bit more context about the exact segment, but I don't see a good way of doing this without passing extra context into the function.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
