### PR TITLE
Fix `too_many_internal_resets` error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,8 +3089,7 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 [[package]]
 name = "hyper"
 version = "0.14.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+source = "git+https://github.com/qdrant/hyper?branch=v0.14.26-qdrant#923b57d062119b6d223beff7f34f8955f9c3dded"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -7692,8 +7691,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+source = "git+https://github.com/qdrant/tonic?branch=v0.11.0-qdrant#a8c90c80dafedcd5e6a6d2c3d7995422ef317437"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,10 @@ smallvec = { version = "1.15.1", features = ["write"] }
 dashmap = "6.1"
 walkdir = "2.5.0"
 
+[patch.crates-io]
+tonic = { git = "https://github.com/qdrant/tonic", branch = "v0.11.0-qdrant" }
+hyper = { git = "https://github.com/qdrant/hyper", branch = "v0.14.26-qdrant" }
+
 [[bin]]
 name = "schema_generator"
 path = "src/schema_generator.rs"

--- a/lib/api/src/grpc/dynamic_channel_pool.rs
+++ b/lib/api/src/grpc/dynamic_channel_pool.rs
@@ -13,7 +13,9 @@ pub async fn make_grpc_channel(
 ) -> Result<Channel, TonicError> {
     let mut endpoint = Channel::builder(uri)
         .timeout(timeout)
-        .connect_timeout(connection_timeout);
+        .connect_timeout(connection_timeout)
+        .http2_max_local_error_reset_streams(None);
+
     if let Some(config) = tls_config {
         endpoint = endpoint.tls_config(config)?;
     }


### PR DESCRIPTION
Patch `tonic` and `hyper` crates to expose `max_local_error_reset_streams`, and *disable* it when creating internal gRPC connections.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
