### PR TITLE
Enable update queue

### DIFF
--- a/lib/collection/src/operations/shared_storage_config.rs
+++ b/lib/collection/src/operations/shared_storage_config.rs
@@ -13,8 +13,8 @@ use crate::shards::transfer::ShardTransferMethod;
 /// Default timeout for search requests.
 /// In cluster mode, this should be aligned with collection timeout.
 const DEFAULT_SEARCH_TIMEOUT: Duration = Duration::from_secs(60);
-const DEFAULT_UPDATE_QUEUE_SIZE: usize = 100;
-const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = 10_000;
+const DEFAULT_UPDATE_QUEUE_SIZE: usize = 1_000_000;
+const DEFAULT_UPDATE_QUEUE_SIZE_LISTENER: usize = DEFAULT_UPDATE_QUEUE_SIZE;
 /// Maximum number of operations which are stored in RAM in update worker queue.
 /// If there are more pending operations, operation data
 /// will be read from WAL when processing the operation.


### PR DESCRIPTION
Enable and integrate the update queue.

Changes the update queue capacity to 1 million so that we can buffer more incoming operations.

Blocked by:
- [x] https://github.com/qdrant/qdrant/pull/8008
- [x] https://github.com/qdrant/qdrant/pull/8050

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?