### PR TITLE
universal file ops

### DIFF
--- a/lib/common/common/src/universal_io/file_ops.rs
+++ b/lib/common/common/src/universal_io/file_ops.rs
@@ -1,0 +1,13 @@
+use std::path::{Path, PathBuf};
+
+pub trait UniversalReadFileOps {
+    /// List files in the storage with the given prefix.
+    /// The prefix is used to filter files, e.g. by directory or filename pattern.
+    ///
+    /// Example: `./gridstore/page_`
+    /// should return
+    /// - `./gridstore/page_1.dat`
+    /// - `./gridstore/page_2.dat`
+    /// - `./gridstore/page_3.dat`
+    fn list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<PathBuf>>;
+}

--- a/lib/common/common/src/universal_io/local_file_ops.rs
+++ b/lib/common/common/src/universal_io/local_file_ops.rs
@@ -1,0 +1,34 @@
+use std::path::{Path, PathBuf};
+
+use crate::universal_io::UniversalIoError;
+
+pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<PathBuf>> {
+    let dir = prefix_path.parent().unwrap_or(Path::new("."));
+    let file_prefix = prefix_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let mut results = Vec::new();
+    let entries = fs_err::read_dir(dir).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            UniversalIoError::NotFound {
+                path: dir.to_path_buf(),
+            }
+        } else {
+            UniversalIoError::from(e)
+        }
+    })?;
+
+    for entry in entries {
+        let entry = entry?;
+        if let Some(name) = entry.file_name().to_str()
+            && name.starts_with(&file_prefix)
+            && entry.file_type()?.is_file()
+        {
+            results.push(dir.join(name));
+        }
+    }
+
+    Ok(results)
+}

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -5,6 +5,8 @@ use crate::mmap::{
     Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, MmapSlice, MmapSliceReadOnly, open_read_mmap,
     open_write_mmap,
 };
+use crate::universal_io::file_ops::UniversalReadFileOps;
+use crate::universal_io::local_file_ops::local_list_files;
 use crate::universal_io::{
     ElementOffset, ElementsRange, Flusher, OpenOptions, Result, UniversalIoError, UniversalRead,
     UniversalWrite,
@@ -21,6 +23,15 @@ pub struct MmapUniversal<T: Copy + 'static> {
     ///
     /// `None` on platforms that do not support multiple memory maps to the same file.
     mmap_seq: Option<MmapSliceReadOnly<T>>,
+}
+
+impl<T> UniversalReadFileOps for MmapUniversal<T>
+where
+    T: 'static + Copy,
+{
+    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
+        local_list_files(prefix_path)
+    }
 }
 
 impl<T> UniversalRead<T> for MmapUniversal<T>

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,3 +1,5 @@
+mod file_ops;
+mod local_file_ops;
 pub mod mmap;
 pub mod read;
 pub mod write;

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -2,10 +2,11 @@ use std::borrow::Cow;
 use std::path::Path;
 
 use super::*;
+use crate::universal_io::file_ops::UniversalReadFileOps;
 
 /// Interface for accessing files in a universal way, abstracting away possible
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
-pub trait UniversalRead<T: Copy + 'static> {
+pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>
     where
         Self: Sized;

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -104,15 +104,6 @@ impl<V: Blob> Gridstore<V> {
     /// `base_path` is the directory where the storage files will be stored.
     /// It should exist already.
     pub fn new(base_path: PathBuf, options: StorageOptions) -> Result<Self> {
-        if !base_path.exists() {
-            return Err(GridstoreError::service_error("Base path does not exist"));
-        }
-        if !base_path.is_dir() {
-            return Err(GridstoreError::service_error(
-                "Base path is not a directory",
-            ));
-        }
-
         let config = StorageConfig::try_from(options).map_err(GridstoreError::service_error)?;
         let config_path = base_path.join(CONFIG_FILENAME);
 

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -131,19 +131,13 @@ impl<V> GridstoreReader<V> {
 pub(super) fn read_config_and_tracker(
     base_path: &std::path::Path,
 ) -> Result<(StorageConfig, Tracker)> {
-    if !base_path.exists() {
-        return Err(GridstoreError::service_error(format!(
-            "Path '{base_path:?}' does not exist"
-        )));
-    }
-    if !base_path.is_dir() {
-        return Err(GridstoreError::service_error(format!(
-            "Path '{base_path:?}' is not a directory"
-        )));
-    }
-
     let config_path = base_path.join(CONFIG_FILENAME);
-    let config: StorageConfig = read_json_via::<MmapUniversal<u8>, StorageConfig>(&config_path)?;
+    let config: StorageConfig = read_json_via::<MmapUniversal<u8>, StorageConfig>(&config_path)
+        .map_err(|err| {
+            GridstoreError::service_error(format!(
+                "Failed to read config from '{config_path:?}': {err}"
+            ))
+        })?;
 
     let tracker = Tracker::open(base_path)?;
 

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,6 +1,7 @@
 use std::mem::MaybeUninit;
 use std::path::Path;
 
+use ahash::HashSet;
 use common::maybe_uninit::assume_init_vec;
 use common::universal_io::{
     ElementsRange, FileIndex, Flusher, OpenOptions, UniversalRead, UniversalWrite,
@@ -35,10 +36,12 @@ impl<S: UniversalRead<u8>> Pages<S> {
     pub fn open(dir: &Path) -> Result<Self> {
         let mut pages = Self::default();
 
+        let page_files: HashSet<_> = S::list_files(&dir.join("page_"))?.into_iter().collect();
+
         for page_id in 0.. {
             let page_path = dir.join(format!("page_{page_id}.dat"));
 
-            if !page_path.exists() {
+            if !page_files.contains(&page_path) {
                 break;
             }
 


### PR DESCRIPTION
Gridstore not only reads from files, but also requires some extra File-system level operations.
We want to make those opeations independent of actual IO layer (aka should work for s3 as well)
