### PR TITLE
Id tracker single write of pending updates

### DIFF
--- a/lib/common/io/src/counting_write.rs
+++ b/lib/common/io/src/counting_write.rs
@@ -1,0 +1,25 @@
+use std::io::{self, Write};
+
+/// A writer that counts the number of bytes written to it without actually storing them.
+#[derive(Default)]
+pub struct CountingWrite {
+    bytes: u64,
+}
+
+impl CountingWrite {
+    /// Returns the total number of bytes that have been "written" to this writer.
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl Write for CountingWrite {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes += buf.len() as u64;
+        Ok(buf.len()) // pretend we wrote everything
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/lib/common/io/src/lib.rs
+++ b/lib/common/io/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod counting_write;
 pub mod file_operations;
 pub mod move_files;
 pub mod safe_delete;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -397,10 +397,7 @@ fn versions_path(segment_path: &Path) -> PathBuf {
 }
 
 /// Store new mapping changes, appending them to the given file
-fn store_mapping_changes(
-    mappings_path: &Path,
-    changes: &Vec<MappingChange>,
-) -> OperationResult<()> {
+fn store_mapping_changes(mappings_path: &Path, changes: &[MappingChange]) -> OperationResult<()> {
     // Estimate required buffer size.
     let mut counting_write = CountingWrite::default();
     write_mapping_changes(&mut counting_write, changes).map_err(|err| {
@@ -469,7 +466,7 @@ fn store_mapping_changes(
 /// See [`read_entry`] and [`write_entry`] for more details.
 fn write_mapping_changes<W: Write>(
     mut writer: W,
-    changes: &Vec<MappingChange>,
+    changes: &[MappingChange],
 ) -> OperationResult<()> {
     for &change in changes {
         write_entry(&mut writer, change)?;

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -440,7 +440,7 @@ fn store_mapping_changes(mappings_path: &Path, changes: &[MappingChange]) -> Ope
         ))
     })?;
 
-    // Flush file contents to ensure all data is written to the OS.
+    // Flush file contents to ensure all data is written.
     file.flush().map_err(|err| {
         OperationError::service_error(format!(
             "Failed to flush ID tracker point mappings ({}): {err}",


### PR DESCRIPTION
### Problem:

The mutable ID tracker collects all pending updates and stores them in the file in `flush`. 

But it is implemented as a separate `write` call for each mapping item. In the out-of-disk case, there is a bug where data may be written partially, and the mappings file will be corrupted.

### Solution:

This PR collects all pending updates into the temporary buffer first and then applies them as a single `write` call. Temporary buffer uses `try_set_capacity_exact` to catch OOM situations.

Please make attention while reviewing that file flushing was changed