### PR TITLE
Deferred points id is owned by ID tracker

### DIFF
--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -93,7 +93,6 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
                     path: index_dir.path(),
                     stopped: &stopped,
                     tick_progress: || (),
-                    deferred_internal_id: None,
                 })
                 .unwrap();
             assert_eq!(sparse_vector_index.indexed_vector_count(), NUM_VECTORS);
@@ -110,7 +109,6 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
             path: index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-            deferred_internal_id: None,
         })
         .unwrap();
 

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -113,7 +113,6 @@ fn sparse_vector_index_search_benchmark_impl(
             path: mmap_index_dir.path(),
             stopped: &stopped,
             tick_progress: || pb.inc(1),
-            deferred_internal_id: None,
         })
         .unwrap();
     pb.finish_and_clear();

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -83,7 +83,6 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
             path: index_dir,
             stopped: &stopped,
             tick_progress: || (),
-            deferred_internal_id: None,
         })?;
 
     assert_eq!(

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -180,6 +180,45 @@ pub trait IdTracker: fmt::Debug {
     fn immutable_files(&self) -> Vec<PathBuf> {
         Vec::new()
     }
+
+    /// Returns the deferred internal ID threshold.
+    /// Points with internal id >= this value are hidden from reads.
+    fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        None
+    }
+
+    /// Returns the count of deleted deferred points.
+    fn deferred_deleted_count(&self) -> usize {
+        0
+    }
+
+    /// Increment the deleted deferred point counter by one.
+    fn increment_deferred_deleted_count(&mut self) {}
+
+    /// Set the deferred point status (threshold and deleted count).
+    fn set_deferred_point_status(
+        &mut self,
+        _deferred_internal_id: PointOffsetType,
+        _deferred_deleted_count: usize,
+    ) {
+    }
+
+    /// Clear the deferred point status.
+    fn clear_deferred_point_status(&mut self) {}
+}
+
+/// Calculate the count of deleted deferred points by iterating the deletion bitslice.
+///
+/// This can be expensive and should only be run once during segment creation/load.
+pub fn calculate_deleted_deferred_count(
+    tracker: &dyn IdTracker,
+    deferred_from: PointOffsetType,
+) -> usize {
+    let total_points = tracker.total_point_count();
+    if total_points < deferred_from as usize {
+        return 0;
+    }
+    tracker.deleted_point_bitslice()[deferred_from as usize..total_points].count_ones()
 }
 
 /// Enum holding a reference to point mappings from an ID tracker.
@@ -543,6 +582,80 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.immutable_files(),
             #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.immutable_files(),
+        }
+    }
+
+    fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
+            #[cfg(feature = "rocksdb")]
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
+        }
+    }
+
+    fn deferred_deleted_count(&self) -> usize {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
+            #[cfg(feature = "rocksdb")]
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
+        }
+    }
+
+    fn increment_deferred_deleted_count(&mut self) {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => {
+                id_tracker.increment_deferred_deleted_count()
+            }
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
+                id_tracker.increment_deferred_deleted_count()
+            }
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
+                id_tracker.increment_deferred_deleted_count()
+            }
+            #[cfg(feature = "rocksdb")]
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
+                id_tracker.increment_deferred_deleted_count()
+            }
+        }
+    }
+
+    fn set_deferred_point_status(
+        &mut self,
+        deferred_internal_id: PointOffsetType,
+        deferred_deleted_count: usize,
+    ) {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => {
+                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
+            }
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
+                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
+            }
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
+                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
+            }
+            #[cfg(feature = "rocksdb")]
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
+                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
+            }
+        }
+    }
+
+    fn clear_deferred_point_status(&mut self) {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.clear_deferred_point_status(),
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
+                id_tracker.clear_deferred_point_status()
+            }
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
+                id_tracker.clear_deferred_point_status()
+            }
+            #[cfg(feature = "rocksdb")]
+            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.clear_deferred_point_status(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -194,17 +194,6 @@ pub trait IdTracker: fmt::Debug {
 
     /// Increment the deleted deferred point counter by one.
     fn increment_deferred_deleted_count(&mut self) {}
-
-    /// Set the deferred point status (threshold and deleted count).
-    fn set_deferred_point_status(
-        &mut self,
-        _deferred_internal_id: PointOffsetType,
-        _deferred_deleted_count: usize,
-    ) {
-    }
-
-    /// Clear the deferred point status.
-    fn clear_deferred_point_status(&mut self) {}
 }
 
 /// Calculate the count of deleted deferred points by iterating the deletion bitslice.
@@ -620,42 +609,6 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
                 id_tracker.increment_deferred_deleted_count()
             }
