### PR TITLE
[disk cache] introduce `trififo` cache controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5982,6 +5982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
 name = "ringbuffer"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7958,12 +7969,14 @@ dependencies = [
  "cap",
  "criterion",
  "foyer",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
  "parking_lot",
  "quick_cache",
  "rand 0.9.2",
  "rand_distr",
  "rayon",
+ "ringbuf",
  "schnellru",
  "strum",
  "tokio",

--- a/lib/trififo/Cargo.toml
+++ b/lib/trififo/Cargo.toml
@@ -13,7 +13,8 @@ workspace = true
 bench_all = []
 
 [dependencies]
-ahash = {workspace = true}
+ahash = { workspace = true }
+hashbrown = "0.16.1"
 
 [dev-dependencies]
 itertools = { workspace = true }
@@ -28,6 +29,9 @@ rayon = { workspace = true }
 quick_cache = "0.6"
 schnellru = "0.2"
 foyer = "0.22"
+
+# For ring buffer comparison test
+ringbuf = "0.4"
 
 # For memory measurement
 cap = "0.1"

--- a/lib/trififo/benches/cache_comparison.rs
+++ b/lib/trififo/benches/cache_comparison.rs
@@ -18,15 +18,18 @@ use std::sync::Arc;
 
 use cap::Cap;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(feature = "bench_all")]
 use foyer::{EvictionConfig, S3FifoConfig};
 use itertools::Itertools;
 use parking_lot::Mutex;
+#[cfg(feature = "bench_all")]
 use quick_cache::sync::Cache as QuickCache;
 use rand::distr::Distribution;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use rand_distr::Zipf;
 use rayon::prelude::*;
+#[cfg(feature = "bench_all")]
 use schnellru::{ByLength, LruMap};
 use strum::{EnumIter, IntoEnumIterator};
 
@@ -154,10 +157,12 @@ trait CacheBench: Send + Sync {
 }
 
 // Quick Cache wrapper
+#[cfg(feature = "bench_all")]
 struct QuickCacheWrapper {
     cache: QuickCache<Key, u32>,
 }
 
