### PR TITLE
Avoid flushing invalid Gridstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,7 @@ dependencies = [
  "fs-err",
  "io",
  "itertools 0.14.0",
+ "log",
  "lz4_flex",
  "memmap2",
  "memory",

--- a/lib/gridstore/Cargo.toml
+++ b/lib/gridstore/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = { workspace = true }
 parking_lot = { workspace = true }
 tempfile = { workspace = true }
 lz4_flex = { version = "0.11.5", default-features = false }
+log = { workspace = true }
 rand = { workspace = true }
 bitvec = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
When creating and deleting payload indices, while running optimizations, the following error would pop up.
```log
2025-11-26T13:09:45.764981Z ERROR qdrant::startup: Panic occurred in file lib/gridstore/src/blob.rs at line 25: Failed to deserialize Vec<ecow::EcoString>: ErrorImpl { code: Message("invalid type: integer `0`, expected a sequence"), offset: 0 }
```

This is a corruption is caused, according to my testing, by a flushing sequence which would try to apply the changes from an earlier instance of gridstore, to another one, potentially overwriting it with old data.

Mental model would go like this.
1. Gridstore_1 provides flusher with pending updates
2. Gridstore_1 gets deleted (by DropPayloadIndex) before flushing
3. Gridstore_2 gets created (by CreatePayloadIndex), and receives new updates
4. Flusher tries to apply Gridstore_1's pending changes into Gridstore_2

Since directories are the same, the flusher will actually be able to apply the changes, but without considering latest changes.

This PR uses weak references to ensure that the instance that provides the pending changes is the one being flushed. Otherwise, since the files are the same, flushing operation will actually corrupt data.

With this PR, we can see something that resembles the hypothesis.
```
2025-11-26T16:31:54.401344Z  INFO actix_web::middleware::logger: 127.0.0.1 "DELETE /collections/benchmark/index/a?wait=true HTTP/1.1" 200 71 "http://localhost:6333/dashboard" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:145.0) Gecko/20100101 Firefox/145.0" 0.523232
2025-11-26T16:31:55.111493Z DEBUG storage::content_manager::toc::collection_meta_ops: Create payload index CreatePayloadIndex { collection_name: "benchmark", field_name: JsonPath { first_key: "a", rest: [] }, field_schema: FieldType(Keyword) }
2025-11-26T16:31:56.579150Z  INFO actix_web::middleware::logger: 127.0.0.1 "PUT /collections/benchmark/index?wait=true HTTP/1.1" 200 75 "http://localhost:6333/dashboard" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:145.0) Gecko/20100101 Firefox/145.0" 1.467731
2025-11-26T16:31:57.437640Z DEBUG storage::content_manager::toc::collection_meta_ops: Drop payload index DropPayloadIndex { collection_name: "benchmark", field_name: JsonPath { first_key: "a", rest: [] } }
2025-11-26T16:31:58.096076Z DEBUG gridstore::gridstore: Aborted flushing on a dropped Gridstore instance
```