### PR TITLE
gridstore iter livelock

### DIFF
--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 fn append_csv_data(storage: &mut gridstore::Gridstore<Payload>, csv_path: &Path) {
     let csv_file = BufReader::new(File::open(csv_path).expect("file should open"));
     let mut rdr = csv::Reader::from_reader(csv_file);
-    let mut point_offset = storage.max_point_id();
+    let mut point_offset = storage.max_point_offset();
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
     for result in rdr.records() {
@@ -68,7 +68,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     append_csv_data(&mut storage, &csv_path);
     storage.flusher()().unwrap();
 
-    assert_eq!(storage.max_point_id(), expected_point_count);
+    assert_eq!(storage.max_point_offset(), expected_point_count);
 
     // flush to get a consistent bitmask
     storage.flusher()().unwrap();
@@ -88,7 +88,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     c.bench_function("scan storage", |b| {
         let hw_counter = HardwareCounterCell::new();
         b.iter(|| {
-            for i in 0..storage.max_point_id() {
+            for i in 0..storage.max_point_offset() {
                 let res = storage.get_value::<false>(i, &hw_counter).unwrap();
                 assert!(res.0.contains_key("article_id"));
             }
@@ -110,7 +110,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
 
     // delete 30% of the points
     let mut rng = rand::rng();
-    for i in 0..storage.max_point_id() {
+    for i in 0..storage.max_point_offset() {
         if rng.random_bool(0.3) {
             storage.delete_value(i).unwrap();
         }

--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -103,7 +104,7 @@ impl<V: Blob> Gridstore<V> {
         self.pages.read().len() as PageId
     }
 
-    pub fn max_point_id(&self) -> PointOffset {
+    pub fn max_point_offset(&self) -> PointOffset {
         self.tracker.read().pointer_count()
     }
 
@@ -532,28 +533,50 @@ impl<V: Blob> Gridstore<V> {
     where
         F: FnMut(PointOffset, V) -> std::result::Result<bool, E>,
     {
-        for (point_offset, pointer) in
-            self.tracker
-                .read()
-                .iter_pointers()
-                .filter_map(|(point_offset, opt_pointer)| {
-                    opt_pointer.map(|pointer| (point_offset, pointer))
-                })
-        {
-            let ValuePointer {
-                page_id,
-                block_offset,
-                length,
-            } = pointer;
+        const BUFFER_SIZE: usize = 128;
+        let max_point_offset = self.max_point_offset();
 
-            let raw = self.read_from_pages::<true>(page_id, block_offset, length);
+        let mut from = 0;
+        let mut buffer = Vec::with_capacity(min(BUFFER_SIZE, max_point_offset as usize));
 
-            hw_counter.incr_delta(raw.len());
+        loop {
+            // Collect pointers into a buffer while holding the lock
+            buffer.clear();
+            buffer.extend(
+                self.tracker
+                    .read()
+                    .iter_pointers(from)
+                    .filter_map(|(point_offset, opt_pointer)| {
+                        opt_pointer.map(|pointer| (point_offset, pointer))
+                    })
+                    .take(BUFFER_SIZE),
+            );
 
-            let decompressed = self.decompress(raw);
-            let value = V::from_bytes(&decompressed);
-            if !callback(point_offset, value)? {
-                return Ok(());
+            // If no more pointers, we're done
+            if buffer.is_empty() {
+                break;
+            }
+
+            // Update `from` for the next iteration
+            from = buffer.last().unwrap().0 + 1;
+
+            // Process buffer without holding the tracker lock
+            for &(point_offset, pointer) in &buffer {
+                let ValuePointer {
+                    page_id,
+                    block_offset,
+                    length,
+                } = pointer;
+
+                let raw = self.read_from_pages::<true>(page_id, block_offset, length);
+
+                hw_counter.incr_delta(raw.len());
+
+                let decompressed = self.decompress(raw);
+                let value = V::from_bytes(&decompressed);
+                if !callback(point_offset, value)? {
+                    return Ok(());
+                }
             }
         }
         Ok(())
@@ -983,7 +1006,7 @@ mod tests {
                 Operation::Clear => {
                     log::debug!("op:{i} CLEAR");
                     storage.clear().unwrap();
-                    assert_eq!(storage.max_point_id(), 0, "storage should be empty");
+                    assert_eq!(storage.max_point_offset(), 0, "storage should be empty");
                     model_hashmap.clear();
                 }
                 Operation::Iter(limit) => {
@@ -1726,6 +1749,6 @@ mod tests {
         let storage = Gridstore::<Payload>::open(path.clone()).unwrap();
         assert_eq!(storage.pages.read().len(), 1);
         assert!(storage.get_pointer(0).is_none(), "point must not exist");
-        assert_eq!(storage.max_point_id(), 0, "must have zero points");
+        assert_eq!(storage.max_point_offset(), 0, "must have zero points");
     }
 }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -363,8 +363,12 @@ impl Tracker {
     }
 
     /// Iterate over the pointers in the tracker
-    pub fn iter_pointers(&self) -> impl Iterator<Item = (PointOffset, Option<ValuePointer>)> + '_ {
-        (0..self.next_pointer_offset).map(move |i| (i, self.get(i as PointOffset)))
+    /// Starts from the given point offset
+    pub fn iter_pointers(
+        &self,
+        from: PointOffset,
+    ) -> impl Iterator<Item = (PointOffset, Option<ValuePointer>)> + '_ {
+        (from..self.next_pointer_offset).map(move |i| (i, self.get(i as PointOffset)))
     }
 
     /// Get the raw value at the given point offset

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -70,7 +70,7 @@ impl MmapSparseVectorStorage {
         let next_point_offset = deleted
             .get_bitslice()
             .last_one()
-            .max(Some(storage.max_point_id() as usize))
+            .max(Some(storage.max_point_offset() as usize))
             .unwrap_or_default();
 
         Ok(Self {


### PR DESCRIPTION
Currently, there is a livelock problem, which reproduces in the following situation:

- we have a stream of search requests hitting a collection
- On the same collection we run create_payload request, which is supposed to create an index for unrelated field

During index building search gets stuck.

Why it happens?

- For building index we iterate over payload storage, which is currently implemented via gridstore.
- We read payloads, and everything is good until suddenly it stucks. Why?
- Flush happes and tries to lock `tracker` inside gridstore. It is unternally mutable.
- Flush can't lock the `tracker` as we have an iterator going on, but it also stays in a queue and prevents incomming requests from reading gridstore. 
- So, everything is waiting on the iterator to finish.

This PR changes behaviour of the iterator, so it doesn't require locking the tracker whole time.
It also includes couple of cosmetic changes



