### PR TITLE
Fix hnsw_incremental_build benchmark

### DIFF
--- a/lib/segment/benches/hnsw_incremental_build.rs
+++ b/lib/segment/benches/hnsw_incremental_build.rs
@@ -50,6 +50,9 @@ use zerocopy::IntoBytes;
 /// To speed up the benchmark across runs, some operations that not related
 /// to incremental HNSW are cached.
 ///
+/// To benchmark only the regular (aka non-incremental) HNSW building,
+/// run it with `--iterations 0` and without `--cache`.
+///
 /// # Plan
 ///
 /// 1. Non-incrementally build initial segment of size `init-vectors`.
@@ -68,8 +71,11 @@ struct Args {
     #[clap(long)]
     bench: bool,
 
-    /// Path to a dataset in numpy format.
+    /// Path to a dataset in numpy format, to benchmark on real data.
     /// Incompatible with `--dimensions`.
+    ///
+    /// See https://github.com/qdrant/qdrant/pull/6615#issuecomment-3018646477
+    /// for scripts to prepare datasets.
     #[clap(long)]
     dataset: Option<PathBuf>,
 


### PR DESCRIPTION
This PR fixes `hnsw_incremental_build` and improves its doc a bit.

```console
$ rm -rf target/tmp
$ cargo bench -p segment --bench hnsw_incremental_build --profile dev -- --dimensions 32 --iterations 1 --init-vectors 1000 
   Compiling segment v0.6.0 (/home/user/qdrant/lib/segment)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.64s
     Running benches/hnsw_incremental_build.rs (target/debug/deps/hnsw_incremental_build-b377c87f7bf354f3)
[2026-01-23T14:05:45Z INFO  hnsw_incremental_build] args=Args { bench: true, dataset: None, dimensions: Some(32), iterations: 1, init_vectors: 1000, to_add: 1000, to_remove: 1000, distance: Cosine, m: 16, ef_construct: 100, queries: 100, ef: 64, accuracy_check_period: 1, random_seed: 42, cache: false }
[2026-01-23T14:05:45Z WARN  memory::mmap_ops] MULTI_MMAP_SUPPORT_CHECK_RESULT should be initialized before accessing MULTI_MMAP_IS_SUPPORTED
[2026-01-23T14:05:45Z DEBUG segment::index::hnsw_index::hnsw] building HNSW for 1000 vectors with 8 CPUs
[2026-01-23T14:05:45Z DEBUG segment::index::hnsw_index::hnsw] Finish main graph in time 82.90585ms
[2026-01-23T14:05:45Z DEBUG segment::index::hnsw_index::hnsw] skip building additional HNSW links
[2026-01-23T14:05:45Z DEBUG segment::index::hnsw_index::hnsw] finish additional payload field indexing
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] valid points: 1000, missing points: 0, missing ratio: 0.000, do_heal: true
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] building HNSW for 1000 vectors with 8 CPUs
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] Reusing 1000 points from the old index, healing 0 points
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] Migrated in 2.364474ms
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] Finish main graph in time 2.956µs
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] skip building additional HNSW links
[2026-01-23T14:05:46Z DEBUG segment::index::hnsw_index::hnsw] finish additional payload field indexing
[2026-01-23T14:05:46Z DEBUG hnsw_incremental_build] Exact search time = 6.486178ms

thread 'main' (1579518) panicked at lib/segment/benches/hnsw_incremental_build.rs:436:67:
called `Result::unwrap()` on an `Err` value: Io(Custom { kind: NotFound, error: PathError { path: "/home/user/qdrant/target/tmp/segment/hnsw_incremental_build/.atomicwriteoU6RPI", err: Os { code: 2, kind: NotFound, message: "No such file or directory" } } })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: bench failed, to rerun pass `-p segment --bench hnsw_incremental_build`
```

I didn't catch this bug earlier because I was running it either with `--cache` (to benchmark incremental HNSW) or with `--iterations 0` (to benchmark non-incremental HNSW).