### PR TITLE
edge 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge-py"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import tomlkit
 
-VERSION = "0.0.0"
+VERSION = "0.6.0"
 
 # Assume this script is in <root>/lib/edge/publish/.
 REPO_ROOT = Path(__file__).parent.parent.parent.parent

--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-edge-py"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Qdrant Team <info@qdrant.tech>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
Preparation for 0.6.0 release.

Release jobs seems to be passing:
- https://github.com/qdrant/qdrant/actions/runs/23303233528
- https://github.com/qdrant/qdrant/actions/runs/23303238858