### PR TITLE
Remove no longer correct assertion in optimize

### DIFF
--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -277,7 +277,7 @@ impl Segment {
     where
         F: FnOnce(&mut Segment) -> OperationResult<(bool, Option<PointOffsetType>)>,
     {
-        // If point does not exist or has lower version, ignore operation
+        // If point exist and has higher version, ignore operation
         if let Some(point_offset) = op_point_offset
             && self
                 .id_tracker

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -452,18 +452,6 @@ fn finish_optimization(
         .filter(|&(point_id, _)| !already_remove_points.contains_key(point_id));
 
     for (&point_id, &versions) in points_diff {
-        // In this specific case we're sure logical point data in the wrapped segment is not
-        // changed at all. We ensure this with an assertion at time of proxying, which makes
-        // sure we only wrap original segments. Because we're sure logical data doesn't change,
-        // we also know pending deletes are always newer. Here we assert that's actually the
-        // case.
-        debug_assert!(
-            versions.operation_version >= optimized_segment.point_version(point_id).unwrap_or(0),
-            "proxied point deletes should have newer version than point in segment {} < {:?}, point id: {}",
-            versions.operation_version,
-            optimized_segment.point_version(point_id),
-            point_id,
-        );
         optimized_segment
             .delete_point(versions.operation_version, point_id, hw_counter)
             .unwrap();


### PR DESCRIPTION
Here is a legit scenario, when we need to keep the point in optimized segment with higher version

```
The scenario:                                                                           
                                                                                                                                                                                                                                             
  1. Segments S1 (point 1181 at version 1694) and S2 (point 1181 at version 2556) are both selected for optimization. Proxies P1 and P2 wrap them.                                                                                           
  2. segment_builder.update() uses for_each_unique_point which picks the max version → optimized segment gets point 1181 at version 2556 (from S2).                                                                                          
  3. During optimization, an update operation arrives for point 1181 at some op_num > 2556. find_points_to_update_and_delete finds:                                                                                                          
    - P1: version 1694 (non-deferred)                                                                                                                                                                                                        
    - P2: version 2556 (non-deferred)                                                                                                                                                                                                        
    - Latest = 2556 in P2. P1 goes to to_delete.                                                                                                                                                                                             
  4. Deduplication delete at segment_holder/mod.rs:576-577: delete_points_from_segments calls P1.delete_point(1694, point_id) using the point's own version (1694), not the current op_num. This records:                                    
  ProxyDeletedPoint { local_version: 1694, operation_version: 1694 }                                                                                                                                                                         
  5. The update is then COW'd through P2 to an appendable segment. The point becomes deferred in the appendable → the delete on P2 is skipped (line 728-730).                                                                                
  6. Result: P1 has delete with operation_version: 1694. P2 has no delete recorded. proxy_deleted_points merges to operation_version: 1694.                                                                                                  
  7. In build_new_segment, optimized_segment.delete_point(1694, point_id) is called but silently no-ops because handle_point_version skips when current_version(2556) > op_num(1694).                                                        
  8. In finish_optimization, point 1181 is still in the optimized segment → not in already_remove_points → enters points_diff → assertion fires: 1694 >= 2556 → PANIC.
  ```