### PR TITLE
Fix abort resharding live-lock

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -36,7 +36,14 @@ impl Collection {
         hw_measurement_acc: HwMeasurementAcc,
         force: bool,
     ) -> CollectionResult<Option<UpdateResult>> {
-        let shard_holder = self.shards_holder.clone().read_owned().await;
+        let shards: Vec<_> = self
+            .shards_holder
+            .clone()
+            .read_owned()
+            .await
+            .all_shards()
+            .map(Arc::clone)
+            .collect();
 
         let results = self
             .update_runtime
@@ -48,25 +55,26 @@ impl Collection {
                 // requests if any of them returns an error, so we *have to* use
                 // `futures::join_all`/`TryStreamExt::collect` instead!
 
-                let local_updates: FuturesUnordered<_> = shard_holder
-                    .all_shards()
-                    .map(|shard| {
-                        // The operation *can't* have a clock tag!
-                        //
-                        // We update *all* shards with a single operation, but each shard has it's own clock,
-                        // so it's *impossible* to assign any single clock tag to this operation.
-                        shard.update_local(
-                            OperationWithClockTag::from(operation.clone()),
-                            wait,
-                            None,
-                            hw_measurement_acc.clone(),
-                            force,
-                        )
-                    })
-                    .collect();
+                let local_updates = FuturesUnordered::new();
+
+                for shard in shards {
+                    // The operation *can't* have a clock tag!
+                    //
+                    // We update *all* shards with a single operation, but each shard has it's own clock,
+                    // so it's *impossible* to assign any single clock tag to this operation.
+                    let operation = OperationWithClockTag::from(operation.clone());
+                    let hw_measurement_acc = hw_measurement_acc.clone();
+
+                    let local_update = async move {
+                        shard
+                            .update_local(operation, wait, None, hw_measurement_acc, force)
+                            .await
+                    };
+
+                    local_updates.push(local_update);
+                }
 
                 let results: Vec<_> = local_updates.collect().await;
-
                 results
             })
             .await?;
