### PR TITLE
use `CowMultiVector` as return type in multivec storages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ futures-util = "0.3.31"
 generic-tests = "0.1.3"
 half = { version = "2.7.1", features = [
     "alloc",
+    "bytemuck",
     "serde",
     "num-traits",
 ] }

--- a/lib/common/common/src/maybe_uninit.rs
+++ b/lib/common/common/src/maybe_uninit.rs
@@ -33,12 +33,14 @@ pub fn maybe_uninit_fill_from<I: IntoIterator>(
     )
 }
 
+pub type InitUninit<'a, T> = (RefDropper<'a, [T]>, &'a mut [MaybeUninit<T>]);
+
 /// Wrapper around [`maybe_uninit_fill_from`] that doesn't leak on drop.
 #[inline(always)]
 pub fn maybe_uninit_fill_from_with_drop<I: IntoIterator>(
     this: &mut [MaybeUninit<I::Item>],
     it: I,
-) -> (RefDropper<'_, [I::Item]>, &mut [MaybeUninit<I::Item>]) {
+) -> InitUninit<'_, I::Item> {
     let (initted, remainder) = maybe_uninit_fill_from(this, it);
     (RefDropper(initted), remainder)
 }

--- a/lib/common/common/src/maybe_uninit.rs
+++ b/lib/common/common/src/maybe_uninit.rs
@@ -1,4 +1,5 @@
 use std::mem::{MaybeUninit, transmute};
+use std::ops::{Deref, DerefMut};
 
 /// [`MaybeUninit::fill_from`] backported to stable.
 ///
@@ -30,4 +31,38 @@ pub fn maybe_uninit_fill_from<I: IntoIterator>(
         unsafe { transmute::<&mut [MaybeUninit<I::Item>], &mut [I::Item]>(initted) },
         remainder,
     )
+}
+
+/// Wrapper around [`maybe_uninit_fill_from`] that doesn't leak on drop.
+#[inline(always)]
+pub fn maybe_uninit_fill_from_with_drop<I: IntoIterator>(
+    this: &mut [MaybeUninit<I::Item>],
+    it: I,
+) -> (RefDropper<'_, [I::Item]>, &mut [MaybeUninit<I::Item>]) {
+    let (initted, remainder) = maybe_uninit_fill_from(this, it);
+    (RefDropper(initted), remainder)
+}
+
+pub struct RefDropper<'a, T: ?Sized>(&'a mut T);
+
+impl<'a, T: ?Sized> Deref for RefDropper<'a, T> {
+    type Target = T;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for RefDropper<'a, T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T: ?Sized> Drop for RefDropper<'a, T> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        unsafe { std::ptr::drop_in_place(self.0) }
+    }
 }

--- a/lib/common/common/src/maybe_uninit.rs
+++ b/lib/common/common/src/maybe_uninit.rs
@@ -1,10 +1,6 @@
-use std::mem::{MaybeUninit, transmute};
-use std::ops::{Deref, DerefMut};
+use std::mem::MaybeUninit;
 
 /// [`MaybeUninit::fill_from`] backported to stable.
-///
-/// Unlike the standard library version, this function does not support [`Drop`]
-/// types, for simplicity of implementation.
 ///
 /// TODO: remove in favor of [`MaybeUninit::fill_from`] once stabilized.
 /// <https://github.com/rust-lang/rust/issues/117428>
