### PR TITLE
Fix openapi min timeout

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -32,7 +32,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -204,7 +205,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -876,7 +878,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -1127,7 +1130,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1222,7 +1226,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1307,7 +1312,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1394,7 +1400,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],
@@ -1879,7 +1886,8 @@
             "in": "query",
             "description": "Wait for operation commit timeout in seconds.\nIf timeout is reached - request will return with service error.\n",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           }
         ],

--- a/openapi/openapi-cluster.ytt.yaml
+++ b/openapi/openapi-cluster.ytt.yaml
@@ -64,6 +64,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
         - name: force
           in: query
           description: If true - removes peer even if it has shards/replicas on it.

--- a/openapi/openapi-collections.ytt.yaml
+++ b/openapi/openapi-collections.ytt.yaml
@@ -53,6 +53,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
 
     patch:
@@ -82,6 +83,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
 
     delete:
@@ -104,6 +106,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
 
   /collections/aliases:
@@ -126,6 +129,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
 
   /collections/{collection_name}/index:
@@ -268,6 +272,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
 
   /collections/{collection_name}/optimizations:

--- a/openapi/openapi-shards.ytt.yaml
+++ b/openapi/openapi-shards.ytt.yaml
@@ -27,6 +27,7 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))
     get:
       tags:
@@ -67,4 +68,5 @@ paths:
             If timeout is reached - request will return with service error.
           schema:
             type: integer
+            minimum: 1
       responses: #@ response(type("boolean"))


### PR DESCRIPTION
Add missing information regarding the min timeout value.

A value of `0` is not accepted.