### PR TITLE
fix wal replay deadlock in update queue

### DIFF
--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -563,3 +563,143 @@ async fn test_wal_replay_loads_pending_to_queue() {
 
     shard.stop_gracefully().await;
 }
+
+/// Test that verifies the WAL recovery process correctly loads pending updates into the update queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_replay_with_smaller_queue_size() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let collection_name = "test".to_string();
+
+    let current_runtime: Handle = Handle::current();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let mut shared_storage_config = SharedStorageConfig {
+        update_queue_size: 10_000,
+        ..Default::default()
+    };
+
+    // We need WAL length > applied_seq + 65 to trigger the queue loading path
+    let total_ops = 500u64;
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(shared_storage_config.clone()),
+        payload_index_schema.clone(),
+        current_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Stop flush worker to prevent automatic WAL truncation.
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Insert all operations
+    for i in 0..total_ops {
+        let point = PointStructPersisted {
+            id: i.into(),
+            vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+            payload: None,
+        };
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        shard
+            .update(op.into(), true, None, hw_acc.clone())
+            .await
+            .unwrap();
+    }
+
+    // Stop the shard without flush to preserve WAL.
+    shard.stop_gracefully().await;
+
+    // Use AppliedSeqHandler to read and manipulate the applied_seq file.
+    // This simulates a scenario where applied_seq is lower than the actual WAL length.
+    // We need to ensure: WAL first_index <= applied_seq < WAL last_index - 65
+    // The WAL might be truncated, so it's important to be careful with the replaced value.
+    let applied_seq_handler = AppliedSeqHandler::load_or_init(collection_dir.path(), total_ops);
+    eprintln!("Applied seq path: {:?}", applied_seq_handler.path());
+
+    // Read the current applied_seq value
+    let current_applied_seq = applied_seq_handler.op_num().unwrap_or(0);
+    eprintln!("Current applied_seq: {current_applied_seq}");
+
+    // Calculate the target low value:
+    // - upper_bound = (total_ops - 100) + 64 = total_ops - 36
+    // - At least 36 entries should go to update queue.
+    // It's ok if they are applied already, segment will skip them.
+    // We only need to ensure they are in the update queue.
+    let low_applied_seq = total_ops.saturating_sub(100);
+
+    // Only modify if the current value is too large
+    if current_applied_seq > low_applied_seq {
+        applied_seq_handler
+            .force_set_and_persist(low_applied_seq)
+            .unwrap();
+        eprintln!(
+            "Reduced applied_seq from {current_applied_seq} to {low_applied_seq}, total_ops: {total_ops}"
+        );
+    } else {
+        eprintln!(
+            "Applied_seq {current_applied_seq} is already <= target {low_applied_seq}, total_ops: {total_ops}"
+        );
+    }
+
+    // Set smaller queue size to force loading into the queue in batches
+    shared_storage_config.update_queue_size = 5;
+
+    // Reload the shard
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        Arc::new(shared_storage_config),
+        payload_index_schema,
+        false,
+        current_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    // Wait for update worker to process all queued operations with a timeout
+    let timeout = std::time::Duration::from_secs(2);
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(10);
+
+    while shard.local_update_queue_info().length > 0 {
+        assert!(
+            start.elapsed() <= timeout,
+            "Timeout waiting for update queue to empty"
+        );
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    // Verify all points are present after processing
+    let info = shard.info().await.unwrap();
+    let points_count = info.points_count.unwrap_or(0);
+    assert_eq!(
+        points_count, total_ops as usize,
+        "All {total_ops} points should be present after WAL replay and update queue processing",
+    );
+
+    shard.stop_gracefully().await;
+}


### PR DESCRIPTION
## Description
If WAL has more records than the update queue size, deadlock is reached while pushing into update queue size.

## Steps to reproduce:
1. Fill update queue using BFB
2. Restart with lower update queue size
3. Deadlock appears while WAL replay

## Solution:
If the update queue is not big enough, replay more records.

This PR includes also a test.