@@ -12,8 +8,6 @@ pub fn maybe_uninit_fill_from<I: IntoIterator>(
     this: &mut [MaybeUninit<I::Item>],
     it: I,
 ) -> (&mut [I::Item], &mut [MaybeUninit<I::Item>]) {
-    const { assert!(!std::mem::needs_drop::<I::Item>(), "Not supported") };
-
     let iter = it.into_iter();
 
     let mut initialized_len = 0;
@@ -27,44 +21,23 @@ pub fn maybe_uninit_fill_from<I: IntoIterator>(
 
     // SAFETY: Valid elements have just been written into `init`, so that portion
     // of `this` is initialized.
-    (
-        unsafe { transmute::<&mut [MaybeUninit<I::Item>], &mut [I::Item]>(initted) },
-        remainder,
-    )
+    (unsafe { assume_init_mut(initted) }, remainder)
 }
 
-pub type InitUninit<'a, T> = (RefDropper<'a, [T]>, &'a mut [MaybeUninit<T>]);
-
-/// Wrapper around [`maybe_uninit_fill_from`] that doesn't leak on drop.
+/// [`<[MaybeUninit]>::assume_init_mut`] backported to stable.
+/// <https://github.com/rust-lang/rust/issues/63569>
+///
+/// Gets a mutable (unique) reference to the contained value.
+///
+/// # Safety
+///
+/// Calling this when the content is not yet fully initialized causes undefined
+/// behavior: it is up to the caller to guarantee that every `MaybeUninit<T>` in the
+/// slice really is in an initialized state. For instance, `.assume_init_mut()` cannot
+/// be used to initialize a `MaybeUninit` slice.
 #[inline(always)]
-pub fn maybe_uninit_fill_from_with_drop<I: IntoIterator>(
-    this: &mut [MaybeUninit<I::Item>],
-    it: I,
-) -> InitUninit<'_, I::Item> {
-    let (initted, remainder) = maybe_uninit_fill_from(this, it);
-    (RefDropper(initted), remainder)
-}
-
-pub struct RefDropper<'a, T: ?Sized>(&'a mut T);
-
-impl<'a, T: ?Sized> Deref for RefDropper<'a, T> {
-    type Target = T;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        self.0
-    }
-}
-
-impl<'a, T: ?Sized> DerefMut for RefDropper<'a, T> {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0
-    }
-}
-
-impl<'a, T: ?Sized> Drop for RefDropper<'a, T> {
-    #[inline(always)]
-    fn drop(&mut self) {
-        unsafe { std::ptr::drop_in_place(self.0) }
-    }
+pub const unsafe fn assume_init_mut<T>(this: &mut [MaybeUninit<T>]) -> &mut [T] {
+    // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
+    // mutable reference which is also guaranteed to be valid for writes.
+    unsafe { &mut *(this as *mut [MaybeUninit<T>] as *mut [T]) }
 }

--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -24,6 +24,16 @@ impl<TElement> CowMultiVector<'_, TElement>
 where
     TElement: PrimitiveVectorElement,
 {
+    pub fn as_ref(&self) -> TypedMultiDenseVectorRef<'_, TElement> {
+        match self {
+            CowMultiVector::Owned(owned) => TypedMultiDenseVectorRef {
+                flattened_vectors: &owned.flattened_vectors,
+                dim: owned.dim,
+            },
+            CowMultiVector::Borrowed(borrowed) => *borrowed,
+        }
+    }
+
     fn flattened_len(&self) -> usize {
         match self {
             CowMultiVector::Owned(typed_multi_dense_vector) => {

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use bytemuck::Pod;
 use half::f16;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -15,6 +16,7 @@ where
     Self: Copy + Clone + Default + Send + Sync + 'static,
     Self: Serialize + for<'a> Deserialize<'a>,
     Self: FromBytes + Immutable + IntoBytes + KnownLayout,
+    Self: Pod,
 {
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -90,6 +90,7 @@ impl GpuMultivectors {
                 .map(|id| {
                     vector_storage
                         .get_multi::<Random>(id as PointOffsetType)
+                        .as_ref()
                         .vectors_count()
                 })
                 // Map count of vectors to start and count of vectors in multivector.

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -501,9 +501,9 @@ impl GpuVectorStorage {
                 vector_storage.total_vector_count(),
                 vector_storage.vector_dim(),
                 (0..vector_storage.total_vector_count()).map(|id| {
-                    VectorElementTypeHalf::slice_from_float_cow(Cow::Borrowed(
+                    VectorElementTypeHalf::slice_from_float_cow(
                         vector_storage.get_dense::<Random>(id as PointOffsetType),
-                    ))
+                    )
                 }),
                 None,
                 None,
@@ -529,9 +529,9 @@ impl GpuVectorStorage {
                 vector_storage.total_vector_count(),
                 vector_storage.vector_dim(),
                 (0..vector_storage.total_vector_count()).map(|id| {
-                    VectorElementTypeHalf::slice_to_float_cow(Cow::Borrowed(
+                    VectorElementTypeHalf::slice_to_float_cow(
                         vector_storage.get_dense::<Random>(id as PointOffsetType),
-                    ))
+                    )
                 }),
                 None,
                 None,
@@ -552,7 +552,7 @@ impl GpuVectorStorage {
             vector_storage.total_vector_count(),
             vector_storage.vector_dim(),
             (0..vector_storage.total_vector_count())
-                .map(|id| Cow::Borrowed(vector_storage.get_dense::<Random>(id as PointOffsetType))),
+                .map(|id| vector_storage.get_dense::<Random>(id as PointOffsetType)),
             None,
             None,
             stopped,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -573,6 +573,7 @@ impl GpuVectorStorage {
                     .map(|id| {
                         vector_storage
                             .get_multi::<Random>(id as PointOffsetType)
+                            .as_ref()
                             .vectors_count()
                     })
                     .sum(),
@@ -605,6 +606,7 @@ impl GpuVectorStorage {
                     .map(|id| {
                         vector_storage
                             .get_multi::<Random>(id as PointOffsetType)
+                            .as_ref()
                             .vectors_count()
                     })
                     .sum(),
@@ -632,6 +634,7 @@ impl GpuVectorStorage {
                 .map(|id| {
                     vector_storage
                         .get_multi::<Random>(id as PointOffsetType)
+                        .as_ref()
                         .vectors_count()
                 })
                 .sum(),

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -77,7 +77,7 @@ pub trait GraphLinksVectors {
 
     /// Link vectors will be included for each link per point.
     /// The layout of each vector must correspond to [`VectorLayout::link`].
-    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>>;
+    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]>;
 
     /// Get the layout of base and link vectors.
     fn vectors_layout(&self) -> GraphLinksVectorsLayout;
@@ -128,10 +128,8 @@ impl<'a> GraphLinksVectors for StorageGraphLinksVectors<'a> {
     }
 
     /// Note: unlike base vectors, link vectors are written in a random order.
-    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
-        Ok(Cow::Borrowed(
-            self.quantized_vectors.get_quantized_vector(point_id),
-        ))
+    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
+        Ok(self.quantized_vectors.get_quantized_vector(point_id))
     }
 
     fn vectors_layout(&self) -> GraphLinksVectorsLayout {
@@ -387,8 +385,8 @@ mod tests {
             Ok(Cow::Borrowed(&self.base_vectors[point_id as usize]))
         }
 
-        fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
-            Ok(Cow::Borrowed(&self.link_vectors[point_id as usize]))
+        fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
+            Ok(&self.link_vectors[point_id as usize])
         }
 
         fn vectors_layout(&self) -> GraphLinksVectorsLayout {
@@ -436,7 +434,7 @@ mod tests {
                     assert!(base_vector.is_empty());
                 }
                 iter.map(|(link, bytes)| {
-                    assert_eq!(bytes, vectors.get_link_vector(link).unwrap().as_ref());
+                    assert_eq!(bytes, vectors.get_link_vector(link).unwrap());
                     link
                 })
                 .collect()

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -1,4 +1,5 @@
 use std::alloc::Layout;
+use std::borrow::Cow;
 use std::io::Cursor;
 use std::path::Path;
 use std::sync::Arc;
@@ -72,11 +73,11 @@ pub enum GraphLinksFormatParam<'a> {
 pub trait GraphLinksVectors {
     /// Base vectors will be included once per point on level 0.
     /// The layout of each vector must correspond to [`VectorLayout::base`].
-    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]>;
+    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>>;
 
     /// Link vectors will be included for each link per point.
     /// The layout of each vector must correspond to [`VectorLayout::link`].
-    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]>;
+    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>>;
 
     /// Get the layout of base and link vectors.
     fn vectors_layout(&self) -> GraphLinksVectorsLayout;
@@ -116,7 +117,7 @@ impl<'a> StorageGraphLinksVectors<'a> {
 impl<'a> GraphLinksVectors for StorageGraphLinksVectors<'a> {
     /// Note: uses [`Sequential`] because [`serializer::serialize_graph_links`]
     /// traverses base vectors in a sequential order.
-    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
+    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
         self.vector_storage
             .get_vector_bytes_opt::<Sequential>(point_id)
             .ok_or_else(|| {
@@ -127,8 +128,10 @@ impl<'a> GraphLinksVectors for StorageGraphLinksVectors<'a> {
     }
 
     /// Note: unlike base vectors, link vectors are written in a random order.
-    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
-        Ok(self.quantized_vectors.get_quantized_vector(point_id))
+    fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(
+            self.quantized_vectors.get_quantized_vector(point_id),
+        ))
     }
 
     fn vectors_layout(&self) -> GraphLinksVectorsLayout {
@@ -380,12 +383,12 @@ mod tests {
     }
 
     impl GraphLinksVectors for TestGraphLinksVectors {
-        fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
-            Ok(&self.base_vectors[point_id as usize])
+        fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
+            Ok(Cow::Borrowed(&self.base_vectors[point_id as usize]))
         }
 
-        fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<&[u8]> {
-            Ok(&self.link_vectors[point_id as usize])
+        fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
+            Ok(Cow::Borrowed(&self.link_vectors[point_id as usize]))
         }
 
         fn vectors_layout(&self) -> GraphLinksVectorsLayout {
@@ -425,12 +428,15 @@ mod tests {
             let links: Vec<_> = if let Some(vectors) = vectors {
                 let (base_vector, iter) = right.links_with_vectors(point_id, level);
                 if level == 0 {
-                    assert_eq!(base_vector, vectors.get_base_vector(point_id).unwrap());
+                    assert_eq!(
+                        base_vector,
+                        vectors.get_base_vector(point_id).unwrap().as_ref()
+                    );
                 } else {
                     assert!(base_vector.is_empty());
                 }
                 iter.map(|(link, bytes)| {
-                    assert_eq!(bytes, vectors.get_link_vector(link).unwrap());
+                    assert_eq!(bytes, vectors.get_link_vector(link).unwrap().as_ref());
                     link
                 })
                 .collect()

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -131,7 +131,7 @@ pub fn serialize_graph_links<W: Write + Seek>(
                         if vector.len() != vectors_layout.base.size() {
                             return Err(OperationError::service_error("Vector size mismatch"));
                         }
-                        writer.write_all(vector)?;
+                        writer.write_all(&vector)?;
                         offset += vector.len();
                     }
 
@@ -156,7 +156,7 @@ pub fn serialize_graph_links<W: Write + Seek>(
                         if vector.len() != vectors_layout.link.size() {
                             return Err(OperationError::service_error("Vector size mismatch"));
                         }
-                        writer.write_all(vector)?;
+                        writer.write_all(&vector)?;
                         offset += vector.len();
                     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -156,7 +156,7 @@ pub fn serialize_graph_links<W: Write + Seek>(
                         if vector.len() != vectors_layout.link.size() {
                             return Err(OperationError::service_error("Vector size mismatch"));
                         }
-                        writer.write_all(&vector)?;
+                        writer.write_all(vector)?;
                         offset += vector.len();
                     }
 

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -80,10 +80,12 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
         self.vectors.dim()
     }
 
-    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
-        self.vectors
-            .get::<P>(key as VectorOffsetType)
-            .expect("mmap vector not found")
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        Cow::Borrowed(
+            self.vectors
+                .get::<P>(key as VectorOffsetType)
+                .expect("mmap vector not found"),
+        )
     }
 
     fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(&self, keys: &[PointOffsetType], f: F) {

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use std::io::Write;
-use std::mem::{self, MaybeUninit, size_of, transmute};
+use std::mem::{self, MaybeUninit, size_of};
 use std::path::Path;
 
 use bitvec::prelude::BitSlice;
 use common::ext::BitSliceExt as _;
-use common::maybe_uninit::maybe_uninit_fill_from;
+use common::maybe_uninit::maybe_uninit_fill_from_with_drop;
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
@@ -135,14 +135,14 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         Some(offset)
     }
 
-    /// Size in bytes of a single raw (packed) vector.
+    /// Size in bytes of a single vector.
     pub fn raw_size(&self) -> usize {
         self.dim * size_of::<T>()
     }
 
     /// Read one vector's worth of bytes from storage at `byte_offset` and reinterpret
     /// the byte slice as `&[T]`.
-    fn raw_vector_offset<P: AccessPattern>(&self, byte_offset: usize) -> &[T] {
+    fn raw_vector_offset<P: AccessPattern>(&self, byte_offset: usize) -> Cow<'_, [T]> {
         let range = BytesRange {
             start: byte_offset as u64,
             length: self.raw_size() as u64,
@@ -156,25 +156,18 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         .expect("vector read from storage failed");
 
         match cow {
-            Cow::Borrowed(byte_slice) => {
-                let arr: &[T] = unsafe { transmute(byte_slice) };
-                &arr[0..self.dim]
-            }
-            Cow::Owned(_) => {
-                unimplemented!(
-                    "owned data access is not yet implemented. Mmap always returns slice."
-                )
-            }
+            Cow::Borrowed(byte_slice) => Cow::Borrowed(bytemuck::cast_slice(byte_slice)),
+            Cow::Owned(byte_vec) => Cow::Owned(bytemuck::cast_vec(byte_vec)),
         }
     }
 
-    /// Returns reference to vector data by key
-    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
+    /// Returns vector data by key
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         self.get_vector_opt::<P>(key).expect("vector not found")
     }
 
-    /// Returns an optional reference to vector data by key
-    pub fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<&[T]> {
+    /// Returns an optional vector data by key
+    pub fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Cow<'_, [T]>> {
         self.data_offset(key)
             .map(|offset| self.raw_vector_offset::<P>(offset))
     }
@@ -185,17 +178,18 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         // The `f` is most likely a scorer function.
         // Fetching all vectors first then scoring them is more cache friendly
         // than fetching and scoring in a single loop.
-        let mut vectors_buffer = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
+
+        let mut vectors_buffer = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
         let vectors = if is_read_with_prefetch_efficient(keys) {
             let iter = keys.iter().map(|key| self.get_vector::<Sequential>(*key));
-            maybe_uninit_fill_from(&mut vectors_buffer, iter).0
+            maybe_uninit_fill_from_with_drop(&mut vectors_buffer, iter).0
         } else {
             let iter = keys.iter().map(|key| self.get_vector::<Random>(*key));
-            maybe_uninit_fill_from(&mut vectors_buffer, iter).0
+            maybe_uninit_fill_from_with_drop(&mut vectors_buffer, iter).0
         };
 
         for (i, vec) in vectors.iter().enumerate() {
-            f(i, vec);
+            f(i, &vec);
         }
     }
 
@@ -229,7 +223,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
     ) {
         for (idx, point) in points.enumerate() {
             let vector = self.get_vector::<Random>(point);
-            callback(idx, point, vector);
+            callback(idx, point, &vector);
         }
     }
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -189,7 +189,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         };
 
         for (i, vec) in vectors.iter().enumerate() {
-            f(i, &vec);
+            f(i, vec);
         }
     }
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use bitvec::prelude::BitSlice;
 use common::ext::BitSliceExt as _;
-use common::maybe_uninit::maybe_uninit_fill_from_with_drop;
+use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
@@ -182,10 +182,10 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         let mut vectors_buffer = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
         let vectors = if is_read_with_prefetch_efficient(keys) {
             let iter = keys.iter().map(|key| self.get_vector::<Sequential>(*key));
-            maybe_uninit_fill_from_with_drop(&mut vectors_buffer, iter).0
+            maybe_uninit_fill_from(&mut vectors_buffer, iter).0
         } else {
             let iter = keys.iter().map(|key| self.get_vector::<Random>(*key));
-            maybe_uninit_fill_from_with_drop(&mut vectors_buffer, iter).0
+            maybe_uninit_fill_from(&mut vectors_buffer, iter).0
         };
 
         for (i, vec) in vectors.iter().enumerate() {

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -162,7 +162,7 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for MemmapDenseVectorStora
         self.vectors.as_ref().unwrap().dim
     }
 
-    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> std::borrow::Cow<'_, [T]> {
         self.vectors
             .as_ref()
             .unwrap()

--- a/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/memmap_dense_vector_storage.rs
@@ -198,7 +198,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector.into()).into())
+            .map(|vector| T::slice_to_float_cow(vector).into())
             .expect("Vector not found")
     }
 
@@ -223,7 +223,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for MemmapDenseVectorStorage<T> {
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector.into()).into())
+            .map(|vector| T::slice_to_float_cow(vector).into())
     }
 
     fn insert_vector(

--- a/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/simple_dense_vector_storage.rs
@@ -234,8 +234,8 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for SimpleDenseVectorStora
         self.dim
     }
 
-    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
-        self.vectors.get(key as VectorOffsetType)
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -81,8 +81,8 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
         self.dim
     }
 
-    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> &[T] {
-        self.vectors.get(key as VectorOffsetType)
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -97,7 +97,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     }
 
     /// Panics if key is not found
-    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T> {
         self.get_multi_opt::<P>(key).expect("vector not found")
     }
 
@@ -105,7 +105,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     fn get_multi_opt<P: AccessPattern>(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
+    ) -> Option<CowMultiVector<'_, T>> {
         self.offsets
             .get::<P>(key as VectorOffsetType)
             .and_then(|mmap_offset| {
@@ -115,9 +115,11 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
                     mmap_offset.count as usize,
                 )
             })
-            .map(|flattened_vectors| TypedMultiDenseVectorRef {
-                flattened_vectors,
-                dim: self.vectors.dim(),
+            .map(|flattened_vectors| {
+                CowMultiVector::Borrowed(TypedMultiDenseVectorRef {
+                    flattened_vectors,
+                    dim: self.vectors.dim(),
+                })
             })
     }
 
@@ -175,9 +177,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt::<P>(key).map(|multi_dense_vector| {
-            CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
-                multi_dense_vector,
-            )))
+            CowVector::MultiDense(T::into_float_multivector(multi_dense_vector))
         })
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/simple_multi_dense_vector_storage.rs
@@ -336,7 +336,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     }
 
     /// Panics if key is out of bounds
-    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T> {
         self.get_multi_opt::<P>(key).expect("vector not found")
     }
 
@@ -344,17 +344,17 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for SimpleMultiDenseVector
     fn get_multi_opt<P: AccessPattern>(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
+    ) -> Option<CowMultiVector<'_, T>> {
         // No sequential optimizations available for in memory storage.
         self.vectors_metadata.get(key as usize).map(|metadata| {
             let flattened_vectors = self
                 .vectors
                 .get_many(metadata.start, metadata.inner_vectors_count)
                 .unwrap_or_else(|| panic!("Vectors does not contain data for {metadata:?}"));
-            TypedMultiDenseVectorRef {
+            CowMultiVector::Borrowed(TypedMultiDenseVectorRef {
                 flattened_vectors,
                 dim: self.dim,
-            }
+            })
         })
     }
 
@@ -403,9 +403,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for SimpleMultiDenseVectorStorage<
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt::<P>(key).map(|multi_dense_vector| {
-            CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
-                multi_dense_vector,
-            )))
+            CowVector::MultiDense(T::into_float_multivector(multi_dense_vector))
         })
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -182,7 +182,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     }
 
     /// Panics if key is out of bounds
