### PR TITLE
Fix Gridstore has_pointer to account for delete pending operation

### DIFF
--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -361,7 +361,7 @@ impl Tracker {
     }
 
     pub fn has_pointer(&self, point_offset: PointOffset) -> bool {
-        self.pending_updates.contains_key(&point_offset) || self.get(point_offset).is_some()
+        self.get(point_offset).is_some()
     }
 
     pub fn set(&mut self, point_offset: PointOffset, value_pointer: ValuePointer) {


### PR DESCRIPTION
This PR fixes a bug in Gridstore's `has_pointer` operation.

The bug manifests itself by an incorrect result from the `put_value` operation.

The contract for the returned boolean is

```rust
    /// Put a value in the storage.
    ///
    /// Returns true if the value existed previously and was updated, false if it was newly inserted.
    pub fn put_value(
        &mut self,
        point_offset: PointOffset,
        value: &V,
        hw_counter: HwMetricRefCounter,
    ) -> Result<bool> {
```

The value returned was incorrect in case of a delete operation present in the pending operation.

Luckily for us, no call site for `put_value` seems to rely on this returned information :relieved: 

