### PR TITLE
Speed up nested filter evaluation

### DIFF
--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -15,6 +15,7 @@ mod histogram;
 mod immutable_point_to_values;
 pub mod index_selector;
 pub mod map_index;
+pub mod nested_element_index;
 pub mod null_index;
 pub mod numeric_index;
 mod stat_tools;

--- a/lib/segment/src/index/field_index/nested_element_index.rs
+++ b/lib/segment/src/index/field_index/nested_element_index.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+use common::types::PointOffsetType;
+use smallvec::SmallVec;
+
+pub type ElementIndices = SmallVec<[u32; 2]>;
+
+/// Per-field index of array element positions, used for nested filter same-element checks.
+#[derive(Debug, Default)]
+pub struct NestedElementIndex {
+    // point_id → type-prefixed value (e.g. "s:foo", "n:42", "b:true") → element indices
+    positions: Vec<HashMap<String, ElementIndices>>,
+}
+
+impl NestedElementIndex {
+    pub fn new() -> Self {
+        Self {
+            positions: Vec::new(),
+        }
+    }
+
+    pub fn add_entry(&mut self, point_id: PointOffsetType, value: String, element_idx: u32) {
+        let idx = point_id as usize;
+        if self.positions.len() <= idx {
+            self.positions.resize_with(idx + 1, HashMap::new);
+        }
+        self.positions[idx]
+            .entry(value)
+            .or_default()
+            .push(element_idx);
+    }
+
+    pub fn get_indices(&self, point_id: PointOffsetType, value: &str) -> Option<&ElementIndices> {
+        self.positions.get(point_id as usize)?.get(value)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.positions.is_empty()
+    }
+}
+
+/// Intersect element indices and return the matching indices.
+pub fn intersect_to_vec(sets: &[&ElementIndices]) -> SmallVec<[u32; 4]> {
+    if sets.is_empty() {
+        return SmallVec::new();
+    }
+    let (smallest_idx, _) = sets
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, s)| s.len())
+        .unwrap();
+
+    let mut result = SmallVec::new();
+    'outer: for &candidate in sets[smallest_idx].iter() {
+        for (i, set) in sets.iter().enumerate() {
+            if i == smallest_idx {
+                continue;
+            }
+            if !set.contains(&candidate) {
+                continue 'outer;
+            }
+        }
+        result.push(candidate);
+    }
+    result
+}
+
+/// Returns true if any element index is present in ALL provided sets.
+pub fn intersect_element_indices(sets: &[&ElementIndices]) -> bool {
+    if sets.is_empty() {
+        return false;
+    }
+    let (smallest_idx, _) = sets
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, s)| s.len())
+        .unwrap();
+
+    'outer: for &candidate in sets[smallest_idx].iter() {
+        for (i, set) in sets.iter().enumerate() {
+            if i == smallest_idx {
+                continue;
+            }
+            if !set.contains(&candidate) {
+                continue 'outer;
+            }
+        }
+        return true;
+    }
+    false
+}

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use crate::id_tracker::IdTracker;
 use crate::index::field_index::FieldIndex;
+use crate::index::field_index::nested_element_index::{self, ElementIndices, NestedElementIndex};
 use crate::index::field_index::null_index::MutableNullIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
@@ -20,7 +21,8 @@ use crate::payload_storage::query_checker::{
 };
 use crate::types::{
     Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon,
-    GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, Range, RangeInterface,
+    GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, PayloadKeyType, Range,
+    RangeInterface,
 };
 use crate::vector_storage::VectorStorage;
 
