### PR TITLE
[cluster telemetry] allow collection access with jwt

### DIFF
--- a/lib/api/src/grpc/proto/telemetry_internal.proto
+++ b/lib/api/src/grpc/proto/telemetry_internal.proto
@@ -8,8 +8,14 @@ option csharp_namespace = "Qdrant.Client.Grpc";
 message GetTelemetryRequest {
   // The level of detail needed
   uint32 details_level = 1;
+  // If present, select these collections
+  CollectionsSelector collections_selector = 2;
   // Timeout in secs for the request
-  uint64 timeout = 2;
+  uint64 timeout = 3;
+}
+
+message CollectionsSelector {
+  repeated string only_collections = 1;
 }
 
 message GetTelemetryResponse {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -12453,9 +12453,19 @@ pub struct GetTelemetryRequest {
     /// The level of detail needed
     #[prost(uint32, tag = "1")]
     pub details_level: u32,
+    /// If present, select these collections
+    #[prost(message, optional, tag = "2")]
+    pub collections_selector: ::core::option::Option<CollectionsSelector>,
     /// Timeout in secs for the request
-    #[prost(uint64, tag = "2")]
+    #[prost(uint64, tag = "3")]
     pub timeout: u64,
+}
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionsSelector {
+    #[prost(string, repeated, tag = "1")]
+    pub only_collections: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -378,7 +378,7 @@ ACTION_ACCESS = {
     ),
     ### Cluster ###
     "get_cluster": EndpointAccess(True, False, True, "GET /cluster", coll_r=False),
-    "cluster_telemetry": EndpointAccess(True, False, True, "GET /cluster/telemetry", coll_r=False),
+    "cluster_telemetry": EndpointAccess(True, True, True, "GET /cluster/telemetry"),
     "recover_raft_state": EndpointAccess(False, False, True, "POST /cluster/recover"),
     "delete_peer": EndpointAccess(False, False, True, "DELETE /cluster/peer/{peer_id}"),
     ### Points ###


### PR DESCRIPTION
Instead of requiring global access, this PR enables cluster telemetry to just show specific collections if jwt access is restricted by collection