### PR TITLE
Skip audit logging for telemetry endpoints

### DIFF
--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -210,7 +210,7 @@ async fn get_cluster_telemetry(
     let pass = new_unchecked_verification_pass();
     helpers::time(async move {
         let toc = dispatcher.toc(&auth, &pass);
-        let access = auth.access("cluster_telemetry");
+        let access = auth.unlogged_access();
 
         let channel_service = toc.get_channel_service();
 

--- a/src/common/telemetry_ops/cluster_telemetry.rs
+++ b/src/common/telemetry_ops/cluster_telemetry.rs
@@ -93,7 +93,8 @@ impl ClusterTelemetry {
     ) -> Option<ClusterTelemetry> {
         let global_access = AccessRequirements::new();
         if auth
-            .check_global_access(global_access, "telemetry_cluster")
+            .unlogged_access()
+            .check_global_access(global_access)
             .is_err()
         {
             return None;

--- a/src/common/telemetry_ops/memory_telemetry.rs
+++ b/src/common/telemetry_ops/memory_telemetry.rs
@@ -37,7 +37,8 @@ impl MemoryTelemetry {
         let required_access = AccessRequirements::new();
         if epoch::advance().is_ok()
             && auth
-                .check_global_access(required_access, "telemetry_memory")
+                .unlogged_access()
+                .check_global_access(required_access)
                 .is_ok()
         {
             Some(MemoryTelemetry {

--- a/src/common/telemetry_ops/requests_telemetry.rs
+++ b/src/common/telemetry_ops/requests_telemetry.rs
@@ -291,7 +291,8 @@ impl RequestsTelemetry {
     ) -> Option<Self> {
         let global_access = AccessRequirements::new();
         if auth
-            .check_global_access(global_access, "telemetry_requests")
+            .unlogged_access()
+            .check_global_access(global_access)
             .is_ok()
         {
             let rest = actix_collector.get_telemetry_data(detail);

--- a/tests/consensus_tests/auth_tests/test_audit_telemetry.py
+++ b/tests/consensus_tests/auth_tests/test_audit_telemetry.py
@@ -1,0 +1,140 @@
+import json
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from consensus_tests import fixtures
+from consensus_tests.utils import kill_all_processes, wait_for
+
+from .utils import (
+    API_KEY_HEADERS,
+    READ_ONLY_API_KEY,
+    REST_URI,
+    SECRET,
+    encode_jwt,
+    start_jwt_protected_cluster,
+)
+
+COLL_NAME = "jwt_audit_telemetry_collection"
+TOKEN_COLL_R = encode_jwt(
+    {"access": [{"collection": COLL_NAME, "access": "r"}]}, SECRET
+)
+
+
+def read_audit_methods(peer_dir: Path) -> list[str]:
+    methods = []
+    for log_file in sorted((peer_dir / "storage" / "audit").glob("audit.*.log")):
+        for line in log_file.read_text().splitlines():
+            if not line.strip():
+                continue
+            methods.append(json.loads(line)["method"])
+    return methods
+
+
+def wait_for_audit_count(peer_dir: Path, expected_count: int):
+    wait_for(
+        lambda: len(read_audit_methods(peer_dir)) == expected_count,
+        wait_for_timeout=10,
+        wait_for_interval=0.1,
+    )
+
+
+@pytest.fixture(scope="module")
+def jwt_audit_cluster(tmp_path_factory: pytest.TempPathFactory):
+    tmp_path = tmp_path_factory.mktemp("jwt_audit_cluster")
+    peer_api_uris, peer_dirs, bootstrap_uri = start_jwt_protected_cluster(
+        tmp_path,
+        extra_env={"QDRANT__AUDIT__ENABLED": "true"},
+    )
+
+    try:
+        fixtures.create_collection(
+            REST_URI,
+            collection=COLL_NAME,
+            sharding_method="custom",
+            headers=API_KEY_HEADERS,
+        )
+        yield peer_api_uris, peer_dirs, bootstrap_uri
+    finally:
+        try:
+            fixtures.drop_collection(REST_URI, COLL_NAME, headers=API_KEY_HEADERS)
+        finally:
+            kill_all_processes()
+
+
+def test_telemetry_scrapes_are_not_added_to_audit_log(jwt_audit_cluster):
+    peer_api_uris, peer_dirs, _ = jwt_audit_cluster
+    peer_url = peer_api_uris[0]
+    peer_dir = Path(peer_dirs[0])
+
+    methods_before = read_audit_methods(peer_dir)
+
+    logger_response = requests.get(
+        f"{peer_url}/logger",
+        headers={"api-key": READ_ONLY_API_KEY},
+    )
+    assert logger_response.status_code == 200
+
+    wait_for_audit_count(peer_dir, len(methods_before) + 1)
+    methods_after_control = read_audit_methods(peer_dir)
+    assert methods_after_control[-1] == "get_logger_config"
+
+    telemetry_response = requests.get(
+        f"{peer_url}/telemetry?details_level=1",
+        headers={"api-key": READ_ONLY_API_KEY},
+    )
+    assert telemetry_response.status_code == 200
+
+    metrics_response = requests.get(
+        f"{peer_url}/metrics",
+        headers={"api-key": READ_ONLY_API_KEY},
+    )
+    assert metrics_response.status_code == 200
+
+    cluster_telemetry_response = requests.get(
+        f"{peer_url}/cluster/telemetry?details_level=2",
+        headers={"api-key": READ_ONLY_API_KEY},
+    )
+    assert cluster_telemetry_response.status_code == 200
+
+    time.sleep(1)
+    assert read_audit_methods(peer_dir) == methods_after_control
+
+
+def test_telemetry_access_checks_still_apply_without_audit_log(jwt_audit_cluster):
+    peer_api_uris, peer_dirs, _ = jwt_audit_cluster
+    peer_url = peer_api_uris[0]
+    peer_dir = Path(peer_dirs[0])
+    methods_before = read_audit_methods(peer_dir)
+    headers = {"authorization": f"Bearer {TOKEN_COLL_R}"}
+
+    telemetry_response = requests.get(
+        f"{peer_url}/telemetry?details_level=1",
+        headers=headers,
+    )
+    assert telemetry_response.status_code == 200
+    telemetry_result = telemetry_response.json()["result"]
+    assert "requests" not in telemetry_result
+    assert "memory" not in telemetry_result
+    assert "cluster" not in telemetry_result
+
+    metrics_response = requests.get(
+        f"{peer_url}/metrics",
+        headers=headers,
+    )
+    assert metrics_response.status_code == 403
+    assert (
+        metrics_response.json()["status"]["error"]
+        == "Forbidden: Global access is required"
+    )
+
+    cluster_telemetry_response = requests.get(
+        f"{peer_url}/cluster/telemetry?details_level=2",
+        headers=headers,
+    )
+    assert cluster_telemetry_response.status_code == 200
+
+    time.sleep(1)
+    assert read_audit_methods(peer_dir) == methods_before

--- a/tests/consensus_tests/auth_tests/utils.py
+++ b/tests/consensus_tests/auth_tests/utils.py
@@ -18,13 +18,17 @@ API_KEY_METADATA = [("api-key", SECRET)]
 READ_ONLY_API_KEY_METADATA = [("api-key", READ_ONLY_API_KEY)]
 
 
-def start_jwt_protected_cluster(tmp_path, num_peers=1):
-    extra_env = {
+def start_jwt_protected_cluster(tmp_path, num_peers=1, extra_env=None):
+    base_env = {
         "QDRANT__SERVICE__API_KEY": SECRET,
         "QDRANT__SERVICE__ALT_API_KEY": ALT_SECRET,
         "QDRANT__SERVICE__READ_ONLY_API_KEY": READ_ONLY_API_KEY,
         "QDRANT__SERVICE__JWT_RBAC": "true",
         "QDRANT__STORAGE__WAL__WAL_CAPACITY_MB": "1",  # to speed up snapshot tests
+    }
+    extra_env = {
+        **base_env,
+        **(extra_env or {}),
     }
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(


### PR DESCRIPTION
## Summary
- Telemetry access checks (`telemetry_memory`, `telemetry_requests`, `telemetry_cluster`, `cluster_telemetry`) fire on every metrics scrape and produce very noisy audit logs with no security-relevant signal.
- Switch all telemetry callers to use `auth.unlogged_access()` to bypass audit logging, consistent with the existing `metrics` and `prepare_data` handlers that already did this.

## Test plan
- [ ] Verify audit logs no longer contain telemetry entries after scraping `/metrics` and `/telemetry`
- [ ] Verify telemetry endpoints still enforce RBAC (access checks still run, just not logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)