### PR TITLE
Document storage compatibility test for v1.15.0

### DIFF
--- a/tests/e2e_tests/test_data_compatibility.py
+++ b/tests/e2e_tests/test_data_compatibility.py
@@ -23,7 +23,7 @@ class TestStorageCompatibility:
         "v1.15.3",
         "v1.15.2",
         "v1.15.1",
-        "v1.15.0",
+        # "v1.15.0", the archive triggers debug_assertion for the UUID payload index https://github.com/qdrant/qdrant/pull/6916
     ]
 
     EXPECTED_COLLECTIONS = [


### PR DESCRIPTION
The archive for `v1.15.0` cannot be restored because it fails with a debug assertion.

```
ERROR qdrant::startup: Panic occurred in file lib/common/common/src/mmap_hashmap.rs at line 474: Error reading u128 from mmap: The conversion failed because the address of the source is not a multiple of the alignment of the destination type.
```

The original bug has been fixed in later version https://github.com/qdrant/qdrant/pull/6916