### PR TITLE
Fix Docker build for local compatibility tests

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -98,6 +98,7 @@ def qdrant_image(docker_client: docker.DockerClient, request) -> str:
         build_cmd = [
             "docker", "buildx", "build",
             "--build-arg=PROFILE=ci",
+            "--build-arg=FEATURES=data-consistency-check,rocksdb,staging",
             "--load",
             str(project_root),
             f"--tag={image_tag}"


### PR DESCRIPTION
We enable feature flags on CI when building the e2e docker image
https://github.com/qdrant/qdrant/blob/master/.github/workflows/integration-tests.yml#L260

Those must propagated to the test script because it is responsible for building the docker image locally.

Without it the snapshots containing Rocksdb storages cannot be restored.