### PR TITLE
Fix flaky test_cancel_optimization

### DIFF
--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -211,7 +211,7 @@ async fn test_cancel_optimization() {
         };
 
         let log = optimizers_log.lock().to_telemetry();
-        assert_eq!(log.len(), expected_optimization_count);
+        assert!(log.len() <= expected_optimization_count);
         for status in log {
             assert_eq!(status.name, "indexing");
             assert!(matches!(status.status, TrackerStatus::Cancelled(_)));


### PR DESCRIPTION
Relax log count assertion from `assert_eq!` to `<=`. 
Early cancellations are intentionally excluded from log (`optimization_worker.rs:376`).

Fixes #7794

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?