### PR TITLE
fix: prevent panic from large limit/group_size in group search

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1134,11 +1134,11 @@ pub struct BaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 10000))]
     pub group_size: u32,
 
     /// Maximum amount of groups to return
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 100000))]
     pub limit: u32,
 
     /// Look for points in another collection using the group ids
@@ -1221,11 +1221,11 @@ pub struct QueryBaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group. Default is 3.
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 10000))]
     pub group_size: Option<usize>,
 
     /// Maximum amount of groups to return. Default is 10.
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 100000))]
     pub limit: Option<usize>,
 
     /// Look for points in another collection using the group ids

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -30,14 +30,24 @@ impl GroupsAggregator {
         grouped_by: JsonPath,
         order: Option<Order>,
     ) -> Self {
+        // Cap individual capacities to prevent overflow and excessive allocation
+        const MAX_CAPACITY: usize = 10_000_000;
+        let groups_capacity = groups.min(MAX_CAPACITY);
+        
+        // Prevent overflow when calculating capacity for all_ids
+        let all_ids_capacity = groups
+            .checked_mul(group_size)
+            .map(|capacity| capacity.min(MAX_CAPACITY))
+            .unwrap_or(MAX_CAPACITY);
+
         Self {
-            groups: AHashMap::with_capacity(groups),
+            groups: AHashMap::with_capacity(groups_capacity),
             max_group_size: group_size,
             grouped_by,
             max_groups: groups,
-            full_groups: AHashSet::with_capacity(groups),
-            group_best_scores: AHashMap::with_capacity(groups),
-            all_ids: AHashSet::with_capacity(groups * group_size),
+            full_groups: AHashSet::with_capacity(groups_capacity),
+            group_best_scores: AHashMap::with_capacity(groups_capacity),
+            all_ids: AHashSet::with_capacity(all_ids_capacity),
             order,
         }
     }
@@ -452,5 +462,22 @@ mod unit_tests {
             let group_id_score: Vec<_> = group.hits.into_iter().map(|x| (x.id, x.score)).collect();
             assert_eq!(expected_id_score, group_id_score);
         }
+    }
+
+    #[test]
+    fn test_large_capacity_does_not_panic() {
+        // Test that creating an aggregator with very large values doesn't panic
+        // due to overflow in capacity calculation. This verifies the fix for
+        // https://github.com/qdrant/qdrant/issues/8406
+        let aggregator = GroupsAggregator::new(
+            usize::MAX,
+            usize::MAX,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
+
+        // The aggregator should be created successfully with capped capacity
+        assert_eq!(aggregator.max_groups, usize::MAX);
+        assert_eq!(aggregator.max_group_size, usize::MAX);
     }
 }

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -260,7 +260,8 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit * self.group_size)
+        // Use checked_mul to prevent overflow with large limit/group_size values
+        self.limit.checked_mul(self.group_size)
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -27,7 +27,9 @@ impl StrictModeVerification for RecommendRequestInternal {
 
 impl StrictModeVerification for RecommendGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
+        // Use checked_mul to prevent overflow with large limit/group_size values
+        (self.group_request.limit as usize)
+            .checked_mul(self.group_request.group_size as usize)
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -97,7 +97,9 @@ impl StrictModeVerification for SearchGroupsRequestInternal {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
+        // Use checked_mul to prevent overflow with large limit/group_size values
+        (self.group_request.limit as usize)
+            .checked_mul(self.group_request.group_size as usize)
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {


### PR DESCRIPTION
Point Group Search queries with large `limit` or `group_size` values cause a thread panic because these values are used directly for HashMap allocation without bounds checking.

Changes:
- Add max validation (10,000 for group_size, 100,000 for limit) in API layer (BaseGroupRequest, QueryBaseGroupRequest)
- Cap HashMap capacities at 10M in GroupsAggregator::new() to prevent overflow
- Use checked_mul in verification query_limit() methods to avoid multiplication overflow

Fixes #8406