### PR TITLE
Move resharding version gate to pre-flight check

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -8,7 +8,7 @@ mod point_ops;
 pub mod query;
 mod resharding;
 mod search;
-mod shard_transfer;
+pub mod shard_transfer;
 mod sharding_keys;
 mod snapshots;
 mod state_management;

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -94,10 +94,26 @@ impl Collection {
                 .channel_service
                 .all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION);
 
+            // This is a safety net — the pre-flight check in
+            // `TocDispatcher::start_shard_transfer` should have already caught this
+            // before proposing to consensus. If we still hit this, let it panic via
+            // service_error so we notice the pre-flight was bypassed.
             if transfer_method.is_resharding() && !is_supported_version {
                 return Err(CollectionError::service_error(format!(
-                    "Cannot start resharding transfer: not all peers support the required version {}",
-                    *NEW_UPDATE_ON_RESHARDING_VERSION
+                    "Cannot start resharding transfer: not all peers support the required version {} while they are at versions {:?} -> {:?}",
+                    *NEW_UPDATE_ON_RESHARDING_VERSION,
+                    self.channel_service
+                        .peers_versions()
+                        .into_iter()
+                        .map(|(peer_id, version)| format!("{}: {}", peer_id, version))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    self.channel_service
+                        .peers_addresses()
+                        .into_iter()
+                        .map(|(peer_id, address)| format!("{}: {}", peer_id, address))
+                        .collect::<Vec<String>>()
+                        .join(", "),
                 )));
             }
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -95,10 +95,10 @@ impl Collection {
                 .all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION);
 
             // This is a safety net — the pre-flight check in
