### PR TITLE
More precise shard transfer for deferred points

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -41,14 +41,18 @@ impl Collection {
             .await
             .map(|config| config.prevent_unoptimized.unwrap_or(false))
             .unwrap_or(false);
+        // Only scan shards for deferred points if prevent_unoptimized is enabled,
+        // since deferred points can only exist with that configuration.
         if prevent_unoptimized {
-            log::info!("Using snapshot transfer method because prevent_unoptimized is enabled");
-            ShardTransferMethod::Snapshot
-        } else {
-            self.shared_storage_config
-                .default_shard_transfer_method
-                .unwrap_or(ShardTransferMethod::StreamRecords)
+            let has_deferred = self.shards_holder.read().await.has_deferred_points().await;
+            if has_deferred {
+                log::info!("Using snapshot transfer method because collection has deferred points");
+                return ShardTransferMethod::Snapshot;
+            }
         }
+        self.shared_storage_config
+            .default_shard_transfer_method
+            .unwrap_or(ShardTransferMethod::StreamRecords)
     }
 
     pub async fn start_shard_transfer<T, F>(

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -331,6 +331,15 @@ impl LocalShard {
         self.segments.clone()
     }
 
+    /// Check if any appendable segment in this shard has deferred points.
+    /// Only appendable segments can have deferred points.
+    pub fn has_deferred_points(&self) -> bool {
+        self.segments
+            .read()
+            .iter_appendable()
+            .any(|segment| segment.get().read().has_deferred_points())
+    }
+
     /// Recovers shard from disk.
     #[allow(clippy::too_many_arguments)]
     pub async fn load(

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -410,6 +410,14 @@ impl ShardReplicaSet {
         self.local.read().await.is_some()
     }
 
+    /// Check if the local shard has any deferred points.
+    pub async fn has_deferred_points(&self) -> bool {
+        match self.local.read().await.as_ref() {
+            Some(shard) => shard.has_deferred_points(),
+            None => false,
+        }
+    }
+
     /// Checks if the shard exists locally and not a proxy.
     pub async fn is_local(&self) -> bool {
         let local_read = self.local.read().await;

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -78,12 +78,16 @@ impl Shard {
     }
 
     /// Check if this shard has any deferred points.
-    /// Only local shards can have deferred points.
+    /// All proxy types delegate to their wrapped local shard.
     pub fn has_deferred_points(&self) -> bool {
         match self {
             Shard::Local(local_shard) => local_shard.has_deferred_points(),
             Shard::Proxy(proxy_shard) => proxy_shard.wrapped_shard.has_deferred_points(),
-            Shard::ForwardProxy(_) | Shard::QueueProxy(_) | Shard::Dummy(_) => false,
+            Shard::ForwardProxy(proxy_shard) => proxy_shard.wrapped_shard.has_deferred_points(),
+            Shard::QueueProxy(proxy_shard) => proxy_shard
+                .wrapped_shard()
+                .is_some_and(|shard| shard.has_deferred_points()),
+            Shard::Dummy(_) => false,
         }
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -77,6 +77,16 @@ impl Shard {
         }
     }
 
+    /// Check if this shard has any deferred points.
+    /// Only local shards can have deferred points.
+    pub fn has_deferred_points(&self) -> bool {
+        match self {
+            Shard::Local(local_shard) => local_shard.has_deferred_points(),
+            Shard::Proxy(proxy_shard) => proxy_shard.wrapped_shard.has_deferred_points(),
+            Shard::ForwardProxy(_) | Shard::QueueProxy(_) | Shard::Dummy(_) => false,
+        }
+    }
+
     pub async fn get_telemetry_data(
         &self,
         detail: TelemetryDetail,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -374,6 +374,16 @@ impl ShardHolder {
         self.shards.iter().map(|(id, shard)| (*id, shard))
     }
 
+    /// Check if any local shard in this holder has deferred points.
+    pub async fn has_deferred_points(&self) -> bool {
+        for replica_set in self.shards.values() {
+            if replica_set.has_deferred_points().await {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn all_shards(&self) -> impl Iterator<Item = &ShardReplicaSet> {
         self.shards.values()
     }


### PR DESCRIPTION
## Summary

 Improve the default shard transfer method selection for collections with `prevent_unoptimized` enabled.

 Instead of always forcing snapshot transfer when the config flag is set, check whether deferred points actually exist in the segments.

  ## Problem

  Previously, any collection with `prevent_unoptimized=true` would unconditionally use snapshot transfer, even if all segments were fully optimized and had no deferred points.

 This prevented using `stream_records` transfer in cases where it would be safe and potentially more efficient.

  ## Fix

  Add `has_deferred_points()` throughout the shard hierarchy (`LocalShard` → `Shard` → `ShardReplicaSet` → `ShardHolder`) to check the actual segment state. The default transfer method selection now:

  1. Checks `prevent_unoptimized` config (cheap gate — deferred points can only exist with this enabled)
  2. Scans appendable segments for actual deferred points (only if the config gate passes)
  3. Forces snapshot transfer only if deferred points are found
  4. Falls back to the configured default transfer method otherwise
