### PR TITLE
Metrics cluster working state and last update

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -528,8 +528,8 @@ impl MetricsProvider for ClusterStatusTelemetry {
                 metrics.push_metric(metric_family(
                     "cluster_last_update_timestamp_seconds",
                     "unix timestamp of last update",
-                    MetricType::GAUGE,
-                    vec![gauge(timestamp as f64, &[])],
+                    MetricType::COUNTER,
+                    vec![counter(timestamp as f64, &[])],
                     prefix,
                 ));
 


### PR DESCRIPTION
Depends on #7479

Adds the following two new metric families to the metrics API:

```
# HELP cluster_last_update_delta time since last update
# TYPE cluster_last_update_delta gauge
cluster_last_update_delta 1.223929901

# HELP cluster_working_state working state of the cluster
# TYPE cluster_working_state gauge
cluster_working_state{state="working"} 1
cluster_working_state{state="stopped"} 0
```

`cluster_working_state` always has two metrics, one with `state=working` and one `state=stopped`.
The active state exports the value `1`.