### PR TITLE
Bump wal to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7800,8 +7800,8 @@ dependencies = [
 
 [[package]]
 name = "wal"
-version = "0.1.2"
-source = "git+https://github.com/qdrant/wal.git?rev=fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172#fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172"
+version = "0.1.4"
+source = "git+https://github.com/qdrant/wal.git?rev=b03a156b0ffdbe8109b2c3c409ce3be2ec6d229e#b03a156b0ffdbe8109b2c3c409ce3be2ec6d229e"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ tonic-reflection = "0.11.0"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.18", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
-wal = { git = "https://github.com/qdrant/wal.git", rev = "fbb2f2a1603222df3f8a34cc6ae2c93ceffbc172" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "b03a156b0ffdbe8109b2c3c409ce3be2ec6d229e" }
 zerocopy = { version = "0.8.31", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"


### PR DESCRIPTION
Includes a critical upstream fix:
- https://github.com/qdrant/wal/pull/103

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?