### PR TITLE
Remove update queue opnum from CollectionInfo

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -8339,13 +8339,6 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
-          },
-          "op_num": {
-            "description": "last operation number processed",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
           }
         }
       },
@@ -12608,7 +12601,7 @@
             "description": "Update queue status",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UpdateQueueInfo"
+                "$ref": "#/components/schemas/ShardUpdateQueueInfo"
               },
               {
                 "nullable": true
@@ -13354,6 +13347,27 @@
             "additionalProperties": false
           }
         ]
+      },
+      "ShardUpdateQueueInfo": {
+        "type": "object",
+        "required": [
+          "length"
+        ],
+        "properties": {
+          "length": {
+            "description": "Number of elements in the queue",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "op_num": {
+            "description": "last operation number processed",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          }
+        }
       },
       "RemoteShardTelemetry": {
         "type": "object",

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -751,8 +751,6 @@ message PayloadSchemaInfo {
 message UpdateQueueInfo {
     // Number of elements in the queue
     uint64 length = 1;
-    // last operation number processed
-    optional uint64 op_num = 2;
 }
 
 message CollectionInfo {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1620,9 +1620,6 @@ pub struct UpdateQueueInfo {
     /// Number of elements in the queue
     #[prost(uint64, tag = "1")]
     pub length: u64,
-    /// last operation number processed
-    #[prost(uint64, optional, tag = "2")]
-    pub op_num: ::core::option::Option<u64>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -355,7 +355,6 @@ impl Collection {
             info.segments_count += segments_count;
             info.warnings.extend(warnings);
             if let Some(queue) = &mut info.update_queue {
-                // TODO remove field `op_num`, no sane way to aggregate across shards
                 queue.length += update_queue.map(|q| q.length).unwrap_or(0);
             } else {
                 info.update_queue = update_queue;

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -576,20 +576,18 @@ impl From<api::grpc::qdrant::CollectionWarning> for CollectionWarning {
 
 impl From<UpdateQueueInfo> for api::grpc::qdrant::UpdateQueueInfo {
     fn from(value: UpdateQueueInfo) -> Self {
-        let UpdateQueueInfo { length, op_num } = value;
+        let UpdateQueueInfo { length } = value;
         Self {
             length: length as u64,
-            op_num: op_num.map(|x| x as u64),
         }
     }
 }
 
 impl From<api::grpc::qdrant::UpdateQueueInfo> for UpdateQueueInfo {
     fn from(value: api::grpc::qdrant::UpdateQueueInfo) -> Self {
-        let api::grpc::qdrant::UpdateQueueInfo { length, op_num } = value;
+        let api::grpc::qdrant::UpdateQueueInfo { length } = value;
         Self {
             length: length as usize,
-            op_num: op_num.map(|x| x as usize),
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -73,7 +73,7 @@ use crate::operations::OperationWithClockTag;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
     CollectionError, CollectionResult, OptimizationSegmentInfo, OptimizersStatus,
-    PendingOptimization, ShardInfoInternal, ShardStatus, UpdateQueueInfo,
+    PendingOptimization, ShardInfoInternal, ShardStatus, ShardUpdateQueueInfo,
     check_sparse_compatible_with_segment_config,
 };
 use crate::optimizers_builder::{OptimizersConfig, build_optimizers, clear_temp_segments};
@@ -940,8 +940,8 @@ impl LocalShard {
         SegmentsSearcher::read_filtered(segments, filter, runtime_handle, hw_counter, timeout).await
     }
 
-    pub fn local_update_queue_info(&self) -> UpdateQueueInfo {
-        UpdateQueueInfo {
+    pub fn local_update_queue_info(&self) -> ShardUpdateQueueInfo {
+        ShardUpdateQueueInfo {
             length: self.update_queue_length(),
             op_num: self.applied_seq_handler.op_num().map(|s| s as usize),
         }

--- a/lib/collection/src/shards/telemetry.rs
+++ b/lib/collection/src/shards/telemetry.rs
@@ -8,7 +8,7 @@ use segment::types::ShardKey;
 use serde::Serialize;
 
 use crate::collection_manager::optimizers::TrackerTelemetry;
-use crate::operations::types::{OptimizersStatus, ShardStatus, UpdateQueueInfo};
+use crate::operations::types::{OptimizersStatus, ShardStatus, ShardUpdateQueueInfo};
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
 
@@ -74,7 +74,7 @@ pub struct LocalShardTelemetry {
     pub indexed_only_excluded_vectors: Option<HashMap<String, usize>>,
     /// Update queue status
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub update_queue: Option<UpdateQueueInfo>,
+    pub update_queue: Option<ShardUpdateQueueInfo>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize, Default)]


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant/pull/8108

The `op_num` field is removed from the `CollectionInfo` because it can't be aggregated.

However we can keep it in the shard level telemetry.