### PR TITLE
Use is_leader func

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -725,7 +725,7 @@ impl Consensus {
     }
 
     fn is_leader(&self) -> bool {
-        self.node.status().ss.raft_state == raft::StateRole::Leader
+        self.node.status().ss.raft_state == StateRole::Leader
     }
 
     fn try_sync_local_state(&self) -> anyhow::Result<()> {
@@ -773,7 +773,7 @@ impl Consensus {
         // If we reached this point, we are the origin peer, but it's impossible to propose anything
         // to consensus, before leader is elected (`propose_conf_change` will return an error),
         // so we have to wait for a few ticks for self-election
-        if status.ss.raft_state != StateRole::Leader {
+        if !self.is_leader() {
             return Err(TryAddOriginError::NotLeader);
         }
 
@@ -808,7 +808,7 @@ impl Consensus {
     /// that guarantees that learner will start voting only after it applies all the changes in the log
     fn try_promote_learner(&mut self) -> anyhow::Result<bool> {
         // Promote only if leader
-        if self.node.status().ss.raft_state != StateRole::Leader {
+        if !self.is_leader() {
             return Ok(false);
         }
 


### PR DESCRIPTION
For code uniformity, the `is_leader` function is used where possible instead of direct verification with `StateRole::Leader`