### PR TITLE
Fix shard clean up on snapshot restore without manifest

### DIFF
--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -235,7 +235,7 @@ impl ShardReplicaSet {
                 shard.stop_gracefully().await;
 
                 None
-            },
+            }
             None if snapshot_manifest.is_empty() => None,
 
             Some(shard) => {

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -251,7 +251,7 @@ async fn _do_recover_from_snapshot(
         log::debug!(
             "Recovering shard {} from {}",
             shard_id,
-            snapshot_shard_path.display()
+            snapshot_shard_path.display(),
         );
 
         // TODO:
@@ -338,7 +338,7 @@ async fn _do_recover_from_snapshot(
                     let (replica_peer_id, _state) =
                         other_active_replicas.into_iter().next().unwrap();
                     log::debug!(
-                        "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}"
+                        "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}",
                     );
 
                     // assume that if there is another peers, the server is distributed


### PR DESCRIPTION
Also gracefully stop local shard if we:
- recover shard from snapshot
- don't provide snapshot manifest

Should fix crasher run:
- https://github.com/qdrant/crasher/actions/runs/19861366275

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?