### PR TITLE
out of disk error variant

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1279,7 +1279,9 @@ impl From<JsonError> for CollectionError {
 
 impl From<std::io::Error> for CollectionError {
     fn from(err: std::io::Error) -> Self {
-        if err.kind() == std::io::ErrorKind::StorageFull {
+        if err.kind() == std::io::ErrorKind::StorageFull
+            || err.kind() == std::io::ErrorKind::FileTooLarge
+        {
             CollectionError::OutOfDisk {
                 description: format!("File IO error: {err}"),
             }
@@ -1432,7 +1434,9 @@ impl From<cancel::Error> for CollectionError {
 
 impl From<tempfile::PathPersistError> for CollectionError {
     fn from(err: tempfile::PathPersistError) -> Self {
-        if err.error.kind() == std::io::ErrorKind::StorageFull {
+        if err.error.kind() == std::io::ErrorKind::StorageFull
+            || err.error.kind() == std::io::ErrorKind::FileTooLarge
+        {
             Self::out_of_disk(format!(
                 "failed to persist temporary file path {}: {}",
                 err.path.display(),

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -64,7 +64,7 @@ impl ShardOperation for LocalShard {
             .await?
             .unwrap_or(false)
         {
-            return Err(CollectionError::service_error(
+            return Err(CollectionError::out_of_disk(
                 "No space left on device: WAL buffer size exceeds available disk space".to_string(),
             ));
         }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -65,7 +65,7 @@ impl ShardOperation for LocalShard {
             .unwrap_or(false)
         {
             return Err(CollectionError::out_of_disk(
-                "No space left on device: WAL buffer size exceeds available disk space".to_string(),
+                "No space left on device: WAL buffer size exceeds available disk space",
             ));
         }
 

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -48,6 +48,8 @@ pub enum OperationError {
     InconsistentStorage { description: String },
     #[error("Out of memory, free: {free}, {description}")]
     OutOfMemory { description: String, free: u64 },
+    #[error("Out of disk space: {description}")]
+    OutOfDisk { description: String },
     #[error("Operation cancelled: {description}")]
     Cancelled { description: String },
     #[error("Timeout error: {description}")]
@@ -132,6 +134,12 @@ impl OperationError {
             ),
         }
     }
+
+    pub fn out_of_disk(description: impl Into<String>) -> Self {
+        Self::OutOfDisk {
+            description: description.into(),
+        }
+    }
 }
 
 /// Contains information regarding last operation error, which should be fixed before next operation could be processed
@@ -190,6 +198,9 @@ impl From<IoError> for OperationError {
                     free: free_memory,
                 }
             }
+            ErrorKind::StorageFull => OperationError::OutOfDisk {
+                description: format!("IO Error: {err}"),
+            },
             _ => OperationError::service_error(format!("IO Error: {err}")),
         }
     }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -201,6 +201,9 @@ impl From<IoError> for OperationError {
             ErrorKind::StorageFull => OperationError::OutOfDisk {
                 description: format!("IO Error: {err}"),
             },
+            ErrorKind::FileTooLarge => OperationError::OutOfDisk {
+                description: format!("IO Error: {err}"),
+            },
             _ => OperationError::service_error(format!("IO Error: {err}")),
         }
     }

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -161,6 +161,10 @@ impl StorageError {
                 description: overriding_description,
                 backtrace: None,
             },
+            CollectionError::OutOfDisk { .. } => StorageError::ServiceError {
+                description: overriding_description,
+                backtrace: None,
+            },
             CollectionError::Timeout { .. } => StorageError::Timeout {
                 description: overriding_description,
             },
@@ -220,6 +224,10 @@ impl From<CollectionError> for StorageError {
                 StorageError::from_inconsistent_shard_failure(*error, full_description)
             }
             CollectionError::OutOfMemory { .. } => StorageError::ServiceError {
+                description: format!("{err}"),
+                backtrace: None,
+            },
+            CollectionError::OutOfDisk { .. } => StorageError::ServiceError {
                 description: format!("{err}"),
                 backtrace: None,
             },


### PR DESCRIPTION
To implement operation retry in the OOD case, we need to first detect if the error is an OOD.

This PR adds an `OutOfDisk` error variant for the `CollectionError` and `Storage` error.
