### PR TITLE
Bump `wal` dependency to fix flush problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=95c4310efaef3c0be227f1b3aff35a1668452ae9#95c4310efaef3c0be227f1b3aff35a1668452ae9"
+source = "git+https://github.com/qdrant/wal.git?rev=fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172#fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,7 @@ tonic-reflection = "0.11.0"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.18", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
-wal = { git = "https://github.com/qdrant/wal.git", rev = "95c4310efaef3c0be227f1b3aff35a1668452ae9" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172" }
 zerocopy = { version = "0.8.27", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"


### PR DESCRIPTION
Related to <https://github.com/qdrant/qdrant/pull/7577>, but merged separately because they are not strictly related.

Critically, this bump contains the following fix: <https://github.com/qdrant/wal/pull/99>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?