### PR TITLE
Revert flusher cancellation to unblock v1.16.3 release

### DIFF
--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use common::panic;
-use segment::common::operation_error::{OperationError, OperationResult};
+use segment::common::operation_error::OperationResult;
 use segment::types::SeqNumberType;
 use shard::segment_holder::LockedSegmentHolder;
 use shard::wal::WalError;
@@ -66,19 +66,8 @@ impl UpdateWorkers {
         let confirmed_version = match confirmed_version {
             Ok(version) => version,
             Err(err) => {
-                // Since Self::flush_segments is flushing asynchronously, we can get the error
-                // from the previous flush cycle, not necessarily this one.
-                match err {
-                    OperationError::Cancelled { description: _ } => {
-                        log::debug!("Flush was cancelled: {err}");
-                        // Don't report as optimizer error here, since cancellation can happen due to
-                        // trying to flush an already dropped segment
-                    }
-                    _ => {
-                        log::error!("Failed to flush: {err}");
-                        segments.write().report_optimizer_error(err);
-                    }
-                }
+                log::error!("Failed to flush: {err}");
+                segments.write().report_optimizer_error(err);
                 return;
             }
         };

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -8,7 +8,7 @@ use parking_lot::{Mutex, RwLock};
 
 use super::dynamic_mmap_flags::DynamicMmapFlags;
 use crate::common::Flusher;
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 
 /// A buffered wrapper around DynamicMmapFlags that provides manual flushing, without interface for reading.
 ///
@@ -66,12 +66,13 @@ impl BufferedDynamicFlags {
         let is_alive_flush_lock = self.is_alive_flush_lock.handle();
 
         Box::new(move || {
-            let (Some(is_alive_flush_guard), Some(flags_arc)) =
-                (is_alive_flush_lock.lock_if_alive(), flags_arc.upgrade())
-            else {
-                return Err(OperationError::cancelled(
-                    "Aborted flushing on a dropped BufferedDynamicFlags instance",
-                ));
+            let Some(is_alive_flush_guard) = is_alive_flush_lock.lock_if_alive() else {
+                return Ok(());
+            };
+
+            let Some(flags_arc) = flags_arc.upgrade() else {
+                log::debug!("skipping flushing on deleted storage");
+                return Ok(());
             };
 
             // lock for the entire flushing process

--- a/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
+++ b/lib/segment/src/common/mmap_bitslice_buffered_update_wrapper.rs
@@ -7,7 +7,6 @@ use memory::mmap_type::MmapBitSlice;
 use parking_lot::{Mutex, RwLock};
 
 use crate::common::Flusher;
-use crate::common::operation_error::OperationError;
 
 /// A wrapper around `MmapBitSlice` that delays writing changes to the underlying file until they get
 /// flushed manually.
@@ -80,17 +79,16 @@ impl MmapBitSliceBufferedUpdateWrapper {
         Box::new(move || {
             let Some(is_alive_flush_guard) = is_alive_flush_lock.lock_if_alive() else {
                 // Already dropped, skip flush
-                return Err(OperationError::cancelled(
-                    "Aborted flushing on a dropped MmapBitSliceBufferedUpdateWrapper instance",
-                ));
+                return Ok(());
             };
 
             let (Some(bitslice), Some(pending_updates_arc)) =
                 (bitslice.upgrade(), pending_updates_arc.upgrade())
             else {
-                return Err(OperationError::cancelled(
-                    "Aborted flushing on a dropped MmapBitSliceBufferedUpdateWrapper instance",
-                ));
+                log::debug!(
+                    "Aborted flushing on a dropped MmapBitSliceBufferedUpdateWrapper instance"
+                );
+                return Ok(());
             };
 
             let mut mmap_slice_write = bitslice.write();

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -112,12 +112,6 @@ impl OperationError {
         }
     }
 
-    pub fn cancelled(description: impl Into<String>) -> Self {
-        Self::Cancelled {
-            description: description.into(),
-        }
-    }
-
     pub fn vector_name_not_exists(vector_name: impl Into<String>) -> Self {
         Self::VectorNameNotExists {
             received_name: vector_name.into(),

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -706,9 +706,7 @@ impl SegmentEntry for Segment {
         let flush_op = move || {
             let Some(is_alive_flush_guard) = is_alive_flush_lock.lock_if_alive() else {
                 // Segment is removed, skip flush
-                return Err(OperationError::cancelled(
-                    "Aborted flushing on a dropped segment",
-                ));
+                return Ok(());
             };
 
             // Flush mapping first to prevent having orphan internal ids.


### PR DESCRIPTION
Revert <https://github.com/qdrant/qdrant/pull/7781> to unblock a patch release.

We merged that PR with good intent, but it uncovered some behavior we don't fully understand yet. We need to invest a bit more time on it before we're confident we can push that to production.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?