### PR TITLE
review: Alternative for #8350

### DIFF
--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -16,32 +16,59 @@ use crate::universal_io::{
 /// Trait for mmap types that support read access to a slice of `T`.
 ///
 /// Both [`MmapSlice<T>`] and [`MmapSliceReadOnly<T>`] satisfy this trait.
-pub trait MmapReadAccess<T>: AsRef<[T]> + std::fmt::Debug {
+pub trait MmapAccess<T>: AsRef<[T]> + std::fmt::Debug {
+    fn open_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> Result<Self>
+    where
+        Self: Sized;
+
     fn populate(&self) -> std::io::Result<()>;
-    fn len(&self) -> usize;
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
 
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
-impl<T: Copy + 'static> MmapReadAccess<T> for MmapSlice<T> {
+// MmapMut-backed slice
+impl<T: Copy + 'static> MmapAccess<T> for MmapSlice<T> {
+    fn open_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> Result<Self> {
+        let mmap = open_write_mmap(path, advice, populate).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                UniversalIoError::NotFound {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                e.into()
+            }
+        })?;
+        Ok(unsafe { MmapSlice::try_from(mmap) }?)
+    }
+
     fn populate(&self) -> std::io::Result<()> {
         MmapSlice::populate(self)
     }
-
-    fn len(&self) -> usize {
-        self.as_ref().len()
-    }
 }
 
-impl<T: Copy + 'static> MmapReadAccess<T> for MmapSliceReadOnly<T> {
-    fn populate(&self) -> std::io::Result<()> {
-        MmapSliceReadOnly::populate(self)
+// Mmap (read only) backed slice
+impl<T: Copy + 'static> MmapAccess<T> for MmapSliceReadOnly<T> {
+    fn open_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> Result<Self> {
+        let mmap = open_read_mmap(path, advice, populate).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                UniversalIoError::NotFound {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                e.into()
+            }
+        })?;
+        Ok(unsafe { MmapSliceReadOnly::try_from(mmap) }?)
     }
 
-    fn len(&self) -> usize {
-        self.as_ref().len()
+    fn populate(&self) -> std::io::Result<()> {
+        MmapSliceReadOnly::populate(self)
     }
 }
 
@@ -50,7 +77,7 @@ impl<T: Copy + 'static> MmapReadAccess<T> for MmapSliceReadOnly<T> {
 /// `M` defaults to [`MmapSlice<T>`] (read-write) for backward compatibility.
 /// Use [`MmapUniversalRo<T>`] for a read-only variant that opens with `Mmap` instead of `MmapMut`.
 #[derive(Debug)]
-pub struct MmapUniversal<T: Copy + 'static, M: MmapReadAccess<T> = MmapSlice<T>> {
+pub struct MmapUniversal<T: Copy + 'static, M: MmapAccess<T> = MmapSlice<T>> {
     path: PathBuf,
     /// Main data mmap slice for read (and optionally write)
     ///
@@ -63,18 +90,16 @@ pub struct MmapUniversal<T: Copy + 'static, M: MmapReadAccess<T> = MmapSlice<T>>
     _phantom: PhantomData<T>,
 }
 
-/// Read-write mmap universal (default, backward-compatible alias).
+/// Read-write mmap universal (default).
 pub type MmapUniversalRw<T> = MmapUniversal<T, MmapSlice<T>>;
 
 /// Read-only mmap universal.
 pub type MmapUniversalRo<T> = MmapUniversal<T, MmapSliceReadOnly<T>>;
 
-// --- Shared read logic ---
-
 impl<T, M> MmapUniversal<T, M>
 where
     T: Copy + 'static,
-    M: MmapReadAccess<T>,
+    M: MmapAccess<T>,
 {
     fn as_seq_slice(&self) -> &[T] {
         self.mmap_seq
@@ -90,8 +115,60 @@ where
             self.mmap.as_ref()
         }
     }
+}
 
