### PR TITLE
Allow filtering collections in `get_telemetry_data`

### DIFF
--- a/lib/storage/src/content_manager/toc/telemetry.rs
+++ b/lib/storage/src/content_manager/toc/telemetry.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
+use ahash::HashSet;
 use collection::operations::types::CollectionResult;
 use collection::telemetry::{
     CollectionSnapshotTelemetry, CollectionTelemetry, CollectionsAggregatedTelemetry,
@@ -52,6 +53,7 @@ impl TableOfContent {
         &self,
         detail: TelemetryDetail,
         access: &Access,
+        only_collections: Option<HashSet<String>>,
         timeout: Duration,
         is_stopped: &AtomicBool,
     ) -> CollectionResult<TocTelemetryData> {
@@ -60,6 +62,11 @@ impl TableOfContent {
         for collection_pass in &all_collections {
             if is_stopped.load(Ordering::Relaxed) {
                 break;
+            }
+            if let Some(only_collections) = &only_collections
+                && !only_collections.contains(collection_pass.name())
+            {
+                continue;
             }
             if let Ok(collection) = self.get_collection(collection_pass).await {
                 collection_telemetry.push(collection.get_telemetry_data(detail, timeout).await?);

--- a/src/actix/api/service_api.rs
+++ b/src/actix/api/service_api.rs
@@ -59,7 +59,7 @@ fn telemetry(
         let telemetry_data = telemetry_collector
             .lock()
             .await
-            .prepare_data(&access, detail, params.timeout())
+            .prepare_data(&access, detail, None, params.timeout())
             .await?;
         let telemetry_data = if anonymize {
             telemetry_data.anonymize()
@@ -104,6 +104,7 @@ async fn metrics(
                 level: DetailsLevel::Level4,
                 histograms: true,
             },
+            None,
             params.timeout(),
         )
         .await;

--- a/src/common/telemetry.rs
+++ b/src/common/telemetry.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahash::HashSet;
 use api::grpc;
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::telemetry::CollectionTelemetry;
@@ -85,6 +86,7 @@ impl TelemetryCollector {
         &self,
         access: &Access,
         detail: TelemetryDetail,
+        only_collections: Option<HashSet<String>>,
         timeout: Option<Duration>,
     ) -> StorageResult<TelemetryData> {
         let timeout = timeout.unwrap_or(DEFAULT_TELEMETRY_TIMEOUT);
@@ -105,6 +107,7 @@ impl TelemetryCollector {
                     CollectionsTelemetry::collect(
                         detail,
                         &access_collection,
+                        only_collections,
                         &toc,
                         timeout,
                         &is_stopped,

--- a/src/common/telemetry_ops/collections_telemetry.rs
+++ b/src/common/telemetry_ops/collections_telemetry.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
+use ahash::HashSet;
 use collection::operations::types::CollectionResult;
 use collection::telemetry::{
     CollectionSnapshotTelemetry, CollectionTelemetry, CollectionsAggregatedTelemetry,
@@ -36,6 +37,7 @@ impl CollectionsTelemetry {
     pub async fn collect(
         detail: TelemetryDetail,
         access: &Access,
+        only_collections: Option<HashSet<String>>,
         toc: &TableOfContent,
         timeout: Duration,
         is_stopped: &AtomicBool,
@@ -44,7 +46,7 @@ impl CollectionsTelemetry {
         let (collections, snapshots) = if detail.level >= DetailsLevel::Level1 {
             let telemetry_data = if detail.level >= DetailsLevel::Level2 {
                 let toc_telemetry = toc
-                    .get_telemetry_data(detail, access, timeout, is_stopped)
+                    .get_telemetry_data(detail, access, only_collections, timeout, is_stopped)
                     .await?;
 
                 let collections: Vec<_> = toc_telemetry

--- a/src/common/telemetry_reporting.rs
+++ b/src/common/telemetry_reporting.rs
@@ -43,7 +43,7 @@ impl TelemetryReporter {
             .telemetry
             .lock()
             .await
-            .prepare_data(&FULL_ACCESS, DETAIL, None)
+            .prepare_data(&FULL_ACCESS, DETAIL, None, None)
             .await?
             .anonymize();
         let data = serde_json::to_string(&data)?;

--- a/src/tonic/api/qdrant_internal_api.rs
+++ b/src/tonic/api/qdrant_internal_api.rs
@@ -94,7 +94,7 @@ impl QdrantInternal for QdrantInternalService {
 
         let telemetry_collector = self.telemetry_collector.lock().await;
         let telemetry_data = telemetry_collector
-            .prepare_data(&access, detail, Some(timeout))
+            .prepare_data(&access, detail, None, Some(timeout))
             .await?;
 
         let response = GetTelemetryResponse {


### PR DESCRIPTION
Adds `only_collection` parameter to telemetry collection. 

This does not expose it yet in API, but will allow internal service telemetry to work nicely with JWT Access, by separating the need to only including some collections, while also including cluster info.