### PR TITLE
Fix vector count in metrics showing minus zero

### DIFF
--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -349,7 +349,10 @@ impl MetricsProvider for CollectionsTelemetry {
         let vector_count = vector_count_by_name
             .iter()
             .map(|m| m.get_gauge().get_value())
-            .sum();
+            .sum::<f64>()
+            // The sum of an empty f64 iterator returns `-0`. Since a negative
+            // number of vectors is impossible, taking the absolute value is always safe.
+            .abs();
 
         metrics.push_metric(metric_family(
             "collections_vector_total",


### PR DESCRIPTION
Picked from <https://github.com/qdrant/qdrant/pull/7670> to allow including it in the patch release

Prevent showing `-0.0` in metrics if we have no vectors.

Documentation: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.sum

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?