### PR TITLE
IoUringFile: don't use io_uring for single operations

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use ::io_uring::types::Fd;
 use fs_err as fs;
-use fs_err::os::unix::fs::OpenOptionsExt;
+use fs_err::os::unix::fs::{FileExt, OpenOptionsExt};
 
 use self::read_iter::{IoUringReadIter, IoUringReadMultiIter};
 use self::runtime::with_uring_runtime;
@@ -81,19 +81,10 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
     }
 
     fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        with_uring_runtime(|mut rt| {
-            let entry = rt.state.read(0, self.fd(), range, self.uses_o_direct)?;
-            rt.enqueue_single(entry)?;
-            // Loop because `submit_and_wait` may return before completions are
-            // available on older kernels.
-            while rt.completion_is_empty() {
-                rt.submit_and_wait(1)?;
-            }
-
-            let (_, resp) = rt.completed().next().expect("read operation completed")?;
-            let items = resp.expect_read();
-            Ok(Cow::from(items))
-        })?
+        let mut result = vec![T::zeroed(); range.length as usize];
+        self.file
+            .read_exact_at(bytemuck::cast_slice_mut(&mut result), range.byte_offset)?;
+        Ok(Cow::Owned(result))
     }
 
     fn read_batch<P: AccessPattern>(
@@ -173,19 +164,9 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
 
 impl<T: bytemuck::Pod + 'static> UniversalWrite<T> for IoUringFile {
     fn write(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
-        with_uring_runtime(|mut rt| {
-            let entry = rt.state.write(0, self.fd(), byte_offset, items)?;
-            rt.enqueue_single(entry)?;
-            // Loop because `submit_and_wait` may return before completions are
-            // available on older kernels.
-            while rt.completion_is_empty() {
-                rt.submit_and_wait(1)?;
-            }
-
-            let (_, resp) = rt.completed().next().expect("write operation completed")?;
-            resp.expect_write();
-            Ok(())
-        })?
+        self.file
+            .write_all_at(bytemuck::cast_slice(items), byte_offset)?;
+        Ok(())
     }
 
     fn write_batch<'a>(

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -43,17 +43,6 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
         }
     }
 
-    pub fn enqueue_single(&mut self, entry: squeue::Entry) -> io::Result<()> {
-        unsafe {
-            self.io_uring
-                .submission()
-                .push(&entry)
-                .map_err(io::Error::other)?;
-        }
-
-        Ok(())
-    }
-
     pub fn enqueue<F>(&mut self, mut entries: F) -> Result<()>
     where
         F: FnMut(&mut IoUringState<'data, T>) -> Result<Option<squeue::Entry>>,
@@ -73,10 +62,6 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
         }
 
         Ok(())
-    }
-
-    pub fn completion_is_empty(&mut self) -> bool {
-        self.io_uring.completion().is_empty()
     }
 
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {


### PR DESCRIPTION
For single (non-batched) read/write operations, it makes more sense to perform a single `pread`/`pwrite` syscall rather than spinning io_uring runtime.

Switching to a single syscall improves performance in a fully-cached scenario. The performance for the IO-bounded scenario is the same. Benchmark results (#8575), compared to `dev` (f473e83e).

```
io_uring/8bytes/read_single
                        time:   [209.50 ns 209.96 ns 210.52 ns]
                        change: [−43.547% −43.325% −43.084%] (p = 0.00 < 0.05)
                        Performance has improved.

io_uring/1KiB/read_single
                        time:   [295.36 ns 296.07 ns 296.81 ns]
                        change: [−32.186% −31.958% −31.721%] (p = 0.00 < 0.05)
                        Performance has improved.

low-mem/io_uring/8bytes/read_single
                        time:   [73.654 µs 73.901 µs 74.246 µs]
                        change: [+0.3456% +0.9137% +1.5243%] (p = 0.00 < 0.05)
                        Change within noise threshold.

low-mem/io_uring/1KiB/read_single
                        time:   [79.656 µs 79.941 µs 80.453 µs]
                        change: [−0.5301% −0.1494% +0.2516%] (p = 0.48 > 0.05)
                        No change in performance detected.
```
