### PR TITLE
Fix: use the search runtime for prepare_query_context

### DIFF
--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -111,6 +111,7 @@ impl LocalShard {
                 self.segments.clone(),
                 &core_request,
                 &collection_config,
+                search_runtime_handle,
                 is_stopped_guard,
                 hw_counter_acc.clone(),
             )


### PR DESCRIPTION
similar to https://github.com/qdrant/qdrant/pull/7569

We were accessing the segments on either the `actix-rt` or the `general` runtime.