### PR TITLE
Optimize gridstore flush

### DIFF
--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -614,23 +614,25 @@ impl<V> Gridstore<V> {
             }
 
             let old_pointers = tracker.write().write_pending_and_flush(pending_updates)?;
-            if !old_pointers.is_empty() {
-                // Update all free blocks in the bitmask
-                bitmask_guard.with_upgraded(|guard| {
-                    for (page_id, pointer_group) in
-                        &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
-                    {
-                        let local_ranges = pointer_group.map(|pointer| {
-                            let start = pointer.block_offset;
-                            let end = pointer.block_offset
-                                + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
-                            start as usize..end as usize
-                        });
-                        guard.mark_blocks_batch(page_id, local_ranges, false);
-                    }
-                });
-                bitmask_guard.flush()?;
+            if old_pointers.is_empty() {
+                return Ok(());
             }
+            // Update all free blocks in the bitmask
+            bitmask_guard.with_upgraded(|guard| {
+                for (page_id, pointer_group) in
+                    &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
+                {
+                    let local_ranges = pointer_group.map(|pointer| {
+                        let start = pointer.block_offset;
+                        let end = pointer.block_offset
+                            + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
+                        start as usize..end as usize
+                    });
+                    guard.mark_blocks_batch(page_id, local_ranges, false);
+                }
+            });
+            bitmask_guard.flush()?;
+
             Ok(())
         })
     }


### PR DESCRIPTION
No need to upgrade the lock and flush the bitmask if there are no pending updates.