### PR TITLE
Add doc for `lib/edge/python/codegen`

### DIFF
--- a/lib/edge/python/codegen/src/lib.rs
+++ b/lib/edge/python/codegen/src/lib.rs
@@ -1,5 +1,45 @@
 mod pyclass_repr;
 
+/// `#[pyclass_repr]` - implements `trait Repr`.
+///
+/// Only methods with `#[getter]` are included into the output.
+///
+/// # Usage example
+///
+/// Input:
+/// ```ignore
+/// #[pyclass_repr]
+/// #[pymethods]
+/// impl PyMyStruct {
+///     #[getter]
+///     pub fn foo(&self) -> &str {
+///         &self.0.foo
+///     }
+///
+///     #[getter]
+///     pub fn bar(&self) -> f32  {
+///         self.0.bar
+///     }
+///
+///     pub fn __repr__(&self) -> String {
+///         self.repr()
+///     }
+/// }
+/// ```
+///
+/// Generated output is roughly equivalent to:
+/// ```ignore
+/// impl crate::repr::Repr for PyMyStruct {
+///     fn fmt(&self, f: &mut crate::repr::Formatter<'_>) -> std::fmt::Result {
+///         use crate::repr::WriteExt as _;
+///
+///         f.class::<Self>(&[
+///             ("foo", &self.foo()),
+///             ("bar", &self.bar()),
+///         ])
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn pyclass_repr(
     _attributes: proc_macro::TokenStream,

--- a/lib/edge/python/src/repr.rs
+++ b/lib/edge/python/src/repr.rs
@@ -4,6 +4,7 @@ use std::fmt;
 pub use edge_py_codegen::pyclass_repr;
 use pyo3::PyTypeInfo;
 
+/// Can be implemented using [macro pyclass_repr].
 pub trait Repr {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result;
 

--- a/lib/macros/src/lib.rs
+++ b/lib/macros/src/lib.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 
 mod anonymize;
 
+/// Grep for `trait Anonymize` for doc.
 #[proc_macro_derive(Anonymize, attributes(anonymize))]
 pub fn derive_anonymize(input: TokenStream) -> TokenStream {
     match anonymize::derive_anonymize(input.into()) {


### PR DESCRIPTION
~~We have two proc-macro packages: `lib/edge/python/codegen` and `lib/macros`. The `edge` package depends on both, the `qdrant` package depends only on `macros`.~~

~~As both of them are pretty minimal, I see no point to have them in separate packages[^†]. So, this PR puts both of them into `lib/macros`.~~

~~Also,~~ this PR adds a short doc for with example to `#[pyclass_repr]`.


[^†]: One possible justification is that we don't want to pull `features = ["full"]` for `syn` into non-`edge` build. But it's already being pulled by other dependencies.
	```console
    …
	$ cargo tree -e features --invert syn@2
	├── syn feature "full"
	│   ├── actix-web-codegen v4.3.0 (proc-macro) (*)
	│   ├── async-trait v0.1.89 (proc-macro) (*)
	│   ├── clap_derive v4.5.55 (proc-macro) (*)
	│   ├── curve25519-dalek-derive v0.1.1 (proc-macro) (*)
	│   ├── darling_core v0.20.8 (*)
	│   ├── darling_core v0.21.3 (*)
	│   ├── delegate v0.13.5 (proc-macro) (*)
	│   ├── futures-macro v0.3.31 (proc-macro) (*)
	│   ├── include-flate-codegen v0.2.0 (proc-macro) (*)
	│   ├── macros v0.1.0 (proc-macro) (*)
	│   ├── prettyplease v0.2.37
	│   │   └── prettyplease feature "default"
	│   │       ├── prost-build v0.12.6 (*)
	│   │       └── tonic-build v0.11.0 (*)
	│   ├── prost-build v0.12.6 (*)
	│   ├── sealed_test_derive v1.1.0 (proc-macro) (*)
	│   ├── serde_with_macros v3.16.1 (proc-macro) (*)
	│   ├── serial_test_derive v3.3.1 (proc-macro) (*)
	│   ├── tokio-macros v2.6.0 (proc-macro) (*)
	│   ├── tracing-attributes v0.1.31 (proc-macro) (*)
	│   ├── typetag-impl v0.2.15 (proc-macro) (*)
	│   └── zerocopy-derive v0.8.39 (proc-macro) (*)
    …
	```