### PR TITLE
Fix flusher data race in Gridstore

### DIFF
--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -1547,10 +1547,11 @@ mod tests {
         );
     }
 
-    /// Test that data is only actually flushed when we didn't bump the flusher lease
+    /// Test that data is only actually flushed when the Gridstore instance is still valid
     ///
     /// Specifically:
-    /// - ensure that 'late' flushers don't write any data if already invalidated
+    /// - ensure that 'late' flushers don't write any data if already invalidated by a clear or
+    ///   something else
     #[test]
     fn test_skip_deferred_flush_after_clear() {
         let (dir, mut storage) = empty_storage();


### PR DESCRIPTION
In <https://github.com/qdrant/qdrant/pull/7624> and <https://github.com/qdrant/qdrant/pull/7627> we improved flushing for Gridstore.

But, there was still a data race left when wiping/clearing Gridstore. After wiping, it was still possible for a pending (now invalid) flush task to write data to disk. We did add a barrier in `wipe`, but that didn't prevent a flusher task to run one more time.

This sequence of events was possible:
- flusher task is created
- flusher task is invoked and upgrades Arc's
- `wipe` is called, falls through bitmask barrier, and deletes files on disk
- flusher task now obtains bitmask lock, and flushes data

I use the same approach as in other places - an 'is alive' flag (for [example](https://github.com/qdrant/qdrant/pull/7416)).

The added test breaks on the old flush behavior. You can try this by commenting out this line: https://github.com/qdrant/qdrant/blob/3aeaa50597f3fe9267b2fa064708a1a7f4486435/lib/gridstore/src/gridstore.rs#L474-L477

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
