### PR TITLE
fix: include boundary points in GeoBoundingBox check

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2878,12 +2878,12 @@ impl GeoBoundingBox {
     pub fn check_point(&self, point: &GeoPoint) -> bool {
         let longitude_check = if self.top_left.lon > self.bottom_right.lon {
             // Handle antimeridian crossing
-            point.lon > self.top_left.lon || point.lon < self.bottom_right.lon
+            point.lon >= self.top_left.lon || point.lon <= self.bottom_right.lon
         } else {
-            self.top_left.lon < point.lon && point.lon < self.bottom_right.lon
+            self.top_left.lon <= point.lon && point.lon <= self.bottom_right.lon
         };
 
-        let latitude_check = self.bottom_right.lat < point.lat && point.lat < self.top_left.lat;
+        let latitude_check = self.bottom_right.lat <= point.lat && point.lat <= self.top_left.lat;
 
         longitude_check && latitude_check
     }


### PR DESCRIPTION
Fixes qdrant/qdrant-client#1188

## Problem

GeoBoundingBox behaves inconsistently between the in-memory backend (Python) and the Rust server backend. Points exactly on the boundary of a GeoBoundingBox are:
- **Included** by the Python in-memory backend
- **Excluded** by the Rust server backend

## Root Cause

The Rust implementation of "GeoBoundingBox::check_point" uses strict inequalities (< and >), while the Python implementation uses inclusive inequalities (<= and >=).

### Python implementation (in-memory):
```python
longitude_condition = condition.top_left.lon <= lon <= condition.bottom_right.lon
latitude_condition = condition.top_left.lat >= lat >= condition.bottom_right.lat
```

### Old Rust implementation (server):
```rust
self.top_left.lon < point.lon && point.lon < self.bottom_right.lon
self.bottom_right.lat < point.lat && point.lat < self.top_left.lat
```

## Fix

Changed strict inequalities to inclusive inequalities in the Rust implementation to match the Python behavior:

```rust
self.top_left.lon <= point.lon && point.lon <= self.bottom_right.lon
self.bottom_right.lat <= point.lat && point.lat <= self.top_left.lat
```

This ensures consistent behavior between both backends - points exactly on the boundary are now included in the match.