### PR TITLE
UIO: add flag to preserve callback order in `read_batch`

### DIFF
--- a/lib/common/common/src/generic_consts.rs
+++ b/lib/common/common/src/generic_consts.rs
@@ -1,3 +1,30 @@
+//! Named consts to use as generic parameters.
+//!
+//! ```ignore
+//! // Not obvious:
+//! fn read<const IS_SEQUENTIAL: bool>(&self);
+//! foo.read::<true>();
+//!
+//! // Better:
+//! fn read<P: AccessPattern>(&self);
+//! foo.read::<Sequential>();
+//! ```
+//!
+//!
+//! Ideally, we should use regular enums instead of traits and unit structs from
+//! this module:
+//! ```ignore
+//! enum AccessPattern { Random, Sequential }
+//! fn read<const P: AccessPattern>(&self);
+//! foo.read::<AccessPattern::Sequential>();
+//! ```
+//! But until <https://github.com/rust-lang/rust/issues/95174> is resolved, we
+//! have to use this workaround.
+
+/// A hint describing the pattern in which the caller retrieves items by IDs.
+/// Affects the performance. The implementation might enable read-ahead aka
+/// pre-fetch for sequential access.
+/// [`Random`] is like `MADV_RANDOM`. [`Sequential`] is like `MADV_SEQUENTIAL`.
 pub trait AccessPattern: Copy {
     const IS_SEQUENTIAL: bool;
 }
@@ -14,4 +41,27 @@ impl AccessPattern for Random {
 
 impl AccessPattern for Sequential {
     const IS_SEQUENTIAL: bool = true;
+}
+
+/// Controls whether the implementation is allowed to reorder callback calls.
+/// Affects the behavior.
+/// [`SubmissionOrder`] - call callbacks in the same order as requested.
+/// [`CompletionOrder`] - an implementation can reorder them for performance
+/// reasons. Async implementations like `io_uring` might benefid from it.
+pub trait YieldOrder: Copy {
+    const IS_COMPLETION_ORDER: bool;
+}
+
+#[derive(Copy, Clone)]
+pub struct CompletionOrder;
+
+#[derive(Copy, Clone)]
+pub struct SubmissionOrder;
+
+impl YieldOrder for CompletionOrder {
+    const IS_COMPLETION_ORDER: bool = true;
+}
+
+impl YieldOrder for SubmissionOrder {
+    const IS_COMPLETION_ORDER: bool = false;
 }

--- a/lib/common/common/src/universal_io/io_uring.rs
+++ b/lib/common/common/src/universal_io/io_uring.rs
@@ -13,16 +13,16 @@ use ahash::AHashMap;
 use fs_err as fs;
 
 use super::*;
-use crate::generic_consts::AccessPattern;
+use crate::generic_consts::{AccessPattern, YieldOrder};
 
 thread_local! {
     static IO_URING: io::Result<RefCell<IoUring>> = init_io_uring().map(RefCell::new);
 }
 
-const IO_URING_QUEUE_LENGTH: u32 = 16;
+const IO_URING_QUEUE_LENGTH: usize = 16;
 
 fn init_io_uring() -> io::Result<IoUring> {
-    let io_uring = IoUring::new(IO_URING_QUEUE_LENGTH)
+    let io_uring = IoUring::new(IO_URING_QUEUE_LENGTH as _)
         .map_err(|err| io_error_context(err, "failed to setup io_uring"))?;
 
     let mut probe = Probe::new();
@@ -95,13 +95,14 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
         })?
     }
 