@@ -151,38 +153,218 @@ impl StructPayloadIndex {
 
                 let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
 
-                let hw = hw_counter.fork();
-                Box::new(move |point_id| {
-                    payload_provider.with_payload(
-                        point_id,
-                        |payload| {
-                            let field_values = payload.get_value(&nested_path);
+                // Try element position indexes before falling back to payload read
+                self.ensure_nested_element_indexes();
 
-                            for value in field_values {
-                                if let Value::Object(object) = value {
-                                    let get_payload = || OwnedPayloadRef::from(object);
-                                    if check_payload(
-                                        Box::new(get_payload),
-                                        // None because has_id in nested is not supported. So retrieving
-                                        // IDs through the tracker would always return None.
-                                        None,
-                                        // Same as above, nested conditions don't support has_vector.
-                                        &HashMap::new(),
-                                        &nested.nested.filter,
-                                        point_id,
-                                        &nested_indexes,
-                                        &hw,
-                                    ) {
-                                        // If at least one nested object matches, return true
-                                        return true;
-                                    }
+                let nei_snapshot = self.nested_element_indexes_snapshot();
+
+                let extract_key = |m: &crate::types::Match| -> Option<String> {
+                    match m {
+                        crate::types::Match::Value(mv) => match &mv.value {
+                            crate::types::ValueVariants::String(s) => Some(format!("s:{s}")),
+                            crate::types::ValueVariants::Integer(i) => Some(format!("n:{i}")),
+                            crate::types::ValueVariants::Bool(b) => Some(format!("b:{b}")),
+                        },
+                        crate::types::Match::Text(_)
+                        | crate::types::Match::TextAny(_)
+                        | crate::types::Match::Phrase(_)
+                        | crate::types::Match::Any(_)
+                        | crate::types::Match::Except(_) => None,
+                    }
+                };
+
+                let mut must_checkers: Vec<(String, PayloadKeyType)> = Vec::new();
+                let mut has_unresolved_must = false;
+                if let Some(conditions) = nested.nested.filter.must.as_ref() {
+                    for cond in conditions {
+                        if let Condition::Field(field_cond) = cond {
+                            let match_value = field_cond.r#match.as_ref().and_then(&extract_key);
+                            let full_path = nested_path.extend(&field_cond.key);
+                            if let Some(val) = match_value {
+                                if nei_snapshot.contains_key(&full_path) {
+                                    must_checkers.push((val, full_path));
+                                    continue;
                                 }
                             }
+                        }
+                        has_unresolved_must = true;
+                    }
+                }
+
+                let mut must_not_checkers: Vec<(String, PayloadKeyType)> = Vec::new();
+                let mut has_unresolved_must_not = false;
+                if let Some(conditions) = nested.nested.filter.must_not.as_ref() {
+                    for cond in conditions {
+                        if let Condition::Field(field_cond) = cond {
+                            let match_value = field_cond.r#match.as_ref().and_then(&extract_key);
+                            let full_path = nested_path.extend(&field_cond.key);
+                            if let Some(val) = match_value {
+                                if nei_snapshot.contains_key(&full_path) {
+                                    must_not_checkers.push((val, full_path));
+                                    continue;
+                                }
+                            }
+                        }
+                        has_unresolved_must_not = true;
+                    }
+                }
+
+                let has_extra_conditions = has_unresolved_must
+                    || has_unresolved_must_not
+                    || nested.nested.filter.should.is_some()
+                    || nested.nested.filter.min_should.is_some();
+
+                if !must_checkers.is_empty() {
+                    let nei = nei_snapshot.clone();
+                    if !has_extra_conditions {
+                        Box::new(move |point_id| {
+                            let nei: &HashMap<PayloadKeyType, NestedElementIndex> = &nei;
+                            let mut sets: Vec<&ElementIndices> =
+                                Vec::with_capacity(must_checkers.len());
+                            for (match_value, full_path) in &must_checkers {
+                                if let Some(index) = nei.get(full_path) {
+                                    if let Some(indices) =
+                                        index.get_indices(point_id, match_value.as_str())
+                                    {
+                                        sets.push(indices);
+                                    } else {
+                                        return false;
+                                    }
+                                } else {
+                                    return false;
+                                }
+                            }
+                            if must_not_checkers.is_empty() {
+                                return nested_element_index::intersect_element_indices(&sets);
+                            }
+                            let candidates = nested_element_index::intersect_to_vec(&sets);
+                            if candidates.is_empty() {
+                                return false;
+                            }
+                            'candidate: for elem_idx in candidates {
+                                for (excl_value, excl_path) in &must_not_checkers {
+                                    if let Some(index) = nei.get(excl_path) {
+                                        if let Some(excl_indices) =
+                                            index.get_indices(point_id, excl_value.as_str())
+                                        {
+                                            if excl_indices.contains(&elem_idx) {
+                                                continue 'candidate;
+                                            }
+                                        }
+                                    } else {
+                                        continue 'candidate;
+                                    }
+                                }
+                                return true;
+                            }
                             false
-                        },
-                        &hw,
-                    )
-                })
+                        })
+                    } else {
+                        let hw = hw_counter.fork();
+                        Box::new(move |point_id| {
+                            let nei: &HashMap<PayloadKeyType, NestedElementIndex> = &nei;
+                            let mut sets: Vec<&ElementIndices> =
+                                Vec::with_capacity(must_checkers.len());
+                            for (match_value, full_path) in &must_checkers {
+                                if let Some(index) = nei.get(full_path) {
+                                    if let Some(indices) =
+                                        index.get_indices(point_id, match_value.as_str())
+                                    {
+                                        sets.push(indices);
+                                    } else {
+                                        return false;
+                                    }
+                                } else {
+                                    return false;
+                                }
+                            }
+
+                            if sets.is_empty() {
+                                return false;
+                            }
+                            let mut candidates = nested_element_index::intersect_to_vec(&sets);
+                            if candidates.is_empty() {
+                                return false;
+                            }
+                            candidates.retain(|elem_idx| {
+                                for (excl_value, excl_path) in &must_not_checkers {
+                                    if let Some(index) = nei.get(excl_path) {
+                                        if let Some(excl_indices) =
+                                            index.get_indices(point_id, excl_value.as_str())
+                                        {
+                                            if excl_indices.contains(elem_idx) {
+                                                return false;
+                                            }
+                                        }
+                                    } else {
+                                        return false;
+                                    }
+                                }
+                                true
+                            });
+                            if candidates.is_empty() {
+                                return false;
+                            }
+
+                            payload_provider.with_payload(
+                                point_id,
+                                |payload| {
+                                    let field_values = payload.get_value(&nested_path);
+
+                                    for &elem_idx in &candidates {
+                                        if let Some(Value::Object(object)) =
+                                            field_values.get(elem_idx as usize)
+                                        {
+                                            let get_payload = || OwnedPayloadRef::from(object);
+                                            if check_payload(
+                                                Box::new(get_payload),
+                                                None,
+                                                &HashMap::new(),
+                                                &nested.nested.filter,
+                                                point_id,
+                                                &nested_indexes,
+                                                &hw,
+                                            ) {
+                                                return true;
+                                            }
+                                        }
+                                    }
+                                    false
+                                },
+                                &hw,
+                            )
+                        })
+                    }
+                } else {
+                    let hw = hw_counter.fork();
+                    Box::new(move |point_id| {
+                        payload_provider.with_payload(
+                            point_id,
+                            |payload| {
+                                let field_values = payload.get_value(&nested_path);
+
+                                for value in field_values {
+                                    if let Value::Object(object) = value {
+                                        let get_payload = || OwnedPayloadRef::from(object);
+                                        if check_payload(
+                                            Box::new(get_payload),
+                                            None,
+                                            &HashMap::new(),
+                                            &nested.nested.filter,
+                                            point_id,
+                                            &nested_indexes,
+                                            &hw,
+                                        ) {
+                                            return true;
+                                        }
+                                    }
+                                }
+                                false
+                            },
+                            &hw,
+                        )
+                    })
+                }
             }
             Condition::CustomIdChecker(cond) => {
                 let segment_ids: AHashSet<_> = id_tracker

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -20,6 +20,7 @@ use super::field_index::index_selector::IndexSelectorRocksDb;
 use super::field_index::index_selector::{
     IndexSelector, IndexSelectorGridstore, IndexSelectorMmap,
 };
+use super::field_index::nested_element_index::NestedElementIndex;
 use super::field_index::{FieldIndexBuilderTrait as _, ResolvedHasId};
 use super::payload_config::{FullPayloadIndexType, PayloadFieldSchemaWithIndexType};
 use crate::common::Flusher;
@@ -89,6 +90,9 @@ pub struct StructPayloadIndex {
     pub(super) vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     /// Indexes, associated with fields
     pub field_indexes: IndexesMap,
+    pub(super) nested_element_indexes:
+        parking_lot::RwLock<Arc<HashMap<PayloadKeyType, NestedElementIndex>>>,
+    nested_element_indexes_initialized: std::sync::atomic::AtomicBool,
     config: PayloadConfig,
     /// Root of index persistence dir
     path: PathBuf,
@@ -174,6 +178,7 @@ impl StructPayloadIndex {
         }
 
         self.field_indexes = field_indexes;
+
         Ok(())
     }
 
@@ -394,6 +399,8 @@ impl StructPayloadIndex {
             id_tracker,
             vector_storages,
             field_indexes: Default::default(),
+            nested_element_indexes: parking_lot::RwLock::new(Arc::new(HashMap::new())),
+            nested_element_indexes_initialized: std::sync::atomic::AtomicBool::new(false),
             config,
             path: path.to_owned(),
             visited_pool: Default::default(),
@@ -826,6 +833,102 @@ impl StructPayloadIndex {
         }
         Ok(())
     }
+
+    pub(super) fn ensure_nested_element_indexes(&self) {
+        if self
+            .nested_element_indexes_initialized
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+
+        // Take the write lock first to serialize concurrent cold builds
+        let mut lock = self.nested_element_indexes.write();
+        if self
+            .nested_element_indexes_initialized
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
+
+        let nested_fields: Vec<_> = self
+            .config
+            .indices
+            .keys()
+            .filter(|f| {
+                f.rest
+                    .iter()
+                    .filter(|item| matches!(item, crate::json_path::JsonPathItem::WildcardIndex))
+                    .count()
+                    == 1
+            })
+            .cloned()
+            .collect();
+
+        if nested_fields.is_empty() {
+            self.nested_element_indexes_initialized
+                .store(true, std::sync::atomic::Ordering::Release);
+            return;
+        }
+
+        let hw_counter = HardwareCounterCell::disposable();
+        let payload_storage = self.payload.borrow();
+        let mut indexes: HashMap<PayloadKeyType, NestedElementIndex> = HashMap::new();
+
+        for field in &nested_fields {
+            indexes.insert(field.clone(), NestedElementIndex::new());
+        }
+
+        let scan_result = payload_storage.iter(
+            |point_id, point_payload| {
+                for field in &nested_fields {
+                    let nei = indexes.get_mut(field).unwrap();
+                    let values_with_positions =
+                        field.value_get_with_element_index(&point_payload.0);
+                    for (value, elem_idx) in values_with_positions {
+                        let key = match value {
+                            Value::String(s) => format!("s:{s}"),
+                            Value::Number(n) => {
+                                if let Some(i) = n.as_i64() {
+                                    format!("n:{i}")
+                                } else {
+                                    format!("n:{n}")
+                                }
+                            }
+                            Value::Bool(b) => format!("b:{b}"),
+                            Value::Null | Value::Object(_) | Value::Array(_) => continue,
+                        };
+                        nei.add_entry(point_id, key, elem_idx);
+                    }
+                }
+                Ok(true)
+            },
+            &hw_counter,
+        );
+
+        drop(payload_storage);
+
+        if let Err(err) = scan_result {
+            log::error!("Failed to build nested element indexes: {err}");
+            self.nested_element_indexes_initialized
+                .store(false, std::sync::atomic::Ordering::Release);
+            return;
+        }
+
+        let built: HashMap<PayloadKeyType, NestedElementIndex> = indexes
+            .into_iter()
+            .filter(|(_, nei)| !nei.is_empty())
+            .collect();
+        *lock = Arc::new(built);
+        self.nested_element_indexes_initialized
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(super) fn nested_element_indexes_snapshot(
+        &self,
+    ) -> Arc<HashMap<PayloadKeyType, NestedElementIndex>> {
+        Arc::clone(&*self.nested_element_indexes.read())
+    }
 }
 
 impl PayloadIndex for StructPayloadIndex {
@@ -869,6 +972,10 @@ impl PayloadIndex for StructPayloadIndex {
             PayloadFieldSchemaWithIndexType::new(payload_schema, index_types),
         );
 
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
+
         self.save_config()?;
 
         Ok(())
@@ -887,12 +994,9 @@ impl PayloadIndex for StructPayloadIndex {
         let field_index = match self.build_index(field, &payload_schema, hw_counter)? {
             BuildIndexResult::Built(field_index) => field_index,
             BuildIndexResult::AlreadyBuilt => {
-                // Index already built, no need to do anything
                 return Ok(());
             }
             BuildIndexResult::IncompatibleSchema => {
-                // We should have fixed it by now explicitly
-                // If it is not fixed, it is a bug
                 return Err(OperationError::service_error(format!(
                     "Incompatible schema for field `{field}`. Please drop the index first."
                 )));
@@ -907,6 +1011,10 @@ impl PayloadIndex for StructPayloadIndex {
     fn drop_index(&mut self, field: PayloadKeyTypeRef) -> OperationResult<bool> {
         let removed_config = self.config.indices.remove(field);
         let removed_indexes = self.field_indexes.remove(field);
+
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
 
         let is_removed = removed_config.is_some() || removed_indexes.is_some();
 
@@ -1029,6 +1137,10 @@ impl PayloadIndex for StructPayloadIndex {
         payload: &Payload,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
+
         self.payload
             .borrow_mut()
             .overwrite(point_id, payload, hw_counter)?;
@@ -1055,6 +1167,10 @@ impl PayloadIndex for StructPayloadIndex {
         key: &Option<JsonPath>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
+
         if let Some(key) = key {
             self.payload
                 .borrow_mut()
@@ -1106,6 +1222,10 @@ impl PayloadIndex for StructPayloadIndex {
         key: PayloadKeyTypeRef,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<Value>> {
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
+
         if let Some(indexes) = self.field_indexes.get_mut(key) {
             for index in indexes {
                 index.remove_point(point_id)?;
@@ -1119,6 +1239,9 @@ impl PayloadIndex for StructPayloadIndex {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<Payload>> {
+        *self.nested_element_indexes.write() = Arc::new(HashMap::new());
+        self.nested_element_indexes_initialized
+            .store(false, std::sync::atomic::Ordering::Release);
         self.clear_index_for_point(point_id)?;
         self.payload.borrow_mut().clear(point_id, hw_counter)
     }

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -55,6 +55,18 @@ impl JsonPath {
         result
     }
 
+    /// Like [`Self::value_get`], but pairs each value with the first wildcard's array index.
+    pub fn value_get_with_element_index<'a>(
+        &self,
+        json_map: &'a serde_json::Map<String, Value>,
+    ) -> Vec<(&'a Value, u32)> {
+        let mut result = Vec::new();
+        if let Some(value) = json_map.get(&self.first_key) {
+            value_get_with_element_index(&self.rest, Some(value), None, &mut result);
+        }
+        result
+    }
+
     /// Set values at a given JSON path in a JSON map.
     pub fn value_set<'a>(
         path: Option<&Self>,
@@ -338,6 +350,36 @@ fn value_get<'a>(
         }
     } else if let Some(value) = value {
         result.push(value);
+    }
+}
+
+fn value_get_with_element_index<'a>(
+    path: &[JsonPathItem],
+    value: Option<&'a Value>,
+    element_idx: Option<u32>,
+    result: &mut Vec<(&'a Value, u32)>,
+) {
+    if let Some((head, tail)) = path.split_first() {
+        match (head, value) {
+            (JsonPathItem::Key(key), Some(Value::Object(map))) => {
+                value_get_with_element_index(tail, map.get(key), element_idx, result)
+            }
+            (JsonPathItem::Index(index), Some(Value::Array(array))) => {
+                if let Some(value) = array.get(*index) {
+                    value_get_with_element_index(tail, Some(value), element_idx, result);
+                }
+            }
+            (JsonPathItem::WildcardIndex, Some(Value::Array(array))) => {
+                for (idx, value) in array.iter().enumerate() {
+                    // First wildcard determines the element index
+                    let elem = element_idx.unwrap_or(idx as u32);
+                    value_get_with_element_index(tail, Some(value), Some(elem), result);
+                }
+            }
+            _ => (),
+        }
+    } else if let Some(value) = value {
+        result.push((value, element_idx.unwrap_or(0)));
     }
 }
 


### PR DESCRIPTION
Nested filters read the full payload for every candidate point to check if multiple conditions match the same array element. For large arrays this causes a big slowdown compared to flat filters.

This remembers which array element each indexed value came from. When a nested query comes in, we intersect element positions across fields to find matching elements without reading the payload. For range or unindexed conditions it narrows down which elements to check so the payload read does less work. The position data is built on first nested query from existing payloads and cleared on any payload change. No changes to storage format.

Relates to #8409

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?