### PR TITLE
fix typo Uint8 -> Int8

### DIFF
--- a/lib/quantization/tests/integration/test_neon.rs
+++ b/lib/quantization/tests/integration/test_neon.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
 
     #[rstest]
-    #[case(ScalarQuantizationMethod::Uint8)]
+    #[case(ScalarQuantizationMethod::Int8)]
     fn test_dot_neon(#[case] method: ScalarQuantizationMethod) {
         let vectors_count = 129;
         let vector_dim = 65;
@@ -56,7 +56,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(ScalarQuantizationMethod::Uint8)]
+    #[case(ScalarQuantizationMethod::Int8)]
     fn test_l2_neon(#[case] method: ScalarQuantizationMethod) {
         let vectors_count = 129;
         let vector_dim = 65;
@@ -100,7 +100,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(ScalarQuantizationMethod::Uint8)]
+    #[case(ScalarQuantizationMethod::Int8)]
     fn test_l1_neon(#[case] method: ScalarQuantizationMethod) {
         let vectors_count = 129;
         let vector_dim = 65;


### PR DESCRIPTION
Fixes typo in recent refactor of neon-specific tests
