### PR TITLE
Fix flaky test_rate_more_per_minute

### DIFF
--- a/lib/common/common/src/rate_limiting.rs
+++ b/lib/common/common/src/rate_limiting.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(limiter.tokens, 599.0);
 
         assert_eq!(limiter.try_consume(10.0), Ok(()));
-        assert_eq_floats(limiter.tokens, 589.0, 0.01);
+        assert!((589.0..=590.0).contains(&limiter.tokens));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7485
Replace exact float assertion with range check [589.0, 590.0] to tolerate
time between consume calls. Test-only. 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?