+#[cfg(feature = "bench_all")]
 impl QuickCacheWrapper {
     fn new(capacity: usize) -> Self {
         let options = quick_cache::OptionsBuilder::new()
@@ -178,6 +183,7 @@ impl QuickCacheWrapper {
     }
 }
 
+#[cfg(feature = "bench_all")]
 impl CacheBench for QuickCacheWrapper {
     fn insert(&self, key: Key, value: u32) {
         self.cache.insert(key, value);
@@ -195,10 +201,12 @@ impl CacheBench for QuickCacheWrapper {
 }
 
 // Schnellru wrapper (needs mutex for thread safety)
+#[cfg(feature = "bench_all")]
 struct SchnellruWrapper {
     cache: Mutex<LruMap<Key, u32, ByLength>>,
 }
 
+#[cfg(feature = "bench_all")]
 impl SchnellruWrapper {
     fn new(capacity: u32) -> Self {
         Self {
@@ -207,6 +215,7 @@ impl SchnellruWrapper {
     }
 }
 
+#[cfg(feature = "bench_all")]
 impl CacheBench for SchnellruWrapper {
     fn insert(&self, key: Key, value: u32) {
         self.cache.lock().insert(key, value);
@@ -225,10 +234,12 @@ impl CacheBench for SchnellruWrapper {
 }
 
 // Foyer in-memory cache wrapper
+#[cfg(feature = "bench_all")]
 struct FoyerWrapper {
     cache: foyer::Cache<Key, u32>,
 }
 
+#[cfg(feature = "bench_all")]
 impl FoyerWrapper {
     fn new(capacity: usize) -> Self {
         Self {
@@ -244,6 +255,7 @@ impl FoyerWrapper {
     }
 }
 
+#[cfg(feature = "bench_all")]
 impl CacheBench for FoyerWrapper {
     fn insert(&self, key: Key, value: u32) {
         self.cache.insert(key, value);
@@ -264,57 +276,77 @@ impl CacheBench for FoyerWrapper {
     }
 }
 
-// TODO: trififo wrapper
-// struct TrififoWrapper {
-//     cache: trififo::Cache,
-// }
-//
-// impl TrififoWrapper {
-//     fn new(capacity: usize) -> Self {
-//         Self {
-//             cache: trififo::Cache::new(capacity),
-//         }
-//     }
-// }
-//
-// impl CacheBench for TrififoWrapper {
-//     fn insert(&self, key: Key, value: u32) {
-//         self.cache.insert(key, value);
-//     }
-//
-//     fn get(&self, key: &Key) -> Option<u32> {
-//         self.cache.get(key)
-//     }
-//
-// }
+struct TrififoWrapper {
+    cache: Mutex<trififo::Cache<Key, u32>>,
+}
+
+impl TrififoWrapper {
+    fn new(capacity: usize) -> Self {
+        Self {
+            cache: Mutex::new(trififo::Cache::new(
+                capacity,
+                0.1,
+                0.5,
+                ahash::RandomState::new(),
+            )),
+        }
+    }
+}
+
+impl CacheBench for TrififoWrapper {
+    fn get(&self, key: &Key) -> Option<u32> {
+        self.cache.lock().get(key).copied()
+    }
+
+    fn insert(&self, key: Key, value: u32) {
+        self.cache.lock().insert(key, value);
+    }
+
+    fn get_or_insert(&self, key: Key, value: u32) -> u32 {
+        if let Some(value) = self.get(&key) {
+            value
+        } else {
+            self.insert(key, value);
+            value
+        }
+    }
+}
 
 /// List of cache implementations to benchmark.
-/// Add "trififo" here when implementation is ready.
 #[derive(EnumIter, Copy, Clone)]
 enum CacheName {
+    Trififo,
+    #[cfg(feature = "bench_all")]
     QuickCache,
+    #[cfg(feature = "bench_all")]
     Schnellru,
+    #[cfg(feature = "bench_all")]
     Foyer,
-    // Trififo,
 }
 
 impl std::fmt::Display for CacheName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            CacheName::Trififo => write!(f, "trififo"),
+            #[cfg(feature = "bench_all")]
             CacheName::QuickCache => write!(f, "quick_cache"),
+            #[cfg(feature = "bench_all")]
             CacheName::Schnellru => write!(f, "schnellru"),
+            #[cfg(feature = "bench_all")]
             CacheName::Foyer => write!(f, "foyer"),
-            // CacheName::Trififo => write!(f, "trififo"),
         }
     }
 }
 
 fn create_cache(name: CacheName, capacity: usize) -> Arc<dyn CacheBench> {
     match name {
+        CacheName::Trififo => Arc::new(TrififoWrapper::new(capacity)),
+        #[cfg(feature = "bench_all")]
         CacheName::QuickCache => Arc::new(QuickCacheWrapper::new(capacity)),
+        #[cfg(feature = "bench_all")]
         CacheName::Schnellru => Arc::new(SchnellruWrapper::new(capacity as u32)),
+        #[cfg(feature = "bench_all")]
         CacheName::Foyer => Arc::new(FoyerWrapper::new(capacity)),
-        // CacheName::Trififo => Arc::new(TrififoWrapper::new(capacity)),
     }
 }
 

--- a/lib/trififo/src/cache.rs
+++ b/lib/trififo/src/cache.rs
@@ -174,12 +174,25 @@ where
         LocalOffset::Small(local_offset as u32)
     }
 
+    /// Updates or inserts the new offset for the key.
     fn update_hashtable(&mut self, key: &K, local_offset: LocalOffset) {
         let hash = self.hash_key(key);
         let global_offset = self.fifos.global_offset(local_offset);
-        self.hashtable
-            .find_mut(hash, |global_offset| self.fifos.key_eq(*global_offset, key))
-            .map(|offset| *offset = global_offset);
+
+        let entry = self.hashtable.entry(
+            hash,
+            |global_offset| self.fifos.key_eq(*global_offset, key),
+            |global_offset| self.fifos.hash_offset(*global_offset, &self.hasher)
+        );
+
+        match entry {
+            hashbrown::hash_table::Entry::Occupied(mut occupied_entry) => {
+                *occupied_entry.get_mut() = global_offset;
+            }
+            hashbrown::hash_table::Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(global_offset);
+            }
+        };
     }
 
     fn remove_from_hashtable(&mut self, key: &K) {
@@ -204,10 +217,9 @@ where
         let hash = self.hash_key(&key);
 
         // If in ghost, insert to main
-        if let Some(global_offset) = self
-            .hashtable
-            .find(hash, |global_offset| self.fifos.key_eq(*global_offset, &key))
-        {
+        if let Some(global_offset) = self.hashtable.find(hash, |global_offset| {
+            self.fifos.key_eq(*global_offset, &key)
+        }) {
             let local_offset = self.fifos.local_offset(*global_offset);
 
             self.promote_existing(local_offset, key, value);
@@ -224,5 +236,475 @@ where
 
         let local_offset = self.push_to_small_queue(entry);
         self.update_hashtable(&key, local_offset);
+    }
+
+    pub fn len(&self) -> usize {
+        self.hashtable.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hashtable.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_new_cache() {
+        let cache: Cache<i32, String> = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_basic_insert_and_get() {
+        // Use large cache to avoid immediate evictions
+        let mut cache = Cache::new(100, 0.1, 0.1, ahash::RandomState::new());
+
+        cache.insert(1, "one");
+        cache.insert(2, "two");
+        cache.insert(3, "three");
+
+        assert_eq!(cache.get(&1), Some(&"one"));
+        assert_eq!(cache.get(&2), Some(&"two"));
+        assert_eq!(cache.get(&3), Some(&"three"));
+        assert_eq!(cache.get(&4), None);
+    }
+
+    #[test]
+    fn test_insert_existing_key_increments_recency() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        cache.insert(1, "one");
+        assert_eq!(cache.get(&1), Some(&"one"));
+
+        // Re-inserting an existing key in small/main queue only increments recency,
+        // doesn't update the value
+        cache.insert(1, "ONE");
+        assert_eq!(cache.get(&1), Some(&"one")); // Still has original value
+
+        // But recency should have increased
+        let entry = cache.get_entry(&1).unwrap();
+        assert!(entry.recency() > 0);
+    }
+
+    #[test]
+    fn test_small_queue_eviction() {
+        // Create cache with 10 capacity, 10% small (1 slot), 10% ghost (1 slot), 90% main (9 slots)
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        // Fill small queue (only 1 slot)
+        cache.insert(1, "one");
+
+        // This should evict from small to ghost (since recency is 0)
+        cache.insert(2, "two");
+
+        // Key 1 should be in ghost queue (not retrievable)
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), Some(&"two"));
+    }
+
+    #[test]
+    fn test_ghost_to_main_promotion() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert into small queue
+        cache.insert(1, "one");
+
+        // Evict Key 1 to ghost queue
+        cache.insert(2, "two");
+
+        // Key 1 is now in ghost, not retrievable
+        assert_eq!(cache.get(&1), None);
+
+        // Re-insert key 1, should promote from ghost to main
+        cache.insert(1, "one_again");
+
+        // Now it should be retrievable from main queue
+        assert_eq!(cache.get(&1), Some(&"one_again"));
+
+        // The second entry should still be in the small queue
+        assert_eq!(cache.get(&2), Some(&"two"));
+    }
+
+    #[test]
+    fn test_recency_promotion_to_main() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert into small queue
+        cache.insert(1, "one");
+
+        // Access it to increase recency
+        cache.get(&1);
+
+        // Insert another item, this should evict key 1 from small
+        // Since recency > 0, it should go to main instead of ghost
+        cache.insert(2, "two");
+
+        // Key 1 should still be retrievable (in main queue)
+        assert_eq!(cache.get(&1), Some(&"one"));
+    }
+
+    #[test]
+    fn test_capacity_limit() {
+        let mut cache = Cache::new(5, 0.2, 0.2, ahash::RandomState::new());
+
+        // Insert more items than capacity
+        for i in 0..20 {
+            cache.insert(i, format!("value_{}", i));
+        }
+
+        // Cache should not exceed capacity (but ghost queue exists)
+        // We can't directly check internal size, but we can verify old items are gone
+        assert_eq!(cache.get(&0), None);
+        assert_eq!(cache.get(&1), None);
+
+        // Recent items should be present
+        assert_eq!(cache.get(&19), Some(&"value_19".to_string()));
+    }
+
+    #[test]
+    fn test_recency_saturation() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        cache.insert(1, "one");
+
+        // Access many times to test saturation at 4
+        for _ in 0..10 {
+            cache.get(&1);
+        }
+
+        // Get the entry directly to check recency
+        let entry = cache.get_entry(&1).unwrap();
+        assert!(entry.recency() <= 4);
+    }
+
+    #[test]
+    fn test_main_queue_eviction_with_recency() {
+        // Small cache to test eviction more easily
+        let mut cache = Cache::new(5, 0.2, 0.2, ahash::RandomState::new());
+        // 5 * 0.2 = 1 small, 1 ghost, 3 main
+
+        // Fill the cache and promote items to main
+        cache.insert(1, "one");
+        cache.get(&1); // Increase recency
+        cache.insert(2, "two"); // Evicts 1 to main
+
+        cache.insert(3, "three");
+        cache.get(&3);
+        cache.insert(4, "four"); // Evicts 3 to main
+
+        cache.insert(5, "five");
+        cache.get(&5);
+        cache.insert(6, "six"); // Evicts 5 to main
+
+        // Fill main queue more
+        cache.insert(7, "seven");
+        cache.insert(8, "eight");
+
+        // Some items should have been evicted
+        // But we can't precisely predict which without knowing internal state
+    }
+
+    #[test]
+    fn test_empty_cache() {
+        let cache: Cache<i32, String> = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        assert_eq!(cache.get(&1), None);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_small_capacity() {
+        // Minimum capacity of 3 to ensure all queues have at least 1 slot
+        // 0.34 * 3 = 1.02 -> 1 small, 0.33 * 3 = 0.99 -> 0 ghost (rounds down), main = 3 - 1 = 2
+        // Actually we need ghost to have at least 1, so let's use capacity 10
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+        // 10 * 0.1 = 1 small, 10 * 0.1 = 1 ghost, main = 10 - 1 = 9
+
+        cache.insert(1, "one".to_string());
+        assert_eq!(cache.get(&1), Some(&"one".to_string()));
+
+        // Fill up the cache beyond capacity
+        for i in 2..20 {
+            cache.insert(i, format!("value_{i}"));
+        }
+
+        // First item should be evicted due to small capacity
+        assert_eq!(cache.get(&1), None);
+    }
+
+    #[test]
+    fn test_different_types() {
+        let mut cache = Cache::new(100, 0.1, 0.1, ahash::RandomState::new());
+
+        cache.insert("key1", 100);
+        cache.insert("key2", 200);
+
+        assert_eq!(cache.get(&"key1"), Some(&100));
+        assert_eq!(cache.get(&"key2"), Some(&200));
+    }
+
+    #[test]
+    fn test_sequential_access_pattern() {
+        let mut cache = Cache::new(100, 0.1, 0.1, ahash::RandomState::new());
+
+        // Sequential insertions
+        for i in 0..50 {
+            cache.insert(i, i * 10);
+        }
+
+        // Recent items should be accessible
+        for i in 40..50 {
+            assert_eq!(cache.get(&i), Some(&(i * 10)));
+        }
+    }
+
+    #[test]
+    fn test_random_access_pattern() {
+        let mut cache = Cache::new(50, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert items
+        for i in 0..100 {
+            cache.insert(i, format!("value_{}", i));
+        }
+
+        // Access some items multiple times
+        let hot_keys = [95, 96, 97, 98, 99];
+        for &key in &hot_keys {
+            for _ in 0..5 {
+                cache.get(&key);
+            }
+        }
+
+        // Hot keys should still be in cache
+        for &key in &hot_keys {
+            assert_eq!(cache.get(&key), Some(&format!("value_{}", key)));
+        }
+    }
+
+    // Model testing against quick_cache
+    #[test]
+    fn test_model_against_quick_cache() {
+        use quick_cache::sync::Cache as QuickCache;
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        const CAPACITY: usize = 100;
+        const OPS: usize = 1000;
+        const KEY_RANGE: i32 = 500;
+
+        let mut our_cache = Cache::new(CAPACITY, 0.1, 0.1, ahash::RandomState::new());
+        let quick_cache = QuickCache::new(CAPACITY);
+
+        // Track what we expect to be in the cache using a reference model
+        let mut reference: HashMap<i32, String> = HashMap::new();
+
+        for _ in 0..OPS {
+            let key = rng.random_range(0..KEY_RANGE);
+            let value = format!("value_{}", key);
+
+            if rng.random_bool(0.7) {
+                // 70% inserts
+                our_cache.insert(key, value.clone());
+                quick_cache.insert(key, value.clone());
+                reference.insert(key, value);
+            } else {
+                // 30% gets
+                let our_result = our_cache.get(&key);
+                let quick_result = quick_cache.get(&key);
+
+                // Both should agree on presence/absence
+                // Note: They might not have the exact same items due to different eviction policies,
+                // but we're testing that our cache behaves reasonably
+                if our_result.is_some() {
+                    assert_eq!(our_result, Some(&reference[&key]));
+                }
+                if quick_result.is_some() {
+                    assert_eq!(quick_result.as_deref(), Some(reference[&key].as_str()));
+                }
+            }
+        }
+
+        // Verify recent hot keys are likely in both caches
+        let hot_key = KEY_RANGE - 1;
+        for _ in 0..10 {
+            our_cache.insert(hot_key, format!("hot_value"));
+            quick_cache.insert(hot_key, format!("hot_value"));
+        }
+
+        assert_eq!(our_cache.get(&hot_key), Some(&"hot_value".to_string()));
+        assert_eq!(quick_cache.get(&hot_key).as_deref(), Some("hot_value"));
+    }
+
+    #[test]
+    fn test_model_workload_correctness() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(123456);
+
+        const CAPACITY: usize = 50;
+        const OPS: usize = 500;
+
+        let mut cache = Cache::new(CAPACITY, 0.1, 0.1, ahash::RandomState::new());
+        let mut model: HashMap<i32, String> = HashMap::new();
+
+        for _ in 0..OPS {
+            let key = rng.random_range(0..200);
+            let value = format!("val_{}", key);
+
+            cache.insert(key, value.clone());
+            model.insert(key, value);
+
+            // Randomly access some keys
+            if rng.random_bool(0.3) {
+                let access_key = rng.random_range(0..200);
+                if let Some(cached_value) = cache.get(&access_key) {
+                    // If in cache, it must match the model
+                    assert_eq!(cached_value, &model[&access_key]);
+                }
+            }
+        }
+
+        // All values in cache must match the model
+        for i in 0..200 {
+            if let Some(cached) = cache.get(&i) {
+                assert_eq!(cached, &model[&i], "Mismatch for key {}", i);
+            }
+        }
+    }
+
+    #[test]
+    fn test_lru_like_behavior() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert 10 items
+        for i in 0..10 {
+            cache.insert(i, format!("value_{}", i));
+        }
+
+        // Access some items to mark them as recently used
+        for i in 5..10 {
+            cache.get(&i);
+        }
+
+        // Insert more items to trigger eviction
+        for i in 10..15 {
+            cache.insert(i, format!("value_{}", i));
+        }
+
+        // Recently accessed items (5-9) are more likely to still be present
+        // This is probabilistic with S3-FIFO, but should generally hold
+        let mut recent_present = 0;
+        for i in 5..10 {
+            if cache.get(&i).is_some() {
+                recent_present += 1;
+            }
+        }
+
+        // At least some recently accessed items should remain
+        assert!(
+            recent_present > 0,
+            "Expected some recently accessed items to remain"
+        );
+    }
+
+    #[test]
+    fn test_scan_resistance() {
+        let mut cache = Cache::new(20, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert hot items and access them multiple times
+        for i in 0..5 {
+            cache.insert(i, format!("hot_{}", i));
+            for _ in 0..3 {
+                cache.get(&i);
+            }
+        }
+
+        // Now perform a scan of many one-time access items
+        for i in 100..200 {
+            cache.insert(i, format!("cold_{}", i));
+        }
+
+        // Hot items should still be present (scan resistance)
+        let mut hot_present = 0;
+        for i in 0..5 {
+            if cache.get(&i).is_some() {
+                hot_present += 1;
+            }
+        }
+
+        // S3-FIFO should protect hot items from scan
+        assert!(
+            hot_present >= 3,
+            "Expected most hot items to survive scan, got {}",
+            hot_present
+        );
+    }
+
+    #[test]
+    fn test_alternating_access_pattern() {
+        let mut cache = Cache::new(10, 0.2, 0.2, ahash::RandomState::new());
+
+        // Alternate between two sets of keys
+        for _ in 0..20 {
+            for i in 0..5 {
+                cache.insert(i, format!("set1_{}", i));
+            }
+            for i in 10..15 {
+                cache.insert(i, format!("set2_{}", i));
+            }
+        }
+
+        // Both sets should have some representation
+        let set1_present = (0..5).filter(|i| cache.get(i).is_some()).count();
+        let set2_present = (10..15).filter(|i| cache.get(i).is_some()).count();
+
+        assert!(set1_present > 0 || set2_present > 0);
+    }
+
+    #[test]
+    fn test_edge_case_all_same_key() {
+        let mut cache = Cache::new(10, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert the same key repeatedly with different values
+        // Note: re-inserting only updates recency, not value (except when promoting from ghost)
+        for i in 0..100 {
+            cache.insert(1, format!("value_{}", i));
+        }
+
+        // Should have the first value (since re-inserts don't update value in small/main queues)
+        assert_eq!(cache.get(&1), Some(&"value_0".to_string()));
+
+        // Cache should only have 1 item
+        assert_eq!(cache.len(), 1);
+
+        // Recency should be saturated
+        let entry = cache.get_entry(&1).unwrap();
+        assert_eq!(entry.recency(), 4);
+    }
+
+    #[test]
+    fn test_hash_collision_resistance() {
+        // Use a simple hasher that might have more collisions
+        let mut cache = Cache::new(100, 0.1, 0.1, ahash::RandomState::new());
+
+        // Insert many items
+        for i in 0..200 {
+            cache.insert(i, format!("value_{}", i));
+        }
+
+        // Verify correctness - any item in cache should have correct value
+        for i in 0..200 {
+            if let Some(value) = cache.get(&i) {
+                assert_eq!(value, &format!("value_{}", i));
+            }
+        }
     }
 }

--- a/lib/trififo/src/cache.rs
+++ b/lib/trififo/src/cache.rs
@@ -1,9 +1,10 @@
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::sync::atomic::{AtomicU8, Ordering};
 
+use hashbrown::HashTable;
+
 use crate::fifos::{Entry, Fifos, LocalOffset};
 use crate::ringbuffer::RingBuffer;
-use hashbrown::HashTable;
 
 pub(crate) type GlobalOffset = u32;
 
@@ -182,7 +183,7 @@ where
         let entry = self.hashtable.entry(
             hash,
             |global_offset| self.fifos.key_eq(*global_offset, key),
-            |global_offset| self.fifos.hash_offset(*global_offset, &self.hasher)
+            |global_offset| self.fifos.hash_offset(*global_offset, &self.hasher),
         );
 
         match entry {
@@ -249,8 +250,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
+
+    use super::*;
 
     #[test]
     fn test_new_cache() {

--- a/lib/trififo/src/cache.rs
+++ b/lib/trififo/src/cache.rs
@@ -1,0 +1,228 @@
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use crate::fifos::{Entry, Fifos, LocalOffset};
+use crate::ringbuffer::RingBuffer;
+use hashbrown::HashTable;
+
+pub(crate) type GlobalOffset = u32;
+
+pub struct Cache<K, V, S = ahash::RandomState> {
+    hashtable: hashbrown::HashTable<GlobalOffset>,
+    fifos: Fifos<K, V>,
+    hasher: S,
+}
+
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Copy + Hash + PartialEq,
+    S: BuildHasher,
+{
+    pub fn new(capacity: usize, small_ratio: f32, ghost_ratio: f32, hasher: S) -> Self {
+        assert!(capacity > 0);
+        let hashtable = HashTable::with_capacity(capacity);
+
+        let small_size = (capacity as f32 * small_ratio) as usize;
+        let small = RingBuffer::with_capacity(small_size);
+
+        let ghost_size = (capacity as f32 * ghost_ratio) as usize;
+        let ghost = RingBuffer::with_capacity(ghost_size);
+
+        let main_size = capacity - small_size;
+        let main = RingBuffer::with_capacity(main_size);
+
+        let small_end = small_size as GlobalOffset;
+        let ghost_end = small_end + ghost_size as GlobalOffset;
+        let main_end = ghost_end + (capacity - small_size) as GlobalOffset;
+
+        Self {
+            hashtable,
+            fifos: Fifos {
+                small,
+                ghost,
+                main,
+                small_end,
+                ghost_end,
+                main_end,
+            },
+            hasher,
+        }
+    }
+
+    /// A convenience method to calculate the hash for a given `key`.
+    #[inline]
+    fn hash_key(&self, key: &K) -> u64 {
+        let mut hasher = self.hasher.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[inline]
+    fn get_entry(&self, key: &K) -> Option<&Entry<K, V>> {
+        let hash = self.hash_key(key);
+        let global_offset = self
+            .hashtable
+            .find(hash, |global_offset| self.fifos.key_eq(*global_offset, key))?;
+        let local_offset = self.fifos.local_offset(*global_offset);
+        self.fifos.get_entry_by_local_offset(local_offset)
+    }
+
+    /// Promotes an entry from ghost to main, or bumps their recency if already in small or main.
+    fn promote_existing(&mut self, local_offset: LocalOffset, key: K, value: V) {
+        match local_offset {
+            LocalOffset::Ghost(offset) => {
+                if let Some(ghost_key) = self.fifos.ghost.get_absolute_unchecked(offset as usize) {
+                    if ghost_key != &key {
+                        debug_assert!(false, "Key mismatch");
+                        return;
+                    }
+
+                    // promote to main queue
+                    let entry = Entry {
+                        key,
+                        value,
+                        recency: AtomicU8::new(0),
+                    };
+
+                    let local_offset = self.push_to_main_queue(entry);
+                    self.update_hashtable(&key, local_offset);
+
+                    // After updating, ghost key will remain in ghost queue, but it won't be referenced by the hashmap.
+                    // This is expected behavior
+                }
+            }
+            LocalOffset::Small(offset) => {
+                if let Some(entry) = self.fifos.small.get_absolute_unchecked(offset as usize) {
+                    entry.incr_recency();
+                }
+            }
+            LocalOffset::Main(offset) => {
+                if let Some(entry) = self.fifos.main.get_absolute_unchecked(offset as usize) {
+                    entry.incr_recency();
+                }
+            }
+        }
+    }
+
+    /// Pushes an entry to the main queue, if it was full, it will re-insert items with recency > 0.
+    /// It will keep reinserting until one entry can be evicted.
+    ///
+    /// Reinserted entries will preserve their absolute offset, so there is no need to update the
+    /// hashtable
+    #[must_use = "The returned LocalOffset is used to update the hashtable"]
+    fn push_to_main_queue(&mut self, entry: Entry<K, V>) -> LocalOffset {
+        // Push if queue is not full
+        let entry = match self.fifos.main.try_push(entry) {
+            Ok(local_offset) => return LocalOffset::Main(local_offset as u32),
+            Err(entry) => entry,
+        };
+
+        // reinsert while there are old entries with non-zero recency
+        while self.fifos.main.reinsert_if(|entry| {
+            if entry.recency.load(Ordering::Relaxed) > 0 {
+                entry.decr_recency();
+                true
+            } else {
+                false
+            }
+        }) {}
+
+        debug_assert!(
+            self.fifos
+                .main
+                .get_absolute_unchecked(self.fifos.main.write_position())
+                .unwrap()
+                .recency
+                .load(Ordering::Relaxed)
+                == 0,
+            "Detected eviction of entry with non-zero recency"
+        );
+
+        let (evicted_entry, local_offset) = self.fifos.main.pop_push(entry);
+
+        self.remove_from_hashtable(&evicted_entry.key);
+
+        LocalOffset::Main(local_offset as u32)
+    }
+
+    /// Push an entry to the small queue. If full, moves the oldest entry to the main queue
+    /// if recency > 0, otherwise moves the key to the ghost queue.
+    ///
+    /// This function updates the hashtable for the keys moved to the other queues.
+    #[must_use = "The returned LocalOffset is used to update the hashtable"]
+    fn push_to_small_queue(&mut self, entry: Entry<K, V>) -> LocalOffset {
+        // If full, send oldest key to ghost queue, or promote to main queue
+        if self.fifos.small.is_full() {
+            let (oldest_entry, small_offset) = self.fifos.small.pop_push(entry);
+            if oldest_entry.recency() > 0 {
+                // promote to main queue
+                let oldest_key = oldest_entry.key;
+                let local_offset = self.push_to_main_queue(oldest_entry);
+                self.update_hashtable(&oldest_key, local_offset);
+            } else {
+                // move key to ghost queue
+                let ghost_offset = self.fifos.ghost.overwriting_push(oldest_entry.key);
+                self.update_hashtable(&oldest_entry.key, LocalOffset::Ghost(ghost_offset as u32));
+            }
+
+            return LocalOffset::Small(small_offset as u32);
+        }
+
+        // else, just push to queue
+        let local_offset = self.fifos.small.overwriting_push(entry);
+
+        LocalOffset::Small(local_offset as u32)
+    }
+
+    fn update_hashtable(&mut self, key: &K, local_offset: LocalOffset) {
+        let hash = self.hash_key(key);
+        let global_offset = self.fifos.global_offset(local_offset);
+        self.hashtable
+            .find_mut(hash, |global_offset| self.fifos.key_eq(*global_offset, key))
+            .map(|offset| *offset = global_offset);
+    }
+
+    fn remove_from_hashtable(&mut self, key: &K) {
+        let hash = self.hash_key(key);
+        if let Ok(entry) = self
+            .hashtable
+            .find_entry(hash, |global_offset| self.fifos.key_eq(*global_offset, key))
+        {
+            entry.remove();
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        let entry = self.get_entry(key)?;
+
+        entry.incr_recency();
+
+        Some(&entry.value)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        let hash = self.hash_key(&key);
+
+        // If in ghost, insert to main
+        if let Some(global_offset) = self
+            .hashtable
+            .find(hash, |global_offset| self.fifos.key_eq(*global_offset, &key))
+        {
+            let local_offset = self.fifos.local_offset(*global_offset);
+
+            self.promote_existing(local_offset, key, value);
+
+            return;
+        }
+
+        // else, insert to small
+        let entry = Entry {
+            key,
+            value,
+            recency: AtomicU8::new(0),
+        };
+
+        let local_offset = self.push_to_small_queue(entry);
+        self.update_hashtable(&key, local_offset);
+    }
+}

--- a/lib/trififo/src/fifos.rs
+++ b/lib/trififo/src/fifos.rs
@@ -87,9 +87,10 @@ where
     /// Generate a hash for the key stored in the global offset provided
     ///
     /// Panics if the global offset does not point to a valid value
-    pub fn hash_offset<S: BuildHasher>(&self, global_offset: GlobalOffset, hasher: &S) -> u64 where
+    pub fn hash_offset<S: BuildHasher>(&self, global_offset: GlobalOffset, hasher: &S) -> u64
+    where
         S: BuildHasher,
-        K: Hash
+        K: Hash,
     {
         let local = self.local_offset(global_offset);
         let key = self

--- a/lib/trififo/src/fifos.rs
+++ b/lib/trififo/src/fifos.rs
@@ -1,3 +1,4 @@
+use std::hash::{BuildHasher, Hash, Hasher};
 use std::sync::atomic::AtomicU8;
 
 use crate::cache::GlobalOffset;
@@ -81,6 +82,22 @@ where
             return false;
         };
         entry_key == key
+    }
+
+    /// Generate a hash for the key stored in the global offset provided
+    ///
+    /// Panics if the global offset does not point to a valid value
+    pub fn hash_offset<S: BuildHasher>(&self, global_offset: GlobalOffset, hasher: &S) -> u64 where
+        S: BuildHasher,
+        K: Hash
+    {
+        let local = self.local_offset(global_offset);
+        let key = self
+            .get_key_by_local_offset(local)
+            .expect("The offset should always return a value");
+        let mut hasher = hasher.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
     }
 }
 

--- a/lib/trififo/src/fifos.rs
+++ b/lib/trififo/src/fifos.rs
@@ -1,4 +1,4 @@
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{BuildHasher, Hash};
 use std::sync::atomic::AtomicU8;
 
 use crate::cache::GlobalOffset;
@@ -87,7 +87,7 @@ where
     /// Generate a hash for the key stored in the global offset provided
     ///
     /// Panics if the global offset does not point to a valid value
-    pub fn hash_offset<S: BuildHasher>(&self, global_offset: GlobalOffset, hasher: &S) -> u64
+    pub fn hash_offset<S>(&self, global_offset: GlobalOffset, hasher: &S) -> u64
     where
         S: BuildHasher,
         K: Hash,
@@ -96,9 +96,7 @@ where
         let key = self
             .get_key_by_local_offset(local)
             .expect("The offset should always return a value");
-        let mut hasher = hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        hasher.hash_one(key)
     }
 }
 

--- a/lib/trififo/src/fifos.rs
+++ b/lib/trififo/src/fifos.rs
@@ -1,0 +1,109 @@
+use std::sync::atomic::AtomicU8;
+
+use crate::cache::GlobalOffset;
+use crate::ringbuffer::RingBuffer;
+
+pub(crate) struct Fifos<K, V> {
+    pub small: RingBuffer<Entry<K, V>>,
+    pub ghost: RingBuffer<K>,
+    pub main: RingBuffer<Entry<K, V>>,
+
+    pub small_end: GlobalOffset,
+    pub ghost_end: GlobalOffset,
+    pub main_end: GlobalOffset,
+}
+
+pub(crate) struct Entry<K, V> {
+    pub key: K,
+    pub value: V,
+    pub recency: AtomicU8,
+}
+
+pub(crate) enum LocalOffset {
+    Small(u32),
+    Ghost(u32),
+    Main(u32),
+}
+
+impl<K, V> Fifos<K, V>
+where
+    K: PartialEq,
+{
+    #[inline]
+    pub fn local_offset(&self, global_offset: GlobalOffset) -> LocalOffset {
+        if global_offset < self.small_end {
+            LocalOffset::Small(global_offset)
+        } else if global_offset < self.ghost_end {
+            LocalOffset::Ghost(global_offset - self.small_end)
+        } else {
+            debug_assert!(global_offset < self.main_end);
+            LocalOffset::Main(global_offset - self.ghost_end)
+        }
+    }
+
+    #[inline]
+    pub fn global_offset(&self, local_offset: LocalOffset) -> GlobalOffset {
+        match local_offset {
+            LocalOffset::Small(offset) => offset,
+            LocalOffset::Ghost(offset) => offset + self.small_end,
+            LocalOffset::Main(offset) => offset + self.ghost_end,
+        }
+    }
+
+    #[inline]
+    pub fn get_entry_by_local_offset(&self, local_offset: LocalOffset) -> Option<&Entry<K, V>> {
+        match local_offset {
+            LocalOffset::Small(offset) => self.small.get_absolute_unchecked(offset as usize),
+            LocalOffset::Ghost(_offset) => None,
+            LocalOffset::Main(offset) => self.main.get_absolute_unchecked(offset as usize),
+        }
+    }
+
+    #[inline]
+    pub fn get_key_by_local_offset(&self, local_offset: LocalOffset) -> Option<&K> {
+        match local_offset {
+            LocalOffset::Small(offset) => self
+                .small
+                .get_absolute_unchecked(offset as usize)
+                .map(|entry| &entry.key),
+            LocalOffset::Ghost(offset) => self.ghost.get_absolute_unchecked(offset as usize),
+            LocalOffset::Main(offset) => self
+                .main
+                .get_absolute_unchecked(offset as usize)
+                .map(|entry| &entry.key),
+        }
+    }
+
+    #[inline]
+    pub fn key_eq(&self, global_offset: GlobalOffset, key: &K) -> bool {
+        let local_offset = self.local_offset(global_offset);
+        let Some(entry_key) = self.get_key_by_local_offset(local_offset) else {
+            return false;
+        };
+        entry_key == key
+    }
+}
+
+impl<K, V> Entry<K, V> {
+    pub fn recency(&self) -> u8 {
+        self.recency.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    // Increase recency by one, but saturate at 4
+    pub fn incr_recency(&self) {
+        let _ = self.recency.fetch_update(
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+            |current| if current < 4 { Some(current + 1) } else { None },
+        );
+    }
+
+    // Decrease recency by one
+    pub fn decr_recency(&self) {
+        let _ = self.recency.fetch_update(
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+            |current| if current > 0 { Some(current - 1) } else { None },
+        );
+    }
+}

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,6 +1,5 @@
-
 mod cache;
-mod ringbuffer;
 mod fifos;
+mod ringbuffer;
 
 pub use cache::Cache;

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,1 +1,6 @@
 
+mod cache;
+mod ringbuffer;
+mod fifos;
+
+pub use cache::Cache;

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -31,9 +31,7 @@ impl<T> RingBuffer<T> {
     pub fn with_capacity(capacity: usize) -> Self {
         assert!(capacity > 0, "Ring buffer capacity must be greater than 0");
 
-        let buffer: Box<[MaybeUninit<T>]> = (0..capacity)
-            .map(|_| MaybeUninit::uninit())
-            .collect();
+        let buffer: Box<[MaybeUninit<T>]> = (0..capacity).map(|_| MaybeUninit::uninit()).collect();
 
         Self {
             buffer,

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -1,0 +1,477 @@
+//! A fixed-capacity ring buffer with absolute position access.
+//!
+//! By design, it can't evict items at the read position, it can only push, or
+//! push while popping the last one.
+//!
+//! This module provides a simple ring buffer implementation using wrapped positions.
+//! Positions wrap around at the capacity (0, 1, 2, ..., capacity-1, 0, 1, 2, ...).
+//!
+//! # Safety
+//!
+//! This ring buffer does NOT track whether a stored offset is still valid. It's the
+//! caller's responsibility to track validity in an external structure and invalidate
+//! offsets when items are overwritten.
+
+use std::mem::MaybeUninit;
+
+pub struct RingBuffer<T> {
+    buffer: Vec<MaybeUninit<T>>,
+    capacity: usize,
+    /// Current write position (0 to capacity-1, wraps around)
+    write_pos: usize,
+    /// Number of elements currently stored
+    len: usize,
+}
+
+impl<T> RingBuffer<T> {
+    /// Creates a new ring buffer with the specified capacity.
+    ///
+    /// # Panics
+    /// Panics if capacity is 0.
+    pub fn with_capacity(capacity: usize) -> Self {
+        assert!(capacity > 0, "Ring buffer capacity must be greater than 0");
+
+        let mut buffer = Vec::with_capacity(capacity);
+        // Reserve space without initializing
+        for _ in 0..capacity {
+            buffer.push(MaybeUninit::uninit());
+        }
+
+        Self {
+            buffer,
+            capacity,
+            write_pos: 0,
+            len: 0,
+        }
+    }
+
+    /// Returns the capacity of the ring buffer.
+    #[cfg(test)]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the number of elements currently stored in the buffer.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns true if the buffer is full.
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.len == self.capacity
+    }
+
+    /// Pushes an item into the ring buffer and returns its position offset.
+    ///
+    /// If the buffer is full, the oldest item is overwritten.
+    /// The returned offset is an absolute position that wraps around at capacity.
+    ///
+    /// # Note
+    /// If an item is overwritten, any previously returned offset pointing to
+    /// that position becomes invalid. It's the caller's responsibility to track
+    /// this in an external structure.
+    pub fn overwriting_push(&mut self, item: T) -> usize {
+        let offset = self.write_pos;
+
+        // Write the new value, potentially overwriting old data
+        self.buffer[offset].write(item);
+
+        // Move write position forward
+        self.write_pos = (self.write_pos + 1) % self.capacity;
+
+        // Update length
+        if self.len < self.capacity {
+            self.len += 1;
+        }
+
+        offset
+    }
+
+    /// Attempts to push an item into the ring buffer without overwriting.
+    ///
+    /// Returns the position offset if successful, or the intpu item if the buffer is full.
+    pub fn try_push(&mut self, item: T) -> Result<usize, T> {
+        if self.is_full() {
+            return Err(item);
+        }
+
+        Ok(self.overwriting_push(item))
+    }
+
+    /// Gets a reference to the item at the given position offset.
+    ///
+    /// Returns None if the offset is out of bounds (>= capacity).
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - `offset < capacity`
+    /// - The offset points to valid (not overwritten) data
+    pub fn get_absolute_unchecked(&self, offset: usize) -> Option<&T> {
+        if offset >= self.capacity {
+            return None;
+        }
+
+        // Safety: We only access positions that have been written to
+        // The caller is responsible for ensuring the offset is still valid
+        unsafe { Some(self.buffer[offset].assume_init_ref()) }
+    }
+
+    /// Returns the oldest valid position offset in the buffer.
+    ///
+    /// Returns None if the buffer is empty.
+    /// This can be used to determine which offsets are still valid.
+    pub fn read_pos(&self) -> Option<usize> {
+        if self.is_empty() {
+            None
+        } else if self.len < self.capacity {
+            // Buffer not full yet, oldest is at position 0
+            Some(0)
+        } else {
+            // Buffer is full, oldest is at write_pos (about to be overwritten)
+            Some(self.write_pos)
+        }
+    }
+
+    /// Clears the ring buffer.
+    #[cfg(test)]
+    pub fn clear(&mut self) {
+        self.write_pos = 0;
+        self.len = 0;
+    }
+
+    /// Returns the current write position (where the next item will be written).
+    #[inline]
+    pub fn write_position(&self) -> usize {
+        self.write_pos
+    }
+
+    /// Reinserts the oldest entry into the buffer, if the closure returns true.
+    ///
+    /// Returns whether it was reinserted or not.
+    ///
+    /// # Safety
+    /// This only reinserts if the buffer is full, otherwise it might panic.
+    pub fn reinsert_if(&mut self, f: impl FnOnce(&T) -> bool) -> bool {
+        match self.read_pos() {
+            None => false,
+            Some(pos) if pos == self.write_pos => {
+                // The start position is the same as the position about to be overwritten
+                let should_reinsert = f(unsafe { self.buffer[self.write_pos].assume_init_ref() });
+
+                if !should_reinsert {
+                    return false;
+                }
+
+                // Advance the write position
+                self.write_pos = (self.write_pos + 1) % self.capacity;
+
+                true
+            }
+            Some(_pos) => {
+                debug_assert!(false, "Detected reinsertion when ringbuffer is not full");
+                false
+            }
+        }
+    }
+
+    /// Pop oldest, and push new item. Returns the oldest value, and the absolute position of the new value
+    ///
+    /// Only use this if the queue was full, otherwise, use `overwriting_push`. Panics if queue wasn't full
+    pub fn pop_push(&mut self, item: T) -> (T, usize) {
+        debug_assert_eq!(self.read_pos().unwrap(), self.write_pos);
+
+        let read_pos = self.write_pos;
+
+        let old_item = std::mem::replace(&mut self.buffer[read_pos], MaybeUninit::new(item));
+        let old_item = unsafe { old_item.assume_init() };
+
+        self.write_pos = (self.write_pos + 1) % self.capacity;
+
+        (old_item, read_pos)
+    }
+}
+
+impl<T> Drop for RingBuffer<T> {
+    fn drop(&mut self) {
+        // Drop all initialized elements
+        if self.len > 0 {
+            let start_pos = if self.len < self.capacity {
+                0
+            } else {
+                self.write_pos
+            };
+
+            for i in 0..self.len {
+                let pos = (start_pos + i) % self.capacity;
+                unsafe {
+                    self.buffer[pos].assume_init_drop();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_buffer_is_empty() {
+        let buffer: RingBuffer<i32> = RingBuffer::with_capacity(5);
+        assert_eq!(buffer.len(), 0);
+        assert!(buffer.is_empty());
+        assert!(!buffer.is_full());
+        assert_eq!(buffer.capacity(), 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "Ring buffer capacity must be greater than 0")]
+    fn test_zero_capacity_panics() {
+        let _buffer: RingBuffer<i32> = RingBuffer::with_capacity(0);
+    }
+
+    #[test]
+    fn test_push_and_get() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        let offset0 = buffer.overwriting_push(10);
+        let offset1 = buffer.overwriting_push(20);
+        let offset2 = buffer.overwriting_push(30);
+
+        assert_eq!(buffer.get_absolute_unchecked(offset0), Some(&10));
+        assert_eq!(buffer.get_absolute_unchecked(offset1), Some(&20));
+        assert_eq!(buffer.get_absolute_unchecked(offset2), Some(&30));
+
+        assert_eq!(buffer.len(), 3);
+        assert!(buffer.is_full());
+    }
+
+    #[test]
+    fn test_offsets_wrap() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        let offset0 = buffer.overwriting_push(10);
+        let offset1 = buffer.overwriting_push(20);
+        let offset2 = buffer.overwriting_push(30);
+
+        // These offsets should wrap around
+        assert_eq!(offset0, 0);
+        assert_eq!(offset1, 1);
+        assert_eq!(offset2, 2);
+
+        let offset3 = buffer.overwriting_push(40);
+        assert_eq!(offset3, 0); // Wraps to 0
+
+        // offset0 and offset3 point to same position
+        assert_eq!(buffer.get_absolute_unchecked(offset0), Some(&40)); // Overwritten!
+        assert_eq!(buffer.get_absolute_unchecked(offset3), Some(&40));
+    }
+
+    #[test]
+    fn test_overwrites_oldest() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        buffer.overwriting_push(10);
+        buffer.overwriting_push(20);
+        buffer.overwriting_push(30);
+        buffer.overwriting_push(40); // Overwrites first item
+
+        // Positions 1 and 2 still have their original values
+        assert_eq!(buffer.get_absolute_unchecked(1), Some(&20));
+        assert_eq!(buffer.get_absolute_unchecked(2), Some(&30));
+        // Position 0 now has the new value
+        assert_eq!(buffer.get_absolute_unchecked(0), Some(&40));
+
+        assert_eq!(buffer.len(), 3);
+        assert!(buffer.is_full());
+    }
+
+    #[test]
+    fn test_continuous_wrapping() {
+        let mut buffer = RingBuffer::with_capacity(3);
+        let mut offsets = Vec::new();
+
+        for i in 0..10 {
+            offsets.push(buffer.overwriting_push(i));
+        }
+
+        // Offsets should cycle: 0, 1, 2, 0, 1, 2, ...
+        assert_eq!(offsets[0], 0);
+        assert_eq!(offsets[1], 1);
+        assert_eq!(offsets[2], 2);
+        assert_eq!(offsets[3], 0);
+        assert_eq!(offsets[6], 0);
+        assert_eq!(offsets[9], 0);
+
+        // Only last 3 items should be accessible
+        assert_eq!(buffer.get_absolute_unchecked(0), Some(&9)); // Position 0
+        assert_eq!(buffer.get_absolute_unchecked(1), Some(&7)); // Position 1
+        assert_eq!(buffer.get_absolute_unchecked(2), Some(&8)); // Position 2
+
+        assert_eq!(buffer.len(), 3);
+    }
+
+    #[test]
+    fn test_oldest_valid_offset() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        assert_eq!(buffer.read_pos(), None);
+
+        buffer.overwriting_push(10);
+        assert_eq!(buffer.read_pos(), Some(0));
+
+        buffer.overwriting_push(20);
+        buffer.overwriting_push(30);
+        assert_eq!(buffer.read_pos(), Some(0)); // Not full yet
+
+        buffer.overwriting_push(40); // Now full and wrapping
+        assert_eq!(buffer.read_pos(), Some(1)); // Oldest is at position 1
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        buffer.overwriting_push(10);
+        buffer.overwriting_push(20);
+        buffer.overwriting_push(30);
+
+        assert_eq!(buffer.len(), 3);
+
+        buffer.clear();
+
+        assert_eq!(buffer.len(), 0);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.read_pos(), None);
+        assert_eq!(buffer.write_position(), 0);
+    }
+
+    #[test]
+    fn test_single_capacity() {
+        let mut buffer = RingBuffer::with_capacity(1);
+
+        let offset0 = buffer.overwriting_push(10);
+        assert_eq!(buffer.get_absolute_unchecked(offset0), Some(&10));
+        assert!(buffer.is_full());
+
+        let offset1 = buffer.overwriting_push(20);
+        assert_eq!(offset1, 0); // Same position
+        assert_eq!(buffer.get_absolute_unchecked(offset1), Some(&20)); // Overwritten
+        assert_eq!(buffer.len(), 1);
+    }
+
+    #[test]
+    fn test_try_push() {
+        let mut buffer = RingBuffer::with_capacity(3);
+
+        // Should succeed when not full
+        assert!(buffer.try_push(10).is_ok());
+        assert!(buffer.try_push(20).is_ok());
+        assert!(buffer.try_push(30).is_ok());
+
+        // Should fail when full
+        assert_eq!(buffer.try_push(40), Err(40));
+        assert_eq!(buffer.len(), 3);
+
+        // Regular push should still work and overwrite
+        let offset = buffer.overwriting_push(40);
+        assert_eq!(buffer.get_absolute_unchecked(offset), Some(&40));
+
+        // try_push should fail again since it's full
+        assert_eq!(buffer.try_push(50), Err(50));
+    }
+
+    #[test]
+    fn test_comparison_with_ringbuf_crate() {
+        use ringbuf::HeapRb;
+        use ringbuf::traits::{Consumer, Observer, RingBuffer as RingBufferTrait};
+
+        const CAPACITY: usize = 5;
+        let mut our_buffer = super::RingBuffer::with_capacity(CAPACITY);
+        let mut their_buffer: HeapRb<i32> = HeapRb::new(CAPACITY);
+
+        // Push some initial items
+        for i in 0..3 {
+            our_buffer.overwriting_push(i);
+            their_buffer.push_overwrite(i);
+        }
+
+        // Verify both have same length
+        assert_eq!(our_buffer.len(), their_buffer.occupied_len());
+
+        // Push more items to cause wrapping
+        for i in 3..10 {
+            our_buffer.overwriting_push(i);
+            their_buffer.push_overwrite(i);
+        }
+
+        // Both should have same length
+        assert_eq!(our_buffer.len(), their_buffer.occupied_len());
+        assert_eq!(our_buffer.len(), CAPACITY);
+
+        // Verify their buffer has same items
+        let their_items: Vec<_> = their_buffer.iter().copied().collect();
+        let our_items: Vec<_> = (0..our_buffer.len()).map(|_| our_buffer.pop_push(0).0).collect();
+
+        assert_eq!(our_items, their_items);
+    }
+
+    #[test]
+    fn test_sequential_access_pattern() {
+        // Simulate a use case where we track offsets in a separate structure
+        let mut buffer = RingBuffer::with_capacity(4);
+        let mut tracker = std::collections::HashMap::new();
+
+        // Add items and track them
+        for i in 0..3 {
+            let offset = buffer.overwriting_push(i * 10);
+            tracker.insert(format!("key{}", i), offset);
+        }
+
+        // Access via tracker
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key0"]), Some(&0));
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key1"]), Some(&10));
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key2"]), Some(&20));
+
+        // Track which keys map to which offsets before wrapping
+        let key0_offset = tracker["key0"];
+        let key3_offset = 3 % buffer.capacity(); // Will be offset 3
+
+        // Add more items, causing wrapping
+        for i in 3..8 {
+            let offset = buffer.overwriting_push(i * 10);
+            tracker.insert(format!("key{}", i), offset);
+        }
+
+        // Note: After pushing 3,4,5,6,7 (5 more items into capacity-4 buffer),
+        // positions 0,1,2,3 get reused. The valid range is now [0,1,2,3] containing [40,50,60,70]
+
+        // Manually invalidate keys that were overwritten
+        // key0 (offset 0) was overwritten by key4 (also offset 0)
+        // key1 (offset 1) was overwritten by key5 (also offset 1)
+        // key2 (offset 2) was overwritten by key6 (also offset 2)
+        // key3 (offset 3) was overwritten by key7 (also offset 3)
+
+        tracker.remove("key0");
+        tracker.remove("key1");
+        tracker.remove("key2");
+        tracker.remove("key3");
+
+        assert_eq!(tracker.len(), 4);
+
+        // Recent keys should still work
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key4"]), Some(&40));
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key5"]), Some(&50));
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key6"]), Some(&60));
+        assert_eq!(buffer.get_absolute_unchecked(tracker["key7"]), Some(&70));
+    }
+
+}


### PR DESCRIPTION
WIP.

Implements S3-FIFO algorithm, using custom circular buffers and storing the key only once (avoiding storing it in the hashmap), which makes it more memory friendly

Some benchmarks:
```
single_thread_latency/insert/trififo
                        time:   [43.973 ms 44.364 ms 44.778 ms]
                        thrpt:  [22.332 Melem/s 22.541 Melem/s 22.741 Melem/s]

single_thread_latency/insert/quick_cache
                        time:   [30.167 ms 30.525 ms 30.899 ms]
                        thrpt:  [32.364 Melem/s 32.760 Melem/s 33.149 Melem/s]

single_thread_latency/insert/schnellru
                        time:   [18.639 ms 18.803 ms 18.979 ms]
                        thrpt:  [52.688 Melem/s 53.183 Melem/s 53.651 Melem/s]

single_thread_latency/insert/foyer
                        time:   [135.36 ms 137.22 ms 139.19 ms]
                        thrpt:  [7.1846 Melem/s 7.2876 Melem/s 7.3875 Melem/s]

single_thread_latency/get_hit/trififo
                        time:   [16.589 ms 16.611 ms 16.634 ms]
                        thrpt:  [60.118 Melem/s 60.202 Melem/s 60.282 Melem/s]

single_thread_latency/get_hit/quick_cache
                        time:   [13.526 ms 13.542 ms 13.559 ms]
                        thrpt:  [73.752 Melem/s 73.843 Melem/s 73.934 Melem/s]

single_thread_latency/get_hit/schnellru
                        time:   [10.487 ms 10.553 ms 10.630 ms]
                        thrpt:  [94.074 Melem/s 94.758 Melem/s 95.353 Melem/s]

single_thread_latency/get_hit/foyer
                        time:   [29.510 ms 29.608 ms 29.712 ms]
                        thrpt:  [33.657 Melem/s 33.774 Melem/s 33.886 Melem/s]

multi_thread_latency/get_or_insert/trififo
                        time:   [113.88 ms 114.23 ms 114.65 ms]
                        thrpt:  [13.956 Melem/s 14.007 Melem/s 14.050 Melem/s]
multi_thread_latency/get_or_insert/quick_cache
                        time:   [288.42 ms 291.10 ms 293.50 ms]
                        thrpt:  [5.4514 Melem/s 5.4964 Melem/s 5.5475 Melem/s]

multi_thread_latency/get_or_insert/schnellru
                        time:   [143.74 ms 145.15 ms 146.07 ms]
                        thrpt:  [10.954 Melem/s 11.023 Melem/s 11.131 Melem/s]

multi_thread_latency/get_or_insert/foyer
                        time:   [547.72 ms 551.12 ms 554.32 ms]
                        thrpt:  [2.8864 Melem/s 2.9032 Melem/s 2.9212 Melem/s]
```