### PR TITLE
Fix shell.nix for tikv-jemallocator 0.6.1

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -60,6 +60,10 @@ mkShell {
     python-env # used in tests
   ];
 
+  # Fix for tikv-jemalloc-sys
+  # https://github.com/tikv/jemallocator/issues/108
+  hardeningDisable = [ "fortify" ];
+
   shellHook = ''
     # Caching for C/C++ deps, particularly for librocksdb-sys
     export CC="ccache $CC"
@@ -72,10 +76,6 @@ mkShell {
     # Caching for lindera-unidic
     [ "''${LINDERA_CACHE+x}" ] ||
       export LINDERA_CACHE="''${XDG_CACHE_HOME:-$HOME/.cache}/lindera"
-
-    # Fix for tikv-jemalloc-sys
-    # https://github.com/NixOS/nixpkgs/issues/370494#issuecomment-2625163369
-    export CFLAGS=-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE
 
     # Fix for older macOS
     # https://github.com/rust-rocksdb/rust-rocksdb/issues/776


### PR DESCRIPTION
The recent #7661 broke the build on nix.

```
   Compiling tikv-jemalloc-sys v0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7
error: failed to run custom build command for `tikv-jemalloc-sys v0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7`

Caused by:
  process didn't exit successfully: `/home/user/qdrant/target/debug/build/tikv-jemalloc-sys-3926e34d8950ee63/build-script-build` (exit status: 101)
  --- stdout
  TARGET=x86_64-unknown-linux-gnu
  …
  #define JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP  

  configure: exit 1

  --- stderr
  configure: error: cannot determine return type of strerror_r

  thread 'main' panicked at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tikv-jemalloc-sys-0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7/build.rs:411:9:
  command did not execute successfully: cd "/home/user/qdrant/target/debug/build/tikv-jemalloc-sys-8e83ccea9b2c7455/out/build" && CC="gcc" CFLAGS="-O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m64 -DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE" CPPFLAGS="-O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m64 -DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE" LDFLAGS="-O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m64 -DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE" "sh" "/home/user/qdrant/target/debug/build/tikv-jemalloc-sys-8e83ccea9b2c7455/out/build/configure" "--with-version=5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7" "--disable-cxx" "--enable-doc=no" "--enable-shared=no" "--with-malloc-conf=background_thread:true" "--with-private-namespace=_rjem_" "--enable-stats" "--host=x86_64-unknown-linux-gnu" "--build=x86_64-unknown-linux-gnu" "--prefix=/home/user/qdrant/target/debug/build/tikv-jemalloc-sys-8e83ccea9b2c7455/out"
  expected success, got: exit status: 1
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR stirs the cauldron of workarounds to fix it. Now it works both for 0.6.0 and 0.6.1.
