### PR TITLE
Wait for segment in QueueProxy

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -58,60 +58,90 @@ message SyncPointsInternal {
   SyncPoints sync_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message UpsertPointsInternal {
   UpsertPoints upsert_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message DeletePointsInternal {
   DeletePoints delete_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message UpdateVectorsInternal {
   UpdatePointVectors update_vectors = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message DeleteVectorsInternal {
   DeletePointVectors delete_vectors = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message SetPayloadPointsInternal {
   SetPayloadPoints set_payload_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message DeletePayloadPointsInternal {
   DeletePayloadPoints delete_payload_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message ClearPayloadPointsInternal {
   ClearPayloadPoints clear_payload_points = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message CreateFieldIndexCollectionInternal {
   CreateFieldIndexCollection create_field_index_collection = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message DeleteFieldIndexCollectionInternal {
   DeleteFieldIndexCollection delete_field_index_collection = 1;
   optional uint32 shard_id = 2;
   optional ClockTag clock_tag = 3;
+  // When present, overrides the `wait` parameter of the wrapped public message.
+  // When absent, falls back to `wait` (backward compatible with older nodes).
+  optional WaitUntil wait_override = 4;
 }
 
 message UpdateOperation {
@@ -132,6 +162,9 @@ message UpdateOperation {
 
 message UpdateBatchInternal {
   repeated UpdateOperation operations = 1;
+  // When present, overrides the `wait` parameter for all operations in the batch.
+  // Propagated to individual operations if not already set.
+  optional WaitUntil wait_override = 2;
 }
 
 // Has to be backward compatible with `PointsOperationResponse`!
@@ -159,6 +192,19 @@ message ClockTag {
   uint64 token = 4;
   bool force = 5;
 }
+
+// Controls how an update operation waits for completion.
+// When present, fully overrides the `wait` boolean from the wrapped public message.
+// When absent, the `wait` boolean is used (backward compatible with older nodes).
+enum WaitUntil {
+  // Wait until the operation is written in WAL (equivalent to wait=false).
+  Wal = 0;
+  // Wait until the operation is written in a segment (but not necessarily visible).
+  Segment = 1;
+  // Wait until the operation is visible in search results (equivalent to wait=true).
+  Visible = 2;
+}
+
 
 message SearchPointsInternal {
   SearchPoints search_points = 1;

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -10302,6 +10302,10 @@ pub struct SyncPointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10315,6 +10319,10 @@ pub struct UpsertPointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10328,6 +10336,10 @@ pub struct DeletePointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10341,6 +10353,10 @@ pub struct UpdateVectorsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10354,6 +10370,10 @@ pub struct DeleteVectorsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10367,6 +10387,10 @@ pub struct SetPayloadPointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10380,6 +10404,10 @@ pub struct DeletePayloadPointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10393,6 +10421,10 @@ pub struct ClearPayloadPointsInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10408,6 +10440,10 @@ pub struct CreateFieldIndexCollectionInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10423,6 +10459,10 @@ pub struct DeleteFieldIndexCollectionInternal {
     pub shard_id: ::core::option::Option<u32>,
     #[prost(message, optional, tag = "3")]
     pub clock_tag: ::core::option::Option<ClockTag>,
+    /// When present, overrides the `wait` parameter of the wrapped public message.
+    /// When absent, falls back to `wait` (backward compatible with older nodes).
+    #[prost(enumeration = "WaitUntil", optional, tag = "4")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10474,6 +10514,10 @@ pub struct UpdateBatchInternal {
     #[prost(message, repeated, tag = "1")]
     #[validate(nested)]
     pub operations: ::prost::alloc::vec::Vec<UpdateOperation>,
+    /// When present, overrides the `wait` parameter for all operations in the batch.
+    /// Propagated to individual operations if not already set.
+    #[prost(enumeration = "WaitUntil", optional, tag = "2")]
+    pub wait_override: ::core::option::Option<i32>,
 }
 /// Has to be backward compatible with `PointsOperationResponse`!
 #[derive(serde::Serialize)]
@@ -11049,6 +11093,42 @@ pub struct FacetResponseInternal {
     pub time: f64,
     #[prost(message, optional, tag = "3")]
     pub usage: ::core::option::Option<HardwareUsage>,
+}
+/// Controls how an update operation waits for completion.
+/// When present, fully overrides the `wait` boolean from the wrapped public message.
+/// When absent, the `wait` boolean is used (backward compatible with older nodes).
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum WaitUntil {
+    /// Wait until the operation is written in WAL (equivalent to wait=false).
+    Wal = 0,
+    /// Wait until the operation is written in a segment (but not necessarily visible).
+    Segment = 1,
+    /// Wait until the operation is visible in search results (equivalent to wait=true).
+    Visible = 2,
+}
+impl WaitUntil {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            WaitUntil::Wal => "Wal",
+            WaitUntil::Segment => "Segment",
+            WaitUntil::Visible => "Visible",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Wal" => Some(Self::Wal),
+            "Segment" => Some(Self::Segment),
+            "Visible" => Some(Self::Visible),
+            _ => None,
+        }
+    }
 }
 /// Generated client implementations.
 pub mod points_internal_client {

--- a/lib/collection/src/collection/payload_index_schema.rs
+++ b/lib/collection/src/collection/payload_index_schema.rs
@@ -12,6 +12,7 @@ use crate::operations::types::{CollectionResult, UpdateResult};
 use crate::operations::universal_query::formula::ExpressionInternal;
 use crate::operations::{CollectionUpdateOperations, CreateIndex, FieldIndexOperations};
 use crate::problems::unindexed_field;
+use crate::shards::shard_trait::WaitUntil;
 
 impl Collection {
     pub(crate) fn payload_index_file(collection_path: &Path) -> PathBuf {
@@ -63,7 +64,7 @@ impl Collection {
             }),
         );
 
-        self.update_all_local(create_index_operation, wait, hw_acc)
+        self.update_all_local(create_index_operation, WaitUntil::from(wait), hw_acc)
             .await
     }
 
@@ -82,7 +83,7 @@ impl Collection {
         let result = self
             .update_all_local(
                 delete_index_operation,
-                false,
+                WaitUntil::from(false),
                 HwMeasurementAcc::disposable(), // Unmeasured API
             )
             .await?;

--- a/lib/collection/src/collection/point_ops.rs
+++ b/lib/collection/src/collection/point_ops.rs
@@ -32,7 +32,7 @@ impl Collection {
     pub async fn update_all_local(
         &self,
         operation: CollectionUpdateOperations,
-        wait: bool,
+        wait: WaitUntil,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<Option<UpdateResult>> {
         let shard_holder = self.shards_holder.clone().read_owned().await;
@@ -56,7 +56,7 @@ impl Collection {
                         // so it's *impossible* to assign any single clock tag to this operation.
                         shard.update_local(
                             OperationWithClockTag::from(operation.clone()),
-                            WaitUntil::from(wait),
+                            wait,
                             None,
                             hw_measurement_acc.clone(),
                             false,
@@ -94,7 +94,7 @@ impl Collection {
         &self,
         operation: OperationWithClockTag,
         shard_selection: ShardId,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
@@ -107,7 +107,7 @@ impl Collection {
             };
 
             match ordering {
-                WriteOrdering::Weak => shard.update_local(operation, WaitUntil::from(wait), timeout, hw_measurement_acc.clone(), false).await,
+                WriteOrdering::Weak => shard.update_local(operation, wait, timeout, hw_measurement_acc.clone(), false).await,
                 WriteOrdering::Medium | WriteOrdering::Strong => {
                     if let Some(clock_tag) = operation.clock_tag {
                         log::warn!(
@@ -143,7 +143,7 @@ impl Collection {
     pub async fn update_from_client(
         &self,
         operation: CollectionUpdateOperations,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         shard_keys_selection: Option<ShardKey>,
@@ -294,8 +294,15 @@ impl Collection {
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<UpdateResult> {
-        self.update_from_client(operation, wait, timeout, ordering, None, hw_measurement_acc)
-            .await
+        self.update_from_client(
+            operation,
+            WaitUntil::from(wait),
+            timeout,
+            ordering,
+            None,
+            hw_measurement_acc,
+        )
+        .await
     }
 
     pub async fn scroll_by(

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -25,13 +25,20 @@ use crate::operations::types::CollectionResult;
 use crate::operations::vector_ops::UpdateVectorsOp;
 use crate::operations::{ClockTag, CreateIndex};
 use crate::shards::shard::ShardId;
+use crate::shards::shard_trait::WaitUntil;
+
+/// Convert `WaitUntil` to the proto `wait_override` field value.
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn wait_override_to_proto(wait: WaitUntil) -> Option<i32> {
+    Some(i32::from(api::grpc::qdrant::WaitUntil::from(wait)))
+}
 
 pub fn internal_sync_points(
     shard_id: Option<ShardId>,
     clock_tag: Option<ClockTag>,
     collection_name: String,
     points_sync_operation: PointSyncOperation,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<SyncPointsInternal> {
@@ -43,9 +50,10 @@ pub fn internal_sync_points(
     Ok(SyncPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         sync_points: Some(SyncPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: points
                 .into_iter()
                 .map(api::grpc::qdrant::PointStruct::try_from)
@@ -63,16 +71,17 @@ pub fn internal_upsert_points(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     point_insert_operations: PointInsertOperationsInternal,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpsertPointsInternal> {
     Ok(UpsertPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         upsert_points: Some(UpsertPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: match point_insert_operations {
                 PointInsertOperationsInternal::PointsBatch(batch) => TryFrom::try_from(batch)?,
                 PointInsertOperationsInternal::PointsList(list) => list
@@ -94,7 +103,7 @@ pub fn internal_conditional_upsert_points(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     point_condition_upsert_operations: ConditionalInsertOperationInternal,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpsertPointsInternal> {
@@ -115,9 +124,10 @@ pub fn internal_conditional_upsert_points(
     Ok(UpsertPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         upsert_points: Some(UpsertPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: match point_insert_operations {
                 PointInsertOperationsInternal::PointsBatch(batch) => TryFrom::try_from(batch)?,
                 PointInsertOperationsInternal::PointsList(list) => list
@@ -139,16 +149,17 @@ pub fn internal_delete_points(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     ids: Vec<PointIdType>,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_points: Some(DeletePoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
                     ids: ids.into_iter().map(|id| id.into()).collect(),
@@ -166,16 +177,17 @@ pub fn internal_delete_points_by_filter(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeletePointsInternal {
     DeletePointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_points: Some(DeletePoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
@@ -191,7 +203,7 @@ pub fn internal_update_vectors(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     update_vectors: UpdateVectorsOp,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> CollectionResult<UpdateVectorsInternal> {
@@ -212,9 +224,10 @@ pub fn internal_update_vectors(
     Ok(UpdateVectorsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         update_vectors: Some(UpdatePointVectors {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: points?,
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
@@ -231,16 +244,17 @@ pub fn internal_delete_vectors(
     collection_name: String,
     ids: Vec<PointIdType>,
     vector_names: Vec<VectorNameBuf>,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeleteVectorsInternal {
     DeleteVectorsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_vectors: Some(DeletePointVectors {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points_selector: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
                     ids: ids.into_iter().map(|id| id.into()).collect(),
@@ -263,16 +277,17 @@ pub fn internal_delete_vectors_by_filter(
     collection_name: String,
     filter: Filter,
     vector_names: Vec<VectorNameBuf>,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeleteVectorsInternal {
     DeleteVectorsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_vectors: Some(DeletePointVectors {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points_selector: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
@@ -291,7 +306,7 @@ pub fn internal_set_payload(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     set_payload: SetPayloadOp,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> SetPayloadPointsInternal {
@@ -310,9 +325,10 @@ pub fn internal_set_payload(
     SetPayloadPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         set_payload_points: Some(SetPayloadPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             payload: payload_to_proto(set_payload.payload),
             points_selector,
             ordering: ordering.map(write_ordering_to_proto),
@@ -328,7 +344,7 @@ pub fn internal_delete_payload(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     delete_payload: DeletePayloadOp,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeletePayloadPointsInternal {
@@ -347,9 +363,10 @@ pub fn internal_delete_payload(
     DeletePayloadPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_payload_points: Some(DeletePayloadPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             keys: delete_payload
                 .keys
                 .into_iter()
@@ -368,16 +385,17 @@ pub fn internal_clear_payload(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     points: Vec<PointIdType>,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Points(PointsIdsList {
                     ids: points.into_iter().map(|id| id.into()).collect(),
@@ -395,16 +413,17 @@ pub fn internal_clear_payload_by_filter(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     filter: Filter,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> ClearPayloadPointsInternal {
     ClearPayloadPointsInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         clear_payload_points: Some(ClearPayloadPoints {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             points: Some(PointsSelector {
                 points_selector_one_of: Some(PointsSelectorOneOf::Filter(filter.into())),
             }),
@@ -420,7 +439,7 @@ pub fn internal_create_index(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     create_index: CreateIndex,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> CreateFieldIndexCollectionInternal {
@@ -441,9 +460,10 @@ pub fn internal_create_index(
     CreateFieldIndexCollectionInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         create_field_index_collection: Some(CreateFieldIndexCollection {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             field_name: create_index.field_name.to_string(),
             field_type,
             field_index_params,
@@ -458,16 +478,17 @@ pub fn internal_delete_index(
     clock_tag: Option<ClockTag>,
     collection_name: String,
     delete_index: JsonPath,
-    wait: bool,
+    wait: WaitUntil,
     wait_timeout: Option<u64>,
     ordering: Option<WriteOrdering>,
 ) -> DeleteFieldIndexCollectionInternal {
     DeleteFieldIndexCollectionInternal {
         shard_id,
         clock_tag: clock_tag.map(Into::into),
+        wait_override: wait_override_to_proto(wait),
         delete_field_index_collection: Some(DeleteFieldIndexCollection {
             collection_name,
-            wait: Some(wait),
+            wait: Some(wait.needs_callback()),
             field_name: delete_index.to_string(),
             ordering: ordering.map(write_ordering_to_proto),
             timeout: wait_timeout,

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -590,12 +590,18 @@ impl Inner {
             drop(update_lock.take());
         }
 
-        // If we are transferring the last batch, we need to wait for it to be applied.
+        // If we are transferring the last batch, we need to wait for it to be written to a segment.
         //  - Why can we not wait? Assuming that order of operations is still enforced by the WAL,
         //    we should end up in exactly the same state with or without waiting.
         //  - Why do we need to wait on the last batch? If we switch to ready state before
         //    updates are actually applied, we might create an inconsistency for read operations.
-        let wait = last_batch;
+        //  - Why Segment and not Visible? We only need the data to be written, not necessarily
+        //    visible through deferred indexing. Waiting for full visibility would be unnecessarily slow.
+        let wait = if last_batch {
+            WaitUntil::Segment
+        } else {
+            WaitUntil::Wal
+        };
 
         // Set initial progress on the first batch
         let is_first = transfer_from == self.started_at;
@@ -822,7 +828,7 @@ impl ShardOperation for Inner {
 async fn transfer_operations_batch(
     batch: &[(u64, OperationWithClockTag)],
     remote_shard: &RemoteShard,
-    wait: bool,
+    wait: WaitUntil,
     timeout: Option<Duration>,
     hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<()> {

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -67,7 +67,7 @@ use crate::shards::conversions::{
     internal_clear_payload, internal_clear_payload_by_filter, internal_create_index,
     internal_delete_index, internal_delete_payload, internal_delete_points,
     internal_delete_points_by_filter, internal_set_payload, internal_sync_points,
-    internal_upsert_points, try_scored_point_from_grpc,
+    internal_upsert_points, try_scored_point_from_grpc, wait_override_to_proto,
 };
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -237,7 +237,7 @@ impl RemoteShard {
     pub async fn forward_update_batch(
         &self,
         operations: Vec<OperationWithClockTag>,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
@@ -457,6 +457,7 @@ impl RemoteShard {
 
         let batch_request = &UpdateBatchInternal {
             operations: updates,
+            wait_override: wait_override_to_proto(wait),
         };
 
         let point_operation_response = self
@@ -486,7 +487,7 @@ impl RemoteShard {
     pub async fn forward_update(
         &self,
         operation: OperationWithClockTag,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
@@ -514,7 +515,7 @@ impl RemoteShard {
         shard_id: Option<ShardId>,
         collection_name: String,
         operation: OperationWithClockTag,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: Option<WriteOrdering>,
         hw_measurement_acc: HwMeasurementAcc,
@@ -1040,7 +1041,7 @@ impl ShardOperation for RemoteShard {
             shard_id,
             self.collection_id.clone(),
             operation,
-            wait.needs_callback(),
+            wait,
             timeout,
             None,
             hw_measurement_acc,

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -137,7 +137,7 @@ impl ShardReplicaSet {
     pub async fn update_with_consistency(
         &self,
         operation: CollectionUpdateOperations,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         update_only_existing: bool,
@@ -170,7 +170,7 @@ impl ShardReplicaSet {
 
             self.update(
                 operation,
-                WaitUntil::from(wait),
+                wait,
                 timeout,
                 update_only_existing,
                 hw_measurement_acc,
@@ -712,7 +712,7 @@ impl ShardReplicaSet {
         &self,
         leader_peer: PeerId,
         operation: CollectionUpdateOperations,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,

--- a/lib/collection/src/shards/shard_trait.rs
+++ b/lib/collection/src/shards/shard_trait.rs
@@ -64,6 +64,26 @@ impl From<bool> for WaitUntil {
     }
 }
 
+impl From<api::grpc::qdrant::WaitUntil> for WaitUntil {
+    fn from(value: api::grpc::qdrant::WaitUntil) -> Self {
+        match value {
+            api::grpc::qdrant::WaitUntil::Wal => WaitUntil::Wal,
+            api::grpc::qdrant::WaitUntil::Segment => WaitUntil::Segment,
+            api::grpc::qdrant::WaitUntil::Visible => WaitUntil::Visible,
+        }
+    }
+}
+
+impl From<WaitUntil> for api::grpc::qdrant::WaitUntil {
+    fn from(value: WaitUntil) -> Self {
+        match value {
+            WaitUntil::Wal => api::grpc::qdrant::WaitUntil::Wal,
+            WaitUntil::Segment => api::grpc::qdrant::WaitUntil::Segment,
+            WaitUntil::Visible => api::grpc::qdrant::WaitUntil::Visible,
+        }
+    }
+}
+
 #[async_trait]
 pub trait ShardOperation {
     async fn update(

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -31,6 +31,7 @@ use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard_trait::WaitUntil;
 
 const DIM: u64 = 4;
 const PEER_ID: u64 = 1;
@@ -121,7 +122,7 @@ async fn fixture() -> Collection {
     collection
         .update_from_client(
             operation,
-            true,
+            WaitUntil::from(true),
             None,
             WriteOrdering::Weak,
             None,

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -13,6 +13,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::*;
 use collection::operations::universal_query::collection_query::CollectionQueryRequest;
 use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
+use collection::shards::shard_trait::WaitUntil;
 use collection::{discovery, recommendations};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::TryStreamExt as _;
@@ -452,7 +453,7 @@ impl TableOfContent {
         collection: &Collection,
         shard_keys: Vec<ShardKey>,
         operation: CollectionUpdateOperations,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         hw_measurement_acc: HwMeasurementAcc,
@@ -490,7 +491,7 @@ impl TableOfContent {
         &self,
         collection_name: &str,
         operation: OperationWithClockTag,
-        wait: bool,
+        wait: WaitUntil,
         timeout: Option<Duration>,
         ordering: WriteOrdering,
         shard_selector: ShardSelectorInternal,

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -67,16 +67,23 @@ impl UpdateParams {
 pub struct InternalUpdateParams {
     pub shard_id: Option<ShardId>,
     pub clock_tag: Option<ClockTag>,
+    /// When present, fully overrides the `wait` boolean from the public API message.
+    /// When absent, falls back to the `wait` boolean (backward compatible with older nodes).
+    pub wait_override: Option<collection::shards::shard_trait::WaitUntil>,
 }
 
 impl InternalUpdateParams {
     pub fn from_grpc(
         shard_id: Option<ShardId>,
         clock_tag: Option<api::grpc::qdrant::ClockTag>,
+        wait_override: Option<i32>,
     ) -> Self {
         Self {
             shard_id,
             clock_tag: clock_tag.map(ClockTag::from),
+            wait_override: wait_override
+                .and_then(|v| api::grpc::qdrant::WaitUntil::try_from(v).ok())
+                .map(collection::shards::shard_trait::WaitUntil::from),
         }
     }
 }
@@ -1037,6 +1044,7 @@ pub async fn update(
     let InternalUpdateParams {
         shard_id,
         clock_tag,
+        wait_override,
     } = internal_params;
 
     let UpdateParams {
@@ -1044,6 +1052,10 @@ pub async fn update(
         ordering,
         timeout: _,
     } = params;
+
+    // Use wait_override if present, otherwise fall back to the wait boolean
+    let wait =
+        wait_override.unwrap_or_else(|| collection::shards::shard_trait::WaitUntil::from(wait));
 
     let shard_selector = match operation {
         CollectionUpdateOperations::PointOperation(point_ops::PointOperations::SyncPoints(_)) => {

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -65,6 +65,7 @@ impl PointsInternalService {
             sync_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = sync_points_internal;
 
         let sync_points = extract_internal_request(sync_points)?;
@@ -73,7 +74,7 @@ impl PointsInternalService {
         let (response, _inference_usage) = sync(
             self.toc.clone(),
             sync_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             inference_params,
         )
@@ -92,6 +93,7 @@ impl PointsInternalService {
             upsert_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = upsert_points_internal;
 
         let upsert_points = extract_internal_request(upsert_points)?;
@@ -103,7 +105,7 @@ impl PointsInternalService {
         upsert(
             StrictModeCheckedInternalTocProvider::new(&self.toc),
             upsert_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             inference_params.clone(),
             hw_metrics,
@@ -119,6 +121,7 @@ impl PointsInternalService {
             delete_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = delete_points_internal;
 
         let delete_points = extract_internal_request(delete_points)?;
@@ -130,7 +133,7 @@ impl PointsInternalService {
         delete(
             UncheckedTocProvider::new_unchecked(&self.toc),
             delete_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -146,6 +149,7 @@ impl PointsInternalService {
             update_vectors,
             shard_id,
             clock_tag,
+            wait_override,
         } = update_vectors_internal;
 
         let update_point_vectors = extract_internal_request(update_vectors)?;
@@ -157,7 +161,7 @@ impl PointsInternalService {
         crate::tonic::api::update_common::update_vectors(
             StrictModeCheckedInternalTocProvider::new(&self.toc),
             update_point_vectors,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             inference_params.clone(),
             hw_metrics,
@@ -173,6 +177,7 @@ impl PointsInternalService {
             delete_vectors,
             shard_id,
             clock_tag,
+            wait_override,
         } = delete_vectors_internal;
 
         let delete_point_vectors = extract_internal_request(delete_vectors)?;
@@ -184,7 +189,7 @@ impl PointsInternalService {
         crate::tonic::api::update_common::delete_vectors(
             UncheckedTocProvider::new_unchecked(&self.toc),
             delete_point_vectors,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -199,6 +204,7 @@ impl PointsInternalService {
             set_payload_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = set_payload_internal;
 
         let set_payload_points = extract_internal_request(set_payload_points)?;
@@ -210,7 +216,7 @@ impl PointsInternalService {
         set_payload(
             StrictModeCheckedInternalTocProvider::new(&self.toc),
             set_payload_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -225,6 +231,7 @@ impl PointsInternalService {
             set_payload_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = overwrite_payload_internal;
 
         let set_payload_points = extract_internal_request(set_payload_points)?;
@@ -236,7 +243,7 @@ impl PointsInternalService {
         overwrite_payload(
             StrictModeCheckedInternalTocProvider::new(&self.toc),
             set_payload_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -251,6 +258,7 @@ impl PointsInternalService {
             delete_payload_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = delete_payload_internal;
 
         let delete_payload_points = extract_internal_request(delete_payload_points)?;
@@ -262,7 +270,7 @@ impl PointsInternalService {
         delete_payload(
             UncheckedTocProvider::new_unchecked(&self.toc),
             delete_payload_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -277,6 +285,7 @@ impl PointsInternalService {
             clear_payload_points,
             shard_id,
             clock_tag,
+            wait_override,
         } = clear_payload_internal;
 
         let clear_payload_points = extract_internal_request(clear_payload_points)?;
@@ -288,7 +297,7 @@ impl PointsInternalService {
         clear_payload(
             UncheckedTocProvider::new_unchecked(&self.toc),
             clear_payload_points,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
             full_internal_auth(),
             hw_metrics,
         )
@@ -303,12 +312,13 @@ impl PointsInternalService {
             create_field_index_collection,
             shard_id,
             clock_tag,
+            wait_override,
         } = create_field_index_collection;
 
         create_field_index_internal(
             self.toc.clone(),
             extract_internal_request(create_field_index_collection)?,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
         )
         .await
     }
@@ -321,12 +331,13 @@ impl PointsInternalService {
             delete_field_index_collection,
             shard_id,
             clock_tag,
+            wait_override,
         } = delete_field_index_collection;
 
         delete_field_index_internal(
             self.toc.clone(),
             extract_internal_request(delete_field_index_collection)?,
-            InternalUpdateParams::from_grpc(shard_id, clock_tag),
+            InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
         )
         .await
     }
@@ -562,6 +573,7 @@ impl PointsInternal for PointsInternalService {
         let inference_params = InferenceParams::new(api_keys, None);
 
         let request_inner = request.into_inner();
+        let batch_wait_override = request_inner.wait_override;
 
         let mut total_usage = HardwareUsage::default();
 
@@ -571,7 +583,45 @@ impl PointsInternal for PointsInternalService {
         // - If one operation fails, it will report the error immediately
         // - If no operations are present, it will return an empty response
         // - If all operations are successful, it will return the last operation result
-        for update in request_inner.operations {
+        for mut update in request_inner.operations {
+            // Propagate batch-level wait_override to individual operations if not already set
+            if let Some(batch_wo) = batch_wait_override
+                && let Some(ref mut op) = update.update
+            {
+                match op {
+                    Update::Sync(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::Upsert(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::Delete(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::UpdateVectors(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::DeleteVectors(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::SetPayload(inner) | Update::OverwritePayload(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::DeletePayload(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::ClearPayload(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::CreateFieldIndex(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                    Update::DeleteFieldIndex(inner) => {
+                        inner.wait_override.get_or_insert(batch_wo);
+                    }
+                }
+            }
+
             let result = match update.update {
                 None => {
                     return Err(Status::invalid_argument("Update is missing"));


### PR DESCRIPTION
Alternative to https://github.com/qdrant/qdrant/pull/8473

AI instructions:

# More granular control for `wait` in internal update operations.


For internal update operations, we need to differentiate between waiting for visibility and waiting till segment writing.

For example, if user sends request with wait=true, we need to wait till visibility,
 but in the internal shard transfer operations and in, for instance, `QueueProxyShard`, we only need to wait till segment writing.

Internally, we already have a enum `WaitUntil`, which have 3 options `Wal`, `Segment` and `Visibility`.
But the internal interface doesn't provide an option to differentiate them yet.


What we need:

Introduce a new parameter into internal update APIs, which would regulate the waiting behavior.

- Do not modify public API, as it is only relevant for internal operations.
- Only make backward compatible changes.
- Make sure new and old version of the service can still interact, assuming new parameter is ignored and defaults to the old behavior (waiting for visibility).


## Implementation suggestions:

- make `update_from_peer` and higher level functions use `WaitUntil` instead of boolean `wait`.
- resolve wait int he API layer, update `InternalUpdateParams` to include extra wait modifier.
