### PR TITLE
Fix optimizer error if segment is already under optimization

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs
@@ -650,9 +650,6 @@ pub trait SegmentOptimizer {
             .filter_map(|x| x.cloned())
             .collect();
 
-        // Check that we have enough disk space for optimization
-        self.check_segments_size(&optimizing_segments)?;
-
         // Check if all segments are not under other optimization or some ids are missing
         let all_segments_ok = optimizing_segments.len() == ids.len()
             && optimizing_segments
@@ -663,6 +660,9 @@ pub trait SegmentOptimizer {
             // Cancel the optimization
             return Ok(0);
         }
+
+        // Check that we have enough disk space for optimization
+        self.check_segments_size(&optimizing_segments)?;
 
         check_process_stopped(stopped)?;
 


### PR DESCRIPTION
Fixes the following log message after merging <https://github.com/qdrant/qdrant/pull/7932>:

```
collection::update_workers::optimization_worker: Optimization error: Service internal error: Proxy segment is not expected here
```

This originates from a wider problem: we start new optimizations for segments that already have an optimization in flight.

Before <https://github.com/qdrant/qdrant/pull/7932>, the same happened but these were silently dropped by [this](https://github.com/qdrant/qdrant/blob/42b1709041162e3b47561738b93395bd2deda5cf/lib/collection/src/collection_manager/optimizers/segment_optimizer.rs#L650) line.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
