### PR TITLE
Replace --all to --workspace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 1. [ ] Does your submission pass tests?
 2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
-3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?
+3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?
 
 ### Changes to Core Features:
 

--- a/lib/collection/tests/integration/continuous_snapshot_test.rs
+++ b/lib/collection/tests/integration/continuous_snapshot_test.rs
@@ -32,7 +32,7 @@ use crate::common::{
     dummy_request_shard_transfer,
 };
 
-// RUST_LOG=trace cargo nextest run --all continuous --nocapture
+// RUST_LOG=trace cargo nextest run --workspace continuous --nocapture
 #[tokio::test(flavor = "multi_thread")]
 async fn test_continuous_snapshot() {
     // Initialize logger for tests


### PR DESCRIPTION
The `--all` option is deprecated for `cargo check/build/clippy/test` and its presence can be confusing, because other places in the code use `--workspace`.