### PR TITLE
fix(segment): use div_ceil() for Rust 1.94 clippy compatibility

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -843,7 +843,7 @@ impl GpuVectorStorage {
 
     /// Number of vectors in each gpu buffer.
     fn points_in_storage_count(num_vectors: usize) -> usize {
-        num_vectors.next_multiple_of(STORAGES_COUNT) / STORAGES_COUNT
+        num_vectors.div_ceil(STORAGES_COUNT)
     }
 
     pub fn descriptor_set_layout(&self) -> Arc<gpu::DescriptorSetLayout> {


### PR DESCRIPTION
Fixes `clippy::manual_div_ceil` in `lib/segment` so the workspace passes with Rust 1.94 beta:

```
cargo +beta clippy --workspace --all-targets --all-features -- -D warnings
```

**Change:** In `gpu_vector_storage::points_in_storage_count`, replace manual ceiling division `num_vectors.next_multiple_of(STORAGES_COUNT) / STORAGES_COUNT` with `num_vectors.div_ceil(STORAGES_COUNT)`. Behavior is unchanged.

Made with [Cursor](https://cursor.com)