### PR TITLE
Remove unecessary flag in OperationData

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -94,7 +94,6 @@ impl ShardOperation for LocalShard {
                 op_num: operation_id,
                 operation: operation.operation,
                 sender: callback_sender,
-                wait,
                 hw_measurements: hw_measurement_acc.clone(),
             }));
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -37,10 +37,9 @@ pub struct OperationData {
     pub op_num: SeqNumberType,
     /// Operation
     pub operation: CollectionUpdateOperations,
-    /// If operation was requested to wait for result
-    pub wait: bool,
     /// Callback notification channel
     pub sender: Option<oneshot::Sender<CollectionResult<usize>>>,
+    /// Hardware measurement for the operation
     pub hw_measurements: HwMeasurementAcc,
 }
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -42,7 +42,6 @@ impl UpdateWorkers {
                     op_num,
                     operation,
                     sender,
-                    wait,
                     hw_measurements,
                 }) => {
                     let collection_name_clone = collection_name.clone();
@@ -68,6 +67,7 @@ impl UpdateWorkers {
                         continue;
                     };
 
+                    let wait = sender.is_some();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         Self::update_worker_internal(
                             collection_name_clone,


### PR DESCRIPTION
The `wait` field is equivalent to the absence or presence of the `send` callback.

https://github.com/qdrant/qdrant/blob/f937d0260ffd7705c6f34d9c25da1e27ebf5ddfd/lib/collection/src/shards/local_shard/shard_ops.rs#L51-L56