### PR TITLE
Standardize delete payload index terminology

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -161,11 +161,11 @@ impl PayloadFieldIndex for BoolIndex {
         }
     }
 
-    fn cleanup(self) -> crate::common::operation_error::OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         match self {
             #[cfg(feature = "rocksdb")]
-            BoolIndex::Simple(index) => index.cleanup(),
-            BoolIndex::Mmap(index) => index.cleanup(),
+            BoolIndex::Simple(index) => index.wipe(),
+            BoolIndex::Mmap(index) => index.wipe(),
         }
     }
 
@@ -265,10 +265,10 @@ impl ValueIndexer for BoolIndex {
 
     fn add_many(
         &mut self,
-        id: common::types::PointOffsetType,
+        id: PointOffsetType,
         values: Vec<Self::ValueType>,
         hw_counter: &HardwareCounterCell,
-    ) -> crate::common::operation_error::OperationResult<()> {
+    ) -> OperationResult<()> {
         match self {
             #[cfg(feature = "rocksdb")]
             BoolIndex::Simple(index) => index.add_many(id, values, hw_counter),
@@ -283,10 +283,7 @@ impl ValueIndexer for BoolIndex {
         }
     }
 
-    fn remove_point(
-        &mut self,
-        id: common::types::PointOffsetType,
-    ) -> crate::common::operation_error::OperationResult<()> {
+    fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         match self {
             #[cfg(feature = "rocksdb")]
             BoolIndex::Simple(index) => index.remove_point(id),

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -307,7 +307,7 @@ impl PayloadFieldIndex for MutableBoolIndex {
         self.indexed_count
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         if self.base_dir.is_dir() {
             fs::remove_dir_all(self.base_dir)?;
         };

--- a/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/simple_bool_index.rs
@@ -333,7 +333,7 @@ impl FieldIndexBuilderTrait for BoolIndexBuilder {
 }
 
 impl PayloadFieldIndex for SimpleBoolIndex {
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         self.db_wrapper.remove_column_family()
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -41,7 +41,7 @@ pub trait PayloadFieldIndex {
     fn count_indexed_points(&self) -> usize;
 
     /// Remove db content or files of the current payload index
-    fn cleanup(self) -> OperationResult<()>;
+    fn wipe(self) -> OperationResult<()>;
 
     /// Return function that flushes all pending updates to disk.
     fn flusher(&self) -> Flusher;
@@ -213,19 +213,19 @@ impl FieldIndex {
         }
     }
 
-    pub fn cleanup(self) -> OperationResult<()> {
+    pub fn wipe(self) -> OperationResult<()> {
         match self {
-            FieldIndex::IntIndex(index) => index.cleanup(),
-            FieldIndex::DatetimeIndex(index) => index.cleanup(),
-            FieldIndex::IntMapIndex(index) => index.cleanup(),
-            FieldIndex::KeywordIndex(index) => index.cleanup(),
-            FieldIndex::FloatIndex(index) => index.cleanup(),
-            FieldIndex::GeoIndex(index) => index.cleanup(),
-            FieldIndex::BoolIndex(index) => index.cleanup(),
-            FieldIndex::FullTextIndex(index) => index.cleanup(),
-            FieldIndex::UuidIndex(index) => index.cleanup(),
-            FieldIndex::UuidMapIndex(index) => index.cleanup(),
-            FieldIndex::NullIndex(index) => index.cleanup(),
+            FieldIndex::IntIndex(index) => index.wipe(),
+            FieldIndex::DatetimeIndex(index) => index.wipe(),
+            FieldIndex::IntMapIndex(index) => index.wipe(),
+            FieldIndex::KeywordIndex(index) => index.wipe(),
+            FieldIndex::FloatIndex(index) => index.wipe(),
+            FieldIndex::GeoIndex(index) => index.wipe(),
+            FieldIndex::BoolIndex(index) => index.wipe(),
+            FieldIndex::FullTextIndex(index) => index.wipe(),
+            FieldIndex::UuidIndex(index) => index.wipe(),
+            FieldIndex::UuidMapIndex(index) => index.wipe(),
+            FieldIndex::NullIndex(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -558,7 +558,7 @@ impl PayloadFieldIndex for FullTextIndex {
         self.points_count()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         match self {
             Self::Mutable(index) => index.wipe(),
             Self::Immutable(index) => index.wipe(),

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -670,7 +670,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         self.points_count()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         match self {
             GeoMapIndex::Mutable(index) => index.wipe(),
             GeoMapIndex::Immutable(index) => index.wipe(),

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -728,7 +728,7 @@ impl PayloadFieldIndex for MapIndex<str> {
         self.get_indexed_points()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
 
@@ -876,7 +876,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
         self.get_indexed_points()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
 
@@ -1065,7 +1065,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         self.get_indexed_points()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
 

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -219,7 +219,7 @@ impl PayloadFieldIndex for MutableNullIndex {
         self.storage.has_values_flags.len()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         let base_dir = self.base_dir.clone();
         // drop mmap handles before deleting files
         drop(self);

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -638,7 +638,7 @@ where
     delegate! {
         to self.inner {
             pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl Fn(&T) -> bool, hw_counter: &HardwareCounterCell) -> bool;
-            pub fn cleanup(self) -> OperationResult<()>;
+            pub fn wipe(self) -> OperationResult<()>;
             pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn values_count(&self, idx: PointOffsetType) -> usize;
             pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>>;
@@ -883,7 +883,7 @@ where
         self.get_points_count()
     }
 
-    fn cleanup(self) -> OperationResult<()> {
+    fn wipe(self) -> OperationResult<()> {
         match self {
             NumericIndexInner::Mutable(index) => index.wipe(),
             NumericIndexInner::Immutable(index) => index.wipe(),

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -272,11 +272,11 @@ impl StructPayloadIndex {
             }
             self.config.skip_rocksdb.replace(true);
 
-            // Clean-up all existing indices
+            // Wipe all existing indices
             for index in indexes.drain(..) {
-                index.cleanup().map_err(|err| {
+                index.wipe().map_err(|err| {
                     OperationError::service_error(format!(
-                        "Failed to clean up payload index for field `{field}` before rebuild: {err}"
+                        "Failed to delete existing payload index for field `{field}` before rebuild: {err}"
                     ))
                 })?;
             }
@@ -897,7 +897,7 @@ impl PayloadIndex for StructPayloadIndex {
 
         if let Some(indexes) = removed_indexes {
             for index in indexes {
-                index.cleanup()?;
+                index.wipe()?;
             }
         }
 


### PR DESCRIPTION
We have too many terms for deleting which causes confusion.

I propose to standardize the usage of `wipe` for deleting a payload index.