### PR TITLE
Log peer version failing check

### DIFF
--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -183,10 +183,10 @@ impl ChannelService {
         if id_to_address.len() > id_to_metadata.len() {
             let peers_without_metadata: HashMap<_, _> = id_to_address
                 .iter()
-                .filter(|(id, _m)| !id_to_metadata.contains_key(id))
+                .filter(|(id, _uri)| !id_to_metadata.contains_key(id))
                 .collect();
             log::info!(
-                "Not all peers at version:{version} because there are peers without metadata {peers_without_metadata:?}"
+                "Not all peers at version:{version} because there are peers without metadata:{peers_without_metadata:?}"
             );
             return false;
         }


### PR DESCRIPTION
The current mechanism for version check of peers is a black box for operators.

This PR adds a log for when the check fails.

```
INFO collection::shards::channel_service: Not all peers at version:1.16.4-dev peers:{
6476872615560361: PeerMetadata { version: Version { major: 1, minor: 16, patch: 3 } }, 
7736355234278729: PeerMetadata { version: Version { major: 1, minor: 16, patch: 3 } },
8361064564809870: PeerMetadata { version: Version { major: 1, minor: 16, patch: 3 } }}
```