### PR TITLE
Fix `bytemuck::cast_vec` panic in `ImmutableDenseVector` with io_uring

### DIFF
--- a/lib/segment/src/vector_storage/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/async_raw_scorer.rs
@@ -28,7 +28,7 @@ pub fn new<'a, T, Storage>(
 ) -> OperationResult<Box<dyn RawScorer + 'a>>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
     CosineMetric: Metric<T>,
     EuclidMetric: Metric<T>,
     DotProductMetric: Metric<T>,
@@ -40,7 +40,7 @@ where
 pub struct AsyncRawScorerImpl<'a, T, Storage, Scorer>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
     Scorer: QueryScorer<TVector = [T]>,
 {
     query_scorer: Scorer,
@@ -50,7 +50,7 @@ where
 impl<'a, T, Storage, Scorer> AsyncRawScorerImpl<'a, T, Storage, Scorer>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
     Scorer: QueryScorer<TVector = [T]>,
 {
     fn new(query_scorer: Scorer, storage: &'a ImmutableDenseVectors<T, Storage>) -> Self {
@@ -64,7 +64,7 @@ where
 impl<'a, T, Storage, Scorer> RawScorer for AsyncRawScorerImpl<'a, T, Storage, Scorer>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
     Scorer: QueryScorer<TVector = [T]>,
 {
     fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]) {
@@ -97,7 +97,7 @@ where
 struct AsyncRawScorerBuilder<'a, T, Storage>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
 {
     query: QueryVector,
     storage: &'a DenseVectorStorageImpl<T, Storage>,
@@ -108,7 +108,7 @@ where
 impl<'a, T, Storage> AsyncRawScorerBuilder<'a, T, Storage>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
 {
     pub fn new(
         query: QueryVector,
@@ -226,7 +226,7 @@ fn async_raw_scorer_from_query_scorer<'a, T, Storage, Scorer>(
 ) -> Box<dyn RawScorer + 'a>
 where
     T: PrimitiveVectorElement,
-    Storage: UniversalRead<u8>,
+    Storage: UniversalRead<T>,
     Scorer: QueryScorer<TVector = [T]> + 'a,
 {
     Box::new(AsyncRawScorerImpl::new(

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -36,10 +36,10 @@ const DELETED_PATH: &str = "deleted.dat";
 ///
 /// Mem-mapped storage can only be constructed from another storage
 #[derive(Debug)]
-pub struct DenseVectorStorageImpl<T, S = MmapUniversal<u8>>
+pub struct DenseVectorStorageImpl<T, S = MmapUniversal<T>>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     vectors_path: PathBuf,
     deleted_path: PathBuf,
@@ -50,7 +50,7 @@ where
 impl<T, S> DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
@@ -161,7 +161,7 @@ fn open_dense_vector_storage_impl<T, S>(
 ) -> OperationResult<DenseVectorStorageImpl<T, S>>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     fs::create_dir_all(path)?;
 
@@ -182,7 +182,7 @@ where
 impl<T, S> DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     pub fn get_mmap_vectors(&self) -> &ImmutableDenseVectors<T, S> {
         self.vectors.as_ref().unwrap()
@@ -192,7 +192,7 @@ where
 impl<T, S> DenseVectorStorage<T> for DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     fn vector_dim(&self) -> usize {
         self.vectors.as_ref().unwrap().dim
@@ -215,7 +215,7 @@ where
 impl<T, S> VectorStorage for DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     fn distance(&self) -> Distance {
         self.distance

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -26,10 +26,10 @@ const DELETED_HEADER: &[u8; HEADER_SIZE] = b"drop";
 
 /// Immutable storage for dense vectors.
 #[derive(Debug)]
-pub struct ImmutableDenseVectors<T, S = MmapUniversal<u8>>
+pub struct ImmutableDenseVectors<T, S = MmapUniversal<T>>
 where
     T: PrimitiveVectorElement,
-    S: UniversalRead<u8>,
+    S: UniversalRead<T>,
 {
     pub dim: usize,
     pub num_vectors: usize,
@@ -42,7 +42,7 @@ where
     _phantom: PhantomData<T>,
 }
 
-impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S> {
+impl<T: PrimitiveVectorElement, S: UniversalRead<T>> ImmutableDenseVectors<T, S> {
     pub fn open(
         vectors_path: &Path,
         deleted_path: &Path,
@@ -62,7 +62,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
             populate: Some(populate),
             advice: None,
         };
-        let storage = UniversalRead::<u8>::open(vectors_path, options).map_err(|e| {
+        let storage = UniversalRead::<T>::open(vectors_path, options).map_err(|e| {
             crate::common::operation_error::OperationError::service_error(format!(
                 "Failed to open vector mmap at {}: {e}",
                 vectors_path.display()
@@ -124,20 +124,16 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
     /// Read one vector's worth of bytes from storage at `byte_offset` and reinterpret
     /// the byte slice as `&[T]`.
     fn raw_vector_offset<P: AccessPattern>(&self, byte_offset: usize) -> Cow<'_, [T]> {
+        debug_assert_eq!(byte_offset % size_of::<T>(), 0);
+
         let range = ElementsRange {
-            start: byte_offset as u64,
+            start: (byte_offset / size_of::<T>()) as u64,
             length: self.raw_size() as u64,
         };
 
-        let cow: Cow<'_, [u8]> = self
-            .storage
+        self.storage
             .read::<P>(range)
-            .expect("vector read from storage failed");
-
-        match cow {
-            Cow::Borrowed(byte_slice) => Cow::Borrowed(bytemuck::cast_slice(byte_slice)),
-            Cow::Owned(byte_vec) => Cow::Owned(bytemuck::cast_vec(byte_vec)),
-        }
+            .expect("vector read succesfully")
     }
 
     /// Returns vector data by key
@@ -203,18 +199,16 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<u8>> ImmutableDenseVectors<T, S
         points: &[PointOffsetType],
         mut callback: impl FnMut(usize, PointOffsetType, &[T]),
     ) -> OperationResult<()> {
-        let vector_size_bytes = size_of::<T>() * self.dim;
+        let header_size_items = HEADER_SIZE / size_of::<T>();
+        debug_assert_eq!(HEADER_SIZE % size_of::<T>(), 0);
+
         let ranges = points.iter().copied().map(|point| ElementsRange {
-            start: (HEADER_SIZE + vector_size_bytes * point as usize) as _,
-            length: vector_size_bytes as _,
+            start: (header_size_items + self.dim * point as usize) as u64,
+            length: self.dim as u64,
         });
 
-        self.storage.read_batch::<P>(ranges, |idx, bytes| {
+        self.storage.read_batch::<P>(ranges, |idx, vector| {
             let point = points.get(idx).copied().expect("point ID tracked");
-
-            #[expect(deprecated, reason = "legacy code refactor")]
-            let vector = unsafe { mmap::transmute_from_u8_to_slice(bytes) };
-
             callback(idx, point, vector);
             Ok(())
         })?;

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -133,7 +133,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead<T>> ImmutableDenseVectors<T, S>
 
         self.storage
             .read::<P>(range)
-            .expect("vector read succesfully")
+            .expect("vector read successfully")
     }
 
     /// Returns vector data by key


### PR DESCRIPTION
Refactor `DenseVectorStorageImpl`/`ImmutableDenseVector` to rely on `UniversalRead<TElement>` instead of `UniversalRead<u8>`.

This should fix `bytemuck::cast_vec` panic during optimization if `DenseUring` storage is used.

There's a small hack that I had to use with `UR<TElement>`: vector storage file has 4 byte header, so I simply added additional `HEADER_SIZE / size_of::<TElement>()` offset. 4 bytes cleanly divisible by `f32`/`f16`/`u8` data types that we use in dense vector storage.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
