### PR TITLE
[gpu] Use c_char pointers for Vulkan extension/layer names (ARM64)

### DIFF
--- a/lib/gpu/src/device.rs
+++ b/lib/gpu/src/device.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 use std::sync::Arc;
 
 use ash::vk;
@@ -225,7 +225,7 @@ impl Device {
             vk_physical_device.vk_physical_device,
             &extensions_cstr,
         )?;
-        let extension_names_raw: Vec<*const i8> = extensions_cstr
+        let extension_names_raw: Vec<*const c_char> = extensions_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();

--- a/lib/gpu/src/instance.rs
+++ b/lib/gpu/src/instance.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -141,7 +141,7 @@ impl Instance {
             .iter()
             .filter_map(|s| CString::new(s.clone().into_bytes()).ok())
             .collect();
-        let extension_names_raw: Vec<*const i8> = extensions_cstr
+        let extension_names_raw: Vec<*const c_char> = extensions_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();
@@ -154,7 +154,7 @@ impl Instance {
             .iter()
             .filter_map(|s| CString::new(s.clone().into_bytes()).ok())
             .collect();
-        let layers_raw: Vec<*const i8> = layers_cstr
+        let layers_raw: Vec<*const c_char> = layers_cstr
             .iter()
             .map(|raw_name| raw_name.as_ptr())
             .collect();


### PR DESCRIPTION
## Summary

Fix ARM64 (arch64) GPU build type mismatch by using c_char pointers for Vulkan extension/layer names instead of hardcoded i8 pointers.

Related issue: #8096

## Problem

In lib/gpu, raw Vulkan name pointer vectors were typed as Vec<*const i8>. On ARM64, c_char differs, which causes pointer type mismatch during GPU build.

## Changes

- lib/gpu/src/instance.rs
  - extension_names_raw: Vec<*const c_char>
  - layers_raw: Vec<*const c_char>
- lib/gpu/src/device.rs
  - extension_names_raw: Vec<*const c_char>
- Added imports:
  - use std::ffi::{CString, c_char};

No behavior changes, only platform-correct pointer typing.

## Validation

- cargo check -p gpu
- cargo test -p gpu --lib
- cargo fmt --all -- --check

All pass locally on current environment.

## Notes

A similar community PR existed earlier and was closed by the author. This PR reintroduces the same focused fix for dev branch in a merge-ready form.
