### PR TITLE
Register trackers only after successfull start

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -364,6 +364,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -397,6 +398,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -527,6 +529,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -568,6 +571,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -704,6 +708,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -748,6 +753,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -400,6 +400,7 @@ mod tests {
                 budget.clone(),
                 &stopped,
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
 
@@ -550,6 +551,7 @@ mod tests {
                 budget.clone(),
                 &stopped,
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         eprintln!("Done");
@@ -567,6 +569,7 @@ mod tests {
                 budget.clone(),
                 &stopped,
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
 
@@ -697,6 +700,7 @@ mod tests {
                 budget.clone(),
                 &stopped,
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
 
@@ -818,6 +822,7 @@ mod tests {
                     budget.clone(),
                     &stopped,
                     ProgressTracker::new_for_test(),
+                    Box::new(|| ()),
                 )
                 .unwrap();
             numer_of_optimizations += 1;
@@ -988,6 +993,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -258,6 +258,7 @@ mod tests {
                 budget,
                 &AtomicBool::new(false),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
 

--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -602,6 +602,7 @@ pub trait SegmentOptimizer {
     /// If there were any record changes during the optimization - an additional plain segment will be created.
     ///
     /// Returns id of the created optimized segment. If no optimization was done - returns None
+    #[expect(clippy::too_many_arguments)]
     fn optimize(
         &self,
         segments: LockedSegmentHolder,
@@ -610,6 +611,7 @@ pub trait SegmentOptimizer {
         resource_budget: ResourceBudget,
         stopped: &AtomicBool,
         progress: ProgressTracker,
+        on_successful_start: Box<dyn FnOnce()>,
     ) -> CollectionResult<usize> {
         check_process_stopped(stopped)?;
 
@@ -655,6 +657,8 @@ pub trait SegmentOptimizer {
         }
 
         check_process_stopped(stopped)?;
+
+        on_successful_start();
 
         let hw_counter = HardwareCounterCell::disposable(); // Internal operation, no measurement needed!
 

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -356,6 +356,7 @@ mod tests {
                 budget.clone(),
                 &AtomicBool::new(false),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
 
@@ -509,6 +510,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");
@@ -626,6 +628,7 @@ mod tests {
                 budget.clone(),
                 &false.into(),
                 ProgressTracker::new_for_test(),
+                Box::new(|| ()),
             )
             .unwrap();
         assert!(changed > 0, "optimizer should have rebuilt this segment");

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -342,7 +342,6 @@ impl UpdateWorkers {
                             let (tracker, progress) =
                                 Tracker::start(optimizer.as_ref().name(), nsi.clone());
                             let tracker_handle = tracker.handle();
-                            optimizers_log.lock().register(tracker);
 
                             // Optimize and handle result
                             let result = optimizer.as_ref().optimize(
@@ -352,6 +351,11 @@ impl UpdateWorkers {
                                 resource_budget,
                                 stopped,
                                 progress,
+                                Box::new(move || {
+                                    // Do not clutter the log with early cancelled optimizations,
+                                    // wait for `on_successful_start` instead.
+                                    optimizers_log.lock().register(tracker);
+                                }),
                             );
                             match result {
                                 // Perform some actions when optimization if finished


### PR DESCRIPTION
# Problem

The optimizers log is polluted with empty cancelled trackers. Consequently, the optimizations endpoint added in #7625 includes many entries like this:
```json
{
  "name": "Segment Optimizing",
  "started_at": "2025-12-09T16:06:18.594754171Z",
  "finished_at": "2025-12-09T16:06:18.944208155Z",
  "duration_sec": 0.349453884
},
{
  "name": "Segment Optimizing",
  "started_at": "2025-12-09T16:06:18.592540546Z",
  "finished_at": "2025-12-09T16:06:18.944175295Z",
  "duration_sec": 0.351634589
}
```

# Solution
Postpone `TrackerLog::register()` after checking for `all_segments_ok` inside `SegmentOptimizer::optimize`.
