### PR TITLE
Fix total count in replicate points progress tracker

### DIFF
--- a/lib/collection/src/shards/transfer/stream_records.rs
+++ b/lib/collection/src/shards/transfer/stream_records.rs
@@ -84,7 +84,7 @@ pub(super) async fn transfer_stream_records(
         };
 
         replica_set
-            .proxify_local(remote_shard.clone(), None, filter)
+            .proxify_local(remote_shard.clone(), None, filter.clone())
             .await?;
 
         // Don't increment hardware usage for internal operations


### PR DESCRIPTION
The transfer progress comment during `replicate_points` transfer was showing full size (assuming that the all points needs to be transferred).

Fixes the total count (and indirectly ETA) during `replicate_points` transfer

```
{
        "shard_id": 1,
        "to_shard_id": 2,
        "from": 1409368792110028,
        "to": 1409368792110028,
        "sync": true,
        "method": "stream_records",
        "comment": "Transferring records (20400/65000), started 32s ago, ETA: 116.64s"
}
```