### PR TITLE
GET /optimizations: re-plan on each request

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -439,15 +439,13 @@ impl Collection {
             let Some(log) = replica_set.optimizers_log().await else {
                 continue;
             };
-
-            let log = log.lock();
-            let IndexingProgressViews { ongoing, completed } = log.progress_views();
-            pending.merge(&log.pending);
-            drop(log);
-
+            let IndexingProgressViews { ongoing, completed } = log.lock().progress_views();
             all_ongoing.extend(ongoing);
             if let Some(all_completed) = all_completed.as_mut() {
                 all_completed.extend(completed);
+            }
+            if let Some(shard_pending) = replica_set.pending_optimizations().await {
+                pending.merge(&shard_pending);
             }
         }
         // Sort - see `OptimizationsResponse` doc

--- a/lib/collection/src/collection_manager/optimizers/mod.rs
+++ b/lib/collection/src/collection_manager/optimizers/mod.rs
@@ -9,8 +9,6 @@ use segment::common::anonymize::Anonymize;
 use serde::{Deserialize, Serialize};
 
 use super::holders::segment_holder::SegmentId;
-use crate::operations::types::PendingOptimizations;
-
 pub mod config_mismatch_optimizer;
 pub mod indexing_optimizer;
 pub mod merge_optimizer;
@@ -26,7 +24,6 @@ const KEEP_LAST_TRACKERS: usize = 16;
 #[derive(Default, Clone, Debug)]
 pub struct TrackerLog {
     descriptions: VecDeque<Tracker>,
-    pub pending: PendingOptimizations,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -39,7 +39,9 @@ use crate::common::collection_size_stats::CollectionSizeStats;
 use crate::common::snapshots_manager::SnapshotStorageManager;
 use crate::config::CollectionConfigInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
+use crate::operations::types::{
+    CollectionError, CollectionResult, PendingOptimizations, UpdateResult, UpdateStatus,
+};
 use crate::operations::{CollectionUpdateOperations, point_ops};
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
@@ -1344,6 +1346,13 @@ impl ShardReplicaSet {
     pub async fn optimizers_log(&self) -> Option<Arc<ParkingMutex<TrackerLog>>> {
         let local = self.local.read().await;
         local.as_ref().and_then(|shard| shard.optimizers_log())
+    }
+
+    pub async fn pending_optimizations(&self) -> Option<PendingOptimizations> {
+        let local = self.local.read().await;
+        local
+            .as_ref()
+            .and_then(|shard| shard.pending_optimizations())
     }
 }
 


### PR DESCRIPTION
# Problem
The endpoint `GET /collections/{collection}/optimizations` might return stale data for pending optimizations. Particularly the plan is made *before* running optimizations and it is not re-evaluated after optimizations are started.

# Solution

Re-evaluate the plan on each request to this endpoint.

We already assume that this is a cheap operation:
- it is re-evaluated on `GET /collections/{collection}` to get green/yellow status.
- it is re-evaluated on update operations.

Also, since we re-evaluating it every time, we don't need to store it in the `TrackerLog`.