### PR TITLE
Print backtrace when incomplete shard drop

### DIFF
--- a/lib/collection/src/shards/local_shard/drop.rs
+++ b/lib/collection/src/shards/local_shard/drop.rs
@@ -14,10 +14,11 @@ impl Drop for LocalShard {
             self.shard_path().display()
         );
 
-        #[cfg(feature = "staging")]
-        {
-            log::debug!("{}", std::backtrace::Backtrace::force_capture());
-        }
+        // Uncomment to investigate shard drop without graceful shutdown
+        // #[cfg(feature = "staging")]
+        // {
+        //     log::debug!("{}", std::backtrace::Backtrace::force_capture());
+        // }
 
         // Normally we expect, that LocalShard should be explicitly stopped in asynchronous
         // runtime before being dropped.


### PR DESCRIPTION
It is tedious to hunt down incomplete shard drop in case of missing graceful shutdown.

This PR adds a debug back trace under the `staging` feature.

This has the inconvenient side effect of generating back traces on shutdown :see_no_evil: 

EDIT: I have decided to leave this comment by default to avoid the noisy shutdown. 
At least the option will be clearly visible next time we investigate.