### PR TITLE
Storage compatibility v1.17.0

### DIFF
--- a/tests/e2e_tests/test_data_compatibility.py
+++ b/tests/e2e_tests/test_data_compatibility.py
@@ -21,14 +21,12 @@ class TestStorageCompatibility:
     """
 
     VERSIONS = [
+        "v1.17.0",
+        "v1.16.3",
+        "v1.16.2",
         "v1.16.1",
         "v1.16.0",
-        "v1.15.5",
-        "v1.15.4",
-        "v1.15.3",
-        "v1.15.2",
-        "v1.15.1",
-        # "v1.15.0", the archive triggers debug_assertion for the UUID payload index https://github.com/qdrant/qdrant/pull/6916
+        "v1.15.5", # technically not guaranteed but kept testing purpose
     ]
 
     EXPECTED_COLLECTIONS = [


### PR DESCRIPTION
Adding `v1.17.0` to the storage compatibility test and added the missing previous archives.

<img width="1302" height="154" alt="bucket" src="https://github.com/user-attachments/assets/f820989d-cdc6-4c8c-823a-d8abcd11cb96" />
