### PR TITLE
Make `ShardTransfer.method` mandatory

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11403,6 +11403,7 @@
         "type": "object",
         "required": [
           "from",
+          "method",
           "shard_id",
           "sync",
           "to"
@@ -11437,14 +11438,7 @@
             "type": "boolean"
           },
           "method": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardTransferMethod"
-              },
-              {
-                "nullable": true
-              }
-            ]
+            "$ref": "#/components/schemas/ShardTransferMethod"
           },
           "comment": {
             "description": "A human-readable report of the transfer progress. Available only on the source peer.",

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -735,8 +735,7 @@ impl Collection {
                     shard_id,
                     to_shard_id: None,
                     sync: true,
-                    // For automatic shard transfers, always select some default method from this point on
-                    method: Some(shard_transfer_method),
+                    method: shard_transfer_method,
                     filter: None,
                 };
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -307,9 +307,8 @@ pub struct ShardTransferInfo {
     #[anonymize(false)]
     pub sync: bool,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
-    pub method: Option<ShardTransferMethod>,
+    pub method: ShardTransferMethod,
 
     /// A human-readable report of the transfer progress. Available only on the source peer.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -57,7 +57,7 @@ pub async fn transfer_shard(
     // Prepare the remote for receiving the shard, waits for the correct state on the remote
     remote_shard.initiate_transfer().await?;
 
-    match transfer_config.method.unwrap_or_default() {
+    match transfer_config.method {
         // Transfer shard record in batches
         ShardTransferMethod::StreamRecords => {
             transfer_stream_records(
@@ -153,7 +153,7 @@ pub async fn transfer_shard_fallback_default(
 ) -> CollectionResult<bool> {
     // Do not attempt to fall back to the same method
     let old_method = transfer_config.method;
-    if old_method.is_some_and(|method| method == fallback_method) {
+    if old_method == fallback_method {
         log::warn!(
             "Failed shard transfer fallback, because it would use the same transfer method: {fallback_method:?}",
         );
@@ -161,7 +161,7 @@ pub async fn transfer_shard_fallback_default(
     }
 
     // Propose to restart transfer with a different method
-    transfer_config.method.replace(fallback_method);
+    transfer_config.method = fallback_method;
     consensus
         .restart_shard_transfer_confirm_and_retry(&transfer_config, collection_id)
         .await?;

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -132,7 +132,7 @@ pub fn validate_transfer(
         )));
     }
 
-    if transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords) {
+    if transfer.method == ShardTransferMethod::ReshardingStreamRecords {
         let Some(destination_replicas) = destination_replicas else {
             return Err(CollectionError::service_error(format!(
                 "Destination shard {} does not exist",

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -331,8 +331,14 @@ async fn _do_recover_from_snapshot(
                     // Replica is the source of truth, we need to sync recovered data with this replica
                     let (replica_peer_id, _state) =
                         other_active_replicas.into_iter().next().unwrap();
+
+                    let method = toc
+                        .get_collection(&collection_pass)
+                        .await?
+                        .default_transfer_method();
+
                     log::debug!(
-                        "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}"
+                        "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id} with `{method:#?}` method"
                     );
 
                     // assume that if there is another peers, the server is distributed
@@ -342,7 +348,7 @@ async fn _do_recover_from_snapshot(
                         *replica_peer_id,
                         this_peer_id,
                         true,
-                        None,
+                        method,
                     )?;
                 }
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -501,7 +501,7 @@ impl TableOfContent {
                     )));
                 };
 
-                if old_transfer.method == Some(transfer_restart.method) {
+                if old_transfer.method == transfer_restart.method {
                     return Err(StorageError::bad_request(format!(
                         "Cannot restart transfer for shard {} from {} to {}, its configuration did not change",
                         transfer_restart.shard_id, transfer_restart.from, transfer_restart.to,
@@ -524,7 +524,7 @@ impl TableOfContent {
                     from: transfer_restart.from,
                     to: transfer_restart.to,
                     sync: old_transfer.sync, // Preserve sync flag from the old transfer
-                    method: Some(transfer_restart.method),
+                    method: transfer_restart.method,
                     filter: None,
                 };
 

--- a/lib/storage/src/content_manager/toc/snapshots.rs
+++ b/lib/storage/src/content_manager/toc/snapshots.rs
@@ -129,7 +129,7 @@ impl TableOfContent {
         from_peer: PeerId,
         to_peer: PeerId,
         sync: bool,
-        method: Option<ShardTransferMethod>,
+        method: ShardTransferMethod,
     ) -> Result<(), StorageError> {
         if let Some(proposal_sender) = &self.consensus_proposal_sender {
             let transfer_request = ShardTransfer {

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -266,6 +266,12 @@ pub async fn do_update_collection_cluster(
             validate_peer_exists(move_shard.to_peer_id)?;
             validate_peer_exists(move_shard.from_peer_id)?;
 
+            let method = move_shard.method.unwrap_or_else(|| {
+                let method = collection.default_transfer_method();
+                log::warn!("No shard transfer method selected, defaulting to {method:?}");
+                method
+            });
+
             // submit operation to consensus
             dispatcher
                 .submit_collection_meta_op(
@@ -277,7 +283,7 @@ pub async fn do_update_collection_cluster(
                             to: move_shard.to_peer_id,
                             from: move_shard.from_peer_id,
                             sync: false,
-                            method: move_shard.method,
+                            method,
                             filter: None,
                         }),
                     ),
@@ -303,6 +309,12 @@ pub async fn do_update_collection_cluster(
             // validate source peer exists
             validate_peer_exists(replicate_shard.from_peer_id)?;
 
+            let method = replicate_shard.method.unwrap_or_else(|| {
+                let method = collection.default_transfer_method();
+                log::warn!("No shard transfer method selected, defaulting to {method:?}");
+                method
+            });
+
             // submit operation to consensus
             dispatcher
                 .submit_collection_meta_op(
@@ -314,7 +326,7 @@ pub async fn do_update_collection_cluster(
                             to: replicate_shard.to_peer_id,
                             from: replicate_shard.from_peer_id,
                             sync: true,
-                            method: replicate_shard.method,
+                            method,
                             filter: None,
                         }),
                     ),
@@ -375,7 +387,7 @@ pub async fn do_update_collection_cluster(
                             from: from_peer_id,
                             to: to_peer_id,
                             sync: true,
-                            method: Some(ShardTransferMethod::StreamRecords),
+                            method: ShardTransferMethod::StreamRecords,
                             filter,
                         }),
                     ),


### PR DESCRIPTION
Partially, a sanity refactor. This PR makes `method` field consistent with the mental model, where it should always have a value once it has been accepted. 

Original motivation was because this was forcing the internal telemetry service proto to set the `method` as optional, when in all cases it should already have a value.

This PR moves the decision point for selecting a method to the caller (`MoveShard`, `ReplicateShard`, `request_shard_transfer`) by using the configured default from collection.