### PR TITLE
Init snapshot metrics on collection creation

### DIFF
--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -250,6 +250,8 @@ impl TableOfContent {
                 );
                 existing_collection.stop_gracefully().await;
             }
+
+            self.telemetry.init_snapshot_telemetry(collection_name);
         }
 
         drop(collection_create_guard);

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -164,8 +164,15 @@ impl TableOfContent {
                 storage_config.optimizers_overwrite.clone(),
             ));
 
-            collections.insert(collection_name, collection);
+            collections.insert(collection_name.clone(), collection);
         }
+
+        // Initialize snapshot telemetry for all loaded collections.
+        let telemetry = TocTelemetryCollector::default();
+        for collection_name in collections.keys() {
+            telemetry.init_snapshot_telemetry(collection_name);
+        }
+
         let alias_path = Path::new(&storage_config.storage_path).join(ALIASES_PATH);
         let alias_persistence = AliasPersistence::open(&alias_path)
             .expect("Can't open database by the provided config");
@@ -202,7 +209,7 @@ impl TableOfContent {
             update_rate_limiter: rate_limiter,
             collection_create_lock: Default::default(),
             collection_hw_metrics: DashMap::new(),
-            telemetry: TocTelemetryCollector::default(),
+            telemetry,
         }
     }
 

--- a/lib/storage/src/content_manager/toc/telemetry.rs
+++ b/lib/storage/src/content_manager/toc/telemetry.rs
@@ -19,6 +19,15 @@ pub(super) struct TocTelemetryCollector {
     snapshots: DashMap<String, SnapshotTelemetryCollector>,
 }
 
+impl TocTelemetryCollector {
+    /// Initialize snapshot telemetry entry for a collection.
+    pub fn init_snapshot_telemetry(&self, collection_name: &str) {
+        self.snapshots
+            .entry(collection_name.to_string())
+            .or_default();
+    }
+}
+
 /// Collected telemetry data provided by ToC.
 pub struct TocTelemetryData {
     pub collection_telemetry: Vec<CollectionTelemetry>,


### PR DESCRIPTION
Snapshot metrics will now appear for all collections immediately. Previously, snapshot metrics (snapshots_created_total, snapshots_creation_running, snapshots_recovery_running) only appeared in /metrics after a snapshot operation was performed on a collection. This was due to lazy initialization of telemetry entries in the DashMap.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
