### PR TITLE
fix: Add bounds checking for Point Group Search limits to prevent panics

### DIFF
--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -11,6 +11,14 @@ use serde_json::Value;
 
 use super::types::{AggregatorError, Group};
 
+/// Maximum number of groups allowed to prevent hash table capacity overflow.
+/// This limit ensures that hash table pre-allocation does not exceed hashbrown's capacity limits.
+const MAX_GROUPS: usize = 10_000;
+
+/// Maximum group size allowed to prevent hash table capacity overflow.
+/// This limit ensures that hash table pre-allocation does not exceed hashbrown's capacity limits.
+const MAX_GROUP_SIZE: usize = 10_000;
+
 type Hits = AHashMap<PointIdType, ScoredPoint>;
 pub(super) struct GroupsAggregator {
     groups: AHashMap<GroupId, Hits>,
@@ -29,8 +37,16 @@ impl GroupsAggregator {
         group_size: usize,
         grouped_by: JsonPath,
         order: Option<Order>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, AggregatorError> {
+        // Validate limits to prevent hash table capacity overflow
+        if groups > MAX_GROUPS {
+            return Err(AggregatorError::GroupsLimitExceeded { groups, max: MAX_GROUPS });
+        }
+        if group_size > MAX_GROUP_SIZE {
+            return Err(AggregatorError::GroupSizeLimitExceeded { group_size, max: MAX_GROUP_SIZE });
+        }
+
+        Ok(Self {
             groups: AHashMap::with_capacity(groups),
             max_group_size: group_size,
             grouped_by,
@@ -39,7 +55,7 @@ impl GroupsAggregator {
             group_best_scores: AHashMap::with_capacity(groups),
             all_ids: AHashSet::with_capacity(groups * group_size),
             order,
-        }
+        })
     }
 
     /// Adds a point to the group that corresponds based on the group_by field, assumes that the point has the group_by field
@@ -116,6 +132,13 @@ impl GroupsAggregator {
             match self.add_point(point) {
                 Ok(()) | Err(AggregatorError::KeyNotFound | AggregatorError::BadKeyType) => {
                     // ignore points that don't have the group_by field
+                }
+                Err(
+                    AggregatorError::GroupsLimitExceeded { .. }
+                    | AggregatorError::GroupSizeLimitExceeded { .. },
+                ) => {
+                    // These errors are only returned during construction, not during add_point
+                    unreachable!("Limit exceeded errors should not occur during add_point")
                 }
             }
         }
@@ -238,7 +261,7 @@ mod unit_tests {
         ];
 
         let mut aggregator =
-            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
         for point in &scored_points {
             aggregator.add_point(point).unwrap();
         }
@@ -285,7 +308,7 @@ mod unit_tests {
     #[test]
     fn it_adds_single_points() {
         let mut aggregator =
-            GroupsAggregator::new(4, 3, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(4, 3, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
 
         // cases
         #[rustfmt::skip]
@@ -389,7 +412,7 @@ mod unit_tests {
     #[test]
     fn test_aggregate_less_groups() {
         let mut aggregator =
-            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
 
         // cases
         [
@@ -452,5 +475,56 @@ mod unit_tests {
             let group_id_score: Vec<_> = group.hits.into_iter().map(|x| (x.id, x.score)).collect();
             assert_eq!(expected_id_score, group_id_score);
         }
+    }
+
+    #[test]
+    fn test_groups_limit_exceeded() {
+        // Test that creating an aggregator with too many groups fails
+        let result = GroupsAggregator::new(
+            MAX_GROUPS + 1,
+            10,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(AggregatorError::GroupsLimitExceeded { groups: _, max: _ })
+            ),
+            "Expected GroupsLimitExceeded error"
+        );
+    }
+
+    #[test]
+    fn test_group_size_limit_exceeded() {
+        // Test that creating an aggregator with too large group size fails
+        let result = GroupsAggregator::new(
+            10,
+            MAX_GROUP_SIZE + 1,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(AggregatorError::GroupSizeLimitExceeded { group_size: _, max: _ })
+            ),
+            "Expected GroupSizeLimitExceeded error"
+        );
+    }
+
+    #[test]
+    fn test_max_limits_accepted() {
+        // Test that the maximum allowed values work correctly
+        let result = GroupsAggregator::new(
+            MAX_GROUPS,
+            MAX_GROUP_SIZE,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
+        assert!(
+            result.is_ok(),
+            "Maximum allowed limits should be accepted"
+        );
     }
 }

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -325,7 +325,7 @@ pub async fn group_by(
         request.group_size,
         request.group_by.clone(),
         score_ordering,
-    );
+    )?;
 
     // Try to complete amount of groups
     let mut needs_filling = true;

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -3,13 +3,34 @@ use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
 use segment::types::{PointIdType, ScoredPoint};
 
-use crate::operations::types::PointGroup;
+use crate::operations::types::{CollectionError, PointGroup};
 use crate::operations::universal_query::shard_query::ShardQueryRequest;
 
 #[derive(PartialEq, Debug)]
 pub(super) enum AggregatorError {
     BadKeyType,
     KeyNotFound,
+    GroupsLimitExceeded { groups: usize, max: usize },
+    GroupSizeLimitExceeded { group_size: usize, max: usize },
+}
+
+impl From<AggregatorError> for CollectionError {
+    fn from(err: AggregatorError) -> Self {
+        match err {
+            AggregatorError::BadKeyType => CollectionError::bad_input(
+                "Group by key must be a string or integer".to_string(),
+            ),
+            AggregatorError::KeyNotFound => CollectionError::bad_input(
+                "Group by key not found in point payload".to_string(),
+            ),
+            AggregatorError::GroupsLimitExceeded { groups, max } => CollectionError::bad_input(
+                format!("Groups limit exceeded: {} > {}. Reduce the 'limit' parameter.", groups, max),
+            ),
+            AggregatorError::GroupSizeLimitExceeded { group_size, max } => CollectionError::bad_input(
+                format!("Group size limit exceeded: {} > {}. Reduce the 'group_size' parameter.", group_size, max),
+            ),
+        }
+    }
 }
 #[derive(Debug, Clone)]
 pub(super) struct Group {


### PR DESCRIPTION
## Problem

Point Group Search queries with large `limit` or `group_size` parameters could cause panics due to hash table capacity overflow in hashbrown (as reported in #8406).

## Solution

This PR adds validation in `GroupsAggregator::new()` to reject excessively large values before attempting hash table allocation:

- `MAX_GROUPS = 10,000` - maximum number of groups allowed
- `MAX_GROUP_SIZE = 10,000` - maximum points per group allowed

When these limits are exceeded, the API now returns a clear `BadInput` error instead of panicking.

## Changes

1. Added two new error variants to `AggregatorError`:
   - `GroupsLimitExceeded`
   - `GroupSizeLimitExceeded`

2. Added `From<AggregatorError>` implementation to convert to `CollectionError`

3. Updated `GroupsAggregator::new()` to return `Result` and validate limits

4. Added unit tests for the new limit validation

## Testing

- All existing grouping tests pass
- New tests verify proper error handling when limits are exceeded
- New tests verify that maximum allowed values work correctly

Fixes #8406