### PR TITLE
Add a user agent to HTTP clients

### DIFF
--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -11,6 +11,9 @@ pub const QDRANT_VERSION_STRING: &str = "1.16.2-dev";
 lazy_static! {
     /// Current Qdrant semver version
     pub static ref QDRANT_VERSION: Version = Version::parse(QDRANT_VERSION_STRING).expect("malformed version string");
+
+    /// User-agent string to use in HTTP clients
+    pub static ref APP_USER_AGENT: String = format!("Qdrant/{QDRANT_VERSION_STRING}");
 }
 
 /// Maximum number of segments to load concurrently when loading a collection.

--- a/src/common/error_reporting.rs
+++ b/src/common/error_reporting.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::common::http_client::APP_USER_AGENT;
+use common::defaults::APP_USER_AGENT;
 
 pub struct ErrorReporter;
 
@@ -15,7 +15,7 @@ impl ErrorReporter {
 
     pub fn report(error: &str, reporting_id: &str, backtrace: Option<&str>) {
         let client = reqwest::blocking::Client::builder()
-            .user_agent(APP_USER_AGENT)
+            .user_agent(APP_USER_AGENT.as_str())
             .build()
             .unwrap();
 

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -1,14 +1,13 @@
 use std::path::Path;
 use std::{io, result};
 
+use common::defaults::APP_USER_AGENT;
 use fs_err as fs;
 use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue};
 use storage::content_manager::errors::StorageError;
 
 use super::auth::HTTP_HEADER_API_KEY;
 use crate::settings::{Settings, TlsConfig};
-
-pub const APP_USER_AGENT: &str = concat!("Qdrant/", env!("CARGO_PKG_VERSION"));
 
 #[derive(Clone)]
 pub struct HttpClient {
@@ -64,7 +63,7 @@ fn https_client(
     tls_config: Option<&TlsConfig>,
     verify_https_client_certificate: bool,
 ) -> Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder().user_agent(APP_USER_AGENT);
+    let mut builder = reqwest::Client::builder().user_agent(APP_USER_AGENT.as_str());
 
     // Configure TLS root certificate and validation
     if let Some(tls_config) = tls_config {

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -7,6 +7,7 @@ use actix_web::http::header::HttpDate;
 use api::rest::models::InferenceUsage;
 use api::rest::{Document, Image, InferenceObject};
 use collection::operations::point_ops::VectorPersisted;
+use common::defaults::APP_USER_AGENT;
 use itertools::{Either, Itertools};
 use parking_lot::RwLock;
 use reqwest::Client;
@@ -15,7 +16,6 @@ use storage::content_manager::errors::StorageError;
 
 pub use super::inference_input::InferenceInput;
 use super::local_model;
-use crate::common::http_client::APP_USER_AGENT;
 use crate::common::inference::config::InferenceConfig;
 use crate::common::inference::params::InferenceParams;
 
@@ -93,7 +93,7 @@ impl InferenceService {
 
         let timeout = timeout.unwrap_or(DEFAULT_INFERENCE_TIMEOUT_SECS);
         let client_builder = Client::builder()
-            .user_agent(APP_USER_AGENT)
+            .user_agent(APP_USER_AGENT.as_str())
             .timeout(Duration::from_secs(timeout));
 
         Self {

--- a/src/common/telemetry_reporting.rs
+++ b/src/common/telemetry_reporting.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::defaults::APP_USER_AGENT;
 use common::types::{DetailsLevel, TelemetryDetail};
 use reqwest::Client;
 use segment::common::anonymize::Anonymize;
@@ -9,7 +10,6 @@ use storage::rbac::Access;
 use tokio::sync::Mutex;
 
 use super::telemetry::TelemetryCollector;
-use crate::common::http_client::APP_USER_AGENT;
 
 const DETAIL: TelemetryDetail = TelemetryDetail {
     level: DetailsLevel::Level2,
@@ -66,7 +66,7 @@ impl TelemetryReporter {
     pub async fn run(telemetry: Arc<Mutex<TelemetryCollector>>) {
         let reporter = Self::new(telemetry);
         let client = Client::builder()
-            .user_agent(APP_USER_AGENT)
+            .user_agent(APP_USER_AGENT.as_str())
             .build()
             .unwrap();
         loop {


### PR DESCRIPTION
Similar to <https://github.com/qdrant/cluster-manager/pull/391>

Adds a user agent to all our internal HTTP clients sending out requests. This allows remotes to identify where requests are coming from.

A Qdrant peer requesting a snapshot from another peer now looks like this in logs:

```
2025-11-26T16:59:33.703884Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /collections/benchmark/shards/0/snapshot HTTP/1.1" 200 587776 "-" "Qdrant/1.16.2-dev" 0.008435
```

Note the user agent at the very end.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?