### PR TITLE
Cap internal peer-forwarded updates to `WaitUntil::Segment`

### DIFF
--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -114,7 +114,8 @@ impl Collection {
                 WriteOrdering::Weak => {
                     let wait = match WaitUntil::from(wait) {
                         WaitUntil::Visible => WaitUntil::Segment,
-                        other => other,
+                        WaitUntil::Segment => WaitUntil::Segment,
+                        WaitUntil::Wal => WaitUntil::Wal,
                     };
                     shard.update_local(operation, wait, timeout, hw_measurement_acc.clone(), false).await
                 }

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -107,7 +107,17 @@ impl Collection {
             };
 
             match ordering {
-                WriteOrdering::Weak => shard.update_local(operation, WaitUntil::from(wait), timeout, hw_measurement_acc.clone(), false).await,
+                // Cap internal peer updates to WaitUntil::Segment to avoid blocking on
+                // wait_for_deferred_points_ready. Internal transfers (e.g. queue proxy last
+                // batch) send wait=true to ensure data reaches segments, but don't need to
+                // wait for deferred point optimization.
+                WriteOrdering::Weak => {
+                    let wait = match WaitUntil::from(wait) {
+                        WaitUntil::Visible => WaitUntil::Segment,
+                        other => other,
+                    };
+                    shard.update_local(operation, wait, timeout, hw_measurement_acc.clone(), false).await
+                }
                 WriteOrdering::Medium | WriteOrdering::Strong => {
                     if let Some(clock_tag) = operation.clock_tag {
                         log::warn!(


### PR DESCRIPTION
## Summary

  Cap internal peer-forwarded updates to `WaitUntil::Segment` instead of `WaitUntil::Visible` to prevent blocking on deferred point optimization.

  ## Problem

  During snapshot-based shard transfers, the `QueueProxyShard` replays WAL updates to the remote peer, sending `wait=true` on the last batch to ensure data reaches segments before the shard goes active. 

On the remote peer, `wait=true` converts to `WaitUntil::Visible`, which enters `wait_for_deferred_points_ready`. With `prevent_unoptimized` enabled, the optimizer on the remote may not resolve deferred points quickly enough, causing the last batch to block indefinitely. The transfer never completes, gets re-proposed by consensus, and the cycle repeats.

  This was observed on chaos testing clusters where shard transfers with `prevent_unoptimized` took 30+ minutes or never finished, while the same transfers completed in seconds without the feature.

  ## Fix

  In `update_from_peer`, cap `WaitUntil::Visible` to `WaitUntil::Segment` for all internal peer-forwarded updates. This ensures writes reach segments (maintaining read consistency when the shard becomes active) without waiting for deferred point optimization.

  The `wait=true` visibility guarantee for deferred points is per-node — fulfilled on the node that receives the user's request directly. Forwarded replicas only need data applied to segments.

  This is consistent with PR #8394 which established the same pattern for `ForwardProxyShard`.