### PR TITLE
Log full transfer info on aborting a shard transfer

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -313,7 +313,7 @@ impl Collection {
     ) -> CollectionResult<()> {
         // TODO: Ensure cancel safety!
         let transfer_key = transfer.key();
-        log::debug!("Aborting shard transfer {transfer_key:?}");
+        log::debug!("Aborting shard transfer {transfer:?}");
 
         let _transfer_result = self
             .transfer_tasks


### PR DESCRIPTION
The shard transfers are identified by peers, shard id and method. Add missing `method` info into the log line emitted by abort_shard_transfer.

Instead 
`2026-03-10T04:25:34.884828Z DEBUG collection::collection::shard_transfer: Aborting shard transfer ShardTransferKey { shard_id: 1, to_shard_id: None, from: X, to: Y }`

Log this:
`2026-03-10T07:57:35.837477Z DEBUG collection::collection::shard_transfer: Aborting shard transfer ShardTransfer { shard_id: 2, to_shard_id: None, from: X, to: Y, sync: true, method: Some(Snapshot), filter: None }`

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --workspace --all-features` command?
