### PR TITLE
Decrease Quickcheck test count for WAL on Windows

### DIFF
--- a/lib/wal/src/lib.rs
+++ b/lib/wal/src/lib.rs
@@ -622,11 +622,18 @@ mod test {
 
     use fs_err as fs;
     use log::trace;
-    use quickcheck::TestResult;
+    use quickcheck::{QuickCheck, TestResult};
     use tempfile::Builder;
 
     use super::{Wal, WalOptions};
     use crate::test_utils::EntryGenerator;
+
+    /// Windows has very slow IO
+    #[cfg(target_os = "windows")]
+    const QC_TESTS: u64 = 10;
+
+    #[cfg(not(target_os = "windows"))]
+    const QC_TESTS: u64 = 100;
 
     fn init_logger() {
         let _ = env_logger::builder().is_test(true).try_init();
@@ -785,7 +792,9 @@ mod test {
             TestResult::passed()
         }
 
-        quickcheck::quickcheck(wal as fn(u8) -> TestResult);
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(wal as fn(u8) -> TestResult);
     }
 
     #[test]
@@ -825,7 +834,9 @@ mod test {
             TestResult::passed()
         }
 
-        quickcheck::quickcheck(check as fn(u8) -> TestResult)
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(check as fn(u8) -> TestResult)
     }
 
     #[test]
@@ -853,7 +864,9 @@ mod test {
             TestResult::from_bool(wal.num_entries() == 0)
         }
 
-        quickcheck::quickcheck(check as fn(u8) -> TestResult)
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(check as fn(u8) -> TestResult)
     }
 
     /// Check that the Wal will read previously written entries.
@@ -913,7 +926,9 @@ mod test {
             TestResult::passed()
         }
 
-        quickcheck::quickcheck(wal as fn(u8) -> TestResult);
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(wal as fn(u8) -> TestResult);
     }
 
     #[test]
@@ -956,7 +971,9 @@ mod test {
             TestResult::from_bool(wal.entry(u64::from(truncate)).is_none())
         }
 
-        quickcheck::quickcheck(truncate as fn(u8, u8) -> TestResult);
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(truncate as fn(u8, u8) -> TestResult);
     }
 
     #[test]
@@ -1012,7 +1029,9 @@ mod test {
                 num_entries <= entry_count && num_entries >= entry_count - until && retained,
             )
         }
-        quickcheck::quickcheck(prefix_truncate as fn(u8, u8, NonZeroU8) -> TestResult);
+        QuickCheck::new()
+            .tests(QC_TESTS)
+            .quickcheck(prefix_truncate as fn(u8, u8, NonZeroU8) -> TestResult);
     }
 
     #[test]


### PR DESCRIPTION
The WAL tests are very slow on CI for Windows.

e.g. https://github.com/qdrant/qdrant/actions/runs/22399763632/job/64842823461?pr=8226

This PR proposes to adjust to number of tests generated by Quickcheck based on the operating system.

## Before

```
PASS [ 590.922s] (1435/1453) wal test::check_clear
PASS [ 656.793s] (1436/1453) wal test::check_last_index
PASS [ 798.044s] (1451/1453) wal test::check_prefix_truncate
PASS [ 383.193s] (1452/1453) wal test::check_wal
PASS [ 459.552s] (1453/1453) wal test::check_truncate
```

## After

```
PASS [  51.934s] (1434/1453) wal test::check_clear
PASS [  55.746s] (1435/1453) wal test::check_last_index
PASS [  77.355s] (1450/1453) wal test::check_prefix_truncate
PASS [  39.111s] (1453/1453) wal test::check_wal
PASS [  63.251s] (1452/1453) wal test::check_truncate
```