### PR TITLE
Test all shard transfer methods for deferred points

### DIFF
--- a/tests/consensus_tests/test_shard_transfer_deferred.py
+++ b/tests/consensus_tests/test_shard_transfer_deferred.py
@@ -231,6 +231,22 @@ def test_shard_transfer_includes_deferred_points(tmp_path: pathlib.Path, transfe
         f"Target should have 1 local shard, got {len(dst_info_after['local_shards'])}"
     )
 
+    # Verify deferred points were transferred: target should have hidden points.
+    # For snapshot, the target gets a raw segment copy — deferred state is preserved exactly.
+    # For stream_records, points are re-inserted on the target and may not be deferred.
+    target_visible = scroll_all(target_uri)
+    target_visible_count = len(target_visible)
+    if transfer_method == "snapshot":
+        assert target_visible_count == visible_count, (
+            f"Snapshot transfer should preserve deferred state: "
+            f"target visible={target_visible_count}, source visible={visible_count}"
+        )
+    else:
+        assert target_visible_count >= visible_count, (
+            f"Target should have at least as many visible points as source: "
+            f"target={target_visible_count}, source={visible_count}"
+        )
+
     # Trigger optimization with wait=true to ensure deferred points are resolved
     trigger_upsert_wait_true(source_uri, total_points)
 


### PR DESCRIPTION
 ## Summary

  Parametrize the deferred points shard transfer consensus test over all transfer methods: `snapshot`, `stream_records`, and `wal_delta`.

  ## Changes

  - Renamed `test_shard_snapshot_transfer_deferred.py` → `test_shard_transfer_deferred.py`
  - Parametrized the main test over `["snapshot", "stream_records"]` using `@pytest.mark.parametrize`
  - Extracted `trigger_upsert_wait_true()` helper for the retry loop shared by all tests
  - Moved optimizer enable before the transfer — `stream_records` uses `wait=true` internally on the last batch, which would hang the transfer if optimizers are disabled
  - Added separate `test_shard_wal_delta_transfer_includes_deferred_points` test because `wal_delta` requires a fundamentally different setup:
    1. Initial small batch (within threshold, no deferred points)
    2. Snapshot transfer to establish shard on both peers
    3. Insert more points that become deferred (beyond threshold)
    4. `wal_delta` syncs the diff — the delta contains the deferred points
    5. Verify both peers see all points after optimization