### PR TITLE
Gridstore noisy log into assert

### DIFF
--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -281,7 +281,10 @@ impl Tracker {
                 if is_empty {
                     let prev = self.pending_updates.remove(&point_offset);
                     if let Some(prev) = prev {
-                        log::trace!("removed pending update offset:{point_offset} prev:{prev:?}");
+                        debug_assert!(
+                            prev.is_empty(),
+                            "remove pending element should be empty but got {prev:?}"
+                        );
                     }
                 }
             }


### PR DESCRIPTION
This log is an artifact from a previous debugging session which is in practice very noisy for crasher's runs.

```
2025-12-17T11:33:21.084481Z TRACE gridstore::tracker: removed pending update offset:451 prev:PointerUpdates { current: None, to_free: [] }
2025-12-17T11:33:21.084489Z TRACE gridstore::tracker: removed pending update offset:443 prev:PointerUpdates { current: None, to_free: [] }
2025-12-17T11:33:21.084498Z TRACE gridstore::tracker: removed pending update offset:440 prev:PointerUpdates { current: None, to_free: [] }
2025-12-17T11:33:21.084507Z TRACE gridstore::tracker: removed pending update offset:444 prev:PointerUpdates { current: None, to_free: [] }
2025-12-17T11:33:21.084515Z TRACE gridstore::tracker: removed pending update offset:446 prev:PointerUpdates { current: None, to_free: [] }
2025-12-17T11:33:21.084524Z TRACE gridstore::tracker: removed pending update offset:448 prev:PointerUpdates { current: None, to_free: [] }
``` 

The pointer updates are expected to be empty at this point, so let's remove the log and turn it into an assertion.