### PR TITLE
bump version to v1.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.17.0"
+version = "1.17.1"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.17.0"
+version = "1.17.1"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.17.0";
+pub const QDRANT_VERSION_STRING: &str = "1.17.1";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=aa8740ff2304a9669a77aaff710dac304e0d3135
+IGNORE_UPTO=fb704e5d13854963fc1886220de88a9340bb9e30
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
```
# Changelog

## Improvements

* https://github.com/qdrant/qdrant/pull/8188 - Gridstore non-blocking flush
* https://github.com/qdrant/qdrant/pull/8235 - Improve performance of filtered search in case of singular payload value
* https://github.com/qdrant/qdrant/pull/8402 - Add request tracing ID into audit log
* https://github.com/qdrant/qdrant/pull/8460 - Propagate WAL errors instead of panicking during loading of shards
* https://github.com/qdrant/qdrant/pull/8301 - Allow peer to bootstrap with used URI if empty

## Bug fixes

* https://github.com/qdrant/qdrant/pull/8177 - GPU: fix raw Vulkan name pointer type
* https://github.com/qdrant/qdrant/pull/8193 - Fix creation of uninitialized shard key with replication factor > 1. This fixes tiered multitenancy workflow.
* https://github.com/qdrant/qdrant/pull/8217 - Prevent `min_should` panic on large amount of conditions
* https://github.com/qdrant/qdrant/pull/8179 - Fix for restore of cluster snapshots which creates unnecessary replicas in Partial state
* https://github.com/qdrant/qdrant/pull/8220 - Fix Server disconnected without sending a response error while performing concurrent ingestion using
* https://github.com/qdrant/qdrant/pull/8341 - Security patch to force snapshot recovery from snapshot directory only
* https://github.com/qdrant/qdrant/pull/8373 - Fix lock for collection-level operations during shard transfer
* https://github.com/qdrant/qdrant/pull/8438 - Do not fail on collection-level operations with dummy shard
* https://github.com/qdrant/qdrant/pull/8455 - Fix WAL reading issue introduced in 1.17.0
* https://github.com/qdrant/qdrant/pull/8454 - Fix another panic in WAL replay
* https://github.com/qdrant/qdrant/pull/8475 - Fix for wal-delta transfer: reject truncated recovery points before equal-pruning
* https://github.com/qdrant/qdrant/pull/8514 - Fix incorrect warning in geo-index


## Preview

This features are not officially released yet, but available in the build:

* https://github.com/qdrant/qdrant/pull/8214 - Per-collection metrics in prometheus
* https://github.com/qdrant/qdrant/pull/8498 - API for reading audit log entries
* https://github.com/qdrant/qdrant/pull/8469 - Max batchsize config in strict mode

## Edge

* Rust Crate for Qdrant Edge v0.6.0 - https://crates.io/crates/qdrant-edge
* Python Package for Qdrant Edge v0.6.0 - https://pypi.org/project/qdrant-edge-py/

```