-    fn read_impl<const SEQUENTIAL: bool>(&self, range: ElementsRange) -> Result<Cow<'_, [T]>> {
+impl<T, M> UniversalReadFileOps for MmapUniversal<T, M>
+where
+    T: 'static + Copy,
+    M: MmapAccess<T>,
+{
+    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
+        local_list_files(prefix_path)
+    }
+
+    fn exists(path: &Path) -> Result<bool> {
+        fs_err::exists(path).map_err(Into::into)
+    }
+}
+
+impl<T, M> UniversalRead<T> for MmapUniversal<T, M>
+where
+    T: Copy + 'static,
+    M: MmapAccess<T>,
+{
+    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let OpenOptions {
+            need_sequential,
+            disk_parallel: _,
+            populate,
+            advice,
+        } = options;
+
+        let mmap_file = path.as_ref();
+        let advice = advice.unwrap_or(AdviceSetting::Global);
+
+        let mmap = M::open_mmap(mmap_file, advice, populate.unwrap_or_default())?;
+
+        let mmap_seq = if *MULTI_MMAP_IS_SUPPORTED && need_sequential {
+            let mmap_seq =
+                open_read_mmap(mmap_file, AdviceSetting::Advice(Advice::Sequential), false)?;
+            Some(unsafe { MmapSliceReadOnly::try_from(mmap_seq) }?)
+        } else {
+            None
+        };
+
+        Ok(MmapUniversal {
+            path: mmap_file.to_path_buf(),
+            mmap,
+            mmap_seq,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn read<const SEQUENTIAL: bool>(&self, range: ElementsRange) -> Result<Cow<'_, [T]>> {
         let data_slice = self.as_slice::<SEQUENTIAL>();
         let start = range.start as usize;
         let end = start + range.length as usize;
@@ -107,7 +184,7 @@ where
         Ok(Cow::Borrowed(data_range))
     }
 
-    fn read_batch_impl<const SEQUENTIAL: bool>(
+    fn read_batch<const SEQUENTIAL: bool>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
         mut callback: impl FnMut(usize, &[T]) -> Result<()>,
@@ -133,12 +210,11 @@ where
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
-    fn len_impl(&self) -> Result<u64> {
+    fn len(&self) -> Result<u64> {
         Ok(self.mmap.len() as u64)
     }
 
-    fn populate_impl(&self) -> Result<()> {
+    fn populate(&self) -> Result<()> {
         if let Some(mmap_seq) = &self.mmap_seq {
             mmap_seq.populate()?;
         } else {
@@ -147,184 +223,13 @@ where
         Ok(())
     }
 
-    fn clear_ram_cache_impl(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> Result<()> {
         crate::fs::clear_disk_cache(&self.path)?;
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
-    fn read_whole_impl(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole(&self) -> Result<Cow<'_, [T]>> {
         Ok(Cow::Borrowed(self.mmap.as_ref()))
-    }
-}
-
-// --- UniversalReadFileOps (generic over M) ---
-
-impl<T, M> UniversalReadFileOps for MmapUniversal<T, M>
-where
-    T: 'static + Copy,
-    M: MmapReadAccess<T>,
-{
-    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
-        local_list_files(prefix_path)
-    }
-
-    fn exists(path: &Path) -> Result<bool> {
-        fs_err::exists(path).map_err(Into::into)
-    }
-}
-
-// --- UniversalRead for read-write variant ---
-
-impl<T> UniversalRead<T> for MmapUniversal<T, MmapSlice<T>>
-where
-    T: Copy + 'static,
-{
-    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        let OpenOptions {
-            need_sequential,
-            disk_parallel: _,
-            populate,
-            advice,
-        } = options;
-
-        let mmap_file = path.as_ref();
-        let advice = advice.unwrap_or(AdviceSetting::Global);
-
-        let mmap =
-            open_write_mmap(mmap_file, advice, populate.unwrap_or_default()).map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    UniversalIoError::NotFound {
-                        path: mmap_file.to_path_buf(),
-                    }
-                } else {
-                    e.into()
-                }
-            })?;
-        let mmap = unsafe { MmapSlice::try_from(mmap) }?;
-
-        let mmap_seq = if *MULTI_MMAP_IS_SUPPORTED && need_sequential {
-            let mmap_seq =
-                open_read_mmap(mmap_file, AdviceSetting::Advice(Advice::Sequential), false)?;
-            Some(unsafe { MmapSliceReadOnly::try_from(mmap_seq) }?)
-        } else {
-            None
-        };
-
-        Ok(MmapUniversal {
-            path: mmap_file.to_path_buf(),
-            mmap,
-            mmap_seq,
-            _phantom: PhantomData,
-        })
-    }
-
-    fn read<const SEQUENTIAL: bool>(&self, range: ElementsRange) -> Result<Cow<'_, [T]>> {
-        self.read_impl::<SEQUENTIAL>(range)
-    }
-
-    fn read_batch<const SEQUENTIAL: bool>(
-        &self,
-        ranges: impl IntoIterator<Item = ElementsRange>,
-        callback: impl FnMut(usize, &[T]) -> Result<()>,
-    ) -> Result<()> {
-        self.read_batch_impl::<SEQUENTIAL>(ranges, callback)
-    }
-
-    fn len(&self) -> Result<u64> {
-        self.len_impl()
-    }
-
-    fn populate(&self) -> Result<()> {
-        self.populate_impl()
-    }
-
-    fn clear_ram_cache(&self) -> Result<()> {
-        self.clear_ram_cache_impl()
-    }
-
-    fn read_whole(&self) -> Result<Cow<'_, [T]>> {
-        self.read_whole_impl()
-    }
-}
-
-// --- UniversalRead for read-only variant ---
-
-impl<T> UniversalRead<T> for MmapUniversal<T, MmapSliceReadOnly<T>>
-where
-    T: Copy + 'static,
-{
-    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        let OpenOptions {
-            need_sequential,
-            disk_parallel: _,
-            populate,
-            advice,
-        } = options;
-
-        let mmap_file = path.as_ref();
-        let advice = advice.unwrap_or(AdviceSetting::Global);
-
-        let mmap =
-            open_read_mmap(mmap_file, advice, populate.unwrap_or_default()).map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    UniversalIoError::NotFound {
-                        path: mmap_file.to_path_buf(),
-                    }
-                } else {
-                    e.into()
-                }
-            })?;
-        let mmap = unsafe { MmapSliceReadOnly::try_from(mmap) }?;
-
-        let mmap_seq = if *MULTI_MMAP_IS_SUPPORTED && need_sequential {
-            let mmap_seq =
-                open_read_mmap(mmap_file, AdviceSetting::Advice(Advice::Sequential), false)?;
-            Some(unsafe { MmapSliceReadOnly::try_from(mmap_seq) }?)
-        } else {
-            None
-        };
-
-        Ok(MmapUniversal {
-            path: mmap_file.to_path_buf(),
-            mmap,
-            mmap_seq,
-            _phantom: PhantomData,
-        })
-    }
-
-    fn read<const SEQUENTIAL: bool>(&self, range: ElementsRange) -> Result<Cow<'_, [T]>> {
-        self.read_impl::<SEQUENTIAL>(range)
-    }
-
-    fn read_batch<const SEQUENTIAL: bool>(
-        &self,
-        ranges: impl IntoIterator<Item = ElementsRange>,
-        callback: impl FnMut(usize, &[T]) -> Result<()>,
-    ) -> Result<()> {
-        self.read_batch_impl::<SEQUENTIAL>(ranges, callback)
-    }
-
-    fn len(&self) -> Result<u64> {
-        self.len_impl()
-    }
-
-    fn populate(&self) -> Result<()> {
-        self.populate_impl()
-    }
-
-    fn clear_ram_cache(&self) -> Result<()> {
-        self.clear_ram_cache_impl()
-    }
-
-    fn read_whole(&self) -> Result<Cow<'_, [T]>> {
-        self.read_whole_impl()
     }
 }
 


### PR DESCRIPTION
I did this as a review for #8350 in a separate PR since it was a substantial change.

Prompt:
> /simplify There are two very similar implementations, only varying in how they open the main mmap. Check if we can get rid of `MmapReadAccess`, or reuse it for opening based on the underlying type.

Then I just did a few nit edits, like renaming to `MmapAccess`.
