### PR TITLE
[trififo] Raw FIFO queues

### DIFF
--- a/lib/trififo/src/entry.rs
+++ b/lib/trififo/src/entry.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const MAX_RECENCY: u8 = 3;
+
+/// Entry stored in the small and main queues.
+#[derive(Debug)]
+pub struct Entry<K, V> {
+    pub key: K,
+    pub value: V,
+    recency: AtomicU8,
+}
+
+impl<K, V> Entry<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self {
+            key,
+            value,
+            recency: AtomicU8::new(0),
+        }
+    }
+
+    pub fn clone(&self) -> Self
+    where
+        K: Copy,
+        V: Clone,
+    {
+        Self {
+            key: self.key,
+            value: self.value.clone(),
+            recency: AtomicU8::new(self.recency.load(Ordering::Relaxed)),
+        }
+    }
+
+    #[inline]
+    pub fn recency(&self) -> u8 {
+        self.recency.load(Ordering::Relaxed)
+    }
+
+    /// Increment recency by 1, saturating at `MAX_RECENCY`
+    #[inline]
+    pub fn incr_recency(&self) {
+        let current = self.recency.load(Ordering::Relaxed);
+        if current < MAX_RECENCY {
+            self.recency.store(current + 1, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn decr_recency(&self) {
+        let current = self.recency.load(Ordering::Relaxed);
+        if current > 0 {
+            self.recency.store(current - 1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recency() {
+        let entry = Entry::new(1u64, "test".to_string());
+
+        assert_eq!(entry.recency(), 0);
+        entry.incr_recency();
+        assert_eq!(entry.recency(), 1);
+        entry.incr_recency();
+        entry.incr_recency();
+        entry.incr_recency(); // Should saturate at 3
+        assert_eq!(entry.recency(), 3);
+
+        entry.decr_recency();
+        assert_eq!(entry.recency(), 2);
+    }
+}

--- a/lib/trififo/src/lib.rs
+++ b/lib/trififo/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod seqlock;
 
 #[expect(dead_code)]
+mod entry;
+#[expect(dead_code)]
+mod raw_fifos;
 mod ringbuffer;

--- a/lib/trififo/src/raw_fifos.rs
+++ b/lib/trififo/src/raw_fifos.rs
@@ -1,0 +1,223 @@
+use std::hash::{BuildHasher, Hash};
+use std::num::NonZeroUsize;
+
+use crate::entry::Entry;
+use crate::ringbuffer::RingBuffer;
+
+pub type GlobalOffset = u32;
+
+/// Local offset within one of the three queues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalOffset {
+    Small(u32),
+    Ghost(u32),
+    Main(u32),
+}
+
+/// Encapsulate the 3 FIFO queues used by S3-FIFO algorithm, where a global offset can be used to
+/// index into any of them, as if they were consecutive arrays.
+pub struct RawFifos<K, V> {
+    pub small: RingBuffer<Entry<K, V>>,
+    pub ghost: RingBuffer<K>,
+    pub main: RingBuffer<Entry<K, V>>,
+
+    small_end: u32,
+    ghost_end: u32,
+}
+
+impl<K, V> RawFifos<K, V> {
+    /// Initialize the queues with the provided sizes. The entire allocation is made upfront.
+    ///
+    /// # Arguments
+    /// * `capacity` - Total capacity for small + main queues. Minimum is 2.
+    /// * `small_ratio` - Fraction of capacity for small queue (typically 0.1)
+    /// * `ghost_ratio` - Fraction of capacity for ghost queue (typically 0.9)
+    pub fn new(capacity: usize, small_ratio: f32, ghost_ratio: f32) -> Self {
+        assert!(small_ratio > 0.0 && small_ratio < 1.0);
+        assert!(ghost_ratio > 0.0 && ghost_ratio < 1.0);
+
+        let small_size = (capacity as f32 * small_ratio).ceil() as usize;
+        let small_size = NonZeroUsize::try_from(small_size).unwrap_or(NonZeroUsize::MIN);
+        let small = RingBuffer::new(small_size);
+
+        let ghost_size = (capacity as f32 * ghost_ratio).ceil() as usize;
+        let ghost_size = NonZeroUsize::try_from(ghost_size).unwrap_or(NonZeroUsize::MIN);
+        let ghost = RingBuffer::new(ghost_size);
+
+        let main_size = capacity - small_size.get();
+        let main_size = NonZeroUsize::try_from(main_size).unwrap_or(NonZeroUsize::MIN);
+        let main = RingBuffer::new(main_size);
+
+        let small_end = small_size.get() as GlobalOffset;
+        let ghost_end = small_end + ghost_size.get() as GlobalOffset;
+
+        RawFifos {
+            small,
+            ghost,
+            main,
+            small_end,
+            ghost_end,
+        }
+    }
+
+    /// Converts a global offset to a local offset.
+    #[inline]
+    pub fn local_offset(&self, global_offset: GlobalOffset) -> LocalOffset {
+        if global_offset < self.small_end {
+            LocalOffset::Small(global_offset)
+        } else if global_offset < self.ghost_end {
+            LocalOffset::Ghost(global_offset - self.small_end)
+        } else {
+            LocalOffset::Main(global_offset - self.ghost_end)
+        }
+    }
+
+    /// Converts a local offset to a global offset.
+    #[inline]
+    pub fn global_offset(&self, local_offset: LocalOffset) -> GlobalOffset {
+        match local_offset {
+            LocalOffset::Small(offset) => offset,
+            LocalOffset::Ghost(offset) => offset + self.small_end,
+            LocalOffset::Main(offset) => offset + self.ghost_end,
+        }
+    }
+
+    /// Gets an entry from the small or main queue by local offset.
+    ///
+    /// Returns None for ghost queue offsets (ghost only stores keys, not full entries).
+    #[inline]
+    pub fn get_entry(&self, local_offset: LocalOffset) -> Option<&Entry<K, V>> {
+        match local_offset {
+            LocalOffset::Small(offset) => Some(self.small.get_absolute(offset as usize)?),
+            LocalOffset::Ghost(_) => None,
+            LocalOffset::Main(offset) => Some(self.main.get_absolute(offset as usize)?),
+        }
+    }
+
+    pub fn get_key(&self, local_offset: LocalOffset) -> Option<&K> {
+        match local_offset {
+            LocalOffset::Small(off) => Some(&self.small.get_absolute(off as usize)?.key),
+            LocalOffset::Main(off) => Some(&self.main.get_absolute(off as usize)?.key),
+            LocalOffset::Ghost(off) => self.ghost.get_absolute(off as usize),
+        }
+    }
+
+    /// Compare the key stored at a global offset with the provided `key`.
+    ///
+    /// This is a convenience used by hashtable lookup helpers to verify whether
+    /// an entry at `global_offset` corresponds to `key`. It resolves the global
+    /// offset into the appropriate queue (small/main/ghost) and compares the
+    /// stored key.
+    #[inline]
+    pub fn key_eq(&self, global_offset: GlobalOffset, key: &K) -> bool
+    where
+        K: PartialEq,
+    {
+        let local_offset = self.local_offset(global_offset);
+        let Some(stored_key) = self.get_key(local_offset) else {
+            return false;
+        };
+        stored_key == key
+    }
+
+    /// Compute the hash for the key stored at `global_offset` using the given
+    /// `hasher`. This function is used by a hashtable for insertion.
+    #[inline]
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    pub fn hash_key_at_offset<S>(&mut self, global_offset: GlobalOffset, hasher: &S) -> u64
+    where
+        S: BuildHasher,
+        K: Copy + Hash,
+    {
+        // Extract the key from the appropriate queue and hash it with the provided hasher.
+        let local_offset = self.local_offset(global_offset);
+        let key = self
+            .get_key(local_offset)
+            // Since we are the only writer, the offset is valid.
+            .expect("We are the only writer, as established by `&mut self`");
+
+        hasher.hash_one(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_fifos() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push to small queue
+        let entry = Entry::new(1u64, "hello".to_string());
+        let offset = fifos.small.overwriting_push(entry);
+        assert_eq!(offset, 0);
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(offset as u32);
+        assert_eq!(local_offset, LocalOffset::Small(0));
+
+        let entry = fifos.get_entry(local_offset).unwrap();
+        assert_eq!(entry.key, 1);
+        assert_eq!(entry.value, "hello");
+    }
+
+    #[test]
+    fn test_ghost_queue() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push key to ghost queue
+        let offset = fifos.ghost.overwriting_push(42u64);
+        let global_offset = fifos.global_offset(LocalOffset::Ghost(offset as u32));
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(global_offset);
+        assert!(matches!(local_offset, LocalOffset::Ghost(_)));
+
+        // Ghost entries return None for get_entry
+        assert!(fifos.get_entry(local_offset).is_none());
+
+        // But the key is still there
+        assert_eq!(*fifos.get_key(local_offset).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_main_queue() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        // Push to main queue
+        let entry = Entry::new(99u64, "main".to_string());
+        let offset = fifos.main.try_push(entry).unwrap();
+        let global_offset = fifos.global_offset(LocalOffset::Main(offset as u32));
+
+        // Read back via fifos
+        let local_offset = fifos.local_offset(global_offset);
+        assert!(matches!(local_offset, LocalOffset::Main(_)));
+
+        let entry = fifos.get_entry(local_offset).unwrap();
+        assert_eq!(entry.key, 99);
+        assert_eq!(entry.value, "main");
+    }
+
+    #[test]
+    fn test_recency() {
+        let mut fifos = RawFifos::<u64, String>::new(100, 0.1, 0.9);
+
+        let entry = Entry::new(1u64, "test".to_string());
+        let offset = fifos.small.overwriting_push(entry);
+
+        let local_offset = fifos.local_offset(offset as u32);
+        let entry = fifos.get_entry(local_offset).unwrap();
+
+        assert_eq!(entry.recency(), 0);
+        entry.incr_recency();
+        assert_eq!(entry.recency(), 1);
+        entry.incr_recency();
+        entry.incr_recency();
+        entry.incr_recency(); // Should saturate at 3
+        assert_eq!(entry.recency(), 3);
+
+        entry.decr_recency();
+        assert_eq!(entry.recency(), 2);
+    }
+}

--- a/lib/trififo/src/ringbuffer.rs
+++ b/lib/trififo/src/ringbuffer.rs
@@ -40,7 +40,6 @@ impl<T> RingBuffer<T> {
     }
 
     /// Returns the number of elements currently stored in the buffer.
-    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.len.load(Ordering::Acquire)
     }


### PR DESCRIPTION
Uses the ringbuffers from #8032 to form the 3 FIFO queues for S3-FIFO algorithm. But it doesn't implement the algorithm yet.

This PR adds the component which maps a global `u32` offset into the corresponding absolute offset within each of the 3 FIFO queues. This mapping is private to the struct, so that callers only need to think in terms of the global offset.

Adds the following data structures:
- `Entry`: core unit of information which holds the key, data, and recency information.
- `RawFifos`: the 3 named queues and its accessors.
- `LocalOffset`: internal to the raw fifos, helps to map global offset into one of the 3 queues.

Having this facilitates implementing S3FIFO easier in a subsequent PR.