### PR TITLE
Use size-based batching for queue proxy WAL transfer

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -42,7 +42,7 @@ use crate::shards::telemetry::LocalShardTelemetry;
 /// Maximum total serialized byte size of a single transfer batch.
 /// Each WAL operation can vary widely in size (a delete vs an upsert of many high-dimensional
 /// vectors), so we use a byte budget rather than a fixed operation count.
-const MAX_BATCH_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+const MAX_BATCH_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
 
 /// Maximum number of operations in a single transfer batch.
 /// Caps memory usage and WAL lock duration when operations are small.

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -42,7 +42,7 @@ use crate::shards::telemetry::LocalShardTelemetry;
 /// Maximum total serialized byte size of a single transfer batch.
 /// Each WAL operation can vary widely in size (a delete vs an upsert of many high-dimensional
 /// vectors), so we use a byte budget rather than a fixed operation count.
-const MAX_BATCH_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+const MAX_BATCH_BYTES: usize = 32 * 1024 * 1024; // 32 MiB
 
 /// Maximum number of operations in a single transfer batch.
 /// Caps memory usage and WAL lock duration when operations are small.

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -561,39 +561,56 @@ impl Inner {
         let mut update_lock = Some(self.update_lock.lock().await);
         let transfer_from = self.transfer_from.load(Ordering::Relaxed);
 
-        // Lock WAL, count pending items to transfer, grab batch up to byte budget
-        let (reached_end, total, batch) = {
+        // Lock WAL, count pending items to transfer, grab raw batch up to byte budget.
+        // We collect raw (not yet deserialized) bytes under the lock to minimize lock hold time,
+        // then deserialize outside the lock.
+        let (reached_end, total, raw_batch) = {
             let wal = self.wrapped_shard.wal.wal.lock().await;
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let items_total = (transfer_from - self.started_at) + items_left;
 
-            let mut batch = Vec::new();
+            let mut raw_batch = Vec::new();
             let mut batch_bytes = 0usize;
-            for result in wal.read_with_size(transfer_from) {
-                let (idx, size, record) = result.map_err(|e| {
+            for result in wal.read_raw_with_size(transfer_from) {
+                let (idx, size, raw) = result.map_err(|e| {
                     CollectionError::service_error(format!(
                         "Failed to read WAL during queue proxy transfer: {e}"
                     ))
                 })?;
 
                 // Always include at least one operation per batch
-                if !batch.is_empty()
-                    && (batch_bytes + size > MAX_BATCH_BYTES || batch.len() >= MAX_BATCH_OPS)
+                if !raw_batch.is_empty()
+                    && (batch_bytes + size > MAX_BATCH_BYTES || raw_batch.len() >= MAX_BATCH_OPS)
                 {
                     break;
                 }
 
                 batch_bytes += size;
-                batch.push((idx, record));
+                raw_batch.push((idx, raw));
             }
 
-            let reached_end = batch.len() as u64 >= items_left;
+            let reached_end = raw_batch.len() as u64 >= items_left;
             debug_assert!(
-                batch.len() as u64 <= items_left,
+                raw_batch.len() as u64 <= items_left,
                 "batch cannot be larger than items_left",
             );
-            (reached_end, items_total, batch)
+            (reached_end, items_total, raw_batch)
         };
+
+        // Deserialize outside the WAL lock
+        let batch: Vec<(u64, OperationWithClockTag)> = raw_batch
+            .into_iter()
+            .map(|(idx, raw)| {
+                let record =
+                    shard::wal::WalRawRecord::<OperationWithClockTag>::deserialize_from(&raw)
+                        .map_err(|e| {
+                            CollectionError::service_error(format!(
+                                "Failed to deserialize WAL record during queue proxy transfer: {e}"
+                            ))
+                        })?;
+                Ok((idx, record))
+            })
+            .collect::<CollectionResult<_>>()?;
 
         log::trace!(
             "Queue proxy transferring batch of {} updates to peer {}",

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -578,15 +578,13 @@ impl Inner {
                     ))
                 })?;
 
-                // Always include at least one operation per batch
-                if !raw_batch.is_empty()
-                    && (batch_bytes + size > MAX_BATCH_BYTES || raw_batch.len() >= MAX_BATCH_OPS)
-                {
-                    break;
-                }
-
                 batch_bytes += size;
                 raw_batch.push((idx, raw));
+
+                // Always include at least one operation per batch
+                if batch_bytes > MAX_BATCH_BYTES || raw_batch.len() >= MAX_BATCH_OPS {
+                    break;
+                }
             }
 
             let reached_end = raw_batch.len() as u64 >= items_left;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -39,8 +39,14 @@ use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::shards::telemetry::LocalShardTelemetry;
 
-/// Number of operations in batch when syncing
-const BATCH_SIZE: usize = 10;
+/// Maximum total serialized byte size of a single transfer batch.
+/// Each WAL operation can vary widely in size (a delete vs an upsert of many high-dimensional
+/// vectors), so we use a byte budget rather than a fixed operation count.
+const MAX_BATCH_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// Maximum number of operations in a single transfer batch.
+/// Caps memory usage and WAL lock duration when operations are small.
+const MAX_BATCH_OPS: usize = 10_000;
 
 /// Number of times to retry transferring updates batch
 const BATCH_RETRIES: usize = MAX_RETRY_COUNT;
@@ -555,25 +561,38 @@ impl Inner {
         let mut update_lock = Some(self.update_lock.lock().await);
         let transfer_from = self.transfer_from.load(Ordering::Relaxed);
 
-        // Lock wall, count pending items to transfer, grab batch
-        let (pending_count, total, batch) = {
+        // Lock WAL, count pending items to transfer, grab batch up to byte budget
+        let (reached_end, total, batch) = {
             let wal = self.wrapped_shard.wal.wal.lock().await;
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let items_total = (transfer_from - self.started_at) + items_left;
-            let batch = wal
-                .read(transfer_from)
-                .take(BATCH_SIZE)
-                .collect::<shard::wal::Result<Vec<_>>>()
-                .map_err(|e| {
+
+            let mut batch = Vec::new();
+            let mut batch_bytes = 0usize;
+            for result in wal.read_with_size(transfer_from) {
+                let (idx, size, record) = result.map_err(|e| {
                     CollectionError::service_error(format!(
                         "Failed to read WAL during queue proxy transfer: {e}"
                     ))
                 })?;
+
+                // Always include at least one operation per batch
+                if !batch.is_empty()
+                    && (batch_bytes + size > MAX_BATCH_BYTES || batch.len() >= MAX_BATCH_OPS)
+                {
+                    break;
+                }
+
+                batch_bytes += size;
+                batch.push((idx, record));
+            }
+
+            let reached_end = batch.len() as u64 >= items_left;
             debug_assert!(
-                batch.len() <= items_left as usize,
+                batch.len() as u64 <= items_left,
                 "batch cannot be larger than items_left",
             );
-            (items_left, items_total, batch)
+            (reached_end, items_total, batch)
         };
 
         log::trace!(
@@ -585,7 +604,7 @@ impl Inner {
         // Normally, we immediately release the update lock to allow new updates.
         // On the last batch we keep the lock to prevent accumulating more updates on the WAL,
         // so we can finalize the transfer after this batch, before accepting new updates.
-        let last_batch = pending_count <= BATCH_SIZE as u64 || batch.is_empty();
+        let last_batch = reached_end || batch.is_empty();
         if !last_batch {
             drop(update_lock.take());
         }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -564,12 +564,12 @@ impl Inner {
         // Lock WAL, count pending items to transfer, grab raw batch up to byte budget.
         // We collect raw (not yet deserialized) bytes under the lock to minimize lock hold time,
         // then deserialize outside the lock.
-        let (reached_end, total, raw_batch) = {
+        let (reached_end, total, batch) = {
             let wal = self.wrapped_shard.wal.wal.lock().await;
             let items_left = (wal.last_index() + 1).saturating_sub(transfer_from);
             let items_total = (transfer_from - self.started_at) + items_left;
 
-            let mut raw_batch = Vec::new();
+            let mut batch = Vec::new();
             let mut batch_bytes = 0usize;
             for result in wal.read_with_size(transfer_from) {
                 let (idx, size, op) = result.map_err(|e| {
@@ -579,27 +579,21 @@ impl Inner {
                 })?;
 
                 batch_bytes += size;
-                raw_batch.push((idx, op));
+                batch.push((idx, op));
 
                 // Always include at least one operation per batch
-                if batch_bytes > MAX_BATCH_BYTES || raw_batch.len() >= MAX_BATCH_OPS {
+                if batch_bytes > MAX_BATCH_BYTES || batch.len() >= MAX_BATCH_OPS {
                     break;
                 }
             }
 
-            let reached_end = raw_batch.len() as u64 >= items_left;
+            let reached_end = batch.len() as u64 >= items_left;
             debug_assert!(
-                raw_batch.len() as u64 <= items_left,
+                batch.len() as u64 <= items_left,
                 "batch cannot be larger than items_left",
             );
-            (reached_end, items_total, raw_batch)
+            (reached_end, items_total, batch)
         };
-
-        // Deserialize outside the WAL lock
-        let batch: Vec<(u64, OperationWithClockTag)> = raw_batch
-            .into_iter()
-            .map(|(idx, record)| Ok((idx, record)))
-            .collect::<CollectionResult<_>>()?;
 
         log::trace!(
             "Queue proxy transferring batch of {} updates to peer {}",

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -571,15 +571,15 @@ impl Inner {
 
             let mut raw_batch = Vec::new();
             let mut batch_bytes = 0usize;
-            for result in wal.read_raw_with_size(transfer_from) {
-                let (idx, size, raw) = result.map_err(|e| {
+            for result in wal.read_with_size(transfer_from) {
+                let (idx, size, op) = result.map_err(|e| {
                     CollectionError::service_error(format!(
                         "Failed to read WAL during queue proxy transfer: {e}"
                     ))
                 })?;
 
                 batch_bytes += size;
-                raw_batch.push((idx, raw));
+                raw_batch.push((idx, op));
 
                 // Always include at least one operation per batch
                 if batch_bytes > MAX_BATCH_BYTES || raw_batch.len() >= MAX_BATCH_OPS {
@@ -598,16 +598,7 @@ impl Inner {
         // Deserialize outside the WAL lock
         let batch: Vec<(u64, OperationWithClockTag)> = raw_batch
             .into_iter()
-            .map(|(idx, raw)| {
-                let record =
-                    shard::wal::WalRawRecord::<OperationWithClockTag>::deserialize_from(&raw)
-                        .map_err(|e| {
-                            CollectionError::service_error(format!(
-                                "Failed to deserialize WAL record during queue proxy transfer: {e}"
-                            ))
-                        })?;
-                Ok((idx, record))
-            })
+            .map(|(idx, record)| Ok((idx, record)))
             .collect::<CollectionResult<_>>()?;
 
         log::trace!(

--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -134,26 +134,45 @@ impl<R: DeserializeOwned + Serialize> SerdeWal<R> {
     }
 
     pub fn read(&self, from: u64) -> impl DoubleEndedIterator<Item = Result<(u64, R)>> + '_ {
+        self.read_with_size(from)
+            .map(|result| result.map(|(idx, _size, record)| (idx, record)))
+    }
+
+    /// Read records from the WAL starting at `from`, including the serialized byte size of each
+    /// entry. Returns an iterator of `(index, serialized_byte_size, record)` tuples.
+    pub fn read_with_size(
+        &self,
+        from: u64,
+    ) -> impl DoubleEndedIterator<Item = Result<(u64, usize, R)>> + '_ {
         // We have to explicitly do `from..self.first_index() + self.len(false)`, instead of more
         // concise `from..=self.last_index()`, because if the WAL is empty, `Wal::last_index`
         // returns `Wal::first_index`, so we end up with `1..=1` instead of an empty range. 😕
 
         let to = self.first_index() + self.len(false);
-        self.read_range(from..to)
+        self.read_range_with_size(from..to)
     }
 
     pub fn read_range(
         &self,
         range: Range<u64>,
     ) -> impl DoubleEndedIterator<Item = Result<(u64, R)>> + '_ {
+        self.read_range_with_size(range)
+            .map(|result| result.map(|(idx, _size, record)| (idx, record)))
+    }
+
+    pub fn read_range_with_size(
+        &self,
+        range: Range<u64>,
+    ) -> impl DoubleEndedIterator<Item = Result<(u64, usize, R)>> + '_ {
         range.map(move |idx| {
             let record_bin = self.wal.entry(idx).ok_or_else(|| {
                 WalError::ReadWalError(format!("Can't read entry {idx} from WAL"))
             })?;
 
+            let size = record_bin.len();
             let record: R = WalRawRecord::deserialize_from(&record_bin)?;
 
-            Ok((idx, record))
+            Ok((idx, size, record))
         })
     }
 
@@ -428,6 +447,133 @@ mod tests {
                 assert_eq!(x.a, 12);
                 assert_eq!(x.b, 13);
             }
+        }
+    }
+
+    #[test]
+    fn test_read_with_size() {
+        let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
+        let wal_options = WalOptions {
+            segment_capacity: 32 * 1024 * 1024,
+            segment_queue_len: 0,
+            retain_closed: NonZeroUsize::new(1).unwrap(),
+        };
+
+        let mut serde_wal: SerdeWal<TestRecord> = SerdeWal::new(dir.path(), wal_options).unwrap();
+
+        // Write records of different sizes
+        let small_record = TestRecord::Struct1(TestInternalStruct1 { data: 1 });
+        let large_record = TestRecord::Struct2(TestInternalStruct2 { a: 42, b: 99 });
+
+        serde_wal
+            .write(&WalRawRecord::new(&small_record).unwrap())
+            .unwrap();
+        serde_wal
+            .write(&WalRawRecord::new(&large_record).unwrap())
+            .unwrap();
+
+        // read_with_size returns correct indices, non-zero sizes, and matching records
+        let entries: Vec<_> = serde_wal
+            .read_with_size(0)
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(entries.len(), 2);
+
+        let (idx0, size0, record0) = &entries[0];
+        let (idx1, size1, record1) = &entries[1];
+
+        assert_eq!(*idx0, 0);
+        assert_eq!(*idx1, 1);
+        assert!(*size0 > 0);
+        assert!(*size1 > 0);
+        assert_eq!(record0, &small_record);
+        assert_eq!(record1, &large_record);
+
+        // Sizes should reflect the actual serialized CBOR byte size
+        let expected_size0 = serde_cbor::to_vec(&small_record).unwrap().len();
+        let expected_size1 = serde_cbor::to_vec(&large_record).unwrap().len();
+        assert_eq!(*size0, expected_size0);
+        assert_eq!(*size1, expected_size1);
+    }
+
+    #[test]
+    fn test_read_with_size_from_offset() {
+        let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
+        let wal_options = WalOptions {
+            segment_capacity: 32 * 1024 * 1024,
+            segment_queue_len: 0,
+            retain_closed: NonZeroUsize::new(1).unwrap(),
+        };
+
+        let mut serde_wal: SerdeWal<TestRecord> = SerdeWal::new(dir.path(), wal_options).unwrap();
+
+        for i in 0..5 {
+            let record = TestRecord::Struct1(TestInternalStruct1 { data: i });
+            serde_wal
+                .write(&WalRawRecord::new(&record).unwrap())
+                .unwrap();
+        }
+
+        // Reading from offset 3 should yield entries 3 and 4
+        let entries: Vec<_> = serde_wal
+            .read_with_size(3)
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, 3);
+        assert_eq!(entries[1].0, 4);
+    }
+
+    #[test]
+    fn test_read_with_size_empty_wal() {
+        let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
+        let wal_options = WalOptions {
+            segment_capacity: 32 * 1024 * 1024,
+            segment_queue_len: 0,
+            retain_closed: NonZeroUsize::new(1).unwrap(),
+        };
+
+        let serde_wal: SerdeWal<TestRecord> = SerdeWal::new(dir.path(), wal_options).unwrap();
+
+        let entries: Vec<_> = serde_wal
+            .read_with_size(0)
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_read_with_size_matches_read() {
+        let dir = Builder::new().prefix("wal_test").tempdir().unwrap();
+        let wal_options = WalOptions {
+            segment_capacity: 32 * 1024 * 1024,
+            segment_queue_len: 0,
+            retain_closed: NonZeroUsize::new(1).unwrap(),
+        };
+
+        let mut serde_wal: SerdeWal<TestRecord> = SerdeWal::new(dir.path(), wal_options).unwrap();
+
+        for i in 0..10 {
+            let record = TestRecord::Struct1(TestInternalStruct1 { data: i });
+            serde_wal
+                .write(&WalRawRecord::new(&record).unwrap())
+                .unwrap();
+        }
+
+        // read_with_size and read should return the same indices and records
+        let with_size: Vec<_> = serde_wal
+            .read_with_size(0)
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        let without_size: Vec<_> = serde_wal.read(0).collect::<Result<Vec<_>>>().unwrap();
+
+        assert_eq!(with_size.len(), without_size.len());
+        for ((idx_s, _size, record_s), (idx, record)) in with_size.iter().zip(without_size.iter()) {
+            assert_eq!(idx_s, idx);
+            assert_eq!(record_s, record);
         }
     }
 

--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -57,7 +57,7 @@ impl<R: DeserializeOwned + Serialize> WalRawRecord<R> {
         Self::deserialize_from(&self.record)
     }
 
-    fn deserialize_from(record: &[u8]) -> Result<R>
+    pub fn deserialize_from(record: &[u8]) -> Result<R>
     where
         R: DeserializeOwned,
     {
@@ -173,6 +173,25 @@ impl<R: DeserializeOwned + Serialize> SerdeWal<R> {
             let record: R = WalRawRecord::deserialize_from(&record_bin)?;
 
             Ok((idx, size, record))
+        })
+    }
+
+    /// Read raw (not deserialized) records from the WAL, including the serialized byte size.
+    /// Returns an iterator of `(index, serialized_byte_size, raw_bytes)` tuples.
+    ///
+    /// Useful when you want to defer deserialization (e.g. to release a lock first).
+    pub fn read_raw_with_size(
+        &self,
+        from: u64,
+    ) -> impl DoubleEndedIterator<Item = Result<(u64, usize, Vec<u8>)>> + '_ {
+        let to = self.first_index() + self.len(false);
+        (from..to).map(move |idx| {
+            let record_bin = self.wal.entry(idx).ok_or_else(|| {
+                WalError::ReadWalError(format!("Can't read entry {idx} from WAL"))
+            })?;
+
+            let size = record_bin.len();
+            Ok((idx, size, record_bin.to_vec()))
         })
     }
 

--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -57,7 +57,7 @@ impl<R: DeserializeOwned + Serialize> WalRawRecord<R> {
         Self::deserialize_from(&self.record)
     }
 
-    pub fn deserialize_from(record: &[u8]) -> Result<R>
+    fn deserialize_from(record: &[u8]) -> Result<R>
     where
         R: DeserializeOwned,
     {
@@ -173,25 +173,6 @@ impl<R: DeserializeOwned + Serialize> SerdeWal<R> {
             let record: R = WalRawRecord::deserialize_from(&record_bin)?;
 
             Ok((idx, size, record))
-        })
-    }
-
-    /// Read raw (not deserialized) records from the WAL, including the serialized byte size.
-    /// Returns an iterator of `(index, serialized_byte_size, raw_bytes)` tuples.
-    ///
-    /// Useful when you want to defer deserialization (e.g. to release a lock first).
-    pub fn read_raw_with_size(
-        &self,
-        from: u64,
-    ) -> impl DoubleEndedIterator<Item = Result<(u64, usize, Vec<u8>)>> + '_ {
-        let to = self.first_index() + self.len(false);
-        (from..to).map(move |idx| {
-            let record_bin = self.wal.entry(idx).ok_or_else(|| {
-                WalError::ReadWalError(format!("Can't read entry {idx} from WAL"))
-            })?;
-
-            let size = record_bin.len();
-            Ok((idx, size, record_bin.to_vec()))
         })
     }
 


### PR DESCRIPTION
  ## Summary

 - Replaced the fixed `BATCH_SIZE = 10` operation count limit in queue proxy WAL transfer with size-based batching using a 16 MiB byte budget (`MAX_BATCH_BYTES`) and a 10,000 operation cap (`MAX_BATCH_OPS`)
 - Added `read_with_size()` and `read_range_with_size()` methods to `SerdeWal` that return the serialized byte size of each WAL entry alongside the deserialized record
 - Added unit tests for the new WAL read methods

  ## Motivation

 The queue proxy shard flushes buffered WAL operations to the remote during snapshot-based shard transfers.
 The previous fixed batch size of 10 operations was set without considering that each WAL operation can vary wildly in size; a single upsert operation can itself contain a large batch of high-dimensional vectors, while a delete is tiny.

With a batch size of 10, each batch paid the full gRPC round-trip cost regardless of payload size. Under sustained write pressure, this could cause the transfer to fall behind and never complete, as new writes accumulated faster than they could be drained.

Size-based batching amortizes network overhead by filling each batch up to a byte budget, naturally adapting to the operation mix. The operation count cap bounds memory usage and WAL lock duration for workloads with many small operations.

  ## Test plan

  - [x] Existing unit tests for `SerdeWal::read()` and `read_range()` still pass (behavior preserved via wrapper)
  - [x] New unit tests for `read_with_size()`: correctness, offset reading, empty WAL, equivalence with `read()`
  - [ ] Run existing shard transfer integration tests (`test_shard_snapshot_transfer` and related)
  - [ ] Performance tests on cluster setup