### PR TITLE
Fix empty sparse vector name validation

### DIFF
--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -196,18 +196,18 @@ impl CreateCollectionOperation {
     ) -> StorageResult<Self> {
         // validate vector names are unique between dense and sparse vectors
         if let Some(sparse_config) = &create_collection.sparse_vectors {
+            if sparse_config.contains_key(DEFAULT_VECTOR_NAME) {
+                return Err(StorageError::bad_input(
+                    "Sparse vector name cannot be empty",
+                ));
+            }
+
             let mut dense_names = create_collection.vectors.params_iter().map(|p| p.0);
             if let Some(duplicate_name) = dense_names.find(|name| sparse_config.contains_key(*name))
             {
                 return Err(StorageError::bad_input(format!(
                     "Dense and sparse vector names must be unique - duplicate found with '{duplicate_name}'",
                 )));
-            }
-
-            if sparse_config.contains_key(DEFAULT_VECTOR_NAME) {
-                return Err(StorageError::bad_input(
-                    "Sparse vector name cannot be empty",
-                ));
             }
         }
 

--- a/tests/openapi/test_sparse_vector_persistence.py
+++ b/tests/openapi/test_sparse_vector_persistence.py
@@ -128,7 +128,7 @@ def test_sparse_dense_vector_naming_validations(collection_name):
         }
     )
     assert not response.ok
-    assert 'Dense and sparse vector names must be unique - duplicate found with \'\'' in response.json()["status"]["error"]
+    assert 'Sparse vector name cannot be empty' in response.json()["status"]["error"]
 
     response = request_with_validation(
         api='/collections/{collection_name}',


### PR DESCRIPTION
Fixes #5209.  

Block empty sparse vector names on collection creation.  
Adds a regression test.  
Does not migrate existing invalid configs.