### PR TITLE
Notify optimization handles to stop on shard drop

### DIFF
--- a/lib/collection/src/shards/local_shard/drop.rs
+++ b/lib/collection/src/shards/local_shard/drop.rs
@@ -47,6 +47,7 @@ impl Drop for LocalShard {
                         return true;
                     }
                     update_handler.stop_flush_worker();
+                    update_handler.notify_optimization_handles_to_stop();
                 }
 
                 // This can block longer, if the channel is full

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -235,6 +235,17 @@ impl UpdateHandler {
         }
     }
 
+    /// Notify optimization handles to stop *without* waiting
+    ///
+    /// Blocking operation
+    pub fn notify_optimization_handles_to_stop(&self) {
+        log::trace!("notify optimization handles to stop");
+        let opt_handles_guard = self.optimization_handles.blocking_lock();
+        for handle in opt_handles_guard.iter() {
+            handle.ask_to_stop();
+        }
+    }
+
     /// Gracefully wait before all optimizations stop
     /// If some optimization is in progress - it will be finished before shutdown.
     pub async fn wait_workers_stops(&mut self) -> CollectionResult<()> {


### PR DESCRIPTION
This PR is a fix to restore a proper shutdown on ctr+c.

Currently the running optimizations are preventing the Qdrant process to shutdown.

The fix is to notify the optimization handles to flip the cancellation flag internally.

No need to wait for an acknowledgement, the optimization loops will eventually stop.

Manually tested with

```bash
bfb -n 10M -d 256 --keywords 100  --float-payloads true --int-payloads 2 --uuid-payloads --bool-payloads --geo-payloads --text-payloads
```