### PR TITLE
fix(settings): reduce misleading config-path load warnings

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -643,6 +643,10 @@ mod tests {
             .expect("absolute custom config must pass validation");
 
         assert_eq!(config.service.http_port, 7666);
+        assert!(
+            config.load_errors.is_empty(),
+            "absolute custom config path should not emit load warnings"
+        );
     }
 
     #[expect(clippy::disallowed_types, reason = "#[sealed_test] uses std::fs::File")]


### PR DESCRIPTION
Fixes #5964

## Summary

This PR improves the behavior of `--config-path` to make it less misleading when a custom configuration file is explicitly provided.

## What changed

- When `--config-path` is specified, Qdrant no longer emits warnings about missing default config files (`config/config` and `config/{RUN_MODE}`).
- These warnings were confusing and gave the impression that the custom config file was ignored.
- Explicit error reporting for invalid `--config-path` (e.g. missing file) remains unchanged.

## Why

In setups where Qdrant is started with a custom config file (e.g. Docker, system services, custom deployment paths), the previous warnings were noisy and misleading, even though the custom config was correctly loaded.

## Tests

Added tests to verify:

- Custom config path without default config files does not produce spurious load warnings.
- Absolute custom config path is loaded correctly.

## Validation

- `cargo test -p qdrant settings::tests -- --nocapture`
- `cargo +nightly fmt --all`
