### PR TITLE
Refactor SQ score_bytes method

### DIFF
--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -46,7 +46,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_avx(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_avx(&encoded_query, quantized_vector);
             }
         });
     });
@@ -56,7 +57,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_sse(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_sse(&encoded_query, quantized_vector);
             }
         });
     });
@@ -66,7 +68,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_neon(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_neon(&encoded_query, quantized_vector);
             }
         });
     });
@@ -79,7 +82,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for &i in &permutation {
-                _s = i8_encoded.score_point_avx(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_avx(&encoded_query, quantized_vector);
             }
         });
     });
@@ -89,7 +93,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         let mut _s = 0.0;
         b.iter(|| {
             for &i in &permutation {
-                _s = i8_encoded.score_point_sse(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_sse(&encoded_query, quantized_vector);
             }
         });
     });
@@ -99,7 +104,8 @@ fn encode_dot_bench(c: &mut Criterion) {
         let mut _s = 0.0;
         b.iter(|| {
             for &i in &permutation {
-                _s = i8_encoded.score_point_neon(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_neon(&encoded_query, quantized_vector);
             }
         });
     });
@@ -144,7 +150,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_avx(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_avx(&encoded_query, quantized_vector);
             }
         });
     });
@@ -154,7 +161,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_sse(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_sse(&encoded_query, quantized_vector);
             }
         });
     });
@@ -177,7 +185,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for &i in &permutation {
-                _s = i8_encoded.score_point_avx(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_avx(&encoded_query, quantized_vector);
             }
         });
     });
@@ -187,7 +196,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         let mut _s = 0.0;
         b.iter(|| {
             for &i in &permutation {
-                _s = i8_encoded.score_point_sse(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_sse(&encoded_query, quantized_vector);
             }
         });
     });

--- a/lib/quantization/tests/integration/test_avx2.rs
+++ b/lib/quantization/tests/integration/test_avx2.rs
@@ -45,7 +45,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_avx(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_avx(&query_u8, quantized_vector);
             let orginal_score = dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -86,7 +87,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_avx(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_avx(&query_u8, quantized_vector);
             let orginal_score = l2_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -131,7 +133,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_avx(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_avx(&query_u8, quantized_vector);
             let orginal_score = l1_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }

--- a/lib/quantization/tests/integration/test_neon.rs
+++ b/lib/quantization/tests/integration/test_neon.rs
@@ -45,7 +45,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_neon(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_neon(&query_u8, quantized_vector);
             let orginal_score = dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -86,7 +87,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_neon(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_neon(&query_u8, quantized_vector);
             let orginal_score = l2_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -127,7 +129,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_neon(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_neon(&query_u8, quantized_vector);
             let orginal_score = l1_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }

--- a/lib/quantization/tests/integration/test_simple.rs
+++ b/lib/quantization/tests/integration/test_simple.rs
@@ -45,7 +45,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -86,7 +87,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = l2_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -131,7 +133,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = l1_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -172,7 +175,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = -dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -213,7 +217,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = -l2_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -258,7 +263,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = -l1_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -379,7 +385,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_simple(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_simple(&query_u8, quantized_vector);
             let orginal_score = dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }

--- a/lib/quantization/tests/integration/test_sse.rs
+++ b/lib/quantization/tests/integration/test_sse.rs
@@ -45,7 +45,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_sse(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_sse(&query_u8, quantized_vector);
             let orginal_score = dot_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -86,7 +87,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_sse(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_sse(&query_u8, quantized_vector);
             let orginal_score = l2_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }
@@ -127,7 +129,8 @@ mod tests {
         let query_u8 = encoded.encode_query(&query);
 
         for (index, vector) in vector_data.iter().enumerate() {
-            let score = encoded.score_point_sse(&query_u8, index as u32);
+            let quantized_vector = encoded.get_quantized_vector(index as u32);
+            let score = encoded.score_point_sse(&query_u8, quantized_vector);
             let orginal_score = l1_similarity(&query, vector);
             assert!((score - orginal_score).abs() < error);
         }


### PR DESCRIPTION
This PR does a simple refactor of `score_bytes` in SQ.
The motivation is to reuse `score_point_avx`, `score_point_sse` etc. These methods were required in tests, but they contain a duplication of scoring logic (like postprocessing of score: `self.metadata.multiplier * score + query.offset + vector_offset`).

With asymmetric SQ we're gonna do another scoring method, and this PR reduces code passes count and makes SQ scoring implementation easier to extend.