### PR TITLE
Bump dev version to v1.17.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "api"
-version = "1.16.4-dev"
+version = "1.17.1-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.16.4-dev"
+version = "1.17.1-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.16.4-dev"
+version = "1.17.1-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.16.4-dev"
+version = "1.17.1-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.16.4-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.17.1-dev";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =


### PR DESCRIPTION
Bumps the development version to 1.17.1-dev for the [Qdrant 1.17.0](https://github.com/qdrant/qdrant/releases/1.17.0) release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/7807>

### Tasks

- [x] Merge <https://github.com/qdrant/qdrant/pull/8160>
- [x] Rebase on `dev`
- [x] Undraft