### PR TITLE
Test resharding up/down with deferred points

### DIFF
--- a/tests/consensus_tests/test_resharding_deferred.py
+++ b/tests/consensus_tests/test_resharding_deferred.py
@@ -294,18 +294,20 @@ def test_resharding_transfer_deferred_points(tmp_path: pathlib.Path, direction: 
         assert_http_ok(resp)
         time.sleep(1)
 
-        # Clean up source shards: delete points that were migrated to the new
-        # shard and no longer belong on the source under the new hash ring.
+    # Complete resharding: commit hash rings and finish.
+    resp = commit_read_hashring(peer_api_uris[0])
+    assert_http_ok(resp)
+
+    if direction == "up":
+        # Clean up source shards between read and write hash ring commits:
+        # delete points that were migrated to the new shard and no longer
+        # belong on the source under the new hash ring.
         for shard_id in range(target_shard_id):
             peer_id, peer_uri = find_replica(shard_id, info, peer_api_uris, peer_ids)
             resp = requests.post(
                 f"{peer_uri}/collections/{COLLECTION_NAME}/shards/{shard_id}/cleanup?wait=true",
             )
             assert_http_ok(resp)
-
-    # Complete resharding: commit hash rings and finish.
-    resp = commit_read_hashring(peer_api_uris[0])
-    assert_http_ok(resp)
 
     resp = commit_write_hashring(peer_api_uris[0])
     assert_http_ok(resp)


### PR DESCRIPTION
Add integration test verifying that deferred points survive resharding (both up and down).

Deferred points are invisible to reads until the segment is optimized. 

The test creates deferred points by inserting with optimizers disabled, then runs the full resharding lifecycle with the optimizer enabled concurrently (required for wait=true on migration batches).

 After resharding completes and optimization resolves the deferred points, all original points must be present.

  - Down (3→2 shards): the removed shard's data is permanently deleted, so any deferred points not transferred are irrecoverably lost. Verifies collection-level count and that each surviving shard grew from
  received migrations.
  - Up (3→4 shards): verifies the new shard received the correct subset of points from source shards via shard-local counts with hash ring filtering.