-        }
-    }
-
-    fn set_deferred_point_status(
-        &mut self,
-        deferred_internal_id: PointOffsetType,
-        deferred_deleted_count: usize,
-    ) {
-        match self {
-            IdTrackerEnum::MutableIdTracker(id_tracker) => {
-                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
-            }
-            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
-                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
-            }
-            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
-                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
-            }
-            #[cfg(feature = "rocksdb")]
-            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
-                id_tracker.set_deferred_point_status(deferred_internal_id, deferred_deleted_count)
-            }
-        }
-    }
-
-    fn clear_deferred_point_status(&mut self) {
-        match self {
-            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.clear_deferred_point_status(),
-            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
-                id_tracker.clear_deferred_point_status()
-            }
-            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
-                id_tracker.clear_deferred_point_status()
-            }
-            #[cfg(feature = "rocksdb")]
-            IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.clear_deferred_point_status(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -196,19 +196,6 @@ pub trait IdTracker: fmt::Debug {
     fn increment_deferred_deleted_count(&mut self) {}
 }
 
-/// Calculate the count of deleted deferred points by iterating the deletion bitslice.
-///
-/// This can be expensive and should only be run once during segment creation/load.
-pub fn calculate_deleted_deferred_count(
-    tracker: &dyn IdTracker,
-    deferred_from: PointOffsetType,
-) -> usize {
-    let total_points = tracker.total_point_count();
-    if total_points < deferred_from as usize {
-        return 0;
-    }
-    tracker.deleted_point_bitslice()[deferred_from as usize..total_points].count_ones()
-}
 
 /// Enum holding a reference to point mappings from an ID tracker.
 ///

--- a/lib/segment/src/id_tracker/id_tracker_base.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base.rs
@@ -191,11 +191,7 @@ pub trait IdTracker: fmt::Debug {
     fn deferred_deleted_count(&self) -> usize {
         0
     }
-
-    /// Increment the deleted deferred point counter by one.
-    fn increment_deferred_deleted_count(&mut self) {}
 }
-
 
 /// Enum holding a reference to point mappings from an ID tracker.
 ///
@@ -578,24 +574,6 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
             #[cfg(feature = "rocksdb")]
             IdTrackerEnum::RocksDbIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
-        }
-    }
-
-    fn increment_deferred_deleted_count(&mut self) {
-        match self {
-            IdTrackerEnum::MutableIdTracker(id_tracker) => {
-                id_tracker.increment_deferred_deleted_count()
-            }
-            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
-                id_tracker.increment_deferred_deleted_count()
-            }
-            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
-                id_tracker.increment_deferred_deleted_count()
-            }
-            #[cfg(feature = "rocksdb")]
-            IdTrackerEnum::RocksDbIdTracker(id_tracker) => {
-                id_tracker.increment_deferred_deleted_count()
-            }
         }
     }
 }

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -914,7 +914,7 @@ pub(super) mod test {
         let db = open_db(dir.path(), &[DB_VECTOR_CF]).unwrap();
 
         let mut id_tracker = InMemoryIdTracker::new();
-        let mut simple_id_tracker = SimpleIdTracker::open(db).unwrap();
+        let mut simple_id_tracker = SimpleIdTracker::open(db, None).unwrap();
 
         // Insert 100 random points into id_tracker
 

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -160,6 +160,14 @@ impl IdTracker for InMemoryIdTracker {
         debug_assert!(false, "InMemoryIdTracker should not be persisted");
         vec![]
     }
+
+    fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        self.mappings.deferred_internal_id()
+    }
+
+    fn deferred_deleted_count(&self) -> usize {
+        self.mappings.deferred_deleted_count()
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -1474,7 +1474,7 @@ pub(super) mod tests {
         let db = open_db(segment_dir.path(), &[DB_VECTOR_CF]).unwrap();
 
         let mut mutable_id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
-        let mut simple_id_tracker = SimpleIdTracker::open(db).unwrap();
+        let mut simple_id_tracker = SimpleIdTracker::open(db, None).unwrap();
 
         // Insert 100 random points into id_tracker
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -417,10 +417,6 @@ impl IdTracker for MutableIdTracker {
     fn deferred_deleted_count(&self) -> usize {
         self.mappings.deferred_deleted_count()
     }
-
-    fn increment_deferred_deleted_count(&mut self) {
-        self.mappings.increment_deferred_deleted_count();
-    }
 }
 
 pub(crate) fn mappings_path(segment_path: &Path) -> PathBuf {

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -119,13 +119,6 @@ pub struct MutableIdTracker {
     /// If we have more bytes on disk it probably indicates a partial flush. If we have less bytes
     /// on disk we hit some kind of a bug.
     mappings_expected_len: Arc<AtomicU64>,
-
-    /// Points with internal id >= this value are hidden from reads.
-    /// Only used for appendable segments with deferred points.
-    deferred_internal_id: Option<PointOffsetType>,
-
-    /// Amount of deleted deferred points.
-    deferred_deleted_count: usize,
 }
 
 impl MutableIdTracker {
@@ -192,8 +185,6 @@ impl MutableIdTracker {
             pending_mappings: Default::default(),
             is_alive_lock: IsAliveLock::new(),
             mappings_expected_len: Arc::new(AtomicU64::new(mappings_expected_len)),
-            deferred_internal_id: None,
-            deferred_deleted_count: 0,
         })
     }
 
@@ -410,15 +401,15 @@ impl IdTracker for MutableIdTracker {
     }
 
     fn deferred_internal_id(&self) -> Option<PointOffsetType> {
-        self.deferred_internal_id
+        self.mappings.deferred_internal_id()
     }
 
     fn deferred_deleted_count(&self) -> usize {
-        self.deferred_deleted_count
+        self.mappings.deferred_deleted_count()
     }
 
     fn increment_deferred_deleted_count(&mut self) {
-        self.deferred_deleted_count += 1;
+        self.mappings.increment_deferred_deleted_count();
     }
 
     fn set_deferred_point_status(
@@ -426,13 +417,12 @@ impl IdTracker for MutableIdTracker {
         deferred_internal_id: PointOffsetType,
         deferred_deleted_count: usize,
     ) {
-        self.deferred_internal_id = Some(deferred_internal_id);
-        self.deferred_deleted_count = deferred_deleted_count;
+        self.mappings
+            .set_deferred_point_status(deferred_internal_id, deferred_deleted_count);
     }
 
     fn clear_deferred_point_status(&mut self) {
-        self.deferred_internal_id = None;
-        self.deferred_deleted_count = 0;
+        self.mappings.clear_deferred_point_status();
     }
 }
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -119,6 +119,13 @@ pub struct MutableIdTracker {
     /// If we have more bytes on disk it probably indicates a partial flush. If we have less bytes
     /// on disk we hit some kind of a bug.
     mappings_expected_len: Arc<AtomicU64>,
+
+    /// Points with internal id >= this value are hidden from reads.
+    /// Only used for appendable segments with deferred points.
+    deferred_internal_id: Option<PointOffsetType>,
+
+    /// Amount of deleted deferred points.
+    deferred_deleted_count: usize,
 }
 
 impl MutableIdTracker {
@@ -185,6 +192,8 @@ impl MutableIdTracker {
             pending_mappings: Default::default(),
             is_alive_lock: IsAliveLock::new(),
             mappings_expected_len: Arc::new(AtomicU64::new(mappings_expected_len)),
+            deferred_internal_id: None,
+            deferred_deleted_count: 0,
         })
     }
 
@@ -398,6 +407,32 @@ impl IdTracker for MutableIdTracker {
     #[inline]
     fn files(&self) -> Vec<PathBuf> {
         Self::segment_files(&self.segment_path)
+    }
+
+    fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        self.deferred_internal_id
+    }
+
+    fn deferred_deleted_count(&self) -> usize {
+        self.deferred_deleted_count
+    }
+
+    fn increment_deferred_deleted_count(&mut self) {
+        self.deferred_deleted_count += 1;
+    }
+
+    fn set_deferred_point_status(
+        &mut self,
+        deferred_internal_id: PointOffsetType,
+        deferred_deleted_count: usize,
+    ) {
+        self.deferred_internal_id = Some(deferred_internal_id);
+        self.deferred_deleted_count = deferred_deleted_count;
+    }
+
+    fn clear_deferred_point_status(&mut self) {
+        self.deferred_internal_id = None;
+        self.deferred_deleted_count = 0;
     }
 }
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker.rs
@@ -122,7 +122,10 @@ pub struct MutableIdTracker {
 }
 
 impl MutableIdTracker {
-    pub fn open(segment_path: impl Into<PathBuf>) -> OperationResult<Self> {
+    pub fn open(
+        segment_path: impl Into<PathBuf>,
+        deferred_internal_id: Option<PointOffsetType>,
+    ) -> OperationResult<Self> {
         let segment_path = segment_path.into();
 
         let (mappings_path, versions_path) =
@@ -146,11 +149,18 @@ impl MutableIdTracker {
         }
 
         let (mappings, mappings_expected_len) = if has_mappings {
-            load_mappings(&mappings_path).map_err(|err| {
+            load_mappings(&mappings_path, deferred_internal_id).map_err(|err| {
                 OperationError::service_error(format!("Failed to load ID tracker mappings: {err}"))
             })?
         } else {
-            (PointMappings::default(), 0)
+            let mappings = PointMappings::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                deferred_internal_id,
+            );
+            (mappings, 0)
         };
 
         let internal_to_version = if has_versions {
@@ -411,19 +421,6 @@ impl IdTracker for MutableIdTracker {
     fn increment_deferred_deleted_count(&mut self) {
         self.mappings.increment_deferred_deleted_count();
     }
-
-    fn set_deferred_point_status(
-        &mut self,
-        deferred_internal_id: PointOffsetType,
-        deferred_deleted_count: usize,
-    ) {
-        self.mappings
-            .set_deferred_point_status(deferred_internal_id, deferred_deleted_count);
-    }
-
-    fn clear_deferred_point_status(&mut self) {
-        self.mappings.clear_deferred_point_status();
-    }
 }
 
 pub(crate) fn mappings_path(segment_path: &Path) -> PathBuf {
@@ -539,12 +536,15 @@ fn write_mapping_changes<W: Write>(
 /// Returns loaded point mappings and the number of bytes read from the file.
 ///
 /// If the file ends with an incomplete entry, it is truncated from the file.
-fn load_mappings(mappings_path: &Path) -> OperationResult<(PointMappings, u64)> {
+fn load_mappings(
+    mappings_path: &Path,
+    deferred_internal_id: Option<PointOffsetType>,
+) -> OperationResult<(PointMappings, u64)> {
     let file = OneshotFile::open(mappings_path)?;
     let file_len = file.metadata()?.len();
     let mut reader = BufReader::new(file);
 
-    let mappings = read_mappings(&mut reader)?;
+    let mappings = read_mappings(&mut reader, deferred_internal_id)?;
 
     let read_to = reader.stream_position()?;
     reader.into_inner().drop_cache()?;
@@ -609,7 +609,10 @@ where
 /// Read point mappings from the given reader
 ///
 /// Returns loaded point mappings.
-fn read_mappings<R>(reader: R) -> OperationResult<PointMappings>
+fn read_mappings<R>(
+    reader: R,
+    deferred_internal_id: Option<PointOffsetType>,
+) -> OperationResult<PointMappings>
 where
     R: Read + Seek,
 {
@@ -696,6 +699,7 @@ where
         internal_to_external,
         external_to_internal_num,
         external_to_internal_uuid,
+        deferred_internal_id,
     );
 
     Ok(mappings)
@@ -964,7 +968,7 @@ pub(super) mod tests {
     fn test_iterator() {
         let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-        let mut id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let mut id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
 
         id_tracker.set_link(200.into(), 0).unwrap();
         id_tracker.set_link(100.into(), 1).unwrap();
@@ -1034,7 +1038,7 @@ pub(super) mod tests {
             (id_tracker.mappings, id_tracker.internal_to_version)
         };
 
-        let mut loaded_id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let mut loaded_id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
 
         assert_eq!(
             old_versions.len(),
@@ -1092,7 +1096,7 @@ pub(super) mod tests {
             (dropped_points, custom_version)
         };
 
-        let id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
         for (index, point) in TEST_POINTS.iter().enumerate() {
             let internal_id = index as PointOffsetType;
 
@@ -1189,7 +1193,7 @@ pub(super) mod tests {
         };
 
         // Point should still be gone
-        let id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
         assert_eq!(id_tracker.internal_id(point_to_delete), None);
 
         old_mappings
@@ -1235,28 +1239,28 @@ pub(super) mod tests {
     fn test_point_mappings_deserializing_special() {
         // Empty reader creates empty mappings
         let buf = Cursor::new(b"");
-        assert_eq!(read_mappings(buf).unwrap().total_point_count(), 0);
+        assert_eq!(read_mappings(buf, None).unwrap().total_point_count(), 0);
 
         // Corrupt if reading invalid type byte
         let buf = Cursor::new(b"\x00");
         assert!(
-            read_mappings(buf)
+            read_mappings(buf, None)
                 .unwrap_err()
                 .to_string()
                 .contains("Corrupted ID tracker mapping storage")
         );
 
         let buf = Cursor::new(b"malformed!");
-        assert!(read_mappings(buf).is_err());
+        assert!(read_mappings(buf, None).is_err());
 
         // Empty if change is not fully written
         let buf = Cursor::new(b"\x01\x01\x00\x00\x00\x00");
-        assert_eq!(read_mappings(buf).unwrap().total_point_count(), 0);
+        assert_eq!(read_mappings(buf, None).unwrap().total_point_count(), 0);
 
         // Exactly one entry
         let buf = Cursor::new(b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00");
         assert_eq!(
-            read_mappings(buf)
+            read_mappings(buf, None)
                 .unwrap()
                 .internal_id(&PointIdType::NumId(1)),
             Some(2)
@@ -1265,7 +1269,7 @@ pub(super) mod tests {
         // Exactly one entry and a malformed second one
         let buf = Cursor::new(b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x01\x00");
         assert!(
-            read_mappings(buf)
+            read_mappings(buf, None)
                 .unwrap_err()
                 .to_string()
                 .contains("Corrupted ID tracker mapping storage")
@@ -1273,7 +1277,7 @@ pub(super) mod tests {
 
         // Exactly one entry and an incomplete second one
         let buf = Cursor::new(b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x01\x00");
-        let mappings = read_mappings(buf).unwrap();
+        let mappings = read_mappings(buf, None).unwrap();
         assert_eq!(mappings.total_point_count(), 1);
         assert_eq!(mappings.internal_id(&PointIdType::NumId(1)), Some(0));
     }
@@ -1334,7 +1338,7 @@ pub(super) mod tests {
         .unwrap();
         assert_eq!(fs::metadata(&mappings_path).unwrap().len(), 13);
         assert_eq!(
-            load_mappings(&mappings_path)
+            load_mappings(&mappings_path, None)
                 .unwrap()
                 .0
                 .internal_id(&PointIdType::NumId(1)),
@@ -1350,7 +1354,7 @@ pub(super) mod tests {
         .unwrap();
         assert_eq!(fs::metadata(&mappings_path).unwrap().len(), 14);
         assert_eq!(
-            load_mappings(&mappings_path)
+            load_mappings(&mappings_path, None)
                 .unwrap()
                 .0
                 .internal_id(&PointIdType::NumId(1)),
@@ -1366,7 +1370,7 @@ pub(super) mod tests {
         .unwrap();
         assert_eq!(fs::metadata(&mappings_path).unwrap().len(), 16);
         assert_eq!(
-            load_mappings(&mappings_path)
+            load_mappings(&mappings_path, None)
                 .unwrap()
                 .0
                 .internal_id(&PointIdType::NumId(1)),
@@ -1381,7 +1385,7 @@ pub(super) mod tests {
         ).unwrap();
         assert_eq!(fs::metadata(&mappings_path).unwrap().len(), 28);
         assert_eq!(
-            load_mappings(&mappings_path)
+            load_mappings(&mappings_path, None)
                 .unwrap()
                 .0
                 .internal_id(&PointIdType::NumId(1)),
@@ -1406,7 +1410,7 @@ pub(super) mod tests {
 
     fn make_mutable_tracker(path: &Path) -> MutableIdTracker {
         let mut id_tracker =
-            MutableIdTracker::open(path).expect("failed to open mutable ID tracker");
+            MutableIdTracker::open(path, None).expect("failed to open mutable ID tracker");
 
         for value in TEST_POINTS.iter() {
             let internal_id = id_tracker.total_point_count() as PointOffsetType;
@@ -1473,7 +1477,7 @@ pub(super) mod tests {
         let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let db = open_db(segment_dir.path(), &[DB_VECTOR_CF]).unwrap();
 
-        let mut mutable_id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let mut mutable_id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
         let mut simple_id_tracker = SimpleIdTracker::open(db).unwrap();
 
         // Insert 100 random points into id_tracker
@@ -1548,7 +1552,7 @@ pub(super) mod tests {
         mutable_id_tracker.mapping_flusher()().unwrap();
         mutable_id_tracker.versions_flusher()().unwrap();
         drop(mutable_id_tracker);
-        let mutable_id_tracker = MutableIdTracker::open(segment_dir.path()).unwrap();
+        let mutable_id_tracker = MutableIdTracker::open(segment_dir.path(), None).unwrap();
 
         check_trackers(&simple_id_tracker, &mutable_id_tracker);
     }

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -129,7 +129,17 @@ impl PointMappings {
         }
 
         if let Some(internal_id) = &internal_id {
+            let was_already_deleted = self.deleted[*internal_id as usize];
             self.deleted.set(*internal_id as usize, true);
+
+            // Track deletion of deferred points.
+            if !was_already_deleted
+                && self
+                    .deferred_internal_id
+                    .is_some_and(|deferred_from| *internal_id >= deferred_from)
+            {
+                self.deferred_deleted_count += 1;
+            }
         }
 
         internal_id
@@ -294,10 +304,6 @@ impl PointMappings {
 
     pub(crate) fn deferred_deleted_count(&self) -> usize {
         self.deferred_deleted_count
-    }
-
-    pub(crate) fn increment_deferred_deleted_count(&mut self) {
-        self.deferred_deleted_count += 1;
     }
 
     /// Generate a random [`PointMappings`].

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -35,6 +35,13 @@ pub struct PointMappings {
     // Having two separate maps allows us iterating only over one type at a time without having to filter.
     external_to_internal_num: BTreeMap<u64, PointOffsetType>,
     external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType>,
+
+    /// Points with internal id >= this value are hidden from reads.
+    /// Only used for appendable segments with deferred points.
+    deferred_internal_id: Option<PointOffsetType>,
+
+    /// Amount of deleted deferred points.
+    deferred_deleted_count: usize,
 }
 
 impl PointMappings {
@@ -49,6 +56,8 @@ impl PointMappings {
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
+            deferred_internal_id: None,
+            deferred_deleted_count: 0,
         }
     }
 
@@ -268,6 +277,32 @@ impl PointMappings {
         self.internal_to_external.len()
     }
 
+    pub(crate) fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        self.deferred_internal_id
+    }
+
+    pub(crate) fn deferred_deleted_count(&self) -> usize {
+        self.deferred_deleted_count
+    }
+
+    pub(crate) fn increment_deferred_deleted_count(&mut self) {
+        self.deferred_deleted_count += 1;
+    }
+
+    pub(crate) fn set_deferred_point_status(
+        &mut self,
+        deferred_internal_id: PointOffsetType,
+        deferred_deleted_count: usize,
+    ) {
+        self.deferred_internal_id = Some(deferred_internal_id);
+        self.deferred_deleted_count = deferred_deleted_count;
+    }
+
+    pub(crate) fn clear_deferred_point_status(&mut self) {
+        self.deferred_internal_id = None;
+        self.deferred_deleted_count = 0;
+    }
+
     /// Generate a random [`PointMappings`].
     #[cfg(test)]
     pub fn random(rand: &mut StdRng, total_size: u32) -> Self {
@@ -326,6 +361,8 @@ impl PointMappings {
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
+            deferred_internal_id: None,
+            deferred_deleted_count: 0,
         }
     }
 

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -50,14 +50,25 @@ impl PointMappings {
         internal_to_external: Vec<PointIdType>,
         external_to_internal_num: BTreeMap<u64, PointOffsetType>,
         external_to_internal_uuid: BTreeMap<Uuid, PointOffsetType>,
+        deferred_internal_id: Option<PointOffsetType>,
     ) -> Self {
+        let deferred_deleted_count = deferred_internal_id
+            .map(|deferred_from| {
+                let total = deleted.len();
+                if total < deferred_from as usize {
+                    0
+                } else {
+                    deleted[deferred_from as usize..total].count_ones()
+                }
+            })
+            .unwrap_or(0);
         Self {
             deleted,
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
-            deferred_internal_id: None,
-            deferred_deleted_count: 0,
+            deferred_internal_id,
+            deferred_deleted_count,
         }
     }
 
@@ -287,20 +298,6 @@ impl PointMappings {
 
     pub(crate) fn increment_deferred_deleted_count(&mut self) {
         self.deferred_deleted_count += 1;
-    }
-
-    pub(crate) fn set_deferred_point_status(
-        &mut self,
-        deferred_internal_id: PointOffsetType,
-        deferred_deleted_count: usize,
-    ) {
-        self.deferred_internal_id = Some(deferred_internal_id);
-        self.deferred_deleted_count = deferred_deleted_count;
-    }
-
-    pub(crate) fn clear_deferred_point_status(&mut self) {
-        self.deferred_internal_id = None;
-        self.deferred_deleted_count = 0;
     }
 
     /// Generate a random [`PointMappings`].

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -36,7 +36,10 @@ pub struct SimpleIdTracker {
 }
 
 impl SimpleIdTracker {
-    pub fn open(store: Arc<RwLock<DB>>) -> OperationResult<Self> {
+    pub fn open(
+        store: Arc<RwLock<DB>>,
+        deferred_internal_id: Option<PointOffsetType>,
+    ) -> OperationResult<Self> {
         let mut deleted = BitVec::new();
         let mut internal_to_external: Vec<PointIdType> = Default::default();
         let mut external_to_internal_num: BTreeMap<u64, PointOffsetType> = Default::default();
@@ -115,7 +118,7 @@ impl SimpleIdTracker {
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
-            None,
+            deferred_internal_id,
         );
 
         #[cfg(debug_assertions)]
@@ -402,7 +405,7 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
-        let mut id_tracker = SimpleIdTracker::open(db).unwrap();
+        let mut id_tracker = SimpleIdTracker::open(db, None).unwrap();
 
         id_tracker.set_link(200.into(), 0).unwrap();
         id_tracker.set_link(100.into(), 1).unwrap();
@@ -436,7 +439,7 @@ mod tests {
         let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
         let db = open_db(dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
-        let mut id_tracker = SimpleIdTracker::open(db).unwrap();
+        let mut id_tracker = SimpleIdTracker::open(db, None).unwrap();
 
         let mut values: Vec<PointIdType> = vec![
             100.into(),
@@ -480,7 +483,7 @@ mod tests {
         let db = open_db(db_dir.path(), &[DB_MAPPING_CF, DB_VERSIONS_CF]).unwrap();
 
         // Create RocksDB ID tracker and insert test points
-        let mut id_tracker = SimpleIdTracker::open(db).unwrap();
+        let mut id_tracker = SimpleIdTracker::open(db, None).unwrap();
         for value in TEST_POINTS.iter() {
             let internal_id = id_tracker.total_point_count() as PointOffsetType;
             id_tracker.set_link(*value, internal_id).unwrap();

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -297,6 +297,14 @@ impl IdTracker for SimpleIdTracker {
     fn files(&self) -> Vec<PathBuf> {
         vec![]
     }
+
+    fn deferred_internal_id(&self) -> Option<PointOffsetType> {
+        self.mappings.deferred_internal_id()
+    }
+
+    fn deferred_deleted_count(&self) -> usize {
+        self.mappings.deferred_deleted_count()
+    }
 }
 
 impl From<&ExtendedPointId> for StoredPointId {

--- a/lib/segment/src/id_tracker/simple_id_tracker.rs
+++ b/lib/segment/src/id_tracker/simple_id_tracker.rs
@@ -115,6 +115,7 @@ impl SimpleIdTracker {
             internal_to_external,
             external_to_internal_num,
             external_to_internal_uuid,
+            None,
         );
 
         #[cfg(debug_assertions)]

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -53,7 +53,6 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,
     scores_memory_pool: ScoresMemoryPool,
-    deferred_internal_id: Option<PointOffsetType>,
 }
 
 /// Getters for internals, used for testing.
@@ -88,7 +87,6 @@ pub struct SparseVectorIndexOpenArgs<'a, F: FnMut()> {
     pub path: &'a Path,
     pub stopped: &'a AtomicBool,
     pub tick_progress: F,
-    pub deferred_internal_id: Option<PointOffsetType>,
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -102,7 +100,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             path,
             stopped,
             tick_progress,
-            deferred_internal_id,
         } = args;
 
         let config_path = SparseIndexConfig::get_config_path(path);
@@ -165,7 +162,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             searches_telemetry,
             indices_tracker,
             scores_memory_pool,
-            deferred_internal_id,
         })
     }
 
@@ -576,7 +572,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         let mut prefiltered_points = None;
 
         debug_assert_eq!(
-            self.deferred_internal_id,
+            self.id_tracker.borrow().deferred_internal_id(),
             query_context.deferred_internal_id(),
             "SparseIndex and VectorQueryContext deferred_internal_id consistency violated."
         );
@@ -691,7 +687,9 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         }
 
         let point_is_deferred = self
-            .deferred_internal_id
+            .id_tracker
+            .borrow()
+            .deferred_internal_id()
             .is_some_and(|deferred| id >= deferred);
 
         if point_is_deferred {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -74,8 +74,9 @@ impl ReadSegmentEntry for Segment {
             .vector_data
             .get(vector_name)
             .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
+        let deferred_internal_id = self.id_tracker.borrow().deferred_internal_id();
         let vector_query_context =
-            query_context.get_vector_context(vector_name, self.deferred_internal_id());
+            query_context.get_vector_context(vector_name, deferred_internal_id);
         let internal_results = vector_data.vector_index.borrow().search(
             query_vectors,
             filter,
@@ -521,7 +522,7 @@ impl ReadSegmentEntry for Segment {
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deferred_points: Some(self.deferred_point_count()),
-            num_deleted_deferred_points: Some(self.deferred_deleted_count().unwrap_or_default()),
+            num_deleted_deferred_points: Some(self.id_tracker.borrow().deferred_deleted_count()),
             num_deleted_vectors: self.deleted_point_count(),
             vectors_size_bytes,  // Considers vector storage, but not indices
             payloads_size_bytes, // Considers payload storage, but not indices
@@ -530,7 +531,7 @@ impl ReadSegmentEntry for Segment {
             is_appendable: self.appendable_flag,
             index_schema: HashMap::new(),
             vector_data: vector_data_info,
-            deferred_internal_id: self.deferred_internal_id(),
+            deferred_internal_id: self.id_tracker.borrow().deferred_internal_id(),
         }
     }
 
@@ -618,8 +619,9 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn point_is_deferred(&self, point_id: PointIdType) -> bool {
-        if let Some(deferred_from) = self.deferred_internal_id()
-            && let Some(internal_id) = self.id_tracker.borrow().internal_id(point_id)
+        let id_tracker = self.id_tracker.borrow();
+        if let Some(deferred_from) = id_tracker.deferred_internal_id()
+            && let Some(internal_id) = id_tracker.internal_id(point_id)
         {
             return self.is_appendable() && internal_id >= deferred_from;
         };
@@ -627,14 +629,18 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn deferred_point_ids(&self) -> Vec<PointIdType> {
-        let Some(deferred_from) = self.deferred_internal_id() else {
+        let id_tracker = self.id_tracker.borrow();
+        let Some(deferred_from) = id_tracker.deferred_internal_id() else {
             return vec![];
         };
-        if self.deferred_point_count() == 0 {
+        let deferred_count = id_tracker
+            .total_point_count()
+            .saturating_sub(deferred_from as usize)
+            .saturating_sub(id_tracker.deferred_deleted_count());
+        if deferred_count == 0 {
             return vec![];
         }
 
-        let id_tracker = self.id_tracker.borrow();
         id_tracker
             .point_mappings()
             .iter_internal()
@@ -644,25 +650,33 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn available_point_count_without_deferred(&self) -> usize {
-        self.id_tracker
-            .borrow()
+        let id_tracker = self.id_tracker.borrow();
+        let deferred_count = match id_tracker.deferred_internal_id() {
+            Some(deferred_from) => id_tracker
+                .total_point_count()
+                .saturating_sub(deferred_from as usize)
+                .saturating_sub(id_tracker.deferred_deleted_count()),
+            None => 0,
+        };
+        id_tracker
             .available_point_count()
-            .saturating_sub(self.deferred_point_count())
+            .saturating_sub(deferred_count)
     }
 
     fn has_deferred_points(&self) -> bool {
-        self.deferred_internal_id()
-            .is_some_and(|deferred_from| self.total_point_count() > deferred_from as usize)
+        let id_tracker = self.id_tracker.borrow();
+        id_tracker
+            .deferred_internal_id()
+            .is_some_and(|deferred_from| id_tracker.total_point_count() > deferred_from as usize)
     }
 
     fn deferred_point_count(&self) -> usize {
-        match self.deferred_internal_id() {
-            Some(internal_id) => self
-                .id_tracker
-                .borrow()
+        let id_tracker = self.id_tracker.borrow();
+        match id_tracker.deferred_internal_id() {
+            Some(deferred_from) => id_tracker
                 .total_point_count()
-                .saturating_sub(internal_id as usize)
-                .saturating_sub(self.deferred_deleted_count().unwrap_or_default()),
+                .saturating_sub(deferred_from as usize)
+                .saturating_sub(id_tracker.deferred_deleted_count()),
             None => 0,
         }
     }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -629,17 +629,14 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn deferred_point_ids(&self) -> Vec<PointIdType> {
+        if self.deferred_point_count() == 0 {
+            return vec![];
+        }
+
         let id_tracker = self.id_tracker.borrow();
         let Some(deferred_from) = id_tracker.deferred_internal_id() else {
             return vec![];
         };
-        let deferred_count = id_tracker
-            .total_point_count()
-            .saturating_sub(deferred_from as usize)
-            .saturating_sub(id_tracker.deferred_deleted_count());
-        if deferred_count == 0 {
-            return vec![];
-        }
 
         id_tracker
             .point_mappings()
@@ -650,17 +647,8 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn available_point_count_without_deferred(&self) -> usize {
-        let id_tracker = self.id_tracker.borrow();
-        let deferred_count = match id_tracker.deferred_internal_id() {
-            Some(deferred_from) => id_tracker
-                .total_point_count()
-                .saturating_sub(deferred_from as usize)
-                .saturating_sub(id_tracker.deferred_deleted_count()),
-            None => 0,
-        };
-        id_tracker
-            .available_point_count()
-            .saturating_sub(deferred_count)
+        let available_point_count = self.id_tracker.borrow().available_point_count();
+        available_point_count.saturating_sub(self.deferred_point_count())
     }
 
     fn has_deferred_points(&self) -> bool {

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -34,6 +34,8 @@ impl Segment {
         let facet_index = payload_index.get_facet_index(&request.key)?;
         let context;
 
+        let deferred_internal_id = self.id_tracker.borrow().deferred_internal_id();
+
         let hits_iter = if let Some(filter) = &request.filter {
             let id_tracker = self.id_tracker.borrow();
             let filter_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
@@ -60,7 +62,7 @@ impl Segment {
                         &filter_cardinality,
                         hw_counter,
                         is_stopped,
-                        self.deferred_internal_id(),
+                        deferred_internal_id,
                     )?
                     .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                     .fold(HashMap::new(), |mut map, point_id| {
@@ -100,8 +102,7 @@ impl Segment {
                         let count = iter
                             .dedup()
                             .take_while(|&point_id| {
-                                point_id
-                                    < self.deferred_internal_id().unwrap_or(PointOffsetType::MAX)
+                                point_id < deferred_internal_id.unwrap_or(PointOffsetType::MAX)
                             })
                             .filter(|&point_id| context.check(point_id))
                             .count();
@@ -115,7 +116,7 @@ impl Segment {
         } else {
             // just count how many points each value has
             let iter = facet_index
-                .iter_counts_per_value(self.deferred_internal_id())
+                .iter_counts_per_value(deferred_internal_id)
                 .stop_if(is_stopped)
                 .filter(|hit| hit.count > 0);
 
@@ -144,8 +145,10 @@ impl Segment {
 
         let facet_index = payload_index.get_facet_index(key)?;
 
+        let id_tracker = self.id_tracker.borrow();
+        let deferred_internal_id = id_tracker.deferred_internal_id();
+
         let values = if let Some(filter) = filter {
-            let id_tracker = self.id_tracker.borrow();
             let filter_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
             let point_mappings = id_tracker.point_mappings();
 
@@ -157,7 +160,7 @@ impl Segment {
                     &filter_cardinality,
                     hw_counter,
                     is_stopped,
-                    self.deferred_internal_id(),
+                    deferred_internal_id,
                 )?
                 .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                 .fold(BTreeSet::new(), |mut set, point_id| {
@@ -169,7 +172,7 @@ impl Segment {
                 .collect()
         } else {
             facet_index
-                .iter_values(hw_counter, self.deferred_internal_id())
+                .iter_values(hw_counter, deferred_internal_id)
                 .stop_if(is_stopped)
                 .map(|value_ref| value_ref.to_owned())
                 .collect()

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::is_alive_lock::IsAliveLock;
 use common::storage_version::StorageVersion;
-use common::types::PointOffsetType;
 use parking_lot::Mutex;
 #[cfg(feature = "rocksdb")]
 use rocksdb::DB;
@@ -94,18 +93,6 @@ pub struct Segment {
     pub error_status: Option<SegmentFailedState>,
     #[cfg(feature = "rocksdb")]
     pub database: Option<Arc<parking_lot::RwLock<DB>>>,
-    pub(crate) deferred_point_status: Option<DeferredPointStatus>,
-}
-
-#[derive(Debug)]
-pub struct DeferredPointStatus {
-    /// Points with internal id >= this value are hidden from reads.
-    /// Available for appendable segments only.
-    pub(crate) deferred_internal_id: PointOffsetType,
-
-    /// Amount of deleted deferred points. Must kept track of properly to be able
-    /// to calculate the amount of available deferred and visible points.
-    pub(crate) deferred_deleted_count: usize,
 }
 
 pub struct VectorData {

--- a/lib/segment/src/segment/order_by.rs
+++ b/lib/segment/src/segment/order_by.rs
@@ -40,7 +40,7 @@ impl Segment {
 
         let start_from = order_by.start_from();
 
-        let effective_deferred_id = deferred_behavior.apply(self.deferred_internal_id());
+        let effective_deferred_id = deferred_behavior.apply(id_tracker.deferred_internal_id());
 
         let point_mappings = id_tracker.point_mappings();
         let values_ids_iterator = payload_index
@@ -111,20 +111,21 @@ impl Segment {
                 key: order_by.key.to_string(),
             })?;
 
+        let id_tracker = self.id_tracker.borrow();
+        let deferred_internal_id = id_tracker.deferred_internal_id();
+
         let range_iter = numeric_index
             .stream_range(&order_by.as_range())
             // We can't early stop the iterator for deferred points because the items are sorted lexicographically by type `(T, internalID)`.
-            .filter(|&(_, internal_id)| {
+            .filter(move |&(_, internal_id)| {
                 deferred_behavior.include_all_points()
-                    || internal_id < self.deferred_internal_id().unwrap_or(PointOffsetType::MAX)
+                    || internal_id < deferred_internal_id.unwrap_or(PointOffsetType::MAX)
             });
 
         let directed_range_iter = match order_by.direction() {
             Direction::Asc => Either::Left(range_iter),
             Direction::Desc => Either::Right(range_iter.rev()),
         };
-
-        let id_tracker = self.id_tracker.borrow();
 
         let filtered_iter = match filter {
             None => Either::Left(directed_range_iter),

--- a/lib/segment/src/segment/sampling.rs
+++ b/lib/segment/src/segment/sampling.rs
@@ -31,7 +31,7 @@ impl Segment {
                 &cardinality_estimation,
                 hw_counter,
                 is_stopped,
-                self.deferred_internal_id(),
+                id_tracker.deferred_internal_id(),
             )?
             .filter_map(|internal_id| id_tracker.external_id(internal_id));
 
@@ -51,11 +51,10 @@ impl Segment {
     ) -> OperationResult<Vec<PointIdType>> {
         let payload_index = self.payload_index.borrow();
         let filter_context = payload_index.filter_context(condition, hw_counter)?;
-        Ok(self
-            .id_tracker
-            .borrow()
+        let id_tracker = self.id_tracker.borrow();
+        Ok(id_tracker
             .point_mappings()
-            .iter_random_visible(self.deferred_internal_id())
+            .iter_random_visible(id_tracker.deferred_internal_id())
             .stop_if(is_stopped)
             .filter(move |(_, internal_id)| filter_context.check(*internal_id))
             .map(|(external_id, _)| external_id)
@@ -64,10 +63,10 @@ impl Segment {
     }
 
     pub(super) fn read_by_random_id(&self, limit: usize) -> Vec<PointIdType> {
-        self.id_tracker
-            .borrow()
+        let id_tracker = self.id_tracker.borrow();
+        id_tracker
             .point_mappings()
-            .iter_random_visible(self.deferred_internal_id())
+            .iter_random_visible(id_tracker.deferred_internal_id())
             .map(|x| x.0)
             .take(limit)
             .collect()

--- a/lib/segment/src/segment/scroll.rs
+++ b/lib/segment/src/segment/scroll.rs
@@ -70,7 +70,8 @@ impl Segment {
         hw_counter: &HardwareCounterCell,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<Vec<PointIdType>> {
-        let effective_deferred_id = deferred_behavior.apply(self.deferred_internal_id());
+        let effective_deferred_id =
+            deferred_behavior.apply(self.id_tracker.borrow().deferred_internal_id());
 
         let payload_index = self.payload_index.borrow();
         let filter_context = payload_index.filter_context(condition, hw_counter)?;
@@ -92,7 +93,8 @@ impl Segment {
         limit: Option<usize>,
         deferred_behavior: DeferredBehavior,
     ) -> Vec<PointIdType> {
-        let effective_deferred_id = deferred_behavior.apply(self.deferred_internal_id());
+        let effective_deferred_id =
+            deferred_behavior.apply(self.id_tracker.borrow().deferred_internal_id());
 
         self.id_tracker
             .borrow()
@@ -112,7 +114,8 @@ impl Segment {
         hw_counter: &HardwareCounterCell,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<Vec<PointIdType>> {
-        let effective_deferred_id = deferred_behavior.apply(self.deferred_internal_id());
+        let effective_deferred_id =
+            deferred_behavior.apply(self.id_tracker.borrow().deferred_internal_id());
 
         let payload_index = self.payload_index.borrow();
         let id_tracker = self.id_tracker.borrow();

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -313,19 +313,7 @@ impl Segment {
 
         let mut id_tracker = self.id_tracker.borrow_mut();
 
-        let is_point_already_deleted = id_tracker.is_deleted_point(internal_id);
-
         id_tracker.drop_internal(internal_id)?;
-
-        // Increase counter for deleted deferred points.
-        if id_tracker
-            .deferred_internal_id()
-            .is_some_and(|deferred_from| internal_id >= deferred_from)
-            // Don't count the deletion of the same point twice
-            && !is_point_already_deleted
-        {
-            id_tracker.increment_deferred_deleted_count();
-        }
 
         // Before, we propagated point deletions to also delete its vectors. This turns
         // out to be problematic because this sometimes makes us lose vector data

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -317,15 +317,14 @@ impl Segment {
 
         id_tracker.drop_internal(internal_id)?;
 
-        let deferred_point_status = self.deferred_point_status.as_mut();
-
-        // Increase counter for deleted points.
-        if let Some(deferred_point_status) = deferred_point_status
-            && internal_id >= deferred_point_status.deferred_internal_id
+        // Increase counter for deleted deferred points.
+        if id_tracker
+            .deferred_internal_id()
+            .is_some_and(|deferred_from| internal_id >= deferred_from)
             // Don't count the deletion of the same point twice
             && !is_point_already_deleted
         {
-            deferred_point_status.deferred_deleted_count += 1;
+            id_tracker.increment_deferred_deleted_count();
         }
 
         // Before, we propagated point deletions to also delete its vectors. This turns
@@ -668,35 +667,6 @@ impl Segment {
     /// Returns list of IDs without mappings which should be removed from segment
     pub fn fix_id_tracker_inconsistencies(&mut self) -> OperationResult<Vec<PointOffsetType>> {
         self.id_tracker.borrow_mut().fix_inconsistencies()
-    }
-
-    /// Calculates the amount of deleted deferred points by iterating over all points in the ID tracker. Therefore this operation
-    /// can be expensive and should only be run once at segment creation.
-    pub(crate) fn calculate_deleted_deferred_point_count(&self) -> usize {
-        let Some(deferred_from) = self.deferred_internal_id() else {
-            return 0;
-        };
-
-        let id_tracker = self.id_tracker.borrow();
-        let total_points = id_tracker.total_point_count();
-
-        if total_points < deferred_from as usize {
-            return 0;
-        }
-
-        id_tracker.deleted_point_bitslice()[deferred_from as usize..total_points].count_ones()
-    }
-
-    pub(crate) fn deferred_internal_id(&self) -> Option<PointOffsetType> {
-        self.deferred_point_status
-            .as_ref()
-            .map(|i| i.deferred_internal_id)
-    }
-
-    pub(crate) fn deferred_deleted_count(&self) -> Option<usize> {
-        self.deferred_point_status
-            .as_ref()
-            .map(|i| i.deferred_deleted_count)
     }
 }
 

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -30,7 +30,6 @@ use crate::entry::entry_point::{
 };
 use crate::entry::{SnapshotEntry as _, StorageSegmentEntry as _};
 use crate::id_tracker::IdTracker;
-use crate::id_tracker::id_tracker_base::calculate_deleted_deferred_count;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::json_path::JsonPath;
 use crate::segment_constructor::simple_segment_constructor::{
@@ -1471,13 +1470,7 @@ fn test_deleted_deferred_point_count() {
                 n_deferred.checked_sub(deleted_count).unwrap()
             );
             assert_eq!(
-                {
-                    let id_tracker = segment.id_tracker.borrow();
-                    calculate_deleted_deferred_count(
-                        &*id_tracker,
-                        id_tracker.deferred_internal_id().unwrap(),
-                    )
-                },
+                segment.id_tracker.borrow().deferred_deleted_count(),
                 deleted_count,
             );
 
@@ -1492,13 +1485,7 @@ fn test_deleted_deferred_point_count() {
             );
 
             assert_eq!(
-                {
-                    let id_tracker = segment.id_tracker.borrow();
-                    calculate_deleted_deferred_count(
-                        &*id_tracker,
-                        id_tracker.deferred_internal_id().unwrap(),
-                    )
-                },
+                segment.id_tracker.borrow().deferred_deleted_count(),
                 deleted_count
             );
 
@@ -1508,13 +1495,7 @@ fn test_deleted_deferred_point_count() {
         // We delete all deferred points in the segment.
         assert_eq!(segment.deferred_point_count(), 0);
         assert_eq!(
-            {
-                let id_tracker = segment.id_tracker.borrow();
-                calculate_deleted_deferred_count(
-                    &*id_tracker,
-                    id_tracker.deferred_internal_id().unwrap(),
-                )
-            },
+            segment.id_tracker.borrow().deferred_deleted_count(),
             n_deferred
         );
         assert_eq!(segment.available_point_count_without_deferred(), N_POINTS);

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -1082,7 +1082,6 @@ fn test_deferred_point_read_operations() {
         },
         |i| i.id,
         true,
-        false,
     );
 
     // Read filtered (count API)
@@ -1102,7 +1101,6 @@ fn test_deferred_point_read_operations() {
         },
         |i| *i,
         true,
-        false,
     );
 
     // Read filtered ordered (scroll)
@@ -1126,7 +1124,6 @@ fn test_deferred_point_read_operations() {
         },
         |i| i.1,
         true,
-        false,
     );
 
     // Read random filtered (random scroll)
@@ -1139,7 +1136,6 @@ fn test_deferred_point_read_operations() {
         },
         |i| *i,
         true,
-        false,
     );
 
     // Retrieve API
@@ -1165,7 +1161,6 @@ fn test_deferred_point_read_operations() {
                 .collect::<Vec<_>>()
         },
         |i| *i,
-        false,
         false,
     );
 }
@@ -1219,7 +1214,6 @@ fn test_deferred_point_sparse() {
                 },
                 |i| i.id,
                 true,
-                true,
             );
 
             // Search feedback
@@ -1244,7 +1238,6 @@ fn test_deferred_point_sparse() {
                         .unwrap()
                 },
                 |i| i.id,
-                true,
                 true,
             );
         }
@@ -1287,24 +1280,15 @@ fn test_deferred_point_facets() {
                     .facet(&request, &AtomicBool::new(false), &hw_counter)
                     .unwrap();
 
-                let old_deferred_id = segment.id_tracker.borrow().deferred_internal_id();
-                let old_deferred_deleted = segment.id_tracker.borrow().deferred_deleted_count();
                 if n_deferred > 0 {
-                    assert!(old_deferred_id.is_some());
+                    assert!(segment.id_tracker.borrow().deferred_internal_id().is_some());
                 }
-                segment
-                    .id_tracker
-                    .borrow_mut()
-                    .clear_deferred_point_status();
-                let facet_res = segment
+                let dir2 = Builder::new().prefix("segment_dir_2").tempdir().unwrap();
+                let segment_no_deferred =
+                    create_deferred_segment(&dir2, 5, N_POINTS + n_deferred, 0);
+                let facet_res = segment_no_deferred
                     .facet(&request, &AtomicBool::new(false), &hw_counter)
                     .unwrap();
-                if let Some(deferred_id) = old_deferred_id {
-                    segment
-                        .id_tracker
-                        .borrow_mut()
-                        .set_deferred_point_status(deferred_id, old_deferred_deleted);
-                }
 
                 let expected_deferred = if filter.is_some() {
                     n_deferred.div_ceil(3)
@@ -1353,7 +1337,6 @@ fn assert_deferred_points_excluded<F, R, T>(
     operation: F,
     to_external_id: R,
     test_with_filter: bool,
-    need_rebuilt_segment: bool,
 ) where
     F: Fn(&Segment, Option<&Filter>) -> Vec<T>,
     R: Fn(&T) -> ExtendedPointId,
@@ -1424,7 +1407,7 @@ fn assert_deferred_points_excluded<F, R, T>(
             log::debug!("  => deferred points = {n_deferred}; filter-set ID = {filter_set_id}",);
 
             let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-            let mut segment = create_deferred_segment(&dir, 5, N_POINTS, n_deferred);
+            let segment = create_deferred_segment(&dir, 5, N_POINTS, n_deferred);
 
             // Search with deferred mode
             let search_res_deferred = operation(&segment, filter_set.filter.as_ref());
@@ -1437,24 +1420,16 @@ fn assert_deferred_points_excluded<F, R, T>(
                 assert!(!segment.point_is_deferred(external_id));
             }
 
-            // Disable deferred points and search again.
-            if need_rebuilt_segment {
-                // Don't run this on windows because this test is already extremely slow (~100s).
-                // Recreating the segment here would double that time.
-                if cfg!(target_os = "windows") {
-                    drop(segment);
-                    dir.close().unwrap();
-                    continue;
-                }
-
-                let dir = Builder::new().prefix("segment_dir_2").tempdir().unwrap();
-                segment = create_deferred_segment(&dir, 5, N_POINTS + n_deferred, 0);
-            } else {
-                segment
-                    .id_tracker
-                    .borrow_mut()
-                    .clear_deferred_point_status();
+            // Create a segment with all points visible (none deferred) and search again.
+            // Don't run this on windows because this test is already extremely slow (~100s).
+            if cfg!(target_os = "windows") {
+                drop(segment);
+                dir.close().unwrap();
+                continue;
             }
+
+            let dir2 = Builder::new().prefix("segment_dir_2").tempdir().unwrap();
+            let segment = create_deferred_segment(&dir2, 5, N_POINTS + n_deferred, 0);
 
             let search_res_normal = operation(&segment, filter_set.filter.as_ref());
             assert_eq!(

--- a/lib/segment/src/segment/tests.rs
+++ b/lib/segment/src/segment/tests.rs
@@ -4,7 +4,7 @@ use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::tar_ext;
 use common::tar_unpack::tar_unpack_file;
-use common::types::DeferredBehavior;
+use common::types::{DeferredBehavior, PointOffsetType};
 use fs_err as fs;
 use fs_err::File;
 use ordered_float::OrderedFloat;
@@ -30,6 +30,7 @@ use crate::entry::entry_point::{
 };
 use crate::entry::{SnapshotEntry as _, StorageSegmentEntry as _};
 use crate::id_tracker::IdTracker;
+use crate::id_tracker::id_tracker_base::calculate_deleted_deferred_count;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::json_path::JsonPath;
 use crate::segment_constructor::simple_segment_constructor::{
@@ -901,7 +902,10 @@ fn create_deferred_segment(
     // Now we should have deferred points
     assert_eq!(segment.has_deferred_points(), n_deferred > 0);
     if n_deferred > 0 {
-        assert_eq!(segment.deferred_internal_id(), Some(n_vectors as u32));
+        assert_eq!(
+            segment.id_tracker.borrow().deferred_internal_id(),
+            Some(n_vectors as u32)
+        );
     }
 
     // Points 1 to n_vectors should NOT be deferred
@@ -998,7 +1002,7 @@ fn test_dense_deferred_points() {
         "Segment should still have deferred points after reopening"
     );
     assert_eq!(
-        segment.deferred_internal_id(),
+        segment.id_tracker.borrow().deferred_internal_id(),
         Some(13),
         "Deferred internal ID should still be `DEFERRED_POINTS_ID` after reopening"
     );
@@ -1045,7 +1049,7 @@ fn test_deferred_point_estimation_with_filter() {
 
         // For consistency we also test that the same cardinality is estimated if no deferred points exist.
         if n_deferred == 0 {
-            assert_eq!(segment.deferred_internal_id(), None);
+            assert_eq!(segment.id_tracker.borrow().deferred_internal_id(), None);
             let estimation = segment
                 .estimate_point_count(Some(&filter), &hw_counter)
                 .unwrap();
@@ -1270,7 +1274,7 @@ fn test_deferred_point_facets() {
                 );
 
                 let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-                let mut segment = create_deferred_segment(&dir, 5, N_POINTS, n_deferred);
+                let segment = create_deferred_segment(&dir, 5, N_POINTS, n_deferred);
 
                 let request = FacetParams {
                     key: key.clone(),
@@ -1283,14 +1287,24 @@ fn test_deferred_point_facets() {
                     .facet(&request, &AtomicBool::new(false), &hw_counter)
                     .unwrap();
 
-                let old_status = segment.deferred_point_status.take();
+                let old_deferred_id = segment.id_tracker.borrow().deferred_internal_id();
+                let old_deferred_deleted = segment.id_tracker.borrow().deferred_deleted_count();
                 if n_deferred > 0 {
-                    assert!(old_status.is_some());
+                    assert!(old_deferred_id.is_some());
                 }
+                segment
+                    .id_tracker
+                    .borrow_mut()
+                    .clear_deferred_point_status();
                 let facet_res = segment
                     .facet(&request, &AtomicBool::new(false), &hw_counter)
                     .unwrap();
-                segment.deferred_point_status = old_status;
+                if let Some(deferred_id) = old_deferred_id {
+                    segment
+                        .id_tracker
+                        .borrow_mut()
+                        .set_deferred_point_status(deferred_id, old_deferred_deleted);
+                }
 
                 let expected_deferred = if filter.is_some() {
                     n_deferred.div_ceil(3)
@@ -1436,7 +1450,10 @@ fn assert_deferred_points_excluded<F, R, T>(
                 let dir = Builder::new().prefix("segment_dir_2").tempdir().unwrap();
                 segment = create_deferred_segment(&dir, 5, N_POINTS + n_deferred, 0);
             } else {
-                segment.deferred_point_status = None;
+                segment
+                    .id_tracker
+                    .borrow_mut()
+                    .clear_deferred_point_status();
             }
 
             let search_res_normal = operation(&segment, filter_set.filter.as_ref());
@@ -1468,7 +1485,7 @@ fn test_deleted_deferred_point_count() {
         assert_eq!(segment.available_point_count_without_deferred(), N_POINTS);
 
         for d in 0..n_deferred {
-            let delete_id = segment.deferred_internal_id().unwrap() + d as u32;
+            let delete_id = segment.id_tracker.borrow().deferred_internal_id().unwrap() + d as u32;
             segment
                 .delete_point_internal(delete_id, &hw_counter)
                 .unwrap();
@@ -1479,7 +1496,13 @@ fn test_deleted_deferred_point_count() {
                 n_deferred.checked_sub(deleted_count).unwrap()
             );
             assert_eq!(
-                segment.calculate_deleted_deferred_point_count(),
+                {
+                    let id_tracker = segment.id_tracker.borrow();
+                    calculate_deleted_deferred_count(
+                        &*id_tracker,
+                        id_tracker.deferred_internal_id().unwrap(),
+                    )
+                },
                 deleted_count,
             );
 
@@ -1494,7 +1517,13 @@ fn test_deleted_deferred_point_count() {
             );
 
             assert_eq!(
-                segment.calculate_deleted_deferred_point_count(),
+                {
+                    let id_tracker = segment.id_tracker.borrow();
+                    calculate_deleted_deferred_count(
+                        &*id_tracker,
+                        id_tracker.deferred_internal_id().unwrap(),
+                    )
+                },
                 deleted_count
             );
 
@@ -1503,7 +1532,16 @@ fn test_deleted_deferred_point_count() {
 
         // We delete all deferred points in the segment.
         assert_eq!(segment.deferred_point_count(), 0);
-        assert_eq!(segment.calculate_deleted_deferred_point_count(), n_deferred);
+        assert_eq!(
+            {
+                let id_tracker = segment.id_tracker.borrow();
+                calculate_deleted_deferred_count(
+                    &*id_tracker,
+                    id_tracker.deferred_internal_id().unwrap(),
+                )
+            },
+            n_deferred
+        );
         assert_eq!(segment.available_point_count_without_deferred(), N_POINTS);
     }
 }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -88,7 +88,7 @@ impl SegmentBuilder {
         let temp_dir = create_temp_dir(temp_dir)?;
 
         let id_tracker = if segment_config.is_appendable() {
-            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path())?)
+            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(temp_dir.path(), None)?)
         } else {
             IdTrackerEnum::InMemoryIdTracker(InMemoryIdTracker::new())
         };

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -675,8 +675,6 @@ impl SegmentBuilder {
                     path: &vector_index_path,
                     stopped,
                     tick_progress: || (),
-                    // We don't use the `index` returned here so we always set deferred to `None`. It's been loaded properly later.
-                    deferred_internal_id: None,
                 })?;
 
                 if sparse_vector_config.storage_type.is_on_disk() {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 use super::rocksdb_builder::RocksDbBuilder;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
+use crate::id_tracker::id_tracker_base::calculate_deleted_deferred_count;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
 #[cfg(feature = "rocksdb")]
@@ -51,9 +52,7 @@ use crate::payload_storage::on_disk_payload_storage::OnDiskPayloadStorage;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 #[cfg(feature = "rocksdb")]
 use crate::payload_storage::simple_payload_storage::SimplePayloadStorage;
-use crate::segment::{
-    DeferredPointStatus, SEGMENT_STATE_FILE, Segment, SegmentVersion, VectorData,
-};
+use crate::segment::{SEGMENT_STATE_FILE, Segment, SegmentVersion, VectorData};
 #[cfg(feature = "rocksdb")]
 use crate::types::MultiVectorConfig;
 use crate::types::{
@@ -647,7 +646,6 @@ fn create_segment(
             path: &vector_index_path,
             stopped,
             tick_progress: || (),
-            deferred_internal_id,
         })?);
         log_load_timing(
             segment_path,
@@ -673,7 +671,7 @@ fn create_segment(
         SegmentType::Plain
     };
 
-    let mut segment = Segment {
+    let segment = Segment {
         uuid,
         initial_version,
         version,
@@ -691,14 +689,12 @@ fn create_segment(
         error_status: None,
         #[cfg(feature = "rocksdb")]
         database: db_builder.build(),
-        deferred_point_status: None,
     };
 
     if let Some(deferred_internal_id) = deferred_internal_id {
-        segment.deferred_point_status = Some(DeferredPointStatus {
-            deferred_internal_id,
-            deferred_deleted_count: segment.calculate_deleted_deferred_point_count(),
-        });
+        let mut id_tracker = segment.id_tracker.borrow_mut();
+        let deleted_count = calculate_deleted_deferred_count(&*id_tracker, deferred_internal_id);
+        id_tracker.set_deferred_point_status(deferred_internal_id, deleted_count);
     }
 
     Ok(segment)

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -280,8 +280,9 @@ pub(crate) fn create_mutable_id_tracker(
 #[cfg(feature = "rocksdb")]
 pub(crate) fn create_rocksdb_id_tracker(
     database: Arc<RwLock<DB>>,
+    deferred_internal_id: Option<PointOffsetType>,
 ) -> OperationResult<SimpleIdTracker> {
-    SimpleIdTracker::open(database)
+    SimpleIdTracker::open(database, deferred_internal_id)
 }
 
 pub(crate) fn create_immutable_id_tracker(
@@ -737,7 +738,8 @@ fn create_segment_id_tracker(
         };
 
         if use_rocksdb_mutable_tracker {
-            let id_tracker = create_rocksdb_id_tracker(db_builder.require()?)?;
+            let id_tracker =
+                create_rocksdb_id_tracker(db_builder.require()?, deferred_internal_id)?;
 
             // Actively migrate RocksDB based ID tracker into mutable ID tracker
             if common::flags::feature_flags().migrate_rocksdb_id_tracker {
@@ -1053,7 +1055,8 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
         segment_path: &Path,
     ) -> OperationResult<MutableIdTracker> {
         // Construct mutable ID tracker
-        let mut new_id_tracker = create_mutable_id_tracker(segment_path, None)?;
+        let mut new_id_tracker =
+            create_mutable_id_tracker(segment_path, old_id_tracker.deferred_internal_id())?;
         debug_assert_eq!(
             new_id_tracker.total_point_count(),
             0,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -31,7 +31,6 @@ use uuid::Uuid;
 use super::rocksdb_builder::RocksDbBuilder;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
-use crate::id_tracker::id_tracker_base::calculate_deleted_deferred_count;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
 #[cfg(feature = "rocksdb")]
@@ -271,8 +270,11 @@ pub(crate) fn create_payload_storage(
     Ok(payload_storage)
 }
 
-pub(crate) fn create_mutable_id_tracker(segment_path: &Path) -> OperationResult<MutableIdTracker> {
-    MutableIdTracker::open(segment_path)
+pub(crate) fn create_mutable_id_tracker(
+    segment_path: &Path,
+    deferred_internal_id: Option<PointOffsetType>,
+) -> OperationResult<MutableIdTracker> {
+    MutableIdTracker::open(segment_path, deferred_internal_id)
 }
 
 #[cfg(feature = "rocksdb")]
@@ -492,6 +494,7 @@ fn create_segment(
     let id_tracker = create_segment_id_tracker(
         use_mutable_id_tracker,
         segment_path,
+        deferred_internal_id,
         #[cfg(feature = "rocksdb")]
         &mut db_builder,
     )?;
@@ -671,7 +674,7 @@ fn create_segment(
         SegmentType::Plain
     };
 
-    let segment = Segment {
+    Ok(Segment {
         uuid,
         initial_version,
         version,
@@ -689,20 +692,13 @@ fn create_segment(
         error_status: None,
         #[cfg(feature = "rocksdb")]
         database: db_builder.build(),
-    };
-
-    if let Some(deferred_internal_id) = deferred_internal_id {
-        let mut id_tracker = segment.id_tracker.borrow_mut();
-        let deleted_count = calculate_deleted_deferred_count(&*id_tracker, deferred_internal_id);
-        id_tracker.set_deferred_point_status(deferred_internal_id, deleted_count);
-    }
-
-    Ok(segment)
+    })
 }
 
 fn create_segment_id_tracker(
     mutable_id_tracker: bool,
     segment_path: &Path,
+    deferred_internal_id: Option<PointOffsetType>,
     #[cfg(feature = "rocksdb")] db_builder: &mut RocksDbBuilder,
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
     if !mutable_id_tracker {
@@ -754,7 +750,7 @@ fn create_segment_id_tracker(
     }
 
     Ok(sp(IdTrackerEnum::MutableIdTracker(
-        create_mutable_id_tracker(segment_path)?,
+        create_mutable_id_tracker(segment_path, deferred_internal_id)?,
     )))
 }
 
@@ -1057,7 +1053,7 @@ pub fn migrate_rocksdb_id_tracker_to_mutable(
         segment_path: &Path,
     ) -> OperationResult<MutableIdTracker> {
         // Construct mutable ID tracker
-        let mut new_id_tracker = create_mutable_id_tracker(segment_path)?;
+        let mut new_id_tracker = create_mutable_id_tracker(segment_path, None)?;
         debug_assert_eq!(
             new_id_tracker.total_point_count(),
             0,

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -184,7 +184,6 @@ fn sparse_index_discover_test() {
         path: index_dir.path(),
         stopped: &stopped,
         tick_progress: || (),
-        deferred_internal_id: None,
     })
     .unwrap();
 
@@ -302,7 +301,6 @@ fn sparse_index_hardware_measurement_test() {
         path: index_dir.path(),
         stopped: &stopped,
         tick_progress: || (),
-        deferred_internal_id: None,
     })
     .unwrap();
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -227,7 +227,6 @@ fn sparse_vector_index_consistent_with_storage() {
             path: mmap_index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-            deferred_internal_id: None,
         })
         .unwrap();
 
@@ -254,7 +253,6 @@ fn sparse_vector_index_consistent_with_storage() {
             path: mmap_index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-            deferred_internal_id: None,
         })
         .unwrap();
 
@@ -691,7 +689,6 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
             path: inverted_index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-            deferred_internal_id: None,
         })
         .unwrap()
     };


### PR DESCRIPTION
This PR moves and ownership from `Segment` into `PointsMapping`. The problem with the previous approach is duplication, where we have to store deferred point id in `SparseVectorIndex`.

This PR does not change logic ownership - we still check whether point is deferred on segment level, this change is the next step of refactoring. Here, it's not included to reduce review complexity.