### PR TITLE
prevent proxy locking while snapshotting

### DIFF
--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -316,9 +316,6 @@ pub fn proxy_all_segments_and_apply<F>(
 where
     F: FnMut(&RwLock<dyn NonAppendableSegmentEntry>) -> OperationResult<()>,
 {
-    // Prevents update operations to accidentally lock on wrapped segments.
-    let update_lock = segments.acquire_updates_lock();
-
     let segments_lock = segments.upgradable_read();
 
     // Proxy all segments
@@ -330,8 +327,6 @@ where
         segment_config,
         payload_index_schema,
     )?;
-
-    drop(update_lock);
 
     // Flush all pending changes of each segment, now wrapped segments won't change anymore
     segments_lock.flush_all(true, true)?;
@@ -349,7 +344,6 @@ where
             LockedSegment::Proxy(proxy_segment) => {
                 let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
                 let segment = wrapped_segment.get();
-                // Call provided function on wrapped segment while holding guard to parent segment
                 operation(segment)
             }
             // All segments to snapshot should be proxy, warn if this is not the case


### PR DESCRIPTION
This PR rolls back changes of https://github.com/qdrant/qdrant/pull/7196

### Why it is problematic?

- Proxy segment was holding a read-lock for the duration of the snapshot, which can be very long.
- Any update operation had to lock proxy segment for write, was stuck for the duration of the snapshot.
- with write operations, all other operation were stuck as well

### Why it should be ok not to hold the lock?

Proxy segments are design explicitly for this situation - allow read + write operations, while underlying segment is accessed for read for a long time. This is how optimization functions.
Requiring it to be locked for the same duration as wrapped segment essentially kills the idea of proxy segment.

---

~Extra changes of a new updates lock for the duration of proxifying didn't show any improvement, but I think it might be good to have anyway - it prevents update operation from reading/writing directly into wrapped segments after they are already proxified.~

:point_up: this doesn't work because of deadlock on parallel snapshots