### PR TITLE
build(deps): bump bytes from 1.10.1 to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ bytemuck = { version = "1.25.0", features = [
     "must_cast",
     "transparentwrapper_extra",
 ] }
-bytes = "1.11.0"
+bytes = "1.11.1"
 chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.56", features = ["derive", "env"] }
 criterion = "0.8.1"


### PR DESCRIPTION
Ports <https://github.com/qdrant/qdrant/pull/8051> to `dev`

---

Bumps [bytes](https://github.com/tokio-rs/bytes) from 1.10.1 to 1.11.1.
- [Release notes](https://github.com/tokio-rs/bytes/releases)
- [Changelog](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md)
- [Commits](https://github.com/tokio-rs/bytes/compare/v1.10.1...v1.11.1)

---
updated-dependencies:
- dependency-name: bytes dependency-version: 1.11.1 dependency-type: direct:production ...
