### PR TITLE
Better `IoUringReadIter`

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -15,7 +15,7 @@ use fs_err as fs;
 use fs_err::os::unix::fs::{FileExt, OpenOptionsExt};
 
 use self::read_iter::{IoUringReadIter, IoUringReadMultiIter};
-use self::runtime::with_uring_runtime;
+use self::runtime::IoUringRuntime;
 use super::*;
 use crate::generic_consts::AccessPattern;
 
@@ -173,65 +173,63 @@ impl<T: bytemuck::Pod + 'static> UniversalWrite<T> for IoUringFile {
         &mut self,
         items: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        with_uring_runtime(|mut rt| {
-            let mut items = items.into_iter().enumerate().peekable();
+        let mut rt = IoUringRuntime::new()?;
+        let mut items = items.into_iter().enumerate().peekable();
 
-            while items.peek().is_some() || rt.in_progress > 0 {
-                rt.enqueue(|state| {
-                    let Some((id, (byte_offset, items))) = items.next() else {
-                        return Ok(None);
-                    };
+        while items.peek().is_some() || rt.in_progress > 0 {
+            rt.enqueue(|state| {
+                let Some((id, (byte_offset, items))) = items.next() else {
+                    return Ok(None);
+                };
 
-                    let entry = state.write(id as _, self.fd(), byte_offset, items)?;
-                    Ok(Some(entry))
-                })?;
+                let entry = state.write(id as _, self.fd(), byte_offset, items)?;
+                Ok(Some(entry))
+            })?;
 
-                rt.submit_and_wait(1)?;
+            rt.submit_and_wait(1)?;
 
-                for result in rt.completed() {
-                    let (_, resp) = result?;
-                    resp.expect_write();
-                }
+            for result in rt.completed() {
+                let (_, resp) = result?;
+                resp.expect_write();
             }
+        }
 
-            Ok(())
-        })?
+        Ok(())
     }
 
     fn write_multi<'a>(
         files: &mut [Self],
         writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        with_uring_runtime(|mut rt| {
-            let mut writes = writes.into_iter().enumerate().peekable();
+        let mut rt = IoUringRuntime::new()?;
+        let mut writes = writes.into_iter().enumerate().peekable();
 
-            while writes.peek().is_some() || rt.in_progress > 0 {
-                rt.enqueue(|state| {
-                    let Some((id, (file_index, byte_offset, items))) = writes.next() else {
-                        return Ok(None);
-                    };
+        while writes.peek().is_some() || rt.in_progress > 0 {
+            rt.enqueue(|state| {
+                let Some((id, (file_index, byte_offset, items))) = writes.next() else {
+                    return Ok(None);
+                };
 
-                    let file = files.get(file_index).ok_or({
-                        UniversalIoError::InvalidFileIndex {
-                            file_index,
-                            files: files.len(),
-                        }
-                    })?;
-
-                    let entry = state.write(id as _, file.fd(), byte_offset, items)?;
-                    Ok(Some(entry))
+                let file = files.get(file_index).ok_or({
+                    UniversalIoError::InvalidFileIndex {
+                        file_index,
+                        files: files.len(),
+                    }
                 })?;
 
-                rt.submit_and_wait(1)?;
+                let entry = state.write(id as _, file.fd(), byte_offset, items)?;
+                Ok(Some(entry))
+            })?;
 
-                for result in rt.completed() {
-                    let (_, resp) = result?;
-                    resp.expect_write();
-                }
+            rt.submit_and_wait(1)?;
+
+            for result in rt.completed() {
+                let (_, resp) = result?;
+                resp.expect_write();
             }
+        }
 
-            Ok(())
-        })?
+        Ok(())
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -177,7 +177,7 @@ impl<T: bytemuck::Pod + 'static> UniversalWrite<T> for IoUringFile {
         let mut items = items.into_iter().enumerate().peekable();
 
         while items.peek().is_some() || rt.in_progress > 0 {
-            rt.enqueue(|state| {
+            rt.enqueue_while(|state| {
                 let Some((id, (byte_offset, items))) = items.next() else {
                     return Ok(None);
                 };
@@ -205,7 +205,7 @@ impl<T: bytemuck::Pod + 'static> UniversalWrite<T> for IoUringFile {
         let mut writes = writes.into_iter().enumerate().peekable();
 
         while writes.peek().is_some() || rt.in_progress > 0 {
-            rt.enqueue(|state| {
+            rt.enqueue_while(|state| {
                 let Some((id, (file_index, byte_offset, items))) = writes.next() else {
                     return Ok(None);
                 };

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -103,7 +103,7 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
         &self,
         ranges: impl IntoIterator<Item = ReadRange>,
     ) -> impl Iterator<Item = Result<(usize, Cow<'_, [T]>)>> {
-        match IoUringReadIter::new(self, ranges) {
+        match IoUringReadIter::new(self, ranges.into_iter()) {
             Ok(iter) => itertools::Either::Left(iter),
             Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
         }
@@ -125,7 +125,7 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
         files: &[Self],
         reads: impl IntoIterator<Item = (FileIndex, ReadRange)>,
     ) -> impl Iterator<Item = Result<(usize, FileIndex, Cow<'_, [T]>)>> {
-        match IoUringReadMultiIter::new(files, reads) {
+        match IoUringReadMultiIter::new(files, reads.into_iter()) {
             Ok(iter) => itertools::Either::Left(iter),
             Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
         }

--- a/lib/common/common/src/universal_io/io_uring/read_iter.rs
+++ b/lib/common/common/src/universal_io/io_uring/read_iter.rs
@@ -96,6 +96,7 @@ where
         Ok(iter)
     }
 
+    #[expect(clippy::type_complexity)]
     fn next_impl(&mut self) -> Result<Option<(usize, FileIndex, Cow<'a, [T]>)>> {
         if self.runtime.completion_is_empty()
             && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)

--- a/lib/common/common/src/universal_io/io_uring/read_iter.rs
+++ b/lib/common/common/src/universal_io/io_uring/read_iter.rs
@@ -35,7 +35,7 @@ where
         if self.runtime.completion_is_empty()
             && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)
         {
-            self.runtime.enqueue(|state| {
+            self.runtime.enqueue_while(|state| {
                 let Some((idx, range)) = self.ranges.next() else {
                     return Ok(None);
                 };
@@ -53,7 +53,7 @@ where
             .completed()
             .next()
             .transpose()?
-            .map(|(idx, resp)| (idx as _, resp.expect_read().into()));
+            .map(|(idx, resp)| (idx as _, Cow::from(resp.expect_read())));
 
         Ok(next)
     }
@@ -73,7 +73,7 @@ where
 
 pub struct IoUringReadMultiIter<'a, T: 'static, I: Iterator> {
     files: &'a [IoUringFile],
-    file_indexes: ahash::HashMap<usize, usize>,
+    file_indexes: ahash::HashMap<usize, FileIndex>,
     ranges: iter::Peekable<iter::Enumerate<I>>,
     runtime: IoUringRuntime<'static, T>,
     _phantom: PhantomData<*const ()>, // `!Send + !Sync`
@@ -101,7 +101,7 @@ where
         if self.runtime.completion_is_empty()
             && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)
         {
-            self.runtime.enqueue(|state| {
+            self.runtime.enqueue_while(|state| {
                 let Some((idx, (file_index, range))) = self.ranges.next() else {
                     return Ok(None);
                 };
@@ -131,7 +131,7 @@ where
             .map(|(idx, resp)| {
                 let idx = idx as _;
                 let file_index = self.file_indexes.remove(&idx).expect("file index tracked");
-                let items = resp.expect_read().into();
+                let items = Cow::from(resp.expect_read());
 
                 (idx, file_index, items)
             });

--- a/lib/common/common/src/universal_io/io_uring/read_iter.rs
+++ b/lib/common/common/src/universal_io/io_uring/read_iter.rs
@@ -1,323 +1,152 @@
 use std::borrow::Cow;
-use std::collections::VecDeque;
-use std::io;
+use std::iter;
 use std::marker::PhantomData;
 
-use ::io_uring::types::Fd;
-use ahash::AHashMap;
+use ahash::HashMapExt as _;
 
-use super::super::*;
-use super::IoUringFile;
-use super::pool::{self, IO_URING_QUEUE_LENGTH, IoUringGuard};
-use super::runtime::{IoUringState, RequestId, io_error_context};
+use super::pool::*;
+use super::runtime::*;
+use super::*;
 
-// ---------------------------------------------------------------------------
-// FileResolver trait — abstracts single-file vs multi-file differences
-// ---------------------------------------------------------------------------
-
-pub(super) trait FileResolver<'a, T: bytemuck::Pod + 'static> {
-    /// Element yielded by the caller's range iterator.
-    type RangeItem;
-    /// Extra data carried per in-flight request.  `()` for single-file,
-    /// `FileIndex` for multi-file.
-    type Meta: Copy;
-    /// The item produced by the `Iterator` impl.
-    type OutputItem;
-
-    /// Map a range item to `(fd, uses_o_direct, range, meta)`.
-    fn resolve(&self, item: Self::RangeItem) -> Result<(Fd, bool, ReadRange, Self::Meta)>;
-
-    /// Record `meta` for an in-flight request (no-op when `Meta = ()`).
-    fn track(&mut self, request_id: RequestId, meta: Self::Meta);
-
-    /// Retrieve and remove `meta` for a completed request.
-    fn untrack(&mut self, request_id: RequestId) -> Self::Meta;
-
-    /// Remove tracking for an aborted request (error / drop path).
-    fn untrack_abort(&mut self, request_id: RequestId);
-
-    /// Build the final output item from index, meta, and data.
-    fn into_output(idx: usize, meta: Self::Meta, data: Vec<T>) -> Self::OutputItem;
-}
-
-// ---------------------------------------------------------------------------
-// SingleFileResolver
-// ---------------------------------------------------------------------------
-
-pub(super) struct SingleFileResolver<'a> {
+pub struct IoUringReadIter<'a, T: 'static, I: Iterator> {
     file: &'a IoUringFile,
+    ranges: iter::Peekable<iter::Enumerate<I>>,
+    runtime: IoUringRuntime<'static, T>,
+    _phantom: PhantomData<*const ()>, // `!Send + !Sync`
 }
 
-impl<'a, T: bytemuck::Pod + 'static> FileResolver<'a, T> for SingleFileResolver<'a> {
-    type RangeItem = ReadRange;
-    type Meta = ();
-    type OutputItem = (usize, Cow<'a, [T]>);
-
-    #[inline(always)]
-    fn resolve(&self, range: ReadRange) -> Result<(Fd, bool, ReadRange, ())> {
-        Ok((self.file.fd(), self.file.uses_o_direct, range, ()))
-    }
-
-    #[inline(always)]
-    fn track(&mut self, _request_id: RequestId, _meta: ()) {}
-
-    #[inline(always)]
-    fn untrack(&mut self, _request_id: RequestId) {}
-
-    #[inline(always)]
-    fn untrack_abort(&mut self, _request_id: RequestId) {}
-
-    #[inline(always)]
-    fn into_output(idx: usize, _meta: (), data: Vec<T>) -> Self::OutputItem {
-        (idx, Cow::Owned(data))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// MultiFileResolver
-// ---------------------------------------------------------------------------
-
-pub(super) struct MultiFileResolver<'a> {
-    files: &'a [IoUringFile],
-    file_indices: AHashMap<RequestId, FileIndex>,
-}
-
-impl<'a, T: bytemuck::Pod + 'static> FileResolver<'a, T> for MultiFileResolver<'a> {
-    type RangeItem = (FileIndex, ReadRange);
-    type Meta = FileIndex;
-    type OutputItem = (usize, FileIndex, Cow<'a, [T]>);
-
-    #[inline]
-    fn resolve(
-        &self,
-        (file_index, range): (FileIndex, ReadRange),
-    ) -> Result<(Fd, bool, ReadRange, FileIndex)> {
-        let file = self
-            .files
-            .get(file_index)
-            .ok_or(UniversalIoError::InvalidFileIndex {
-                file_index,
-                files: self.files.len(),
-            })?;
-        Ok((file.fd(), file.uses_o_direct, range, file_index))
-    }
-
-    #[inline]
-    fn track(&mut self, request_id: RequestId, meta: FileIndex) {
-        self.file_indices.insert(request_id, meta);
-    }
-
-    #[inline]
-    fn untrack(&mut self, request_id: RequestId) -> FileIndex {
-        self.file_indices
-            .remove(&request_id)
-            .expect("file index is tracked")
-    }
-
-    #[inline]
-    fn untrack_abort(&mut self, request_id: RequestId) {
-        self.file_indices.remove(&request_id);
-    }
-
-    #[inline]
-    fn into_output(idx: usize, meta: FileIndex, data: Vec<T>) -> Self::OutputItem {
-        (idx, meta, Cow::Owned(data))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Unified iterator
-// ---------------------------------------------------------------------------
-
-/// Lazy, pipelined iterator over io_uring read results.
-///
-/// Keeps the io_uring submission queue continuously full: on every [`next()`] call it
-/// refills free queue slots with new reads before waiting for completions. This means
-/// the kernel always has work queued, maximising I/O parallelism.
-///
-/// Parameterised over a [`FileResolver`] so that the same code handles both
-/// single-file and multi-file reads with zero overhead for the single-file case.
-pub(super) struct IoUringReadIterInner<
-    'a,
-    T: bytemuck::Pod + 'static,
-    I: Iterator<Item = R::RangeItem>,
-    R: FileResolver<'a, T>,
-> {
-    resolver: R,
-    /// Exclusive `IoUring` instance taken from the pool — returned on drop.
-    guard: IoUringGuard,
-    ranges: std::iter::Enumerate<I>,
-    buffer: VecDeque<(usize, R::Meta, Vec<T>)>,
-    state: IoUringState<'static, T>,
-    in_progress: usize,
-    /// `!Send + !Sync` — the iterator is tied to the thread whose pool it uses.
-    _not_send: PhantomData<*const ()>,
-    _lifetime: PhantomData<&'a ()>,
-}
-
-/// Single-file read iterator.
-pub(super) type IoUringReadIter<'a, T, I> = IoUringReadIterInner<'a, T, I, SingleFileResolver<'a>>;
-
-/// Multi-file read iterator.
-pub(super) type IoUringReadMultiIter<'a, T, I> =
-    IoUringReadIterInner<'a, T, I, MultiFileResolver<'a>>;
-
-// -- Constructors -----------------------------------------------------------
-
-impl<'a, T: bytemuck::Pod + 'static, I: Iterator<Item = ReadRange>>
-    IoUringReadIterInner<'a, T, I, SingleFileResolver<'a>>
+impl<'a, T, I> IoUringReadIter<'a, T, I>
+where
+    T: bytemuck::Pod,
+    I: Iterator<Item = ReadRange>,
 {
-    pub fn new(file: &'a IoUringFile, ranges: impl IntoIterator<IntoIter = I>) -> Result<Self> {
-        Self::new_inner(SingleFileResolver { file }, ranges)
-    }
-}
+    pub fn new(file: &'a IoUringFile, ranges: I) -> Result<Self> {
+        let iter = Self {
+            file,
+            ranges: ranges.enumerate().peekable(),
+            runtime: IoUringRuntime::new()?,
+            _phantom: PhantomData,
+        };
 
-impl<'a, T: bytemuck::Pod + 'static, I: Iterator<Item = (FileIndex, ReadRange)>>
-    IoUringReadIterInner<'a, T, I, MultiFileResolver<'a>>
-{
-    pub fn new(files: &'a [IoUringFile], reads: impl IntoIterator<IntoIter = I>) -> Result<Self> {
-        Self::new_inner(
-            MultiFileResolver {
-                files,
-                file_indices: AHashMap::new(),
-            },
-            reads,
-        )
-    }
-}
-
-// -- Shared logic -----------------------------------------------------------
-
-impl<'a, T: bytemuck::Pod + 'static, I: Iterator<Item = R::RangeItem>, R: FileResolver<'a, T>>
-    IoUringReadIterInner<'a, T, I, R>
-{
-    fn new_inner(resolver: R, ranges: impl IntoIterator<IntoIter = I>) -> Result<Self> {
-        let guard = pool::take_io_uring().map_err(UniversalIoError::IoUringNotSupported)?;
-        Ok(Self {
-            resolver,
-            guard,
-            ranges: ranges.into_iter().enumerate(),
-            buffer: VecDeque::new(),
-            state: IoUringState::new(),
-            in_progress: 0,
-            _not_send: PhantomData,
-            _lifetime: PhantomData,
-        })
+        Ok(iter)
     }
 
-    /// Refill the submission queue, submit, and collect completions.
-    ///
-    /// Returns `true` if there is (or may be) more work, `false` if fully exhausted.
-    fn step(&mut self) -> Result<bool> {
-        let io_uring = self.guard.io_uring();
-
-        // Fill every free slot in the submission queue with a new read.
-        let mut newly_queued = 0usize;
+    fn next_impl(&mut self) -> Result<Option<(usize, Cow<'a, [T]>)>> {
+        if self.runtime.completion_is_empty()
+            && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)
         {
-            let mut sqe = io_uring.submission();
-            while self.in_progress + sqe.len() < IO_URING_QUEUE_LENGTH as usize {
-                let Some((id, range_item)) = self.ranges.next() else {
-                    break;
+            self.runtime.enqueue(|state| {
+                let Some((idx, range)) = self.ranges.next() else {
+                    return Ok(None);
                 };
 
-                let (fd, uses_o_direct, range, meta) = self.resolver.resolve(range_item)?;
-                self.resolver.track(id as RequestId, meta);
+                let entry = state.read(idx as _, self.file.fd(), range, self.file.uses_o_direct)?;
 
-                let entry = self.state.read(id as _, fd, range, uses_o_direct)?;
-                unsafe { sqe.push(&entry).expect("SQE is not full") };
-                newly_queued += 1;
-            }
-            // SubmissionQueue::drop syncs the tail pointer.
+                Ok(Some(entry))
+            })?;
+
+            self.runtime.submit_and_wait(1)?;
         }
 
-        // Nothing queued AND nothing in flight → exhausted.
-        if self.in_progress == 0 && newly_queued == 0 {
-            return Ok(false);
-        }
+        let next = self
+            .runtime
+            .completed()
+            .next()
+            .transpose()?
+            .map(|(idx, resp)| (idx as _, resp.expect_read().into()));
 
-        // `submit_and_wait` may return before completions are available on
-        // older kernels; retry until at least one completion is ready.
-        while io_uring.completion().is_empty() {
-            self.in_progress += io_uring
-                .submit_and_wait(1)
-                .map_err(|err| io_error_context(err, "failed to submit io_uring operations"))?;
-        }
-
-        // Reap all available completions.
-        let cqes: Vec<_> = io_uring
-            .completion()
-            .map(|cqe: ::io_uring::cqueue::Entry| (cqe.user_data(), cqe.result()))
-            .collect();
-
-        for (id, result) in cqes {
-            self.in_progress -= 1;
-
-            if result < 0 {
-                self.state.abort(id);
-                self.resolver.untrack_abort(id);
-                return Err(io_error_context(
-                    io::Error::from_raw_os_error(-result),
-                    format!("io_uring operation {id} failed"),
-                )
-                .into());
-            }
-
-            let meta = self.resolver.untrack(id);
-
-            let length = result as _;
-            let resp = self.state.finalize(id, length)?;
-            let items = resp.expect_read();
-            self.buffer.push_back((id as usize, meta, items));
-        }
-
-        Ok(true)
+        Ok(next)
     }
 }
 
-impl<'a, T: bytemuck::Pod + 'static, I: Iterator<Item = R::RangeItem>, R: FileResolver<'a, T>>
-    Iterator for IoUringReadIterInner<'a, T, I, R>
+impl<'a, T, I> Iterator for IoUringReadIter<'a, T, I>
+where
+    T: bytemuck::Pod,
+    I: Iterator<Item = ReadRange>,
 {
-    type Item = Result<R::OutputItem>;
+    type Item = Result<(usize, Cow<'a, [T]>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.buffer.is_empty() {
-            match self.step() {
-                Ok(false) => return None,
-                Err(e) => return Some(Err(e)),
-                _ => {}
-            }
-        }
-
-        let (idx, meta, data) = self.buffer.pop_front()?;
-        Some(Ok(R::into_output(idx, meta, data)))
+        self.next_impl().transpose()
     }
 }
 
-impl<'a, T: bytemuck::Pod + 'static, I: Iterator<Item = R::RangeItem>, R: FileResolver<'a, T>> Drop
-    for IoUringReadIterInner<'a, T, I, R>
+pub struct IoUringReadMultiIter<'a, T: 'static, I: Iterator> {
+    files: &'a [IoUringFile],
+    file_indexes: ahash::HashMap<usize, usize>,
+    ranges: iter::Peekable<iter::Enumerate<I>>,
+    runtime: IoUringRuntime<'static, T>,
+    _phantom: PhantomData<*const ()>, // `!Send + !Sync`
+}
+
+impl<'a, T, I> IoUringReadMultiIter<'a, T, I>
+where
+    T: bytemuck::Pod,
+    I: Iterator<Item = (FileIndex, ReadRange)>,
 {
-    fn drop(&mut self) {
-        if self.in_progress == 0 {
-            return;
+    pub fn new(files: &'a [IoUringFile], ranges: I) -> Result<Self> {
+        let iter = Self {
+            files,
+            file_indexes: ahash::HashMap::with_capacity(IO_URING_QUEUE_LENGTH as _),
+            ranges: ranges.enumerate().peekable(),
+            runtime: IoUringRuntime::new()?,
+            _phantom: PhantomData,
+        };
+
+        Ok(iter)
+    }
+
+    fn next_impl(&mut self) -> Result<Option<(usize, FileIndex, Cow<'a, [T]>)>> {
+        if self.runtime.completion_is_empty()
+            && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)
+        {
+            self.runtime.enqueue(|state| {
+                let Some((idx, (file_index, range))) = self.ranges.next() else {
+                    return Ok(None);
+                };
+
+                let file =
+                    self.files
+                        .get(file_index)
+                        .ok_or(UniversalIoError::InvalidFileIndex {
+                            file_index,
+                            files: self.files.len(),
+                        })?;
+
+                self.file_indexes.insert(idx, file_index);
+
+                let entry = state.read(idx as _, file.fd(), range, file.uses_o_direct)?;
+                Ok(Some(entry))
+            })?;
+
+            self.runtime.submit_and_wait(1)?;
         }
-        let io_uring = self.guard.io_uring();
-        while self.in_progress > 0 {
-            if io_uring.submit_and_wait(self.in_progress).is_err() {
-                break;
-            }
-            let cqes: Vec<_> = io_uring
-                .completion()
-                .map(|cqe: ::io_uring::cqueue::Entry| (cqe.user_data(), cqe.result()))
-                .collect();
-            for (id, result) in cqes {
-                self.in_progress -= 1;
-                self.resolver.untrack_abort(id);
-                if result < 0 {
-                    self.state.abort(id);
-                } else {
-                    let _ = self.state.finalize(id, result as _);
-                }
-            }
-        }
+
+        let next = self
+            .runtime
+            .completed()
+            .next()
+            .transpose()?
+            .map(|(idx, resp)| {
+                let idx = idx as _;
+                let file_index = self.file_indexes.remove(&idx).expect("file index tracked");
+                let items = resp.expect_read().into();
+
+                (idx, file_index, items)
+            });
+
+        Ok(next)
+    }
+}
+
+impl<'a, T, I> Iterator for IoUringReadMultiIter<'a, T, I>
+where
+    T: bytemuck::Pod,
+    I: Iterator<Item = (FileIndex, ReadRange)>,
+{
+    type Item = Result<(usize, FileIndex, Cow<'a, [T]>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_impl().transpose()
     }
 }

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -3,51 +3,35 @@ use std::io;
 use std::mem::{self, MaybeUninit};
 
 use ::io_uring::types::Fd;
-use ::io_uring::{IoUring, opcode, squeue};
+use ::io_uring::{opcode, squeue};
 use ahash::AHashMap;
 
 use super::super::*;
-use super::pool::{self, IO_URING_QUEUE_LENGTH};
+use super::pool::{self, IO_URING_QUEUE_LENGTH, IoUringGuard};
 use crate::maybe_uninit::assume_init_vec;
 
-/// Run a closure with exclusive access to an `IoUring` instance from the pool.
-///
-/// `'data` is the lifetime of any write buffers that will be submitted to io_uring.
-/// The compiler enforces that write data outlives all in-flight operations, because
-/// `IoUringState<'data, T>` holds `&'data [T]` references until operations complete.
-///
-/// The io_uring borrow lifetime is handled via HRTB (`for<'uring>`), keeping it
-/// independent from the caller's data lifetime.
-pub(super) fn with_uring_runtime<'data, T: 'data, Out, F>(with_uring: F) -> Result<Out>
-where
-    F: for<'uring> FnOnce(IoUringRuntime<'uring, 'data, T>) -> Out,
-{
-    let mut guard = pool::take_io_uring().map_err(UniversalIoError::IoUringNotSupported)?;
-    let rt = IoUringRuntime::new(guard.io_uring());
-    let output = with_uring(rt);
-    Ok(output)
-}
-
-pub(super) struct IoUringRuntime<'uring, 'data, T> {
-    io_uring: &'uring mut IoUring,
+pub struct IoUringRuntime<'data, T> {
+    io_uring: IoUringGuard,
     pub state: IoUringState<'data, T>,
     pub in_progress: usize,
 }
 
-impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
-    pub fn new(io_uring: &'uring mut IoUring) -> Self {
-        Self {
-            io_uring,
+impl<'data, T> IoUringRuntime<'data, T> {
+    pub fn new() -> Result<Self> {
+        let rt = Self {
+            io_uring: pool::take_io_uring()?,
             state: IoUringState::new(),
             in_progress: 0,
-        }
+        };
+
+        Ok(rt)
     }
 
     pub fn enqueue<F>(&mut self, mut entries: F) -> Result<()>
     where
         F: FnMut(&mut IoUringState<'data, T>) -> Result<Option<squeue::Entry>>,
     {
-        let mut sqe = self.io_uring.submission();
+        let mut sqe = self.io_uring.io_uring().submission();
 
         if self.in_progress + sqe.len() >= IO_URING_QUEUE_LENGTH as _ {
             return Ok(());
@@ -67,6 +51,7 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {
         self.in_progress += self
             .io_uring
+            .io_uring()
             .submit_and_wait(want)
             .map_err(|err| io_error_context(err, "failed to submit io_uring operations"))?;
 
@@ -74,7 +59,7 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
     }
 
     pub fn completed(&mut self) -> impl Iterator<Item = io::Result<(u64, IoUringResponse<T>)>> {
-        self.io_uring.completion().map(|entry| {
+        self.io_uring.io_uring().completion().map(|entry| {
             self.in_progress -= 1;
 
             let id = entry.user_data();
@@ -96,7 +81,7 @@ impl<'uring, 'data, T> IoUringRuntime<'uring, 'data, T> {
     }
 }
 
-impl<'uring, 'data, T> Drop for IoUringRuntime<'uring, 'data, T> {
+impl<'data, T> Drop for IoUringRuntime<'data, T> {
     fn drop(&mut self) {
         while self.in_progress > 0 {
             // TODO: Cancel operations with `io_uring::Submitter::register_sync_cancel`?
@@ -207,7 +192,7 @@ impl<'data, T> IoUringState<'data, T> {
         let req = self
             .requests
             .remove(&id)
-            .ok_or_else(|| io::Error::other("request {id} does not exist"))?;
+            .ok_or_else(|| io::Error::other(format!("request {id} does not exist")))?;
 
         let resp = match req {
             IoUringRequest::Read {

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -67,7 +67,7 @@ impl<'data, T> IoUringRuntime<'data, T> {
         self.submit_and_wait_retry_early_wakeup(want)?;
 
         let remaining = self.io_uring.io_uring().submission().len();
-        debug_assert!(enqueued > remaining);
+        debug_assert!(enqueued == 0 || enqueued > remaining);
         debug_assert_eq!(remaining, 0);
 
         self.in_progress += enqueued - remaining;

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -27,7 +27,9 @@ impl<'data, T> IoUringRuntime<'data, T> {
         Ok(rt)
     }
 
-    pub fn enqueue<F>(&mut self, mut entries: F) -> Result<()>
+    /// Push entries into Submission Queue while `entries` returns `Ok(Something)`
+    /// or the queue is full.
+    pub fn enqueue_while<F>(&mut self, mut entries: F) -> Result<()>
     where
         F: FnMut(&mut IoUringState<'data, T>) -> Result<Option<squeue::Entry>>,
     {

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -48,6 +48,10 @@ impl<'data, T> IoUringRuntime<'data, T> {
         Ok(())
     }
 
+    pub fn completion_is_empty(&mut self) -> bool {
+        self.io_uring.io_uring().completion().is_empty()
+    }
+
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {
         let enqueued = self.io_uring.io_uring().submission().len();
 

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -122,7 +122,7 @@ impl<'data, T> IoUringRuntime<'data, T> {
 
 impl<'data, T> Drop for IoUringRuntime<'data, T> {
     fn drop(&mut self) {
-        while self.in_progress > 0 {
+        while self.in_progress > 0 || !self.io_uring.io_uring().submission().is_empty() {
             // TODO: Cancel operations with `io_uring::Submitter::register_sync_cancel`?
 
             // TODO: Implement `wait` (without submit) based on `io_uring::Submitter::enter`?

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -49,12 +49,45 @@ impl<'data, T> IoUringRuntime<'data, T> {
     }
 
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {
-        self.in_progress += self
-            .io_uring
-            .io_uring()
-            .submit_and_wait(want)
-            .map_err(|err| io_error_context(err, "failed to submit io_uring operations"))?;
+        let enqueued = self.io_uring.io_uring().submission().len();
 
+        debug_assert!(
+            want == 0 || enqueued + self.in_progress >= want,
+            "io_uring would block: \
+             requested to wait for {want} operations to complete, \
+             but not enough operations are enqueued or in-progress"
+        );
+
+        self.submit_and_wait_retry_early_wakeup(want)?;
+
+        let remaining = self.io_uring.io_uring().submission().len();
+        debug_assert!(enqueued > remaining);
+        debug_assert_eq!(remaining, 0);
+
+        self.in_progress += enqueued - remaining;
+
+        Ok(())
+    }
+
+    fn submit_and_wait_retry_early_wakeup(&mut self, want: usize) -> io::Result<()> {
+        self.submit_and_wait_retry_eintr(want)?;
+
+        while want > 0 && self.io_uring.io_uring().completion().is_empty() {
+            self.submit_and_wait_retry_eintr(want)?;
+        }
+
+        Ok(())
+    }
+
+    fn submit_and_wait_retry_eintr(&mut self, want: usize) -> io::Result<()> {
+        let result = loop {
+            match self.io_uring.io_uring().submit_and_wait(want) {
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => (),
+                res => break res,
+            }
+        };
+
+        result.map_err(|err| io_error_context(err, "failed to submit io_uring operations"))?;
         Ok(())
     }
 


### PR DESCRIPTION
Refactor `IoUringReadIter` to reuse `IoUringRuntime`, be more efficient (no allocations or syscalls beyond necessary) and also handle `EINTR` errors during `IoUring::submit_and_wait`.

This PR re-introduces `ReadIter`/`ReadMultiIter`, but I'll merge them back together in the follow-up PRs.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
