### PR TITLE
fix clippy lint on non-linux

### DIFF
--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -6,6 +6,7 @@ use std::{error, result};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Itertools;
+#[cfg(target_os = "linux")]
 use memory::madvise::AdviceSetting;
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;


### PR DESCRIPTION
This was introduced recently when used under `target_os = "linux"` flagging, which caused `unused_import` lint