### PR TITLE
POINT_TO_TOKENS_COUNT_FILE is not immutable

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -373,11 +373,7 @@ impl MmapInvertedIndex {
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        vec![
-            self.path.join(POSTINGS_FILE),
-            self.path.join(VOCAB_FILE),
-            self.path.join(POINT_TO_TOKENS_COUNT_FILE),
-        ]
+        vec![self.path.join(POSTINGS_FILE), self.path.join(VOCAB_FILE)]
     }
 
     pub fn flusher(&self) -> Flusher {


### PR DESCRIPTION
Remove this file from `MapInvertedIndex::immutable_files`, as it is modified.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
