### PR TITLE
For snapshots directly restored, use default temp path in storage volume

### DIFF
--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -122,7 +122,8 @@ async fn _do_recover_from_snapshot(
     } = download_snapshot(
         client,
         location,
-        &toc.optional_temp_or_snapshot_temp_path()?,
+        // Default temporary path to storage dir, to allow faster recovery within the same volume
+        &toc.optional_temp_or_storage_temp_path()?,
         checksum.is_some(),
     )
     .await?;

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -165,7 +165,8 @@ pub async fn recover_shard_snapshot(
             let collection = toc.get_collection(&collection_pass).await?;
             collection.assert_shard_exists(shard_id).await?;
 
-            let download_dir = toc.optional_temp_or_snapshot_temp_path()?;
+            // Default temporary path to storage dir, to allow faster recovery within the same volume
+            let download_dir = toc.optional_temp_or_storage_temp_path()?;
 
             let DownloadResult {
                 snapshot,
@@ -289,7 +290,8 @@ pub async fn recover_shard_snapshot_impl(
             recovery_type,
             toc.this_peer_id,
             toc.is_distributed(),
-            &toc.optional_temp_or_snapshot_temp_path()?,
+            // Default temporary path to storage dir, to allow faster recovery within the same volume
+            &toc.optional_temp_or_storage_temp_path()?,
             cancel,
         )
         .await?


### PR DESCRIPTION
With <https://github.com/qdrant/qdrant/pull/8025> we now stream unpacking on snapshot recovery.

This changes the default temporary directory for those actions from the snapshot directory to the storage directory.

In practice this means the snapshot is stored on the storage directory directly. This is significant for environments having a separate storage and snapshot volume, like our own cloud. Before a snapshot had to be moved across volumes to be promoted, which is very expensive. Now promotion is a simple directory rename making it super fast.

A minimal change to make the above behavior happen. We might do a more significant refactoring of how we configure and handle temporary files in the future.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