-    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T> {
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T> {
         self.get_multi_opt::<P>(key).expect("vector not found")
     }
 
@@ -190,17 +190,17 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     fn get_multi_opt<P: AccessPattern>(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<'_, T>> {
+    ) -> Option<CowMultiVector<'_, T>> {
         // No sequential optimizations available for in memory storage.
         self.vectors_metadata.get(key as usize).map(|metadata| {
             let flattened_vectors = self
                 .vectors
                 .get_many(metadata.start, metadata.inner_vectors_count)
                 .unwrap_or_else(|| panic!("Vectors does not contain data for {metadata:?}"));
-            TypedMultiDenseVectorRef {
+            CowMultiVector::Borrowed(TypedMultiDenseVectorRef {
                 flattened_vectors,
                 dim: self.dim,
-            }
+            })
         })
     }
 
@@ -249,9 +249,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorag
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.get_multi_opt::<P>(key).map(|multi_dense_vector| {
-            CowVector::MultiDense(T::into_float_multivector(CowMultiVector::Borrowed(
-                multi_dense_vector,
-            )))
+            CowVector::MultiDense(T::into_float_multivector(multi_dense_vector))
         })
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -767,7 +767,12 @@ impl QuantizedVectors {
             Self::construct_vector_parameters(distance, dim, inner_vectors_count, storage_type);
 
         let offsets = (0..vectors_count as PointOffsetType)
-            .map(|idx| vector_storage.get_multi::<Random>(idx).vectors_count() as PointOffsetType)
+            .map(|idx| {
+                vector_storage
+                    .get_multi::<Random>(idx)
+                    .as_ref()
+                    .vectors_count() as PointOffsetType
+            })
             .scan(0, |offset_acc, multi_vector_len| {
                 let offset = *offset_acc;
                 *offset_acc += multi_vector_len;

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -87,7 +87,7 @@ impl<
         let stored = self.vector_storage.get_dense::<Random>(idx);
         self.hardware_counter.vector_io_read().incr();
 
-        self.score(stored)
+        self.score(&stored)
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -70,7 +70,7 @@ impl<
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
         self.hardware_counter.vector_io_read().incr();
-        TMetric::similarity(&self.query, self.vector_storage.get_dense::<Random>(idx))
+        TMetric::similarity(&self.query, &self.vector_storage.get_dense::<Random>(idx))
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
@@ -96,7 +96,7 @@ impl<
         self.hardware_counter.cpu_counter().incr();
         let v1 = self.vector_storage.get_dense::<Random>(point_a);
         let v2 = self.vector_storage.get_dense::<Random>(point_b);
-        TMetric::similarity(v1, v2)
+        TMetric::similarity(&v1, &v2)
     }
 
     type SupportsBytes = True;

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -120,28 +120,28 @@ impl<
         let stored = self.vector_storage.get_multi::<Random>(idx);
         self.hardware_counter
             .vector_io_read()
-            .incr_delta(stored.vectors_count());
+            .incr_delta(stored.as_ref().vectors_count());
 
-        self.score_ref(stored)
+        self.score_ref(stored.as_ref())
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
         debug_assert_eq!(ids.len(), scores.len());
 
-        let mut vectors = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
+        let mut vectors = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
         let vectors = self
             .vector_storage
             .get_batch_multi(ids, &mut vectors[..ids.len()]);
 
-        let total_loaded_vectors: usize = vectors.iter().map(|v| v.vectors_count()).sum();
+        let total_loaded_vectors: usize = vectors.iter().map(|v| v.as_ref().vectors_count()).sum();
 
         self.hardware_counter
             .vector_io_read()
             .incr_delta(total_loaded_vectors);
 
         for idx in 0..ids.len() {
-            scores[idx] = self.score_ref(vectors[idx]);
+            scores[idx] = self.score_ref(vectors[idx].as_ref());
         }
     }
 

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -97,9 +97,9 @@ impl<
         let stored = self.vector_storage.get_multi::<Random>(idx);
         self.hardware_counter
             .vector_io_read()
-            .incr_delta(stored.vectors_count());
+            .incr_delta(stored.as_ref().vectors_count());
 
-        self.score_multi(TypedMultiDenseVectorRef::from(&self.query), stored)
+        self.score_multi(TypedMultiDenseVectorRef::from(&self.query), stored.as_ref())
     }
 
     #[inline]
