### PR TITLE
Fix panic in WAL replay

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -710,21 +710,23 @@ impl LocalShard {
 
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
-        let to = self
-            .applied_seq_handler
-            .op_num_upper_bound()
-            .unwrap_or(last_wal_index);
+        let op_num_upper_bound = self.applied_seq_handler.op_num_upper_bound();
+        let to = op_num_upper_bound.unwrap_or(last_wal_index);
 
         // Cap the number of WAL entries to move to the update queue size,
         // since the update queue is limited and must hold all pending operations.
         let update_queue_size = self.update_sender.load().capacity();
-        let to = std::cmp::max(
+        let to = cmp::max(
             to,
             last_wal_index.saturating_sub(update_queue_size as u64 - 1),
         );
 
-        let to = std::cmp::min(to, last_wal_index);
-        let wal_entries_to_replay = to - from;
+        let to = cmp::min(to, last_wal_index);
+        debug_assert!(
+            from <= to,
+            "WAL first_index ({from}) is ahead of replay target ({to}) (last_wal_index:{last_wal_index} op_num_upper_bound:{op_num_upper_bound:?})"
+        );
+        let wal_entries_to_replay = to.saturating_sub(from);
 
         assert!(
             last_wal_index - to <= update_queue_size as u64,


### PR DESCRIPTION
I can't repro the error unfortunately but it was real.

```
2026-03-19T14:48:13.089626Z ERROR qdrant::startup: Panic backtrace: 
   0: {closure#0}
             at ./src/startup.rs:21:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/alloc/src/boxed.rs:2220:9
   2: std::panicking::panic_with_hook
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:833:13
   3: std::panicking::panic_handler::{{closure}}
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:691:13
   4: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/sys/backtrace.rs:182:18
   5: __rustc::rust_begin_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:689:5
   6: core::panicking::panic_fmt
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:80:14
   7: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:175:17
   8: {async_fn#0}
             at ./lib/collection/src/shards/local_shard/mod.rs:728:37
   9: {async_fn#0}
             at ./lib/collection/src/shards/local_shard/mod.rs:525:50
  10: {async_fn#0}
             at ./lib/collection/src/shards/replica_set/mod.rs:315:18
  11: {async_block#0}
             at ./lib/collection/src/shards/shard_holder/mod.rs:955:18
  12: poll_next<collection::shards::shard_holder::{impl#0}::load_shards::{async_fn#0}::{closure#0}::{async_block_env#0}>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/futures_unordered/mod.rs:528:24
  13: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
  14: poll_next<futures_util::stream::iter::Iter<core::iter::adapters::map::Map<alloc::vec::into_iter::IntoIter<u32, alloc::alloc::Global>, collection::shards::shard_holder::{impl#0}::load_shards::{async_fn#0}::{closure_env#0}>>>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/buffer_unordered.rs:75:38
  15: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
  16: <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/next.rs:32:21
  17: {async_fn#0}
             at ./lib/collection/src/shards/shard_holder/mod.rs:966:72
  18: {async_fn#0}
             at ./lib/collection/src/collection/mod.rs:284:14
  19: {async_block#0}
             at ./lib/storage/src/content_manager/toc/mod.rs:181:18
  20: poll_next<storage::content_manager::toc::{impl#0}::new::{async_block_env#0}>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/futures_unordered/mod.rs:528:24
  21: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
  22: poll_next<futures_util::stream::iter::Iter<alloc::vec::into_iter::IntoIter<storage::content_manager::toc::{impl#0}::new::{async_block_env#0}, alloc::alloc::Global>>>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/buffer_unordered.rs:75:38
  23: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
  24: <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/next.rs:32:21
  25: {async_block#1}
             at ./lib/storage/src/content_manager/toc/mod.rs:197:86
  26: {closure#0}<storage::content_manager::toc::{impl#0}::new::{async_block_env#1}>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/park.rs:284:71
  27: with_budget<core::task::poll::Poll<()>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<storage::content_manager::toc::{impl#0}::new::{async_block_env#1}>>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:167:5
  28: budget<core::task::poll::Poll<()>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<storage::content_manager::toc::{impl#0}::new::{async_block_env#1}>>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:133:5
  29: block_on<storage::content_manager::toc::{impl#0}::new::{async_block_env#1}>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/park.rs:284:31
  30: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/blocking.rs:66:14
  31: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/mod.rs:89:22
  32: tokio::runtime::context::runtime::enter_runtime
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/runtime.rs:65:16
  33: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/mod.rs:88:9
  34: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/runtime.rs:373:50
  35: block_on<storage::content_manager::toc::{impl#0}::new::{async_block_env#1}>
             at /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/runtime.rs:345:18
  36: new
             at ./lib/storage/src/content_manager/toc/mod.rs:196:25
  37: main
             at ./src/main.rs:390:15
  38: core::ops::function::FnOnce::call_once
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  39: __rust_begin_short_backtrace<fn() -> core::result::Result<(), anyhow::Error>, core::result::Result<(), anyhow::Error>>
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:166:18
  40: {closure#0}<core::result::Result<(), anyhow::Error>>
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:206:18
  41: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/ops/function.rs:287:21
  42: std::panicking::catch_unwind::do_call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:581:40
  43: std::panicking::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:544:19
  44: std::panic::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panic.rs:359:14
  45: std::rt::lang_start_internal::{{closure}}
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:175:24
  46: std::panicking::catch_unwind::do_call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:581:40
  47: std::panicking::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:544:19
  48: std::panic::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panic.rs:359:14
  49: std::rt::lang_start_internal
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:171:5
  50: std::rt::lang_start
             at /home/agourlay/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:205:5
  51: main
  52: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  53: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  54: _start

2026-03-19T14:48:13.089792Z ERROR qdrant::startup: Panic occurred in file lib/collection/src/shards/local_shard/mod.rs at line 728: attempt to subtract with overflow
```

I extracted the following values during debug.

```
load_from_wal: from: 3024987 to: 3010302
```

On top of the safe subtraction, the PR adds a debug assert so that we catch this error during development as well.