### PR TITLE
Use pyroscope lib-1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,18 +4964,39 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "findshlibs",
- "framehop",
  "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "prost-derive 0.12.6",
+ "sha2",
+ "smallvec",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pprof-pyroscope-fork"
+version = "0.1500.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a81f1489b882945ce89a4c93dbb50b1bf31839188d3c83fb5e5eded6bad6ee2d"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "framehop",
  "libc",
  "log",
  "memmap2 0.5.10",
  "nix 0.26.4",
  "object 0.29.0",
  "once_cell",
- "prost 0.12.6",
- "prost-build 0.12.6",
- "prost-derive 0.12.6",
- "sha2",
  "smallvec",
  "spin 0.10.0",
  "symbolic-demangle",
@@ -5432,29 +5453,21 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "0.5.9"
-source = "git+https://github.com/grafana/pyroscope-rs?tag=lib-0.5.9#5a060b4ade591058a2613a0a34976fae7bbc4691"
+version = "1.0.1"
+source = "git+https://github.com/grafana/pyroscope-rs?tag=lib-1.0.1#6607a33fc58596ce8dc1725d772e8d2b06c17953"
 dependencies = [
+ "lazy_static",
  "libc",
  "libflate",
  "log",
  "names",
+ "pprof-pyroscope-fork",
  "prost 0.14.3",
  "reqwest 0.13.2",
  "serde_json",
  "thiserror 2.0.18",
  "url",
- "winapi",
-]
-
-[[package]]
-name = "pyroscope_pprofrs"
-version = "0.2.10"
-source = "git+https://github.com/grafana/pyroscope-rs?tag=lib-0.5.9#5a060b4ade591058a2613a0a34976fae7bbc4691"
-dependencies = [
- "log",
- "pprof",
- "pyroscope",
+ "uuid",
 ]
 
 [[package]]
@@ -5496,7 +5509,6 @@ dependencies = [
  "prometheus",
  "prost 0.11.9",
  "pyroscope",
- "pyroscope_pprofrs",
  "raft",
  "raft-proto",
  "rand 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,10 +152,9 @@ actix-web-extras = "0.1.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18.0", default-features = false }
 # Pyroscope integration
-# Using lib-0.5.9 tag for jemalloc signal-safety fix (pyroscope-rs#165):
-# pprof2 replaced with pprof 0.15 + framehop unwinder (no allocations in signal handler)
-pyroscope = { git = "https://github.com/grafana/pyroscope-rs", tag = "lib-0.5.9" }
-pyroscope_pprofrs = { git = "https://github.com/grafana/pyroscope-rs", tag = "lib-0.5.9" }
+# Using lib-1.0.1: pprof backend integrated into main crate, uses pprof-pyroscope-fork
+# with signal-safety fix (tikv/pprof-rs#282) — no allocations in signal handler
+pyroscope = { git = "https://github.com/grafana/pyroscope-rs", tag = "lib-1.0.1", features = ["backend-pprof-rs"] }
 # Backtrace
 rstack-self = { version = "0.3.0", optional = true }
 

--- a/src/common/pyroscope_state.rs
+++ b/src/common/pyroscope_state.rs
@@ -1,10 +1,9 @@
 #[cfg(target_os = "linux")]
 pub mod pyro {
 
-    use pyroscope::backend::BackendConfig;
+    use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
     use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
     use pyroscope::{PyroscopeAgent, PyroscopeError};
-    use pyroscope_pprofrs::{PprofConfig, pprof_backend};
 
     use crate::common::debugger::PyroscopeConfig;
 
@@ -29,9 +28,8 @@ pub mod pyro {
                 }
             }
 
-            let pprof_config = PprofConfig {
-                sample_rate: config.sampling_rate.unwrap_or(100),
-            };
+            let sample_rate = config.sampling_rate.unwrap_or(100);
+            let pprof_config = PprofConfig { sample_rate };
             let backend_impl = pprof_backend(pprof_config, BackendConfig::default());
 
             log::info!(
@@ -39,9 +37,16 @@ pub mod pyro {
                 &config.identifier
             );
             // TODO: Add more tags like peerId and peerUrl
-            let agent = PyroscopeAgentBuilder::new(config.url.clone(), "qdrant", backend_impl)
-                .tags(vec![("app", "Qdrant"), ("identifier", &config.identifier)])
-                .build()?;
+            let agent = PyroscopeAgentBuilder::new(
+                config.url.clone(),
+                "qdrant",
+                sample_rate,
+                "pyroscope-rs",
+                env!("CARGO_PKG_VERSION"),
+                backend_impl,
+            )
+            .tags(vec![("app", "Qdrant"), ("identifier", &config.identifier)])
+            .build()?;
             let running_agent = agent.start()?;
 
             Ok(running_agent)


### PR DESCRIPTION
Previous version used `pprof 0.15.0` with a bug, the fix for which hasn't been released. `lib-1.0.1` uses pprof-pyroscope-fork, a Grafana-maintained fork of pprof-rs that includes the fix.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [X] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
