### PR TITLE
Fix flaky test_shard_transfer_includes_deferred_points

### DIFF
--- a/tests/consensus_tests/test_shard_transfer_deferred.py
+++ b/tests/consensus_tests/test_shard_transfer_deferred.py
@@ -195,9 +195,10 @@ def test_shard_transfer_includes_deferred_points(tmp_path: pathlib.Path, transfe
     except requests.exceptions.ReadTimeout:
         pass  # Expected: server blocks forever, client times out
 
-    # Enable optimizers to resolve deferred points.
     # This must happen before the transfer because stream_records uses wait=true
     # internally on the last batch, which would hang with disabled optimizers.
+    # For snapshot, the update worker must also not be blocked on deferred points
+    # for the snapshot to proceed.
     update_collection_config(source_uri, {
         "optimizers_config": {"max_optimization_threads": "auto"},
     })
@@ -232,13 +233,22 @@ def test_shard_transfer_includes_deferred_points(tmp_path: pathlib.Path, transfe
     )
 
     # Verify deferred points were transferred: target should have hidden points.
-    # For snapshot, the target gets a raw segment copy — deferred state is preserved exactly.
+    # For snapshot, the target gets a raw segment copy preserving deferred state.
+    # The optimizer is enabled before the transfer (required to unblock the plunger
+    # and for stream_records' internal wait=true), so the exact visible count may
+    # differ from the pre-optimizer measurement due to the optimizer racing with
+    # the snapshot. The key invariant is that the target still has deferred points
+    # (not all points are visible yet).
     # For stream_records, points are re-inserted on the target and may not be deferred.
     target_visible = scroll_all(target_uri)
     target_visible_count = len(target_visible)
     if transfer_method == "snapshot":
-        assert target_visible_count == visible_count, (
-            f"Snapshot transfer should preserve deferred state: "
+        assert target_visible_count < total_points, (
+            f"Snapshot transfer should preserve deferred state (not all points visible): "
+            f"target visible={target_visible_count}, total={total_points}"
+        )
+        assert target_visible_count >= visible_count, (
+            f"Target should have at least as many visible points as source had before optimizer: "
             f"target visible={target_visible_count}, source visible={visible_count}"
         )
     else:


### PR DESCRIPTION
Failure example https://github.com/qdrant/qdrant/actions/runs/23643485394/job/68869740783#step:11:253

```
        if transfer_method == "snapshot":
>           assert target_visible_count == visible_count, (
                f"Snapshot transfer should preserve deferred state: "
                f"target visible={target_visible_count}, source visible={visible_count}"
            )
E           AssertionError: Snapshot transfer should preserve deferred state: target visible=256, source visible=200
E           assert 256 == 200

tests/consensus_tests/test_shard_transfer_deferred.py:240: AssertionError
```

The test enables optimizers before the snapshot transfer but the optimizer starts running on the source and races with the snapshot creation.

The snapshot captures segment state at a slightly different point in time than when visible_count was measured, resulting in a different visible count on the target (255 vs 200).

  Fix: Instead of asserting exact equality (target_visible == source_visible), the snapshot assertion now checks two meaningful invariants:
  1. Deferred state is preserved: target_visible < total_points - not all points are visible, proving deferred points were transferred
  2. No data loss: target_visible >= visible_count - the target has at least as many visible points as the source had before the optimizer started

  The test's later assertions still verify that after optimization, ALL points (including deferred) become visible on both peers with identical point sets.