### PR TITLE
Fix shard crate testing feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6492,6 +6492,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "shard",
  "smallvec",
  "sparse",
  "strum",

--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 segment = { path = "../segment", default-features = false, features = ["testing"] }
+shard = { path = ".", default-features = false, features = ["testing"] }
 
 fs-err = { workspace = true }
 proptest = { workspace = true }


### PR DESCRIPTION
Running tests on the shard crate with `-p shard` fails with:

```
error[E0432]: unresolved import `crate::fixtures`
  --> lib/shard/src/proxy_segment/tests.rs:14:12
   |
14 | use crate::fixtures::*;
   |            ^^^^^^^^
   |            |
   |            unresolved import
   |            help: a similar path exists: `segment::fixtures`

error[E0432]: unresolved import `crate::fixtures`
  --> lib/shard/src/segment_holder/tests.rs:14:12
   |
14 | use crate::fixtures::*;
   |            ^^^^^^^^
   |            |
   |            unresolved import
   |            help: a similar path exists: `segment::fixtures`

error[E0432]: unresolved import `crate::fixtures`
   --> lib/shard/src/update.rs:924:16
    |
924 |     use crate::fixtures::{build_segment_1, build_segment_2};
    |                ^^^^^^^^
    |                |
    |                unresolved import
    |                help: a similar path exists: `segment::fixtures`
    |
note: found an item that was configured out
   --> lib/shard/src/lib.rs:16:9
    |
 15 | #[cfg(feature = "testing")]
    |       ------------------- the item is gated behind the `testing` feature
 16 | pub mod fixtures;
    |         ^^^^^^^^

error[E0282]: type annotations needed
   --> lib/shard/src/segment_holder/tests.rs:455:13
    |
455 |             segment
    |             ^^^^^^^ cannot infer type

Some errors have detailed explanations: E0282, E0432.
For more information about an error, try `rustc --explain E0282`.
error: could not compile `shard` (lib test) due to 4 previous errors
```

It is necessary to add a dev dependency with the testing feature flag.