### PR TITLE
Align version of jemalloc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7092,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,13 +157,14 @@ pyroscope_pprofrs = "0.2.10"
 # Backtrace
 rstack-self = { version = "0.3.0", optional = true }
 
+# Jemalloc
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = [
+tikv-jemallocator = { version = "0.6.1", features = [
     "stats",
     "unprefixed_malloc_on_supported_platforms",
     "background_threads",
 ] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
+tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats"] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"


### PR DESCRIPTION
Dependabot forgot to bump `tikv-jemalloc-ctl` to version [0.6.1](https://github.com/tikv/jemallocator/releases/tag/0.6.1) as well.