### PR TITLE
Hotfix to prevent deadlock when restoring snapshot on single CPU

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -80,6 +80,8 @@ pub struct Collection {
     // Lock is acquired for read on update operation and can be acquired for write externally,
     // which will block all update operations until the lock is released.
     updates_lock: Arc<RwLock<()>>,
+    // General runtime handle.
+    general_runtime: Handle,
     // Update runtime handle.
     update_runtime: Handle,
     // Search runtime handle.
@@ -111,6 +113,7 @@ impl Collection {
         on_replica_failure: ChangePeerFromState,
         request_shard_transfer: RequestShardTransfer,
         abort_shard_transfer: replica_set::AbortShardTransfer,
+        general_runtime: Option<Handle>,
         search_runtime: Option<Handle>,
         update_runtime: Option<Handle>,
         optimizer_resource_budget: ResourceBudget,
@@ -190,6 +193,7 @@ impl Collection {
             init_time: start_time.elapsed(),
             is_initialized: Default::default(),
             updates_lock: Default::default(),
+            general_runtime: general_runtime.unwrap_or_else(Handle::current),
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_resource_budget,
@@ -209,6 +213,7 @@ impl Collection {
         on_replica_failure: replica_set::ChangePeerFromState,
         request_shard_transfer: RequestShardTransfer,
         abort_shard_transfer: replica_set::AbortShardTransfer,
+        general_runtime: Option<Handle>,
         search_runtime: Option<Handle>,
         update_runtime: Option<Handle>,
         optimizer_resource_budget: ResourceBudget,
@@ -306,6 +311,7 @@ impl Collection {
             init_time: start_time.elapsed(),
             is_initialized: Default::default(),
             updates_lock: Default::default(),
+            general_runtime: general_runtime.unwrap_or_else(Handle::current),
             update_runtime: update_runtime.unwrap_or_else(Handle::current),
             search_runtime: search_runtime.unwrap_or_else(Handle::current),
             optimizer_resource_budget,

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -326,7 +326,8 @@ impl Collection {
 
         // `ShardHolder::restore_shard_snapshot` is *not* cancel safe, so we spawn it onto runtime,
         // so that it won't be cancelled if current future is dropped
-        let restore = self.update_runtime.spawn(async move {
+        // TODO(timvisee): properly fix LocalShard::drop to not be blocking, then use update runtime here!
+        let restore = self.general_runtime.spawn(async move {
             shard_holder
                 .restore_shard_snapshot(
                     &snapshot_path,

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -537,6 +537,7 @@ mod test {
             dummy_abort_shard_transfer(),
             None,
             None,
+            None,
             ResourceBudget::default(),
             None,
         )

--- a/lib/collection/src/shards/shard_holder/shard_mapping.rs
+++ b/lib/collection/src/shards/shard_holder/shard_mapping.rs
@@ -206,6 +206,7 @@ mod test {
             dummy_abort_shard_transfer(),
             None,
             None,
+            None,
             ResourceBudget::default(),
             None,
         )
@@ -293,6 +294,7 @@ mod test {
                 dummy_on_replica_failure(),
                 dummy_request_shard_transfer(),
                 dummy_abort_shard_transfer(),
+                None,
                 None,
                 None,
                 ResourceBudget::default(),

--- a/lib/collection/src/tests/points_dedup.rs
+++ b/lib/collection/src/tests/points_dedup.rs
@@ -91,6 +91,7 @@ async fn fixture() -> Collection {
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -89,6 +89,7 @@ async fn fixture() -> Collection {
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )

--- a/lib/collection/src/tests/snapshot_test.rs
+++ b/lib/collection/src/tests/snapshot_test.rs
@@ -90,6 +90,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )
@@ -145,6 +146,7 @@ async fn _test_snapshot_collection(node_type: NodeType) {
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         dummy_abort_shard_transfer(),
+        None,
         None,
         None,
         ResourceBudget::default(),

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -106,6 +106,7 @@ pub async fn new_local_collection(
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )
@@ -139,6 +140,7 @@ pub async fn load_local_collection(
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         dummy_abort_shard_transfer(),
+        None,
         None,
         None,
         ResourceBudget::default(),

--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -86,6 +86,7 @@ async fn test_continuous_snapshot() {
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )

--- a/lib/collection/tests/integration/snapshot_recovery_test.rs
+++ b/lib/collection/tests/integration/snapshot_recovery_test.rs
@@ -83,6 +83,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         dummy_abort_shard_transfer(),
         None,
         None,
+        None,
         ResourceBudget::default(),
         None,
     )
@@ -141,6 +142,7 @@ async fn _test_snapshot_and_recover_collection(node_type: NodeType) {
         dummy_on_replica_failure(),
         dummy_request_shard_transfer(),
         dummy_abort_shard_transfer(),
+        None,
         None,
         None,
         ResourceBudget::default(),

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -201,6 +201,7 @@ impl TableOfContent {
                             self.consensus_proposal_sender.clone(),
                             id.clone(),
                         ),
+                        Some(self.general_runtime.handle().clone()),
                         Some(self.search_runtime.handle().clone()),
                         Some(self.update_runtime.handle().clone()),
                         self.optimizer_resource_budget.clone(),

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -227,6 +227,7 @@ impl TableOfContent {
                 self.consensus_proposal_sender.clone(),
                 collection_name.to_string(),
             ),
+            Some(self.general_runtime.handle().clone()),
             Some(self.search_runtime.handle().clone()),
             Some(self.update_runtime.handle().clone()),
             self.optimizer_resource_budget.clone(),

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -157,6 +157,7 @@ impl TableOfContent {
                     consensus_proposal_sender.clone(),
                     collection_name.clone(),
                 ),
+                Some(general_runtime.handle().clone()),
                 Some(search_runtime.handle().clone()),
                 Some(update_runtime.handle().clone()),
                 optimizer_resource_budget.clone(),


### PR DESCRIPTION
Temporary runtime tweak for <https://github.com/qdrant/qdrant/pull/7629> because it currently allows to easily trigger a deadlock.

A proper fix is more involved and will take more time to implement. Once implemented, this PR will be reverted.

The proper fix consists of restructuring the on drop handler for local shards. We'll have to gracefully stop shard workers through an async function, not through the drop handler.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?