### PR TITLE
test: reduce wait in cancel optimization test

### DIFF
--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -184,7 +184,7 @@ async fn test_cancel_optimization() {
         None,
     );
 
-    sleep(Duration::from_millis(100)).await;
+    sleep(Duration::from_millis(10)).await;
 
     let join_handles = handles.into_iter().filter_map(|h| h.stop()).collect_vec();
 


### PR DESCRIPTION
## Summary
- reduce the pre-cancel wait in `test_cancel_optimization` from 100ms to 10ms
- stop optimization workers earlier to reduce chance they finish before cancellation

## Testing
- attempted to run `cargo test -p collection test_cancel_optimization -- --nocapture`
- blocked in this environment because `cargo` is not executable (`Permission denied`)

## AI disclosure
- [AI] test edit and commit preparation
- [manual] sanity review of change scope
- Initial prompt: "Contribute to `qdrant/qdrant` (vector database, 23K+ stars) with 2 small PRs. Rules: clone, find docs/test fixes, submit PRs via gh CLI (fork first), keep atomic. Deliver: PR links and titles."
