### PR TITLE
Cleanup shard level search timeout

### DIFF
--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -24,11 +24,9 @@ impl LocalShard {
         &self,
         request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<FacetValueHit>> {
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
-
         let stopping_guard = StoppingGuard::new();
 
         let spawn_read = |segment: LockedSegment, hw_counter: &HardwareCounterCell| {
@@ -93,16 +91,13 @@ impl LocalShard {
         &self,
         request: Arc<FacetParams>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<FacetValueHit>> {
         // To return exact counts we need to consider that the same point can be in different segments if it has different versions.
         // So, we need to consider all point ids for a given filter in all segments to do an accurate count.
         //
         // To do this we will perform exact counts for each of the values in the field.
-
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
-
         let instant = std::time::Instant::now();
 
         // Get unique values for the field

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1008,6 +1008,11 @@ impl LocalShard {
         }
         Ok(())
     }
+
+    // Returns configured default search timeout if timeout is None
+    pub fn timeout_or_default_search_timeout(&self, timeout: Option<Duration>) -> Duration {
+        timeout.unwrap_or(self.shared_storage_config.search_timeout)
+    }
 }
 
 fn deduplicate_points_async(

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -60,18 +60,16 @@ impl LocalShard {
         &self,
         request: PlannedQuery,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_counter_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ShardQueryResponse>> {
         let start_time = std::time::Instant::now();
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
-
         let searches_f = self.do_search(
             Arc::new(CoreSearchRequestBatch {
                 searches: request.searches,
             }),
             search_runtime_handle,
-            Some(timeout),
+            timeout,
             hw_counter_acc.clone(),
         );
 
@@ -356,7 +354,7 @@ impl LocalShard {
                 self.do_search(
                     Arc::new(rescoring_core_search_request),
                     search_runtime_handle,
-                    Some(timeout),
+                    timeout,
                     hw_counter_acc,
                 )
                 .await?

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -42,7 +42,7 @@ impl LocalShard {
             self.query_scroll(
                 request,
                 search_runtime_handle,
-                Some(timeout),
+                timeout,
                 hw_measurement_acc.clone(),
             )
         });
@@ -62,7 +62,7 @@ impl LocalShard {
         &self,
         request: &QueryScrollRequestInternal,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let QueryScrollRequestInternal {
@@ -143,11 +143,10 @@ impl LocalShard {
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let start = Instant::now();
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
@@ -228,11 +227,10 @@ impl LocalShard {
         filter: Option<&Filter>,
         search_runtime_handle: &Handle,
         order_by: &OrderBy,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let start = Instant::now();
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 
@@ -327,11 +325,10 @@ impl LocalShard {
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<RecordInternal>> {
         let start = Instant::now();
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
         let stopping_guard = StoppingGuard::new();
         let segments = self.segments.clone();
 

--- a/lib/collection/src/shards/local_shard/search.rs
+++ b/lib/collection/src/shards/local_shard/search.rs
@@ -31,7 +31,7 @@ impl LocalShard {
         &self,
         core_request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_counter_acc: HwMeasurementAcc,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
         if core_request.searches.is_empty() {
@@ -100,7 +100,7 @@ impl LocalShard {
         &self,
         core_request: Arc<CoreSearchRequestBatch>,
         search_runtime_handle: &Handle,
-        timeout: Option<Duration>,
+        timeout: Duration,
         hw_counter_acc: HwMeasurementAcc,
         is_stopped_guard: &StoppingGuard,
     ) -> CollectionResult<Vec<Vec<ScoredPoint>>> {
@@ -132,8 +132,6 @@ impl LocalShard {
             true,
             query_context,
         );
-
-        let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
 
         let res = tokio::time::timeout(timeout, search_request)
             .await

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -84,7 +84,7 @@ async fn test_hw_metrics_cancellation() {
             .do_search(
                 Arc::new(req),
                 &current_runtime,
-                Some(Duration::from_millis(10)), // Very short duration to hit timeout before the search finishes
+                Duration::from_millis(10), // Very short duration to hit timeout before the search finishes
                 hw_counter,
             )
             .await;


### PR DESCRIPTION
Small cleanup to:
- force shard search internals to have a timeout provided
- centralize the timeout fallback value