### PR TITLE
Remove TODOs for assigning clock tags in forward proxy

### DIFF
--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -114,7 +114,7 @@ impl ForwardProxyShard {
             // TODO: Is cancelling `RemoteShard::update` safe for *receiver*?
             self.remote_shard
                 .update(
-                    // TODO: Assign clock tag!? 🤔
+                    // Don't add clock tag, this transfers indices out of regular order
                     OperationWithClockTag::from(CollectionUpdateOperations::FieldIndexOperation(
                         FieldIndexOperations::CreateIndex(CreateIndex {
                             field_name: index_key,
@@ -181,11 +181,12 @@ impl ForwardProxyShard {
 
         self.remote_shard
             .update(
+                // Don't add clock tag, this transfers points out of regular order (SyncPoints)
                 OperationWithClockTag::from(insert_points_operation),
                 wait,
                 None,
                 HwMeasurementAcc::disposable(), // Internal operation
-            ) // TODO: Assign clock tag!? 🤔
+            )
             .await?;
 
         Ok((next_page_offset, count))


### PR DESCRIPTION
In the forward proxy, two TODOs remained for assigning clock tags. This removes the TODOs.

Only user operations get a clock tag at the entry node.

The operations we generate here (e.g. sync points) are not user generated and are out of order. They don't relate to a specific user operation. We should therefore assign no clock tags.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?