### PR TITLE
More segments lock timeout on read

### DIFF
--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -122,7 +122,12 @@ impl LocalShard {
             let hw_acc = hw_measurement_acc.clone();
             async move {
                 let count = self
-                    .read_filtered(filter.as_ref(), search_runtime_handle, hw_acc)
+                    .read_filtered(
+                        filter.as_ref(),
+                        search_runtime_handle,
+                        hw_acc,
+                        Some(timeout.saturating_sub(instant.elapsed())),
+                    )
                     .await?
                     .len();
                 CollectionResult::Ok(FacetValueHit { value, count })

--- a/lib/collection/src/shards/local_shard/formula_rescore.rs
+++ b/lib/collection/src/shards/local_shard/formula_rescore.rs
@@ -36,6 +36,7 @@ impl LocalShard {
             arc_ctx,
             &self.search_runtime,
             hw_measurement_acc,
+            timeout,
         );
 
         let res = tokio::time::timeout(timeout, future)

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -841,9 +841,10 @@ impl LocalShard {
         filter: Option<&'a Filter>,
         runtime_handle: &Handle,
         hw_counter: HwMeasurementAcc,
+        timeout: Option<Duration>,
     ) -> CollectionResult<BTreeSet<PointIdType>> {
         let segments = self.segments.clone();
-        SegmentsSearcher::read_filtered(segments, filter, runtime_handle, hw_counter).await
+        SegmentsSearcher::read_filtered(segments, filter, runtime_handle, hw_counter, timeout).await
     }
 
     pub async fn local_shard_status(&self) -> (ShardStatus, OptimizersStatus) {

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -258,6 +258,7 @@ impl ShardOperation for LocalShard {
                     request.filter.as_ref(),
                     search_runtime_handle,
                     hw_measurement_acc,
+                    Some(timeout),
                 ),
             )
             .await

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -214,7 +214,12 @@ impl ShardOperation for ProxyShard {
                 } else {
                     let runtime_handle = self.wrapped_shard.search_runtime.clone();
                     let points = local_shard
-                        .read_filtered(Some(filter), &runtime_handle, hw_measurement_acc.clone())
+                        .read_filtered(
+                            Some(filter),
+                            &runtime_handle,
+                            hw_measurement_acc.clone(),
+                            None, // no timeout on update path
+                        )
                         .await?;
                     PointsOperationEffect::Some(points.into_iter().collect())
                 }


### PR DESCRIPTION
This PR adds a few missing timeout on the segment holder acquisition for various read operations.

I did not perform it as well on the individual segment as it makes things quite ugly.

This PR is keeping the existing style while we research a better way to pass deadlines around.
