### PR TITLE
[disk cache] `trififo` as lock-free cache controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,6 +5974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
 name = "ringbuffer"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7959,6 +7970,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr",
  "rayon",
+ "ringbuf",
  "schnellru",
  "static_assertions",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7952,6 +7952,7 @@ dependencies = [
  "cap",
  "criterion",
  "foyer",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
  "parking_lot",
  "quick_cache",

--- a/lib/trififo/Cargo.toml
+++ b/lib/trififo/Cargo.toml
@@ -13,7 +13,8 @@ workspace = true
 bench_all = []
 
 [dependencies]
-ahash = {workspace = true}
+ahash = { workspace = true }
+hashbrown = { version = "0.16.1" }
 
 [dev-dependencies]
 itertools = { workspace = true }

--- a/lib/trififo/Cargo.toml
+++ b/lib/trififo/Cargo.toml
@@ -14,7 +14,11 @@ bench_all = []
 
 [dependencies]
 ahash = { workspace = true }
-hashbrown = { version = "0.16.1" }
+
+# when bumping hashbrown, make sure this condition hasn't changed, since it may compromise concurrent readers
+# https://github.com/rust-lang/hashbrown/blob/9641fb3eea9a07933fb631da6e4f5070d2f7e1da/src/raw.rs#L2775
+hashbrown = "0.16.1"
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 itertools = { workspace = true }
@@ -30,6 +34,9 @@ static_assertions = { version = "1.1.0" }
 quick_cache = "0.6"
 schnellru = "0.2"
 foyer = "0.22"
+
+# For ring buffer comparison test
+ringbuf = "0.4"
 
 # For memory measurement
 cap = "0.1"

--- a/lib/trififo/benches/cache_comparison.rs
+++ b/lib/trififo/benches/cache_comparison.rs
@@ -33,6 +33,7 @@ use rayon::prelude::*;
 #[cfg(feature = "bench_all")]
 use schnellru::{ByLength, LruMap};
 use strum::{EnumIter, IntoEnumIterator};
+use trififo::lifecycle::NoLifecycle;
 
 /// Cache key representing a file descriptor and page offset.
 ///
@@ -282,7 +283,7 @@ struct TrififoWrapper {
 impl TrififoWrapper {
     fn new(capacity: usize) -> Self {
         Self {
-            cache: trififo::Cache::with_config(capacity, 0.1, 0.5),
+            cache: trififo::Cache::with_config(capacity, 0.1, 0.5, NoLifecycle),
         }
     }
 }

--- a/lib/trififo/src/cache.rs
+++ b/lib/trififo/src/cache.rs
@@ -1,0 +1,355 @@
+use std::hash::{BuildHasher, Hash};
+
+use parking_lot::Mutex;
+
+use crate::s3fifo::S3Fifo;
+use crate::seqlock::{SeqLock, SeqLockReader, SeqLockWriter};
+
+/// A concurrent S3-FIFO cache with a `hashbrown::HashTable` which stores the
+/// keys in the FIFO queues for lower memory overhead.
+///
+/// Design:
+/// - Reads are lock-free (only atomic seqlock checks) and can happen concurrently.
+/// - Writers share the same writer behind a mutex, so they will contend if another
+///   write is taking place.
+pub struct Cache<K, V, S = ahash::RandomState> {
+    /// Shared state for lock-free readers.
+    reader: SeqLockReader<S3Fifo<K, V, S>>,
+
+    writer: Mutex<SeqLockWriter<S3Fifo<K, V, S>>>,
+}
+
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Copy + Hash + Eq,
+    V: Clone,
+    S: BuildHasher + Default,
+{
+    /// Create a new concurrent cache with default disruptor size and producer pool.
+    pub fn new(capacity: usize) -> Self {
+        Self::with_config(capacity, 0.1, 0.9)
+    }
+
+    /// Create with custom disruptor ring size.
+    pub fn with_config(capacity: usize, small_ratio: f32, ghost_ratio: f32) -> Self {
+        assert!(capacity > 0);
+
+        let s3fifo = S3Fifo::new(capacity, small_ratio, ghost_ratio);
+
+        // Create seqlock reader/writer pair
+        let (reader, cache_writer) = SeqLock::new_reader_writer(s3fifo);
+
+        Self {
+            reader,
+            writer: Mutex::new(cache_writer),
+        }
+    }
+
+    /// Read a value from the cache.
+    ///
+    /// Returns a cloned value (if present).
+    #[inline]
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.reader.read(|s3fifo| s3fifo.get(key))
+    }
+
+    /// Publish an insert for processing by the writer thread.
+    #[inline]
+    pub fn insert(&self, key: K, value: V) {
+        let mut writer_guard = self.writer.lock();
+        writer_guard.write(|cache| cache.do_insert(key, value));
+    }
+
+    pub fn len(&self) -> usize {
+        self.reader.read(|s3fifo| s3fifo.len())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use rand::Rng;
+
+    use super::*;
+
+    #[test]
+    fn basic_insert_get() {
+        let cache = Cache::<u64, String>::new(100);
+
+        cache.insert(1, "hello".to_string());
+        thread::sleep(Duration::from_millis(10));
+
+        let got = cache.get(&1);
+        assert_eq!(got, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn concurrent_reads() {
+        let cache = Cache::<u64, String>::new(200);
+
+        for i in 0..20u64 {
+            cache.insert(i, format!("val_{i}"));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+
+        let arc = Arc::new(cache);
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let c = Arc::clone(&arc);
+                thread::spawn(move || {
+                    for _ in 0..100 {
+                        for k in 0..20u64 {
+                            let _ = c.get(&k);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn multi_threaded_inserts() {
+        let cache = Arc::new(Cache::<u64, u64>::new(5000));
+
+        const THREADS: usize = 4;
+        const PER: u64 = 1000;
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|t| {
+                let c = Arc::clone(&cache);
+                thread::spawn(move || {
+                    let start = (t as u64) * PER;
+                    for i in start..(start + PER) {
+                        c.insert(i, i * 2);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        thread::sleep(Duration::from_millis(100));
+
+        // At least some entries should be present
+        let mut found = 0usize;
+        for i in 0..(THREADS as u64 * PER) {
+            if cache.get(&i).is_some() {
+                found += 1;
+            }
+        }
+        assert!(found > 0);
+    }
+
+    #[test]
+    fn high_contention_inserts() {
+        let cache = Arc::new(Cache::<u64, u64>::new(2000));
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        const THREADS: usize = 8;
+        const INSERTS: usize = 500;
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let c = Arc::clone(&cache);
+                let ctr = Arc::clone(&counter);
+                thread::spawn(move || {
+                    for _ in 0..INSERTS {
+                        let k = ctr.fetch_add(1, Ordering::Relaxed) as u64;
+                        c.insert(k, k);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        thread::sleep(Duration::from_millis(100));
+        assert!(!cache.is_empty());
+    }
+
+    // --- Fuzz test for immediately-consistent cache ----------------------------
+
+    /// Fuzz test that verifies the cache is immediately consistent: once an
+    /// insert returns, readers must see either that value or a newer one.
+    ///
+    /// This test ensures:
+    /// 1. Values are immediately visible after insert returns
+    /// 2. No data corruption occurs under concurrent access
+    /// 3. Only valid values (from our pre-generated set) are ever returned
+    #[test]
+    fn fuzz_immediate_consistency() {
+        const CAPACITY: usize = 10240;
+        let cache = Arc::new(Cache::<u64, u64>::new(CAPACITY));
+
+        const KEY_SPACE: u64 = 256000; // Smaller key space for more contention
+        const THREADS: usize = 8;
+        const OPS_PER_THREAD: usize = 5_000_000;
+
+        // Pre-generate a hashmap of keys -> ordered sequence of values.
+        // Writers will write values in order, and readers verify they only
+        // see values from the valid set (no corruption).
+        let mut key_values: HashMap<u64, Vec<u64>> = HashMap::new();
+        for k in 0..KEY_SPACE {
+            // Each key gets a sequence of unique values
+            let count = 16;
+            let mut values = HashSet::new();
+            while values.len() < count {
+                values.insert(rand::random::<u64>());
+            }
+            key_values.insert(k, values.into_iter().collect());
+        }
+        let key_values = Arc::new(key_values);
+
+        let mut handles = Vec::with_capacity(THREADS);
+
+        // Each thread does both reads and writes to maximize interleaving
+        for _ in 0..THREADS {
+            let c = Arc::clone(&cache);
+            let kv = Arc::clone(&key_values);
+            handles.push(thread::spawn(move || {
+                let mut rnd = rand::rng();
+                // Queue of keys to check later for delayed corruption
+                const DEFERRED_CHECK_WINDOW: usize = 1000;
+                let mut deferred_checks: VecDeque<u64> = VecDeque::with_capacity(DEFERRED_CHECK_WINDOW + 1);
+
+                for _ in 0..OPS_PER_THREAD {
+                    let key = rnd.random_range(0..KEY_SPACE);
+                    let values = &kv[&key];
+
+                    if rnd.random::<bool>() {
+                        // Write: pick a random valid value and insert
+                        let value = values[rnd.random_range(0..values.len())];
+                        c.insert(key, value);
+
+                        // Immediately verify the write is visible (immediate consistency)
+                        // The cache may evict entries, so we check if present, it must be valid
+                        if let Some(read_value) = c.get(&key) {
+                            assert!(
+                                values.contains(&read_value),
+                                "immediate read after write returned invalid value {read_value} for key {key}",
+                            );
+                        }
+
+                        // Queue this key for deferred verification to catch delayed corruption
+                        deferred_checks.push_back(key);
+                        if deferred_checks.len() > DEFERRED_CHECK_WINDOW {
+                            let old_key = deferred_checks.pop_front().unwrap();
+                            if let Some(v) = c.get(&old_key) {
+                                let old_values = &kv[&old_key];
+                                assert!(
+                                    old_values.contains(&v),
+                                    "deferred check: corrupted value {v} for key {old_key}",
+                                );
+                            }
+                        }
+                    } else {
+                        // Read: verify any returned value is from the valid set
+                        if let Some(v) = c.get(&key) {
+                            assert!(
+                                values.contains(&v),
+                                "cache returned corrupted/invalid value {v} for key {key}",
+                            );
+                        }
+                    }
+
+                    // Occasional yield to increase interleaving
+                    if (rnd.random::<u32>() & 0xff) == 0 {
+                        thread::yield_now();
+                    }
+                }
+
+                // Drain remaining deferred checks
+                for old_key in deferred_checks {
+                    if let Some(v) = c.get(&old_key) {
+                        let values = &kv[&old_key];
+                        assert!(
+                            values.contains(&v),
+                            "final deferred check: corrupted value {v} for key {old_key}",
+                        );
+                    }
+                }
+            }));
+        }
+
+        // Wait for all threads to finish
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Final verification: all cached values must be from valid sets
+        for k in 0..KEY_SPACE {
+            if let Some(v) = cache.get(&k) {
+                let values = &key_values[&k];
+                assert!(
+                    values.contains(&v),
+                    "final check: returned {v} for key {k} which wasn't in the valid set",
+                );
+            }
+        }
+    }
+
+    /// Test that specifically verifies write-then-read consistency:
+    /// After a successful insert, the value must be immediately readable.
+    #[test]
+    fn fuzz_write_read_consistency() {
+        const CAPACITY: usize = 512;
+        let cache = Arc::new(Cache::<u64, u64>::new(CAPACITY));
+
+        const KEY_SPACE: u64 = 64; // Small key space to stay within capacity
+        const THREADS: usize = 4;
+        const OPS_PER_THREAD: usize = 10_000;
+
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for thread_id in 0..THREADS {
+            let c = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let mut rnd = rand::rng();
+                for i in 0..OPS_PER_THREAD {
+                    // Use thread-local keys to avoid eviction from other threads
+                    let key = (thread_id as u64 * KEY_SPACE / THREADS as u64)
+                        + rnd.random_range(0..(KEY_SPACE / THREADS as u64));
+                    let value = (thread_id * OPS_PER_THREAD + i) as u64;
+
+                    c.insert(key, value);
+
+                    // The value we just inserted must be immediately visible
+                    // (unless another thread overwrote it, in which case we
+                    // should see their valid value)
+                    let read = c.get(&key);
+                    assert!(
+                        read.is_some(),
+                        "key {key} not visible immediately after insert",
+                    );
+
+                    // Occasional yield
+                    if (rnd.random::<u32>() & 0x1ff) == 0 {
+                        thread::yield_now();
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/lib/trififo/src/entry.rs
+++ b/lib/trififo/src/entry.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const MAX_RECENCY: u8 = 3;
+
+/// Entry stored in the small and main queues.
+#[derive(Debug)]
+pub struct Entry<K, V> {
+    pub key: K,
+    pub value: V,
+    recency: AtomicU8,
+}
+
+impl<K, V> Entry<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self {
+            key,
+            value,
+            recency: AtomicU8::new(0),
+        }
+    }
+
+    pub fn clone(&self) -> Self
+    where
+        K: Copy,
+        V: Clone,
+    {
+        Self {
+            key: self.key,
+            value: self.value.clone(),
+            recency: AtomicU8::new(self.recency.load(Ordering::Relaxed)),
+        }
+    }
+
+    #[inline]
+    pub fn recency(&self) -> u8 {
+        self.recency.load(Ordering::Relaxed)
+    }
+
+    /// Increment recency by 1, saturating at `MAX_RECENCY`
+    #[inline]
+    pub fn incr_recency(&self) {
+        let current = self.recency.load(Ordering::Relaxed);
+        if current < MAX_RECENCY {
+            self.recency.store(current + 1, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn decr_recency(&self) {
+        let current = self.recency.load(Ordering::Relaxed);
+        if current > 0 {
+            self.recency.store(current - 1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recency() {
+        let entry = Entry::new(1u64, "test".to_string());
+
+        assert_eq!(entry.recency(), 0);
+        entry.incr_recency();
+        assert_eq!(entry.recency(), 1);
+        entry.incr_recency();
+        entry.incr_recency();
+        entry.incr_recency(); // Should saturate at 3
+        assert_eq!(entry.recency(), 3);
+
+        entry.decr_recency();
+        assert_eq!(entry.recency(), 2);
+    }
+}

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod seqlock;
 
-#[expect(dead_code)]
 mod entry;
-#[expect(dead_code)]
 mod raw_fifos;
 mod ringbuffer;
+#[expect(dead_code)]
+mod s3fifo;

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod seqlock;
-
+mod cache;
 mod entry;
 mod raw_fifos;
 mod ringbuffer;
-#[expect(dead_code)]
 mod s3fifo;
+pub mod seqlock;
+
+pub use cache::Cache;

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod seqlock;
 
 #[expect(dead_code)]
+mod entry;
+#[expect(dead_code)]
+mod raw_fifos;
 mod ringbuffer;

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,5 +1,6 @@
 mod cache;
 mod entry;
+pub mod lifecycle;
 mod raw_fifos;
 mod ringbuffer;
 mod s3fifo;

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod seqlock;
+
+#[expect(dead_code)]
+mod ringbuffer;

--- a/lib/trififo/src/lifecycle.rs
+++ b/lib/trififo/src/lifecycle.rs
@@ -1,0 +1,10 @@
+pub trait Lifecycle<K, V> {
+    fn on_evict(&self, key: K, value: V);
+}
+
+#[derive(Default)]
+pub struct NoLifecycle;
+
+impl<K, V> Lifecycle<K, V> for NoLifecycle {
+    fn on_evict(&self, _key: K, _value: V) {}
+}

--- a/lib/trififo/src/raw_fifos.rs
+++ b/lib/trififo/src/raw_fifos.rs
@@ -189,14 +189,21 @@ impl<K, V> RawFifos<K, V> {
         self.small.get_absolute(position)
     }
 
-    pub fn ghost_eviction_candidate(&self) -> Option<&K> {
+    pub fn ghost_eviction_candidate(&self) -> Option<(GlobalOffset, &K)> {
         let position = self.ghost.write_position();
-        self.ghost.get_absolute(position)
+
+        let key = self.ghost.get_absolute(position)?;
+        let global_offset = self.global_offset(LocalOffset::Ghost(position as u32));
+
+        Some((global_offset, key))
     }
 
-    pub fn main_eviction_candidate(&self) -> Option<&Entry<K, V>> {
+    pub fn main_eviction_candidate(&self) -> Option<(GlobalOffset, &Entry<K, V>)> {
         let position = self.main.write_position();
-        self.main.get_absolute(position)
+        let entry = self.main.get_absolute(position)?;
+        let global_offset = self.global_offset(LocalOffset::Main(position as u32));
+
+        Some((global_offset, entry))
     }
 }
 

--- a/lib/trififo/src/raw_fifos.rs
+++ b/lib/trififo/src/raw_fifos.rs
@@ -184,9 +184,13 @@ impl<K, V> RawFifos<K, V> {
         self.main.reinsert_if(f)
     }
 
-    pub fn small_eviction_candidate(&self) -> Option<&Entry<K, V>> {
+    pub fn small_eviction_candidate(&self) -> Option<(GlobalOffset, &Entry<K, V>)> {
         let position = self.small.write_position();
-        self.small.get_absolute(position)
+
+        let entry = self.small.get_absolute(position)?;
+        let global_offset = self.global_offset(LocalOffset::Small(position as u32));
+
+        Some((global_offset, entry))
     }
 
     pub fn ghost_eviction_candidate(&self) -> Option<(GlobalOffset, &K)> {

--- a/lib/trififo/src/raw_fifos.rs
+++ b/lib/trififo/src/raw_fifos.rs
@@ -1,0 +1,223 @@
+use std::hash::{BuildHasher, Hash};
+use std::num::NonZeroUsize;
+
+use crate::entry::Entry;
+use crate::ringbuffer::RingBuffer;
+
+pub type GlobalOffset = u32;
+
+/// Local offset within one of the three queues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalOffset {
+    Small(u32),
+    Ghost(u32),
+    Main(u32),
+}
+
+/// Encapsulate the 3 FIFO queues used by S3-FIFO algorithm, where a global offset can be used to
+/// index into any of them, as if they were consecutive arrays.
+pub struct RawFifos<K, V> {
+    pub small: RingBuffer<Entry<K, V>>,
+    pub ghost: RingBuffer<K>,
+    pub main: RingBuffer<Entry<K, V>>,
+
+    small_end: u32,
+    ghost_end: u32,
+}
+
+impl<K, V> RawFifos<K, V> {
+    /// Initialize the queues with the provided sizes. The entire allocation is made upfront.
+    ///
+    /// # Arguments
+    /// * `capacity` - Total capacity for small + main queues. Minimum is 2.
+    /// * `small_ratio` - Fraction of capacity for small queue (typically 0.1)
+    /// * `ghost_ratio` - Fraction of capacity for ghost queue (typically 0.9)
+    pub fn new(capacity: usize, small_ratio: f32, ghost_ratio: f32) -> Self {
+        assert!(small_ratio > 0.0 && small_ratio < 1.0);
+        assert!(ghost_ratio > 0.0 && ghost_ratio < 1.0);
+
+        let small_size = (capacity as f32 * small_ratio).ceil() as usize;
+        let small_size = NonZeroUsize::try_from(small_size).unwrap_or(NonZeroUsize::MIN);
+        let small = RingBuffer::new(small_size);
+
+        let ghost_size = (capacity as f32 * ghost_ratio).ceil() as usize;
+        let ghost_size = NonZeroUsize::try_from(ghost_size).unwrap_or(NonZeroUsize::MIN);
+        let ghost = RingBuffer::new(ghost_size);
+
+        let main_size = capacity - small_size.get();
+        let main_size = NonZeroUsize::try_from(main_size).unwrap_or(NonZeroUsize::MIN);
+        let main = RingBuffer::new(main_size);
+
+        let small_end = small_size.get() as GlobalOffset;
+        let ghost_end = small_end + ghost_size.get() as GlobalOffset;
+
+        RawFifos {
+            small,
+            ghost,
+            main,
+            small_end,
+            ghost_end,
+        }
+    }
+
+    /// Converts a global offset to a local offset.
+    #[inline]
+    pub fn local_offset(&self, global_offset: GlobalOffset) -> LocalOffset {
+        if global_offset < self.small_end {
+            LocalOffset::Small(global_offset)
+        } else if global_offset < self.ghost_end {
+            LocalOffset::Ghost(global_offset - self.small_end)
+        } else {
+            LocalOffset::Main(global_offset - self.ghost_end)
+        }
+    }
+
+    /// Converts a local offset to a global offset.
+    #[inline]
+    pub fn global_offset(&self, local_offset: LocalOffset) -> GlobalOffset {
+        match local_offset {
+            LocalOffset::Small(offset) => offset,
+            LocalOffset::Ghost(offset) => offset + self.small_end,
+            LocalOffset::Main(offset) => offset + self.ghost_end,
+        }
+    }
+
+    /// Gets an entry from the small or main queue by local offset.
+    ///
+    /// Returns None for ghost queue offsets (ghost only stores keys, not full entries).
+    #[inline]
+    pub fn get_entry(&self, local_offset: LocalOffset) -> Option<&Entry<K, V>> {
+        match local_offset {
+            LocalOffset::Small(offset) => Some(self.small.get_absolute(offset as usize)?),
+            LocalOffset::Ghost(_) => None,
+            LocalOffset::Main(offset) => Some(self.main.get_absolute(offset as usize)?),
+        }
+    }
+
+    pub fn get_key(&self, local_offset: LocalOffset) -> Option<&K> {
+        match local_offset {
+            LocalOffset::Small(off) => Some(&self.small.get_absolute(off as usize)?.key),
+            LocalOffset::Main(off) => Some(&self.main.get_absolute(off as usize)?.key),
+            LocalOffset::Ghost(off) => self.ghost.get_absolute(off as usize),
+        }
+    }
+
+    /// Compare the key stored at a global offset with the provided `key`.
+    ///
+    /// This is a convenience used by hashtable lookup helpers to verify whether
+    /// an entry at `global_offset` corresponds to `key`. It resolves the global
+    /// offset into the appropriate queue (small/main/ghost) and compares the
+    /// stored key.
+    #[inline]
+    pub fn key_eq(&self, global_offset: GlobalOffset, key: &K) -> bool
+    where
+        K: PartialEq,
+    {
+        let local_offset = self.local_offset(global_offset);
+        let Some(stored_key) = self.get_key(local_offset) else {
+            return false;
+        };
+        stored_key == key
+    }
+
+    /// Compute the hash for the key stored at `global_offset` using the given
+    /// `hasher`. This function is used by a hashtable for insertion.
+    #[inline]
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    pub fn hash_key_at_offset<S>(&mut self, global_offset: GlobalOffset, hasher: &S) -> u64
+    where
+        S: BuildHasher,
+        K: Copy + Hash,
+    {
+        // Extract the key from the appropriate queue and hash it with the provided hasher.
+        let local_offset = self.local_offset(global_offset);
+        let key = self
+            .get_key(local_offset)
+            // Since we are the only writer, the offset is valid.
+            .expect("We are the only writer, as established by `&mut self`");
+
+        hasher.hash_one(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_fifos() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push to small queue
+        let entry = Entry::new(1u64, "hello".to_string());
+        let offset = fifos.small.overwriting_push(entry);
+        assert_eq!(offset, 0);
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(offset as u32);
+        assert_eq!(local_offset, LocalOffset::Small(0));
+
+        let entry = fifos.get_entry(local_offset).unwrap();
+        assert_eq!(entry.key, 1);
+        assert_eq!(entry.value, "hello");
+    }
+
+    #[test]
+    fn test_ghost_queue() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push key to ghost queue
+        let offset = fifos.ghost.overwriting_push(42u64);
+        let global_offset = fifos.global_offset(LocalOffset::Ghost(offset as u32));
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(global_offset);
+        assert!(matches!(local_offset, LocalOffset::Ghost(_)));
+
+        // Ghost entries return None for get_entry
+        assert!(fifos.get_entry(local_offset).is_none());
+
+        // But the key is still there
+        assert_eq!(*fifos.get_key(local_offset).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_main_queue() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push to main queue
+        let entry = Entry::new(99u64, "main".to_string());
+        let offset = fifos.main.try_push(entry).unwrap();
+        let global_offset = fifos.global_offset(LocalOffset::Main(offset as u32));
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(global_offset);
+        assert!(matches!(local_offset, LocalOffset::Main(_)));
+
+        let entry = fifos.get_entry(local_offset).unwrap();
+        assert_eq!(entry.key, 99);
+        assert_eq!(entry.value, "main");
+    }
+
+    #[test]
+    fn test_recency() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        let entry = Entry::new(1u64, "test".to_string());
+        let offset = fifos.small.overwriting_push(entry);
+
+        let local_offset = fifos.local_offset(offset as u32);
+        let entry = fifos.get_entry(local_offset).unwrap();
+
+        assert_eq!(entry.recency(), 0);
+        entry.incr_recency();
+        assert_eq!(entry.recency(), 1);
+        entry.incr_recency();
+        entry.incr_recency();
+        entry.incr_recency(); // Should saturate at 3
+        assert_eq!(entry.recency(), 3);
+
+        entry.decr_recency();
+        assert_eq!(entry.recency(), 2);
+    }
+}

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -1,0 +1,228 @@
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Fixed-size ringbuffer with support for absolute indexing into its contents.
+///
+/// There is explicitly no way to remove elements before they are overwritten by
+/// filling the capacity. This can be changed, but other methods like `is_in_range` would
+/// need to be reviewed carefully.
+pub struct RingBuffer<T> {
+    /// Container for elements
+    buffer: Box<[MaybeUninit<T>]>,
+
+    /// Maximum number of elements in the buffer
+    capacity: usize,
+
+    /// Current write position (0 to capacity-1, wraps around)
+    write_pos: AtomicUsize,
+
+    /// Number of elements currently stored
+    len: AtomicUsize,
+}
+
+impl<T> RingBuffer<T> {
+    pub fn new(capacity: usize) -> Self {
+        let buffer: Box<[MaybeUninit<T>]> = (0..capacity).map(|_| MaybeUninit::uninit()).collect();
+
+        Self {
+            buffer,
+            capacity,
+            write_pos: AtomicUsize::new(0),
+            len: AtomicUsize::new(0),
+        }
+    }
+
+    /// Returns the number of elements currently stored in the buffer.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.len.load(Ordering::Acquire)
+    }
+
+    /// Returns true if the buffer is full.
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.len.load(Ordering::Acquire) == self.capacity
+    }
+
+    /// Returns the current write position.
+    #[inline]
+    pub fn write_position(&self) -> usize {
+        self.write_pos.load(Ordering::Acquire)
+    }
+
+    /// Returns the oldest valid position offset in the buffer.
+    ///
+    /// Returns None if the buffer is empty.
+    pub fn read_position(&self) -> Option<usize> {
+        let len = self.len.load(Ordering::Acquire);
+        if len == 0 {
+            None
+        } else if len < self.capacity {
+            Some(0)
+        } else {
+            Some(self.write_pos.load(Ordering::Acquire))
+        }
+    }
+
+    /// Checks whether the position has an active value in the buffer.
+    #[inline]
+    fn is_in_range(&self, position: usize) -> bool {
+        // Since we are never shrinking the number of active elements
+        // in `self.buffer`, we can assume that, as long as position is
+        // within 0..self.len, there is something initialized in that slot.
+        position < self.len.load(Ordering::Acquire)
+    }
+
+    /// Gets a reference to the item at the given position offset.
+    ///
+    /// # SeqLock un/safety
+    /// If there is a concurrent writer, this will still check bounds appropriately
+    /// because it uses atomics for bounds.
+    ///
+    /// The value itself is not protected and can exhibit a torn read.
+    #[inline]
+    pub fn get_absolute(&self, position: usize) -> Option<&T> {
+        if !self.is_in_range(position) {
+            return None;
+        }
+
+        // Safety: We just checked the value is within bounds
+        let value = &self.buffer[position];
+        let value = unsafe { value.assume_init_ref() };
+        Some(value)
+    }
+
+    /// Pushes an item into the ring buffer and returns its position offset.
+    ///
+    /// If the buffer is full, the oldest item is overwritten.
+    pub fn overwriting_push(&mut self, item: T) -> usize {
+        let offset = self.write_pos.load(Ordering::Relaxed);
+
+        // Write the new value
+        self.buffer[offset].write(item);
+
+        // Update write position with Release ordering to ensure the write
+        // is visible to readers before they see the new position
+        let new_write_pos = (offset + 1) % self.capacity;
+        self.write_pos.store(new_write_pos, Ordering::Release);
+
+        // Update length
+        let current_len = self.len.load(Ordering::Relaxed);
+        if current_len < self.capacity {
+            self.len.store(current_len + 1, Ordering::Release);
+        }
+
+        offset
+    }
+
+    /// Attempts to push an item without overwriting.
+    ///
+    /// Returns the position offset if successful, or the input item if full.
+    pub fn try_push(&mut self, item: T) -> Result<usize, T> {
+        if self.is_full() {
+            return Err(item);
+        }
+        Ok(self.overwriting_push(item))
+    }
+
+    /// Reinserts the oldest entry if the predicate returns true.
+    ///
+    /// Returns whether the reinsertion happened.
+    ///
+    /// Only works when the buffer is full.
+    pub fn reinsert_if(&mut self, f: impl FnOnce(&T) -> bool) -> bool {
+        let write_pos = self.write_pos.load(Ordering::Relaxed);
+        let read_pos = match self.read_position() {
+            Some(pos) if pos == write_pos => pos,
+            // Buffer not full, won't reinsert
+            _ => return false,
+        };
+
+        // Ask the callback if we should reinsert
+        let entry = unsafe { (self.buffer[read_pos]).assume_init_ref() };
+        if !f(entry) {
+            return false;
+        }
+
+        // Advance write position (entry stays in place, effectively reinserted)
+        let new_write_pos = (write_pos + 1) % self.capacity;
+        self.write_pos.store(new_write_pos, Ordering::Release);
+
+        true
+    }
+}
+
+impl<T> Drop for RingBuffer<T> {
+    fn drop(&mut self) {
+        let len = *self.len.get_mut();
+
+        for pos in 0..len {
+            unsafe {
+                std::ptr::drop_in_place(self.buffer[pos].as_mut_ptr());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Ring buffer capacity must be greater than 0")]
+    fn test_zero_capacity_panics() {
+        let _ = RingBuffer::<i32>::new(0);
+    }
+
+    #[test]
+    fn test_push_and_get() {
+        let mut buffer = RingBuffer::<i32>::new(3);
+
+        let offset0 = buffer.overwriting_push(10);
+        let offset1 = buffer.overwriting_push(20);
+        let offset2 = buffer.overwriting_push(30);
+
+        assert_eq!(buffer.get_absolute(offset0).unwrap(), &10);
+        assert_eq!(buffer.get_absolute(offset1).unwrap(), &20);
+        assert_eq!(buffer.get_absolute(offset2).unwrap(), &30);
+
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.len(), 3);
+        assert!(buffer.is_full());
+        assert!(buffer.is_full());
+    }
+
+    #[test]
+    fn test_offsets_wrap() {
+        let mut buffer = RingBuffer::<i32>::new(3);
+
+        let offset0 = buffer.overwriting_push(10);
+        let offset1 = buffer.overwriting_push(20);
+        let offset2 = buffer.overwriting_push(30);
+
+        assert_eq!(offset0, 0);
+        assert_eq!(offset1, 1);
+        assert_eq!(offset2, 2);
+
+        let offset3 = buffer.overwriting_push(40);
+        assert_eq!(offset3, 0); // Wraps to 0
+
+        // offset0 and offset3 point to same position (overwritten)
+        assert_eq!(buffer.get_absolute(offset3).unwrap(), &40);
+        assert_eq!(buffer.get_absolute(offset0).unwrap(), &40);
+    }
+
+    #[test]
+    fn test_try_push() {
+        let mut buffer = RingBuffer::<i32>::new(3);
+
+        assert!(buffer.try_push(10).is_ok());
+        assert!(buffer.try_push(20).is_ok());
+        assert!(buffer.try_push(30).is_ok());
+
+        // Should fail when full
+        assert_eq!(buffer.try_push(40), Err(40));
+        assert_eq!(buffer.len(), 3);
+    }
+}

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -180,10 +180,8 @@ impl<T> Drop for RingBuffer<T> {
     fn drop(&mut self) {
         let len = *self.len.get_mut();
 
-        for pos in 0..len {
-            unsafe {
-                std::ptr::drop_in_place(self.buffer[pos].as_mut_ptr());
-            }
+        for slot in &mut self.buffer[..len] {
+            unsafe { slot.assume_init_drop() };
         }
     }
 }

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -40,7 +40,6 @@ impl<T> RingBuffer<T> {
     }
 
     /// Returns the number of elements currently stored in the buffer.
-    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.len.load(Ordering::Acquire)
     }

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -118,7 +118,7 @@ impl<T> RingBuffer<T> {
 
         // Update write position with Release ordering to ensure the write
         // is visible to readers before they see the new position
-        let new_write_pos = (offset + 1) % self.capacity;
+        let new_write_pos = self.next_position(offset);
         self.write_pos.store(new_write_pos, Ordering::Release);
 
         // Update length
@@ -159,10 +159,20 @@ impl<T> RingBuffer<T> {
         }
 
         // Advance write position (entry stays in place, effectively reinserted)
-        let new_write_pos = (write_pos + 1) % self.capacity;
+        let new_write_pos = self.next_position(write_pos);
         self.write_pos.store(new_write_pos, Ordering::Release);
 
         true
+    }
+
+    #[inline]
+    fn next_position(&self, position: usize) -> usize {
+        let next_position = position + 1;
+        if next_position < self.capacity.get() {
+            next_position
+        } else {
+            0
+        }
     }
 }
 

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -104,9 +104,10 @@ impl<T> RingBuffer<T> {
     /// If the buffer is full, the oldest item is overwritten.
     pub fn overwriting_push(&mut self, item: T) -> usize {
         let offset = self.write_pos.load(Ordering::Relaxed);
+        let current_len = self.len.load(Ordering::Relaxed);
 
         // Write the new value
-        if offset >= self.len.load(Ordering::Relaxed) {
+        if offset >= current_len {
             // write into an uninitialized slot
             self.buffer[offset].write(item);
         } else {
@@ -121,7 +122,6 @@ impl<T> RingBuffer<T> {
         self.write_pos.store(new_write_pos, Ordering::Release);
 
         // Update length
-        let current_len = self.len.load(Ordering::Relaxed);
         if current_len < self.capacity.get() {
             self.len.store(current_len + 1, Ordering::Release);
         }

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -4,6 +4,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Fixed-size ringbuffer with support for absolute indexing into its contents.
 ///
+/// This needs to exist, and not use external crates because we need absolute indexing.
+/// The only crate which allows that is `ringbuffer`, but it has a specific format which
+/// includes an epoch number, and cannot be constructed out of thin air. We want to be able
+/// to use u32/usize indexing directly.
+///
 /// There is explicitly no way to remove elements before they are overwritten by
 /// filling the capacity. This can be changed, but other methods like `is_in_range` would
 /// need to be reviewed carefully.

--- a/lib/trififo/src/s3fifo.rs
+++ b/lib/trififo/src/s3fifo.rs
@@ -1,0 +1,242 @@
+use std::hash::{BuildHasher, Hash};
+
+use hashbrown::HashTable;
+
+use crate::entry::Entry;
+use crate::raw_fifos::{GlobalOffset, LocalOffset, RawFifos};
+
+pub(crate) struct S3Fifo<K, V, S = ahash::RandomState> {
+    /// Non-concurrent hashtable mapping key -> global offset in the FIFOs.
+    hashtable: HashTable<GlobalOffset>,
+
+    /// The actual FIFO structures (small, ghost, main).
+    fifos: RawFifos<K, V>,
+
+    /// Hasher state used to compute the hash for lookups.
+    hasher: S,
+}
+
+impl<K, V, S> S3Fifo<K, V, S>
+where
+    K: Copy + Hash + Eq,
+    V: Clone,
+    S: BuildHasher + Default,
+{
+    pub fn new(capacity: usize, small_ratio: f32, ghost_ratio: f32) -> Self {
+        assert!(capacity > 0);
+
+        // Create FIFOs (reader + writer halves are managed by S3Fifo)
+        let fifos = RawFifos::new(capacity, small_ratio, ghost_ratio);
+
+        // Create a hashbrown hashtable with requested capacity.
+        //
+        // Maximum entries = small + main + ghost = capacity + ghost_size
+        let max_entries = capacity + (capacity as f32 * ghost_ratio) as usize;
+
+        // IMPORTANT: Allocate for 2x as much entries so that hashtable can be rehashed in-place if needed,
+        // but never resized and reallocate.
+        // See: https://github.com/rust-lang/hashbrown/blob/9641fb3eea9a07933fb631da6e4f5070d2f7e1da/src/raw.rs#L2775
+        //
+        // Internally, the capacity might increase to 1/8 higher, but that should only make it more robust.
+        // By doing this, we ensure that concurrent readers will not get to a use-after-free error.
+        let table_capacity = max_entries * 2;
+        let hashtable = HashTable::with_capacity(table_capacity);
+
+        Self {
+            hashtable,
+            fifos,
+            hasher: S::default(),
+        }
+    }
+
+    /// Convenience to compute hash for a key using stored hasher.
+    #[inline]
+    fn hash_key(&self, key: &K) -> u64 {
+        self.hasher.hash_one(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.fifos.entries_len()
+    }
+
+    pub fn get(&self, key: &K) -> Option<V> {
+        let hash = self.hash_key(key);
+
+        let global_offset = self
+            .hashtable
+            .find(hash, |global_offset| self.fifos.key_eq(*global_offset, key))?;
+
+        let entry = self.fifos.get_entry(*global_offset)?;
+
+        entry.incr_recency();
+
+        Some(entry.value.clone())
+    }
+
+    /// Entrypoint insert implementation
+    pub fn do_insert(&mut self, key: K, value: V) {
+        // Check existing entry
+        let hash = self.hash_key(&key);
+        if let Some(global_offset) = self.hashtable.find(hash, |global_offset| {
+            self.fifos.key_eq(*global_offset, &key)
+        }) {
+            self.promote_existing(*global_offset, key, value);
+            return;
+        }
+
+        // New entry -> insert into small queue
+        let entry = Entry::new(key, value);
+        let local = self.push_to_small_queue(entry);
+        self.insert_unique_to_hashtable(&key, local);
+    }
+
+    /// Promote existing entry or increment recency.
+    fn promote_existing(&mut self, global_offset: GlobalOffset, key: K, value: V) {
+        let local_offset = self.fifos.local_offset(global_offset);
+        match local_offset {
+            LocalOffset::Ghost(_) => {
+                let entry = Entry::new(key, value);
+                let new_offset = self.push_to_main_queue(entry);
+                self.update_hashtable(&key, new_offset);
+            }
+            LocalOffset::Small(_) | LocalOffset::Main(_) => {
+                if let Some(entry) = self.fifos.get_local_entry(local_offset) {
+                    entry.incr_recency();
+                }
+            }
+        }
+    }
+
+    /// Push to main queue. Evict or reinsert based on recency.
+    #[must_use]
+    fn push_to_main_queue(&mut self, entry: Entry<K, V>) -> GlobalOffset {
+        // Try fast path
+        let entry = match self.fifos.main_try_push(entry) {
+            Ok(offset) => return offset,
+            Err(entry) => entry,
+        };
+
+        // Reinsert while entries with recency > 0 exist
+        while self.fifos.main_reinsert_if(|e| {
+            if e.recency() > 0 {
+                e.decr_recency();
+                true
+            } else {
+                false
+            }
+        }) {}
+
+        // We need to remove from hashtable BEFORE overwriting the slot,
+        // because remove_from_hashtable uses key_eq which reads the current
+        // slot contents. If we remove after overwriting_push, the slot
+        // already contains the new key, so key_eq fails and the entry
+        // becomes a zombie (never removed).
+        let eviction_candidate_key = self
+            .fifos
+            .main_eviction_candidate()
+            .expect("We are the only writer, no torn read")
+            .key;
+        self.remove_from_hashtable(&eviction_candidate_key);
+
+        // Now safe to overwrite the slot
+        self.fifos.main_overwriting_push(entry)
+    }
+
+    /// Push to small queue, handling eviction to main/ghost and updating hashtable.
+    #[must_use]
+    fn push_to_small_queue(&mut self, entry: Entry<K, V>) -> GlobalOffset {
+        // Try fast path
+        let entry = match self.fifos.small_try_push(entry) {
+            Ok(offset) => return offset,
+            Err(entry) => entry,
+        };
+
+        // We need to read the oldest entry and update the hashtable BEFORE
+        // overwriting the slot. This is because update_hashtable use key_eq
+        // which reads the current slot contents. If we do this after overwriting_push,
+        // the slot contains the new key, so key_eq fails and we fail to update the hashtable.
+        let oldest_entry = self
+            .fifos
+            .small_eviction_candidate()
+            .expect("We are the only writer");
+        let oldest_key = oldest_entry.key;
+
+        let new_offset = if oldest_entry.recency() > 0 {
+            // Promote to main queue
+            self.push_to_main_queue(oldest_entry.clone())
+        } else {
+            // Demote key to ghost queue
+            self.push_to_ghost_queue(oldest_key)
+        };
+
+        // Update the hashtable to now find the moved entry at the main/ghost queue.
+        // SAFETY: Entry is currently at two places, but:
+        // 1. We have removed the bucket pointing to the overwritten position in main/ghost.
+        // 2. So key_eq will only succeed with the one in small queue.
+        self.update_hashtable(&oldest_key, new_offset);
+
+        // Now safe to overwrite the slot
+        self.fifos.small_overwriting_push(entry)
+    }
+
+    fn push_to_ghost_queue(&mut self, key: K) -> GlobalOffset {
+        // Try fast path
+        let key = match self.fifos.ghost_try_push(key) {
+            Ok(offset) => return offset,
+            Err(key) => key,
+        };
+
+        // We need to remove from hashtable BEFORE overwriting the slot,
+        // because remove_from_hashtable uses key_eq which reads the current
+        // slot contents. If we remove after pop_push_unchecked, the slot
+        // already contains the new key, so key_eq fails and the entry
+        // becomes a zombie (never removed).
+        let eviction_candidate = *self
+            .fifos
+            .ghost_eviction_candidate()
+            .expect("We are the only writer");
+        self.remove_from_hashtable(&eviction_candidate);
+
+        // Now safe to overwrite the slot
+        self.fifos.ghost_overwriting_push(key)
+    }
+
+    /// Update hashtable entry for `key`. If it did not exist, does nothing.
+    fn update_hashtable(&mut self, key: &K, global_offset: GlobalOffset) {
+        let hash = self.hash_key(key);
+
+        // Use the find_entry API to update.
+        let entry = self
+            .hashtable
+            .find_entry(hash, |global_offset| self.fifos.key_eq(*global_offset, key));
+
+        if let Ok(mut occupied) = entry {
+            *occupied.get_mut() = global_offset;
+        }
+    }
+
+    /// Remove a key from the hashtable if present.
+    #[inline]
+    fn remove_from_hashtable(&mut self, key: &K) {
+        let hash = self.hash_key(key);
+        if let Ok(entry) = self
+            .hashtable
+            .find_entry(hash, |global_offset| self.fifos.key_eq(*global_offset, key))
+        {
+            entry.remove();
+        }
+    }
+
+    /// Insert a fresh entry into the hashtable. Use this when we've already
+    /// removed the old entry and need to insert at a new location.
+    fn insert_unique_to_hashtable(&mut self, key: &K, global_offset: GlobalOffset) {
+        let hash = self.hash_key(key);
+
+        // Insert directly without searching for existing entry.
+        // Caller must ensure the old entry was already removed.
+        self.hashtable
+            .insert_unique(hash, global_offset, |global_offset| {
+                self.fifos.hash_key_at_offset(*global_offset, &self.hasher)
+            });
+    }
+}

--- a/lib/trififo/src/s3fifo.rs
+++ b/lib/trififo/src/s3fifo.rs
@@ -4,6 +4,7 @@ use hashbrown::HashTable;
 
 use crate::entry::Entry;
 use crate::raw_fifos::{GlobalOffset, LocalOffset, RawFifos};
+use crate::seqlock::SeqLockSafe;
 
 pub(crate) struct S3Fifo<K, V, S = ahash::RandomState> {
     /// Non-concurrent hashtable mapping key -> global offset in the FIFOs.
@@ -15,6 +16,8 @@ pub(crate) struct S3Fifo<K, V, S = ahash::RandomState> {
     /// Hasher state used to compute the hash for lookups.
     hasher: S,
 }
+
+unsafe impl<K, V, S> SeqLockSafe for S3Fifo<K, V, S> {}
 
 impl<K, V, S> S3Fifo<K, V, S>
 where


### PR DESCRIPTION
Supercedes #7973 

WIP

Preliminary results:
```log
=== Memory Usage Report ===
trififo: 26214400 entries, 1195392523 bytes total, ~45.6 bytes/entry
  26214400/26214400 entries correctly cached
quick_cache: 26214400 entries, 1241526344 bytes total, ~47.4 bytes/entry
  26196630/26214400 entries correctly cached
schnellru: 26214400 entries, 704643184 bytes total, ~26.9 bytes/entry
  26214400/26214400 entries correctly cached
foyer: 26214400 entries, 2608499816 bytes total, ~99.5 bytes/entry
  26207585/26214400 entries correctly cached


=== Hit Ratio Report ===
Cache capacity: 100000
Number of accesses: 10000000

Pattern: zipf_1.2
  trififo: 93.73%
  quick_cache: 95.24%
  schnellru: 94.68%
  foyer: 95.25%

Pattern: zipf_1.0
  trififo: 77.25%
  quick_cache: 81.39%
  schnellru: 77.71%
  foyer: 81.42%

Pattern: sequential
  trififo: 0.00%
  quick_cache: 0.00%
  schnellru: 0.00%
  foyer: 0.00%

Pattern: scan_resistant
  trififo: 41.12%
  quick_cache: 43.87%
  schnellru: 36.03%
  foyer: 43.00%

single_thread_latency/insert/trififo
                        time:   [18.643 ms 19.038 ms 19.445 ms]
                        thrpt:  [51.426 Melem/s 52.527 Melem/s 53.640 Melem/s]

single_thread_latency/insert/quick_cache
                        time:   [30.122 ms 30.201 ms 30.289 ms]
                        thrpt:  [33.015 Melem/s 33.112 Melem/s 33.198 Melem/s]

single_thread_latency/insert/schnellru
                        time:   [17.261 ms 17.290 ms 17.321 ms]
                        thrpt:  [57.733 Melem/s 57.837 Melem/s 57.933 Melem/s]

single_thread_latency/insert/foyer
                        time:   [126.91 ms 127.48 ms 128.14 ms]
                        thrpt:  [7.8037 Melem/s 7.8444 Melem/s 7.8795 Melem/s]

single_thread_latency/get_hit/trififo
                        time:   [5.8270 ms 5.8539 ms 5.9000 ms]
                        thrpt:  [169.49 Melem/s 170.82 Melem/s 171.61 Melem/s]

single_thread_latency/get_hit/quick_cache
                        time:   [14.884 ms 14.900 ms 14.918 ms]
                        thrpt:  [67.032 Melem/s 67.113 Melem/s 67.188 Melem/s]

single_thread_latency/get_hit/schnellru
                        time:   [9.8562 ms 9.8757 ms 9.8969 ms]
                        thrpt:  [101.04 Melem/s 101.26 Melem/s 101.46 Melem/s]

single_thread_latency/get_hit/foyer
                        time:   [32.182 ms 32.205 ms 32.230 ms]
                        thrpt:  [31.027 Melem/s 31.051 Melem/s 31.073 Melem/s]

multi_thread_latency/get_or_insert/trififo
                        time:   [59.874 ms 60.513 ms 61.235 ms]
                        thrpt:  [26.129 Melem/s 26.440 Melem/s 26.723 Melem/s]

multi_thread_latency/get_or_insert/quick_cache
                        time:   [70.640 ms 71.783 ms 72.991 ms]
                        thrpt:  [21.921 Melem/s 22.290 Melem/s 22.650 Melem/s]

multi_thread_latency/get_or_insert/schnellru
                        time:   [133.26 ms 142.96 ms 149.28 ms]
                        thrpt:  [10.718 Melem/s 11.192 Melem/s 12.006 Melem/s]

multi_thread_latency/get_or_insert/foyer
                        time:   [301.56 ms 302.71 ms 303.93 ms]
                        thrpt:  [5.2644 Melem/s 5.2856 Melem/s 5.3058 Melem/s]
```