@@ -100,10 +108,16 @@ impl Collection {
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<UpdateResult> {
-        let shard_holder = self.shards_holder.clone().read_owned().await;
+        let shard = self
+            .shards_holder
+            .clone()
+            .read_owned()
+            .await
+            .get_shard(shard_selection)
+            .cloned();
 
         let result = self.update_runtime.spawn(async move {
-            let Some(shard) = shard_holder.get_shard(shard_selection) else {
+            let Some(shard) = shard else {
                 return Ok(None);
             };
 
@@ -162,7 +176,9 @@ impl Collection {
                 for (shard, operation) in operations {
                     let operation = shard_holder.split_by_mode(shard.shard_id, operation);
 
+                    let shard = shard.clone();
                     let hw_acc = hw_measurement_acc.clone();
+
                     updates.push(async move {
                         let mut result = UpdateResult {
                             operation_id: None,
@@ -208,8 +224,10 @@ impl Collection {
                     });
                 }
 
-                let results: Vec<_> = updates.collect().await;
+                // Do not hold `shard_holder` read-lock during update
+                drop(shard_holder);
 
+                let results: Vec<_> = updates.collect().await;
                 CollectionResult::Ok(results)
             })
             .await??;

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -164,73 +164,67 @@ impl Collection {
         shard_keys_selection: Option<ShardKey>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<UpdateResult> {
-        let shard_holder = self.shards_holder.clone().read_owned().await;
+        let updates = FuturesUnordered::new();
+
+        {
+            let shard_holder = self.shards_holder.clone().read_owned().await;
+            let operations = shard_holder.split_by_shard(operation, &shard_keys_selection)?;
+
+            for (shard, operation) in operations {
+                let operation = shard_holder.split_by_mode(shard.shard_id, operation);
+
+                let shard = shard.clone();
+                let hw_acc = hw_measurement_acc.clone();
+
+                updates.push(async move {
+                    let mut result = UpdateResult {
+                        operation_id: None,
+                        status: UpdateStatus::Acknowledged,
+                        clock_tag: None,
+                    };
+
+                    for operation in operation.update_all {
+                        result = shard
+                            .update_with_consistency(
+                                operation,
+                                wait,
+                                timeout,
+                                ordering,
+                                false,
+                                hw_acc.clone(),
+                            )
+                            .await?;
+                    }
+
+                    for operation in operation.update_only_existing {
+                        let res = shard
+                            .update_with_consistency(
+                                operation,
+                                wait,
+                                timeout,
+                                ordering,
+                                true,
+                                hw_acc.clone(),
+                            )
+                            .await;
+
+                        if let Err(err) = &res
+                            && err.is_missing_point()
+                        {
+                            continue;
+                        }
+
+                        result = res?;
+                    }
+
+                    CollectionResult::Ok(result)
+                });
+            }
+        }
+
         let start_time = std::time::Instant::now();
 
-        let results = self
-            .update_runtime
-            .spawn(async move {
-                let updates = FuturesUnordered::new();
-                let operations = shard_holder.split_by_shard(operation, &shard_keys_selection)?;
-
-                for (shard, operation) in operations {
-                    let operation = shard_holder.split_by_mode(shard.shard_id, operation);
-
-                    let shard = shard.clone();
-                    let hw_acc = hw_measurement_acc.clone();
-
-                    updates.push(async move {
-                        let mut result = UpdateResult {
-                            operation_id: None,
-                            status: UpdateStatus::Acknowledged,
-                            clock_tag: None,
-                        };
-
-                        for operation in operation.update_all {
-                            result = shard
-                                .update_with_consistency(
-                                    operation,
-                                    wait,
-                                    timeout,
-                                    ordering,
-                                    false,
-                                    hw_acc.clone(),
-                                )
-                                .await?;
-                        }
-
-                        for operation in operation.update_only_existing {
-                            let res = shard
-                                .update_with_consistency(
-                                    operation,
-                                    wait,
-                                    timeout,
-                                    ordering,
-                                    true,
-                                    hw_acc.clone(),
-                                )
-                                .await;
-
-                            if let Err(err) = &res
-                                && err.is_missing_point()
-                            {
-                                continue;
-                            }
-
-                            result = res?;
-                        }
-
-                        CollectionResult::Ok(result)
-                    });
-                }
-
-                // Do not hold `shard_holder` read-lock during update
-                drop(shard_holder);
-
-                let results: Vec<_> = updates.collect().await;
-                CollectionResult::Ok(results)
-            })
-            .await??;
+        let results: Vec<_> = self.update_runtime.spawn(updates.collect()).await?;
 
         if results.is_empty() {
             return Err(CollectionError::bad_request(

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -745,19 +745,13 @@ impl ShardReplicaSet {
 
             // Deactivate replica in consensus if it matches the state we expect.
             // We filter out transient transfer states (Partial, Recovery, etc.)
-            // because those can change rapidly between proposal and apply, and
-            // we want the deactivation to go through even if the state has
-            // moved on. Resharding/ReshardingScaleDown are stable through the
-            // resharding lifecycle (only flipped by finish_migrating_points
-            // → Active or by this same deactivation flow → Dead), so we keep
-            // them populated. Carrying the captured pre-state in the consensus
-            // log entry is what lets the local `abort_resharding` side-effect
-            // in `Collection::set_shard_replica_state` re-fire correctly on
-            // replay — without it, replay reads `current_state` as Dead from
-            // disk and silently skips the side-effect, leaving
-            // resharding_state stale.
-            let from_state = Some(peer_state)
-                .filter(|state| !state.is_partial_or_recovery() || state.is_resharding());
+            // because those can change rapidly between proposal and apply.
+            //
+            // Note, we explicitly *don't* want to use `from_state` for `ReshardingScaleDown`,
+            // because it interacts poorly with how abort resharding currently works. 😔
+            //
+            // See https://github.com/qdrant/qdrant/pull/7849#issuecomment-4720894619
+            let from_state = Some(peer_state).filter(|state| !state.is_partial_or_recovery());
 
             self.add_locally_disabled(Some(state), *peer_id, from_state);
         }

--- a/tests/consensus_tests/test_resharding_abort_live_lock.py
+++ b/tests/consensus_tests/test_resharding_abort_live_lock.py
@@ -1,0 +1,34 @@
+import pathlib
+
+from .fixtures import *
+from .test_resharding import all_replicas, bootstrap_resharding, migrate_points
+from .utils import *
+
+
+def test_resharding_abort_live_lock(tmp_path: pathlib.Path):
+    # Bootstrap resharding cluster
+    peer_uris, _ = bootstrap_resharding(tmp_path, direction="down")
+
+    # Trigger resharding transfers to last peer, to put replicas into `ReshardingScaleDown` state
+    info = get_collection_cluster_info(peer_uris[-1], "test_collection")
+
+    target_shard = max(all_replicas(info), key=lambda shard: shard["shard_id"])
+
+    for local_shard in info["local_shards"]:
+        if local_shard["shard_id"] == target_shard["shard_id"]:
+            continue
+
+        migrate_points(
+            peer_uris[0],
+            info["peer_id"],
+            local_shard["shard_id"],
+            target_shard["peer_id"],
+            target_shard["shard_id"],
+            "down",
+        )
+
+    # Kill last peer
+    processes.pop().kill()
+
+    # Upsert some points, to trigger resharding abort live-lock
+    upsert_random_points(peer_uris[0], 20, timeout=20)


### PR DESCRIPTION
We are testing shard-holder live-lock during scale-down resharding abort.

- while applying update, we **hold shard-holder read-lock**
- when consensus marks `ReshardingScaleDown` node as `Dead`, it aborts resharding
  - when aborting resharding, we need to briefly **acquire write-lock to shard-holder**
- when updates to *multiple* shards land in right order, it is possible to have a live-lock, because
  - update holds shard-holder read-lock
  - at the same time, consensus tries to abort resharding, which tries to write-lock shard-holder
  - but update also **waits for abort resharding consensus operation to resolve**
  - which locks consensus operation, because update holds shard-holder read-lock...
  - fortunately, there's a timeout when update is waiting for consensus, so everything unblocks after 30 seconds

So, currently, we expect *last line* in the test (`upsert_random_points`) to fail with a timeout.

On my machine, the test is 80-90% reliable. It _sometimes_ gives false-positive (passes, even though the bug is present), but 4 out of 5 runs fails as expected. It's timing related, not sure how to make it completely deterministic. 😬

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
