### PR TITLE
Change minimum WAL batch version into constant

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -43,8 +43,7 @@ const BATCH_SIZE: usize = 10;
 /// Number of times to retry transferring updates batch
 const BATCH_RETRIES: usize = MAX_RETRY_COUNT;
 
-static MINIMAL_VERSION_FOR_BATCH_WAL_TRANSFER: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("1.14.1-dev").unwrap());
+const MINIMAL_VERSION_FOR_BATCH_WAL_TRANSFER: Version = Version::new(1, 14, 1);
 
 /// QueueProxyShard shard
 ///


### PR DESCRIPTION
Now we do work at compile time, which is better.

We can safely change this because 1.14.2-dev is more than two minor versions ago. It still closely reflects what it was before.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?