### PR TITLE
Gridstore iter: re-fix livelock

### DIFF
--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -3,6 +3,7 @@ mod reader;
 mod tests;
 pub(crate) mod view;
 
+use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -419,28 +420,13 @@ impl<V: Blob> Gridstore<V> {
     {
         const BATCH_SIZE: usize = 128;
 
-        let mut last_offset = 0;
         let mut from_offset = 0;
-
         // Iterate in batches to allow releasing read locks, see:
         // <https://github.com/qdrant/qdrant/pull/7983>
-        while self.with_view(|view| {
-            view.iter(
-                from_offset,
-                BATCH_SIZE,
-                |point_offset, value| {
-                    last_offset = point_offset;
-
-                    callback(point_offset, value)
-                },
-                hw_counter,
-            )
-        })? {
-            if last_offset == from_offset {
-                break;
-            }
-
-            from_offset = last_offset + 1;
+        while let ControlFlow::Continue(next_offset) =
+            self.with_view(|view| view.iter(from_offset, BATCH_SIZE, &mut callback, hw_counter))?
+        {
+            from_offset = next_offset;
         }
 
         Ok(())

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -1,4 +1,5 @@
 use std::io::BufReader;
+use std::ops::ControlFlow;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -105,7 +106,10 @@ impl<V: Blob> GridstoreReader<V> {
         F: FnMut(PointOffset, V) -> std::result::Result<bool, E>,
         E: From<GridstoreError>,
     {
-        self.view().iter(0, usize::MAX, callback, hw_counter)?;
+        let control_flow = self.view().iter(0, usize::MAX, callback, hw_counter)?;
+
+        // we set usize::MAX as the max iteration, so we should always iterate the entire thing.
+        debug_assert!(matches!(control_flow, ControlFlow::Break(())));
 
         Ok(())
     }

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{ControlFlow, Deref};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
@@ -146,27 +146,38 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     /// - it has iterated `max_iters` times
     /// - there are no more results.
     ///
-    /// Returns the last value returned by `callback`.
+    /// ## Control Flow
+    /// Returns `Ok(Continue(next_offset))` if iteration can be continued starting from `next_offset`
+    ///  (i.e. `max_iters` was reached, but there are more results).
+    ///
+    /// Returns `Ok(Break())` when any of:
+    /// - `callback` returned false
+    /// - there are no more results.
+    ///
     pub fn iter<F, E>(
         &self,
         from: PointOffset,
         max_iters: usize,
         mut callback: F,
         hw_counter: HwMetricRefCounter,
-    ) -> std::result::Result<bool, E>
+    ) -> std::result::Result<ControlFlow<(), PointOffset>, E>
     where
         F: FnMut(PointOffset, V) -> std::result::Result<bool, E>,
         E: From<GridstoreError>,
     {
-        let pointers_iter = self
+        let mut pointers_iter = self
             .tracker
             .iter_pointers(from)
             .filter_map(|(point_offset, opt_pointer)| {
                 opt_pointer.map(|pointer| (point_offset, pointer))
             })
-            .take(max_iters);
+            .enumerate();
 
-        for (point_offset, pointer) in pointers_iter {
+        for (nth, (point_offset, pointer)) in pointers_iter.by_ref() {
+            if nth == max_iters {
+                return Ok(ControlFlow::Continue(point_offset));
+            }
+
             let ValuePointer {
                 page_id,
                 block_offset,
@@ -180,10 +191,9 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
             let decompressed = self.decompress(raw);
             let value = V::from_bytes(&decompressed);
             if !callback(point_offset, value)? {
-                return Ok(false);
+                return Ok(ControlFlow::Break(()));
             }
         }
-
-        Ok(true)
+        Ok(ControlFlow::Break(()))
     }
 }


### PR DESCRIPTION
After #8244, the issue fixed by #7983 was reintroduced. 

This PR fixes it again by making the iteration release its locks every 128 iterations. 

It doesn't rely on buffering anymore, and the unlocked section is shorter, but it should allow flush jobs to progress in between the batched iteration