@@ -114,19 +114,19 @@ impl<
         debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
         debug_assert_eq!(ids.len(), scores.len());
 
-        let mut vectors = [MaybeUninit::uninit(); VECTOR_READ_BATCH_SIZE];
+        let mut vectors = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
         let vectors = self
             .vector_storage
             .get_batch_multi(ids, &mut vectors[..ids.len()]);
 
-        let total_read = vectors.iter().map(|v| v.vectors_count()).sum();
+        let total_read = vectors.iter().map(|v| v.as_ref().vectors_count()).sum();
 
         self.hardware_counter
             .vector_io_read()
             .incr_delta(total_read);
 
         for idx in 0..ids.len() {
-            scores[idx] = self.score_ref(vectors[idx]);
+            scores[idx] = self.score_ref(vectors[idx].as_ref());
         }
     }
 
@@ -135,9 +135,9 @@ impl<
         let v2 = self.vector_storage.get_multi::<Random>(point_b);
         self.hardware_counter
             .vector_io_read()
-            .incr_delta(v1.vectors_count() + v2.vectors_count());
+            .incr_delta(v1.as_ref().vectors_count() + v2.as_ref().vectors_count());
 
-        self.score_multi(v1, v2)
+        self.score_multi(v1.as_ref(), v2.as_ref())
     }
 
     type SupportsBytes = False;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -24,11 +24,11 @@ use super::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use super::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::named_vectors::CowVector;
