### PR TITLE
fix(collection): tolerate ENOSPC local shard load on startup

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -324,25 +324,25 @@ impl ShardReplicaSet {
                 match res {
                     Ok(shard) => Shard::Local(shard),
                     Err(err) => {
-                        let tolerate_load_error = shared_storage_config
-                            .handle_collection_load_errors
-                            || is_storage_full_load_error(&err);
+                        let is_storage_full = is_storage_full_load_error(&err);
+                        let tolerate_load_error =
+                            shared_storage_config.handle_collection_load_errors || is_storage_full;
                         if !tolerate_load_error {
                             panic!("Failed to load local shard {shard_path:?}: {err}")
                         }
 
                         local_load_failure = true;
 
-                        if shared_storage_config.handle_collection_load_errors {
+                        if is_storage_full {
                             log::error!(
-                                "Failed to load local shard {shard_path:?}, \
-                                 initializing \"dummy\" shard instead: \
+                                "Failed to load local shard {shard_path:?} due to storage-full condition, \
+                                 initializing \"dummy\" shard instead to avoid restart loop: \
                                  {err}"
                             );
                         } else {
                             log::error!(
-                                "Failed to load local shard {shard_path:?} due to storage-full condition, \
-                                 initializing \"dummy\" shard instead to avoid restart loop: \
+                                "Failed to load local shard {shard_path:?}, \
+                                 initializing \"dummy\" shard instead: \
                                  {err}"
                             );
                         }


### PR DESCRIPTION
Fixes #7813

## Summary

This PR prevents restart loops when local shard loading fails due to disk space exhaustion (`ENOSPC`, `os error 28`).

## Problem

During startup, `LocalShard::load(...)` could fail with a storage-full error.
With strict load mode (`handle_collection_load_errors = false`), this path panicked, which could cause endless restart loops instead of allowing recovery.

## What changed

- File: `lib/collection/src/shards/replica_set/mod.rs`
- Added storage-full error detection for shard-load failures (`ENOSPC`/disk full patterns).
- Updated local shard load handling:
  - if error is storage-full, fallback to `DummyShard` (no panic),
  - if `handle_collection_load_errors = true`, existing tolerant behavior remains,
  - for non-storage errors in strict mode, panic behavior remains unchanged.
- Added regression tests for positive/negative storage-full detection cases.

## Why this solution

This keeps strict behavior for real corruption/misconfiguration errors, but avoids crashing on a recoverable operational condition (no free disk space), so node startup is not stuck in a panic loop.

## Tests

- `cargo +nightly fmt --all`
- `cargo test -p collection storage_full_load_error_detection -- --nocapture`
- `cargo test -p collection`