### PR TITLE
fix: cap GroupsAggregator allocation to prevent hash overflow (#8406)

### DIFF
--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -2,6 +2,10 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 
 use ahash::{AHashMap, AHashSet};
+
+/// Cap allocation sizes to prevent hash table capacity overflow when user-supplied
+/// limit/group_size are very large (e.g. u64::MAX). See issue #8406.
+const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
 use itertools::Itertools;
 use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
@@ -30,14 +34,18 @@ impl GroupsAggregator {
         grouped_by: JsonPath,
         order: Option<Order>,
     ) -> Self {
+        let groups_cap = groups.min(LARGEST_REASONABLE_ALLOCATION_SIZE);
+        let all_ids_cap = groups
+            .saturating_mul(group_size)
+            .min(LARGEST_REASONABLE_ALLOCATION_SIZE);
         Self {
-            groups: AHashMap::with_capacity(groups),
+            groups: AHashMap::with_capacity(groups_cap),
             max_group_size: group_size,
             grouped_by,
             max_groups: groups,
-            full_groups: AHashSet::with_capacity(groups),
-            group_best_scores: AHashMap::with_capacity(groups),
-            all_ids: AHashSet::with_capacity(groups * group_size),
+            full_groups: AHashSet::with_capacity(groups_cap),
+            group_best_scores: AHashMap::with_capacity(groups_cap),
+            all_ids: AHashSet::with_capacity(all_ids_cap),
             order,
         }
     }
@@ -71,7 +79,11 @@ impl GroupsAggregator {
             let group = self
                 .groups
                 .entry(group_key.clone())
-                .or_insert_with(|| AHashMap::with_capacity(self.max_group_size));
+                .or_insert_with(|| {
+                    AHashMap::with_capacity(
+                        self.max_group_size.min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+                    )
+                });
 
             let entry = group.entry(point.id);
 
@@ -227,6 +239,18 @@ mod unit_tests {
             shard_key: None,
             order_value: None,
         }
+    }
+
+    /// Regression test for #8406: large limit/group_size must not cause hash table
+    /// capacity overflow panic. GroupsAggregator caps allocation sizes internally.
+    #[test]
+    fn test_large_groups_and_group_size_do_not_panic() {
+        let _ = GroupsAggregator::new(
+            usize::MAX,
+            usize::MAX,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #8406.

**Root cause:** User-supplied `limit` and `group_size` in Point Group Search were used directly for `HashMap`/`HashSet` `with_capacity()`, causing hash table capacity overflow panic when values are very large (e.g. `u64::MAX`).

**Fix:** Cap allocation sizes to `LARGEST_REASONABLE_ALLOCATION_SIZE` (1M) in `GroupsAggregator::new` and per-group hash map creation, matching the pattern used in `SearchResultAggregator` and `FixedLengthPriorityQueue`.

## Changes

- `lib/collection/src/grouping/aggregator.rs`: Add capacity capping constant and apply to all `with_capacity` calls; cap per-group hash map allocation in `add_point`

## Testing

- Added `test_large_groups_and_group_size_do_not_panic` covering `usize::MAX` for both groups and group_size
- Existing aggregator unit tests pass
- Change is minimal and follows existing patterns (e.g. `lib/shard/src/search_result_aggregator.rs`)

Made with [Cursor](https://cursor.com)