### PR TITLE
Propagate HardwareCounterCell through MmapMapIndex::get_values

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -181,6 +181,7 @@ impl FacetIndex for BoolIndex {
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
+        _hw_counter: &HardwareCounterCell,
     ) -> impl Iterator<Item = FacetValueRef<'_>> + '_ {
         self.get_point_values(point_id)
             .into_iter()

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -11,6 +11,7 @@ pub trait FacetIndex {
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
     ) -> impl Iterator<Item = FacetValueRef<'_>> + '_;
 
     /// Get all values in the index
@@ -40,14 +41,21 @@ impl<'a> FacetIndexEnum<'a> {
     pub fn get_point_values(
         &self,
         point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
     ) -> Box<dyn Iterator<Item = FacetValueRef<'a>> + 'a> {
         match self {
             FacetIndexEnum::Keyword(index) => {
-                Box::new(FacetIndex::get_point_values(*index, point_id))
+                Box::new(FacetIndex::get_point_values(*index, point_id, hw_counter))
             }
-            FacetIndexEnum::Int(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
-            FacetIndexEnum::Uuid(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
-            FacetIndexEnum::Bool(index) => Box::new(FacetIndex::get_point_values(*index, point_id)),
+            FacetIndexEnum::Int(index) => {
+                Box::new(FacetIndex::get_point_values(*index, point_id, hw_counter))
+            }
+            FacetIndexEnum::Uuid(index) => {
+                Box::new(FacetIndex::get_point_values(*index, point_id, hw_counter))
+            }
+            FacetIndexEnum::Bool(index) => {
+                Box::new(FacetIndex::get_point_values(*index, point_id, hw_counter))
+            }
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -215,7 +215,13 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     pub fn get_values(
         &self,
         idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = Cow<'_, N>> + '_>> {
+        let hw_counter = self.make_conditioned_counter(hw_counter);
+
+        // We can account cost of reading `bool`, but it will likely be more expensive, than
+        // actually reading bool itself.
+
         self.storage
             .deleted
             .get(idx as usize)
@@ -223,8 +229,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             .and_then(|_| {
                 self.storage
                     .point_to_values
-                    // TODO: Propagate counter upwards
-                    .values_iter(idx, ConditionedCounter::never())
+                    .values_iter(idx, hw_counter)
                     .ok()?
                     .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = Cow<'_, N>>>)
             })

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -157,11 +157,12 @@ where
     pub fn get_values(
         &self,
         idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
     ) -> Option<Box<dyn Iterator<Item = Cow<'_, N>> + '_>> {
         match self {
             MapIndex::Mutable(index) => Some(Box::new(index.get_values(idx)?)),
             MapIndex::Immutable(index) => Some(Box::new(index.get_values(idx)?)),
-            MapIndex::Mmap(index) => Some(Box::new(index.get_values(idx)?)),
+            MapIndex::Mmap(index) => Some(Box::new(index.get_values(idx, hw_counter)?)),
         }
     }
 
@@ -1203,8 +1204,9 @@ where
     fn get_point_values(
         &self,
         point_id: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
     ) -> impl Iterator<Item = FacetValueRef<'_>> + '_ {
-        MapIndex::get_values(self, point_id)
+        MapIndex::get_values(self, point_id, hw_counter)
             .into_iter()
             .flatten()
             .map(|v| v.into())
@@ -1398,9 +1400,10 @@ mod tests {
             IndexType::Mmap => MapIndex::<N>::new_mmap(path, true).unwrap().unwrap(),
             IndexType::RamMmap => MapIndex::<N>::new_mmap(path, false).unwrap().unwrap(),
         };
+        let hw_counter = HardwareCounterCell::new();
         for (idx, values) in data.iter().enumerate() {
             let index_values: HashSet<<N as MapIndexKey>::Owned> = index
-                .get_values(idx as PointOffsetType)
+                .get_values(idx as PointOffsetType, &hw_counter)
                 .unwrap()
                 .map(|v| MapIndexKey::to_owned(v.as_ref()))
                 .collect();
@@ -1456,9 +1459,10 @@ mod tests {
         }
 
         let index = builder.finalize().unwrap();
+        let hw_counter = HardwareCounterCell::new();
         for (idx, values) in data.iter().enumerate().rev() {
             let res: Vec<_> = index
-                .get_values(idx as u32)
+                .get_values(idx as u32, &hw_counter)
                 .unwrap()
                 .map(|i| *i as i32)
                 .collect();

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -1560,4 +1560,50 @@ mod tests {
                 .equals_min_exp_max(&CardinalityEstimation::exact(0))
         );
     }
+
+    /// Test that `get_values` on an on-disk mmap index actually increments the hardware counter.
+    #[test]
+    fn test_mmap_get_values_hw_counter() {
+        let data = vec![vec![1i64, 2, 3], vec![4, 5], vec![6]];
+
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+        save_map_index::<IntPayloadType>(&data, temp_dir.path(), IndexType::Mmap, |v| (*v).into());
+        let index = load_map_index::<IntPayloadType>(&data, temp_dir.path(), IndexType::Mmap);
+
+        // Read values with a fresh counter
+        let hw_counter = HardwareCounterCell::new();
+        for idx in 0..data.len() {
+            let _values: Vec<_> = index
+                .get_values(idx as PointOffsetType, &hw_counter)
+                .unwrap()
+                .collect();
+        }
+
+        // On-disk mmap variant should have tracked IO reads
+        assert!(
+            hw_counter.payload_index_io_read_counter().get() > 0,
+            "Expected on-disk mmap get_values to track payload index IO reads, but counter was 0"
+        );
+
+        // Contrast with RamMmap (is_on_disk=false) — counter should remain zero
+        let temp_dir2 = Builder::new().prefix("store_dir").tempdir().unwrap();
+        save_map_index::<IntPayloadType>(&data, temp_dir2.path(), IndexType::RamMmap, |v| {
+            (*v).into()
+        });
+        let index2 = load_map_index::<IntPayloadType>(&data, temp_dir2.path(), IndexType::RamMmap);
+
+        let hw_counter2 = HardwareCounterCell::new();
+        for idx in 0..data.len() {
+            let _values: Vec<_> = index2
+                .get_values(idx as PointOffsetType, &hw_counter2)
+                .unwrap()
+                .collect();
+        }
+
+        assert_eq!(
+            hw_counter2.payload_index_io_read_counter().get(),
+            0,
+            "Expected RAM mmap get_values NOT to track IO reads, but counter was non-zero"
+        );
+    }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -56,7 +56,11 @@ where
 {
     indices
         .get(json_path)
-        .and_then(|indices| indices.iter().find_map(indexed_variable_retriever))
+        .and_then(|indices| {
+            indices
+                .iter()
+                .find_map(|index| indexed_variable_retriever(index, hw_counter))
+        })
         // TODO(scoreboost): optimize by reusing the same payload for all variables?
         .unwrap_or_else(|| {
             // if the variable is not found in the index, try to find it in the payload
@@ -103,7 +107,13 @@ fn payload_variable_retriever(
 /// Returns function to extract all the values a point has in the index
 ///
 /// If there is no appropriate index, returns None
-fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn<'_>> {
+fn indexed_variable_retriever<'a, 'q>(
+    index: &'a FieldIndex,
+    hw_counter: &'q HardwareCounterCell,
+) -> Option<VariableRetrieverFn<'q>>
+where
+    'a: 'q,
+{
     match index {
         FieldIndex::IntIndex(numeric_index) => {
             let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
@@ -119,7 +129,7 @@ fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn<
         FieldIndex::IntMapIndex(map_index) => {
             let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
                 map_index
-                    .get_values(point_id)
+                    .get_values(point_id, hw_counter)
                     .into_iter()
                     .flatten()
                     .map(|v| Value::Number(Number::from(*v)))
@@ -154,7 +164,7 @@ fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn<
         FieldIndex::KeywordIndex(keyword_index) => {
             let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
                 keyword_index
-                    .get_values(point_id)
+                    .get_values(point_id, hw_counter)
                     .into_iter()
                     .flatten()
                     .filter_map(|v| serde_json::to_value(v).ok())
@@ -187,7 +197,7 @@ fn indexed_variable_retriever(index: &FieldIndex) -> Option<VariableRetrieverFn<
         FieldIndex::UuidMapIndex(uuid_index) => {
             let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
                 uuid_index
-                    .get_values(point_id)
+                    .get_values(point_id, hw_counter)
                     .into_iter()
                     .flatten()
                     .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -65,7 +65,7 @@ impl Segment {
                     .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                     .fold(HashMap::new(), |mut map, point_id| {
                         facet_index
-                            .get_point_values(point_id)
+                            .get_point_values(point_id, hw_counter)
                             .unique()
                             .for_each(|value| {
                                 *map.entry(value).or_insert(0) += 1;
@@ -161,7 +161,7 @@ impl Segment {
                 )?
                 .filter(|point_id| !id_tracker.is_deleted_point(*point_id))
                 .fold(BTreeSet::new(), |mut set, point_id| {
-                    set.extend(facet_index.get_point_values(point_id));
+                    set.extend(facet_index.get_point_values(point_id, hw_counter));
                     set
                 })
                 .into_iter()

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -170,12 +170,16 @@ impl SegmentBuilder {
     ///
     /// Note: This value doesn't guarantee strict ordering in ambiguous cases.
     ///       It should only be used in optimization purposes, not for correctness.
-    fn _get_ordering_value(internal_id: PointOffsetType, indices: &[FieldIndex]) -> u64 {
+    fn _get_ordering_value(
+        internal_id: PointOffsetType,
+        indices: &[FieldIndex],
+        hw_counter: &HardwareCounterCell,
+    ) -> u64 {
         let mut ordering = 0;
         for payload_index in indices {
             match payload_index {
                 FieldIndex::IntMapIndex(index) => {
-                    if let Some(numbers) = index.get_values(internal_id) {
+                    if let Some(numbers) = index.get_values(internal_id, hw_counter) {
                         for number in numbers {
                             ordering = ordering.wrapping_add(*number as u64);
                         }
@@ -183,7 +187,7 @@ impl SegmentBuilder {
                     break;
                 }
                 FieldIndex::KeywordIndex(index) => {
-                    if let Some(keywords) = index.get_values(internal_id) {
+                    if let Some(keywords) = index.get_values(internal_id, hw_counter) {
                         for keyword in keywords {
                             let mut hasher = AHasher::default();
                             keyword.hash(&mut hasher);
@@ -227,7 +231,7 @@ impl SegmentBuilder {
                     break;
                 }
                 FieldIndex::UuidMapIndex(index) => {
-                    if let Some(ids) = index.get_values(internal_id) {
+                    if let Some(ids) = index.get_values(internal_id, hw_counter) {
                         uuid_hash(&mut ordering, ids.map(Cow::into_owned));
                     }
                     break;
@@ -256,7 +260,12 @@ impl SegmentBuilder {
     ///
     /// * `bool` - if `true` - data successfully added, if `false` - process was interrupted
     ///
-    pub fn update(&mut self, segments: &[&Segment], stopped: &AtomicBool) -> OperationResult<bool> {
+    pub fn update(
+        &mut self,
+        segments: &[&Segment],
+        stopped: &AtomicBool,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
         if segments.is_empty() {
             return Ok(true);
         }
@@ -296,6 +305,7 @@ impl SegmentBuilder {
                 point_data.ordering = point_data.ordering.wrapping_add(Self::_get_ordering_value(
                     point_data.internal_id,
                     payload_indices,
+                    hw_counter,
                 ));
             }
         }

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -94,9 +94,11 @@ fn test_rebuild_with_removed_vectors() {
     )
     .unwrap();
 
-    builder.update(&[&segment1, &segment2], &stopped).unwrap();
-
     let hw_counter = HardwareCounterCell::new();
+
+    builder
+        .update(&[&segment1, &segment2], &stopped, &hw_counter)
+        .unwrap();
 
     let merged_segment = builder.build_for_test(dir.path());
 

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -442,7 +442,8 @@ fn test_build_hnsw_using_quantization() {
     let mut builder =
         SegmentBuilder::new(temp_dir.path(), &config, &HnswGlobalConfig::default()).unwrap();
 
-    builder.update(&[&segment1], &stopped).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    builder.update(&[&segment1], &stopped, &hw_counter).unwrap();
 
     let built_segment = builder.build_for_test(dir.path());
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -290,8 +290,10 @@ impl TestSegments {
         )
         .unwrap();
 
-        builder.update(&[plain_segment], &stopped).unwrap();
         let hw_counter = HardwareCounterCell::new();
+        builder
+            .update(&[plain_segment], &stopped, &hw_counter)
+            .unwrap();
 
         let mut segment = builder.build_for_test(path);
         let opnum = segment.version() + 1;

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -63,7 +63,7 @@ fn test_building_new_segment() {
         .unwrap();
 
     builder
-        .update(&[&segment1, &segment2, &segment2], &stopped)
+        .update(&[&segment1, &segment2, &segment2], &stopped, &hw_counter)
         .unwrap();
 
     // Check what happens if segment building fails here
@@ -142,7 +142,9 @@ fn test_building_new_defragmented_segment() {
 
     builder.set_defragment_keys(vec![defragment_key.clone()]);
 
-    builder.update(&[&segment1, &segment2], &stopped).unwrap();
+    builder
+        .update(&[&segment1, &segment2], &stopped, &hw_counter)
+        .unwrap();
 
     // Check what happens if segment building fails here
 
@@ -266,7 +268,7 @@ fn test_building_new_sparse_segment() {
         .unwrap();
 
     builder
-        .update(&[&segment1, &segment2, &segment2], &stopped)
+        .update(&[&segment1, &segment2, &segment2], &stopped, &hw_counter)
         .unwrap();
 
     // Check what happens if segment building fails here
@@ -334,7 +336,8 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u6
     )
     .unwrap();
 
-    builder.update(&[segment], &stopped).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    builder.update(&[segment], &stopped, &hw_counter).unwrap();
 
     let now = Instant::now();
 
@@ -423,7 +426,9 @@ fn test_building_new_segment_bug_5614() {
         .upsert_point(124, 100.into(), vector_100_high.clone(), &hw_counter)
         .unwrap();
 
-    builder.update(&[&segment1, &segment2], &stopped).unwrap();
+    builder
+        .update(&[&segment1, &segment2], &stopped, &hw_counter)
+        .unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -138,7 +138,10 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
         &HnswGlobalConfig::default(),
     )
     .unwrap();
-    segment_builder.update(&[&segment], &false.into()).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    segment_builder
+        .update(&[&segment], &false.into(), &hw_counter)
+        .unwrap();
     let segment = segment_builder.build_for_test(segment_base_dir.path());
 
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -209,6 +209,7 @@ fn build_new_segment<F: ?Sized + OptimizationStrategy>(
         segment_builder.update(
             &segment_guards.iter().map(Deref::deref).collect_vec(),
             stopped,
+            hw_counter,
         )?;
         drop(progress_copy_data);
     }


### PR DESCRIPTION
My prompt:

```
take a look at `// TODO: Propagate counter upwards` in lib/segment/src/index/field_index/map_index/mmap_map_index.rs, propose a fix

do not use HardwareCounterCell::disposable(), properly propagate all the way
```

---
AI from here

## Summary
- Propagate `HardwareCounterCell` through `MmapMapIndex::get_values` instead of using `ConditionedCounter::never()`, so that disk IO from mmap map index value reads is properly tracked.
- Thread the counter through the full call chain: `MapIndex::get_values`, `FacetIndex::get_point_values` trait, `indexed_variable_retriever`, and `SegmentBuilder::update`/`_get_ordering_value`.
- All callers that previously created `HardwareCounterCell::disposable()` or ignored tracking now receive and forward a real counter from their caller context.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo check -p segment --tests` passes
- [x] `cargo clippy --all-targets --workspace` passes with no warnings
- [ ] Existing integration tests pass (no behavioral change, only counter propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)