### PR TITLE
Concurrent gridstore value deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7022,6 +7022,7 @@ dependencies = [
  "clap",
  "common",
  "criterion",
+ "dashmap",
  "data-encoding",
  "dataset",
  "delegate",

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -304,7 +304,7 @@ impl<V: Blob> Gridstore<V> {
     ///
     /// Returns None if the point_offset, page, or value was not found.
     /// Returns the deleted value otherwise.
-    pub fn delete_value(&mut self, point_offset: PointOffset) -> Result<Option<V>> {
+    pub fn delete_value(&self, point_offset: PointOffset) -> Result<Option<V>> {
         let Some(pointer) = self.tracker.write().unset(point_offset)? else {
             return Ok(None);
         };

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -924,7 +924,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(path.clone()).unwrap();
+    let storage = Gridstore::<Payload>::open(path.clone()).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let flusher = storage.flusher();

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -43,6 +43,7 @@ pprof = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
+dashmap = { workspace = true }
 data-encoding = { workspace = true }
 delegate = { workspace = true }
 fs-err = { workspace = true }

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -233,7 +233,7 @@ mod tests {
 
     pub fn fixture_payload_provider() -> PayloadProvider {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
-        let mut in_memory_storage = InMemoryPayloadStorage::default();
+        let in_memory_storage = InMemoryPayloadStorage::default();
 
         // For point id 0: a payload with a numeric value.
         let payload0: Payload = from_value(json!({

--- a/lib/segment/src/payload_storage/in_memory_payload_storage.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage.rs
@@ -1,5 +1,5 @@
-use ahash::AHashMap;
 use common::types::PointOffsetType;
+use dashmap::DashMap;
 
 use crate::types::Payload;
 
@@ -7,11 +7,14 @@ use crate::types::Payload;
 /// Warn: for tests only
 #[derive(Debug, Default)]
 pub struct InMemoryPayloadStorage {
-    pub(crate) payload: AHashMap<PointOffsetType, Payload>,
+    pub(crate) payload: DashMap<PointOffsetType, Payload>,
 }
 
 impl InMemoryPayloadStorage {
-    pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
+    pub fn payload_ptr(
+        &self,
+        point_id: PointOffsetType,
+    ) -> Option<dashmap::mapref::one::Ref<'_, u32, Payload>> {
         self.payload.get(&point_id)
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -29,7 +29,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         _hw_counter: &HardwareCounterCell, // No measurement needed for in memory payload
     ) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge(payload),
+            Some(mut point_payload) => point_payload.merge(payload),
             None => {
                 self.payload.insert(point_id, payload.to_owned());
             }
@@ -45,7 +45,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge_by_key(payload, key),
+            Some(mut point_payload) => point_payload.merge_by_key(payload, key),
             None => {
                 let mut dest_payload = Payload::default();
                 dest_payload.merge_by_key(payload, key);
@@ -82,7 +82,7 @@ impl PayloadStorage for InMemoryPayloadStorage {
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<Vec<Value>> {
         match self.payload.get_mut(&point_id) {
-            Some(payload) => {
+            Some(mut payload) => {
                 let res = payload.remove(key);
                 Ok(res)
             }
@@ -91,17 +91,17 @@ impl PayloadStorage for InMemoryPayloadStorage {
     }
 
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<Option<Payload>> {
         let res = self.payload.remove(&point_id);
-        Ok(res)
+        Ok(res.map(|(_key, value)| value))
     }
 
     #[cfg(test)]
     fn clear_all(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
-        self.payload = ahash::AHashMap::new();
+        self.payload = Default::default();
         Ok(())
     }
 
@@ -113,8 +113,8 @@ impl PayloadStorage for InMemoryPayloadStorage {
     where
         F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
     {
-        for (key, val) in self.payload.iter() {
-            let do_continue = callback(*key, val)?;
+        for entry in self.payload.iter() {
+            let do_continue = callback(*entry.key(), entry.value())?;
             if !do_continue {
                 return Ok(());
             }
@@ -128,10 +128,10 @@ impl PayloadStorage for InMemoryPayloadStorage {
 
     fn get_storage_size_bytes(&self) -> OperationResult<usize> {
         let mut estimated_size = 0;
-        for (_p_id, val) in self.payload.iter() {
+        for payload_entry in self.payload.iter() {
             // account for point_id
             estimated_size += size_of::<PointOffsetType>();
-            for (key, val) in val.0.iter() {
+            for (key, val) in payload_entry.value().0.iter() {
                 // account for key and value
                 estimated_size += key.len() + serde_json::to_string(val).unwrap().len()
             }

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -193,7 +193,7 @@ impl PayloadStorage for MmapPayloadStorage {
     }
 
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         _: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>> {

--- a/lib/segment/src/payload_storage/on_disk_payload_storage.rs
+++ b/lib/segment/src/payload_storage/on_disk_payload_storage.rs
@@ -169,7 +169,7 @@ impl PayloadStorage for OnDiskPayloadStorage {
     }
 
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>> {

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -58,7 +58,7 @@ pub trait PayloadStorage {
 
     /// Clear all payload of the point
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>>;

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -172,7 +172,7 @@ impl PayloadStorage for PayloadStorageEnum {
     }
 
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>> {

--- a/lib/segment/src/payload_storage/simple_payload_storage.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use dashmap::DashMap;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
@@ -15,13 +15,13 @@ use crate::types::Payload;
 /// Persists all changes to disk using `store`, but only uses this storage during the initial load
 #[derive(Debug)]
 pub struct SimplePayloadStorage {
-    pub(crate) payload: AHashMap<PointOffsetType, Payload>,
+    pub(crate) payload: DashMap<PointOffsetType, Payload>,
     pub(crate) db_wrapper: DatabaseColumnScheduledDeleteWrapper,
 }
 
 impl SimplePayloadStorage {
     pub fn open(database: Arc<RwLock<DB>>) -> OperationResult<Self> {
-        let mut payload_map: AHashMap<PointOffsetType, Payload> = Default::default();
+        let payload_map: DashMap<PointOffsetType, Payload> = Default::default();
 
         let db_wrapper = DatabaseColumnScheduledDeleteWrapper::new(DatabaseColumnWrapper::new(
             database,
@@ -55,7 +55,7 @@ impl SimplePayloadStorage {
         match self.payload.get(&point_id) {
             None => self.db_wrapper.remove(point_id_serialized),
             Some(payload) => {
-                let payload_serialized = serde_cbor::to_vec(payload).unwrap();
+                let payload_serialized = serde_cbor::to_vec(&*payload).unwrap();
                 hw_counter
                     .payload_io_write_counter()
                     .incr_delta(payload_serialized.len());
@@ -64,7 +64,10 @@ impl SimplePayloadStorage {
         }
     }
 
-    pub fn payload_ptr(&self, point_id: PointOffsetType) -> Option<&Payload> {
+    pub fn payload_ptr(
+        &self,
+        point_id: PointOffsetType,
+    ) -> Option<dashmap::mapref::one::Ref<'_, u32, Payload>> {
         self.payload.get(&point_id)
     }
 

--- a/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/simple_payload_storage_impl.rs
@@ -30,7 +30,7 @@ impl PayloadStorage for SimplePayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge(payload),
+            Some(mut point_payload) => point_payload.merge(payload),
             None => {
                 self.payload.insert(point_id, payload.to_owned());
             }
@@ -49,7 +49,7 @@ impl PayloadStorage for SimplePayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge_by_key(payload, key),
+            Some(mut point_payload) => point_payload.merge_by_key(payload, key),
             None => {
                 let mut dest_payload = Payload::default();
                 dest_payload.merge_by_key(payload, key);
@@ -85,7 +85,7 @@ impl PayloadStorage for SimplePayloadStorage {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<Value>> {
         match self.payload.get_mut(&point_id) {
-            Some(payload) => {
+            Some(mut payload) => {
                 let res = payload.remove(key);
                 if !res.is_empty() {
                     self.update_storage(point_id, hw_counter)?;
@@ -97,18 +97,18 @@ impl PayloadStorage for SimplePayloadStorage {
     }
 
     fn clear(
-        &mut self,
+        &self,
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>> {
         let res = self.payload.remove(&point_id);
         self.update_storage(point_id, hw_counter)?;
-        Ok(res)
+        Ok(res.map(|(_key, payload)| payload))
     }
 
     #[cfg(test)]
     fn clear_all(&mut self, _: &HardwareCounterCell) -> OperationResult<()> {
-        self.payload = ahash::AHashMap::new();
+        self.payload = Default::default();
         self.db_wrapper.recreate_column_family()
     }
 
@@ -120,8 +120,8 @@ impl PayloadStorage for SimplePayloadStorage {
     where
         F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
     {
-        for (key, val) in self.payload.iter() {
-            let do_continue = callback(*key, val)?;
+        for entry in self.payload.iter() {
+            let do_continue = callback(*entry.key(), entry.value())?;
             if !do_continue {
                 return Ok(());
             }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -13,6 +13,7 @@ use ahash::AHashSet;
 use bytemuck::{Pod, Zeroable};
 use common::stable_hash::StableHash;
 use common::types::{PointOffsetType, ScoreType};
+use dashmap::mapref::one::Ref as DashMapRef;
 use ecow::EcoString;
 use fnv::FnvBuildHasher;
 use geo::{Contains, Coord, Distance as GeoDistance, Haversine, LineString, Point, Polygon};
@@ -2034,6 +2035,7 @@ impl From<Map<String, Value>> for Payload {
 #[derive(Clone, Debug)]
 pub enum OwnedPayloadRef<'a> {
     Ref(&'a Map<String, Value>),
+    DashMapRef(Rc<DashMapRef<'a, u32, Payload>>),
     Owned(Rc<Map<String, Value>>),
 }
 
@@ -2043,6 +2045,7 @@ impl Deref for OwnedPayloadRef<'_> {
     fn deref(&self) -> &Self::Target {
         match self {
             OwnedPayloadRef::Ref(reference) => reference,
+            OwnedPayloadRef::DashMapRef(dashmap_ref) => &dashmap_ref.deref().0,
             OwnedPayloadRef::Owned(owned) => owned.deref(),
         }
     }
@@ -2052,6 +2055,7 @@ impl AsRef<Map<String, Value>> for OwnedPayloadRef<'_> {
     fn as_ref(&self) -> &Map<String, Value> {
         match self {
             OwnedPayloadRef::Ref(reference) => reference,
+            OwnedPayloadRef::DashMapRef(dashmap_ref) => &dashmap_ref.deref().0,
             OwnedPayloadRef::Owned(owned) => owned.deref(),
         }
     }
@@ -2072,6 +2076,12 @@ impl From<Map<String, Value>> for OwnedPayloadRef<'_> {
 impl<'a> From<&'a Payload> for OwnedPayloadRef<'a> {
     fn from(payload: &'a Payload) -> Self {
         OwnedPayloadRef::Ref(&payload.0)
+    }
+}
+
+impl<'a> From<DashMapRef<'a, u32, Payload>> for OwnedPayloadRef<'a> {
+    fn from(payload: DashMapRef<'a, u32, Payload>) -> Self {
+        OwnedPayloadRef::DashMapRef(Rc::new(payload))
     }
 }
 


### PR DESCRIPTION
Allow gridstore value deletion to be concurrent with value retrieval.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
