### PR TITLE
Fix quantization encode bench

### DIFF
--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -172,7 +172,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = i8_encoded.score_point_neon(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_neon(&encoded_query, quantized_vector);
             }
         });
     });
@@ -207,7 +208,8 @@ fn encode_l1_bench(c: &mut Criterion) {
         let mut _s = 0.0;
         b.iter(|| {
             for &i in &permutation {
-                _s = i8_encoded.score_point_neon(&encoded_query, i);
+                let quantized_vector = i8_encoded.get_quantized_vector(i);
+                _s = i8_encoded.score_point_neon(&encoded_query, quantized_vector);
             }
         });
     });


### PR DESCRIPTION
This may not have been linted due to being specific to `aarch64` architecture, but it is a simple fix.