### PR TITLE
Optimize ImmutablePointToValues: inline single-value points to reduce RAM usage and increase performance

### DIFF
--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -38,7 +38,7 @@ pub struct ImmutablePointToValues<N: Default> {
     /// Per-point entry describing where (or how) its values are stored.
     /// Indexed by `PointOffsetType`.
     point_entries: Vec<PointValueEntry<N>>,
-    /// Shared container holding values for points that have zero or multiple values.
+    /// Shared container holding values for points that have multiple values.
     /// Single-value points are **not** stored here — they live inline in `point_entries`.
     values_container: Vec<N>,
 }

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -1,140 +1,153 @@
 use common::types::PointOffsetType;
 
-#[derive(Debug, Clone, Default)]
-struct PointMeta<N: Default> {
-    // `u32` is used instead of `usize` because it's more RAM efficient
-    // We can expect that we will never have more than 4 billion values per segment
-    offset: u32,
-    length: u32,
-    // For single values, we store them directly in the meta to eliminate an extra query.
-    value: N,
+/// Represents how values for a single point are stored.
+///
+/// - `Single(N)`: The point has exactly one value, stored inline to avoid
+///   container indirection and save memory.
+/// - `Slice { start, count }`: The point has zero or multiple (2+) values,
+///   stored as a contiguous slice in the shared `values_container`.
+///   When `count == 0`, the point has no values (also used after removal).
+#[derive(Debug, Clone)]
+enum PointValueEntry<N> {
+    /// Exactly one value, stored inline for efficiency.
+    Single(N),
+    /// Zero or multiple values stored in the external `values_container`.
+    /// `start` is the index of the first value, `count` is the number of values.
+    /// `u32` is used instead of `usize` because it's more RAM efficient —
+    /// we can expect that we will never have more than 4 billion values per segment.
+    Slice { start: u32, count: u32 },
 }
 
-// This structure doesn't support adding new values, only removing.
-// It's used in immutable field indices like `ImmutableMapIndex`, `ImmutableNumericIndex`, etc to store points-to-values map.
+impl<N> Default for PointValueEntry<N> {
+    /// Default represents "no values" — an empty slice.
+    fn default() -> Self {
+        PointValueEntry::Slice { start: 0, count: 0 }
+    }
+}
+
+/// Flattened points-to-values map.
+///
+/// An analogue of `Vec<Vec<N>>` but more RAM efficient:
+/// - Points with exactly **one** value store it inline in the entry (no container overhead).
+/// - Points with **zero** or **multiple** values store them in a shared, contiguous `Vec<N>`.
+///
+/// This structure doesn't support adding new values, only removing.
+/// It's used in immutable field indices like `ImmutableMapIndex`, `ImmutableNumericIndex`, etc.
 #[derive(Debug, Clone, Default)]
 pub struct ImmutablePointToValues<N: Default> {
-    metas: Vec<PointMeta<N>>,
-    // Flatten points-to-values map
-    // It's an analogue of `Vec<Vec<N>>` but more RAM efficient because it stores values in a single Vec.
-    multi_value_container: Vec<N>,
+    /// Per-point entry describing where (or how) its values are stored.
+    /// Indexed by `PointOffsetType`.
+    point_entries: Vec<PointValueEntry<N>>,
+    /// Shared container holding values for points that have zero or multiple values.
+    /// Single-value points are **not** stored here — they live inline in `point_entries`.
+    values_container: Vec<N>,
 }
 
 impl<N: Default> ImmutablePointToValues<N> {
     pub fn new(src: Vec<Vec<N>>) -> Self {
-        let (multi_value_count, point_count) = src.iter().fold((0, 0), |(multi, point), values| {
-            let length = values.len();
-            match length {
-                0 | 1 => (multi, point + 1),
-                _ => (multi + length, point + 1),
-            }
-        });
+        let mut point_entries = Vec::with_capacity(src.len());
 
-        let mut metas = Vec::with_capacity(point_count);
-        let mut multi_value_container = Vec::with_capacity(multi_value_count);
+        // Only values from empty or multi-value points go into the container.
+        let container_capacity = src
+            .iter()
+            .filter(|values| values.len() != 1)
+            .fold(0, |acc, values| acc + values.len());
+        let mut values_container = Vec::with_capacity(container_capacity);
 
         for values in src {
-            let length = values.len() as u32;
-            match length {
-                0 => {
-                    metas.push(PointMeta {
-                        offset: 0,
-                        length,
-                        value: N::default(),
-                    });
-                }
-                1 => {
-                    let mut values = values;
-                    let value = values.pop().unwrap();
-                    metas.push(PointMeta {
-                        offset: 0,
-                        length,
-                        value,
-                    });
-                }
-                _ => {
-                    metas.push(PointMeta {
-                        offset: multi_value_container.len() as u32,
-                        length,
-                        value: N::default(),
-                    });
-                    multi_value_container.extend(values);
-                }
+            if values.len() == 1 {
+                // Single value — store inline, skip container entirely.
+                let value = values.into_iter().next().expect("length checked above");
+                point_entries.push(PointValueEntry::Single(value));
+            } else {
+                // Zero or multiple values — store in container, record slice location.
+                let start = values_container.len() as u32;
+                let count = values.len() as u32;
+                point_entries.push(PointValueEntry::Slice { start, count });
+                values_container.extend(values);
             }
         }
 
         Self {
-            metas,
-            multi_value_container,
+            point_entries,
+            values_container,
         }
     }
 
     pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl FnMut(&N) -> bool) -> bool {
-        let Some(meta) = self.metas.get(idx as usize) else {
+        let Some(entry) = self.point_entries.get(idx as usize) else {
             return false;
         };
 
-        let vlen = meta.length as usize;
-
-        match vlen {
-            1 => std::iter::once(&meta.value).any(check_fn),
-            // Since zero-length cases are uncommon, handling them here improves performance.
-            _ => {
-                let start = meta.offset as usize;
-                self.multi_value_container
-                    .get(start..start + vlen)
-                    .map_or(false, |values| values.iter().any(check_fn))
+        match entry {
+            PointValueEntry::Single(v) => std::iter::once(v).any(check_fn),
+            PointValueEntry::Slice { start, count } => {
+                let range = *start as usize..(*start + *count) as usize;
+                if let Some(values) = self.values_container.get(range) {
+                    values.iter().any(check_fn)
+                } else {
+                    false
+                }
             }
         }
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<impl Iterator<Item = &N> + '_> {
-        let meta = self.metas.get(idx as usize)?;
-
-        match meta.length {
-            0 => Some(std::slice::from_ref(&meta.value)[0..0].iter()),
-            1 => Some(std::slice::from_ref(&meta.value).iter()),
-            _ => self
-                .multi_value_container
-                .get(meta.offset as usize..(meta.offset + meta.length) as usize)
-                .map(|s| s.iter()),
+        let entry = self.point_entries.get(idx as usize)?;
+        match entry {
+            PointValueEntry::Single(v) => Some(std::slice::from_ref(v).iter()),
+            PointValueEntry::Slice { start, count } => {
+                let range = *start as usize..(*start + *count) as usize;
+                Some(self.values_container[range].iter())
+            }
         }
     }
 
     pub fn get_values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        self.metas
-            .get(idx as usize)
-            .map(|meta| meta.length as usize)
+        let entry = self.point_entries.get(idx as usize)?;
+        match entry {
+            PointValueEntry::Single(_) => Some(1),
+            PointValueEntry::Slice { count, .. } => Some(*count as usize),
+        }
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> Vec<N> {
-        let Some(meta) = self.metas.get_mut(idx as usize) else {
+        if self.point_entries.len() <= idx as usize {
             return Default::default();
-        };
+        }
 
-        let offset = meta.offset;
-        let length = meta.length;
+        // Replace the entry with default (empty slice) and take ownership of the old one.
+        let removed_entry = std::mem::take(&mut self.point_entries[idx as usize]);
 
-        match length {
-            0 => Default::default(),
-            1 => {
-                meta.length = Default::default();
-                vec![std::mem::take(&mut meta.value)]
-            }
-            _ => {
-                meta.length = Default::default();
-                let mut result = Vec::with_capacity(length as usize);
-                for value_index in offset as usize..(offset + length) as usize {
-                    result.push(std::mem::take(&mut self.multi_value_container[value_index]));
+        match removed_entry {
+            PointValueEntry::Single(v) => vec![v],
+            PointValueEntry::Slice { start, count } => {
+                let mut result = Vec::with_capacity(count as usize);
+                for i in start..(start + count) {
+                    // Deleted values still occupy RAM in the container, but optimizers
+                    // will rebuild the index to actually reclaim memory.
+                    let value = std::mem::take(&mut self.values_container[i as usize]);
+                    result.push(value);
                 }
                 result
             }
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Helper: assert that `get_values` for every index matches the expected `values` slice.
+    fn check_values(point_to_values: &ImmutablePointToValues<i32>, values: &[Vec<i32>]) {
+        for (idx, expected) in values.iter().enumerate() {
+            let actual: Option<Vec<_>> = point_to_values
+                .get_values(idx as PointOffsetType)
+                .map(|i| i.copied().collect());
+            assert_eq!(actual, Some(expected.clone()));
+        }
+    }
 
     #[test]
     fn test_immutable_point_to_values_remove() {
@@ -151,29 +164,188 @@ mod tests {
 
         let mut point_to_values = ImmutablePointToValues::new(values.clone());
 
-        let check = |point_to_values: &ImmutablePointToValues<_>, values: &[Vec<_>]| {
-            for (idx, values) in values.iter().enumerate() {
-                let values_vec: Option<Vec<_>> = point_to_values
-                    .get_values(idx as PointOffsetType)
-                    .map(|i| i.copied().collect());
-                assert_eq!(values_vec, Some(values.clone()),);
-            }
-        };
-
-        check(&point_to_values, values.as_slice());
+        check_values(&point_to_values, values.as_slice());
 
         point_to_values.remove_point(0);
         values[0].clear();
 
-        check(&point_to_values, values.as_slice());
+        check_values(&point_to_values, values.as_slice());
 
         point_to_values.remove_point(3);
         values[3].clear();
 
-        check(&point_to_values, values.as_slice());
-        point_to_values.remove_point(6);
-        let removed_values: Vec<_> = point_to_values.get_values(6).unwrap().copied().collect();
-        assert!(removed_values.is_empty());
-        assert_eq!(Some(0), point_to_values.get_values_count(6));
+        check_values(&point_to_values, values.as_slice());
+    }
+
+    #[test]
+    fn test_single_value_stored_inline() {
+        // Points with exactly one value should be stored as Single entries,
+        // and should NOT appear in the values_container.
+        let src = vec![
+            vec![42],   // single — inline
+            vec![1, 2], // multi — in container
+            vec![99],   // single — inline
+            vec![],     // empty — in container (count=0)
+        ];
+
+        let ptv = ImmutablePointToValues::new(src);
+
+        // Only values from multi-value points go into the container: [1, 2]
+        assert_eq!(ptv.values_container.len(), 2);
+
+        // Verify all values are correctly retrievable.
+        assert_eq!(
+            ptv.get_values(0).map(|i| i.copied().collect::<Vec<_>>()),
+            Some(vec![42]),
+        );
+        assert_eq!(
+            ptv.get_values(1).map(|i| i.copied().collect::<Vec<_>>()),
+            Some(vec![1, 2]),
+        );
+        assert_eq!(
+            ptv.get_values(2).map(|i| i.copied().collect::<Vec<_>>()),
+            Some(vec![99]),
+        );
+        assert_eq!(
+            ptv.get_values(3).map(|i| i.copied().collect::<Vec<_>>()),
+            Some(vec![]),
+        );
+    }
+
+    #[test]
+    fn test_get_values_count() {
+        let src = vec![vec![1, 2, 3], vec![10], vec![], vec![4, 5]];
+
+        let ptv = ImmutablePointToValues::new(src);
+
+        assert_eq!(ptv.get_values_count(0), Some(3));
+        assert_eq!(ptv.get_values_count(1), Some(1));
+        assert_eq!(ptv.get_values_count(2), Some(0));
+        assert_eq!(ptv.get_values_count(3), Some(2));
+        // Out-of-bounds index returns None.
+        assert_eq!(ptv.get_values_count(100), None);
+    }
+
+    #[test]
+    fn test_check_values_any() {
+        let src = vec![vec![1, 2, 3], vec![10], vec![], vec![4, 5]];
+
+        let ptv = ImmutablePointToValues::new(src);
+
+        // Multi-value point: check existing and missing values.
+        assert!(ptv.check_values_any(0, |v| *v == 2));
+        assert!(!ptv.check_values_any(0, |v| *v == 99));
+
+        // Single-value point.
+        assert!(ptv.check_values_any(1, |v| *v == 10));
+        assert!(!ptv.check_values_any(1, |v| *v == 0));
+
+        // Empty point always returns false.
+        assert!(!ptv.check_values_any(2, |_| true));
+
+        // Out-of-bounds index returns false.
+        assert!(!ptv.check_values_any(100, |_| true));
+    }
+
+    /// Helper: assert that the point entry at `idx` has been reset to the default
+    /// value (i.e., zero values, as if it were an empty slice).
+    fn assert_point_entry_is_default(ptv: &ImmutablePointToValues<i32>, idx: PointOffsetType) {
+        // Default entry should report a count of 0.
+        assert_eq!(
+            ptv.get_values_count(idx),
+            Some(0),
+            "Expected values count to be Some(0) for removed point {idx}"
+        );
+        // get_values should return Some(empty iterator).
+        let vals: Vec<i32> = ptv
+            .get_values(idx)
+            .expect("Entry should still exist after removal")
+            .copied()
+            .collect();
+        assert!(
+            vals.is_empty(),
+            "Expected no values for removed point {idx}, got {vals:?}"
+        );
+        // check_values_any should always return false for a default (empty) entry.
+        assert!(
+            !ptv.check_values_any(idx, |_| true),
+            "Expected check_values_any to return false for removed point {idx}"
+        );
+    }
+
+    #[test]
+    fn test_remove_single_value_point() {
+        let mut values = vec![
+            vec![10],     // single — inline
+            vec![20, 30], // multi — in container
+            vec![40],     // single — inline
+        ];
+
+        let mut ptv = ImmutablePointToValues::new(values.clone());
+
+        // Remove the inline single-value point.
+        let removed = ptv.remove_point(0);
+        assert_eq!(removed, vec![10]);
+        values[0].clear();
+
+        check_values(&ptv, &values);
+        assert_point_entry_is_default(&ptv, 0);
+
+        // Remove the second inline single-value point.
+        let removed = ptv.remove_point(2);
+        assert_eq!(removed, vec![40]);
+        values[2].clear();
+
+        check_values(&ptv, &values);
+        assert_point_entry_is_default(&ptv, 2);
+
+        // Multi-value point should still be intact.
+        let removed = ptv.remove_point(1);
+        assert_eq!(removed, vec![20, 30]);
+        values[1].clear();
+
+        check_values(&ptv, &values);
+        assert_point_entry_is_default(&ptv, 1);
+    }
+
+    #[test]
+    fn test_remove_out_of_bounds() {
+        let ptv_src = vec![vec![1]];
+        let mut ptv = ImmutablePointToValues::new(ptv_src);
+
+        // Removing an out-of-bounds index should return an empty vec.
+        let removed = ptv.remove_point(999);
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_get_values_out_of_bounds() {
+        let ptv = ImmutablePointToValues::<i32>::new(vec![vec![1]]);
+        assert!(ptv.get_values(10).is_none());
+    }
+
+    #[test]
+    fn test_all_single_values() {
+        // When every point has exactly one value, the container should be empty.
+        let src = vec![vec![1], vec![2], vec![3], vec![4], vec![5]];
+
+        let ptv = ImmutablePointToValues::new(src);
+
+        assert!(ptv.values_container.is_empty());
+
+        for i in 0..5 {
+            assert_eq!(ptv.get_values_count(i), Some(1));
+            let vals: Vec<_> = ptv.get_values(i).unwrap().copied().collect();
+            assert_eq!(vals, vec![(i + 1) as i32]);
+        }
+    }
+
+    #[test]
+    fn test_empty_source() {
+        let mut ptv = ImmutablePointToValues::<i32>::new(vec![]);
+        assert!(ptv.get_values(0).is_none());
+        assert_eq!(ptv.get_values_count(0), None);
+        assert!(!ptv.check_values_any(0, |_| true));
+        assert!(ptv.remove_point(0).is_empty());
     }
 }

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -47,24 +47,32 @@ impl<N: Default> ImmutablePointToValues<N> {
     pub fn new(src: Vec<Vec<N>>) -> Self {
         let mut point_entries = Vec::with_capacity(src.len());
 
-        // Only values from empty or multi-value points go into the container.
+        // Only values from multi-value points go into the container.
         let container_capacity = src
             .iter()
-            .filter(|values| values.len() != 1)
-            .fold(0, |acc, values| acc + values.len());
+            .map(|values| values.len())
+            .filter(|&size| size > 1)
+            .sum();
         let mut values_container = Vec::with_capacity(container_capacity);
 
         for values in src {
-            if values.len() == 1 {
-                // Single value — store inline, skip container entirely.
-                let value = values.into_iter().next().expect("length checked above");
-                point_entries.push(PointValueEntry::Single(value));
-            } else {
-                // Zero or multiple values — store in container, record slice location.
-                let start = values_container.len() as u32;
-                let count = values.len() as u32;
-                point_entries.push(PointValueEntry::Slice { start, count });
-                values_container.extend(values);
+            match values.len() {
+                // Zero values — store inline
+                0 => {
+                    point_entries.push(PointValueEntry::default());
+                }
+                // Single value — store inline, skip container entirely
+                1 => {
+                    let value = values.into_iter().next().expect("length checked above");
+                    point_entries.push(PointValueEntry::Single(value));
+                }
+                // Multiple values — store in container, record slice location
+                2.. => {
+                    let start = values_container.len() as u32;
+                    let count = values.len() as u32;
+                    point_entries.push(PointValueEntry::Slice { start, count });
+                    values_container.extend(values);
+                }
             }
         }
 
@@ -74,13 +82,18 @@ impl<N: Default> ImmutablePointToValues<N> {
         }
     }
 
-    pub fn check_values_any(&self, idx: PointOffsetType, check_fn: impl FnMut(&N) -> bool) -> bool {
+    pub fn check_values_any(
+        &self,
+        idx: PointOffsetType,
+        mut check_fn: impl FnMut(&N) -> bool,
+    ) -> bool {
         let Some(entry) = self.point_entries.get(idx as usize) else {
             return false;
         };
 
         match entry {
-            PointValueEntry::Single(v) => std::iter::once(v).any(check_fn),
+            PointValueEntry::Single(v) => check_fn(v),
+            PointValueEntry::Slice { start: _, count: 0 } => false,
             PointValueEntry::Slice { start, count } => {
                 let range = *start as usize..(*start + *count) as usize;
                 if let Some(values) = self.values_container.get(range) {
@@ -107,7 +120,7 @@ impl<N: Default> ImmutablePointToValues<N> {
         let entry = self.point_entries.get(idx as usize)?;
         match entry {
             PointValueEntry::Single(_) => Some(1),
-            PointValueEntry::Slice { count, .. } => Some(*count as usize),
+            PointValueEntry::Slice { start: _, count } => Some(*count as usize),
         }
     }
 
@@ -185,13 +198,13 @@ mod tests {
             vec![42],   // single — inline
             vec![1, 2], // multi — in container
             vec![99],   // single — inline
-            vec![],     // empty — in container (count=0)
+            vec![],     // empty — inline (count=0)
         ];
 
         let ptv = ImmutablePointToValues::new(src);
 
         // Only values from multi-value points go into the container: [1, 2]
-        assert_eq!(ptv.values_container.len(), 2);
+        assert_eq!(ptv.values_container, [1, 2]);
 
         // Verify all values are correctly retrievable.
         assert_eq!(

--- a/lib/segment/src/index/field_index/immutable_point_to_values.rs
+++ b/lib/segment/src/index/field_index/immutable_point_to_values.rs
@@ -93,7 +93,6 @@ impl<N: Default> ImmutablePointToValues<N> {
 
         match entry {
             PointValueEntry::Single(v) => check_fn(v),
-            PointValueEntry::Slice { start: _, count: 0 } => false,
             PointValueEntry::Slice { start, count } => {
                 let range = *start as usize..(*start + *count) as usize;
                 if let Some(values) = self.values_container.get(range) {


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

Refactors `ImmutablePointToValues<N>` in `lib/segment/src/index/field_index/immutable_point_to_values.rs` to store **single-value points inline** instead of placing them in the shared `values_container`. This reduces memory indirection and improves performance for the common case where a payload field holds exactly one value per point (e.g. a `category` or `status` field).

## Motivation

The original implementation stored each point's values as a `Range<u32>` in `point_to_values`, with the actual values being stored in the `point_to_values_container`:

```rust
// OLD layout
point_to_values: Vec<Range<u32>>,   // 8 bytes per point
point_to_values_container: Vec<N>,  // all values, including single-value points
```

For a single-value point this meant:
1. An 8-byte `Range<u32>` entry in `point_to_values`.
2. The actual value `N` stored separately inside `point_to_values_container`.

In practice, the majority of payload fields (keyword, integer, float…) store **exactly one value per point**. Forcing those values through the container adds unnecessary heap indirection and wastes allocations that could be avoided entirely.

## Changes

### New `PointValueEntry<N>` enum

Replaces the `Range<u32>` with a enum:

```rust
enum PointValueEntry<N> {
    /// Exactly one value — stored inline, no container access needed.
    Single(N),
    /// Zero or 2+ values — stored as a contiguous slice in `values_container`.
    Slice { start: u32, count: u32 },
}
```

| Cardinality | Old storage | New storage |
|-------------|-------------|-------------|
| 0 values | `Range<u32>` (empty) + nothing in container | `Slice { start: 0, count: 0 }` |
| **1 value** | `Range<u32>` + `N` in container | **`Single(N)` — fully inline** |
| 2+ values | `Range<u32>` + `N…` in container | `Slice { start, count }` + `N…` in container |

### Updated struct fields

| Old | New |
|-----|-----|
| `point_to_values: Vec<Range<u32>>` | `point_entries: Vec<PointValueEntry<N>>` |
| `point_to_values_container: Vec<N>` | `values_container: Vec<N>` |

### Smarter `values_container` pre-allocation

The constructor now calculates capacity by **excluding single-value points**, so the container is pre-allocated to exactly the right size:

```rust
let container_capacity = src
    .iter()
    .filter(|values| values.len() != 1)
    .fold(0, |acc, values| acc + values.len());
```

### All public methods updated

- `new()` — dispatches to `Single` vs `Slice` during construction.
- `check_values_any()` — matches on the entry variant; `Single` avoids a container lookup entirely.
- `get_values()` — returns a uniform `std::slice::Iter<'_, N>` for both variants.
- `get_values_count()` — returns `Some(1)` directly for `Single`, no container access.
- `remove_point()` — uses `std::mem::take` on the entry; `Single` extracts the value directly without touching the container.

## Impact

For a segment where every point has exactly one value in a given field, the `values_container` will be **completely empty** after this change — all values will live inline in `point_entries`. The previously mandatory container entries are completely eliminated.

When searching for a field that has exactly one value per point, we no longer need to get a `Range<u32>` and then retrieve values from the `point_to_values_container`. Instead, we can get the value directly from `point_entries`, avoiding indirection and improving cache locality.

## Tests

The existing `test_immutable_point_to_values_remove` test is preserved and refactored to use the new shared `check_values` helper. The following new test cases are added:

| Test | What it covers |
|------|----------------|
| `test_single_value_stored_inline` | Verifies that single-value points do **not** appear in `values_container` |
| `test_all_single_values` | Verifies `values_container` is empty when every point has exactly one value |
| `test_get_values_count` | Correct counts for all cardinalities (0, 1, 2+) |
| `test_check_values_any` | Predicate evaluation across all variants and edge cases |
| `test_remove_single_value_point` | Removal correctness for inline `Single` entries |
| `test_remove_out_of_bounds` | Out-of-bounds removal returns an empty `Vec` |
| `test_get_values_out_of_bounds` | Out-of-bounds lookup returns `None` |
| `test_empty_source` | Constructing from an empty `Vec` is a no-op with safe default behaviour |


## Compatibility

- [x] Logic is fully backward-compatible (same public API surface)
- [x] All existing tests pass
- [x] New tests cover all entry variants and boundary conditions
- [x] No unsafe code introduced
- [x] `u32` is preserved throughout to maintain the existing RAM-efficiency guarantee for indices


## Performance Test in a Real Scenario
In our test collection with 260 million points, filtered-query RPS improved from 358 to 569 (about a 58% improvement). The test configuration is shown below.

In this test, each filtered field has at most one value per point (some points have no value).

<details>
<summary><b>Collection Config</b></summary>

```json
{
    "vectors": {
        "pv": {
            "size": 768,
            "distance": "Dot",
            "hnsw_config": {
                "m": 48,
                "ef_construct": 512,
                "on_disk": false,
                "payload_m": 48
            },
            "quantization_config": {
                "binary": {
                    "always_ram": true,
                    "encoding": "two_bits"
                }
            },
            "on_disk": true
        }
    },
    "sharding_method": "auto",
    "shard_number": 15,
    "replication_factor": 2,
    "write_consistency_factor": 2,
    "on_disk_payload": true,
    "optimizer_config": {
        "default_segment_number": 4,
        "max_segment_size": 16777216
    }
}
```

</details>

<details>
<summary><b>Query Sample</b></summary>

```python
{
    "query": pv_test,
    "using": "pv",
    "params": {
        "hnsw_ef": 48,
        "exact": False,
        "quantization": {"ignore": False, "rescore": True, "oversampling": 2},
    },
    "limit": 60,
    "filter": {
        "must": [
            {
                "key": "A",
                "range": {
                    "gte": A1,
                    "lte": A2,
                },
            },
            {"key": "B", "match": {"any": B_list}},
            {"key": "C", "match": {"any": [C1, C2]}},
            {"key": "D", "match": {"value": D2}},
            {"key": "E", "range": {"gte": E1, "lte": E2}},
            {
                "key": "F",
                "match": {"except": [F1, F2, F3]},
            },
        ]
    },
    "with_payload": ["S", "V"],
    "with_vector": False,
}
```
</details>

## Benches
We extracted the core logic from both structs, focused on `check_values_any`, and ran benchmarks. The results are shown below.

| Cardinality | Old storage | New storage |
|-------------|-------------|-------------|
| single-value  | [1.7936 ms 1.7941 ms 1.7948 ms] | [834.23 µs 835.15 µs 836.41 µs] |
| sparse values | [1.6957 ms 1.6972 ms 1.6993 ms] | [864.67 µs 864.78 µs 864.91 µs] |
| multi-values  | [3.4935 ms 3.5153 ms 3.5442 ms] | [3.2952 ms 3.2977 ms 3.3012 ms] |

**single-value** means every point has exactly one value.<br/>
**sparse values** means every point has at most one value.<br/>
**multi-values** means every point has a random number of values.<br/>

And the detail benchmark file as shown below:

<details>
<summary>common.rs</summary>

```rust
#![allow(dead_code)]

use std::time::Duration;

use criterion::BenchmarkGroup;
use criterion::measurement::WallTime;
use rand::{RngExt, SeedableRng};

/// Change this alias to switch the value type used by every benchmark.
pub type ValueType = i64;

use qdrant_filter_test::inline;
use qdrant_filter_test::origin;

// ── Shared constants ─────────────────────────────────────────────────────────
// Change these once and every benchmark will pick up the new values.

/// Seed used to generate the point data.
pub const DATA_SEED: u64 = 42;

/// Seed used to generate random query point IDs.
pub const QUERY_SEED: u64 = 123;

/// Total number of points to generate.
pub const POINTS_NUM: usize = 4000_0000;

/// Upper bound (inclusive) for the random value assigned to each point.
pub const MAX_VALUE: ValueType = 2;

/// Number of point IDs to query during the benchmark.
pub const QUERY_COUNT: usize = 10_0000;

/// The value we pass to `check_values_any` as the predicate target.
pub const CHECK_VALUE: ValueType = 1;

/// Ratio of inner `Vec`s that are empty in the sparse-single-value data type.
/// Must be in the range `0.0..=1.0`. For example, `0.3` means 30 % of entries
/// will be empty.
pub const EMPTY_RATIO: f64 = 0.1;

/// Maximum number of elements in each inner `Vec` for the multi-value data
/// type. Each inner `Vec` will have a random length in `1..=MAX_VALUES_PER_POINT`.
pub const MAX_VALUES_PER_POINT: usize = 5;

// ── Data builders ────────────────────────────────────────────────────────────

/// **Type 1 – single value**: every inner `Vec` has exactly one element.
pub fn build_single_value_data(
    seed: u64,
    points_num: usize,
    max_value: ValueType,
) -> Vec<Vec<ValueType>> {
    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
    let mut values = Vec::with_capacity(points_num);
    for _ in 0..points_num {
        let value: ValueType = rng.random_range(0..=max_value);
        values.push(vec![value]);
    }
    values
}

/// **Type 2 – sparse single value**: every inner `Vec` has *at most* one
/// element. A proportion of `empty_ratio` entries will be empty.
pub fn build_sparse_single_value_data(
    seed: u64,
    points_num: usize,
    max_value: ValueType,
    empty_ratio: f64,
) -> Vec<Vec<ValueType>> {
    use rand::seq::SliceRandom;

    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
    let empty_count = (points_num as f64 * empty_ratio).round() as usize;
    let non_empty_count = points_num - empty_count;

    let mut values = Vec::with_capacity(points_num);

    // First, push all non-empty entries
    for _ in 0..non_empty_count {
        let value: ValueType = rng.random_range(0..=max_value);
        values.push(vec![value]);
    }

    // Then, push all empty entries
    for _ in 0..empty_count {
        values.push(vec![]);
    }

    // Shuffle to distribute empties randomly
    values.shuffle(&mut rng);

    values
}

/// **Type 3 – multi value**: every inner `Vec` has a random number of elements
/// in `1..=max_values_per_point`.
pub fn build_multi_value_data(
    seed: u64,
    points_num: usize,
    max_value: ValueType,
    max_values_per_point: usize,
) -> Vec<Vec<ValueType>> {
    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
    let mut values = Vec::with_capacity(points_num);
    for _ in 0..points_num {
        let count = rng.random_range(1..=max_values_per_point);
        let inner: Vec<ValueType> = (0..count)
            .map(|_| rng.random_range(0..=max_value))
            .collect();
        values.push(inner);
    }
    values
}

// ── TestData ─────────────────────────────────────────────────────────────────

/// Pre-built instances of every implementation, ready for benchmarking.
pub struct TestData {
    pub inline: inline::ImmutablePointToValues<ValueType>,
    pub origin: origin::ImmutablePointToValues<ValueType>,
}

impl TestData {
    /// Construct all implementations from the given raw data.
    pub fn from_data(points_values: Vec<Vec<ValueType>>) -> Self {
        let inline = inline::ImmutablePointToValues::new(points_values.clone());
        let origin = origin::ImmutablePointToValues::new(points_values.clone());

        Self { inline, origin }
    }

    /// Convenience: build from the *single-value* data type using the shared
    /// constants.
    pub fn single_value() -> Self {
        Self::from_data(build_single_value_data(DATA_SEED, POINTS_NUM, MAX_VALUE))
    }

    /// Convenience: build from the *sparse-single-value* data type using the
    /// shared constants.
    pub fn sparse_single_value() -> Self {
        Self::from_data(build_sparse_single_value_data(
            DATA_SEED,
            POINTS_NUM,
            MAX_VALUE,
            EMPTY_RATIO,
        ))
    }

    /// Convenience: build from the *multi-value* data type using the shared
    /// constants.
    pub fn multi_value() -> Self {
        Self::from_data(build_multi_value_data(
            DATA_SEED,
            POINTS_NUM,
            MAX_VALUE,
            MAX_VALUES_PER_POINT,
        ))
    }
}

// ── Query-ID helpers ─────────────────────────────────────────────────────────

/// Generate `QUERY_COUNT` random point IDs in `[0, POINTS_NUM)`.
pub fn build_random_point_ids() -> Vec<u32> {
    let mut rng = rand::rngs::StdRng::seed_from_u64(QUERY_SEED);
    (0..QUERY_COUNT)
        .map(|_| rng.random_range(0..POINTS_NUM as u32))
        .collect()
}

// ── Bench Group Config ───────────────────────────────────────────────────────

/// Configure a benchmark group with standardised timing parameters.
pub fn configure_benchmark(group: &mut BenchmarkGroup<WallTime>) {
    group.measurement_time(Duration::from_secs(30));
}
```
</details>

<details>
    <summary>random.rs</summary>

```rust
mod common;

use criterion::{Criterion, black_box, criterion_group, criterion_main, configure_benchmark};

use crate::common::{CHECK_VALUE, TestData, build_random_point_ids};

// ── Helper: run all implementations against one TestData ─────────────────────

fn bench_all_impls(
    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
    data: &TestData,
    point_ids: &[u32],
) {
    configure_benchmark(group);

    group.bench_function("origin", |b| {
        b.iter(|| {
            for &point_id in point_ids {
                black_box(
                    data.origin
                        .check_values_any(black_box(point_id), |v| *v == CHECK_VALUE),
                );
            }
        });
    });

    group.bench_function("inline", |b| {
        b.iter(|| {
            for &point_id in point_ids {
                black_box(
                    data.inline
                        .check_values_any(black_box(point_id), |v| *v == CHECK_VALUE),
                );
            }
        });
    });
}

// ── Benchmarks ───────────────────────────────────────────────────────────────

fn random_single_value(c: &mut Criterion) {
    let data = TestData::single_value();
    let point_ids = build_random_point_ids();

    let mut group = c.benchmark_group("Random single_value");
    bench_all_impls(&mut group, &data, &point_ids);
    group.finish();
}

fn random_sparse_single_value(c: &mut Criterion) {
    let data = TestData::sparse_single_value();
    let point_ids = build_random_point_ids();

    let mut group = c.benchmark_group("Random sparse_single_value");
    bench_all_impls(&mut group, &data, &point_ids);
    group.finish();
}

fn random_multi_value(c: &mut Criterion) {
    let data = TestData::multi_value();
    let point_ids = build_random_point_ids();

    let mut group = c.benchmark_group("Random multi_value");
    bench_all_impls(&mut group, &data, &point_ids);
    group.finish();
}

criterion_group!(
    benches,
    random_single_value,
    random_sparse_single_value,
    random_multi_value,
);
criterion_main!(benches);
```
</details>


<details>
    <summary>origin.rs</summary>

```rust
use std::ops::Range;

pub struct ImmutablePointToValues<N: Default> {
    point_to_values: Vec<Range<u32>>,
    point_to_values_container: Vec<N>,
}

impl<N: Default> ImmutablePointToValues<N> {
    pub fn new(src: Vec<Vec<N>>) -> Self {
        let mut point_to_values = Vec::with_capacity(src.len());
        let all_values_count = src.iter().fold(0, |acc, values| acc + values.len());
        let mut point_to_values_container = Vec::with_capacity(all_values_count);
        for values in src {
            let container_len = point_to_values_container.len() as u32;
            let range = container_len..container_len + values.len() as u32;
            point_to_values.push(range.clone());
            point_to_values_container.extend(values);
        }
        Self {
            point_to_values,
            point_to_values_container,
        }
    }

    pub fn check_values_any(&self, idx: u32, check_fn: impl FnMut(&N) -> bool) -> bool {
        let Some(range) = self.point_to_values.get(idx as usize) else {
            return false;
        };

        let range = range.start as usize..range.end as usize;
        if let Some(values) = self.point_to_values_container.get(range) {
            values.iter().any(check_fn)
        } else {
            false
        }
    }
}
```
</details>

<details>
    <summary>inline.rs</summary>

```rust
#[derive(Debug, Clone)]
enum PointValueEntry<N> {
    Single(N),
    Slice { start: u32, count: u32 },
}

impl<N> Default for PointValueEntry<N> {
    fn default() -> Self {
        PointValueEntry::Slice { start: 0, count: 0 }
    }
}

#[derive(Debug, Clone, Default)]
pub struct ImmutablePointToValues<N: Default> {
    point_entries: Vec<PointValueEntry<N>>,
    values_container: Vec<N>,
}

impl<N: Default> ImmutablePointToValues<N> {
    pub fn new(src: Vec<Vec<N>>) -> Self {
        let mut point_entries = Vec::with_capacity(src.len());
        let container_capacity = src
            .iter()
            .filter(|values| values.len() != 1)
            .fold(0, |acc, values| acc + values.len());
        let mut values_container = Vec::with_capacity(container_capacity);

        for values in src {
            if values.len() == 1 {
                let value = values.into_iter().next().expect("length checked above");
                point_entries.push(PointValueEntry::Single(value));
            } else {
                let start = values_container.len() as u32;
                let count = values.len() as u32;
                point_entries.push(PointValueEntry::Slice { start, count });
                values_container.extend(values);
            }
        }

        Self {
            point_entries,
            values_container,
        }
    }

    pub fn check_values_any(&self, idx: u32, check_fn: impl FnMut(&N) -> bool) -> bool {
        let Some(entry) = self.point_entries.get(idx as usize) else {
            return false;
        };

        match entry {
            PointValueEntry::Single(v) => std::iter::once(v).any(check_fn),
            PointValueEntry::Slice { start, count } => {
                let range = *start as usize..(*start + *count) as usize;
                if let Some(values) = self.values_container.get(range) {
                    values.iter().any(check_fn)
                } else {
                    false
                }
            }
        }
    }
}
```
</details>

