### PR TITLE
fix: use c_char for Vulkan pointers to support ARM64

### DIFF
--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -225,7 +225,7 @@ impl Device {
             vk_physical_device.vk_physical_device,
             &extensions_cstr,
         )?;
-        let extension_names_raw: Vec<*const i8> = extensions_cstr
+        let extension_names_raw: Vec<*const std::ffi::c_char> = extensions_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();

--- a/lib/gpu/src/instance.rs
+++ b/lib/gpu/src/instance.rs
@@ -141,7 +141,7 @@ impl Instance {
             .iter()
             .filter_map(|s| CString::new(s.clone().into_bytes()).ok())
             .collect();
-        let extension_names_raw: Vec<*const i8> = extensions_cstr
+        let extension_names_raw: Vec<*const std::ffi::c_char> = extensions_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();
@@ -154,7 +154,7 @@ impl Instance {
             .iter()
             .filter_map(|s| CString::new(s.clone().into_bytes()).ok())
             .collect();
-        let layers_raw: Vec<*const i8> = layers_cstr
+        let layers_raw: Vec<*const std::ffi::c_char> = layers_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();


### PR DESCRIPTION
## Summary
Fixes #8096

This PR fixes compilation failures when building Qdrant with GPU support on ARM64 (aarch64) architecture.

## The Problem
On ARM64, `c_char` is defined as `u8`, while on x86_64 it is `i8`. The code was using hardcoded `*const i8` types for Vulkan string pointers, which caused type mismatches when compiling on ARM64:

```
error[E0308]: mismatched types
expected `*const i8`, found `*const u8`
```

Vulkan bindings expect `*const c_char` pointers, which resolves to the correct platform-specific type.

## The Solution
Replace all instances of `Vec<*const i8>` with `Vec<*const std::ffi::c_char>` in:
- `lib/gpu/src/instance.rs`: `extension_names_raw` (line 144)
- `lib/gpu/src/instance.rs`: `layers_raw` (line 157)
- `lib/gpu/src/device.rs`: `extension_names_raw` (line 228)

This ensures the code compiles correctly on both x86_64 (where `c_char = i8`) and ARM64 (where `c_char = u8`).

## Testing
This fix follows the standard Rust FFI pattern for C string pointers and is consistent with the Vulkan ash crate's API which expects `*const c_char`.