### PR TITLE
Use dedup() instead of unique()

### DIFF
--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -85,6 +85,16 @@ impl Segment {
                     .iter_values_map(hw_counter)
                     .stop_if(is_stopped)
                     .filter_map(|(value, iter)| {
+                        #[cfg(debug_assertions)]
+                        let iter = {
+                            let mut prev_id = None;
+                            iter.inspect(move |&id| {
+                                let previous = prev_id.get_or_insert(id);
+                                debug_assert!(*previous <= id, "Sorted iter assertion broken");
+                                *previous = id;
+                            })
+                        };
+
                         let count = iter
                             .dedup()
                             .take_while(|&point_id| {


### PR DESCRIPTION
Since `iter` is ordered here, we can use [dedup()](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.dedup) instead of [unique()](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.unique), which does unnecessary allocations.
dedup() prevents these, resulting in better performance and less allocations.