-            // `TocDispatcher::start_shard_transfer` should have already caught this
-            // before proposing to consensus. If we still hit this, returning a
-            // service_error will lead to a consensus panic so we notice the
-            // pre-flight was bypassed.
+            // `StartResharding` and `TocDispatcher::start_shard_transfer`
+            // should have already caught this before proposing to consensus.
+            // If we still hit this, returning a service_error will lead to a
+            // consensus panic so we notice the pre-flight was bypassed.
             if transfer_method.is_resharding() && !is_supported_version {
                 return Err(CollectionError::service_error(format!(
                     "Cannot start resharding transfer: not all peers support the required version {} while they are at versions [{}] -> addresses [{}]",

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -96,11 +96,12 @@ impl Collection {
 
             // This is a safety net — the pre-flight check in
             // `TocDispatcher::start_shard_transfer` should have already caught this
-            // before proposing to consensus. If we still hit this, let it panic via
-            // service_error so we notice the pre-flight was bypassed.
+            // before proposing to consensus. If we still hit this, returning a
+            // service_error will lead to a consensus panic so we notice the
+            // pre-flight was bypassed.
             if transfer_method.is_resharding() && !is_supported_version {
                 return Err(CollectionError::service_error(format!(
-                    "Cannot start resharding transfer: not all peers support the required version {} while they are at versions {:?} -> {:?}",
+                    "Cannot start resharding transfer: not all peers support the required version {} while they are at versions [{}] -> addresses [{}]",
                     *NEW_UPDATE_ON_RESHARDING_VERSION,
                     self.channel_service
                         .peers_versions()

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -105,13 +105,13 @@ impl Collection {
                     self.channel_service
                         .peers_versions()
                         .into_iter()
-                        .map(|(peer_id, version)| format!("{}: {}", peer_id, version))
+                        .map(|(peer_id, version)| format!("{peer_id}: {version}"))
                         .collect::<Vec<String>>()
                         .join(", "),
                     self.channel_service
                         .peers_addresses()
                         .into_iter()
-                        .map(|(peer_id, address)| format!("{}: {}", peer_id, address))
+                        .map(|(peer_id, address)| format!("{peer_id}: {address}"))
                         .collect::<Vec<String>>()
                         .join(", "),
                 )));

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -189,6 +189,20 @@ impl ChannelService {
             .all(|metadata| &metadata.version >= version)
     }
 
+    /// Get the versions of all peers
+    pub fn peers_versions(&self) -> HashMap<PeerId, Version> {
+        self.id_to_metadata
+            .read()
+            .iter()
+            .map(|(peer_id, metadata)| (*peer_id, metadata.version.clone()))
+            .collect()
+    }
+
+    /// Get peer addresses:
+    pub fn peers_addresses(&self) -> HashMap<PeerId, Uri> {
+        self.id_to_address.read().clone()
+    }
+
     /// Check whether the specified peer is running at least the given version
     ///
     /// If the version is not known for the peer, this returns `false`.

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -189,20 +189,6 @@ impl ChannelService {
             .all(|metadata| &metadata.version >= version)
     }
 
-    /// Get the versions of all peers
-    pub fn peers_versions(&self) -> HashMap<PeerId, Version> {
-        self.id_to_metadata
-            .read()
-            .iter()
-            .map(|(peer_id, metadata)| (*peer_id, metadata.version.clone()))
-            .collect()
-    }
-
-    /// Get peer addresses:
-    pub fn peers_addresses(&self) -> HashMap<PeerId, Uri> {
-        self.id_to_address.read().clone()
-    }
-
     /// Check whether the specified peer is running at least the given version
     ///
     /// If the version is not known for the peer, this returns `false`.

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use collection::collection::shard_transfer::NEW_UPDATE_ON_RESHARDING_VERSION;
 use collection::operations::types::{CollectionError, CollectionResult};
 use collection::shards::CollectionId;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
@@ -65,37 +64,6 @@ impl ShardTransferConsensus for TocDispatcher {
         transfer_config: ShardTransfer,
         collection_id: CollectionId,
     ) -> CollectionResult<()> {
-        // Pre-flight: version gate for resharding transfers
-        // Check before proposing to consensus to return a normal API error
-        // instead of failing during consensus apply (which could stop consensus).
-        if transfer_config.is_resharding() {
-            let Some(toc) = self.toc.upgrade() else {
-                return Err(CollectionError::service_error(
-                    "Can't check resharding version gate, table of contents is dropped",
-                ));
-            };
-            let channel_service = toc.get_channel_service();
-            if !channel_service.all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION) {
-                return Err(CollectionError::pre_condition_failed(format!(
-                    "Cannot start resharding transfer: not all peers support the required \
-                     version {} while they are at versions [{}] -> addresses [{}]",
-                    *NEW_UPDATE_ON_RESHARDING_VERSION,
-                    channel_service
-                        .peers_versions()
-                        .into_iter()
-                        .map(|(peer_id, version)| format!("{peer_id}: {version}"))
-                        .collect::<Vec<String>>()
-                        .join(", "),
-                    channel_service
-                        .peers_addresses()
-                        .into_iter()
-                        .map(|(peer_id, address)| format!("{peer_id}: {address}"))
-                        .collect::<Vec<String>>()
-                        .join(", "),
-                )));
-            }
-        }
-
         let operation =
             ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::TransferShard(
                 collection_id,

--- a/lib/storage/src/content_manager/toc/transfer.rs
+++ b/lib/storage/src/content_manager/toc/transfer.rs
@@ -68,28 +68,28 @@ impl ShardTransferConsensus for TocDispatcher {
         // Pre-flight: version gate for resharding transfers
         // Check before proposing to consensus to return a normal API error
         // instead of failing during consensus apply (which could stop consensus).
-        if transfer_config.is_resharding() {
-            if let Some(toc) = self.toc.upgrade() {
-                let channel_service = toc.get_channel_service();
-                if !channel_service.all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION) {
-                    return Err(CollectionError::pre_condition_failed(format!(
-                        "Cannot start resharding transfer: not all peers support the required \
-                         version {} while they are at versions {:?} -> {:?}",
-                        *NEW_UPDATE_ON_RESHARDING_VERSION,
-                        channel_service
-                            .peers_versions()
-                            .into_iter()
-                            .map(|(peer_id, version)| format!("{}: {}", peer_id, version))
-                            .collect::<Vec<String>>()
-                            .join(", "),
-                        channel_service
-                            .peers_addresses()
-                            .into_iter()
-                            .map(|(peer_id, address)| format!("{}: {}", peer_id, address))
-                            .collect::<Vec<String>>()
-                            .join(", "),
-                    )));
-                }
+        if transfer_config.is_resharding()
+            && let Some(toc) = self.toc.upgrade()
+        {
+            let channel_service = toc.get_channel_service();
+            if !channel_service.all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION) {
+                return Err(CollectionError::pre_condition_failed(format!(
+                    "Cannot start resharding transfer: not all peers support the required \
+                     version {} while they are at versions {:?} -> {:?}",
+                    *NEW_UPDATE_ON_RESHARDING_VERSION,
+                    channel_service
+                        .peers_versions()
+                        .into_iter()
+                        .map(|(peer_id, version)| format!("{peer_id}: {version}"))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    channel_service
+                        .peers_addresses()
+                        .into_iter()
+                        .map(|(peer_id, address)| format!("{peer_id}: {address}"))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                )));
             }
         }
 

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -672,26 +672,14 @@ pub async fn do_update_collection_cluster(
                 ));
             }
 
-            // Version gate: all peers must support the resharding transfer version
+            // Resharding now requires a new type of update operation,
+            // so all peers must be at the version that supports it.
             let toc = dispatcher.toc(&access, &pass);
             let channel_service = toc.get_channel_service();
             if !channel_service.all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION) {
                 return Err(StorageError::bad_request(format!(
-                    "Cannot start resharding: not all peers support the required version {}. \
-                     Peer versions: [{}], peer addresses: [{}]",
+                    "Cannot start resharding: not all peers support the required version {}",
                     *NEW_UPDATE_ON_RESHARDING_VERSION,
-                    channel_service
-                        .peers_versions()
-                        .into_iter()
-                        .map(|(peer_id, version)| format!("{peer_id}: {version}"))
-                        .collect::<Vec<String>>()
-                        .join(", "),
-                    channel_service
-                        .peers_addresses()
-                        .into_iter()
-                        .map(|(peer_id, address)| format!("{peer_id}: {address}"))
-                        .collect::<Vec<String>>()
-                        .join(", "),
                 )));
             }
 

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -674,7 +674,7 @@ pub async fn do_update_collection_cluster(
 
             // Resharding now requires a new type of update operation,
             // so all peers must be at the version that supports it.
-            let toc = dispatcher.toc(&access, &pass);
+            let toc = dispatcher.toc(&auth, &pass);
             let channel_service = toc.get_channel_service();
             if !channel_service.all_peers_at_version(&NEW_UPDATE_ON_RESHARDING_VERSION) {
                 return Err(StorageError::bad_request(format!(


### PR DESCRIPTION
## Summary

Adds a pre-flight version check before proposing resharding transfers to consensus, returning a clean API error instead of
crashing consensus. 

## Problem

The version gate in `Collection::start_shard_transfer()` checks `all_peers_at_version()` during consensus apply. When this check fails, it returns a `ServiceError` which **stops consensus entirely**. It's affecting all CM resharding integration tests.

This can happen in two scenarios:

1. **Resharding during cluster scaling**: When a node recently joined or restarted, its address is registered immediately but
  metadata propagates asynchronously. If a resharding transfer is applied through consensus in that window, the check fails
because `id_to_address.len() > id_to_metadata.len()`.

2. **Resharding during rolling upgrade**: If some peers are still running a version older than `1.16.4-dev`, the version
check fails. Instead of a clean rejection, consensus stops.



## Fix

Added the same version check as a pre-flight in `TocDispatcher::start_shard_transfer()` before proposing to consensus. This
way failures return a normal API error that callers can handle/retry, instead of killing consensus.
