### PR TITLE
Always capture segments flusher first for consistency

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -637,6 +637,7 @@ impl SegmentEntry for Segment {
             (_, _) => {}
         }
 
+        // Capture all flushers first to improve data consistency
         let vector_storage_flushers: Vec<_> = self
             .vector_data
             .values()


### PR DESCRIPTION
Small change for the sake of consistency and flushing hygiene.

It unfortunately does not fix our data inconsistency issue but makes sure we capture the internal states at roughly the same time.