### PR TITLE
openning read-only mmap should not require creation and append mode

### DIFF
--- a/lib/common/common/src/mmap/ops.rs
+++ b/lib/common/common/src/mmap/ops.rs
@@ -84,11 +84,7 @@ pub fn create_and_ensure_length(path: &Path, length: usize) -> io::Result<File> 
 }
 
 pub fn open_read_mmap(path: &Path, advice: AdviceSetting, populate: bool) -> io::Result<Mmap> {
-    let file = OpenOptions::new()
-        .read(true)
-        .append(true)
-        .create(true)
-        .open(path)?;
+    let file = OpenOptions::new().read(true).open(path)?;
 
     let mmap = unsafe { Mmap::map(&file)? };
 


### PR DESCRIPTION
This change is needed to make make Mmap-based file reading re-usable in the situations, where file might not exist and we want explicitly handle it.


From AI:

```
Every single caller is opening a file that's expected to already exist. None of them need .create(true):

1. sparse/src/index/loaders.rs — Csr::open — opens existing sparse index data
2. common/src/universal_io/mmap.rs — MmapUniversal::open sequential read mmap — opens existing data file
3. segment/src/index/hnsw_index/graph_links.rs — opens existing HNSW graph links file
4. common/src/mmap_hashmap.rs — MmapHashMap::open — opens existing hash map file
5. sparse/src/index/inverted_index/inverted_index_mmap.rs — opens existing inverted index data
6. sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs — opens existing compressed inverted index data (2 call sites)
7. segment/src/index/field_index/.../mmap_postings.rs — opens existing full-text postings file
8. common/src/fs/check.rs — opens a magic file that was just created by open_write_mmap moments earlier (2 call sites)
9. common/src/mmap/mmap_rw.rs — test, opens a temp file that already exists
10. common/src/mmap/mmap_readonly.rs — test, opens a temp file that already exists

None of these callers want or need file creation. Every single one expects the file to already exist. The .create(true).append(true) in open_read_mmap is a bug — it should be simply .read(true), matching the read-only intent:
```

