### PR TITLE
Hotfix: fix search aggregator error with limit 0

### DIFF
--- a/lib/shard/src/search_result_aggregator.rs
+++ b/lib/shard/src/search_result_aggregator.rs
@@ -26,12 +26,12 @@ impl SearchResultAggregator {
     }
 
     pub fn push(&mut self, point: ScoredPoint) {
-        // Skip already seen points
-        if !self.seen.insert(point.id) {
+        let Some(queue) = self.queue.as_mut() else {
             return;
-        }
+        };
 
-        if let Some(queue) = self.queue.as_mut() {
+        // Only add unseen points
+        if self.seen.insert(point.id) {
             queue.push(point);
         }
     }


### PR DESCRIPTION
Hotfix for <https://github.com/qdrant/qdrant/issues/7967>

It hits the unwrap here: https://github.com/qdrant/qdrant/blob/e86d60e6b086b545ae65940515150403a43c2737/lib/common/common/src/fixed_length_priority_queue.rs#L40

I wasn't able to reproduce the exact issue reported by the user, but we clearly see a limit of 0 reached the search aggregator. There seem to be multiple ways to make this happen.

This applies a hotfix to accept a limit of 0, which will just collect no results.

In my opinion a better fix would be to propagate `NonZeroUsize` to more places, and to not process any queries with a limit of 0 at all. But it didn't seem very trivial to implement that so I'd like to give that a shot in a separate PR.

We hit a similar issue before here: <https://github.com/qdrant/qdrant/issues/7632>

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?