### PR TITLE
Download compatibility archives once in e2e test

### DIFF
--- a/tests/e2e_tests/test_data_compatibility.py
+++ b/tests/e2e_tests/test_data_compatibility.py
@@ -1,19 +1,23 @@
 import uuid
+from pathlib import Path
+from typing import Optional
 
 import pytest
 import requests
-from pathlib import Path
+from docker.errors import NotFound
 
 from e2e_tests.conftest import QdrantContainerConfig
 from e2e_tests.client_utils import ClientUtils
-from e2e_tests.utils import extract_archive
+from e2e_tests.utils import extract_archive, remove_dir
 
 
 class TestStorageCompatibility:
     """Test storage and snapshot compatibility with defined previous Qdrant versions.
 
-    These tests are grouped to run sequentially on the same worker using xdist_group marker.
-    This prevents parallel downloads of large archives and disk saturation.
+    These tests use pytest-subtests to run both storage and snapshot compatibility
+    tests for each version while downloading the compatibility data only once.
+    This minimizes disk usage (critical for GitHub runners with limited space)
+    while maintaining granular test reporting.
     """
 
     VERSIONS = [
@@ -43,7 +47,7 @@ class TestStorageCompatibility:
     ]
 
     @staticmethod
-    def _download_compatibility_data(version: str, storage_test_dir: Path):
+    def _download_compatibility_data(version: str, storage_test_dir: Path) -> Path:
         """Download compatibility data for a specific version.
 
         Args:
@@ -74,7 +78,7 @@ class TestStorageCompatibility:
         return compatibility_file
 
     @staticmethod
-    def _extract_storage_data(compatibility_file: Path, storage_test_dir: Path):
+    def _extract_storage_data(compatibility_file: Path, storage_test_dir: Path) -> Path:
         """Extract storage data from compatibility archive."""
         extract_archive(compatibility_file, storage_test_dir, cleanup_archive=True)
 
@@ -86,7 +90,7 @@ class TestStorageCompatibility:
         return storage_test_dir / "storage"
 
     @staticmethod
-    def _extract_snapshot_data(storage_test_dir: Path):
+    def _extract_snapshot_data(storage_test_dir: Path) -> Optional[Path]:
         """Extract snapshot data."""
         snapshot_gz = storage_test_dir / "full-snapshot.snapshot.gz"
 
@@ -96,79 +100,126 @@ class TestStorageCompatibility:
 
         return None
 
-    @staticmethod
-    def _check_collections(host: str, port: int) -> bool:
-        """Check that all collections are loaded properly."""
+    def _check_collections(self, host: str, port: int) -> tuple[bool, str]:
+        """Check that all collections are loaded properly.
+
+        Returns:
+            Tuple of (success: bool, error_message: str)
+        """
         client = ClientUtils(host=host, port=port)
 
         try:
             collections = client.list_collections_names()
         except Exception as e:
-            print(f"Error listing collections: {e}")
-            return False
+            return False, f"Error listing collections: {e}"
 
-        expected = set(TestStorageCompatibility.EXPECTED_COLLECTIONS)
+        expected = set(self.EXPECTED_COLLECTIONS)
         found = set(collections)
         missing = expected - found
         if missing:
-            print(f"Missing expected collections: {sorted(missing)}")
-            return False
+            return False, f"Missing expected collections: {sorted(missing)}"
 
         for collection in expected:
             try:
                 collection_info = client.get_collection_info_dict(collection)
                 if collection_info["status"] != "ok":
-                    print(f"Collection {collection} returned status {collection_info['status']}")
-                    return False
+                    return False, f"Collection {collection} returned status {collection_info['status']}"
             except Exception as error:
-                print(f"Failed to get collection info for {collection}: {error}")
-                return False
-        return True
+                return False, f"Failed to get collection info for {collection}: {error}"
 
+        return True, ""
 
-    @pytest.mark.xdist_group("compatibility")
-    @pytest.mark.parametrize("version", VERSIONS)
-    def test_storage_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version,
-                                   qdrant_container_factory):
-        """Test storage compatibility with previous versions."""
-        compatibility_file = self._download_compatibility_data(version, temp_storage_dir)
-        storage_dir = self._extract_storage_data(compatibility_file, temp_storage_dir)
+    def _run_test(
+        self,
+        config: QdrantContainerConfig,
+        test_name: str,
+        version: str,
+        qdrant_container_factory,
+        cleanup_dir: Optional[Path] = None
+    ) -> tuple[bool, str]:
+        """Run a Qdrant container test with the given configuration.
 
