### PR TITLE
fix: race in start_slow_downloads causes streaming assert to fail (#8349)

### DIFF
--- a/tests/consensus_tests/test_streaming_snapshot_consensus_freeze.py
+++ b/tests/consensus_tests/test_streaming_snapshot_consensus_freeze.py
@@ -117,7 +117,7 @@ def trigger_write_lock(peer_uri, result):
 
 
 def start_slow_downloads(peer_uri, shard_id, stop_event, n=2):
-    """Start n slow snapshot downloads, wait until streaming. Returns (results, threads)."""
+    """Start n slow snapshot downloads, wait until streaming with actual bytes. Returns (results, threads)."""
     results = [{} for _ in range(n)]
     threads = []
     for i in range(n):
@@ -127,10 +127,16 @@ def start_slow_downloads(peer_uri, shard_id, stop_event, n=2):
         threads.append(t)
         t.start()
 
-    deadline = time.time() + 15
+    # Wait until each download is truly streaming (bytes flowing), not just headers received.
+    # This closes the race condition where phase="streaming" is set on HTTP header receipt
+    # but result["bytes"] is only populated after the first body chunk arrives.
+    deadline = time.time() + 30
     for r in results:
         while time.time() < deadline:
-            if r.get("phase") in ("streaming", "done", "error", "stopped"):
+            phase = r.get("phase")
+            if phase in ("done", "error", "stopped"):
+                break
+            if phase == "streaming" and r.get("bytes", 0) > 0:
                 break
             time.sleep(0.2)
 
@@ -208,3 +214,4 @@ def test_streaming_snapshot_freezes_collection_via_consensus(tmp_path: pathlib.P
     # Assertions
     assert not frozen, f"Deadlock detected: {len(frozen)} ops frozen: {list(frozen.keys())}"
     print(f"{len(frozen)} operations frozen by consensus deadlock")
+      


### PR DESCRIPTION
The test fails with:

    AssertionError: No downloads streaming: [{'phase': 'streaming'}, {'phase': 'streaming'}]
    assert 0 > 0

`slow_download` sets `result["phase"] = "streaming"` as soon as the HTTP
headers come back, then enters `iter_content()`. `result["bytes"]` is only
written when the first chunk lands. The wait loop in `start_slow_downloads`
broke out on `phase == "streaming"`, so the assert below it could run before
any chunk had been received — hence `bytes` missing from the dict entirely.

Fix: loop until `bytes > 0` as well (or a terminal phase). Also bumps the
per-download deadline to 30 s; with 50 k × dim-128 vectors the snapshot
generator needs a moment before the first byte goes out on a loaded runner.

Reproduces reliably with:
    pytest tests/consensus_tests/test_streaming_snapshot_consensus_freeze.py -s -v
