### PR TITLE
Fix minor clippy expect error

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -100,7 +100,6 @@ pub fn serialize_graph_links<W: Write + Seek>(
     let mut offsets = Vec::with_capacity(total_offsets_len as usize);
     offsets.push(0);
 
-    #[expect(clippy::needless_range_loop)]
     // this clippy lint is positively demented, can't wait till they remove it 🙄
     for level in 0..levels_count {
         let count = point_count_by_level.iter().skip(level).sum::<u64>() as usize;


### PR DESCRIPTION
Annoying error

```
error: this lint expectation is unfulfilled
   --> lib/segment/src/index/hnsw_index/graph_links/serializer.rs:103:14
    |
103 |     #[expect(clippy::needless_range_loop)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unfulfilled_lint_expectations)]`
```