### PR TITLE
Avoid cast_vec of bytemuck

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -72,9 +72,15 @@ pub enum GraphLinksFormatParam<'a> {
 
 /// This trait lets the [`serialize_graph_links`] to access vector values.
 pub trait GraphLinksVectors {
+    /// Call `f` with the raw bytes of the base vector for `point_id`.
+    ///
     /// Base vectors will be included once per point on level 0.
     /// The layout of each vector must correspond to [`VectorLayout::base`].
-    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>>;
+    fn for_base_vector(
+        &self,
+        point_id: PointOffsetType,
+        f: &mut dyn FnMut(&[u8]) -> OperationResult<()>,
+    ) -> OperationResult<()>;
 
     /// Link vectors will be included for each link per point.
     /// The layout of each vector must correspond to [`VectorLayout::link`].
@@ -118,13 +124,17 @@ impl<'a> StorageGraphLinksVectors<'a> {
 impl<'a> GraphLinksVectors for StorageGraphLinksVectors<'a> {
     /// Note: uses [`Sequential`] because [`serializer::serialize_graph_links`]
     /// traverses base vectors in a sequential order.
-    fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
+    fn for_base_vector(
+        &self,
+        point_id: PointOffsetType,
+        f: &mut dyn FnMut(&[u8]) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         self.vector_storage
-            .get_vector_bytes_opt::<Sequential>(point_id)
-            .ok_or_else(|| {
-                OperationError::service_error(format!(
+            .with_vector_bytes_opt::<Sequential, _>(point_id, f)
+            .unwrap_or_else(|| {
+                Err(OperationError::service_error(format!(
                     "Point {point_id} not found in vector storage"
-                ))
+                )))
             })
     }
 
@@ -382,8 +392,12 @@ mod tests {
     }
 
     impl GraphLinksVectors for TestGraphLinksVectors {
-        fn get_base_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
-            Ok(Cow::Borrowed(&self.base_vectors[point_id as usize]))
+        fn for_base_vector(
+            &self,
+            point_id: PointOffsetType,
+            f: &mut dyn FnMut(&[u8]) -> OperationResult<()>,
+        ) -> OperationResult<()> {
+            f(&self.base_vectors[point_id as usize])
         }
 
         fn get_link_vector(&self, point_id: PointOffsetType) -> OperationResult<Cow<'_, [u8]>> {
@@ -427,10 +441,12 @@ mod tests {
             let links: Vec<_> = if let Some(vectors) = vectors {
                 let (base_vector, iter) = right.links_with_vectors(point_id, level);
                 if level == 0 {
-                    assert_eq!(
-                        base_vector,
-                        vectors.get_base_vector(point_id).unwrap().as_ref()
-                    );
+                    vectors
+                        .for_base_vector(point_id, &mut |bytes| {
+                            assert_eq!(base_vector, bytes);
+                            Ok(())
+                        })
+                        .unwrap();
                 } else {
                     assert!(base_vector.is_empty());
                 }

--- a/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/serializer.rs
@@ -127,12 +127,14 @@ pub fn serialize_graph_links<W: Write + Seek>(
 
                     // 1. Base vector (`B` in the doc, only on level 0).
                     if level == 0 {
-                        let vector = vectors.get_base_vector(id)?;
-                        if vector.len() != vectors_layout.base.size() {
-                            return Err(OperationError::service_error("Vector size mismatch"));
-                        }
-                        writer.write_all(&vector)?;
-                        offset += vector.len();
+                        vectors.for_base_vector(id, &mut |vector_bytes| {
+                            if vector_bytes.len() != vectors_layout.base.size() {
+                                return Err(OperationError::service_error("Vector size mismatch"));
+                            }
+                            writer.write_all(vector_bytes)?;
+                            Ok(())
+                        })?;
+                        offset += vectors_layout.base.size();
                     }
 
                     // 2. The varint-encoded length (`#` in the doc).

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -169,11 +169,17 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]>;
 
-    /// Get the raw bytes of the vector by the given key if it exists
-    fn get_dense_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
-        ((key as usize) < self.total_vector_count()).then(|| match self.get_dense::<P>(key) {
-            Cow::Borrowed(slice) => Cow::Borrowed(bytemuck::cast_slice(slice)),
-            Cow::Owned(vec) => Cow::Owned(bytemuck::cast_vec(vec)),
+    /// Call `f` with the raw bytes of the vector if it exists.
+    ///
+    /// Uses `bytemuck::cast_slice` on the borrowed data — zero copy, zero allocation.
+    fn with_dense_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        ((key as usize) < self.total_vector_count()).then(|| {
+            let dense = self.get_dense::<P>(key);
+            f(bytemuck::cast_slice(&dense))
         })
     }
 
@@ -573,37 +579,42 @@ impl VectorStorageEnum {
         Ok(())
     }
 
-    /// Get the raw bytes of the vector by the given key if it exists
-    pub fn get_vector_bytes_opt<P: AccessPattern>(
+    /// Call `f` with the raw bytes of the vector if it exists.
+    pub fn with_vector_bytes_opt<P: AccessPattern, R>(
         &self,
         key: PointOffsetType,
-    ) -> Option<Cow<'_, [u8]>> {
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
         match self {
             #[cfg(feature = "rocksdb")]
-            VectorStorageEnum::DenseSimple(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseSimple(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(feature = "rocksdb")]
-            VectorStorageEnum::DenseSimpleByte(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseSimpleByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(feature = "rocksdb")]
-            VectorStorageEnum::DenseSimpleHalf(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseVolatile(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseSimpleHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseVolatile(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseVolatileByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseMemmap(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseMemmapByte(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseVolatileHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmapByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
 
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseUring(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseUringByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseUringHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
 
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_dense_bytes_opt::<P>(key),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_dense_bytes_opt::<P>(key),
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.with_dense_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.with_dense_bytes_opt::<P, R>(key, f)
+            }
             #[cfg(feature = "rocksdb")]
             VectorStorageEnum::SparseSimple(_) => None,
             VectorStorageEnum::SparseVolatile(_) => None,


### PR DESCRIPTION


`bytemuck::cast_vec` is not safe. We need to avoid to use it. We also need to avoid extra generic in HNSW graph builder, as we only care about bytes.