### PR TITLE
Ignore failing deferred points test during investigation

### DIFF
--- a/tests/consensus_tests/test_shard_snapshot_transfer_deferred.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_deferred.py
@@ -103,6 +103,7 @@ def update_collection_config(peer_url, config):
     assert_http_ok(r)
 
 
+@pytest.mark.skip(reason="Investigating CI hang - deferred wait blocks on constrained resources")
 def test_shard_snapshot_transfer_includes_deferred_points(tmp_path: pathlib.Path):
     """Snapshot shard transfer must include deferred points.
 


### PR DESCRIPTION
The test works locally but hangs often on CI.

Let's disable it during the investigation to unblock the `dev` pipeline`.