### PR TITLE
Support aarch64-pc-windows-msvc

### DIFF
--- a/lib/quantization/cpp/neon.c
+++ b/lib/quantization/cpp/neon.c
@@ -3,6 +3,11 @@
 
 #include "export_macro.h"
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#define __builtin_popcount __popcnt
+#endif
+
 EXPORT float impl_score_dot_neon(
     const uint8_t* query_ptr,
     const uint8_t* vector_ptr,

--- a/lib/segment/src/spaces/metric_f16/cpp/neon.c
+++ b/lib/segment/src/spaces/metric_f16/cpp/neon.c
@@ -1,4 +1,3 @@
-#if !defined PC_VER
 #include <arm_neon.h>
 
 #if defined(_MSC_VER) || defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
@@ -133,5 +132,4 @@ float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
 
     return manhattanDistance;
 }
-#endif
 #endif

--- a/lib/segment/src/spaces/metric_f16/cpp/neon.c
+++ b/lib/segment/src/spaces/metric_f16/cpp/neon.c
@@ -1,8 +1,7 @@
 #if !defined PC_VER
 #include <arm_neon.h>
-#endif
 
-#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
+#if defined(_MSC_VER) || defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
 #include <arm_fp16.h>
 float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
 {
@@ -134,4 +133,5 @@ float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
 
     return manhattanDistance;
 }
+#endif
 #endif


### PR DESCRIPTION
Hotfix for https://github.com/qdrant/qdrant/issues/7686

MSVC has differences in std in comparison with GCC/Clang. This PR fixes this errors:
1. fix missed `__builtin_popcount ` in MSVC

2. don't check `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` flag which is not defined in MSVC

Note: this is untested