### PR TITLE
test(segment): stabilize flaky building cancellation timing assertions

### DIFF
--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -497,7 +497,9 @@ fn test_building_cancellation() {
     let late_stop_delay = time_baseline / 5;
     let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, Some(late_stop_delay));
 
-    let acceptable_stopping_delay = 600; // millis
+    // Timing on CI (especially Windows) can be noisy due to scheduler delays.
+    // Keep a fixed lower bound but scale tolerance for slower baseline runs.
+    let acceptable_stopping_delay = std::cmp::max(600, time_baseline / 8); // millis
 
     assert!(was_cancelled_early);
     assert!(
@@ -509,6 +511,10 @@ fn test_building_cancellation() {
     assert!(
         time_long < late_stop_delay + acceptable_stopping_delay,
         "time_later: {time_long}, late_stop_delay: {late_stop_delay}"
+    );
+    assert!(
+        time_long < time_baseline,
+        "cancelled build should be faster than baseline: time_later={time_long}, baseline={time_baseline}",
     );
 
     assert!(


### PR DESCRIPTION
Fixes #5667

## Summary

This PR stabilizes segment_builder_test::test_building_cancellation by making cancellation timing assertions adaptive to baseline build time variability on CI.

## Problem

The test used a fixed 600ms tolerance for cancellation timing. On slower and noisier runners, cancellation still happens correctly but observed wall-clock delay can exceed this fixed bound, causing flaky failures.

## What changed

- Replaced fixed acceptable_stopping_delay=600 with adaptive tolerance max(600, time_baseline/8).
- Kept strict cancellation semantics checks: was_cancelled_early, was_cancelled_later, and ordering check time_fast < time_long.
- Added guard assertion that cancelled late run remains faster than full baseline build: time_long < time_baseline.

## Solution

Use baseline-relative timing tolerance to absorb scheduler jitter while preserving semantic guarantees that cancellation triggers and shortens build time compared to non-cancelled baseline.

## Why

This keeps the test meaningful while removing a known source of platform-dependent timing flakiness unrelated to functional correctness.

## Tests

- `cargo +nightly fmt --all`
- `cargo test -p segment test_building_cancellation -- --nocapture (repeated 25x locally)`
- `cargo clippy -p segment --all-targets -- -D warnings`
