### PR TITLE
Deletions with deferred points bug

### DIFF
--- a/lib/collection/src/tests/deferred_points_dedup.rs
+++ b/lib/collection/src/tests/deferred_points_dedup.rs
@@ -7,7 +7,7 @@ use common::save_on_disk::SaveOnDisk;
 use rand::rng;
 use segment::data_types::vectors::VectorStructInternal;
 use segment::fixtures::payload_fixtures::random_vector;
-use segment::types::Distance;
+use segment::types::{Distance, Filter, PointIdType};
 use tempfile::{Builder, TempDir};
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -270,6 +270,137 @@ async fn test_deferred_points_dedup_after_optimization() {
 
     // Step 4: Assert no duplicate non-deferred point IDs across segments
     assert_no_duplicate_point_ids(&shard);
+
+    shard.stop_gracefully().await;
+}
+
+fn delete_by_ids_op(ids: Vec<PointIdType>) -> OperationWithClockTag {
+    CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints { ids }).into()
+}
+
+fn delete_by_filter_op(filter: Filter) -> OperationWithClockTag {
+    CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(filter)).into()
+}
+
+/// Count total available (non-deleted) points across all segments.
+fn total_point_count(shard: &LocalShard) -> usize {
+    let segments = shard.segments();
+    let holder = segments.read();
+    holder
+        .iter()
+        .map(|(_, segment)| segment.get().read().available_point_count())
+        .sum()
+}
+
+/// Set up a shard where points have a newer deferred copy and an older non-deferred copy.
+///
+/// Returns the shard after:
+/// 1. Insert points + wait for optimization (all points non-deferred in optimized segment)
+/// 2. Overwrite all points (creates deferred copies in appendable segment)
+/// 3. Plunge to apply update, verify deferred points exist
+async fn setup_shard_with_deferred_points() -> (LocalShard, TempDir) {
+    let (shard, tmp_dir) = build_shard().await;
+    let hw_acc = HwMeasurementAcc::new();
+    let timeout = Duration::from_secs(30);
+
+    // Insert initial points and wait for optimization so they are non-deferred in optimized segment
+    shard
+        .update(upsert_op(random_points()), true, None, hw_acc.clone())
+        .await
+        .unwrap();
+    wait_optimization(&shard, timeout).await;
+
+    // Overwrite all points — creates newer deferred copies in appendable segment
+    // while old non-deferred copies remain in the optimized segment
+    shard
+        .update(upsert_op(random_points()), false, None, hw_acc.clone())
+        .await
+        .unwrap();
+    shard.plunge_async().await.unwrap().await.unwrap();
+
+    // Verify we actually have deferred points, otherwise the test scenario is invalid
+    let has_deferred = shard
+        .segments()
+        .read()
+        .iter()
+        .any(|segment| !segment.1.get().read().deferred_point_ids().is_empty());
+    assert!(
+        has_deferred,
+        "Expected deferred points after overwrites, but found none"
+    );
+
+    (shard, tmp_dir)
+}
+
+/// Test that delete-by-ID removes all copies of a point, including old non-deferred
+/// copies when the latest version is deferred.
+///
+/// Bug scenario:
+/// 1. Point X is in optimized segment (v5, non-deferred, visible)
+/// 2. Upsert creates a new copy in appendable segment (v10, deferred, hidden)
+/// 3. Delete by ID should remove from ALL segments
+/// 4. After optimization, point should be completely gone
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_by_id_with_deferred_points() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let (shard, _tmp_dir) = setup_shard_with_deferred_points().await;
+    let hw_acc = HwMeasurementAcc::new();
+    let timeout = Duration::from_secs(30);
+
+    // Delete all points by ID
+    let all_ids: Vec<PointIdType> = (0..NUM_POINTS).map(|i| i.into()).collect();
+    shard
+        .update(delete_by_ids_op(all_ids), false, None, hw_acc.clone())
+        .await
+        .unwrap();
+    shard.plunge_async().await.unwrap().await.unwrap();
+
+    // Wait for optimization to settle (deferred points trigger optimization)
+    wait_optimization(&shard, timeout).await;
+
+    // All points should be gone
+    let remaining = total_point_count(&shard);
+    assert_eq!(
+        remaining, 0,
+        "Expected 0 points after delete-by-ID, but {remaining} survived \
+         (old non-deferred copies likely not deleted when latest was deferred)"
+    );
+
+    shard.stop_gracefully().await;
+}
+
+/// Test that delete-by-filter removes all copies of a point, including deferred ones.
+/// This uses an empty filter (matches all points) to mirror the delete-by-ID test above.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_by_filter_with_deferred_points() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let (shard, _tmp_dir) = setup_shard_with_deferred_points().await;
+    let hw_acc = HwMeasurementAcc::new();
+    let timeout = Duration::from_secs(30);
+
+    // Delete all points by filter (empty filter = match all)
+    shard
+        .update(
+            delete_by_filter_op(Filter::default()),
+            false,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .unwrap();
+    shard.plunge_async().await.unwrap().await.unwrap();
+
+    // Wait for optimization to settle
+    wait_optimization(&shard, timeout).await;
+
+    // All points should be gone
+    let remaining = total_point_count(&shard);
+    assert_eq!(
+        remaining, 0,
+        "Expected 0 points after delete-by-filter, but {remaining} survived"
+    );
 
     shard.stop_gracefully().await;
 }

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -338,7 +338,11 @@ fn upsert_with_payload(
 /// Max amount of points to delete in a batched deletion iteration
 const DELETION_BATCH_SIZE: usize = 512;
 
-/// Tries to delete points from all segments, returns number of actually deleted points
+/// Tries to delete points from all segments, returns number of actually deleted points.
+///
+/// Iterates all segments directly (rather than going through `apply_points`) to ensure
+/// that ALL copies of a point are deleted, including old non-deferred copies in optimized
+/// segments when the latest version is deferred in an appendable segment.
 pub fn delete_points(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
@@ -348,12 +352,19 @@ pub fn delete_points(
     let mut total_deleted_points = 0;
 
     for batch in ids.chunks(DELETION_BATCH_SIZE) {
-        let deleted_points =
-            segments.apply_points(batch, hw_counter, |id, _idx, write_segment| {
-                write_segment.delete_point(op_num, id, hw_counter)
-            })?;
+        for (_segment_id, segment) in segments.iter() {
+            let segment_arc = segment.get();
+            let mut write_segment = segment_arc.write();
+            for &id in batch {
+                if write_segment.delete_point(op_num, id, hw_counter)? {
+                    total_deleted_points += 1;
+                }
+            }
+        }
+    }
 
-        total_deleted_points += deleted_points;
+    if total_deleted_points == 0 {
+        segments.bump_max_segment_version_overwrite(op_num);
     }
 
     Ok(total_deleted_points)


### PR DESCRIPTION
## Summary
Fix `delete_points` (by ID) failing to remove old non-deferred copies of points when the latest version is deferred
Add regression tests for delete-by-ID and delete-by-filter with deferred points

## Bug
When a point exists as both an old non-deferred copy in an optimized segment (visible to searches) and a newer deferred copy in an appendable segment (hidden until optimization), `delete_points` only deleted the deferred copy. The old non-deferred copy survived, leaving the point still visible to users after deletion.

Root cause: `delete_points` went through `apply_points` → `find_points_to_update_and_delete`, which intentionally keeps older non-deferred copies when the latest version is deferred-only (`latest_has_non_deferred == false`). This rule is correct for upsert/payload operations (keeps the point visible while deferred indexing completes), but wrong for deletes where the user expects the point to disappear entirely.

Reproduction: Insert points, wait for optimization, overwrite all points (creates deferred copies), then delete all by ID — 196/200 points survive.

Notably, delete_points_by_filter was not affected because it bypasses find_points_to_update_and_delete and iterates all segments directly.

## Fix
Changed `delete_points` to iterate all segments directly and call `delete_point` on each — the same pattern already used by `delete_points_by_filter`. No changes to `find_points_to_update_and_delete` or `apply_points` (their behavior remains correct for non-delete operations).