### PR TITLE
rename common -> qdrant_common to avoid name with other python packages

### DIFF
--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -4,7 +4,7 @@ package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "json_with_int.proto";
-import "common.proto";
+import "qdrant_common.proto";
 
 enum Datatype {
   Default = 0;

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -4,7 +4,7 @@ package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "collections.proto";
-import "common.proto";
+import "qdrant_common.proto";
 import "google/protobuf/timestamp.proto";
 import "json_with_int.proto";
 

--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 import "points.proto";
-import "common.proto";
+import "qdrant_common.proto";
 
 package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";

--- a/lib/api/src/grpc/proto/qdrant_common.proto
+++ b/lib/api/src/grpc/proto/qdrant_common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package qdrant;
 
 option csharp_namespace = "Qdrant.Client.Grpc";
+option java_outer_classname = "Common";
 
 import "google/protobuf/timestamp.proto";
 


### PR DESCRIPTION
Related to https://github.com/qdrant/qdrant-client/issues/1119