### PR TITLE
Storage compat. tests all supported versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -261,9 +261,9 @@ jobs:
       - name: Verify Docker image
         run: docker images | grep qdrant
       - name: Run e2e tests
-        run: poetry --project tests run pytest -n 2 tests/e2e_tests -v --tb=short --durations=5
+        run: poetry --project tests run pytest -n 4 --dist=loadgroup tests/e2e_tests -v --tb=short --durations=5
         shell: bash
-        timeout-minutes: 5
+        timeout-minutes: 10
       - name: Upload test logs on failure
         uses: actions/upload-artifact@v5
         if: failure()

--- a/tests/e2e_tests/test_data_compatibility.py
+++ b/tests/e2e_tests/test_data_compatibility.py
@@ -10,7 +10,11 @@ from e2e_tests.utils import extract_archive
 
 
 class TestStorageCompatibility:
-    """Test storage and snapshot compatibility with defined previous Qdrant versions."""
+    """Test storage and snapshot compatibility with defined previous Qdrant versions.
+
+    These tests are grouped to run sequentially on the same worker using xdist_group marker.
+    This prevents parallel downloads of large archives and disk saturation.
+    """
 
     VERSIONS = [
         "v1.16.0",
@@ -19,7 +23,7 @@ class TestStorageCompatibility:
         "v1.15.3",
         "v1.15.2",
         "v1.15.1",
-        #"v1.15.0", # TODO when restoring Qdrant adds a missing payload_storage folder owned by `root` which messes up the cleanup
+        # "v1.15.0", # TODO when restoring Qdrant adds a missing payload_storage folder owned by `root` which messes up the cleanup
     ]
 
     EXPECTED_COLLECTIONS = [
@@ -39,7 +43,15 @@ class TestStorageCompatibility:
 
     @staticmethod
     def _download_compatibility_data(version: str, storage_test_dir: Path):
-        """Download compatibility data for a specific version."""
+        """Download compatibility data for a specific version.
+
+        Args:
+            version: Version string (e.g., "v1.16.0")
+            storage_test_dir: Directory to download the archive to
+
+        Returns:
+            Path to the downloaded compatibility archive
+        """
         # Use test-specific filename to avoid conflicts in parallel execution
         test_id = str(uuid.uuid4())[:8]
         compatibility_file = storage_test_dir / f"compatibility_{version}_{test_id}.tar"
@@ -113,8 +125,10 @@ class TestStorageCompatibility:
         return True
 
 
+    @pytest.mark.xdist_group("compatibility")
     @pytest.mark.parametrize("version", VERSIONS)
-    def test_storage_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version, qdrant_container_factory):
+    def test_storage_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version,
+                                   qdrant_container_factory):
         """Test storage compatibility with previous versions."""
         compatibility_file = self._download_compatibility_data(version, temp_storage_dir)
         storage_dir = self._extract_storage_data(compatibility_file, temp_storage_dir)
@@ -132,8 +146,10 @@ class TestStorageCompatibility:
         if not self._check_collections(container_info.host, container_info.http_port):
             pytest.fail(f"Storage compatibility failed for {version}")
 
+    @pytest.mark.xdist_group("compatibility")
     @pytest.mark.parametrize("version", VERSIONS)
-    def test_snapshot_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version, qdrant_container_factory):
+    def test_snapshot_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version,
+                                    qdrant_container_factory):
         """Test snapshot recovery compatibility with previous versions."""
         compatibility_file = self._download_compatibility_data(version, temp_storage_dir)
         self._extract_storage_data(compatibility_file, temp_storage_dir)

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -20,6 +20,14 @@ docker = "^7.1.0"
 pytest-xdist = "^3.8.0"
 qdrant-client = "^1.15.1"
 
+[tool.pytest.ini_options]
+markers = [
+    "xdist_group: group tests to run on the same worker (for pytest-xdist)",
+]
+addopts = """
+    --dist=loadgroup
+"""
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
To avoid breaking changes between patch versions, we need to exhaustively test all compatible versions.

This requires downloading more archives and modifying the test runners to support a larger workload (thanks to @tellet-q).

~~All tests that share the same group name are guaranteed to run in the same worker process. This way we download each archive only once.~~

> Each test runs independently, so it downloads and then removes the files, any other strategy will lead to disk saturation. The grouping ensures that even we run pytest with several parallel workers these particular tests will run on the same worker sequentially.

# Future work

Handle properly the archive for `v1.15.0` which currently creates issues due to file system access control.