### PR TITLE
Put unreliable unsafe block behind "testing" feature flag

### DIFF
--- a/lib/sparse/src/index/loaders.rs
+++ b/lib/sparse/src/index/loaders.rs
@@ -77,6 +77,10 @@ impl Csr {
 
     #[inline]
     unsafe fn vec(&self, row: usize) -> Result<SparseVector, ValidationErrors> {
+        const _: () = assert!(
+            cfg!(feature = "testing"),
+            "This unsafe block should be used only in internal benchmarks"
+        );
         unsafe {
             let start = *self.intptr.get_unchecked(row) as usize;
             let end = *self.intptr.get_unchecked(row + 1) as usize;

--- a/lib/sparse/src/index/mod.rs
+++ b/lib/sparse/src/index/mod.rs
@@ -1,5 +1,6 @@
 pub mod compressed_posting_list;
 pub mod inverted_index;
+#[cfg(feature = "testing")]
 pub mod loaders;
 pub mod posting_list;
 pub mod posting_list_common;


### PR DESCRIPTION
The unsafe block inside `Csr::vec()` is not reliable. This PR puts it behind the `testing` feature flag to explicitly indicate that this code is not related to the production code and it is used only in internal benchmarks.