### PR TITLE
Await for consensus before unproxifying

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -398,9 +398,22 @@ impl ShardReplicaSet {
         self.local.read().await.is_some()
     }
 
+    /// Checks if the shard exists locally and not a proxy.
     pub async fn is_local(&self) -> bool {
         let local_read = self.local.read().await;
         matches!(*local_read, Some(Shard::Local(_) | Shard::Dummy(_)))
+    }
+
+    pub async fn is_proxy(&self) -> bool {
+        let local_read = self.local.read().await;
+        match *local_read {
+            None => false,
+            Some(Shard::Local(_)) => false,
+            Some(Shard::Proxy(_)) => true,
+            Some(Shard::ForwardProxy(_)) => true,
+            Some(Shard::QueueProxy(_)) => true,
+            Some(Shard::Dummy(_)) => false,
+        }
     }
 
     pub async fn is_queue_proxy(&self) -> bool {


### PR DESCRIPTION
We observed the `Unwrapping proxy shard` log message shortly followed by consensus error in production.

There are several problems with that:

- Current logic doesn't prevent `Unwrapping proxy shard` in case if the consensus is significantly delayed on receiver. It was checking for sahrd to be local, but didn't check if the relevant transfer status was received.
- There were no guarantee, that no other consensus operations should have been executed after `Unwrapping proxy shard`.
- There is no clear way to reproduce original consensus error, but having `Unwrapping proxy shard` in the out-of-order operation is suspecious enough for this PR


What this PR does:

- instead of unproxifying and then checking for consensus status, we first await that the receiver accepts consensus operation with the exact shard transfer we are waiting for.
- Only after awaiting for consensus we do checks for local shards, including the check for `Unwrapping proxy shard`
- `Unwrapping proxy shard` is promoted to an error, as we should not see it anymore, assuming the logic is not compromised somewhere else.

 

