### PR TITLE
Remove rocksdb from gpu tests

### DIFF
--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -59,7 +59,7 @@ fn test_gpu_filterable_hnsw() {
         .try_init();
 
     let stopped = AtomicBool::new(false);
-    let max_failures = 5;
+    let max_failures = 7;
     let dim = 8;
     let m = 8;
     let num_vectors: u64 = 10_000;


### PR DESCRIPTION
This PR removes RocksDB dependency from GPU tests (it was required for an obsolete vector storage creation).
Also, this test increases the acc error for the final HNSW test to make it more stable on llvmpipe