### PR TITLE
Change Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.92"
 default-run = "qdrant"
 
 [lints]


### PR DESCRIPTION
Versions of Rust up to 1.92 give a compilation error when running the `cargo clippy` command:
```
error: you are implementing `Ord` explicitly but have derived `PartialOrd`
  --> lib\segment\src\index\field_index\histogram.rs:42:1
   |
42 | / impl<T: PartialOrd + Copy> Ord for Point<T> {
43 | |     fn cmp(&self, other: &Point<T>) -> std::cmp::Ordering {
44 | |         (self.val, self.idx)
45 | |             .partial_cmp(&(other.val, other.idx))
...  |
48 | | }
   | |_^
   |
note: `PartialOrd` implemented here
  --> lib\segment\src\index\field_index\histogram.rs:27:21
   |
27 | #[derive(PartialEq, PartialOrd, Debug, Clone, Serialize, Deserialize)]
   |                     ^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#derive_ord_xor_partial_ord
   = note: `#[deny(clippy::derive_ord_xor_partial_ord)]` on by default

warning: `segment` (lib) generated 1 warning
error: could not compile `segment` (lib) due to 1 previous error; 1 warning emitted
```
```
$ echo $?
101
```
After installing version 1.92:
```
$ echo $?
0
```