### PR TITLE
disable `multi_threaded_readers_consistent` test

### DIFF
--- a/lib/trififo/src/seqlock.rs
+++ b/lib/trififo/src/seqlock.rs
@@ -197,6 +197,7 @@ mod tests {
     unsafe impl SeqLockSafe for Pair {}
 
     #[test]
+    #[ignore = "too slow for CI"]
     fn multi_threaded_readers_consistent() {
         // Create a seqlock-wrapped Pair.
         let (reader, mut writer) = SeqLock::new_reader_writer(Pair { a: 0, b: 0 });


### PR DESCRIPTION
This was proving to be too slow on CI. As a quickfix, we just ignore it
