### PR TITLE
Disk cache with `UniversalRead` for slow disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "ordered-float 5.3.0",
+ "papaya",
  "parking_lot",
  "ph",
  "quick_cache",
@@ -4873,6 +4874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "papaya"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7015,6 +7026,16 @@ dependencies = [
  "vaporetto",
  "walkdir",
  "zerocopy",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -32,6 +32,7 @@ nix = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = "1.17"
 ordered-float = { workspace = true }
+papaya = "0.2.3"
 parking_lot = { workspace = true }
 ph = { workspace = true }
 quick_cache = "0.6.19"

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use super::controller::CacheRead;
 use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, FileId};
-use crate::universal_io;
 use crate::universal_io::io_uring::IoUringFile;
+use crate::universal_io::{self, ReadRange};
 
 /// Typed view over a cached file, simulating a `&[T]` backed by the block cache.
 ///
@@ -53,19 +53,23 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
     /// reference into the mmap. Otherwise, it will allocate a `Vec<T>` and copy
     /// block data into it. Allocating as `Vec<T>` (rather than `Vec<u8>`)
     /// guarantees correct alignment for any `T`.
-    pub fn get_range(&self, range: Range<usize>) -> universal_io::Result<Cow<'_, [T]>> {
+    pub fn get_range(&self, range: ReadRange) -> universal_io::Result<Cow<'_, [T]>> {
         let t_size = mem::size_of::<T>();
         debug_assert!(t_size != 0, "cannot use zero-sized type");
 
-        let total_elements = range.end - range.start;
-        if total_elements == 0 {
+        if range.length == 0 {
             return Ok(Cow::Borrowed(&[]));
         }
 
-        let byte_range = range.start * t_size..range.end * t_size;
+        let byte_start =
+            usize::try_from(range.byte_offset).expect("range.byte_offset is within usize");
+        let byte_length =
+            usize::try_from(range.length).expect("range.length is within usize") * t_size;
+        let byte_range = byte_start..byte_start + byte_length;
+
         let mut blocks_iter = self.blocks_for(byte_range);
 
-        // TODO(perf): if blocks are consecutive in the big cache file, we can still return without allocating.
+        // TODO(perf): if blocks are consecutive in the big cache file, we can potentially return without allocating.
         if blocks_iter.len() == 1 {
             let req = blocks_iter.next().expect("We just checked len() == 1");
             let result = self.controller.get_from_cache(req, |bytes| {
@@ -80,22 +84,115 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
             });
         }
 
-        // Multi-block: allocate Vec<T> directly for correct alignment.
-        let mut result = vec![T::zeroed(); total_elements];
-        let result_bytes = bytemuck::cast_slice_mut::<T, u8>(&mut result);
-        let mut copied = 0;
-        let mut copy_block = |slice: &[u8]| {
-            let end = copied + slice.len();
-            result_bytes[copied..end].copy_from_slice(slice);
-            copied = end;
-        };
-        for req in blocks_iter {
-            let read = self.controller.get_from_cache(req, &mut copy_block)?;
-            if let CacheRead::Hit(slice) = read {
-                copy_block(slice);
-            }
+        // Multi-block: delegate to the batch path which submits all
+        // cold-storage reads together via io_uring.
+        let mut result = None;
+        self.get_range_batch(std::iter::once(((), range)), |_meta, buf| {
+            result = Some(buf.to_vec());
+            Ok(())
+        })?;
+        Ok(Cow::Owned(result.expect("callback was called")))
+    }
+
+    /// Batch version of [`get_range`](Self::get_range).
+    ///
+    /// All block reads across every range are submitted together via a single
+    /// `get_from_cache_batch` call, so cold-storage I/O is batched through
+    /// io_uring.
+    ///
+    /// `callback(range_idx, &[T])` is called once per input range with the
+    /// fully assembled data for that range.
+    pub fn get_range_batch<'a, Meta: 'a>(
+        &self,
+        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
+        mut callback: impl FnMut(Meta, &[T]) -> universal_io::Result<()>,
+    ) -> universal_io::Result<()> {
+        let t_size = mem::size_of::<T>();
+        debug_assert!(t_size != 0, "cannot use zero-sized type");
+
+        struct BlockMeta {
+            range_idx: usize,
+            /// For multi-block ranges: index into `multiblock_buffers` and byte
+            /// offset within that buffer. `None` for single-block ranges
+            /// (delivered inline without a buffer).
+            multiblock: Option<(usize, usize)>,
         }
-        Ok(Cow::Owned(result))
+
+        let mut range_meta: Vec<Option<Meta>> = Vec::new();
+        let mut block_requests: Vec<BlockRequest> = Vec::new();
+        let mut block_meta: Vec<BlockMeta> = Vec::new();
+        // Dense list of (range_idx, buffer) for multi-block ranges only.
+        // Empty (no heap allocation) when all ranges are single-block.
+        let mut multiblock_buffers: Vec<(usize, Vec<T>)> = Vec::new();
+
+        for (range_idx, (meta, range)) in ranges.into_iter().enumerate() {
+            let byte_start =
+                usize::try_from(range.byte_offset).expect("range.byte_offset is within usize");
+            let byte_length =
+                usize::try_from(range.length).expect("range.length is within usize") * t_size;
+            let byte_range = byte_start..byte_start + byte_length;
+            let blocks = self.blocks_for(byte_range);
+
+            let buffer_idx = (blocks.len() > 1).then(|| {
+                let buffer_idx = multiblock_buffers.len();
+                multiblock_buffers.push((range_idx, vec![T::zeroed(); range.length as usize]));
+                buffer_idx
+            });
+
+            let mut dest_offset = 0;
+            for block in blocks {
+                block_meta.push(BlockMeta {
+                    range_idx,
+                    multiblock: buffer_idx.map(|idx| (idx, dest_offset)),
+                });
+                dest_offset += block.range.len();
+                block_requests.push(block);
+            }
+
+            range_meta.push(Some(meta));
+        }
+
+        if block_requests.is_empty() {
+            return Ok(());
+        }
+
+        let mut callback_err: Option<universal_io::UniversalIoError> = None;
+
+        self.controller
+            .get_from_cache_batch(block_requests, |block_idx, slice| {
+                if callback_err.is_some() {
+                    return;
+                }
+
+                let BlockMeta {
+                    range_idx,
+                    multiblock,
+                } = block_meta[block_idx];
+                if let Some((buffer_idx, dest_offset)) = multiblock {
+                    // Multi-block range: copy into the multiblock buffer.
+                    let buf = &mut multiblock_buffers[buffer_idx].1;
+                    let buf_bytes = bytemuck::cast_slice_mut::<T, u8>(buf);
+                    buf_bytes[dest_offset..dest_offset + slice.len()].copy_from_slice(slice);
+                } else {
+                    // Single-block range: deliver directly, no buffer needed.
+                    let meta = range_meta[range_idx].take().expect("Only consumed once");
+                    if let Err(e) = callback(meta, bytemuck::cast_slice(slice)) {
+                        callback_err = Some(e);
+                    }
+                }
+            })?;
+
+        if let Some(err) = callback_err {
+            return Err(err);
+        }
+
+        // Deliver assembled multi-block buffers.
+        for (range_idx, buf) in multiblock_buffers {
+            let meta = range_meta[range_idx].take().expect("Only consumed once");
+            callback(meta, &buf)?;
+        }
+
+        Ok(())
     }
 
     /// Try to make every block this file spans present in the cache.
@@ -130,7 +227,10 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
 
     #[cfg(test)]
     pub fn get(&self, idx: usize) -> universal_io::Result<Cow<'_, T>> {
-        let slice = self.get_range(idx..idx + 1)?;
+        let slice = self.get_range(ReadRange {
+            byte_offset: (idx * size_of::<T>()) as u64,
+            length: 1,
+        })?;
 
         let cow = match slice {
             Cow::Borrowed(slice) => Cow::Borrowed(&slice[0]),

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -1,11 +1,14 @@
 use std::borrow::Cow;
-use std::io;
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
-use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, CacheRead, FileId};
+use super::controller::CacheRead;
+use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, FileId};
+use crate::universal_io;
+use crate::universal_io::io_uring::IoUringFile;
 
 /// Typed view over a cached file, simulating a `&[T]` backed by the block cache.
 ///
