### PR TITLE
Fix panic in volatile_chunked_vectors

### DIFF
--- a/lib/segment/src/vector_storage/volatile_chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/volatile_chunked_vectors.rs
@@ -209,4 +209,12 @@ mod tests {
         // check if middle chunk is fully allocated
         assert_eq!(vectors.get(5_000_000), &[0, 0, 0]);
     }
+
+    #[test]
+    fn test_try_set_capacity_exact_zero_does_not_panic() {
+        let mut vectors = VolatileChunkedVectors::<u8>::new(3);
+        vectors.try_set_capacity_exact(0).unwrap();
+        assert!(vectors.chunks.is_empty());
+        assert_eq!(vectors.len(), 0);
+    }
 }


### PR DESCRIPTION
I can't repro the error unfortunately but it was real.

```
2026-03-18T15:08:19.911790Z DEBUG collection::update_workers::optimization_worker: Optimizer 'vacuum' running on segments: 6622f85a-01e1-448d-a984-117c84abbf9d
2026-03-18T15:08:19.912134Z DEBUG shard::optimize: Available space: 861.29 GiB, needed for optimization: 3.54 GiB
2026-03-18T15:08:20.216394Z ERROR qdrant::startup: Panic backtrace:
   0: {closure#0}
             at ./src/startup.rs:21:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/alloc/src/boxed.rs:2220:9
   2: std::panicking::panic_with_hook
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:833:13
   3: std::panicking::panic_handler::{{closure}}
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:691:13
   4: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/sys/backtrace.rs:182:18
   5: __rustc::rust_begin_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:689:5
   6: core::panicking::panic_fmt
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:80:14
   7: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:175:17
   8: <segment::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors<T> as segment::common::vector_utils::TrySetCapacityExact>::try_set_capacity_exact
             at ./lib/segment/src/vector_storage/volatile_chunked_vectors.rs:172:30
   9: segment::vector_storage::quantized::quantized_ram_storage::QuantizedRamStorageBuilder::new
             at ./lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs:92:17
  10: segment::vector_storage::quantized::quantized_vectors::QuantizedVectors::create_scalar
             at ./lib/segment/src/vector_storage/quantized/quantized_vectors.rs:1307:35
  11: segment::vector_storage::quantized::quantized_vectors::QuantizedVectors::create_impl
             at ./lib/segment/src/vector_storage/quantized/quantized_vectors.rs:689:19
  12: segment::vector_storage::quantized::quantized_vectors::QuantizedVectors::create
             at ./lib/segment/src/vector_storage/quantized/quantized_vectors.rs:516:50
  13: segment::segment_constructor::segment_builder::SegmentBuilder::update_quantization
             at ./lib/segment/src/segment_constructor/segment_builder.rs:782:41
  14: build<rand::rngs::thread::ThreadRng>
             at ./lib/segment/src/segment_constructor/segment_builder.rs:543:41
  15: build_new_segment<shard::optimizers::segment_optimizer::ShardOptimizationStrategy<shard::optimizers::vacuum_optimizer::VacuumOptimizer>>
             at ./lib/shard/src/optimize.rs:288:49
  16: shard::optimize::optimize_segment_propagate_changes
             at ./lib/shard/src/optimize.rs:370:29
  17: shard::optimize::execute_optimization
             at ./lib/shard/src/optimize.rs:739:24
  18: shard::optimizers::segment_optimizer::SegmentOptimizer::optimize
             at ./lib/shard/src/optimizers/segment_optimizer.rs:345:22
  19: {closure#0}<collection::update_workers::optimization_worker::{impl#0}::process_optimization::{async_fn#0}::{closure_env#0}>
             at ./lib/collection/src/update_workers/optimization_worker.rs:364:40
  20: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  21: do_call<core::panic::unwind_safe::AssertUnwindSafe<collection::update_workers::optimization_worker::{impl#0}::launch_optimization::{closure#3}::{closure_env#0}<collection::update_workers::optimization_work
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  22: __rust_try
-- snip --
  50: __rust_try
  51: catch_unwind<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  52: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>>,
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  53: {closure#1}<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/lifecycle.rs:89:26
  54: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  55: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/alloc/src/boxed.rs:2206:9
  56: std::sys::thread::unix::Thread::new::thread_start
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/sys/thread/unix.rs:127:17
  57: start_thread
             at ./nptl/pthread_create.c:448:8
  58: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78:0

2026-03-18T15:08:20.216707Z ERROR qdrant::startup: Panic occurred in file lib/segment/src/vector_storage/volatile_chunked_vectors.rs at line 172: attempt to subtract with overflow
2026-03-18T15:08:20.217652Z  WARN collection::update_workers::optimization_worker: Optimization task panicked, collection may be in unstable state: attempt to subtract with overflow
```