### PR TITLE
SQ with metadata as enum

### DIFF
--- a/lib/quantization/tests/integration/test_simple.rs
+++ b/lib/quantization/tests/integration/test_simple.rs
@@ -412,8 +412,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(ScalarQuantizationMethod::Int8)]
-    fn test_sq_u8_encode_internal(#[case] method: ScalarQuantizationMethod) {
+    #[case(ScalarQuantizationMethod::Int8, false)]
+    #[case(ScalarQuantizationMethod::Int8, true)]
+    fn test_sq_u8_encode_internal(#[case] method: ScalarQuantizationMethod, #[case] invert: bool) {
         let vectors_count = 129;
         let vector_dim = 70;
         let error = 1e-3;
@@ -427,12 +428,12 @@ mod tests {
             vector_data.push(vector);
         }
 
-        for distance_type in [DistanceType::Dot, DistanceType::L2] {
+        for distance_type in [DistanceType::Dot, DistanceType::L2, DistanceType::L1] {
             let vector_parameters = VectorParameters {
                 dim: vector_dim,
                 deprecated_count: None,
                 distance_type,
-                invert: false,
+                invert,
             };
             let quantized_vector_size =
                 EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_quantization.rs
@@ -213,7 +213,7 @@ impl GpuScalarQuantization {
     ) -> OperationResult<Self> {
         Ok(GpuScalarQuantization {
             multiplier: quantized_storage.get_multiplier(),
-            diff: quantized_storage.get_diff(),
+            diff: quantized_storage.get_shift(),
             offsets_buffer: GpuScalarQuantization::create_sq_offsets_buffer(
                 device,
                 quantized_storage,


### PR DESCRIPTION
This PR is a refector of SQ, where we want to add new encodings.

New changes:

# Metadata is a enum
Before:
```
#[derive(Serialize, Deserialize)]
struct Metadata {
//....
}
```

After:
```
#[derive(Serialize, Deserialize)]
#[serde(untagged)]
enum Metadata {
    Int8(MetadataInt8),
}

#[derive(Serialize, Deserialize)]
struct MetadataInt8 {
//....
}
```

This change introduces an easy way to add a new encoding method.

Everything else is a change to fix the compilation. Or minor refactors like removing logic duplication
