### PR TITLE
Fix API response after resetting the debugger profiler

### DIFF
--- a/src/common/debugger.rs
+++ b/src/common/debugger.rs
@@ -73,9 +73,7 @@ impl DebuggerState {
                         }
                     }
 
-                    if let Some(new_config) = new_config {
-                        *pyroscope_guard = PyroscopeState::from_config(Some(new_config));
-                    }
+                    *pyroscope_guard = PyroscopeState::from_config(new_config);
                     true
                 }
             }


### PR DESCRIPTION
Previously sending `PATCH /debugger {"pyroscope": null}` after starting profiling did stop the profiling but did NOT refresh the state, so `GET /debugger` returned outdated pyroscope config. This PR fixes it. 

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --workspace --all-features` command?
