### PR TITLE
Reduce update queue ram usage by optimizing hw

### DIFF
--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -76,7 +76,7 @@ async fn test_hw_metrics_cancellation() {
         }],
     };
 
-    let outer_hw = HwSharedDrain::default();
+    let outer_hw = Arc::new(HwSharedDrain::default());
 
     {
         let hw_counter = HwMeasurementAcc::new_with_metrics_drain(outer_hw.clone());

--- a/lib/common/common/src/counter/hardware_accumulator.rs
+++ b/lib/common/common/src/counter/hardware_accumulator.rs
@@ -9,13 +9,13 @@ use super::hardware_data::HardwareData;
 /// as it doesn't provide any checks on drop.
 #[derive(Debug)]
 pub struct HwSharedDrain {
-    pub(crate) cpu_counter: Arc<AtomicUsize>,
-    pub(crate) payload_io_read_counter: Arc<AtomicUsize>,
-    pub(crate) payload_io_write_counter: Arc<AtomicUsize>,
-    pub(crate) payload_index_io_read_counter: Arc<AtomicUsize>,
-    pub(crate) payload_index_io_write_counter: Arc<AtomicUsize>,
-    pub(crate) vector_io_read_counter: Arc<AtomicUsize>,
-    pub(crate) vector_io_write_counter: Arc<AtomicUsize>,
+    pub(crate) cpu_counter: AtomicUsize,
+    pub(crate) payload_io_read_counter: AtomicUsize,
+    pub(crate) payload_io_write_counter: AtomicUsize,
+    pub(crate) payload_index_io_read_counter: AtomicUsize,
+    pub(crate) payload_index_io_write_counter: AtomicUsize,
+    pub(crate) vector_io_read_counter: AtomicUsize,
+    pub(crate) vector_io_write_counter: AtomicUsize,
 }
 
 impl HwSharedDrain {
@@ -69,29 +69,16 @@ impl HwSharedDrain {
     }
 }
 
-impl Clone for HwSharedDrain {
-    fn clone(&self) -> Self {
-        HwSharedDrain {
-            cpu_counter: self.cpu_counter.clone(),
-            payload_io_read_counter: self.payload_io_read_counter.clone(),
-            payload_io_write_counter: self.payload_io_write_counter.clone(),
-            payload_index_io_read_counter: self.payload_index_io_read_counter.clone(),
-            payload_index_io_write_counter: self.payload_index_io_write_counter.clone(),
-            vector_io_read_counter: self.vector_io_read_counter.clone(),
-            vector_io_write_counter: self.vector_io_write_counter.clone(),
-        }
-    }
-}
 impl Default for HwSharedDrain {
     fn default() -> Self {
         Self {
-            cpu_counter: Arc::new(AtomicUsize::new(0)),
-            payload_io_read_counter: Arc::new(AtomicUsize::new(0)),
-            payload_io_write_counter: Arc::new(AtomicUsize::new(0)),
-            payload_index_io_read_counter: Arc::new(AtomicUsize::new(0)),
-            payload_index_io_write_counter: Arc::new(AtomicUsize::new(0)),
-            vector_io_read_counter: Arc::new(AtomicUsize::new(0)),
-            vector_io_write_counter: Arc::new(AtomicUsize::new(0)),
+            cpu_counter: AtomicUsize::new(0),
+            payload_io_read_counter: AtomicUsize::new(0),
+            payload_io_write_counter: AtomicUsize::new(0),
+            payload_index_io_read_counter: AtomicUsize::new(0),
+            payload_index_io_write_counter: AtomicUsize::new(0),
+            vector_io_read_counter: AtomicUsize::new(0),
+            vector_io_write_counter: AtomicUsize::new(0),
         }
     }
 }
@@ -100,8 +87,8 @@ impl Default for HwSharedDrain {
 /// This type is completely reference counted and clones of this type will read/write the same values as their origin structure.
 #[derive(Debug)]
 pub struct HwMeasurementAcc {
-    request_drain: HwSharedDrain,
-    metrics_drain: HwSharedDrain,
+    request_drain: Arc<HwSharedDrain>,
+    metrics_drain: Arc<HwSharedDrain>,
     /// If this is set to true, the accumulator will not accumulate any values.
     disposable: bool,
 }
@@ -110,8 +97,8 @@ impl HwMeasurementAcc {
     #[cfg(feature = "testing")]
     pub fn new() -> Self {
         Self {
-            request_drain: HwSharedDrain::default(),
-            metrics_drain: HwSharedDrain::default(),
+            request_drain: Arc::new(HwSharedDrain::default()),
+            metrics_drain: Arc::new(HwSharedDrain::default()),
             disposable: false,
         }
     }
@@ -122,8 +109,8 @@ impl HwMeasurementAcc {
     /// Prefer `new` to be used in tests.
     pub fn disposable() -> Self {
         Self {
-            request_drain: HwSharedDrain::default(),
-            metrics_drain: HwSharedDrain::default(),
+            request_drain: Arc::new(HwSharedDrain::default()),
+            metrics_drain: Arc::new(HwSharedDrain::default()),
             disposable: true,
         }
     }
@@ -142,9 +129,9 @@ impl HwMeasurementAcc {
         HardwareCounterCell::new_with_accumulator(self.clone())
     }
 
-    pub fn new_with_metrics_drain(metrics_drain: HwSharedDrain) -> Self {
+    pub fn new_with_metrics_drain(metrics_drain: Arc<HwSharedDrain>) -> Self {
         Self {
-            request_drain: HwSharedDrain::default(),
+            request_drain: Arc::new(HwSharedDrain::default()),
             metrics_drain,
             disposable: false,
         }
@@ -201,7 +188,7 @@ impl HwMeasurementAcc {
             payload_index_io_write_counter,
             vector_io_read_counter,
             vector_io_write_counter,
-        } = &self.request_drain;
+        } = self.request_drain.as_ref();
 
         HardwareData {
             cpu: cpu_counter.load(Ordering::Relaxed),

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -89,7 +89,7 @@ pub struct TableOfContent {
     /// Effectively, this lock ensures that `create_collection` is called sequentially.
     collection_create_lock: Mutex<()>,
     /// Aggregation of all hardware measurements for each alias or collection config.
-    collection_hw_metrics: DashMap<CollectionId, HwSharedDrain>,
+    collection_hw_metrics: DashMap<CollectionId, Arc<HwSharedDrain>>,
     /// Collector for various telemetry/metrics.
     telemetry: TocTelemetryCollector,
 }

--- a/lib/storage/src/content_manager/toc/request_hw_counter.rs
+++ b/lib/storage/src/content_manager/toc/request_hw_counter.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use common::counter::hardware_accumulator::{HwMeasurementAcc, HwSharedDrain};
 
 use super::TableOfContent;
 
 impl TableOfContent {
-    pub fn get_collection_hw_metrics(&self, collection_id: String) -> HwSharedDrain {
+    pub fn get_collection_hw_metrics(&self, collection_id: String) -> Arc<HwSharedDrain> {
         self.collection_hw_metrics
             .entry(collection_id)
             .or_default()

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -343,7 +343,7 @@ impl Dispatcher {
     }
 
     #[must_use]
-    pub fn get_collection_hw_metrics(&self, collection: String) -> HwSharedDrain {
+    pub fn get_collection_hw_metrics(&self, collection: String) -> Arc<HwSharedDrain> {
         self.toc.get_collection_hw_metrics(collection)
     }
 }


### PR DESCRIPTION
## Summary
This PR reduces the heap size of `UpdateSignal` structure by optimizing size of `HwSharedDrain`.

## Implementation details
This PR refactors `HwSharedDrain` and removes `Arc` from each field. The whole `HwSharedDrain` is covered by a single `Arc` instead.

This change might be useful for the unlimited queue task, because it allows to use x3 larger update channel.

## RAM profit
Before changes, size of `UpdateSignal` is 152 bytes.
After this changes, 56 bytes.