### PR TITLE
Fix unused `self` lint in macos

### DIFF
--- a/lib/wal/src/mmap_view_sync.rs
+++ b/lib/wal/src/mmap_view_sync.rs
@@ -19,7 +19,7 @@ pub struct MmapViewSync {
 }
 
 impl MmapViewSync {
-    #[cfg_attr(target_os = "macos", expect(clippy::unused_self))]
+    #[cfg_attr(not(target_os = "linux"), expect(clippy::unused_self))]
     pub fn close(&self) {
         #[cfg(target_os = "linux")]
         unsafe {


### PR DESCRIPTION
After porting WAL repo to here, I am seeing a new lint in macos. Let's just `expect` it.