### PR TITLE
Wait for resharding to finish on all peers

### DIFF
--- a/tests/consensus_tests/test_resharding.py
+++ b/tests/consensus_tests/test_resharding.py
@@ -300,8 +300,9 @@ def test_resharding_down_abort_cleanup(tmp_path: pathlib.Path, peers: int):
     resp = abort_resharding(peer_uris[0])
     assert_http_ok(resp)
 
-    # Wait for resharding to abort
-    wait_for_collection_resharding_operations_count(peer_uris[0], COLLECTION_NAME, 0)
+    # Wait for resharding to abort on all peers
+    for peer_uri in replica_uris:
+        wait_for_collection_resharding_operations_count(peer_uri, COLLECTION_NAME, 0)
 
     # Assert that all replicas are in `Active` state
     info = get_collection_cluster_info(peer_uris[0], COLLECTION_NAME)


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/8579>, <https://github.com/qdrant/qdrant/issues/7574>

Resharding may not be finished by the time we check all shards for point count.

To fix it, we wait for resharding on all peers explicitly.

I did notice the flakyness on my local machine when running with `QDRANT_NUM_CPUS=1`. Now it seems to be gone.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?