### PR TITLE
Include RocksDB features in Docker dev build

### DIFF
--- a/.github/actions/branch-build-and-push/action.yaml
+++ b/.github/actions/branch-build-and-push/action.yaml
@@ -80,13 +80,12 @@ runs:
         fi
 
         # Prepare feature flags
-        FEATURES_ARG=""
+        FEATURES="rocksdb"
         if [ "${{ inputs.staging-build }}" = "true" ]; then
           echo "Staging feature enabled"
-          FEATURES_ARG="--build-arg FEATURES=rocksdb,staging"
-        else
-          FEATURES_ARG="--build-arg FEATURES=rocksdb"
+          FEATURES="${FEATURES},staging"
         fi
+        FEATURES_ARG="--build-arg FEATURES=${FEATURES}"
 
         # Function to build and push with given suffix and build args
         build_image() {


### PR DESCRIPTION
The `rocksdb` feature was disabled in `qdrant/qdrant:dev` builds. We should keep it until 1.18.0.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
