### PR TITLE
Bump dev version to 1.16.4-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "api"
-version = "1.16.3-dev"
+version = "1.16.4-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.16.3-dev"
+version = "1.16.4-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.16.3-dev"
+version = "1.16.4-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.16.3-dev"
+version = "1.16.4-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.16.3-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.16.4-dev";
 
 lazy_static! {
     /// Current Qdrant semver version


### PR DESCRIPTION
Bumps the development version to 1.16.4-dev for the [Qdrant 1.16.3](https://github.com/qdrant/qdrant/releases/tag/v1.16.3) ([PR](https://github.com/qdrant/qdrant/pull/7806)) release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/7682>