### PR TITLE
Sync `LocalShard::optimizers`

### DIFF
--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -62,6 +62,7 @@ impl LocalShard {
 
         let optimizations: OperationDurationStatistics = self
             .optimizers
+            .load()
             .iter()
             .map(|optimizer| {
                 optimizer

--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -51,10 +51,12 @@ impl LocalShard {
             &self.shared_storage_config.hnsw_global_config,
             &config.quantization_config,
         );
-        update_handler.optimizers = new_optimizers;
+        update_handler.optimizers = new_optimizers.clone();
         update_handler.flush_interval_sec = config.optimizer_config.flush_interval_sec;
         update_handler.max_optimization_threads = config.optimizer_config.max_optimization_threads;
         update_handler.run_workers(update_receiver);
+
+        self.optimizers.store(new_optimizers);
 
         self.update_sender.load().send(UpdateSignal::Nop).await?;
 


### PR DESCRIPTION
Follow up fix to #7945.

# Repro

1. Update collection parameters.
   `curl -X PATCH 127.1:6333/a/benchmark -d '{"hnsw_config":{"ef_construct":101}}'`
2. Wait til green status.
3. **The issue**: observe that `pending.optimizations` is not zero (which contradicts with the green status)
   `curl -s 127.1:6333/collections/a/optimizations`
4. After restarting the server, `pending.optimizations` becomes `0` (as expected)

# Cause

Both `UpdateHandler` and `LocalShard` contain a copy of `Vec<Arc<Optimizers>>`. (and each optimizer is supposed to hold a copy of the config)
But `LocalShard::optimizers` is never updated, so it becomes stale.

# Solution

The solution is to update them both at the same time.

This PR puts `LocalShard::optimizers` into `ArcSwap`. The new synchronization order feels sloppy (I wont be surprised if there is some subtle race condition). But given that `LocalShard::optimizers` is only used for the `/optimizations` endpoint and for the telemetry, it shouldn't be a big deal.
