### PR TITLE
Add some context to background flush error propagation

### DIFF
--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -124,9 +124,12 @@ impl SegmentHolder {
         std::mem::swap(&mut join_handle, &mut lock);
         if let Some(join_handle) = join_handle {
             // Flush result was reported to segment, so we don't need this value anymore
-            join_handle
+            let flush_result = join_handle
                 .join()
-                .map_err(|_err| OperationError::service_error("failed to join flush thread"))??;
+                .map_err(|_err| OperationError::service_error("failed to join flush thread"))?;
+            flush_result.map_err(|err| {
+                OperationError::service_error(format!("last background flush failed: {err}"))
+            })?;
         }
         Ok(lock)
     }


### PR DESCRIPTION
We can join a background flushing thread in other places, in our snapshot logic for example.

This extends the error with "last background flush failed:" so that it is more obvious the error originates from a previous background flush.

Also gets rid of a double try (`??`).

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?