### PR TITLE
Fix edge sparse vector search panic on score postprocessing

### DIFF
--- a/lib/edge/python/examples/sparse-search.py
+++ b/lib/edge/python/examples/sparse-search.py
@@ -1,0 +1,39 @@
+import os, shutil
+from pathlib import Path
+
+from qdrant_edge import (
+    EdgeShard, EdgeConfig, EdgeVectorParams, EdgeSparseVectorParams,
+    Distance, Modifier, Query, QueryRequest,
+    Point, SparseVector, UpdateOperation,
+)
+
+
+DATA_DIR = Path(__file__).parent.parent.parent / "data"
+TMP_DIR = DATA_DIR / "tmp"
+
+path = TMP_DIR / "qdrant_edge_sparse_bug"
+shutil.rmtree(path, ignore_errors=True)
+os.makedirs(path)
+
+config = EdgeConfig(
+    vectors=EdgeVectorParams(size=4, distance=Distance.Cosine),
+    sparse_vectors={"sparse": EdgeSparseVectorParams(modifier=Modifier.Idf)},
+)
+shard = EdgeShard.create(path, config)
+
+shard.update(UpdateOperation.upsert_points([
+    Point(1, {"": [0.5, 0.5, 0.3, 0.1], "sparse": SparseVector(indices=[1, 2], values=[1.0, 0.5])}, {"text": "doc 1"}),
+    Point(2, {"": [0.1, 0.9, 0.3, 0.1], "sparse": SparseVector(indices=[2, 3], values=[1.0, 0.5])}, {"text": "doc 2"}),
+    Point(3, {"": [0.9, 0.1, 0.3, 0.1], "sparse": SparseVector(indices=[1, 3], values=[1.0, 0.5])}, {"text": "doc 3"}),
+]))
+shard.optimize()
+print(f"Info: {shard.info()}")  # Shows indexed_vectors_count=3
+
+# Dense search - works fine
+r = shard.query(QueryRequest(limit=3, query=Query.Nearest([0.5, 0.5, 0.3, 0.1]), with_payload=True))
+print(f"Dense: {len(r)} results")  # OK: 3 results
+
+# Sparse search - panics
+sv = SparseVector(indices=[1, 2], values=[1.0, 0.5])
+r = shard.query(QueryRequest(limit=3, query=Query.Nearest(sv, using="sparse"), with_payload=True))
+print(f"Sparse: {len(r)} results")

--- a/lib/edge/python/examples/sparse-search.py
+++ b/lib/edge/python/examples/sparse-search.py
@@ -29,11 +29,13 @@ shard.update(UpdateOperation.upsert_points([
 shard.optimize()
 print(f"Info: {shard.info()}")  # Shows indexed_vectors_count=3
 
-# Dense search - works fine
+# Dense search
 r = shard.query(QueryRequest(limit=3, query=Query.Nearest([0.5, 0.5, 0.3, 0.1]), with_payload=True))
-print(f"Dense: {len(r)} results")  # OK: 3 results
+print(f"Dense: {len(r)} results")
+assert len(r) == 3, f"Dense query should return 3 results, got {len(r)}"
 
-# Sparse search - panics
+# Sparse search
 sv = SparseVector(indices=[1, 2], values=[1.0, 0.5])
 r = shard.query(QueryRequest(limit=3, query=Query.Nearest(sv, using="sparse"), with_payload=True))
 print(f"Sparse: {len(r)} results")
+assert len(r) == 3, f"Sparse query should return 3 results, got {len(r)}"

--- a/lib/edge/src/search.rs
+++ b/lib/edge/src/search.rs
@@ -99,7 +99,6 @@ impl EdgeShard {
             .try_into()
             .expect("single batched search result");
 
-
         let distance = {
             let config = self.config.read();
             if let Some(dense) = config.vectors.get(&vector_name) {

--- a/lib/edge/src/search.rs
+++ b/lib/edge/src/search.rs
@@ -106,7 +106,11 @@ impl EdgeShard {
             } else if config.sparse_vectors.contains_key(&vector_name) {
                 segment::types::Distance::Dot
             } else {
-                panic!("vector config for '{vector_name}' does not exist")
+                return Err(
+                    segment::common::operation_error::OperationError::service_error(format!(
+                        "vector config for '{vector_name}' does not exist"
+                    )),
+                );
             }
         };
 

--- a/lib/edge/src/search.rs
+++ b/lib/edge/src/search.rs
@@ -99,13 +99,17 @@ impl EdgeShard {
             .try_into()
             .expect("single batched search result");
 
-        let distance = self
-            .config
-            .read()
-            .vectors
-            .get(&vector_name)
-            .expect("vector config exist")
-            .distance;
+
+        let distance = {
+            let config = self.config.read();
+            if let Some(dense) = config.vectors.get(&vector_name) {
+                dense.distance
+            } else if config.sparse_vectors.contains_key(&vector_name) {
+                segment::types::Distance::Dot
+            } else {
+                panic!("vector config for '{vector_name}' does not exist")
+            }
+        };
 
         match &query_vector {
             QueryVector::Nearest(_) => {


### PR DESCRIPTION
Fix for https://github.com/qdrant/qdrant/issues/8540


## Summary
- Fixed panic in `lib/edge/src/search.rs` when querying sparse vectors — the distance lookup for score postprocessing only checked dense vector configs (`config.vectors`), causing a panic for sparse vector names
- Fall back to `Distance::Dot` for sparse vectors found in `config.sparse_vectors`, matching the full server behavior in `collection/src/config.rs`
- Added `sparse-search.py` example demonstrating sparse vector search

## Test plan
- [x] Ran `sparse-search.py` example end-to-end: dense and sparse queries both return 3 results without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)