### PR TITLE
Improve port logging in case port 0 requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5481,6 +5481,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic 0.11.0",
  "tonic-reflection",
@@ -7656,9 +7657,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ console-subscriber = { version = "0.5.0", default-features = false, features = [
 ], optional = true }
 tracing-tracy = { version = "0.11.4", features = ["ondemand"], optional = true }
 actix-web-extras = "0.1.0"
+tokio-stream = { version = "0.1.18", features = ["net"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18.0", default-features = false }

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -195,7 +195,11 @@ pub fn init(
             server.bind(bind_addr)?
         };
 
+        // checking actually bound port is needed when port 0 is requested
+        // server has successfully bound to bind_addr above, unwrap is safe
+        let port = server.addrs().first().unwrap().port();
         log::info!("Qdrant HTTP listening on {port}");
+
         server.run().await
     })
 }


### PR DESCRIPTION
When port 0 is requested a random free port is assigned, but log statements will show qdrant is listening on port 0. This MR fixes the log statements to show the assigned port instead

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