+use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte,
-    VectorElementTypeHalf, VectorInternal, VectorRef,
+    MultiDenseVectorInternal, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+    VectorInternal, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
@@ -222,16 +222,16 @@ pub trait SparseVectorStorage: VectorStorage {
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     fn vector_dim(&self) -> usize;
-    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> TypedMultiDenseVectorRef<'_, T>;
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T>;
     fn get_multi_opt<P: AccessPattern>(
         &self,
         key: PointOffsetType,
-    ) -> Option<TypedMultiDenseVectorRef<'_, T>>;
+    ) -> Option<CowMultiVector<'_, T>>;
     fn get_batch_multi<'a>(
         &'a self,
         keys: &[PointOffsetType],
-        vectors: &'a mut [MaybeUninit<TypedMultiDenseVectorRef<'a, T>>],
-    ) -> &'a [TypedMultiDenseVectorRef<'a, T>] {
+        vectors: &'a mut [MaybeUninit<CowMultiVector<'a, T>>],
+    ) -> &'a [CowMultiVector<'a, T>] {
         debug_assert_eq!(keys.len(), vectors.len());
         debug_assert!(keys.len() <= VECTOR_READ_BATCH_SIZE);
         let iter = keys.iter().map(|key| self.get_multi::<Random>(*key));


### PR DESCRIPTION
Similar to #8221, but for multi-dense storages.

This one comes with a slight (and more explicit) overhead when dereferencing, since the borrowed type is an owned struct with a lifetime, it needs to copy the `dim` and the slice's fat pointer when doing `as_ref`.

There is an alternative, that comes with a higher refactoring cost: To just return the flattened vec, and read the `dim` field at the usage sites. It would require lots of extra changes though, so I decided not to do it and use this cheap-copying approach instead.