### PR TITLE
UIO read benchmark

### DIFF
--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -82,3 +82,7 @@ harness = false
 [[bench]]
 name = "atomic_stop"
 harness = false
+
+[[bench]]
+name = "universal_io"
+harness = false

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -1,0 +1,224 @@
+use std::hint::black_box;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use common::generic_consts::{Random, Sequential};
+use common::universal_io::{IoUringFile, MmapFile, OpenOptions, ReadRange, UniversalRead};
+use criterion::{Criterion, criterion_group, criterion_main};
+use fs_err as fs;
+use rand::rngs::StdRng;
+use rand::{Rng as _, RngExt, SeedableRng as _};
+
+const FILE_SIZE_BYTES: u64 = 512 * 1024 * 1024;
+
+#[cfg(target_os = "linux")]
+const LIMIT_MEMORY_ENV: &str = "LIMIT_MEMORY";
+const LIMIT_MEMORY_ENV_INTERNAL: &str = "_LIMIT_MEMORY_INTERNAL";
+
+fn benches(c: &mut Criterion) {
+    let path = make_random_file();
+
+    #[cfg(target_os = "linux")]
+    if std::env::var_os(LIMIT_MEMORY_ENV).is_some() {
+        // Without memory limit, the file contents caches in the RAM quickly and
+        // we are measuring the "everything fits in kernel page cache" scenario.
+        //
+        // OTOH, to measure the IO-heavy scenario, we can limit the available
+        // process memory. There are many ways to do that, and systemd-run is
+        // one of them. If it doesn't work, try containers.
+
+        eprintln!("Dropping cache via `echo 3 > /proc/sys/vm/drop_caches` (requires sudo)...");
+        let rc = std::process::Command::new("sudo")
+            .args(["sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"])
+            .status()
+            .expect("Failed to drop caches");
+        assert!(rc.success(), "Failed to drop caches");
+
+        eprintln!("Rerunning benchmark with memory limit...");
+        let rc = std::process::Command::new("systemd-run")
+            .args(["--user", "--scope", "-p", "MemoryMax=64M", "--"])
+            .args(std::env::args())
+            .env_remove(LIMIT_MEMORY_ENV) // prevent recursion
+            .env(LIMIT_MEMORY_ENV_INTERNAL, "") // for `low-mem/` prefix
+            .status()
+            .expect("Failed to rerun benchmark with memory limit");
+        std::process::exit(rc.code().unwrap_or(1));
+    }
+
+    #[cfg(target_os = "linux")]
+    read_benches::<u64, IoUringFile>(c, "io_uring", "8bytes", &path);
+    read_benches::<u64, MmapFile>(c, "mmap", "8bytes", &path);
+    #[cfg(target_os = "linux")]
+    read_benches::<[u64; 128], IoUringFile>(c, "io_uring", "1KiB", &path);
+    read_benches::<[u64; 128], MmapFile>(c, "mmap", "1KiB", &path);
+
+    #[cfg(target_os = "linux")]
+    if std::env::var_os(LIMIT_MEMORY_ENV_INTERNAL).is_none() {
+        eprintln!("hint: Rerun with {LIMIT_MEMORY_ENV}=1 to enable memory limit");
+    }
+}
+
+fn read_benches<T: bytemuck::Pod, C: UniversalRead<T>>(
+    c: &mut Criterion,
+    impl_name: &str, // Corresponds to `C`
+    elem_size: &str, // Corresponds to `T`
+    path: &Path,
+) {
+    let options = OpenOptions {
+        writeable: false,
+        need_sequential: true,
+        disk_parallel: None,
+        populate: Some(false),
+        advice: None,
+        prevent_caching: Some(false),
+    };
+    let storage = C::open(path, options).unwrap();
+    let len = FILE_SIZE_BYTES / size_of::<T>() as u64;
+    let mut rng = rand::rng();
+    assert_eq!(storage.len().unwrap(), len);
+
+    let low_mem = std::env::var_os(LIMIT_MEMORY_ENV_INTERNAL).is_some();
+
+    if !low_mem {
+        storage.populate().unwrap();
+    }
+
+    let prefix = if low_mem { "low-mem/" } else { "" };
+    let group_name = format!("{prefix}{impl_name}/{elem_size}");
+    let mut group = c.benchmark_group(&group_name);
+
+    // `read_single` - single non-batched read at a random offset
+    group.bench_function("read_single", |b| {
+        b.iter(|| {
+            let mut sum = 0u64;
+            let offset = rng.random_range(0..len) * size_of::<T>() as u64;
+            let data = storage
+                .read::<Random>(ReadRange {
+                    byte_offset: offset,
+                    length: 1,
+                })
+                .unwrap();
+            for &item in bytemuck::cast_slice::<T, u64>(&data) {
+                sum = sum.wrapping_add(item);
+            }
+            black_box(sum);
+        })
+    });
+
+    // `read_batch_small_random` - batch of 8 random reads, each at a random offset
+    group.bench_function("read_batch_small_random", |b| {
+        b.iter(|| {
+            let mut sum = 0u64;
+            let ranges = (0..8).map(|_| ReadRange {
+                byte_offset: rng.random_range(0..len) * size_of::<T>() as u64,
+                length: 1,
+            });
+            storage
+                .read_batch::<Random>(ranges, |_, chunk| {
+                    for &item in bytemuck::cast_slice::<T, u64>(chunk) {
+                        sum = sum.wrapping_add(item);
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            black_box(sum);
+        })
+    });
+
+    // `read_batch_small_sequential` - batch of 8 reads at sequential offsets
+    group.bench_function("read_batch_small_sequential", |b| {
+        b.iter(|| {
+            let mut sum = 0u64;
+            let start = rng.random_range(0..len - 8) * size_of::<T>() as u64;
+            let ranges = (0..8).map(move |i| ReadRange {
+                byte_offset: start + i * size_of::<T>() as u64,
+                length: 1,
+            });
+            storage
+                .read_batch::<Sequential>(ranges, |_, chunk| {
+                    for &item in bytemuck::cast_slice::<T, u64>(chunk) {
+                        sum = sum.wrapping_add(item);
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            black_box(sum);
+        })
+    });
+
+    // `read_batch_full` - read the whole file
+    // Since it can be very slow, run only a single iteration first.
+    let read_batch_full = || {
+        let mut sum = 0u64;
+        storage
+            .read_batch::<Sequential>(ranges_full_file::<T>(), |_, chunk| {
+                for &item in bytemuck::cast_slice::<T, u64>(chunk) {
+                    sum = sum.wrapping_add(item);
+                }
+                Ok(())
+            })
+            .unwrap();
+        black_box(sum);
+    };
+    let duration = time_it(read_batch_full);
+    if duration.as_secs_f64() <= 1.0 {
+        group.bench_function("read_batch_full", |b| b.iter(read_batch_full));
+    } else {
+        eprintln!("{group_name}/read_batch_full: {duration:.2?} (single iteration)");
+    }
+}
+
+fn time_it<F: FnOnce()>(f: F) -> Duration {
+    let start = Instant::now();
+    f();
+    start.elapsed()
+}
+
+fn ranges_full_file<T>() -> impl Iterator<Item = ReadRange> {
+    let len = FILE_SIZE_BYTES / size_of::<T>() as u64;
+    (0..len).map(move |i| ReadRange {
+        byte_offset: i * size_of::<T>() as u64,
+        length: 1,
+    })
+}
+
+fn make_random_file() -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(env!("CARGO_PKG_NAME"))
+        .join(env!("CARGO_CRATE_NAME"))
+        .join(format!("random-{FILE_SIZE_BYTES}.bin"));
+
+    if let Ok(metadata) = fs::metadata(&path)
+        && metadata.len() == FILE_SIZE_BYTES
+    {
+        return path;
+    }
+
+    eprintln!("Building random benchmark file at {path:?}...");
+    fs_err::create_dir_all(path.parent().unwrap()).unwrap();
+
+    let mut file = fs::File::create(&path).unwrap();
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut buffer = vec![0; 1024 * 1024];
+    let mut bytes_left = FILE_SIZE_BYTES as usize;
+
+    while bytes_left > 0 {
+        let len = bytes_left.min(buffer.len());
+        rng.fill_bytes(&mut buffer[..len]);
+        file.write_all(&buffer[..len]).unwrap();
+        bytes_left -= len;
+    }
+
+    file.flush().unwrap();
+    eprintln!("Random benchmark file cached at {path:?}.");
+    path
+}
+
+criterion_group! {
+    name = bench_group;
+    config = Criterion::default();
+    targets = benches
+}
+
+criterion_main!(bench_group);


### PR DESCRIPTION
This PR adds `universal_io` benchmark to the `common` package.

Benchmark dimensions:
1. `mmem`  /  `io_uring`
2. 4 bytes  /  1 KiB
3. Data fits in RAM/page cache  /  memory is limited by 64MiB.
4. Access patterns:
   - `read_single` - single non-batched read at a random offset
   - `read_batch_small_random` - batch of 8 random reads, each at a random offset
   - `read_batch_small_sequential` - batch of 8 reads at sequential offsets
   - `read_batch_full` - read the whole file

All of these are performed on a single 512 MiB file.

## Results

Comparing 4f5dac4c (before #8535) vs f473e83e (#8535 merge) on my machine.

Tables contain these numbers from criterion output:
```
low-mem/mmap/1KiB/read_batch_small_random
                        time:   [630.78 µs 632.37 µs 634.82 µs]
                                 ^^^^^^^^^ ^^^^^^^^^ ^^^^^^^^^
                        change: [+0.6477% +1.1314% +1.5645%] (p = 0.00 < 0.05)
                                          ^^^^^^^^
```
### 8 bytes

<table>
  <tr>
    <th rowspan="2">Benchmark
    <th colspan="3">io_uring
    <th colspan="3">mmap
  <tr>
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
  <tr>
    <td>read_single
    <td>330.84&nbsp;ns<br>332.59&nbsp;ns<br>334.49&nbsp;ns
    <td>369.88&nbsp;ns<br>371.37&nbsp;ns<br>372.79&nbsp;ns
    <td>+10.140%
    <td>19.861&nbsp;ns<br>19.880&nbsp;ns<br>19.903&nbsp;ns
    <td>19.906&nbsp;ns<br>19.929&nbsp;ns<br>19.953&nbsp;ns
    <td>+0.1588%
  <tr>
    <td>read_batch_small_random
    <td>2.0432&nbsp;µs<br>2.0469&nbsp;µs<br>2.0512&nbsp;µs
    <td>2.1622&nbsp;µs<br>2.1645&nbsp;µs<br>2.1672&nbsp;µs
    <td>+6.0597%
    <td>134.54&nbsp;ns<br>134.68&nbsp;ns<br>134.84&nbsp;ns
    <td>133.76&nbsp;ns<br>133.89&nbsp;ns<br>134.03&nbsp;ns
    <td>−0.7143%
  <tr>
    <td>read_batch_small_sequential
    <td>1.2672&nbsp;µs<br>1.2696&nbsp;µs<br>1.2722&nbsp;µs
    <td>1.3754&nbsp;µs<br>1.3767&nbsp;µs<br>1.3783&nbsp;µs
    <td>+8.5054%
    <td>27.501&nbsp;ns<br>27.527&nbsp;ns<br>27.560&nbsp;ns
    <td>27.597&nbsp;ns<br>27.628&nbsp;ns<br>27.658&nbsp;ns
    <td>+0.1982%
  <tr>
    <td>read_batch_full
    <td>8.39s
    <td>8.40s
    <td>+0.1192%
    <td>13.133&nbsp;ms<br>13.146&nbsp;ms<br>13.161&nbsp;ms
    <td>13.430&nbsp;ms<br>13.454&nbsp;ms<br>13.483&nbsp;ms
    <td>+2.3454%
</table>

### 1 KiB

<table>
  <tr>
    <th rowspan="2">Benchmark
    <th colspan="3">io_uring
    <th colspan="3">mmap
  <tr>
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
  <tr>
    <td>read_single
    <td>405.45&nbsp;ns<br>406.33&nbsp;ns<br>407.07&nbsp;ns
    <td>433.29&nbsp;ns<br>433.48&nbsp;ns<br>433.66&nbsp;ns
    <td>+6.4594%
    <td>114.28&nbsp;ns<br>114.38&nbsp;ns<br>114.49&nbsp;ns
    <td>114.66&nbsp;ns<br>114.81&nbsp;ns<br>115.00&nbsp;ns
    <td>+0.5291%
  <tr>
    <td>read_batch_small_random
    <td>2.5687&nbsp;µs<br>2.5836&nbsp;µs<br>2.6045&nbsp;µs
    <td>2.6206&nbsp;µs<br>2.6249&nbsp;µs<br>2.6303&nbsp;µs
    <td>+1.4189%
    <td>939.86&nbsp;ns<br>940.74&nbsp;ns<br>941.75&nbsp;ns
    <td>942.32&nbsp;ns<br>943.21&nbsp;ns<br>944.33&nbsp;ns
    <td>−0.1586%
  <tr>
    <td>read_batch_small_sequential
    <td>1.6790&nbsp;µs<br>1.6817&nbsp;µs<br>1.6847&nbsp;µs
    <td>1.8349&nbsp;µs<br>1.8414&nbsp;µs<br>1.8474&nbsp;µs
    <td>+9.7358%
    <td>563.72&nbsp;ns<br>564.50&nbsp;ns<br>565.43&nbsp;ns
    <td>589.91&nbsp;ns<br>592.03&nbsp;ns<br>593.81&nbsp;ns
    <td>+5.5811%
  <tr>
    <td>read_batch_full
    <td>92.303&nbsp;ms<br>92.373&nbsp;ms<br>92.444&nbsp;ms
    <td>96.114&nbsp;ms<br>96.156&nbsp;ms<br>96.198&nbsp;ms
    <td>+4.0958%
    <td>10.667&nbsp;ms<br>10.684&nbsp;ms<br>10.702&nbsp;ms
    <td>11.143&nbsp;ms<br>11.165&nbsp;ms<br>11.189&nbsp;ms
    <td>+4.4965%
</table>

### 8 bytes (low memory)

<table>
  <tr>
    <th rowspan="2">Benchmark
    <th colspan="3">io_uring
    <th colspan="3">mmap
  <tr>
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
  <tr>
    <td>read_single
    <td>73.203&nbsp;µs<br>73.335&nbsp;µs<br>73.480&nbsp;µs
    <td>74.053&nbsp;µs<br>74.393&nbsp;µs<br>75.022&nbsp;µs
    <td>+1.7417%
    <td>79.855&nbsp;µs<br>79.967&nbsp;µs<br>80.090&nbsp;µs
    <td>81.134&nbsp;µs<br>81.255&nbsp;µs<br>81.393&nbsp;µs
    <td>+2.9164%
  <tr>
    <td>read_batch_small_random
    <td>143.75&nbsp;µs<br>144.15&nbsp;µs<br>144.63&nbsp;µs
    <td>144.66&nbsp;µs<br>145.04&nbsp;µs<br>145.49&nbsp;µs
    <td>+0.7041%
    <td>623.36&nbsp;µs<br>624.60&nbsp;µs<br>625.93&nbsp;µs
    <td>620.47&nbsp;µs<br>623.01&nbsp;µs<br>626.96&nbsp;µs
    <td>−0.4168%
  <tr>
    <td>read_batch_small_sequential
    <td>79.505&nbsp;µs<br>79.718&nbsp;µs<br>80.035&nbsp;µs
    <td>81.792&nbsp;µs<br>81.932&nbsp;µs<br>82.104&nbsp;µs
    <td>+2.5702%
    <td>1.2237&nbsp;ms<br>1.2293&nbsp;ms<br>1.2352&nbsp;ms
    <td>1.2378&nbsp;ms<br>1.2437&nbsp;ms<br>1.2498&nbsp;ms
    <td>+0.9939%
  <tr>
    <td>read_batch_full
    <td>8.48s
    <td>8.52s
    <td>+0.4717%
    <td>166.49&nbsp;ms<br>166.90&nbsp;ms<br>167.56&nbsp;ms
    <td>170.13&nbsp;ms<br>174.94&nbsp;ms<br>180.54&nbsp;ms
    <td>+4.8186%
</table>

### 1 KiB (low memory)

<table>
  <tr>
    <th rowspan="2">Benchmark
    <th colspan="3">io_uring
    <th colspan="3">mmap
  <tr>
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
    <th>4f5dac4c
    <th>f473e83e
    <th>Change
  <tr>
    <td>read_single
    <td>75.470&nbsp;µs<br>75.627&nbsp;µs<br>75.800&nbsp;µs
    <td>78.730&nbsp;µs<br>78.936&nbsp;µs<br>79.244&nbsp;µs
    <td>+4.4061%
    <td>77.416&nbsp;µs<br>77.536&nbsp;µs<br>77.663&nbsp;µs
    <td>78.993&nbsp;µs<br>79.173&nbsp;µs<br>79.447&nbsp;µs
    <td>+1.9959%
  <tr>
    <td>read_batch_small_random
    <td>144.11&nbsp;µs<br>144.45&nbsp;µs<br>144.88&nbsp;µs
    <td>145.25&nbsp;µs<br>145.76&nbsp;µs<br>146.50&nbsp;µs
    <td>+0.5592%
    <td>622.45&nbsp;µs<br>624.53&nbsp;µs<br>628.07&nbsp;µs
    <td>630.78&nbsp;µs<br>632.37&nbsp;µs<br>634.82&nbsp;µs
    <td>+1.1314%
  <tr>
    <td>read_batch_small_sequential
    <td>123.01&nbsp;µs<br>123.63&nbsp;µs<br>124.50&nbsp;µs
    <td>123.47&nbsp;µs<br>123.72&nbsp;µs<br>123.96&nbsp;µs
    <td>+0.4953%
    <td>1.8051&nbsp;ms<br>1.8150&nbsp;ms<br>1.8248&nbsp;ms
    <td>1.8266&nbsp;ms<br>1.8370&nbsp;ms<br>1.8475&nbsp;ms
    <td>+1.5649%
  <tr>
    <td>read_batch_full
    <td>181.71&nbsp;ms<br>182.39&nbsp;ms<br>183.14&nbsp;ms
    <td>189.87&nbsp;ms<br>190.92&nbsp;ms<br>191.97&nbsp;ms
    <td>+4.6765%
    <td>169.84&nbsp;ms<br>174.43&nbsp;ms<br>179.84&nbsp;ms
    <td>167.60&nbsp;ms<br>168.42&nbsp;ms<br>169.74&nbsp;ms
    <td>−3.4447%
</table>
