### PR TITLE
fix: prevent Point Group Search panic with large limits

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -1134,11 +1134,11 @@ pub struct BaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 1_000_000))]
     pub group_size: u32,
 
     /// Maximum amount of groups to return
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 1_000_000))]
     pub limit: u32,
 
     /// Look for points in another collection using the group ids
@@ -1221,11 +1221,11 @@ pub struct QueryBaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group. Default is 3.
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 1_000_000))]
     pub group_size: Option<usize>,
 
     /// Maximum amount of groups to return. Default is 10.
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 1_000_000))]
     pub limit: Option<usize>,
 
     /// Look for points in another collection using the group ids

--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -23,23 +23,39 @@ pub(super) struct GroupsAggregator {
     order: Option<Order>,
 }
 
+/// Maximum number of groups allowed to prevent memory overflow
+pub const MAX_GROUPS: usize = 1_000_000;
+/// Maximum group size allowed to prevent memory overflow
+pub const MAX_GROUP_SIZE: usize = 1_000_000;
+
 impl GroupsAggregator {
     pub(super) fn new(
         groups: usize,
         group_size: usize,
         grouped_by: JsonPath,
         order: Option<Order>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, AggregatorError> {
+        // Validate limits to prevent memory overflow
+        if groups > MAX_GROUPS {
+            return Err(AggregatorError::GroupsLimitExceeded { limit: MAX_GROUPS });
+        }
+        if group_size > MAX_GROUP_SIZE {
+            return Err(AggregatorError::GroupSizeLimitExceeded { limit: MAX_GROUP_SIZE });
+        }
+
+        // Use saturating multiplication to prevent overflow
+        let all_ids_capacity = groups.saturating_mul(group_size);
+
+        Ok(Self {
             groups: AHashMap::with_capacity(groups),
             max_group_size: group_size,
             grouped_by,
             max_groups: groups,
             full_groups: AHashSet::with_capacity(groups),
             group_best_scores: AHashMap::with_capacity(groups),
-            all_ids: AHashSet::with_capacity(groups * group_size),
+            all_ids: AHashSet::with_capacity(all_ids_capacity.min(MAX_GROUPS * MAX_GROUP_SIZE)),
             order,
-        }
+        })
     }
 
     /// Adds a point to the group that corresponds based on the group_by field, assumes that the point has the group_by field
@@ -238,7 +254,7 @@ mod unit_tests {
         ];
 
         let mut aggregator =
-            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
         for point in &scored_points {
             aggregator.add_point(point).unwrap();
         }
@@ -285,7 +301,7 @@ mod unit_tests {
     #[test]
     fn it_adds_single_points() {
         let mut aggregator =
-            GroupsAggregator::new(4, 3, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(4, 3, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
 
         // cases
         #[rustfmt::skip]
@@ -389,7 +405,7 @@ mod unit_tests {
     #[test]
     fn test_aggregate_less_groups() {
         let mut aggregator =
-            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter));
+            GroupsAggregator::new(3, 2, "docId".parse().unwrap(), Some(Order::LargeBetter)).unwrap();
 
         // cases
         [

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -152,7 +152,8 @@ impl QueryGroupRequest {
         let mut request = self.source.clone();
 
         // Adjust limit to fetch enough points to fill groups
-        request.limit = self.groups * self.group_size;
+        // Use saturating multiplication to prevent overflow (limits are validated in GroupsAggregator::new)
+        request.limit = self.groups.saturating_mul(self.group_size);
         request.prefetches.iter_mut().for_each(|prefetch| {
             increase_limit_for_group(prefetch, self.group_size);
         });
@@ -325,7 +326,18 @@ pub async fn group_by(
         request.group_size,
         request.group_by.clone(),
         score_ordering,
-    );
+    )
+    .map_err(|e| match e {
+        AggregatorError::GroupsLimitExceeded { limit } => CollectionError::bad_request(format!(
+            "Groups limit exceeded: maximum allowed is {}",
+            limit
+        )),
+        AggregatorError::GroupSizeLimitExceeded { limit } => CollectionError::bad_request(format!(
+            "Group size limit exceeded: maximum allowed is {}",
+            limit
+        )),
+        _ => CollectionError::bad_request("Invalid group request".to_string()),
+    })?;
 
     // Try to complete amount of groups
     let mut needs_filling = true;
@@ -544,7 +556,7 @@ fn values_to_any_variants(values: &[Value]) -> Vec<AnyVariants> {
 }
 
 fn increase_limit_for_group(shard_prefetch: &mut ShardPrefetch, group_size: usize) {
-    shard_prefetch.limit *= group_size;
+    shard_prefetch.limit = shard_prefetch.limit.saturating_mul(group_size);
     shard_prefetch.prefetches.iter_mut().for_each(|prefetch| {
         increase_limit_for_group(prefetch, group_size);
     });

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -10,6 +10,8 @@ use crate::operations::universal_query::shard_query::ShardQueryRequest;
 pub(super) enum AggregatorError {
     BadKeyType,
     KeyNotFound,
+    GroupsLimitExceeded { limit: usize },
+    GroupSizeLimitExceeded { limit: usize },
 }
 #[derive(Debug, Clone)]
 pub(super) struct Group {


### PR DESCRIPTION
Fixes #8406

## Problem
Point Group Search queries with large `limit` or `group_size` values (e.g., `u64::MAX`) cause thread panics due to hash table capacity overflow. The issue occurs because these user-supplied values are directly used to allocate memory without validation or batch processing.

## Solution
Add validation and safeguards to prevent memory overflow:

1. **API Validation**: Added `max = 1_000_000` validation for `group_size` and `limit` in both `BaseGroupRequest` and `QueryBaseGroupRequest`

2. **Runtime Protection**: `GroupsAggregator::new()` now returns a `Result` and validates limits before allocation

3. **Overflow Prevention**: Use saturating multiplication instead of regular multiplication when calculating capacities

## Changes
- `lib/api/src/rest/schema.rs`: Add max validation constraints
- `lib/collection/src/grouping/types.rs`: Add `GroupsLimitExceeded` and `GroupSizeLimitExceeded` error variants  
- `lib/collection/src/grouping/aggregator.rs`: Add validation and use saturating arithmetic
- `lib/collection/src/grouping/group_by.rs`: Handle Result from GroupsAggregator::new() and use saturating multiplication

## Testing
The existing unit tests have been updated to handle the new Result return type. The fix prevents the panic described in #8406 by rejecting excessively large values before they can cause memory allocation failures.