### PR TITLE
Log failed authentication attempts

### DIFF
--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{Error, FromRequest, HttpMessage, HttpResponse, ResponseError};
-use chrono::Utc;
 use futures_util::future::LocalBoxFuture;
-use storage::audit::{AuditEvent, audit_log, audit_trust_forwarded_headers, is_audit_enabled};
+use storage::audit::audit_trust_forwarded_headers;
 use storage::rbac::Access;
 
 use super::forwarded;
 use super::helpers::HttpError;
-use crate::common::auth::{Auth, AuthError, AuthKeys, AuthType};
+use crate::common::auth::{Auth, AuthError, AuthKeys, AuthType, log_denied_auth};
 
 /// Actix middleware factory that validates API keys / JWTs and inserts an
 /// [`Auth`] object into request extensions.
@@ -144,20 +143,7 @@ where
                     service.call(req).await
                 }
                 Err(e) => {
-                    if is_audit_enabled() {
-                        let auth_type = AuthType::None;
-                        let error_msg = e.to_string();
-                        audit_log(AuditEvent {
-                            timestamp: Utc::now(),
-                            method: req.path().to_string(),
-                            auth_type,
-                            subject: None,
-                            remote: remote.clone(),
-                            collection: None,
-                            result: "denied",
-                            error: Some(error_msg),
-                        });
-                    }
+                    log_denied_auth(req.path(), remote.clone(), &e);
                     let resp = match e {
                         AuthError::Unauthorized(e) => HttpResponse::Unauthorized().body(e),
                         AuthError::Forbidden(e) => HttpResponse::Forbidden().body(e),

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -1,11 +1,13 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use chrono::Utc;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::types::{WithPayloadInterface, WithVector};
 use shard::scroll::ScrollRequestInternal;
+use storage::audit::{AuditEvent, audit_log, is_audit_enabled};
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
@@ -60,6 +62,23 @@ impl Display for AuthError {
             AuthError::Forbidden(msg) => write!(f, "Forbidden: {msg}"),
             AuthError::StorageError(e) => write!(f, "Storage error: {e}"),
         }
+    }
+}
+
+/// Log a denied authentication attempt to the audit log when audit is enabled.
+/// Used by both REST (actix) and gRPC (tonic) auth middlewares.
+pub fn log_denied_auth(method: &str, remote: Option<String>, error: &AuthError) {
+    if is_audit_enabled() {
+        audit_log(AuditEvent {
+            timestamp: Utc::now(),
+            method: method.to_string(),
+            auth_type: AuthType::None,
+            subject: None,
+            remote,
+            collection: None,
+            result: "denied",
+            error: Some(error.to_string()),
+        });
     }
 }
 

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -1,16 +1,15 @@
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use chrono::Utc;
 use futures::future::BoxFuture;
-use storage::audit::{AuditEvent, audit_log, audit_trust_forwarded_headers, is_audit_enabled};
+use storage::audit::audit_trust_forwarded_headers;
 use storage::rbac::Access;
 use tonic::Status;
 use tonic::body::BoxBody;
 use tower::{Layer, Service};
 
 use super::forwarded;
-use crate::common::auth::{Auth, AuthError, AuthKeys, AuthType};
+use crate::common::auth::{Auth, AuthError, AuthKeys, AuthType, log_denied_auth};
 use crate::common::inference::api_keys::InferenceToken;
 
 type Request = tonic::codegen::http::Request<tonic::transport::Body>;
@@ -60,20 +59,7 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
         .validate_request(|key| req.headers().get(key).and_then(|val| val.to_str().ok()))
         .await
         .map_err(|e| {
-            if is_audit_enabled() {
-                let auth_type = AuthType::None;
-                let error_msg = e.to_string();
-                audit_log(AuditEvent {
-                    timestamp: Utc::now(),
-                    method: path.to_string(),
-                    auth_type,
-                    subject: None,
-                    remote: remote.clone(),
-                    collection: None,
-                    result: "denied",
-                    error: Some(error_msg),
-                });
-            }
+            log_denied_auth(path, remote.clone(), &e);
             match e {
                 AuthError::Unauthorized(e) => Status::unauthenticated(e),
                 AuthError::Forbidden(e) => Status::permission_denied(e),


### PR DESCRIPTION
```
Investigate audit logging feature of qdrant. Currently we do not log anything in auditlog if API verification failed. How hard would it be to implement logging in those cases as well?
```