### PR TITLE
chore: Use the qdrant/murmur3 fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,7 +4190,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "murmur3"
 version = "0.5.2"
-source = "git+https://github.com/stusmall/murmur3?rev=2c39087#2c39087f094ae982a463e1cda9cf4d483a09192b"
+source = "git+https://github.com/qdrant/murmur3?rev=2c39087#2c39087f094ae982a463e1cda9cf4d483a09192b"
 
 [[package]]
 name = "names"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ prometheus = { version = "0.14.0", default-features = false }
 validator = { workspace = true }
 jsonwebtoken = { version = "10.0", features = ["rust_crypto"] }
 
-murmur3 = { git = "https://github.com/stusmall/murmur3", rev = "2c39087" }
+murmur3 = { git = "https://github.com/qdrant/murmur3", rev = "2c39087" }
 
 tempfile = { workspace = true }
 


### PR DESCRIPTION
# Description

Point the `murmur3` dependency at our fork to ensure long-term build availability if upstream disappears.

EDIT: Because, If https://github.com/stusmall/murmur3 is deleted, our builds will break.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
