### PR TITLE
bump actix-files from 0.6.9 to 0.6.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-files"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4009a8beb4dc78a58286ac9d58969ee0a8acecb7912d5ce898b4da4335579341"
+checksum = "df8c4f30e3272d7c345f88ae0aac3848507ef5ba871f9cc2a41c8085a0f0523b"
 dependencies = [
  "actix-http",
  "actix-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ private_intra_doc_links = "allow"
 [workspace.dependencies]
 actix-web-validator = "7.0.0"
 actix-web = { version = "4.12.1", features = ["rustls-0_23", "actix-tls"] }
-actix-files = "0.6.9"
+actix-files = "0.6.10"
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.100"
 async-trait = "0.1.89"


### PR DESCRIPTION
Apply security patch on `dev` https://github.com/qdrant/qdrant/pull/8070