### PR TITLE
Fixed the deduplicate snapshot path problem

### DIFF
--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -216,6 +216,30 @@ impl SnapshotStorageManager {
     }
 }
 
+/// Resolves and validates that `snapshot_name` is a file that lives inside `snapshots_path`.
+fn resolve_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> CollectionResult<PathBuf> {
+    let absolute_snapshot_dir = fs::canonicalize(snapshots_path).map_err(|_| {
+        CollectionError::not_found(format!("Snapshot directory: {}", snapshots_path.display()))
+    })?;
+
+    let absolute_snapshot_path = fs::canonicalize(absolute_snapshot_dir.join(snapshot_name))
+        .map_err(|_| CollectionError::not_found(format!("Snapshot {snapshot_name}")))?;
+
+    if !absolute_snapshot_path.starts_with(&absolute_snapshot_dir) {
+        return Err(CollectionError::not_found(format!(
+            "Snapshot {snapshot_name}"
+        )));
+    }
+
+    if !absolute_snapshot_path.is_file() {
+        return Err(CollectionError::not_found(format!(
+            "Snapshot {snapshot_name}"
+        )));
+    }
+
+    Ok(absolute_snapshot_path)
+}
+
 impl SnapshotStorageLocalFS {
     async fn delete_snapshot(&self, snapshot_path: &Path) -> CollectionResult<bool> {
         let checksum_path = get_checksum_path(snapshot_path);
@@ -327,52 +351,14 @@ impl SnapshotStorageLocalFS {
         snapshots_path: &Path,
         snapshot_name: &str,
     ) -> CollectionResult<PathBuf> {
-        let absolute_snapshot_dir = fs::canonicalize(snapshots_path).map_err(|_| {
-            CollectionError::not_found(format!("Snapshot directory: {}", snapshots_path.display()))
-        })?;
-
-        let absolute_snapshot_path = fs::canonicalize(absolute_snapshot_dir.join(snapshot_name))
-            .map_err(|_| CollectionError::not_found(format!("Snapshot {snapshot_name}")))?;
-
-        if !absolute_snapshot_path.starts_with(absolute_snapshot_dir) {
-            return Err(CollectionError::not_found(format!(
-                "Snapshot {snapshot_name}"
-            )));
-        }
-
-        if !absolute_snapshot_path.is_file() {
-            return Err(CollectionError::not_found(format!(
-                "Snapshot {snapshot_name}"
-            )));
-        }
-
-        Ok(absolute_snapshot_path)
+        resolve_snapshot_path(snapshots_path, snapshot_name)
     }
 
     /// Get absolute file path for a collection snapshot by name
     ///
     /// This enforces the file to be inside the snapshots directory
     fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> CollectionResult<PathBuf> {
-        let absolute_snapshot_dir = fs::canonicalize(snapshots_path).map_err(|_| {
-            CollectionError::not_found(format!("Snapshot directory: {}", snapshots_path.display()))
-        })?;
-
-        let absolute_snapshot_path = fs::canonicalize(absolute_snapshot_dir.join(snapshot_name))
-            .map_err(|_| CollectionError::not_found(format!("Snapshot {snapshot_name}")))?;
-
-        if !absolute_snapshot_path.starts_with(absolute_snapshot_dir) {
-            return Err(CollectionError::not_found(format!(
-                "Snapshot {snapshot_name}"
-            )));
-        }
-
-        if !absolute_snapshot_path.is_file() {
-            return Err(CollectionError::not_found(format!(
-                "Snapshot {snapshot_name}"
-            )));
-        }
-
-        Ok(absolute_snapshot_path)
+        resolve_snapshot_path(snapshots_path, snapshot_name)
     }
 
     fn get_snapshot_file(


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Description
**Refactor:** Deduplicate identical `get_snapshot_path` / `get_full_snapshot_path` in `SnapshotStorageLocalFS`.
The two private methods `get_snapshot_path` and `get_full_snapshot_path` on `SnapshotStorageLocalFS` were  identical. 
The only difference between them was the doc-comment ("full snapshot" vs "collection snapshot").

### Fix

Extracted a single private free function:

```rust
fn resolve_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> CollectionResult<PathBuf>
```

Both `get_full_snapshot_path` and `get_snapshot_path` on `SnapshotStorageLocalFS` now delegate to it, eliminating ~25 lines of duplicated logic.