-    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
+    fn read_batch<P: AccessPattern, O: YieldOrder, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
         mut callback: impl FnMut(usize, &[T]) -> Result<(), E>,
     ) -> Result<(), E> {
         with_uring_runtime(|mut rt| {
             let mut ranges = ranges.into_iter().enumerate().peekable();
+            let mut reorder_queue = ReorderingQueue::<Vec<T>, IO_URING_QUEUE_LENGTH>::new();
 
             while ranges.peek().is_some() || rt.in_progress > 0 {
                 rt.enqueue(|state| {
@@ -118,10 +119,18 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
                 for result in rt.completed() {
                     let (id, resp) = result.map_err(UniversalIoError::from)?;
                     let items = resp.expect_read();
-                    callback(id as _, &items)?;
+                    if O::IS_COMPLETION_ORDER {
+                        callback(id as _, &items)?;
+                    } else {
+                        reorder_queue.put(id as _, items);
+                        while let Some((id, items)) = reorder_queue.get() {
+                            callback(id as _, &items)?;
+                        }
+                    }
                 }
             }
 
+            debug_assert!(reorder_queue.is_empty());
             Ok(())
         })?
     }
@@ -342,14 +351,14 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
     {
         let mut sqe = self.io_uring.submission();
 
-        if self.in_progress + sqe.len() >= IO_URING_QUEUE_LENGTH as _ {
+        if self.in_progress + sqe.len() >= IO_URING_QUEUE_LENGTH {
             return Ok(());
         }
 
         while let Some(entry) = entries(&mut self.state)? {
             unsafe { sqe.push(&entry).expect("SQE is not full") };
 
-            if self.in_progress + sqe.len() >= IO_URING_QUEUE_LENGTH as _ {
+            if self.in_progress + sqe.len() >= IO_URING_QUEUE_LENGTH {
                 break;
             }
         }

--- a/lib/common/common/src/universal_io/io_uring.rs
+++ b/lib/common/common/src/universal_io/io_uring.rs
@@ -95,11 +95,11 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
         })?
     }
 
-    fn read_batch<P: AccessPattern>(
+    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
-        mut callback: impl FnMut(usize, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(usize, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         with_uring_runtime(|mut rt| {
             let mut ranges = ranges.into_iter().enumerate().peekable();
 
@@ -113,10 +113,10 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
                     Ok(Some(entry))
                 })?;
 
-                rt.submit_and_wait(1)?;
+                rt.submit_and_wait(1).map_err(UniversalIoError::from)?;
 
                 for result in rt.completed() {
-                    let (id, resp) = result?;
+                    let (id, resp) = result.map_err(UniversalIoError::from)?;
                     let items = resp.expect_read();
                     callback(id as _, &items)?;
                 }
@@ -126,11 +126,11 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
         })?
     }
 
-    fn read_multi<P: AccessPattern>(
+    fn read_multi<P: AccessPattern, E: From<UniversalIoError>>(
         files: &[Self],
         reads: impl IntoIterator<Item = (FileIndex, ElementsRange)>,
-        mut callback: impl FnMut(usize, FileIndex, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(usize, FileIndex, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         with_uring_runtime(|mut rt| {
             let mut reads = reads.into_iter().enumerate().peekable();
             let mut file_indices = Vec::new();
@@ -154,10 +154,10 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
                     Ok(Some(entry))
                 })?;
 
-                rt.submit_and_wait(1)?;
+                rt.submit_and_wait(1).map_err(UniversalIoError::from)?;
 
                 for result in rt.completed() {
-                    let (id, resp) = result?;
+                    let (id, resp) = result.map_err(UniversalIoError::from)?;
 
                     let file_idx = file_indices
                         .get(id as usize)

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
-use crate::generic_consts::AccessPattern;
+use crate::generic_consts::{AccessPattern, YieldOrder};
 use crate::mmap::{
     Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, MmapSlice, MmapSliceReadOnly, open_read_mmap,
     open_write_mmap,
@@ -166,7 +166,7 @@ where
         Ok(Cow::Borrowed(data_range))
     }
 
-    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
+    fn read_batch<P: AccessPattern, O: YieldOrder, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
         mut callback: impl FnMut(usize, &[T]) -> Result<(), E>,

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -166,11 +166,11 @@ where
         Ok(Cow::Borrowed(data_range))
     }
 
-    fn read_batch<P: AccessPattern>(
+    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
-        mut callback: impl FnMut(usize, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(usize, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         let data_slice = self.as_slice::<P>();
         let data_length = data_slice.len();
 

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -5,10 +5,12 @@ pub mod io_uring;
 pub mod local_file_ops;
 pub mod mmap;
 pub mod read;
+mod reordering_queue;
 pub mod write;
 
 use std::path::Path;
 
+use reordering_queue::ReorderingQueue;
 use serde::de::DeserializeOwned;
 
 pub use self::error::UniversalIoError;

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::path::Path;
 
 use super::*;
-use crate::generic_consts::{AccessPattern, Sequential};
+use crate::generic_consts::{AccessPattern, Sequential, YieldOrder};
 use crate::universal_io::file_ops::UniversalReadFileOps;
 
 /// Interface for accessing files in a universal way, abstracting away possible
@@ -25,7 +25,7 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
         })
     }
 
-    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
+    fn read_batch<P: AccessPattern, O: YieldOrder, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
         callback: impl FnMut(usize, &[T]) -> Result<(), E>,

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -25,11 +25,11 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
         })
     }
 
-    fn read_batch<P: AccessPattern>(
+    fn read_batch<P: AccessPattern, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = ElementsRange>,
-        callback: impl FnMut(usize, &[T]) -> Result<()>,
-    ) -> Result<()>;
+        callback: impl FnMut(usize, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>;
 
     fn len(&self) -> Result<u64>;
 
@@ -48,11 +48,11 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
     fn clear_ram_cache(&self) -> Result<()>;
 
     /// Read from multiple files in a single operation.
-    fn read_multi<P: AccessPattern>(
+    fn read_multi<P: AccessPattern, E: From<UniversalIoError>>(
         files: &[Self],
         reads: impl IntoIterator<Item = (FileIndex, ElementsRange)>,
-        mut callback: impl FnMut(usize, FileIndex, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(usize, FileIndex, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         for (operation_index, (file_index, range)) in reads.into_iter().enumerate() {
             let file = files
                 .get(file_index)

--- a/lib/common/common/src/universal_io/reordering_queue.rs
+++ b/lib/common/common/src/universal_io/reordering_queue.rs
@@ -1,0 +1,141 @@
+use std::mem::MaybeUninit;
+
+use bitvec::array::BitArray;
+
+/// A queue that accepts items in an arbitrary order (with limitations), and
+/// reorders them based on their sequence numbers.
+///
+/// Has some sensible limitations on the order of accepted items to make it
+/// usable within `io_uring` executor. Rules: start seqnums from 0, don't
+/// spread them more than `DEPTH` elements apart, don't skip seqnums.
+pub struct ReorderingQueue<T, const DEPTH: usize> {
+    next_read: usize,
+    occupied: OccupiedBitArray,
+    buffer: [MaybeUninit<T>; DEPTH],
+}
+
+type OccupiedBitArray = BitArray<[u64; 1]>;
+const MAX_DEPTH: usize = bitvec::mem::bits_of::<OccupiedBitArray>();
+
+impl<T, const DEPTH: usize> ReorderingQueue<T, DEPTH> {
+    /// Should be cheap as we don't zero-fill the buffer.
+    pub fn new() -> Self {
+        const { assert!(DEPTH <= MAX_DEPTH) };
+        Self {
+            next_read: 0,
+            occupied: BitArray::ZERO,
+            buffer: [const { MaybeUninit::uninit() }; _],
+        }
+    }
+
+    /// Puts an item into the queue.
+    ///
+    /// Panics if rules mentioned in the [`ReorderingQueue`] doc are violated.
+    pub fn put(&mut self, seqnum: usize, value: T) {
+        let (min_seqnum, max_seqnum) = (self.next_read, self.next_read + DEPTH - 1);
+        assert!(
+            (min_seqnum..=max_seqnum).contains(&seqnum),
+            "seqnums spread too far apart: {seqnum} is not in {min_seqnum}..={max_seqnum}",
+        );
+        assert!(!self.occupied[seqnum % DEPTH], "duplicate seqnum {seqnum}");
+
+        let slot = seqnum % DEPTH;
+        self.occupied.set(slot, true);
+        self.buffer[slot].write(value);
+    }
+
+    /// Takes a single item out of this queue. You can assume that returned
+    /// seqnums are strictly sequential across all calls to this method. A value
+    /// of `None` means that the item with the next expected seqnum is not yet
+    /// available (but items with higher seqnums might be already buffered).
+    pub fn get(&mut self) -> Option<(usize, T)> {
+        let slot = self.next_read % DEPTH;
+        if !self.occupied[slot] {
+            return None;
+        }
+        self.occupied.set(slot, false);
+        self.next_read += 1;
+        let value = unsafe { self.buffer[slot].assume_init_read() };
+        Some((self.next_read - 1, value))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.occupied.not_any()
+    }
+}
+
+impl<T, const DEPTH: usize> Drop for ReorderingQueue<T, DEPTH> {
+    fn drop(&mut self) {
+        for i in self.occupied.iter_ones() {
+            unsafe { self.buffer[i].assume_init_drop() };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let mut q = ReorderingQueue::<_, 6>::new();
+        assert!(q.is_empty());
+        q.put(0, "0");
+        q.put(2, "2");
+        q.put(3, "3");
+
+        assert_eq!(q.get(), Some((0, "0")));
+        assert_eq!(q.get(), None); // 1 is not yet available
+
+        q.put(1, "1");
+        assert_eq!(q.get(), Some((1, "1")));
+        assert_eq!(q.get(), Some((2, "2")));
+        assert_eq!(q.get(), Some((3, "3")));
+        assert_eq!(q.get(), None);
+
+        q.put(9, "9"); // This is max accepted ID (6 + 3)
+        assert_eq!(q.get(), None);
+        q.put(8, "8");
+        assert_eq!(q.get(), None);
+        q.put(7, "7");
+        assert_eq!(q.get(), None);
+        q.put(6, "6");
+        assert_eq!(q.get(), None);
+        q.put(5, "5");
+        assert_eq!(q.get(), None);
+        q.put(4, "4");
+        assert_eq!(q.get(), Some((4, "4")));
+        assert_eq!(q.get(), Some((5, "5")));
+        assert_eq!(q.get(), Some((6, "6")));
+        assert_eq!(q.get(), Some((7, "7")));
+        assert_eq!(q.get(), Some((8, "8")));
+        assert_eq!(q.get(), Some((9, "9")));
+        assert_eq!(q.get(), None);
+    }
+
+    #[test]
+    fn test_max() {
+        let mut q = ReorderingQueue::<_, MAX_DEPTH>::new();
+        q.put(0, 0.to_string());
+        assert_eq!(q.get(), Some((0, 0.to_string())));
+
+        for i in 1..MAX_DEPTH + 1 {
+            q.put(i, i.to_string());
+        }
+        for i in 1..MAX_DEPTH + 1 {
+            assert_eq!(q.get(), Some((i, i.to_string())));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "seqnums spread too far apart")]
+    fn test_max_plus_1() {
+        let mut q = ReorderingQueue::<_, MAX_DEPTH>::new();
+        q.put(0, 0.to_string());
+        assert_eq!(q.get(), Some((0, 0.to_string())));
+
+        for i in 1..MAX_DEPTH + 2 {
+            q.put(i, i.to_string());
+        }
+    }
+}

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -148,10 +148,10 @@ impl<S: UniversalRead<u8>> Pages<S> {
 
         let (read_ranges, buffer_offsets) = Self::get_page_value_ranges(pointer, config);
 
-        S::read_multi::<P>(self.pages.as_slice(), read_ranges, |idx, _, slice| {
+        S::read_multi::<P, _>(self.pages.as_slice(), read_ranges, |idx, _, slice| {
             let offset = buffer_offsets[idx];
             raw_value[offset..offset + slice.len()].write_copy_of_slice(slice);
-            Ok(())
+            Result::Ok(())
         })?;
 
         Ok(unsafe { assume_init_vec(raw_value) })


### PR DESCRIPTION
I plan to implement an iterator interface on top of `UniversalRead`.
Particularly, I want to implement the [`FallibleIterator::try_fold`](https://docs.rs/fallible-iterator/latest/fallible_iterator/trait.FallibleIterator.html#method.try_fold) method.

To do so, I need to adjust `read_batch` to let it call callbacks items in order.
This PR adds an additional generic parameter `YieldOrder` to force strict ordering.

For `io_uring` implementation, the strict ordering is achieved by using the new ringbuf-like structure that holds items that completed out of sequence. The same structure can be reused later for S3 or other async implementations.

Also, this PR adds a generic error parameter `E` to `read_batch` to let it fit into the `try_fold` interface. (and I think this approach is more idiomatic anyway)