### PR TITLE
Also specify clone behavior for new facet types in edge

### DIFF
--- a/lib/edge/python/src/facet.rs
+++ b/lib/edge/python/src/facet.rs
@@ -9,7 +9,7 @@ use shard::facet::FacetRequestInternal;
 use crate::repr::*;
 use crate::types::{PyFilter, PyJsonPath};
 
-#[pyclass(name = "FacetRequest")]
+#[pyclass(name = "FacetRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
 pub struct PyFacetRequest(FacetRequestInternal);
 
@@ -48,7 +48,7 @@ impl PyFacetRequest {
     }
 }
 
-#[pyclass(name = "FacetHit")]
+#[pyclass(name = "FacetHit", from_py_object)]
 #[derive(Clone, Debug, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyFacetHit(FacetValueHit);
@@ -80,7 +80,7 @@ impl Repr for PyFacetHit {
     }
 }
 
-#[pyclass(name = "FacetResponse")]
+#[pyclass(name = "FacetResponse", from_py_object)]
 #[derive(Clone, Debug, TransparentWrapper)]
 #[repr(transparent)]
 pub struct PyFacetResponse(FacetResponse);


### PR DESCRIPTION
<https://github.com/qdrant/qdrant/pull/8034> now specifies explicit clone behavior of edge types in Python.

It looks like it conflicts with <https://github.com/qdrant/qdrant/pull/8045>. This PR resolves the issue by applying the same treatment to the new types.

Fixes the following errors on `dev`: https://github.com/qdrant/qdrant/actions/runs/21665392742/job/62459439181

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?