### PR TITLE
Fix: Handle limit=0 gracefully in SearchResultAggregator

### DIFF
--- a/lib/shard/src/search_result_aggregator.rs
+++ b/lib/shard/src/search_result_aggregator.rs
@@ -9,31 +9,40 @@ use segment::types::{PointIdType, ScoredPoint, SeqNumberType};
 const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
 
 pub struct SearchResultAggregator {
-    queue: FixedLengthPriorityQueue<ScoredPoint>,
+    queue: Option<FixedLengthPriorityQueue<ScoredPoint>>,
     seen: AHashSet<PointIdType>, // Point ids seen
 }
 
 impl SearchResultAggregator {
     pub fn new(limit: usize) -> Self {
         SearchResultAggregator {
-            queue: FixedLengthPriorityQueue::new(limit),
+            queue: if limit > 0 {
+                Some(FixedLengthPriorityQueue::new(limit))
+            } else {
+                None
+            },
             seen: AHashSet::with_capacity(limit.min(LARGEST_REASONABLE_ALLOCATION_SIZE)),
         }
     }
 
     pub fn push(&mut self, point: ScoredPoint) {
+        let Some(queue) = self.queue.as_mut() else {
+            return;
+        };
         // track new value in `queue`
         if self.seen.insert(point.id) {
-            self.queue.push(point);
+            queue.push(point);
         }
     }
 
     pub fn into_vec(self) -> Vec<ScoredPoint> {
-        self.queue.into_sorted_vec()
+        self.queue
+            .map(|queue| queue.into_sorted_vec())
+            .unwrap_or_default()
     }
 
     pub fn lowest(&self) -> Option<&ScoredPoint> {
-        self.queue.top()
+        self.queue.as_ref().and_then(|queue| queue.top())
     }
 }
 


### PR DESCRIPTION
Wrap the priority queue in Option to prevent panic when limit=0 is passed to search queries. When limit is 0, the queue is None and operations return early or return empty results instead of panicking.

Fixes the assertion failure in fixed_length_priority_queue.rs that occurred when NonZeroUsize::new(0) was called.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
