### PR TITLE
Reduce search spikes, don't lock Gridstore bitmask for duration of flush

### DIFF
--- a/lib/gridstore/src/gridstore.rs
+++ b/lib/gridstore/src/gridstore.rs
@@ -617,8 +617,7 @@ impl<V> Gridstore<V> {
                 return Err(GridstoreError::FlushCancelled);
             };
 
-            let mut bitmask_guard = bitmask.upgradable_read();
-            bitmask_guard.flush()?;
+            bitmask.read().flush()?;
             for page in pages.read().iter() {
                 page.flush()?;
             }
@@ -629,21 +628,25 @@ impl<V> Gridstore<V> {
                 // Nothing to do flush here
                 return Ok(());
             }
+
             // Update all free blocks in the bitmask
-            bitmask_guard.with_upgraded(|guard| {
-                for (page_id, pointer_group) in
-                    &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
-                {
-                    let local_ranges = pointer_group.map(|pointer| {
-                        let start = pointer.block_offset;
-                        let end = pointer.block_offset
-                            + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
-                        start as usize..end as usize
-                    });
-                    guard.mark_blocks_batch(page_id, local_ranges, false);
-                }
-            });
-            bitmask_guard.flush()?;
+            {
+                let mut bitmask_guard = bitmask.upgradable_read();
+                bitmask_guard.with_upgraded(|guard| {
+                    for (page_id, pointer_group) in
+                        &old_pointers.into_iter().chunk_by(|pointer| pointer.page_id)
+                    {
+                        let local_ranges = pointer_group.map(|pointer| {
+                            let start = pointer.block_offset;
+                            let end = pointer.block_offset
+                                + Self::blocks_for_value(pointer.length as usize, block_size_bytes);
+                            start as usize..end as usize
+                        });
+                        guard.mark_blocks_batch(page_id, local_ranges, false);
+                    }
+                });
+                bitmask_guard.flush()?;
+            }
 
             // Keep the guard till the end of the flush to prevent concurrent drop/flushes
             drop(is_alive_flush_guard);


### PR DESCRIPTION
Supersedes <https://github.com/qdrant/qdrant/pull/8167>

In the Gridstore flusher, a lock on the bitmask was held across the full duration of the flusher including IO. On big flushes, it means we could hold the lock for a long time.

It blocks writes on Gridstore and can in turn lock reads as well. We assume this has been causing spikes in searches.

It turns out we don't have to hold the lock. In stead we can lock in two separate stages and make the critical sections short.

As far as I can tell this change is sound. I've not been able to come up with a problematic scenario.

Thanks @IvanPleshkov for finding this one.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
