### PR TITLE
fix(wal): harden first-index loading during snapshot restore startup

### DIFF
--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -552,7 +552,7 @@ mod tests {
     /// Missing `ack_index` in object payload should fail WAL initialization.
     fn test_wal_new_fails_on_missing_ack_index_in_object() {
         let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
-        fs::write(dir.path().join(FIRST_INDEX_FILE), r#"{}"#).unwrap();
+        fs::write(dir.path().join(FIRST_INDEX_FILE), r"{}").unwrap();
 
         let err = SerdeWal::<TestRecord>::new(dir.path(), wal_options(1024 * 1024)).unwrap_err();
         assert!(


### PR DESCRIPTION
Fixes #7956

## Summary

This PR hardens WAL startup when snapshot restore leaves `first-index` in a non-usable state (`null` / empty content).

## What changed

- Updated `lib/shard/src/wal.rs` first-index loading to treat empty/whitespace and `null` as recoverable, with fallback to WAL bounds and warning logs.
- Kept strict failure for invalid first-index shapes/types (for example `{"ack_index":"oops"}`) to avoid masking real corruption.
- Added regression tests for null, empty, and invalid first-index content.

## Why

In snapshot restore scenarios, `first-index` may be present but not parseable as a valid `WalState`, which previously could fail WAL init and block startup. This change keeps startup resilient for recoverable states while preserving strict validation for truly invalid formats.

## Tests

- `cargo +nightly fmt --all`
- `cargo clippy -p shard --all-targets -- -D warnings`
- `cargo test -p shard wal::tests -- --nocapture`
- `cargo test -p collection snapshot_test::test_snapshot_collection_normal -- --nocapture`
