### PR TITLE
Ignore deprecation warnings for schemathesis

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -29,6 +29,10 @@ markers = [
 addopts = """
     --dist=loadgroup
 """
+filterwarnings = [
+    "ignore:jsonschema.RefResolver is deprecated:DeprecationWarning:schemathesis",
+    "ignore:jsonschema.exceptions.RefResolutionError is deprecated:DeprecationWarning:schemathesis",
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Each time I run `pytest tests/openapi`, I get following annoying warnings:

```
=============================== warnings summary ===============================
../../../.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/references.py:11
  /home/runner/.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/references.py:11: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError

../../../.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/references.py:51
  /home/runner/.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/references.py:51: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    class InliningResolver(jsonschema.RefResolver):

../../../.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/generation/coverage.py:305
  /home/runner/.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

../../../.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/schemas.py:89
  /home/runner/.cache/pypoetry/virtualenvs/qdrant-test-deps-FyR9sbRm-py3.13/lib/python3.13/site-packages/schemathesis/specs/openapi/schemas.py:89: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    SCHEMA_PARSING_ERRORS = (KeyError, AttributeError, jsonschema.exceptions.RefResolutionError)
```

This PR ignores these warnings by adding them to the `filterwarnings` list of pytest.

I've also tried to migrate to newer schemathesis (we use 4.18, the latest is 5.x), but it requires some fixes in `tests/openapi/helpers/helpers.py` that I'm not able to figure out. Whatever, let's just stick to the current version and ignore these warnings.
