### PR TITLE
Do not create a dedicated runtime for Actix

### DIFF
--- a/src/actix/metrics_service.rs
+++ b/src/actix/metrics_service.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use actix_web::middleware::Compress;
 use actix_web::{App, HttpServer, web};
+use tokio::runtime::Handle;
 
 use crate::actix::api::service_api::config_metrics_api;
 use crate::actix::certificate_helpers;
@@ -13,8 +14,9 @@ pub fn init_metrics(
     port: u16,
     telemetry_collector: Arc<tokio::sync::Mutex<TelemetryCollector>>,
     settings: Settings,
+    runtime: Handle,
 ) -> io::Result<()> {
-    actix_web::rt::System::new().block_on(async {
+    runtime.block_on(async {
         let telemetry_collector_data = web::Data::from(telemetry_collector);
         let service_config = web::Data::new(settings.service.clone());
 

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -22,6 +22,7 @@ use collection::operations::validation;
 use collection::operations::verification::new_unchecked_verification_pass;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::{Access, Auth};
+use tokio::runtime::Handle;
 
 use crate::actix::api::cluster_api::config_cluster_api;
 use crate::actix::api::collections_api::config_collections_api;
@@ -60,8 +61,9 @@ pub fn init(
     health_checker: Option<Arc<health::HealthChecker>>,
     settings: Settings,
     logger_handle: LoggerHandle,
+    runtime: Handle,
 ) -> io::Result<()> {
-    actix_web::rt::System::new().block_on(async {
+    runtime.block_on(async {
         // Nothing to verify here.
         let pass = new_unchecked_verification_pass();
         let auth = Auth::new_internal(Access::full("Service initialization"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,6 +595,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(metrics_port) = settings.service.metrics_port {
         let telemetry_collector = telemetry_collector.clone();
         let settings = settings.clone();
+        let actix_runtime = runtime_handle.clone();
         let handle = thread::Builder::new()
             .name("metrics".to_string())
             .spawn(move || {
@@ -604,6 +605,7 @@ fn main() -> anyhow::Result<()> {
                         metrics_port,
                         telemetry_collector,
                         settings,
+                        actix_runtime,
                     ),
                 )
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -568,6 +568,7 @@ fn main() -> anyhow::Result<()> {
         let dispatcher_arc = dispatcher_arc.clone();
         let telemetry_collector = telemetry_collector.clone();
         let settings = settings.clone();
+        let actix_runtime = runtime_handle.clone();
         let handle = thread::Builder::new()
             .name("web".to_string())
             .spawn(move || {
@@ -579,6 +580,7 @@ fn main() -> anyhow::Result<()> {
                         health_checker,
                         settings,
                         logger_handle,
+                        actix_runtime,
                     ),
                 )
             })
@@ -615,6 +617,7 @@ fn main() -> anyhow::Result<()> {
 
     if let Some(grpc_port) = settings.service.grpc_port {
         let settings = settings.clone();
+        let grpc_runtime = runtime_handle.clone();
         let handle = thread::Builder::new()
             .name("grpc".to_string())
             .spawn(move || {
@@ -625,7 +628,7 @@ fn main() -> anyhow::Result<()> {
                         tonic_telemetry_collector,
                         settings,
                         grpc_port,
-                        runtime_handle,
+                        grpc_runtime,
                     ),
                 )
             })


### PR DESCRIPTION
We spawn many threads on startup, an idle Qdrant has 84 threads on my 24 cores machine.

This PR proposes to not create a dedicated Tokio runtime for actix but simply use the general runtime like for gRPC.

We still create the same amount of workers with `.workers(max_web_workers(&settings));` but the additional runtime is gone.

Disclaimer: I see no difference in performance but also no difference in thread count :man_shrugging: 
