### PR TITLE
Bump Poetry 2.2.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * *" # Every day at midnight UTC
 
 env:
-  POETRY_VERSION: 2.1.3
+  POETRY_VERSION: 2.2.1
 
 jobs:
   unit-coverage:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  POETRY_VERSION: 2.1.3
+  POETRY_VERSION: 2.2.1
 
 jobs:
   integration-tests:


### PR DESCRIPTION
I am using this version locally for a while without any problems.

The version [2.2.x](https://github.com/python-poetry/poetry/releases/tag/2.2.0) is required to run our tests on Python 3.14 in the future.