### PR TITLE
Fix prevent_unoptimized not being updated at runtime in update worker

### DIFF
--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -73,9 +73,16 @@ impl LocalShard {
             &self.shared_storage_config.hnsw_global_config,
             &config.quantization_config,
         );
+        let prevent_unoptimized_threshold_kb = config
+            .optimizer_config
+            .prevent_unoptimized
+            .unwrap_or_default()
+            .then(|| config.optimizer_config.get_indexing_threshold_kb());
+
         update_handler.optimizers = new_optimizers.clone();
         update_handler.flush_interval_sec = config.optimizer_config.flush_interval_sec;
         update_handler.max_optimization_threads = config.optimizer_config.max_optimization_threads;
+        update_handler.prevent_unoptimized_threshold_kb = prevent_unoptimized_threshold_kb;
         update_handler.run_workers(update_receiver);
 
         self.optimizers.store(new_optimizers);

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -113,7 +113,7 @@ pub struct UpdateHandler {
     /// If specified, this threshold (in kilobytes) configures a max size of unoptimized segment
     /// which can still be updated. If there are unoptimized segments larger than this threshold,
     /// updates will be blocked until those segments are optimized.
-    prevent_unoptimized_threshold_kb: Option<usize>,
+    pub prevent_unoptimized_threshold_kb: Option<usize>,
 
     /// Highest and cutoff clocks for the shard WAL.
     clocks: LocalShardClocks,


### PR DESCRIPTION
Fixes

```
PATCH /collections/benchmark
{
    "optimizers_config": {
      "prevent_unoptimized": true
    }
}
```

not bumping the setting in the update worker at runtime.

I tested this by adding some log lines that show me the state of `prevent_unoptimized_threshold_kb` while processing each update.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
