### PR TITLE
High priority IO for search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "criterion",
  "fs-err",
  "itertools 0.14.0",
+ "libc",
  "log",
  "memmap2",
  "memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,6 +244,7 @@ urlencoding = "2.1.3"
 indicatif = { version = "0.18.3", features = ["rayon"] }
 integer-encoding = "4.1.0"
 itertools = "0.14.0"
+libc = "0.2"
 log = "0.4.29"
 memmap2 = "0.9.9"
 mockito = "1.7"

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -56,6 +56,7 @@ serde_json = { workspace = true }
 tango-bench = "0.6.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
 thread-priority = "3.0.0"
 
 [[bench]]

--- a/lib/common/common/src/cpu.rs
+++ b/lib/common/common/src/cpu.rs
@@ -94,10 +94,6 @@ fn set_linux_thread_priority(priority: u8) -> Result<(), ThreadPriorityError> {
 
 /// On Linux, set high I/O priority (best-effort class, priority 0) for the current thread.
 ///
-/// Uses the `ioprio_set` syscall to set the I/O scheduling class to `IOPRIO_CLASS_BE` (best
-/// effort) with the highest priority level (0) within that class. This is useful for threads
-/// serving user-facing API requests (e.g. gRPC and REST) to reduce I/O latency.
-///
 /// Only works on Linux because the `ioprio_set` syscall is Linux-specific.
 /// - <https://man7.org/linux/man-pages/man2/ioprio_set.2.html>
 #[cfg(target_os = "linux")]

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -93,6 +93,11 @@ pub fn init(
         }
 
         let mut server = HttpServer::new(move || {
+            #[cfg(target_os = "linux")]
+            if let Err(err) = common::cpu::linux_high_io_priority() {
+                log::error!("Failed to set high IO priority for actix worker thread: {err}");
+            }
+
             let cors = Cors::default()
                 .allow_any_origin()
                 .allow_any_method()

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -93,11 +93,6 @@ pub fn init(
         }
 
         let mut server = HttpServer::new(move || {
-            #[cfg(target_os = "linux")]
-            if let Err(err) = common::cpu::linux_high_io_priority() {
-                log::error!("Failed to set high IO priority for actix worker thread: {err}");
-            }
-
             let cors = Cors::default()
                 .allow_any_origin()
                 .allow_any_method()

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -20,6 +20,12 @@ pub fn create_search_runtime(max_search_threads: usize) -> io::Result<Runtime> {
             let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
             format!("search-{id}")
         })
+        .on_thread_start(|| {
+            #[cfg(target_os = "linux")]
+            if let Err(err) = common::cpu::linux_high_io_priority() {
+                log::error!("Failed to set high IO priority for search runtime thread: {err}");
+            }
+        })
         .build()
 }
 
@@ -54,6 +60,12 @@ pub fn create_general_purpose_runtime() -> io::Result<Runtime> {
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
             let general_id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
             format!("general-{general_id}")
+        })
+        .on_thread_start(|| {
+            #[cfg(target_os = "linux")]
+            if let Err(err) = common::cpu::linux_high_io_priority() {
+                log::error!("Failed to set high IO priority for general runtime thread: {err}");
+            }
         })
         .build()
 }


### PR DESCRIPTION
Linux has a system call to set IO priority for the thread.
https://man7.org/linux/man-pages/man2/ioprio_set.2.html

This PR adds this system call to give more IO priority to search and general runtime.

The goal is reduce IO pressure from optimization, flush thread, and give more resources to the search.
