### PR TITLE
Synchronize Rust and Python edge examples

### DIFF
--- a/.github/workflows/edge-py-test.yml
+++ b/.github/workflows/edge-py-test.yml
@@ -58,6 +58,6 @@ jobs:
 
           source .venv/bin/activate
 
-          python examples/qdrant-edge.py
+          python examples/demo.py
           python examples/fusion-query.py
           python examples/mmr-query.py

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -124,10 +124,14 @@ def main() -> None:
             pub use edge::*;
             pub mod segment;
             pub mod shard;
+            pub mod sparse;
             """
         ).lstrip()
         + "".join(
-            sorted(f"mod {pkg};\n" for pkg in packages.keys() - {"segment", "shard"})
+            sorted(
+                f"mod {pkg};\n"
+                for pkg in packages.keys() - {"segment", "shard", "sparse"}
+            )
         ),
         encoding="utf-8",
     )

--- a/lib/edge/publish/examples/Cargo.toml
+++ b/lib/edge/publish/examples/Cargo.toml
@@ -9,4 +9,8 @@ description = "Examples demonstrating how to use the Qdrant Edge library"
 qdrant-edge = { path = "../qdrant-edge" }
 anyhow = "1"
 fs-err = "3"
+ordered-float = "5"
 serde_json = "1"
+tempfile = "3"
+ureq = "3"
+uuid = { version = "1.21", features = ["v4"] }

--- a/lib/edge/publish/examples/src/bin/demo.rs
+++ b/lib/edge/publish/examples/src/bin/demo.rs
@@ -1,195 +1,281 @@
+// See lib/edge/python/examples/demo.py for the equivalent Python example.
+
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
 
+use examples::{load_new_shard, point};
+use ordered_float::OrderedFloat;
 use qdrant_edge::EdgeShard;
-use qdrant_edge::segment::data_types::vectors::{NamedQuery, VectorInternal, VectorStructInternal};
+use qdrant_edge::segment::data_types::vectors::{
+    MultiDenseVectorInternal, NamedQuery, VectorInternal, VectorStructInternal,
+};
 use qdrant_edge::segment::types::{
-    Distance, ExtendedPointId, Payload, PayloadStorageType, SegmentConfig, VectorDataConfig,
-    VectorStorageType, WithPayloadInterface, WithVector,
+    Condition, ExtendedPointId, FieldCondition, Filter, Match, MatchTextAny, PayloadFieldSchema,
+    PayloadSchemaType, Range, WithPayloadInterface, WithVector,
 };
 use qdrant_edge::shard::count::CountRequestInternal;
 use qdrant_edge::shard::facet::FacetRequestInternal;
-use qdrant_edge::shard::operations::CollectionUpdateOperations::PointOperation;
+use qdrant_edge::shard::operations::CollectionUpdateOperations::{
+    FieldIndexOperation, PointOperation,
+};
 use qdrant_edge::shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
 use qdrant_edge::shard::operations::point_ops::PointOperations::UpsertPoints;
-use qdrant_edge::shard::operations::point_ops::PointStructPersisted;
+use qdrant_edge::shard::operations::{CreateIndex, FieldIndexOperations};
 use qdrant_edge::shard::query::query_enum::QueryEnum;
 use qdrant_edge::shard::query::{ScoringQuery, ShardQueryRequest};
 use qdrant_edge::shard::scroll::ScrollRequestInternal;
-use serde_json::{Value, json};
+use qdrant_edge::shard::search::CoreSearchRequest;
+use qdrant_edge::sparse::common::sparse_vector::SparseVector;
+use serde_json::json;
+use uuid::Uuid;
 
 const DATA_DIR: &str = "./data/demo";
-const VECTOR_NAME: &str = "example-vector";
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("---- Load shard ----");
-    let shard = load_new_shard()?;
+    println!("---- Point conversions ----");
 
-    println!("---- Upsert ----");
     let points = vec![
         point(
-            1,
-            vec![6.0, 9.0, 4.0, 2.0],
-            json!({"color": "red", "price": 100.0}),
+            10u64,
+            VectorStructInternal::MultiDense(MultiDenseVectorInternal::new(
+                vec![1.0, 2.0, 3.0, 3.0, 4.0, 5.0],
+                3,
+            )),
+            json!({}),
         ),
         point(
-            2,
-            vec![1.0, 2.0, 3.0, 4.0],
-            json!({"color": "blue", "price": 200.0}),
-        ),
-        point(
-            3,
-            vec![5.0, 5.0, 5.0, 5.0],
-            json!({"color": "green", "price": 500.0}),
+            11,
+            VectorStructInternal::Named(HashMap::from_iter([(
+                "sparse".to_string(),
+                VectorInternal::Sparse(SparseVector::new(vec![0, 2], vec![1.0, 3.0]).unwrap()),
+            )])),
+            json!({}),
         ),
     ];
 
-    shard.update(PointOperation(UpsertPoints(PointsList(points))))?;
-    println!("Upserted 3 points");
+    for point in &points {
+        println!("{point:?}");
+    }
+
+    println!("---- Load shard ----");
+
+    let shard = load_new_shard(DATA_DIR)?;
+
+    println!("---- Upsert ----");
+
+    shard.update(PointOperation(UpsertPoints(PointsList(vec![
+        point(
+            1u64,
+            VectorStructInternal::Single(vec![6.0, 9.0, 4.0, 2.0]),
+            json!({
+                "null": null,
+                "str": "string",
+                "uint": 42,
+                "int": -69,
+                "float": 4.20,
+                "bool": true,
+                "obj": {
+                    "null": null,
+                    "str": "string",
+                    "uint": 42,
+                    "int": -69,
+                    "float": 4.20,
+                    "bool": true,
+                    "obj": {},
+                    "arr": [],
+                },
+                "arr": [null, "string", 42, -69, 4.20, true, {}, []],
+            }),
+        ),
+        point(
+            ExtendedPointId::Uuid("e9408f2b-b917-4af1-ab75-d97ac6b2c047".parse().unwrap()),
+            VectorStructInternal::Single(vec![6.0, 9.0, 3.0, -2.0]),
+            json!({
+                "hello": "world",
+                "price": 199.99,
+            }),
+        ),
+        point(
+            ExtendedPointId::Uuid(Uuid::new_v4()),
+            VectorStructInternal::Single(vec![1.0, 6.0, 4.0, 2.0]),
+            json!({
+                "hello": "world",
+                "price": 999.99,
+            }),
+        ),
+    ]))))?;
 
     println!("---- Query ----");
-    let query_vec: VectorInternal = vec![6.0, 9.0, 4.0, 2.0].into();
-    let results = shard.query(ShardQueryRequest {
+
+    let result = shard.query(ShardQueryRequest {
         prefetches: vec![],
         query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: query_vec,
-            using: Some(VECTOR_NAME.to_string()),
+            query: vec![6.0, 9.0, 4.0, 2.0].into(),
+            using: None,
         }))),
         filter: None,
         score_threshold: None,
         limit: 10,
         offset: 0,
         params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(false),
+        with_vector: WithVector::Bool(true),
+        with_payload: WithPayloadInterface::Bool(true),
     })?;
 
-    for p in &results {
-        println!("ID: {}, Score: {}", p.id, p.score);
+    for point in &result {
+        println!("{point:?}");
+    }
+
+    println!("---- Search ----");
+
+    let points = shard.search(CoreSearchRequest {
+        query: QueryEnum::Nearest(NamedQuery {
+            query: vec![1.0, 1.0, 1.0, 1.0].into(),
+            using: None,
+        }),
+        filter: None,
+        params: None,
+        limit: 10,
+        offset: 0,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: Some(WithVector::Bool(true)),
+        score_threshold: None,
+    })?;
+
+    for point in &points {
+        println!("{point:?}");
+    }
+
+    println!("---- Search + Filter ----");
+
+    let search_filter = Filter {
+        should: None,
+        min_should: None,
+        must: Some(vec![
+            Condition::Field(FieldCondition::new_match(
+                "hello".try_into().unwrap(),
+                Match::TextAny(MatchTextAny {
+                    text_any: "world".to_string(),
+                }),
+            )),
+            Condition::Field(FieldCondition::new_range(
+                "price".try_into().unwrap(),
+                Range {
+                    lt: None,
+                    gt: None,
+                    gte: Some(OrderedFloat(500.0)),
+                    lte: None,
+                },
+            )),
+        ]),
+        must_not: None,
+    };
+
+    let points = shard.search(CoreSearchRequest {
+        query: QueryEnum::Nearest(NamedQuery {
+            query: vec![1.0, 1.0, 1.0, 1.0].into(),
+            using: None,
+        }),
+        filter: Some(search_filter),
+        params: None,
+        limit: 10,
+        offset: 0,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: Some(WithVector::Bool(true)),
+        score_threshold: None,
+    })?;
+
+    for point in &points {
+        println!("{point:?}");
     }
 
     println!("---- Retrieve ----");
-    let retrieved = shard.retrieve(
+
+    let points = shard.retrieve(
         &[ExtendedPointId::NumId(1)],
-        Some(WithPayloadInterface::Bool(false)),
-        Some(WithVector::Bool(false)),
+        Some(WithPayloadInterface::Bool(true)),
+        Some(WithVector::Bool(true)),
     )?;
-    for p in &retrieved {
-        println!("ID: {}", p.id);
+
+    for point in &points {
+        println!("{point:?}");
     }
 
     println!("---- Scroll ----");
-    let (records, _) = shard.scroll(ScrollRequestInternal {
+
+    let (scroll_result, mut next_offset) = shard.scroll(ScrollRequestInternal {
         offset: None,
-        limit: Some(3),
+        limit: Some(2),
         filter: None,
-        with_payload: Some(WithPayloadInterface::Bool(false)),
+        with_payload: None,
         with_vector: WithVector::Bool(false),
         order_by: None,
     })?;
-    for r in &records {
-        println!("ID: {}", r.id);
+    for point in &scroll_result {
+        println!("{point:?}");
+    }
+
+    while let Some(offset) = next_offset {
+        println!("--- Next scroll (offset = {offset})---");
+        let (scroll_result, next) = shard.scroll(ScrollRequestInternal {
+            offset: Some(offset),
+            limit: Some(2),
+            filter: None,
+            with_payload: None,
+            with_vector: WithVector::Bool(false),
+            order_by: None,
+        })?;
+        next_offset = next;
+        for point in &scroll_result {
+            println!("{point:?}");
+        }
     }
 
     println!("---- Count ----");
+
     let count = shard.count(CountRequestInternal {
         filter: None,
         exact: true,
     })?;
-    println!("Total points: {count}");
+    println!("Total points count: {count}");
 
-    println!("---- Facet (requires payload index) ----");
-    // Note: Facet requires a payload index on the field being faceted.
-    // In Edge, payload indexes cannot be created directly - you need to:
-    // 1. Create the index in a full Qdrant instance
-    // 2. Create a shard snapshot
-    // 3. Load the snapshot into Edge
-    let facet_result = shard.facet(FacetRequestInternal {
-        key: "color".try_into().unwrap(),
+    println!("---- Facet ----");
+
+    shard.update(FieldIndexOperation(FieldIndexOperations::CreateIndex(
+        CreateIndex {
+            field_name: "hello".try_into().unwrap(),
+            field_schema: Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)),
+        },
+    )))?;
+
+    let response = shard.facet(FacetRequestInternal {
+        key: "hello".try_into().unwrap(),
         limit: 10,
         filter: None,
         exact: false,
-    });
-    match facet_result {
-        Ok(response) => {
-            println!("Facet results:");
-            for hit in &response.hits {
-                println!("  {:?}: {}", hit.value, hit.count);
-            }
-        }
-        Err(e) => {
-            // Expected error when no payload index exists
-            println!("Facet error (expected without payload index): {e}");
-        }
+    })?;
+
+    println!("Facet results ({} hits):", response.hits.len());
+
+    for hit in &response.hits {
+        println!("  {:?}: {}", hit.value, hit.count);
     }
 
     println!("---- Info ----");
-    let info = shard.info();
-    println!(
-        "Segments: {}, Approx Points: {}",
-        info.segments_count, info.points_count
-    );
 
-    println!("---- Close and reopen ----");
+    let info = shard.info();
+    println!("{info:?}");
+
+    println!("---- Close and reopen shard ----");
+
     drop(shard);
-    let reopened = EdgeShard::load(Path::new(DATA_DIR), None)?;
+
+    let reopened_shard = EdgeShard::load(Path::new(DATA_DIR), None)?;
     println!(
         "Edge shard reopened. Approx Points: {}",
-        reopened.info().points_count
+        reopened_shard.info().points_count
     );
 
     Ok(())
-}
-
-fn load_new_shard() -> Result<EdgeShard, Box<dyn Error>> {
-    if Path::new(DATA_DIR).exists() {
-        fs_err::remove_dir_all(DATA_DIR)?;
-    }
-    fs_err::create_dir_all(DATA_DIR)?;
-
-    let config = SegmentConfig {
-        vector_data: {
-            let mut m = HashMap::new();
-            m.insert(
-                VECTOR_NAME.to_string(),
-                VectorDataConfig {
-                    size: 4,
-                    distance: Distance::Dot,
-                    storage_type: VectorStorageType::ChunkedMmap,
-                    index: Default::default(),
-                    quantization_config: None,
-                    multivector_config: None,
-                    datatype: None,
-                },
-            );
-            m
-        },
-        sparse_vector_data: HashMap::new(),
-        payload_storage_type: PayloadStorageType::Mmap,
-    };
-
-    Ok(EdgeShard::load(Path::new(DATA_DIR), Some(config))?)
-}
-
-fn point(id: u64, vector: Vec<f32>, payload: Value) -> PointStructPersisted {
-    let mut vectors = HashMap::new();
-    vectors.insert(VECTOR_NAME.to_string(), VectorInternal::from(vector));
-    PointStructPersisted {
-        id: ExtendedPointId::NumId(id),
-        vector: VectorStructInternal::Named(vectors).into(),
-        payload: Some(json_to_payload(payload)),
-    }
-}
-
-fn json_to_payload(value: Value) -> Payload {
-    if let Value::Object(map) = value {
-        let mut payload = Payload::default();
-        for (k, v) in map {
-            payload.0.insert(k, v);
-        }
-        payload
-    } else {
-        Payload::default()
-    }
 }

--- a/lib/edge/publish/examples/src/bin/fusion-query.rs
+++ b/lib/edge/publish/examples/src/bin/fusion-query.rs
@@ -1,0 +1,109 @@
+// See lib/edge/python/examples/fusion-query.py for the equivalent Python example.
+
+use std::error::Error;
+
+use examples::{fill_dummy_data, load_new_shard};
+use ordered_float::OrderedFloat;
+use qdrant_edge::segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal};
+use qdrant_edge::segment::types::{
+    Condition, FieldCondition, Filter, Match, ValueVariants, WithPayloadInterface, WithVector,
+};
+use qdrant_edge::shard::query::query_enum::QueryEnum;
+use qdrant_edge::shard::query::{FusionInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest};
+
+const DATA_DIR: &str = "./data/fusion-query";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let shard = load_new_shard(DATA_DIR)?;
+    fill_dummy_data(&shard)?;
+
+    let search_filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        "color".try_into().unwrap(),
+        Match::new_value(ValueVariants::String("red".to_string())),
+    )));
+
+    // Basic RRF fusion (equal weights)
+    println!("=== Basic RRF Fusion ===");
+    let result = shard.query(ShardQueryRequest {
+        prefetches: vec![
+            ShardPrefetch {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0]))),
+                limit: 5,
+                params: None,
+                filter: None,
+                score_threshold: None,
+            },
+            ShardPrefetch {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0]))),
+                limit: 5,
+                params: None,
+                filter: Some(search_filter.clone()),
+                score_threshold: None,
+            },
+        ],
+        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf {
+            k: 2,
+            weights: None,
+        })),
+        filter: None,
+        score_threshold: None,
+        limit: 10,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(true),
+        with_payload: WithPayloadInterface::Bool(true),
+    })?;
+
+    for point in &result {
+        println!("{point:?}");
+    }
+
+    // Weighted RRF fusion - first prefetch has 3x weight
+    println!("\n=== Weighted RRF Fusion (3:1) ===");
+    let result = shard.query(ShardQueryRequest {
+        prefetches: vec![
+            ShardPrefetch {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0]))),
+                limit: 5,
+                params: None,
+                filter: None,
+                score_threshold: None,
+            },
+            ShardPrefetch {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0]))),
+                limit: 5,
+                params: None,
+                filter: Some(search_filter),
+                score_threshold: None,
+            },
+        ],
+        query: Some(ScoringQuery::Fusion(FusionInternal::Rrf {
+            k: 2,
+            weights: Some(vec![OrderedFloat(3.0), OrderedFloat(1.0)]), // First prefetch has 3x weight
+        })),
+        filter: None,
+        score_threshold: None,
+        limit: 10,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(true),
+        with_payload: WithPayloadInterface::Bool(true),
+    })?;
+
+    for point in &result {
+        println!("{point:?}");
+    }
+
+    Ok(())
+}
+
+fn nearest(vec: [f32; 4]) -> QueryEnum {
+    QueryEnum::Nearest(NamedQuery {
+        query: VectorInternal::from(vec.to_vec()),
+        using: Some(DEFAULT_VECTOR_NAME.to_string()),
+    })
+}

--- a/lib/edge/publish/examples/src/bin/load-existing.rs
+++ b/lib/edge/publish/examples/src/bin/load-existing.rs
@@ -1,0 +1,92 @@
+// See lib/edge/python/examples/load-existing.py for the equivalent Python example.
+
+use std::error::Error;
+use std::path::Path;
+
+use examples::{load_new_shard, point};
+use qdrant_edge::EdgeShard;
+use qdrant_edge::segment::data_types::vectors::VectorStructInternal;
+use qdrant_edge::segment::types::{ExtendedPointId, WithPayloadInterface, WithVector};
+use qdrant_edge::shard::operations::CollectionUpdateOperations::PointOperation;
+use qdrant_edge::shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+use qdrant_edge::shard::operations::point_ops::PointOperations::UpsertPoints;
+use qdrant_edge::shard::scroll::ScrollRequestInternal;
+use serde_json::json;
+use uuid::Uuid;
+
+const DATA_DIR: &str = "./data/load-existing";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Create *new* edge shard and upsert some points
+    let edge = load_new_shard(DATA_DIR)?;
+
+    edge.update(PointOperation(UpsertPoints(PointsList(vec![
+        point(
+            1u64,
+            VectorStructInternal::Single(vec![6.0, 9.0, 4.0, 2.0]),
+            json!({
+                "null": null,
+                "str": "string",
+                "uint": 42,
+                "int": -69,
+                "float": 4.20,
+                "bool": true,
+                "obj": {
+                    "null": null,
+                    "str": "string",
+                    "uint": 42,
+                    "int": -69,
+                    "float": 4.20,
+                    "bool": true,
+                    "obj": {},
+                    "arr": [],
+                },
+                "arr": [null, "string", 42, -69, 4.20, true, {}, []],
+            }),
+        ),
+        point(
+            ExtendedPointId::Uuid("e9408f2b-b917-4af1-ab75-d97ac6b2c047".parse().unwrap()),
+            VectorStructInternal::Single(vec![6.0, 9.0, 3.0, -2.0]),
+            json!({
+                "hello": "world",
+                "price": 199.99,
+            }),
+        ),
+        point(
+            ExtendedPointId::Uuid(Uuid::new_v4()),
+            VectorStructInternal::Single(vec![1.0, 6.0, 4.0, 2.0]),
+            json!({
+                "hello": "world",
+                "price": 999.99,
+            }),
+        ),
+    ]))))?;
+
+    let (expected_points, _) = edge.scroll(ScrollRequestInternal {
+        offset: None,
+        limit: Some(5),
+        filter: None,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: WithVector::Bool(true),
+        order_by: None,
+    })?;
+    println!("{expected_points:?}");
+
+    // Re-load edge shard from disk, assert points are available
+    drop(edge);
+    let edge = EdgeShard::load(Path::new(DATA_DIR), None)?;
+
+    let (points, _) = edge.scroll(ScrollRequestInternal {
+        offset: None,
+        limit: Some(5),
+        filter: None,
+        with_payload: Some(WithPayloadInterface::Bool(true)),
+        with_vector: WithVector::Bool(true),
+        order_by: None,
+    })?;
+    println!("{points:?}");
+
+    assert_eq!(points, expected_points);
+
+    Ok(())
+}

--- a/lib/edge/publish/examples/src/bin/mmr-query.rs
+++ b/lib/edge/publish/examples/src/bin/mmr-query.rs
@@ -1,0 +1,39 @@
+// See lib/edge/python/examples/mmr-query.py for the equivalent Python example.
+
+use std::error::Error;
+
+use examples::{fill_dummy_data, load_new_shard};
+use ordered_float::OrderedFloat;
+use qdrant_edge::segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use qdrant_edge::segment::types::{WithPayloadInterface, WithVector};
+use qdrant_edge::shard::query::{MmrInternal, ScoringQuery, ShardQueryRequest};
+
+const DATA_DIR: &str = "./data/mmr-query";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let shard = load_new_shard(DATA_DIR)?;
+    fill_dummy_data(&shard)?;
+
+    let result = shard.query(ShardQueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Mmr(MmrInternal {
+            vector: vec![6.0, 9.0, 4.0, 2.0].into(),
+            using: DEFAULT_VECTOR_NAME.to_string(),
+            lambda: OrderedFloat(0.9),
+            candidates_limit: 100,
+        })),
+        filter: None,
+        score_threshold: None,
+        limit: 10,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(true),
+        with_payload: WithPayloadInterface::Bool(true),
+    })?;
+
+    for point in &result {
+        println!("{point:?}");
+    }
+
+    Ok(())
+}

--- a/lib/edge/publish/examples/src/bin/restore-snapshot.rs
+++ b/lib/edge/publish/examples/src/bin/restore-snapshot.rs
@@ -1,0 +1,142 @@
+// See lib/edge/python/examples/restore-snapshot.py for the equivalent Python example.
+
+use std::error::Error;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use qdrant_edge::EdgeShard;
+use qdrant_edge::segment::types::{ExtendedPointId, WithPayloadInterface, WithVector};
+use qdrant_edge::shard::files::{clear_data, move_data};
+use qdrant_edge::shard::snapshots::snapshot_manifest::SnapshotManifest;
+
+const SNAPSHOT_URL: &str =
+    "https://storage.googleapis.com/qdrant-benchmark-snapshots/test-shard.snapshot";
+
+// Obtained via download_partial.py and manually inserting a new point with ID 100500
+const PARTIAL_SNAPSHOT_URL: &str =
+    "https://storage.googleapis.com/qdrant-benchmark-snapshots/partial.snapshot";
+
+const DATA_DIRECTORY: &str = "./data/restore-snapshot";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let snapshot_path = download_snapshot(SNAPSHOT_URL, DATA_DIRECTORY)?;
+    println!("Snapshot downloaded to: {}", snapshot_path.display());
+
+    let recovered_path = Path::new(DATA_DIRECTORY).join("restored_shard");
+    println!(
+        "Restoring shard from snapshot to: {}",
+        recovered_path.display()
+    );
+    if recovered_path.exists() {
+        println!("Removing existing recovered shard directory...");
+        fs_err::remove_dir_all(&recovered_path)?;
+    }
+
+    EdgeShard::unpack_snapshot(&snapshot_path, &recovered_path)?;
+
+    let shard = EdgeShard::load(&recovered_path, None)?;
+
+    let points = shard.retrieve(
+        &[
+            ExtendedPointId::NumId(1),
+            ExtendedPointId::NumId(2),
+            ExtendedPointId::NumId(3),
+        ],
+        Some(WithPayloadInterface::Bool(true)),
+        Some(WithVector::Bool(false)),
+    )?;
+
+    for point in &points {
+        println!("{point:?}");
+    }
+
+    let manifest = shard.snapshot_manifest()?;
+    println!(
+        "Manifest of restored shard: {}",
+        serde_json::to_string_pretty(&manifest)?
+    );
+
+    let partial_snapshot_path = download_snapshot(PARTIAL_SNAPSHOT_URL, DATA_DIRECTORY)?;
+
+    update_from_snapshot(shard, &recovered_path, &partial_snapshot_path)?;
+
+    let shard = EdgeShard::load(&recovered_path, None)?;
+
+    let points = shard.retrieve(
+        &[ExtendedPointId::NumId(100500)],
+        Some(WithPayloadInterface::Bool(true)),
+        Some(WithVector::Bool(false)),
+    )?;
+
+    for point in &points {
+        println!("{point:?}");
+    }
+
+    let info = shard.info();
+
+    println!("{info:?}");
+
+    Ok(())
+}
+
+// Download the snapshot file into data directory
+fn download_snapshot(url: &str, dest_folder: &str) -> Result<PathBuf, Box<dyn Error>> {
+    fs_err::create_dir_all(dest_folder)?;
+
+    let filename = url.split('/').next_back().unwrap();
+    let local_filename = Path::new(dest_folder).join(filename);
+    if local_filename.exists() {
+        println!("Snapshot already exists at: {}", local_filename.display());
+        return Ok(local_filename);
+    }
+
+    let response = ureq::get(url).call()?;
+    let mut file = fs_err::File::create(&local_filename)?;
+    let mut reader = response.into_body().into_reader();
+    std::io::copy(&mut reader, &mut file)?;
+    file.flush()?;
+
+    Ok(local_filename)
+}
+
+// NOTE: This function is copy-pasted from PyEdgeShard::update_from_snapshot
+// because it's not available in EdgeShard yet.
+//
+// Later we either port it to EdgeShard; or, more likely, we'll replace it with
+// different mechanism and remove it from all examples.
+fn update_from_snapshot(
+    shard: EdgeShard,
+    shard_path: &Path,
+    snapshot_path: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let tmp_dir = snapshot_path.parent().unwrap_or(Path::new("."));
+
+    // A place where we can temporarily unpack the snapshot
+    let unpack_dir = tempfile::Builder::new().tempdir_in(tmp_dir)?;
+    EdgeShard::unpack_snapshot(snapshot_path, unpack_dir.path())?;
+
+    let snapshot_manifest = SnapshotManifest::load_from_snapshot(unpack_dir.path(), None)?;
+
+    // Assume full snapshot recovery in case of empty manifest
+    let full_recovery = snapshot_manifest.is_empty();
+
+    if full_recovery {
+        drop(shard);
+        clear_data(shard_path)?;
+        move_data(unpack_dir.path(), shard_path)?;
+        return Ok(());
+    }
+
+    let current_manifest = shard.snapshot_manifest()?;
+
+    drop(shard);
+
+    EdgeShard::recover_partial_snapshot(
+        shard_path,
+        &current_manifest,
+        unpack_dir.path(),
+        &snapshot_manifest,
+    )?;
+
+    Ok(())
+}

--- a/lib/edge/publish/examples/src/lib.rs
+++ b/lib/edge/publish/examples/src/lib.rs
@@ -1,0 +1,122 @@
+// Common helper items for the examples.
+// See lib/edge/python/examples/common.py for the equivalent Python helpers.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+use qdrant_edge::segment::data_types::vectors::{VectorStructInternal, DEFAULT_VECTOR_NAME};
+use qdrant_edge::segment::types::{
+    Distance, ExtendedPointId, Payload, PayloadStorageType, SegmentConfig, VectorDataConfig,
+    VectorStorageType,
+};
+use qdrant_edge::shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+use qdrant_edge::shard::operations::point_ops::PointOperations::UpsertPoints;
+use qdrant_edge::shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
+use qdrant_edge::shard::operations::CollectionUpdateOperations::PointOperation;
+use qdrant_edge::EdgeShard;
+use serde_json::{json, Value};
+
+pub fn load_new_shard(data_dir: &str) -> Result<EdgeShard, Box<dyn Error>> {
+    println!("---- Load shard ----");
+
+    // Clear and recreate data directory
+    if Path::new(data_dir).exists() {
+        fs_err::remove_dir_all(data_dir)?;
+    }
+
+    fs_err::create_dir_all(data_dir)?;
+
+    // Load Qdrant Edge shard
+    let config = SegmentConfig {
+        vector_data: {
+            HashMap::from_iter([(
+                DEFAULT_VECTOR_NAME.to_string(),
+                VectorDataConfig {
+                    size: 4,
+                    distance: Distance::Dot,
+                    storage_type: VectorStorageType::ChunkedMmap,
+                    index: Default::default(),
+                    quantization_config: None,
+                    multivector_config: None,
+                    datatype: None,
+                },
+            )])
+        },
+        sparse_vector_data: HashMap::new(),
+        payload_storage_type: PayloadStorageType::Mmap,
+    };
+
+    Ok(EdgeShard::load(Path::new(data_dir), Some(config))?)
+}
+
+pub fn fill_dummy_data(shard: &EdgeShard) -> Result<(), Box<dyn Error>> {
+    shard.update(PointOperation(UpsertPoints(PointsList(vec![
+        point(
+            1,
+            VectorStructInternal::Single(vec![0.05, 0.61, 0.76, 0.74]),
+            json!({"color": "red", "city": ["Moscow", "Berlin"]}),
+        ),
+        point(
+            2,
+            VectorStructInternal::Single(vec![0.19, 0.81, 0.75, 0.11]),
+            json!({"color": "red", "city": "Mexico"}),
+        ),
+        point(
+            3,
+            VectorStructInternal::Single(vec![0.36, 0.55, 0.47, 0.94]),
+            json!({"color": "blue", "city": ["Berlin", "Barcelona"]}),
+        ),
+        point(
+            4,
+            VectorStructInternal::Single(vec![0.12, 0.34, 0.56, 0.78]),
+            json!({"color": "green", "city": "Lisbon", "rating": 4.5}),
+        ),
+        point(
+            5,
+            VectorStructInternal::Single(vec![0.88, 0.12, 0.33, 0.44]),
+            json!({"color": "yellow", "city": ["Paris"], "active": true}),
+        ),
+        point(
+            6,
+            VectorStructInternal::Single(vec![0.21, 0.22, 0.23, 0.24]),
+            json!({"color": "blue", "city": "Tokyo", "tags": ["night", "food"]}),
+        ),
+        point(
+            7,
+            VectorStructInternal::Single(vec![0.99, 0.01, 0.50, 0.50]),
+            json!({"color": "red", "city": ["New York", "Boston"], "visits": 7}),
+        ),
+        point(
+            8,
+            VectorStructInternal::Single(vec![0.10, 0.20, 0.30, 0.40]),
+            json!({"color": "blue", "city": "Seoul", "meta": {"source": "import"}}),
+        ),
+        point(
+            9,
+            VectorStructInternal::Single(vec![0.45, 0.55, 0.65, 0.75]),
+            json!({"color": "green", "city": ["Berlin"], "score": 0.92}),
+        ),
+        point(
+            10,
+            VectorStructInternal::Single(vec![0.01, 0.02, 0.03, 0.04]),
+            json!({"color": "yellow", "city": null, "featured": false}),
+        ),
+    ]))))?;
+    Ok(())
+}
+
+pub fn point(
+    id: impl Into<ExtendedPointId>,
+    vector: impl Into<VectorStructInternal>,
+    payload: Value,
+) -> PointStructPersisted {
+    PointStructPersisted {
+        id: id.into(),
+        vector: VectorStructPersisted::from(vector.into()),
+        payload: match payload {
+            Value::Object(map) => Some(Payload(map.into_iter().collect())),
+            _ => panic!("Payload must be a JSON object"),
+        },
+    }
+}

--- a/lib/edge/python/README.md
+++ b/lib/edge/python/README.md
@@ -19,5 +19,5 @@ maturin develop --no-default-features
 Run example
 
 ```bash
-python examples/qdrant-edge.py
+python examples/demo.py
 ```

--- a/lib/edge/python/examples/common.py
+++ b/lib/edge/python/examples/common.py
@@ -1,3 +1,6 @@
+# Common helper items for the examples.
+# See lib/edge/publish/examples/src/lib.rs for the equivalent Rust helpers.
+
 import os
 import shutil
 import uuid

--- a/lib/edge/python/examples/demo.py
+++ b/lib/edge/python/examples/demo.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+# See lib/edge/publish/examples/src/bin/demo.rs for the equivalent Rust example.
 
-from common import *
 from qdrant_edge import *
 
+from common import *
 
 print("---- Point conversions ----")
 
@@ -187,6 +188,4 @@ print("---- Close and reopen shard ----")
 shard.close()
 
 reopened_shard = EdgeShard(DATA_DIRECTORY)
-
-info = reopened_shard.info()
-print(info)
+print(f"Edge shard reopened. Approx Points: {reopened_shard.info().points_count}")

--- a/lib/edge/python/examples/download_partial.py
+++ b/lib/edge/python/examples/download_partial.py
@@ -1,4 +1,6 @@
+#!/usr/bin/env python3
 # This script downloads a partial snapshot using a predefined manifest.
+
 import requests
 
 manifest = {

--- a/lib/edge/python/examples/fusion-query.py
+++ b/lib/edge/python/examples/fusion-query.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# See lib/edge/publish/examples/src/bin/fusion-query.rs for the equivalent Rust example.
+
 from qdrant_edge import *
 from common import *
 

--- a/lib/edge/python/examples/load-existing.py
+++ b/lib/edge/python/examples/load-existing.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# See lib/edge/publish/examples/src/bin/load-existing.rs for the equivalent Rust example.
 
 from qdrant_edge import *
 from common import *

--- a/lib/edge/python/examples/mmr-query.py
+++ b/lib/edge/python/examples/mmr-query.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# See lib/edge/publish/examples/src/bin/mmr-query.rs for the equivalent Rust example.
+
 from qdrant_edge import *
 from common import *
 

--- a/lib/edge/python/examples/restore-snapshot.py
+++ b/lib/edge/python/examples/restore-snapshot.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# See lib/edge/publish/examples/src/bin/restore-snapshot.rs for the equivalent Rust example.
+
 import os
 import requests
 import shutil


### PR DESCRIPTION
Mostly, port Python examples to Rust.

Changes:
- `qdrant-edge.py` example renamed to `demo.py` to match `demo.rs` (introduced in #8020).
- **Major:** A lot of logic copied from `qdrant-edge.py`/`demo.py` into `demo.rs`.
- Ported util library used in examples (`common.py` → `lib.rs`).
- **Major:** Ported `fusion-query.py`, `load-existing.py`, `mmr-query.py` 1-to-1.
- **Major:** Ported `restore-snapshot.py` (but one method is missing)
  The method `update_from_snapshot` exists only in Python (#7852). In this PR method is re-implemented/copy-pasted to the Rust example. (Probably we'll get rid of `update_from_snapshot` at all later).
- Not ported:
  - `download_partial.py` -- it's a helper script, not related to qdrant-edge usage.
  - `repr.py` -- it's more of a test of `__repr__` implementation? I don't think we need to test `Debug` in Rust.
- It turns out that we need to re-export `sparse` to be able to create sparse vectors.
- Make python examples executable. (shebangs + `chmod +x`)

---

The most tedious parts are done by Claude and Codex, with following prompt for Codex to let it generate prompt for Claude.
> This example is ported from similar python example by Claude.
> Review them and check whether they are 1-to-1 translation from existing python examples.
> I.e. no comments are missing, and no extra comments are added. Code structure is same, variable names are the same. No corners are cut.
> Permitted differences: in python we have constructors with default parameters. In Rust we have to initialize structures by specifying all arguments. Don't lest such differences.
> 
> In case of differences, list them (don't fix them yet). Also include short one-two line snippets to illustrate each difference.