### PR TITLE
Fix panic on startup with old storage, reenable old shard key format

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -91,7 +91,7 @@ impl ShardHolder {
         let key_mapping: SaveOnDisk<ShardKeyMapping> =
             SaveOnDisk::load_or_init_default(collection_path.join(SHARD_KEY_MAPPING_FILE))?;
 
-        // TODO(shardkey): Remove once the old shardkey format has been removed entirely.
+        // TODO(1.17.0): Remove once the old shardkey format has been removed entirely.
         Self::migrate_shard_key_if_needed(&key_mapping)?;
 
         let mut shard_id_to_key_mapping = AHashMap::new();
@@ -1448,7 +1448,7 @@ impl ShardHolder {
     }
 
     /// Migrates the old shard-key format to the new one if necessary.
-    /// TODO(shardkey): Remove once the old shardkey format has been removed entirely.
+    // TODO(1.17.0): Remove once the old shardkey format has been removed entirely.
     fn migrate_shard_key_if_needed(
         key_mapping: &SaveOnDisk<ShardKeyMapping>,
     ) -> CollectionResult<()> {

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -15,7 +15,7 @@ pub struct ShardKeyMapping {
     shard_key_to_shard_ids: HashMap<ShardKey, HashSet<ShardId>>,
 
     /// `true` if the ShardKeyMapping was specified in the old format.
-    /// TODO(shardkey): Remove once all keys are migrated.
+    // TODO(1.17.0): Remove once all keys are migrated.
     #[serde(skip)]
     pub(crate) was_old_format: bool,
 }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/7559>

Fixes a panic on startup if old storage is used. In Qdrant 1.15.0 to 1.15.3 we didn't migrate this properly.

This reenables support for the old format by reverting <https://github.com/qdrant/qdrant/pull/7047> that removed it.

We can merge and release this in our next patch so that all storages will be migrated in Qdrant 1.16.1 and onward. In Qdrant 1.17.0 we can remove it again.

See <https://github.com/qdrant/qdrant/issues/7559#issuecomment-3551604466> for more details, including a reproducible example.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?