### PR TITLE
gridstore live reload

### DIFF
--- a/lib/common/common/src/universal_io/file_ops.rs
+++ b/lib/common/common/src/universal_io/file_ops.rs
@@ -10,4 +10,7 @@ pub trait UniversalReadFileOps {
     /// - `./gridstore/page_2.dat`
     /// - `./gridstore/page_3.dat`
     fn list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<PathBuf>>;
+
+    /// Check if a file exists at the given path.
+    fn exists(path: &Path) -> crate::universal_io::Result<bool>;
 }

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -34,7 +34,7 @@ where
     }
 
     fn exists(path: &Path) -> Result<bool> {
-        Ok(path.exists())
+        fs_err::exists(path).map_err(Into::into)
     }
 }
 

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -32,6 +32,10 @@ where
     fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
         local_list_files(prefix_path)
     }
+
+    fn exists(path: &Path) -> Result<bool> {
+        Ok(path.exists())
+    }
 }
 
 impl<T> UniversalRead<T> for MmapUniversal<T>

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -396,9 +396,15 @@ impl<V: Blob> Gridstore<V> {
         let mut from_offset = 0;
         // Iterate in batches to allow releasing read locks, see:
         // <https://github.com/qdrant/qdrant/pull/7983>
-        while let ControlFlow::Continue(next_offset) =
-            self.with_view(|view| view.iter(from_offset, BATCH_SIZE, &mut callback, hw_counter))?
-        {
+        while let ControlFlow::Continue(next_offset) = self.with_view(|view| {
+            view.iter(
+                from_offset,
+                PointOffset::MAX,
+                BATCH_SIZE,
+                &mut callback,
+                hw_counter,
+            )
+        })? {
             from_offset = next_offset;
         }
 

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -61,14 +61,15 @@ impl<V: Blob> Gridstore<V> {
     /// List all files belonging to this storage (tracker, pages, bitmask, config).
     pub fn files(&self) -> Vec<PathBuf> {
         let tracker = self.tracker.read();
-        let num_pages = self.pages.read().num_pages();
+        let pages = self.pages.read();
+        let num_pages = pages.num_pages();
 
         let mut paths = Vec::with_capacity(num_pages + 2);
         for tracker_file in tracker.files() {
             paths.push(tracker_file);
         }
         for page_id in 0..num_pages as PageId {
-            paths.push(self.pages.read().page_path(page_id));
+            paths.push(pages.page_path(page_id));
         }
         paths.push(self.base_path.join(CONFIG_FILENAME));
         for bitmask_file in self.bitmask.read().files() {

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -25,7 +25,7 @@ use crate::bitmask::Bitmask;
 use crate::blob::Blob;
 use crate::config::{StorageConfig, StorageOptions};
 use crate::error::GridstoreError;
-use crate::pages::Pages;
+use crate::pages::{Pages, page_path};
 use crate::tracker::{BlockOffset, PageId, PointOffset, PointerUpdates, ValuePointer};
 use crate::{Result, Tracker};
 
@@ -68,7 +68,7 @@ impl<V: Blob> Gridstore<V> {
             paths.push(tracker_file);
         }
         for page_id in 0..num_pages as PageId {
-            paths.push(self.page_path(page_id));
+            paths.push(self.pages.read().page_path(page_id));
         }
         paths.push(self.base_path.join(CONFIG_FILENAME));
         for bitmask_file in self.bitmask.read().files() {
@@ -111,7 +111,7 @@ impl<V: Blob> Gridstore<V> {
 
         let storage = Self {
             tracker: Arc::new(RwLock::new(Tracker::new(&base_path, None)?)),
-            pages: Default::default(),
+            pages: Arc::new(RwLock::new(Pages::new(base_path.clone()))),
             base_path,
             config,
             _value_type: std::marker::PhantomData,
@@ -120,7 +120,7 @@ impl<V: Blob> Gridstore<V> {
         };
 
         let new_page_id = storage.next_page_id();
-        let path = storage.page_path(new_page_id);
+        let path = page_path(&storage.base_path, new_page_id);
         create_and_ensure_length(&path, storage.config.page_size_bytes)?;
         storage.pages.write().attach_page(&path)?;
 
@@ -138,10 +138,13 @@ impl<V: Blob> Gridstore<V> {
         let bitmask = Bitmask::open(&base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
-        let mut pages = Pages::default();
-        for page_id in 0..num_pages as PageId {
-            let page_path = base_path.join(format!("page_{page_id}.dat"));
-            pages.attach_page(&page_path)?;
+        let pages = Pages::open(&base_path)?;
+        let loaded_pages = pages.num_pages();
+
+        if loaded_pages != num_pages {
+            return Err(GridstoreError::service_error(format!(
+                "Inconsistent number of gridstore pages at {base_path:?}: expected {num_pages}, but found {loaded_pages}",
+            )));
         }
 
         Ok(Self {
@@ -159,7 +162,7 @@ impl<V: Blob> Gridstore<V> {
     #[allow(clippy::needless_pass_by_ref_mut)]
     fn create_new_page(&mut self) -> Result<u32> {
         let new_page_id = self.next_page_id();
-        let path = self.page_path(new_page_id);
+        let path = page_path(&self.base_path, new_page_id);
         create_and_ensure_length(&path, self.config.page_size_bytes)?;
         self.pages.write().attach_page(&path)?;
 
@@ -405,10 +408,6 @@ impl<V: Blob> Gridstore<V> {
 impl<V> Gridstore<V> {
     fn next_page_id(&self) -> PageId {
         self.pages.read().num_pages() as PageId
-    }
-
-    fn page_path(&self, page_id: u32) -> PathBuf {
-        self.base_path.join(format!("page_{page_id}.dat"))
     }
 
     #[inline]

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -108,6 +108,26 @@ impl<V: Blob> GridstoreReader<V> {
     pub fn get_storage_size_bytes(&self) -> usize {
         self.view().get_storage_size_bytes()
     }
+
+    /// This method reloads the Gridstore data from "disk", so that
+    /// it should make newly written data is readable.
+    ///
+    /// Important assumptions:
+    ///
+    /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
+    /// - Partial writes are possible, it is up to the caller to read only fully written data.
+    ///
+    pub fn live_reload(&mut self) -> Result<()> {
+        let has_new_data = self.tracker.live_reload()?;
+
+        if !has_new_data {
+            return Ok(());
+        }
+
+        self.pages.live_reload()?;
+
+        Ok(())
+    }
 }
 
 impl<V> GridstoreReader<V> {

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -87,6 +87,7 @@ impl<V: Blob> GridstoreReader<V> {
 
     pub fn iter<F, E>(
         &self,
+        max_id: PointOffset,
         callback: F,
         hw_counter: HwMetricRefCounter,
     ) -> std::result::Result<(), E>
@@ -94,7 +95,9 @@ impl<V: Blob> GridstoreReader<V> {
         F: FnMut(PointOffset, V) -> std::result::Result<bool, E>,
         E: From<GridstoreError>,
     {
-        let control_flow = self.view().iter(0, usize::MAX, callback, hw_counter)?;
+        let control_flow = self
+            .view()
+            .iter(0, max_id, usize::MAX, callback, hw_counter)?;
 
         // we set usize::MAX as the max iteration, so we should always iterate the entire thing.
         debug_assert!(matches!(control_flow, ControlFlow::Break(())));

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1028,6 +1028,153 @@ fn test_deferred_flush_with_delete() {
     );
 }
 
+/// Test that `GridstoreReader::live_reload` picks up new data written by a `Gridstore`.
+///
+/// Scenario:
+/// 1. Create a writable Gridstore, write some data, flush.
+/// 2. Open a GridstoreReader on the same path.
+/// 3. Verify reader sees initial data.
+/// 4. Write more data via Gridstore, flush.
+/// 5. Call `live_reload` on reader, verify it sees new data.
+/// 6. Also test that live_reload is a no-op when nothing changed.
+#[test]
+fn test_live_reload() {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let make_payload = |key: &str, value: &str| -> Payload {
+        let mut payload = Payload::default();
+        payload
+            .0
+            .insert(key.to_string(), serde_json::Value::String(value.to_string()));
+        payload
+    };
+
+    // Step 1: Write initial data and flush
+    let mut storage = Gridstore::new(path.clone(), Default::default()).unwrap();
+
+    let payload_0 = make_payload("key", "value_0");
+    let payload_1 = make_payload("key", "value_1");
+    storage.put_value(0, &payload_0, hw_counter_ref).unwrap();
+    storage.put_value(1, &payload_1, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    // Step 2: Open a reader
+    let mut reader = GridstoreReader::<Payload>::open(path.clone()).unwrap();
+    assert_eq!(reader.max_point_offset(), 2);
+
+    // Step 3: Verify reader sees initial data
+    let v0 = reader.get_value::<false>(0, &hw_counter).unwrap();
+    assert_eq!(v0.as_ref(), Some(&payload_0));
+    let v1 = reader.get_value::<false>(1, &hw_counter).unwrap();
+    assert_eq!(v1.as_ref(), Some(&payload_1));
+
+    // Step 4: live_reload when nothing changed should be a no-op
+    reader.live_reload().unwrap();
+    assert_eq!(reader.max_point_offset(), 2);
+    let v0 = reader.get_value::<false>(0, &hw_counter).unwrap();
+    assert_eq!(v0.as_ref(), Some(&payload_0));
+
+    // Step 5: Write more data via writable storage and flush
+    let payload_2 = make_payload("key", "value_2");
+    let payload_3 = make_payload("key", "value_3");
+    storage.put_value(2, &payload_2, hw_counter_ref).unwrap();
+    storage.put_value(3, &payload_3, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    // Reader's max_point_offset is stale before live_reload
+    assert_eq!(reader.max_point_offset(), 2);
+
+    // Step 6: live_reload should update max_point_offset and make new data accessible
+    reader.live_reload().unwrap();
+    assert_eq!(reader.max_point_offset(), 4);
+    let v2 = reader.get_value::<false>(2, &hw_counter).unwrap();
+    assert_eq!(v2.as_ref(), Some(&payload_2));
+    let v3 = reader.get_value::<false>(3, &hw_counter).unwrap();
+    assert_eq!(v3.as_ref(), Some(&payload_3));
+
+    // Original data should still be readable
+    let v0 = reader.get_value::<false>(0, &hw_counter).unwrap();
+    assert_eq!(v0.as_ref(), Some(&payload_0));
+    let v1 = reader.get_value::<false>(1, &hw_counter).unwrap();
+    assert_eq!(v1.as_ref(), Some(&payload_1));
+}
+
+/// Test that `live_reload` works across page boundaries.
+///
+/// Writes enough data to fill pages, then writes more data that creates new pages,
+/// and verifies that live_reload picks up the new pages too.
+#[test]
+fn test_live_reload_across_pages() {
+    use crate::config::DEFAULT_BLOCK_SIZE_BYTES;
+    use crate::fixtures::minimal_payload;
+
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    // Use small page size to force multiple pages
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let options = StorageOptions {
+        page_size_bytes: Some(page_size),
+        ..Default::default()
+    };
+    let mut storage = Gridstore::new(path.clone(), options).unwrap();
+
+    let payload = minimal_payload();
+
+    // Fill one page
+    let blocks_per_page = page_size / DEFAULT_BLOCK_SIZE_BYTES;
+    let first_batch = blocks_per_page as u32;
+    for i in 0..first_batch {
+        storage.put_value(i, &payload, hw_counter_ref).unwrap();
+    }
+    storage.flusher()().unwrap();
+
+    let initial_pages = storage.pages.read().num_pages();
+
+    // Open reader
+    let mut reader = GridstoreReader::<Payload>::open(path.clone()).unwrap();
+    assert_eq!(reader.max_point_offset(), first_batch);
+
+    // Verify reader can read all initial data
+    for i in 0..first_batch {
+        let v = reader.get_value::<false>(i, &hw_counter).unwrap();
+        assert_eq!(v.as_ref(), Some(&payload), "missing point {i}");
+    }
+
+    // Write more data that should create new pages
+    let second_batch = blocks_per_page as u32;
+    for i in first_batch..(first_batch + second_batch) {
+        storage.put_value(i, &payload, hw_counter_ref).unwrap();
+    }
+    storage.flusher()().unwrap();
+
+    let new_pages = storage.pages.read().num_pages();
+    assert!(
+        new_pages > initial_pages,
+        "expected more pages after second batch: {new_pages} vs {initial_pages}"
+    );
+
+    // Reader should not see new data yet
+    assert_eq!(reader.max_point_offset(), first_batch);
+
+    // Live reload should pick up new pages and data
+    reader.live_reload().unwrap();
+    assert_eq!(reader.max_point_offset(), first_batch + second_batch);
+
+    // Verify all data is readable
+    for i in 0..(first_batch + second_batch) {
+        let v = reader.get_value::<false>(i, &hw_counter).unwrap();
+        assert_eq!(v.as_ref(), Some(&payload), "missing point {i} after reload");
+    }
+}
+
 /// Test that data is only actually flushed when the Gridstore instance is still valid
 ///
 /// Specifically:

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1047,9 +1047,10 @@ fn test_live_reload() {
 
     let make_payload = |key: &str, value: &str| -> Payload {
         let mut payload = Payload::default();
-        payload
-            .0
-            .insert(key.to_string(), serde_json::Value::String(value.to_string()));
+        payload.0.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
         payload
     };
 

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -10,7 +10,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PointOffset, Tracker as TrackerGeneric, ValuePointer};
+use crate::tracker::{PointOffset, Tracker, ValuePointer};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {
@@ -31,7 +31,7 @@ pub(super) fn decompress_lz4(value: &[u8]) -> Vec<u8> {
 /// Constructed from either [`super::Gridstore`] or [`super::GridstoreReader`].
 pub struct GridstoreView<'a, V, S: UniversalRead<u8>> {
     pub(super) config: &'a StorageConfig,
-    pub(super) tracker: &'a TrackerGeneric<S>,
+    pub(super) tracker: &'a Tracker<S>,
     pub(super) pages: &'a Pages<S>,
     pub(super) _value_type: std::marker::PhantomData<V>,
 }
@@ -39,7 +39,7 @@ pub struct GridstoreView<'a, V, S: UniversalRead<u8>> {
 impl<'a, V, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     pub(crate) fn new(
         config: &'a StorageConfig,
-        tracker: &'a TrackerGeneric<S>,
+        tracker: &'a Tracker<S>,
         pages: &'a Pages<S>,
     ) -> Self {
         Self {
@@ -125,7 +125,8 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     /// Returns `Err(e)` if reading from the tracker fails (no silent skip).
     pub fn iter<F, E>(
         &self,
-        from: PointOffset,
+        from_id: PointOffset,
+        max_id: PointOffset,
         max_iters: usize,
         mut callback: F,
         hw_counter: HwMetricRefCounter,
@@ -135,7 +136,7 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         E: From<GridstoreError>,
     {
         let mut nth = 0;
-        for (point_offset, res) in self.tracker.iter_pointers(from) {
+        for (point_offset, res) in self.tracker.iter_pointers(from_id, max_id) {
             let pointer = match res {
                 Ok(Some(p)) => p,
                 Ok(None) => continue,

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -183,19 +183,25 @@ impl<S: UniversalRead<u8>> Pages<S> {
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     pub fn live_reload(&mut self) -> Result<()> {
         let num_pages = self.pages.len();
-        let mut last_page_id = (num_pages - 1) as PageId;
+        let next_page_id = if num_pages == 0 {
+            0
+        } else {
+            num_pages as PageId
+        };
+
         if num_pages > 0 {
             self.pages.pop();
             // Re-attach the last page, which should have the latest data.
-            let page_path = self.page_path(last_page_id);
+            let page_path = self.page_path((num_pages - 1) as PageId);
             self.attach_page(&page_path)?;
         }
 
+        let mut page_id = next_page_id;
         loop {
-            last_page_id += 1;
-            let page_path = self.page_path(last_page_id);
+            let page_path = self.page_path(page_id);
             if S::exists(&page_path)? {
                 self.attach_page(&page_path)?;
+                page_id += 1;
             } else {
                 break;
             }

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -183,28 +183,21 @@ impl<S: UniversalRead<u8>> Pages<S> {
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     pub fn live_reload(&mut self) -> Result<()> {
         let num_pages = self.pages.len();
-        let next_page_id = if num_pages == 0 {
-            0
-        } else {
-            num_pages as PageId
-        };
+        let next_page_id = num_pages as PageId;
 
         if num_pages > 0 {
-            self.pages.pop();
             // Re-attach the last page, which should have the latest data.
+            self.pages.pop();
             let page_path = self.page_path((num_pages - 1) as PageId);
             self.attach_page(&page_path)?;
         }
 
-        let mut page_id = next_page_id;
-        loop {
+        for page_id in next_page_id.. {
             let page_path = self.page_path(page_id);
-            if S::exists(&page_path)? {
-                self.attach_page(&page_path)?;
-                page_id += 1;
-            } else {
+            if !S::exists(&page_path)? {
                 break;
             }
+            self.attach_page(&page_path)?;
         }
 
         Ok(())

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,5 +1,5 @@
 use std::mem::MaybeUninit;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use ahash::HashSet;
 use common::maybe_uninit::assume_init_vec;
@@ -10,20 +10,19 @@ use smallvec::SmallVec;
 
 use crate::Result;
 use crate::config::StorageConfig;
-use crate::tracker::ValuePointer;
+use crate::tracker::{PageId, ValuePointer};
 
 type PageRanges = SmallVec<[(FileIndex, ElementsRange); 2]>;
 type BufferOffsets = SmallVec<[usize; 2]>;
 
-#[derive(Debug)]
-pub(crate) struct Pages<S> {
-    pages: Vec<S>,
+pub fn page_path(base_path: &Path, page_id: PageId) -> PathBuf {
+    base_path.join(format!("page_{page_id}.dat"))
 }
 
-impl<S> Default for Pages<S> {
-    fn default() -> Self {
-        Self { pages: Vec::new() }
-    }
+#[derive(Debug)]
+pub(crate) struct Pages<S> {
+    base_path: PathBuf,
+    pages: Vec<S>,
 }
 
 impl<S> Pages<S> {
@@ -33,18 +32,23 @@ impl<S> Pages<S> {
 }
 
 impl<S: UniversalRead<u8>> Pages<S> {
+    pub fn new(base_path: PathBuf) -> Self {
+        Self {
+            base_path,
+            pages: Vec::new(),
+        }
+    }
+
     pub fn open(dir: &Path) -> Result<Self> {
-        let mut pages = Self::default();
+        let mut pages = Self::new(dir.to_path_buf());
 
         let page_files: HashSet<_> = S::list_files(&dir.join("page_"))?.into_iter().collect();
 
         for page_id in 0.. {
-            let page_path = dir.join(format!("page_{page_id}.dat"));
-
+            let page_path = pages.page_path(page_id);
             if !page_files.contains(&page_path) {
                 break;
             }
-
             pages.attach_page(&page_path)?;
         }
 
@@ -67,6 +71,10 @@ impl<S: UniversalRead<u8>> Pages<S> {
 
     pub fn num_pages(&self) -> usize {
         self.pages.len()
+    }
+
+    pub fn page_path(&self, page_id: PageId) -> PathBuf {
+        page_path(&self.base_path, page_id)
     }
 
     /// Computes the page ranges and relative offsets for reading or writing a value described by
@@ -162,6 +170,37 @@ impl<S: UniversalRead<u8>> Pages<S> {
         for page in &self.pages {
             page.clear_ram_cache()?;
         }
+        Ok(())
+    }
+
+    /// This method reloads the pages storage from "disk", so that
+    /// it should make newly written data is readable.
+    ///
+    /// Important assumptions:
+    ///
+    /// - Should only be called on read-only instances of the Pages.
+    /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
+    /// - Partial writes are possible, it is up to the caller to read only fully written data.
+    pub fn live_reload(&mut self) -> Result<()> {
+        let num_pages = self.pages.len();
+        let mut last_page_id = (num_pages - 1) as PageId;
+        if num_pages > 0 {
+            self.pages.pop();
+            // Re-attach the last page, which should have the latest data.
+            let page_path = self.page_path(last_page_id);
+            self.attach_page(&page_path)?;
+        }
+
+        loop {
+            last_page_id += 1;
+            let page_path = self.page_path(last_page_id);
+            if S::exists(&page_path)? {
+                self.attach_page(&page_path)?;
+            } else {
+                break;
+            }
+        }
+
         Ok(())
     }
 }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -319,7 +319,7 @@ impl<S: UniversalRead<u8>> Tracker<S> {
 
         if new_header.next_pointer_offset < self.next_pointer_offset {
             Err(GridstoreError::service_error(format!(
-                "live reload cannot decrease pointer count, possible data loss: old size {:#?}, new size {:#?}",
+                "live reload cannot decrease pointer count, possible data loss: old count {:#?}, new count {:#?}",
                 self.next_pointer_offset, new_header.next_pointer_offset
             )))
         } else if new_header.next_pointer_offset == self.next_pointer_offset {
@@ -374,8 +374,10 @@ impl<S: UniversalRead<u8>> Tracker<S> {
     pub fn iter_pointers(
         &self,
         from: PointOffset,
+        max: PointOffset,
     ) -> impl Iterator<Item = (PointOffset, Result<Option<ValuePointer>>)> + '_ {
-        (from..self.next_pointer_offset).map(move |i| (i, self.get(i)))
+        let to = self.next_pointer_offset.min(max + 1);
+        (from..to).map(move |i| (i, self.get(i)))
     }
 
     pub fn has_pointer(&self, point_offset: PointOffset) -> Result<bool> {

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -326,12 +326,13 @@ impl<S: UniversalRead<u8>> Tracker<S> {
             // No new pointers, no need to reload
             Ok(false)
         } else {
-            // Update in-memory state to reflect new pointers
-            self.header = new_header;
-            self.next_pointer_offset = new_header.next_pointer_offset;
             // reopen storage to make new data visible
             // For some storages it should be a no-op.
             self.storage = Self::open_storage(&self.path)?;
+
+            // Update in-memory state to reflect new pointers
+            self.header = new_header;
+            self.next_pointer_offset = new_header.next_pointer_offset;
             Ok(true)
         }
     }
@@ -376,7 +377,7 @@ impl<S: UniversalRead<u8>> Tracker<S> {
         from: PointOffset,
         max: PointOffset,
     ) -> impl Iterator<Item = (PointOffset, Result<Option<ValuePointer>>)> + '_ {
-        let to = self.next_pointer_offset.min(max + 1);
+        let to = self.next_pointer_offset.min(max.saturating_add(1));
         (from..to).map(move |i| (i, self.get(i)))
     }
 

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -270,22 +270,8 @@ impl<S: UniversalRead<u8>> Tracker<S> {
     /// If the file does not exist, return an error
     pub fn open(path: &Path) -> Result<Self> {
         let path = Self::tracker_file_name(path);
-        let storage = match S::open(&path, tracker_open_options()) {
-            Err(UniversalIoError::NotFound { .. }) => {
-                return Err(GridstoreError::service_error(format!(
-                    "Tracker file does not exist: {}",
-                    path.display()
-                )));
-            }
-            other => other?,
-        };
-        let header_bytes = storage.read::<false>(ElementsRange {
-            start: 0,
-            length: std::mem::size_of::<TrackerHeader>() as u64,
-        })?;
-        #[expect(deprecated, reason = "legacy code")]
-        let header: TrackerHeader =
-            *unsafe { transmute_from_u8::<TrackerHeader>(header_bytes.as_ref()) };
+        let storage = Self::open_storage(&path)?;
+        let header: TrackerHeader = Self::read_header(&storage)?;
         let pending_updates = AHashMap::new();
         Ok(Self {
             next_pointer_offset: header.next_pointer_offset,
@@ -294,6 +280,60 @@ impl<S: UniversalRead<u8>> Tracker<S> {
             storage,
             pending_updates,
         })
+    }
+
+    fn read_header(storage: &S) -> Result<TrackerHeader> {
+        let header_bytes = storage.read::<false>(ElementsRange {
+            start: 0,
+            length: std::mem::size_of::<TrackerHeader>() as u64,
+        })?;
+        #[expect(deprecated, reason = "legacy code")]
+        Ok(*unsafe { transmute_from_u8::<TrackerHeader>(header_bytes.as_ref()) })
+    }
+
+    fn open_storage(path: &Path) -> Result<S> {
+        let storage = match S::open(path, tracker_open_options()) {
+            Err(UniversalIoError::NotFound { .. }) => {
+                return Err(GridstoreError::service_error(format!(
+                    "Tracker file does not exist: {}",
+                    path.display()
+                )));
+            }
+            other => other?,
+        };
+        Ok(storage)
+    }
+
+    /// This method reloads the tracker storage from "disk", so that
+    /// it should make newly written data visible to the tracker.
+    ///
+    /// Important assumptions:
+    ///
+    /// - Should only be called on read-only instances of the tracker.
+    /// - Only appending new pointers is supported, not modifications of existing pointers.
+    /// - Partial writes are possible, but ignored. Header is a source of truth.
+    ///
+    /// Returns `true` if there are new changes, `false` if the tracker is already up to date.
+    pub fn live_reload(&mut self) -> Result<bool> {
+        let new_header = Self::read_header(&self.storage)?;
+
+        if new_header.next_pointer_offset < self.next_pointer_offset {
+            Err(GridstoreError::service_error(format!(
+                "live reload cannot decrease pointer count, possible data loss: old size {:#?}, new size {:#?}",
+                self.next_pointer_offset, new_header.next_pointer_offset
+            )))
+        } else if new_header.next_pointer_offset == self.next_pointer_offset {
+            // No new pointers, no need to reload
+            Ok(false)
+        } else {
+            // Update in-memory state to reflect new pointers
+            self.header = new_header;
+            self.next_pointer_offset = new_header.next_pointer_offset;
+            // reopen storage to make new data visible
+            // For some storages it should be a no-op.
+            self.storage = Self::open_storage(&self.path)?;
+            Ok(true)
+        }
     }
 
     /// Get the raw value at the given point offset


### PR DESCRIPTION
Introduces `live_reload` function to gridstore, which is supposed to allow read-only replica to access newly written data by append-only replica.

---

- **[manual] live reload functions for gridstore-read**
- **[AI] tests for life reload**
- **fmt**
