### PR TITLE
Lock free clock set

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -118,7 +118,7 @@ pub struct ShardReplicaSet {
     /// Lock to serialized write operations on the replicaset when a write ordering is used.
     write_ordering_lock: Mutex<()>,
     /// Local clock set, used to tag new operations on this shard.
-    clock_set: Mutex<ClockSet>,
+    clock_set: ClockSet,
     write_rate_limiter: Option<parking_lot::Mutex<RateLimiter>>,
     pub partial_snapshot_meta: PartialSnapshotMeta,
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -224,7 +224,7 @@ impl ShardReplicaSet {
 
     pub async fn get_clock(&self) -> ClockGuard {
         loop {
-            match self.clock_set.lock().await.get_clock() {
+            match self.clock_set.get_clock() {
                 Some(clock) => return clock,
                 // Prevent blocking async runtime with spinlock
                 None => yield_now().await,

--- a/lib/collection/src/shards/test.rs
+++ b/lib/collection/src/shards/test.rs
@@ -88,7 +88,7 @@ impl Helper {
         }
     }
 
-    pub fn tick_clock(&mut self) -> TickClockStatus {
+    pub fn tick_clock(&self) -> TickClockStatus {
         let mut clock = self.clock_set.get_clock().unwrap(); // unwrap in test is fine
         let clock_tag = ClockTag::new(PEER_ID, clock.id() as _, clock.tick_once());
         TickClockStatus { clock_tag }

--- a/lib/collection/src/shards/test.rs
+++ b/lib/collection/src/shards/test.rs
@@ -72,7 +72,7 @@ fn clock_set_clock_map_workflow() {
     helper.tick_clock().assert(101);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct Helper {
     clock_set: ClockSet,
     clock_map: ClockMap,

--- a/lib/collection/src/wal_delta.rs
+++ b/lib/collection/src/wal_delta.rs
@@ -358,7 +358,7 @@ mod tests {
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
         // Create clock set for peer A, start first clock from 1
-        let mut a_clock_set = ClockSet::new();
+        let a_clock_set = ClockSet::new();
         a_clock_set.get_clock().unwrap().advance_to(0);
 
         // Create operation on peer A
@@ -456,7 +456,7 @@ mod tests {
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
         // Create clock set for peer A, start first clock from 1
-        let mut a_clock_set = ClockSet::new();
+        let a_clock_set = ClockSet::new();
         a_clock_set.get_clock().unwrap().advance_to(0);
 
         // Create N operations on peer A
@@ -561,7 +561,7 @@ mod tests {
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
         // Create clock set for peer A, start first clock from 1
-        let mut a_clock_set = ClockSet::new();
+        let a_clock_set = ClockSet::new();
         a_clock_set.get_clock().unwrap().advance_to(0);
 
         // Create N operations on peer A
@@ -658,8 +658,8 @@ mod tests {
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
         // Create clock sets for peer A and B
-        let mut a_clock_set = ClockSet::new();
-        let mut b_clock_set = ClockSet::new();
+        let a_clock_set = ClockSet::new();
+        let b_clock_set = ClockSet::new();
 
         // Create N operations on peer A
         for i in 0..N {
@@ -760,8 +760,8 @@ mod tests {
         let (c_wal, _c_wal_dir) = fixture_empty_wal();
 
         // Create clock sets for peer A and B, start first clocks from 1
-        let mut a_clock_set = ClockSet::new();
-        let mut b_clock_set = ClockSet::new();
+        let a_clock_set = ClockSet::new();
+        let b_clock_set = ClockSet::new();
         a_clock_set.get_clock().unwrap().advance_to(0);
         b_clock_set.get_clock().unwrap().advance_to(0);
 
@@ -961,8 +961,8 @@ mod tests {
 
         let (e_wal, _e_wal_dir) = fixture_empty_wal();
 
-        let mut c_clock_set = ClockSet::new();
-        let mut d_clock_set = ClockSet::new();
+        let c_clock_set = ClockSet::new();
+        let d_clock_set = ClockSet::new();
 
         let node_c_peer_id = 1;
         let node_d_peer_id = 2;
@@ -1297,7 +1297,7 @@ mod tests {
         let mut wals = std::iter::repeat_with(fixture_empty_wal)
             .take(node_count)
             .collect::<Vec<_>>();
-        let mut clock_sets = std::iter::repeat_with(|| ClockSet::with_max_clocks(256))
+        let clock_sets = std::iter::repeat_with(|| ClockSet::with_max_clocks(256))
             .take(node_count)
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
After this PR https://github.com/qdrant/qdrant/pull/8105 it's possible to make `ClockSet` lock-free using atomic len.
This PR makes `ClockSet` lock free and removes tokio mutex.