@@ -21,14 +24,17 @@ pub struct CachedSlice<T> {
     len_bytes: usize,
 
     /// The controller backing this structure.
-    controller: Arc<CacheController>,
+    controller: Arc<CacheController<IoUringFile>>,
 
     r#type: PhantomData<T>,
 }
 
 impl<T: bytemuck::Pod> CachedSlice<T> {
     /// Open a file through the cache controller and return a typed view over it.
-    pub fn open(controller: &Arc<CacheController>, path: &Path) -> io::Result<Self> {
+    pub fn open(
+        controller: &Arc<CacheController<IoUringFile>>,
+        path: &Path,
+    ) -> universal_io::Result<Self> {
         let (file_id, len) = controller.open_file(path)?;
         Ok(Self {
             file_id,
@@ -47,8 +53,8 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
     /// reference into the mmap. Otherwise, it will allocate a `Vec<T>` and copy
     /// block data into it. Allocating as `Vec<T>` (rather than `Vec<u8>`)
     /// guarantees correct alignment for any `T`.
-    pub fn get_range(&self, range: Range<usize>) -> io::Result<Cow<'_, [T]>> {
-        let t_size = size_of::<T>();
+    pub fn get_range(&self, range: Range<usize>) -> universal_io::Result<Cow<'_, [T]>> {
+        let t_size = mem::size_of::<T>();
         debug_assert!(t_size != 0, "cannot use zero-sized type");
 
         let total_elements = range.end - range.start;
@@ -96,7 +102,7 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
     ///
     /// Touches one byte per block in a sequential pass. On miss, the full
     /// block is read from cold storage into the cache.
-    pub fn populate(&self) -> io::Result<()> {
+    pub fn populate(&self) -> universal_io::Result<()> {
         if self.len_bytes == 0 {
             return Ok(());
         }
@@ -123,7 +129,7 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
     }
 
     #[cfg(test)]
-    pub fn get(&self, idx: usize) -> io::Result<Cow<'_, T>> {
+    pub fn get(&self, idx: usize) -> universal_io::Result<Cow<'_, T>> {
         let slice = self.get_range(idx..idx + 1)?;
 
         let cow = match slice {

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -163,33 +163,33 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
         if block_requests.is_empty() {
             return Ok(());
         }
-        let controller = controller.expect("non-empty block_requests implies there is a controller");
+        let controller =
+            controller.expect("non-empty block_requests implies there is a controller");
 
         let mut callback_err: Option<universal_io::UniversalIoError> = None;
 
-        controller
-            .get_from_cache_batch(block_requests, |block_idx, slice| {
-                if callback_err.is_some() {
-                    return;
-                }
+        controller.get_from_cache_batch(block_requests, |block_idx, slice| {
+            if callback_err.is_some() {
+                return;
+            }
 
-                let BlockMeta {
-                    range_idx,
-                    multiblock,
-                } = block_meta[block_idx];
-                if let Some((buffer_idx, dest_offset)) = multiblock {
-                    // Multi-block range: copy into the multiblock buffer.
-                    let buf = &mut multiblock_buffers[buffer_idx].1;
-                    let buf_bytes = bytemuck::cast_slice_mut::<T, u8>(buf);
-                    buf_bytes[dest_offset..dest_offset + slice.len()].copy_from_slice(slice);
-                } else {
-                    // Single-block range: deliver directly, no buffer needed.
-                    let meta = range_meta[range_idx].take().expect("Only consumed once");
-                    if let Err(e) = callback(meta, bytemuck::cast_slice(slice)) {
-                        callback_err = Some(e);
-                    }
+            let BlockMeta {
+                range_idx,
+                multiblock,
+            } = block_meta[block_idx];
+            if let Some((buffer_idx, dest_offset)) = multiblock {
+                // Multi-block range: copy into the multiblock buffer.
+                let buf = &mut multiblock_buffers[buffer_idx].1;
+                let buf_bytes = bytemuck::cast_slice_mut::<T, u8>(buf);
+                buf_bytes[dest_offset..dest_offset + slice.len()].copy_from_slice(slice);
+            } else {
+                // Single-block range: deliver directly, no buffer needed.
+                let meta = range_meta[range_idx].take().expect("Only consumed once");
+                if let Err(e) = callback(meta, bytemuck::cast_slice(slice)) {
+                    callback_err = Some(e);
                 }
-            })?;
+            }
+        })?;
 
         if let Some(err) = callback_err {
             return Err(err);

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -87,26 +87,25 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
         // Multi-block: delegate to the batch path which submits all
         // cold-storage reads together via io_uring.
         let mut result = None;
-        self.get_range_batch(std::iter::once(((), range)), |_meta, buf| {
+        Self::read_multi(std::iter::once(((), self, range)), |_meta, buf| {
             result = Some(buf.to_vec());
             Ok(())
         })?;
         Ok(Cow::Owned(result.expect("callback was called")))
     }
 
-    /// Batch version of [`get_range`](Self::get_range).
+    /// Batch read across any number of `CachedSlice`s sharing the same cache
+    /// controller.
     ///
-    /// All block reads across every range are submitted together via a single
-    /// `get_from_cache_batch` call, so cold-storage I/O is batched through
-    /// io_uring.
-    ///
-    /// `callback(range_idx, &[T])` is called once per input range with the
-    /// fully assembled data for that range.
-    pub fn get_range_batch<'a, Meta: 'a>(
-        &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
+    /// All block reads for every `(meta, &CachedSlice, range)` tuple are
+    /// submitted together via a single `get_from_cache_batch` call.
+    pub fn read_multi<'a, Meta: 'a>(
+        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
         mut callback: impl FnMut(Meta, &[T]) -> universal_io::Result<()>,
-    ) -> universal_io::Result<()> {
+    ) -> universal_io::Result<()>
+    where
+        Self: 'a,
+    {
         let t_size = mem::size_of::<T>();
         debug_assert!(t_size != 0, "cannot use zero-sized type");
 
@@ -124,14 +123,23 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
         // Dense list of (range_idx, buffer) for multi-block ranges only.
         // Empty (no heap allocation) when all ranges are single-block.
         let mut multiblock_buffers: Vec<(usize, Vec<T>)> = Vec::new();
+        let mut controller: Option<Arc<CacheController<IoUringFile>>> = None;
 
-        for (range_idx, (meta, range)) in ranges.into_iter().enumerate() {
+        for (range_idx, (meta, file, range)) in reads.into_iter().enumerate() {
+            match &controller {
+                None => controller = Some(Arc::clone(&file.controller)),
+                Some(existing) => debug_assert!(
+                    Arc::ptr_eq(existing, &file.controller),
+                    "all CachedSlices in read_multi must share the same controller",
+                ),
+            }
+
             let byte_start =
                 usize::try_from(range.byte_offset).expect("range.byte_offset is within usize");
             let byte_length =
                 usize::try_from(range.length).expect("range.length is within usize") * t_size;
             let byte_range = byte_start..byte_start + byte_length;
-            let blocks = self.blocks_for(byte_range);
+            let blocks = file.blocks_for(byte_range);
 
             let buffer_idx = (blocks.len() > 1).then(|| {
                 let buffer_idx = multiblock_buffers.len();
@@ -155,10 +163,11 @@ impl<T: bytemuck::Pod> CachedSlice<T> {
         if block_requests.is_empty() {
             return Ok(());
         }
+        let controller = controller.expect("non-empty block_requests implies there is a controller");
 
         let mut callback_err: Option<universal_io::UniversalIoError> = None;
 
-        self.controller
+        controller
             .get_from_cache_batch(block_requests, |block_idx, slice| {
                 if callback_err.is_some() {
                     return;

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
@@ -6,16 +5,16 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use fs_err as fs;
-use fs_err::os::unix::fs::FileExt;
-#[cfg(target_os = "linux")]
-use fs_err::os::unix::fs::OpenOptionsExt;
 use memmap2::MmapRaw;
-use parking_lot::{Condvar, Mutex, RwLock};
+use parking_lot::{Condvar, Mutex};
 use quick_cache::UnitWeighter;
 use quick_cache::sync::GuardResult;
 
 use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, FileId};
 use crate::fs::clear_disk_cache;
+use crate::generic_consts::Random;
+use crate::universal_io::io_uring::IoUringFile;
+use crate::universal_io::{self, ReadRange, OpenOptions, UniversalRead};
 
 const UNUSED_BLOCKS_MARGIN: u64 = 16;
 
@@ -57,10 +56,9 @@ impl<const N: usize> DerefMut for AlignedBuf<N> {
 ///
 /// It only supports immutable files, so it does not handle dirty pages or manual eviction.
 #[derive(Debug)]
-pub struct CacheController {
+pub struct CacheController<SlowFile: UniversalRead<u8> = IoUringFile> {
     /// Mapping from the assigned file id, to its file descriptor
-    // TODO: use nested `impl UniversalRead` instead
-    files: RwLock<HashMap<FileId, fs::File>>,
+    files: papaya::HashMap<FileId, SlowFile>,
 
     /// Used to assign file ids on new files.
     file_id_counter: AtomicU32,
@@ -82,9 +80,9 @@ pub struct CacheController {
     cache_mmap: memmap2::MmapRaw,
 }
 
-impl CacheController {
+impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
     /// Create a new cache instance.
-    pub fn new(cache_path: &Path, size_bytes: u64) -> io::Result<Arc<CacheController>> {
+    pub fn new(cache_path: &Path, size_bytes: u64) -> io::Result<Arc<Self>> {
         let size_bytes = size_bytes.next_multiple_of(BLOCK_SIZE as u64);
         let size_blocks = size_bytes / BLOCK_SIZE as u64;
 
@@ -128,7 +126,7 @@ impl CacheController {
         );
 
         Ok(Arc::new(CacheController {
-            files: RwLock::new(HashMap::new()),
+            files: papaya::HashMap::new(),
             file_id_counter: AtomicU32::new(0),
             cache,
             blocks_lifecycle,
@@ -138,33 +136,29 @@ impl CacheController {
 
     /// Opens a new file, registers it with the cache, and returns its
     /// internal id and byte length.
-    pub(super) fn open_file(&self, path: &Path) -> io::Result<(FileId, usize)> {
+    pub(super) fn open_file(&self, path: &Path) -> universal_io::Result<(FileId, usize)> {
         // FIXME: clear_disk_cache is no-op on macos
         clear_disk_cache(path)?;
 
-        let mut opts = fs::File::options();
-        opts.read(true);
-        #[cfg(target_os = "linux")]
-        opts.custom_flags(nix::libc::O_DIRECT);
-        let f = opts.open(path)?;
-        #[cfg(target_os = "macos")]
-        {
-            // TODO: add this to `nix` crate
-            use std::os::fd::AsRawFd;
-            // SAFETY: valid fd and known fcntl command
-            let ret = unsafe { nix::libc::fcntl(f.as_raw_fd(), nix::libc::F_NOCACHE, 1) };
-            if ret == -1 {
-                return Err(io::Error::last_os_error());
-            }
-        }
+        let opts = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            disk_parallel: None,
+            populate: Some(false),
+            advice: None,
+            prevent_caching: Some(true),
+        };
 
-        let len = f.metadata()?.len() as usize;
+        let f = SlowFile::open(path, opts)?;
+
+        let len = f.len()? as usize;
 
         // TODO: this will wrap when we have > 4.29 billion files, what to do then?
         let file_id = self.file_id_counter.fetch_add(1, Ordering::SeqCst);
         let file_id = FileId(file_id);
 
-        self.files.write().insert(file_id, f);
+        self.files.pin().insert(file_id, f);
+
         Ok((file_id, len))
     }
 
@@ -177,7 +171,7 @@ impl CacheController {
         &self,
         req: BlockRequest,
         on_miss: impl FnOnce(&[u8]) -> O,
-    ) -> io::Result<CacheRead<'_, O>> {
+    ) -> universal_io::Result<CacheRead<'_, O>> {
         let BlockRequest { key, range } = req;
 
         match self.cache.get_value_or_guard(&key, None) {
@@ -201,23 +195,20 @@ impl CacheController {
                 // 1. Read from cold storage.
                 // --------------------------
 
-                let mut buf = AlignedBuf::<BLOCK_SIZE>::new();
+                // let mut buf = AlignedBuf::<BLOCK_SIZE>::new();
 
-                let files = self.files.read();
+                let files = self.files.pin();
                 let file = files
                     .get(&key.file_id)
                     .expect("cached file descriptor is not open");
-                if range.len() == BLOCK_SIZE {
-                    file.read_exact_at(&mut buf, key.offset.bytes() as u64)?;
-                } else {
-                    let bytes_read = file.read_at(&mut buf, key.offset.bytes() as u64)?;
-                    if bytes_read < range.len() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            "short read from cold storage",
-                        ));
-                    }
-                }
+
+                let elem_range = ReadRange {
+                    byte_offset: key.offset.bytes() as u64,
+                    length: ((file.len()? as usize).saturating_sub(key.offset.bytes()))
+                        .min(BLOCK_SIZE) as u64,
+                };
+
+                let cow = file.read::<Random>(elem_range)?;
 
                 // 2. Write to hot storage.
                 // ------------------------
@@ -228,10 +219,12 @@ impl CacheController {
                 // SAFETY: non-overlapping regions are guaranteed by the block allocation logic;
                 // the insert guard prevent concurrent writes to the same block.
                 unsafe {
-                    self.cache_mmap
-                        .as_mut_ptr()
-                        .add(offset)
-                        .copy_from(buf.as_ptr(), BLOCK_SIZE);
+                    let dst = self.cache_mmap.as_mut_ptr().add(offset);
+                    let data_len = elem_range.length as usize;
+                    dst.copy_from(cow.as_ptr(), data_len);
+                    if data_len < BLOCK_SIZE {
+                        dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);
+                    }
                 }
 
                 // 3. Commit.
@@ -240,7 +233,7 @@ impl CacheController {
                 // FIXME: unwrap panics when `key` deleted while guard is still alive.
                 guard.insert(allocated_offset).unwrap();
 
-                Ok(CacheRead::Miss(on_miss(&buf[range])))
+                Ok(CacheRead::Miss(on_miss(&cow[range])))
             }
             GuardResult::Timeout => unreachable!("We didn't set a timeout"),
         }

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -309,7 +309,7 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
         // We expect usage to be batched for a single file at a time anyway, but chunk to be sure.
         let per_file = misses.into_iter().chunk_by(|op| op.req.key.file_id);
 
-        for (file_id, ops) in per_file.into_iter() {
+        for (file_id, ops) in &per_file {
             let file = files
                 .get(&file_id)
                 .expect("cached file descriptor is not open");

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -5,16 +5,17 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use fs_err as fs;
+use itertools::Itertools;
 use memmap2::MmapRaw;
 use parking_lot::{Condvar, Mutex};
 use quick_cache::UnitWeighter;
-use quick_cache::sync::GuardResult;
+use quick_cache::sync::{GuardResult, PlaceholderGuard};
 
 use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, FileId};
 use crate::fs::clear_disk_cache;
 use crate::generic_consts::Random;
 use crate::universal_io::io_uring::IoUringFile;
-use crate::universal_io::{self, ReadRange, OpenOptions, UniversalRead};
+use crate::universal_io::{self, OpenOptions, ReadRange, UniversalRead};
 
 const UNUSED_BLOCKS_MARGIN: u64 = 16;
 
@@ -51,6 +52,9 @@ impl<const N: usize> DerefMut for AlignedBuf<N> {
         &mut self.0
     }
 }
+
+type CacheGuard<'a> =
+    PlaceholderGuard<'a, BlockId, BlockOffset, UnitWeighter, ahash::RandomState, BlocksLifecycle>;
 
 /// Caching layer for files in a slow disk, to be mapped into a file in a fast disk.
 ///
@@ -239,6 +243,121 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
             }
             GuardResult::Timeout => unreachable!("We didn't set a timeout"),
         }
+    }
+
+    /// Fetch multiple blocks from cache, batching cold-storage reads via `read_batch`.
+    ///
+    /// Cache hits are served immediately from the mmap. Cache misses are collected
+    /// and submitted as a single `read_batch` call per file for asynchronous I/O,
+    /// then written to hot storage and committed to the cache.
+    ///
+    /// For each request, calls `on_result(index, &[u8])` with the requested byte
+    /// slice. The `index` corresponds to the position in the `requests` iterator.
+    pub(super) fn get_from_cache_batch(
+        &self,
+        requests: impl IntoIterator<Item = BlockRequest>,
+        mut on_result: impl FnMut(usize, &[u8]),
+    ) -> universal_io::Result<()> {
+        // Phase 1: Check cache, serve hits immediately, collect misses.
+        struct SlowReadOp<'a> {
+            req_idx: usize,
+            req: BlockRequest,
+            insert_guard: Option<CacheGuard<'a>>,
+        }
+        let mut misses: Vec<SlowReadOp> = Vec::new();
+
+        for (idx, req) in requests.into_iter().enumerate() {
+            let BlockRequest { key, ref range } = req;
+
+            match self.cache.get_value_or_guard(&key, None) {
+                GuardResult::Value(block_offset) => {
+                    let byte_range =
+                        block_offset.bytes() + range.start..block_offset.bytes() + range.end;
+                    let slice = unsafe {
+                        std::slice::from_raw_parts(
+                            self.cache_mmap.as_ptr().add(byte_range.start),
+                            byte_range.len(),
+                        )
+                    };
+                    on_result(idx, slice);
+                }
+                GuardResult::Guard(guard) => {
+                    misses.push(SlowReadOp {
+                        req_idx: idx,
+                        req: req,
+                        insert_guard: Some(guard),
+                    });
+                }
+                GuardResult::Timeout => unreachable!("We didn't set a timeout"),
+            }
+        }
+
+        if misses.is_empty() {
+            return Ok(());
+        }
+
+        // Phase 2: Batch read all misses from cold storage.
+        //
+        // Group misses by file_id so each group can be submitted as a single
+        // `read_batch` call. Collect ranges upfront to avoid borrowing `misses`
+        // while the callback also needs mutable access to it.
+
+        let files = self.files.pin();
+
+        // We expect usage to be batched for a single file at a time anyway, but chunk to be sure.
+        let per_file = misses.into_iter().chunk_by(|op| op.req.key.file_id);
+
+        for (file_id, ops) in per_file.into_iter() {
+            let file = files
+                .get(&file_id)
+                .expect("cached file descriptor is not open");
+
+            let mut ops = ops.collect_vec();
+            let ranges = ops
+                .iter()
+                .map(|op| {
+                    ReadRange {
+                        byte_offset: op.req.key.offset.bytes() as u64,
+                        // Always request entire block, if we get to EOF, UniversalRead should return a short read.
+                        // We don't want to request less than this because O_DIRECT requires to be aligned to some block size
+                        length: BLOCK_SIZE as u64,
+                    }
+                })
+                .enumerate()
+                .collect_vec();
+
+            file.read_batch::<Random, usize>(ranges, |op_idx, data: &[u8]| {
+                let SlowReadOp {
+                    req_idx,
+                    ref req,
+                    ref mut insert_guard,
+                } = ops[op_idx];
+
+                // Write to hot storage.
+                let allocated_offset = self.blocks_lifecycle.pop_unused_block();
+                let offset = allocated_offset.bytes();
+                // SAFETY: the blocks_lifecycle ensures we are writing in a safe section of the mmap,
+                // and the insert guard makes sure we are the only ones doing so.
+                unsafe {
+                    let dst = self.cache_mmap.as_mut_ptr().add(offset);
+                    let data_len = data.len();
+                    dst.copy_from(data.as_ptr(), data_len);
+                    if data_len < BLOCK_SIZE {
+                        // Zero out the rest of the block in case we had a short read.
+                        dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);
+                    }
+                }
+
+                // Commit to cache.
+                let guard = insert_guard.take();
+                guard.expect("each read is only carried out once").insert(allocated_offset).expect("There are no remove operations happening, and we always insert through placeholder");
+
+                on_result(req_idx, &data[req.range.clone()]);
+                Ok(())
+            })?;
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -166,6 +166,34 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
         Ok((file_id, len))
     }
 
+    /// Read a slice from the hot-storage mmap at the given block offset and byte range.
+    ///
+    /// # Safety
+    /// The caller must ensure `block_offset` and `range` refer to a valid,
+    /// previously-written region of `cache_mmap`.
+    unsafe fn read_cache_mmap(&self, block_offset: BlockOffset, range: Range<usize>) -> &[u8] {
+        let start = block_offset.bytes() + range.start;
+        let len = range.end - range.start;
+        unsafe { std::slice::from_raw_parts(self.cache_mmap.as_ptr().add(start), len) }
+    }
+
+    /// Write a block's data into hot storage at the given offset,
+    /// zero-padding if the data is shorter than `BLOCK_SIZE`.
+    ///
+    /// # Safety
+    /// The caller must ensure `allocated_offset` points to a region that is not
+    /// concurrently read or written (guaranteed by the block lifecycle + insert guard).
+    unsafe fn write_cache_mmap(&self, allocated_offset: BlockOffset, data: &[u8]) {
+        unsafe {
+            let dst = self.cache_mmap.as_mut_ptr().add(allocated_offset.bytes());
+            let data_len = data.len();
+            dst.copy_from(data.as_ptr(), data_len);
+            if data_len < BLOCK_SIZE {
+                dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);
+            }
+        }
+    }
+
     /// Fetch a block from cache, or read it from cold storage on miss.
     ///
     /// On hit, returns a borrowed slice from the mmap. On miss, calls
@@ -181,17 +209,9 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
         match self.cache.get_value_or_guard(&key, None) {
             // Cache hit.
             GuardResult::Value(block_offset) => {
-                // Read from hot mmap.
-                let range = block_offset.bytes() + range.start..block_offset.bytes() + range.end;
-
                 // TODO: Pin the block_id, track the lifetime of the borrow,
                 // then release the block_id when the borrow ends
-                let slice = unsafe {
-                    std::slice::from_raw_parts(
-                        self.cache_mmap.as_ptr().add(range.start),
-                        range.len(),
-                    )
-                };
+                let slice = unsafe { self.read_cache_mmap(block_offset, range) };
                 Ok(CacheRead::Hit(slice))
             }
             // Cache miss.
@@ -220,18 +240,7 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
                 // ------------------------
 
                 let allocated_offset = self.blocks_lifecycle.pop_unused_block();
-
-                let offset = allocated_offset.bytes();
-                // SAFETY: non-overlapping regions are guaranteed by the block allocation logic;
-                // the insert guard prevent concurrent writes to the same block.
-                unsafe {
-                    let dst = self.cache_mmap.as_mut_ptr().add(offset);
-                    let data_len = cow.len();
-                    dst.copy_from(cow.as_ptr(), data_len);
-                    if data_len < BLOCK_SIZE {
-                        dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);
-                    }
-                }
+                unsafe { self.write_cache_mmap(allocated_offset, &cow) };
 
                 // 3. Commit.
                 // ----------
@@ -271,20 +280,13 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
 
             match self.cache.get_value_or_guard(&key, None) {
                 GuardResult::Value(block_offset) => {
-                    let byte_range =
-                        block_offset.bytes() + range.start..block_offset.bytes() + range.end;
-                    let slice = unsafe {
-                        std::slice::from_raw_parts(
-                            self.cache_mmap.as_ptr().add(byte_range.start),
-                            byte_range.len(),
-                        )
-                    };
+                    let slice = unsafe { self.read_cache_mmap(block_offset, range.clone()) };
                     on_result(idx, slice);
                 }
                 GuardResult::Guard(guard) => {
                     misses.push(SlowReadOp {
                         req_idx: idx,
-                        req: req,
+                        req,
                         insert_guard: Some(guard),
                     });
                 }
@@ -335,18 +337,7 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
 
                 // Write to hot storage.
                 let allocated_offset = self.blocks_lifecycle.pop_unused_block();
-                let offset = allocated_offset.bytes();
-                // SAFETY: the blocks_lifecycle ensures we are writing in a safe section of the mmap,
-                // and the insert guard makes sure we are the only ones doing so.
-                unsafe {
-                    let dst = self.cache_mmap.as_mut_ptr().add(offset);
-                    let data_len = data.len();
-                    dst.copy_from(data.as_ptr(), data_len);
-                    if data_len < BLOCK_SIZE {
-                        // Zero out the rest of the block in case we had a short read.
-                        dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);
-                    }
-                }
+                unsafe { self.write_cache_mmap(allocated_offset, data) };
 
                 // Commit to cache.
                 let guard = insert_guard.take();

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -202,10 +202,12 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
                     .get(&key.file_id)
                     .expect("cached file descriptor is not open");
 
+                // Always request a full BLOCK_SIZE so that the read length stays
+                // sector-aligned (required by O_DIRECT). The kernel will return a
+                // short read for the last block of the file.
                 let elem_range = ReadRange {
                     byte_offset: key.offset.bytes() as u64,
-                    length: ((file.len()? as usize).saturating_sub(key.offset.bytes()))
-                        .min(BLOCK_SIZE) as u64,
+                    length: BLOCK_SIZE as u64,
                 };
 
                 let cow = file.read::<Random>(elem_range)?;
@@ -220,7 +222,7 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
                 // the insert guard prevent concurrent writes to the same block.
                 unsafe {
                     let dst = self.cache_mmap.as_mut_ptr().add(offset);
-                    let data_len = elem_range.length as usize;
+                    let data_len = cow.len();
                     dst.copy_from(cow.as_ptr(), data_len);
                     if data_len < BLOCK_SIZE {
                         dst.add(data_len).write_bytes(0, BLOCK_SIZE - data_len);

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Range};
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -317,13 +317,11 @@ impl<SlowFile: UniversalRead<u8>> CacheController<SlowFile> {
             let mut ops = ops.collect_vec();
             let ranges = ops
                 .iter()
-                .map(|op| {
-                    ReadRange {
-                        byte_offset: op.req.key.offset.bytes() as u64,
-                        // Always request entire block, if we get to EOF, UniversalRead should return a short read.
-                        // We don't want to request less than this because O_DIRECT requires to be aligned to some block size
-                        length: BLOCK_SIZE as u64,
-                    }
+                .map(|op| ReadRange {
+                    byte_offset: op.req.key.offset.bytes() as u64,
+                    // Always request entire block, if we get to EOF, UniversalRead should return a short read.
+                    // We don't want to request less than this because O_DIRECT requires to be aligned to some block size
+                    length: BLOCK_SIZE as u64,
                 })
                 .enumerate()
                 .collect_vec();

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -95,7 +95,20 @@ impl<T: bytemuck::Pod> UniversalRead<T> for CachedSlice<T> {
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()> {
-        self.get_range_batch(ranges, callback)
+        CachedSlice::read_multi(
+            ranges.into_iter().map(|(meta, range)| (meta, self, range)),
+            callback,
+        )
+    }
+
+    fn read_multi<'a, P: AccessPattern, Meta: 'a>(
+        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
+        callback: impl FnMut(Meta, &[T]) -> Result<()>,
+    ) -> Result<()>
+    where
+        Self: 'a,
+    {
+        CachedSlice::read_multi(reads, callback)
     }
 
     fn len(&self) -> Result<u64> {

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -16,7 +16,7 @@ mod controller;
 mod tests;
 
 pub use cached_slice::CachedSlice;
-use controller::{CacheController, CacheRead};
+use controller::CacheController;
 
 /// We cache data in blocks of this size.
 /// Should be multiple of filesystem block size (usually 4 KiB).
@@ -87,26 +87,15 @@ impl<T: bytemuck::Pod> UniversalRead<T> for CachedSlice<T> {
     }
 
     fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        let elem_start = usize::try_from(range.byte_offset).expect("range.start is within usize")
-            / size_of::<T>();
-        let elem_length = usize::try_from(range.length).expect("range.length is within usize");
-
-        let range = elem_start..elem_start + elem_length;
-
-        Ok(self.get_range(range)?)
+        self.get_range(range)
     }
 
     fn read_batch<'a, P: AccessPattern, Meta: 'a>(
         &'a self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-        mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
+        callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()> {
-        for (meta, range) in ranges {
-            let data = self.read::<P>(range)?;
-            callback(meta, &data)?;
-        }
-
-        Ok(())
+        self.get_range_batch(ranges, callback)
     }
 
     fn len(&self) -> Result<u64> {

--- a/lib/common/common/src/universal_io/disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/disk_cache/tests.rs
@@ -6,6 +6,8 @@ use fs_err as fs;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
+use crate::universal_io::ReadRange;
+
 use super::{BLOCK_SIZE, CacheController, CachedSlice};
 
 #[test]
@@ -20,30 +22,57 @@ fn test_cacher() {
 
     eprintln!(
         "data0: {}",
-        fancy_decode(&fd.get_range(BLOCK_SIZE * 3..BLOCK_SIZE * 3).unwrap())
+        fancy_decode(
+            &fd.get_range(ReadRange {
+                byte_offset: (BLOCK_SIZE * 3) as u64,
+                length: 0
+            })
+            .unwrap()
+        )
     );
 
     eprintln!(
         "data0a: {}",
         fancy_decode(
-            &fd.get_range(BLOCK_SIZE * 3 + 3..BLOCK_SIZE * 3 + 14)
-                .unwrap()
+            &fd.get_range(ReadRange {
+                byte_offset: (BLOCK_SIZE * 3 + 3) as u64,
+                length: 14
+            })
+            .unwrap()
         )
     );
 
     eprintln!(
         "data1: {}",
-        fancy_decode(&fd.get_range(BLOCK_SIZE * 3..BLOCK_SIZE * 4 - 1).unwrap())
+        fancy_decode(
+            &fd.get_range(ReadRange {
+                byte_offset: (BLOCK_SIZE * 3) as u64,
+                length: BLOCK_SIZE as u64 - 1
+            })
+            .unwrap()
+        )
     );
 
     eprintln!(
         "data2: {}",
-        fancy_decode(&fd.get_range(BLOCK_SIZE * 3..BLOCK_SIZE * 4).unwrap())
+        fancy_decode(
+            &fd.get_range(ReadRange {
+                byte_offset: (BLOCK_SIZE * 3) as u64,
+                length: BLOCK_SIZE as u64
+            })
+            .unwrap()
+        )
     );
 
     eprintln!(
         "data3: {}",
-        fancy_decode(&fd.get_range(BLOCK_SIZE * 3..BLOCK_SIZE * 4 + 1).unwrap())
+        fancy_decode(
+            &fd.get_range(ReadRange {
+                byte_offset: (BLOCK_SIZE * 3) as u64,
+                length: (BLOCK_SIZE + 1) as u64
+            })
+            .unwrap()
+        )
     );
 }
 
@@ -138,7 +167,11 @@ fn test_cached_slice_vectors_sequential() {
     for vec_idx in 0..NUM_VECTORS {
         let start = vec_idx * VECTOR_DIM;
         let end = start + VECTOR_DIM;
-        let cached_vec = cached_slice.get_range(start..end).unwrap();
+        let range = ReadRange {
+            byte_offset: (vec_idx * VECTOR_DIM * size_of::<f32>()) as u64,
+            length: VECTOR_DIM as u64,
+        };
+        let cached_vec = cached_slice.get_range(range).unwrap();
         assert_eq!(
             cached_vec.as_ref(),
             &vectors[start..end],
@@ -181,7 +214,11 @@ fn test_cached_slice_vectors_random_access() {
         let vec_idx = rng.random_range(0..NUM_VECTORS);
         let start = vec_idx * VECTOR_DIM;
         let end = start + VECTOR_DIM;
-        let cached_vec = cached_slice.get_range(start..end).unwrap();
+        let range = ReadRange {
+            byte_offset: (vec_idx * VECTOR_DIM * size_of::<f32>()) as u64,
+            length: VECTOR_DIM as u64,
+        };
+        let cached_vec = cached_slice.get_range(range).unwrap();
         assert_eq!(
             cached_vec.as_ref(),
             &vectors[start..end],
@@ -197,7 +234,13 @@ fn test_cached_slice_vectors_random_access() {
             continue;
         }
         let b = a + rng.random_range(1..=max_len);
-        let cached_range = cached_slice.get_range(a..b).unwrap();
+        dbg!(a..b);
+        let range = ReadRange {
+            byte_offset: (a * size_of::<f32>()) as u64,
+            length: (b - a) as u64,
+        };
+        dbg!(range);
+        let cached_range = cached_slice.get_range(range).unwrap();
         assert_eq!(
             cached_range.as_ref(),
             &vectors[a..b],
@@ -246,8 +289,11 @@ fn test_no_more_blocks_concurrent_exhaustion() {
             std::thread::spawn(move || {
                 barrier.wait();
                 for block in 0..blocks_per_file {
-                    fd.get_range(block * BLOCK_SIZE..(block + 1) * BLOCK_SIZE)
-                        .unwrap();
+                    fd.get_range(ReadRange {
+                        byte_offset: (block * BLOCK_SIZE) as u64,
+                        length: BLOCK_SIZE as u64,
+                    })
+                    .unwrap();
                 }
             })
         })

--- a/lib/common/common/src/universal_io/disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/disk_cache/tests.rs
@@ -6,9 +6,8 @@ use fs_err as fs;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
-use crate::universal_io::ReadRange;
-
 use super::{BLOCK_SIZE, CacheController, CachedSlice};
+use crate::universal_io::ReadRange;
 
 #[test]
 fn test_cacher() {

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -86,7 +86,11 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
     fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         let mut items = vec![T::zeroed(); range.length as usize];
         let bytes = bytemuck::cast_slice_mut(&mut items);
-        self.file.read_exact_at(bytes, range.byte_offset)?;
+        if self.direct_io {
+            self.file.read_at(bytes, range.byte_offset)?;
+        } else {
+            self.file.read_exact_at(bytes, range.byte_offset)?;
+        }
         Ok(Cow::Owned(items))
     }
 

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub mod disk_cache;
 pub mod error;
 pub mod file_ops;


### PR DESCRIPTION
Builds on top of #8466 

 - adds a `prevent_caching` parameter for `OpenOptions`, so that, if possible for the implementation, it skips caching the reads.
   - this lets `CachedFile` be opened with a generic backend for reading from the slow disk. Particularly, it chooses `IoUringFile` by default.
- add `read_batch` implementation all the way into fetching from slow disk.
