### PR TITLE
Fix Openapi schema for DELETE issues

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -475,18 +475,61 @@
           "Beta"
         ],
         "responses": {
-          "200": {
-            "description": "Successful response",
+          "default": {
+            "description": "error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "4XX": {
-            "description": "error"
+            "description": "error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/Usage"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Time spent to process this request",
+                      "example": 0.002
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "result": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/openapi/openapi-service.ytt.yaml
+++ b/openapi/openapi-service.ytt.yaml
@@ -167,12 +167,4 @@ paths:
       operationId: clear_issues
       tags:
         - Beta
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: boolean
-        "4XX":
-          description: error
+      responses: #@ response(type("boolean"))

--- a/tests/openapi/test_service.py
+++ b/tests/openapi/test_service.py
@@ -101,3 +101,21 @@ def test_telemetry_detail(level: int):
 
             segment = local_shard['segments'][0]
             assert set(segment.keys()) == {'info', 'config', 'vector_index_searches', 'payload_field_indices'}
+
+
+def test_issues():
+    response = request_with_validation(
+        api='/issues',
+        method="GET",
+    )
+    assert response.ok
+    result = response.json()['result']['issues']
+    assert len(result) == 0
+
+    response = request_with_validation(
+        api='/issues',
+        method="DELETE",
+    )
+    assert response.ok
+    result = response.json()['result']
+    assert result


### PR DESCRIPTION
The returned object is not a boolean when deleting an issue.

```
      responses:
      responses: #@ response(type("boolean"))
        "200":
          description: Successful response
          content:
            application/json:
              schema:
                type: boolean
```

It is actually our usual result shape.

The included test fails with the previous API definition.

```
        if error is not None:
>           raise error
E           jsonschema.exceptions.ValidationError: {'result': True, 'status': 'ok', 'time': 2.6941e-05} is not of type 'boolean'
E
E           Failed validating 'type' in schema:
E               {'type': 'boolean'}
E
E           On instance:
E               {'result': True, 'status': 'ok', 'time': 2.6941e-05}

tests/.venv/lib/python3.13/site-packages/jsonschema/validators.py:1332: ValidationError
```