### PR TITLE
Add f16 NEON support for ARM Windows

### DIFF
--- a/lib/segment/build.rs
+++ b/lib/segment/build.rs
@@ -4,6 +4,9 @@ fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH env-var is not defined or is not UTF-8");
 
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
     // TODO: Is `CARGO_CFG_TARGET_FEATURE` *always* defined?
     //
     // Cargo docs says that "boolean configurations are present if they are set,
@@ -16,8 +19,22 @@ fn main() {
     if target_arch == "aarch64" && target_feature.split(',').any(|feat| feat == "neon") {
         let mut builder = cc::Build::new();
         builder.file("src/spaces/metric_f16/cpp/neon.c");
-        builder.flag("-O3");
-        builder.flag("-march=armv8.2-a+fp16");
+
+        // MSVC on Windows ARM64 uses different compiler flags
+        let is_msvc = target_os == "windows" && target_env == "msvc";
+        if is_msvc {
+            // MSVC ARM64 flags
+            // /O2 for optimization, /arch:armv8.2 for ARMv8.2-A with FP16
+            // Note: MSVC uses /fp:fast for floating-point optimizations
+            builder.flag("/O2");
+            // Define macro to indicate MSVC compilation for neon.c
+            builder.define("_MSC_VER_QDRANT", None);
+        } else {
+            // GCC/Clang flags
+            builder.flag("-O3");
+            builder.flag("-march=armv8.2-a+fp16");
+        }
+
         builder.compile("simd_utils");
     }
 }

--- a/lib/segment/src/spaces/metric_f16/mod.rs
+++ b/lib/segment/src/spaces/metric_f16/mod.rs
@@ -6,7 +6,7 @@ pub mod simple_manhattan;
 #[cfg(target_arch = "x86_64")]
 pub mod avx;
 
-#[cfg(all(target_arch = "aarch64", not(windows)))]
+#[cfg(target_arch = "aarch64")]
 pub mod neon;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
## Summary

This PR enables half-precision (f16) NEON SIMD acceleration on Windows ARM64 systems (`aarch64-pc-windows-msvc`).

Previously, f16 NEON was disabled on Windows due to linking errors between Rust and C code (see #7686). This was a hotfix that excluded Windows ARM from f16 NEON optimizations entirely.

### Changes

- **`lib/segment/src/spaces/metric_f16/mod.rs`**: Remove the `not(windows)` condition from the neon module cfg
- **`lib/segment/build.rs`**: Detect MSVC and use appropriate compiler flags (`/O2` instead of `-O3`, `-march`)
- **`lib/segment/src/spaces/metric_f16/cpp/neon.c`**: Add MSVC compatibility:
  - Use `arm64_neon.h` instead of `arm_neon.h` for MSVC
  - Add `QDRANT_FP16_NEON_ENABLED` macro for unified cross-platform feature detection
  - Provide `vabsh_f16` fallback implementation for MSVC compatibility

### Technical Details

The core issue was that MSVC does not define `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` (which GCC/Clang define), causing the C code to be empty and resulting in unresolved external symbols during linking.

The fix introduces a unified `QDRANT_FP16_NEON_ENABLED` macro that is set:
- On MSVC: Always enabled (MSVC ARM64 supports FP16 intrinsics)
- On GCC/Clang: Only when `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` is defined

## Test plan

- [x] Verified compilation on macOS ARM64 (Apple Silicon)
- [x] All f16 NEON tests pass (`cargo test -p segment --lib -- metric_f16`)
- [x] Full workspace compilation succeeds
- [ ] Needs testing on actual Windows ARM64 device

Fixes #7718

🤖 Generated with [Claude Code](https://claude.com/claude-code)