### PR TITLE
WAL: advise mmap to cleanup closed segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8253,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "wal"
 version = "0.1.4"
-source = "git+https://github.com/qdrant/wal.git?rev=2209eb2c4a359d9c32f63d868c580df360efa4a9#2209eb2c4a359d9c32f63d868c580df360efa4a9"
+source = "git+https://github.com/qdrant/wal.git?rev=c07fb56ebc8120ebe4e3c602d31ce98f356f4676#c07fb56ebc8120ebe4e3c602d31ce98f356f4676"
 dependencies = [
  "byteorder",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ tonic-reflection = "0.11.0"
 tracing = { version = "0.1", features = ["async-await"] }
 uuid = { version = "1.21", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
-wal = { git = "https://github.com/qdrant/wal.git", rev = "2209eb2c4a359d9c32f63d868c580df360efa4a9" }
+wal = { git = "https://github.com/qdrant/wal.git", rev = "c07fb56ebc8120ebe4e3c602d31ce98f356f4676" }
 zerocopy = { version = "0.8.39", features = ["derive"] }
 atomic_refcell = "0.1.13"
 byteorder = "1.5.0"


### PR DESCRIPTION
Bump WAL dependency to include <https://github.com/qdrant/wal/pull/108>

This explicitly applies the DontNeed madvise on WAL segments that are closed to reduce memory pressure.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
