### PR TITLE
Enable RocksDB support in GitHub release Linux binaries

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           bin: qdrant
           target: ${{ matrix.target }}
+          features: rocksdb
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Debian Package
         if: matrix.target == 'x86_64-unknown-linux-musl'


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/8180>

It appears we built and released Linux binaries without RocksDB support. It's important to include support until we officially drop it in a later version. Without support, migrations fail.

For the other build steps we already specify the `rocksdb` feature. It seems we forgot it for this one.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
