### PR TITLE
Add security caution banner to quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker run -p 6333:6333 qdrant/qdrant
 ```
 
 > [!CAUTION]
-> Starts an insecure deployment without authentication open to all network interfaces. Refer to [secure your instance](https://qdrant.tech/documentation/guides/security/#secure-your-instance) for more details.
+> Starts an insecure deployment without authentication open to all network interfaces. Please refer to [secure your instance](https://qdrant.tech/documentation/guides/security/#secure-your-instance).
 
 Now you can connect to this with any client, including Python:
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -18,7 +18,7 @@ docker run -p 6333:6333 qdrant/qdrant
 ```
 
 > [!CAUTION]
-> Starts an insecure deployment without authentication open to all network interfaces. Refer to [secure your instance](https://qdrant.tech/documentation/guides/security/#secure-your-instance) for more details.
+> Starts an insecure deployment without authentication open to all network interfaces. Please refer to [secure your instance](https://qdrant.tech/documentation/guides/security/#secure-your-instance).
 
 Build your own from source
 


### PR DESCRIPTION
Emphasize deployments with quick start command are **not** secure:

Docs now refer:

<img width="1591" height="688" alt="image" src="https://github.com/user-attachments/assets/54eef0a2-73e4-44d1-811f-e2aa01377bf3" />

To a dedicated section like this (<https://github.com/qdrant/landing_page/pull/2061>):

<img width="1332" height="832" alt="image" src="https://github.com/user-attachments/assets/502070d2-1fd6-4f7f-b7da-34c274d23ebe" />


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?