### PR TITLE
fix: prevent panic when snapshot path contains non-UTF-8 characters

### DIFF
--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -114,7 +114,7 @@ pub fn recover_full_snapshot(
         .map(|(collection_name, snapshot_file)| {
             format!(
                 "{}:{collection_name}",
-                snapshot_temp_path.join(snapshot_file).to_str().unwrap(),
+                snapshot_temp_path.join(snapshot_file).display(),
             )
         })
         .collect();


### PR DESCRIPTION
## Problem
The code at `src/snapshots.rs:117` uses `.to_str().unwrap()` which can panic if the file path contains non-UTF-8 characters.

When recovering snapshots, this `unwrap()` will cause the process to terminate immediately if the joined path is not valid UTF-8. While rare on Unix systems (which typically use UTF-8 paths), this can occur on Windows systems and with certain locale/encoding configurations.

## Solution
Replace the unsafe `unwrap()` with `.display()`, which gracefully handles any path encoding.

```diff
- snapshot_temp_path.join(snapshot_file).to_str().unwrap(),
+ snapshot_temp_path.join(snapshot_file).display(),
```

This matches the pattern used elsewhere in the codebase:
- `actix/api/snapshot_api.rs:101`
- `tonic/auth.rs:59`
- `tonic/forwarded.rs:26`

## Changes
- 1 file modified (`src/snapshots.rs`)
- 1 line changed
- No breaking changes
- Defensive fix for an edge case

Fixes #8563

---
*Retargeted from #8564 to `dev` branch per reviewer feedback. Thanks @timvisee!*