### PR TITLE
[WIP] Avoid unecessary IDF filling blocking Task

### DIFF
--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -82,6 +82,10 @@ impl QueryContext {
         self.available_point_count += count;
     }
 
+    pub fn uses_idf(&self) -> bool {
+        !self.idf_stats.idf.is_empty() && !self.idf_stats.indexed_vectors.is_empty()
+    }
+
     /// Fill indices of sparse vectors, which are required for `idf-dot` similarity
     /// with zeros, so the statistics can be collected.
     pub fn init_idf(&mut self, vector_name: &VectorName, indices: &[DimId]) {


### PR DESCRIPTION
Filling the IDF statistics is done through a blocking task because it needs to acquire blocking locks:
- read segment holder
- read each non appendable segment

One insight of this PR is that we always perform this task whether IDF is required by the query.

The fix enables to avoid spawning a blocking task and introducing lock contention for non IDF queries.