### PR TITLE
Use `FsType::ExFat` on non-Linux, so that Rust won't complain

### DIFF
--- a/lib/common/common/src/fs/check.rs
+++ b/lib/common/common/src/fs/check.rs
@@ -84,6 +84,7 @@ impl FsType {
             "xfs" => Self::Xfs,
             "ntfs" => Self::Ntfs,
             "fat" | "fat12" | "fat16" | "fat32" => Self::Fat,
+            "exfat" => Self::ExFat,
             "nfs" => Self::Nfs,
             "hfs" | "htf+" => Self::Hfs,
             "apfs" => Self::Apfs,


### PR DESCRIPTION
`FsType::ExFat` variant was never used on non-Linux and produced a warning, so I've added a branch for it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
