### PR TITLE
Bump misc. integration test deps

### DIFF
--- a/tests/e2e_tests/client_utils.py
+++ b/tests/e2e_tests/client_utils.py
@@ -69,7 +69,6 @@ class ClientUtils:
             return {
                 "result": {
                     "status": collection_info.status.value if hasattr(collection_info.status, 'value') else str(collection_info.status),
-                    "vectors_count": collection_info.vectors_count,
                     "points_count": collection_info.points_count,
                     "config": collection_info.config,
                     "indexed_vectors_count": collection_info.indexed_vectors_count,
@@ -202,7 +201,6 @@ class ClientUtils:
             optimizers_config=collection_config.get("optimizers_config"),
             wal_config=collection_config.get("wal_config"),
             quantization_config=collection_config.get("quantization_config"),
-            init_from=collection_config.get("init_from"),
             timeout=self.timeout
         )
 

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -1084,14 +1084,14 @@ files = [
 
 [[package]]
 name = "more-itertools"
-version = "10.7.0"
+version = "10.8.0"
 description = "More routines for operating on iterables, beyond itertools"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e"},
-    {file = "more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3"},
+    {file = "more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b"},
+    {file = "more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd"},
 ]
 
 [[package]]
@@ -2001,14 +2001,14 @@ files = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.15.1"
+version = "1.16.1"
 description = "Client library for the Qdrant vector search engine"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "qdrant_client-1.15.1-py3-none-any.whl", hash = "sha256:2b975099b378382f6ca1cfb43f0d59e541be6e16a5892f282a4b8de7eff5cb63"},
-    {file = "qdrant_client-1.15.1.tar.gz", hash = "sha256:631f1f3caebfad0fd0c1fba98f41be81d9962b7bf3ca653bed3b727c0e0cbe0e"},
+    {file = "qdrant_client-1.16.1-py3-none-any.whl", hash = "sha256:1eefe89f66e8a468ba0de1680e28b441e69825cfb62e8fb2e457c15e24ce5e3b"},
+    {file = "qdrant_client-1.16.1.tar.gz", hash = "sha256:676c7c10fd4d4cb2981b8fcb32fd764f5f661b04b7334d024034d07212f971fd"},
 ]
 
 [package.dependencies]
@@ -2047,14 +2047,14 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
-    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
+    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
 
 [package.dependencies]
@@ -2538,21 +2538,21 @@ dev = ["flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
+    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "webcolors"
@@ -2706,4 +2706,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "49a431b45e79103510294fe0157d02732f80b6715ac4f3fd99d42b7c7a4d8d5d"
+content-hash = "fc8f1329dd934636ca83cdbb63efa3efd9439feeb6e5e565be56441e85a964b5"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -7,19 +7,19 @@ python = "^3.10"
 
 grpc-interceptor = "^0.15"
 grpc-requests = "^0.1"
-more-itertools = "^10.7"
+more-itertools = "^10.8"
 pyjwt = "^2.10"
 jsons = "^1.6.3"
 pytest = "^8.4"
 pytest-timeout = "^2.4"
 pytest-cases = "^3.9.1"
-requests = "^2.32.4"
-schemathesis = "^3.39.16"
+requests = "^2.32.5"
+schemathesis = "^3.39.16" # 4.x contains a lot of breaking changes
 retry = "^0.9.2"
 docker = "^7.1.0"
 pytest-xdist = "^3.8.0"
 pytest-subtests = "^0.14.1"
-qdrant-client = "^1.15.1"
+qdrant-client = "^1.16.1"
 tqdm = "^4.67.1"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Several birds with one stone:

- handle vulnerability report https://github.com/qdrant/qdrant/pull/7705
- bump `qdrant-client` 1.16.x with breaking changes
- bump other possible dependencies
- document `schemathesis` status