### PR TITLE
Fix cosign error on release image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,7 +59,7 @@ jobs:
         docker push $GITHUB_TAG
 
         DIGEST=$(docker buildx imagetools inspect ${DOCKERHUB_TAG} --format '{{ json .Manifest.Digest }}' | cut -d '"' -f 2)
-        cosign sign --new-bundle-format=false --use-signing-config=false--yes "${DOCKERHUB_TAG}@${DIGEST}"
+        cosign sign --new-bundle-format=false --use-signing-config=false --yes "${DOCKERHUB_TAG}@${DIGEST}"
 
         # Build unprivileged image for Docker Hub
         DOCKERHUB_TAG_UNPRIVILEGED="qdrant/qdrant:${{ github.ref_name }}-unprivileged"


### PR DESCRIPTION
This broke our release workflow:

```
v1.16.1: digest: sha256:895e7869805728b91e26fab10c7e7f9243cb012d692a52a2fa5a2851875d92a9 size: 3228
Error: invalid argument "false--yes" for "--use-signing-config" flag: strconv.ParseBool: parsing "false--yes": invalid syntax
error during command execution: invalid argument "false--yes" for "--use-signing-config" flag: strconv.ParseBool: parsing "false--yes": invalid syntax
Error: Process completed with exit code 1.
```

See: https://github.com/qdrant/qdrant/actions/runs/19672110900/job/56347297184#step:7:5542

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?