### PR TITLE
urlencode collection_name on calling partial snapshot create API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5241,6 +5241,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "tracing-tracy",
+ "urlencoding",
  "uuid",
  "validator",
  "wal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ sys-info = "0.9.1"
 wal = { workspace = true }
 ordered-float = { workspace = true }
 ahash = { workspace = true }
+urlencoding = { workspace = true }
 
 config = { version = "0.15.13", default-features = false, features = ["yaml"] }
 

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -734,8 +734,9 @@ async fn recover_partial_snapshot_from(
 
             let http_client = http_client.client(api_key.as_deref())?;
 
+            let encoded_collection_name = urlencoding::encode(&collection_name);
             let create_snapshot_url = format!(
-                "{peer_url}/collections/{collection_name}/shards/{shard_id}/snapshot/partial/create"
+                "{peer_url}/collections/{encoded_collection_name}/shards/{shard_id}/snapshot/partial/create"
             );
 
             let snapshot_manifest = collection.get_partial_snapshot_manifest(shard_id).await?;


### PR DESCRIPTION
Otherwise partial snapshots on `test%20collection` fails.