### PR TITLE
Add explicit `SharedShardHolder` type instead of `LockedShardHolder` type-alias

### DIFF
--- a/lib/collection/src/collection/clean.rs
+++ b/lib/collection/src/collection/clean.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ahash::AHashMap;
@@ -15,7 +15,7 @@ use super::Collection;
 use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
 use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::shard_holder::{SharedShardHolder, WeakShardHolder};
 use crate::telemetry::{
     ShardCleanStatusFailedTelemetry, ShardCleanStatusProgressTelemetry, ShardCleanStatusTelemetry,
 };
@@ -59,7 +59,7 @@ impl ShardCleanTasks {
     /// will not abort any ongoing task.
     async fn clean_and_await(
         &self,
-        shards_holder: &Arc<LockedShardHolder>,
+        shards_holder: &SharedShardHolder,
         shard_id: ShardId,
         wait: bool,
         timeout: Option<Duration>,
@@ -197,9 +197,9 @@ pub(super) struct ShardCleanTask {
 
 impl ShardCleanTask {
     /// Create a new shard clean task and immediately execute it
-    pub fn new(shards_holder: &Arc<LockedShardHolder>, shard_id: ShardId) -> Self {
+    pub fn new(shards_holder: &SharedShardHolder, shard_id: ShardId) -> Self {
         let (sender, receiver) = tokio::sync::watch::channel(ShardCleanStatus::Started);
-        let shard_holder = Arc::downgrade(shards_holder);
+        let shard_holder = shards_holder.downgrade();
         let cancel = CancellationToken::default();
 
         let task = tokio::task::spawn(Self::task(shard_holder, shard_id, sender, cancel.clone()));
@@ -225,7 +225,7 @@ impl ShardCleanTask {
     }
 
     async fn task(
-        shard_holder: Weak<LockedShardHolder>,
+        shard_holder: WeakShardHolder,
         shard_id: ShardId,
         sender: Sender<ShardCleanStatus>,
         cancel: CancellationToken,
@@ -254,7 +254,7 @@ impl ShardCleanTask {
 }
 
 async fn clean_task(
-    shard_holder: Weak<LockedShardHolder>,
+    shard_holder: WeakShardHolder,
     shard_id: ShardId,
     sender: Sender<ShardCleanStatus>,
 ) -> CollectionResult<()> {

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Arc;
 
 use common::tar_ext::BuilderExt;
 use common::tempfile_ext::MaybeTempPath;
@@ -286,8 +285,8 @@ impl Collection {
         temp_dir: &Path,
     ) -> CollectionResult<SnapshotStream> {
         let shard = OwnedRwLockReadGuard::try_map(
-            Arc::clone(&self.shards_holder).read_owned().await,
-            |x| x.get_shard(shard_id),
+            self.shards_holder.clone().read_owned().await,
+            |shard_holder| shard_holder.get_shard(shard_id),
         )
         .map_err(|_| shard_not_found_error(shard_id))?;
 

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,5 +1,6 @@
 mod resharding;
 pub(crate) mod shard_mapping;
+pub mod shared_shard_holder;
 
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref as _;
@@ -28,6 +29,7 @@ use tokio::sync::{OwnedRwLockReadGuard, RwLock, broadcast};
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::io::SyncIoBridge;
 
+pub use self::shared_shard_holder::*;
 use super::replica_set::snapshots::RecoveryType;
 use super::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use super::resharding::{ReshardState, ReshardingStage};
@@ -73,8 +75,6 @@ pub struct ShardHolder {
     shard_id_to_key_mapping: AHashMap<ShardId, ShardKey>,
     sharding_method: ShardingMethod,
 }
-
-pub type LockedShardHolder = RwLock<ShardHolder>;
 
 impl ShardHolder {
     pub async fn trigger_optimizers(&self) {

--- a/lib/collection/src/shards/shard_holder/shared_shard_holder.rs
+++ b/lib/collection/src/shards/shard_holder/shared_shard_holder.rs
@@ -1,0 +1,43 @@
+use std::sync::{Arc, Weak};
+
+use tokio::sync;
+
+use super::ShardHolder;
+
+#[derive(Clone)]
+pub struct SharedShardHolder(Arc<sync::RwLock<ShardHolder>>);
+
+impl SharedShardHolder {
+    pub fn new(shard_holder: ShardHolder) -> Self {
+        Self(Arc::new(sync::RwLock::new(shard_holder)))
+    }
+
+    pub async fn read(&self) -> sync::RwLockReadGuard<'_, ShardHolder> {
+        self.0.read().await
+    }
+
+    pub async fn read_owned(self) -> sync::OwnedRwLockReadGuard<ShardHolder> {
+        self.0.read_owned().await
+    }
+
+    pub async fn write(&self) -> sync::RwLockWriteGuard<'_, ShardHolder> {
+        self.0.write().await
+    }
+
+    pub async fn write_owned(self) -> sync::OwnedRwLockWriteGuard<ShardHolder> {
+        self.0.write_owned().await
+    }
+
+    pub fn downgrade(&self) -> WeakShardHolder {
+        WeakShardHolder(Arc::downgrade(&self.0))
+    }
+}
+
+#[derive(Clone)]
+pub struct WeakShardHolder(Weak<sync::RwLock<ShardHolder>>);
+
+impl WeakShardHolder {
+    pub fn upgrade(&self) -> Option<SharedShardHolder> {
+        self.0.upgrade().map(SharedShardHolder)
+    }
+}

--- a/lib/collection/src/shards/transfer/driver.rs
+++ b/lib/collection/src/shards/transfer/driver.rs
@@ -17,7 +17,7 @@ use crate::operations::types::CollectionResult;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::{LockedShardHolder, ShardHolder};
+use crate::shards::shard_holder::{ShardHolder, SharedShardHolder};
 use crate::shards::{CollectionId, await_consensus_sync};
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -35,7 +35,7 @@ pub(crate) const MAX_RETRY_COUNT: usize = 3;
 pub async fn transfer_shard(
     transfer_config: ShardTransfer,
     progress: Arc<Mutex<TransferTaskProgress>>,
-    shard_holder: Arc<LockedShardHolder>,
+    shard_holder: SharedShardHolder,
     consensus: &dyn ShardTransferConsensus,
     collection_id: CollectionId,
     channel_service: ChannelService,
@@ -193,7 +193,7 @@ pub async fn revert_proxy_shard_to_local(
 
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_transfer_task<T, F>(
-    shards_holder: Arc<LockedShardHolder>,
+    shards_holder: SharedShardHolder,
     progress: Arc<Mutex<TransferTaskProgress>>,
     transfer: ShardTransfer,
     consensus: Box<dyn ShardTransferConsensus>,

--- a/lib/collection/src/shards/transfer/resharding_stream_records.rs
+++ b/lib/collection/src/shards/transfer/resharding_stream_records.rs
@@ -9,7 +9,7 @@ use crate::operations::types::{CollectionError, CollectionResult, CountRequestIn
 use crate::shards::CollectionId;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::shard_holder::SharedShardHolder;
 use crate::shards::transfer::stream_records::TRANSFER_BATCH_SIZE;
 
 /// Orchestrate shard transfer by streaming records, but only the points that fall into the new
@@ -25,7 +25,7 @@ use crate::shards::transfer::stream_records::TRANSFER_BATCH_SIZE;
 ///
 /// This function is cancel safe.
 pub(crate) async fn transfer_resharding_stream_records(
-    shard_holder: Arc<LockedShardHolder>,
+    shard_holder: SharedShardHolder,
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -15,7 +15,7 @@ use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::shard_holder::SharedShardHolder;
 
 /// Orchestrate shard snapshot transfer
 ///
@@ -156,7 +156,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn transfer_snapshot(
     transfer_config: ShardTransfer,
-    shard_holder: Arc<LockedShardHolder>,
+    shard_holder: SharedShardHolder,
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,

--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -10,7 +10,7 @@ use crate::shards::CollectionId;
 use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::shard_holder::SharedShardHolder;
 use crate::shards::transfer::{ShardTransfer, ShardTransferConsensus};
 
 pub(super) const TRANSFER_BATCH_SIZE: usize = 100;
@@ -32,7 +32,7 @@ const STATE_ACTIVE_READ_MIN_VERSION: Version = Version::new(1, 16, 0);
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn transfer_stream_records(
     transfer_config: ShardTransfer,
-    shard_holder: Arc<LockedShardHolder>,
+    shard_holder: SharedShardHolder,
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,

--- a/lib/collection/src/shards/transfer/wal_delta.rs
+++ b/lib/collection/src/shards/transfer/wal_delta.rs
@@ -10,7 +10,7 @@ use crate::shards::CollectionId;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::LockedShardHolder;
+use crate::shards::shard_holder::SharedShardHolder;
 
 /// Orchestrate shard diff transfer
 ///
@@ -73,7 +73,7 @@ use crate::shards::shard_holder::LockedShardHolder;
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn transfer_wal_delta(
     transfer_config: ShardTransfer,
-    shard_holder: Arc<LockedShardHolder>,
+    shard_holder: SharedShardHolder,
     progress: Arc<Mutex<TransferTaskProgress>>,
     shard_id: ShardId,
     remote_shard: RemoteShard,


### PR DESCRIPTION
**Motivation:** easier to navigate and debug `ShardHolder`-related issues

E.g.:
- **"find all references" on `read`/`write` methods shows every single place where `ShardHolder` is locked**
  - it's also very easy to instrument (log, time, etc) shard holder locks now
- "find all references" on `SharedShardHolder` shows every single place where it's used
  - there were one or two places where `RwLock<ShardHolder>` was used instead of `LockedShardHolder`  type-alias, which did not show up if you "find all references" on type-alias

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