+        Args:
+            config: Container configuration
+            test_name: Name of the test for error messages (e.g., "storage", "snapshot")
+            version: Version string for error messages
+            qdrant_container_factory: Factory fixture to create containers
+            cleanup_dir: Optional directory to remove after test completion
+
+        Returns:
+            Tuple of (success: bool, error_message: str)
+        """
+        try:
+            container_info = qdrant_container_factory(config)
+        except (NotFound, RuntimeError) as e:
+            return False, f"Container failed to start for {version}: {e}"
+
+        try:
+            client = ClientUtils(host=container_info.host, port=container_info.http_port)
+            if not client.wait_for_server():
+                return False, f"Server failed to start for {test_name} test ({version})"
+
+            success, error_msg = self._check_collections(container_info.host, container_info.http_port)
+            if not success:
+                return False, f"{test_name.capitalize()} compatibility failed for {version}: {error_msg}"
+
+            return True, ""
+        finally:
+            try:
+                container_info.container.stop()
+                container_info.container.remove(force=True)
+            except NotFound:
+                pass
+            if cleanup_dir:
+                remove_dir(cleanup_dir)
+
+    def _run_storage_test(self, storage_dir: Path, version: str, qdrant_container_factory) -> tuple[bool, str]:
+        """Run storage compatibility test."""
         config = QdrantContainerConfig(
             volumes={str(storage_dir): {"bind": "/qdrant/storage", "mode": "rw"}},
-            exit_on_error=False
+            exit_on_error=False,
+            remove=False,
         )
-        container_info = qdrant_container_factory(config)
+        return self._run_test(
+            config, "storage", version, qdrant_container_factory, cleanup_dir=storage_dir
+        )
 
-        client = ClientUtils(host=container_info.host, port=container_info.http_port)
-        if not client.wait_for_server():
-            pytest.fail(f"Server failed to start for {version}")
-
-        if not self._check_collections(container_info.host, container_info.http_port):
-            pytest.fail(f"Storage compatibility failed for {version}")
-
-    @pytest.mark.xdist_group("compatibility")
-    @pytest.mark.parametrize("version", VERSIONS)
-    def test_snapshot_compatibility(self, docker_client, qdrant_image, temp_storage_dir, version,
-                                    qdrant_container_factory):
-        """Test snapshot recovery compatibility with previous versions."""
-        compatibility_file = self._download_compatibility_data(version, temp_storage_dir)
-        self._extract_storage_data(compatibility_file, temp_storage_dir)
-        snapshot_file = self._extract_snapshot_data(temp_storage_dir)
-
+    def _run_snapshot_test(self, snapshot_file: Optional[Path], version: str, qdrant_container_factory) -> tuple[bool, str]:
+        """Run snapshot compatibility test."""
         if not snapshot_file:
-            pytest.fail(f"No snapshot file found for {version}")
+            return False, f"No snapshot file found for {version}"
 
         config = QdrantContainerConfig(
             volumes={str(snapshot_file): {"bind": "/qdrant/snapshot.snapshot", "mode": "ro"}},
             command=["./qdrant", "--storage-snapshot", "/qdrant/snapshot.snapshot"],
-            exit_on_error=False
+            exit_on_error=False,
+            remove=False,
         )
-        container_info = qdrant_container_factory(config)
+        return self._run_test(config, "snapshot", version, qdrant_container_factory)
 
-        client = ClientUtils(host=container_info.host, port=container_info.http_port)
-        if not client.wait_for_server():
-            pytest.fail(f"Server failed to start from snapshot for {version}")
+    @pytest.mark.xdist_group("compatibility")
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_compatibility(self, temp_storage_dir, version, qdrant_container_factory, subtests):
+        """Test both storage and snapshot compatibility for a specific version.
 
-        if not self._check_collections(container_info.host, container_info.http_port):
-            pytest.fail(f"Snapshot compatibility failed for {version}")
+        This test downloads compatibility data once and runs both storage and snapshot
+        subtests, minimizing disk usage while maintaining granular test reporting.
+
+        Subtests:
+            - storage: Tests that Qdrant can load storage data from the previous version
+            - snapshot: Tests that Qdrant can recover from a snapshot created by the previous version
+        """
+        # Download and extract compatibility data once for both subtests
+        compatibility_file = self._download_compatibility_data(version, temp_storage_dir)
+        storage_dir = self._extract_storage_data(compatibility_file, temp_storage_dir)
+        snapshot_file = self._extract_snapshot_data(temp_storage_dir)
+
+        # Subtest 1: Storage compatibility
+        with subtests.test(msg="storage", version=version):
+            success, error_msg = self._run_storage_test(storage_dir, version, qdrant_container_factory)
+            assert success, error_msg
+
+        # Subtest 2: Snapshot compatibility
+        with subtests.test(msg="snapshot", version=version):
+            success, error_msg = self._run_snapshot_test(snapshot_file, version, qdrant_container_factory)
+            assert success, error_msg

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -2706,4 +2706,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "55d223e45ffcf72c809fb9beebf6f65e65bc3b646a8fe3d914b313cd5f5b4e73"
+content-hash = "49a431b45e79103510294fe0157d02732f80b6715ac4f3fd99d42b7c7a4d8d5d"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -18,6 +18,7 @@ schemathesis = "^3.39.16"
 retry = "^0.9.2"
 docker = "^7.1.0"
 pytest-xdist = "^3.8.0"
+pytest-subtests = "^0.14.1"
 qdrant-client = "^1.15.1"
 tqdm = "^4.67.1"
 


### PR DESCRIPTION
Optimize the data compatibility tests to reduce network bandwidth and disk usage by downloading compatibility archives only once per version instead of twice.

Changes:
* Combine 2 independent tests (storage_recovery and snapshot_recovery) into 1 test with 2 _subtests_ in order to only download each version's archive once and one at a time (save CI runner time and disk space)
* Leverage pytest-subtests feature to still receive separate reports on subtests

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
