### PR TITLE
Fix Gridstore flushing, correctly implement drain persist

### DIFF
--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -709,8 +709,11 @@ mod tests {
         }
     }
 
+    /// Test pointer drain edge case that was previously broken.
+    ///
+    /// See: <https://github.com/qdrant/qdrant/pull/7741>
     #[test]
-    fn test_value_pointer_drain_set_unset_set() {
+    fn test_value_pointer_drain_bug_7741() {
         // current:
         // - latest: true
         // - history: [block_offset:1, block_offset:2]
@@ -745,6 +748,9 @@ mod tests {
             expected.set(ValuePointer::new(1, 2, 1));
             expected
         };
-        assert_eq!(updates, expected, "must have correct remaining updates");
+        assert_eq!(
+            updates, expected,
+            "must have one pending update to set block offset 2",
+        );
     }
 }


### PR DESCRIPTION
Fix a critical Gridstore bug that breaks flushing with alternating puts and deletes.

Gridstore uses deferred flushing. It means that we copy the list of pending updates when the flusher is created. Once flushing is invoked and updates are persisted, we remove these from the current list of updates (which might already have new entries). This 'removing' we call 'drain persisted'. It is critical to persist every change only once.

This drain function was broken and failed on some edge cases. For the problematic edge case we found in testing, I've added a new test.

The problem only appears when deferring a flush (for some time). If flushing immediately, the pending and persisted set of updates are equal and everything works as expected.

Bear in mind that I use the concept of a 'set' and 'unset' list in this PR. I plan to open a separate PR to apply this concept everywhere as it's much more easy to understand. Since it's only partially applied in this PR it might look like boilerplate.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
