### PR TITLE
Use `OperationError` funcs

### DIFF
--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -17,13 +17,11 @@ fn convert_to_plain_multi_vector(
 ) -> Result<MultiDenseVector, OperationError> {
     let dim = data.len() / vectors_count;
     if dim * vectors_count != data.len() {
-        return Err(OperationError::ValidationError {
-            description: format!(
-                "Data length is not divisible by vectors count. Data length: {}, vectors count: {}",
-                data.len(),
-                vectors_count
-            ),
-        });
+        return Err(OperationError::validation_error(format!(
+            "Data length is not divisible by vectors count. Data length: {}, vectors count: {}",
+            data.len(),
+            vectors_count
+        )));
     }
 
     Ok(data
@@ -372,9 +370,9 @@ impl TryFrom<grpc::VectorsOutput> for VectorStructInternal {
                                 Ok(VectorStructInternal::Single(data))
                             }
                             grpc::vector_output::Vector::Sparse(_sparse) => {
-                                return Err(OperationError::ValidationError {
-                                    description: "Sparse vector must be named".to_string(),
-                                });
+                                return Err(OperationError::validation_error(
+                                    "Sparse vector must be named",
+                                ));
                             }
                             grpc::vector_output::Vector::MultiDense(multi) => {
                                 Ok(VectorStructInternal::MultiDense(
@@ -385,9 +383,9 @@ impl TryFrom<grpc::VectorsOutput> for VectorStructInternal {
                     }
 
                     if indices.is_some() {
-                        return Err(OperationError::ValidationError {
-                            description: "Sparse vector must be named".to_string(),
-                        });
+                        return Err(OperationError::validation_error(
+                            "Sparse vector must be named",
+                        ));
                     }
 
                     if let Some(vectors_count) = vectors_count {
@@ -408,9 +406,7 @@ impl TryFrom<grpc::VectorsOutput> for VectorStructInternal {
                     VectorStructInternal::Named(named_vectors?)
                 }
             }),
-            None => Err(OperationError::ValidationError {
-                description: "No Vector Provided".to_string(),
-            }),
+            None => Err(OperationError::validation_error("No Vector Provided")),
         }
     }
 }

--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -18,9 +18,8 @@ fn convert_to_plain_multi_vector(
     let dim = data.len() / vectors_count;
     if dim * vectors_count != data.len() {
         return Err(OperationError::validation_error(format!(
-            "Data length is not divisible by vectors count. Data length: {}, vectors count: {}",
+            "Data length is not divisible by vectors count. Data length: {}, vectors count: {vectors_count}",
             data.len(),
-            vectors_count
         )));
     }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1749,9 +1749,7 @@ impl VectorsConfigDiff {
                 .vectors
                 .get_params(vector_name)
                 .map(|_| ())
-                .ok_or_else(|| OperationError::VectorNameNotExists {
-                    received_name: vector_name.clone(),
-                })?;
+                .ok_or_else(|| OperationError::vector_name_not_exists(vector_name.clone()))?;
         }
         Ok(())
     }

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -58,9 +58,9 @@ impl UnindexedField {
         collection_name: String,
     ) -> Result<Self, OperationError> {
         if field_schemas.is_empty() {
-            return Err(OperationError::ValidationError {
-                description: "Cannot create issue which won't have a solution".to_string(),
-            });
+            return Err(OperationError::validation_error(
+                "Cannot create issue which won't have a solution",
+            ));
         }
 
         let encoded_collection_name = urlencoding::encode(&collection_name);
@@ -72,9 +72,7 @@ impl UnindexedField {
             Ok(uri) => uri,
             Err(e) => {
                 log::trace!("Failed to build uri: {e}");
-                return Err(OperationError::ValidationError {
-                    description: "Bad collection name".to_string(),
-                });
+                return Err(OperationError::validation_error("Bad collection name"));
             }
         };
 

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -232,9 +232,7 @@ fn check_sparse_vector_against_config(
 
 pub fn check_stopped(is_stopped: &AtomicBool) -> OperationResult<()> {
     if is_stopped.load(std::sync::atomic::Ordering::Relaxed) {
-        return Err(OperationError::Cancelled {
-            description: "Operation is stopped externally".to_string(),
-        });
+        return Err(OperationError::cancelled("Operation is stopped externally"));
     }
     Ok(())
 }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -141,10 +141,7 @@ pub struct SegmentFailedState {
 
 impl From<ThreadPoolBuildError> for OperationError {
     fn from(error: ThreadPoolBuildError) -> Self {
-        OperationError::ServiceError {
-            description: format!("{error}"),
-            backtrace: Some(Backtrace::force_capture().to_string()),
-        }
+        Self::service_error(format!("{error}"))
     }
 }
 
@@ -163,36 +160,30 @@ impl From<MmapError> for OperationError {
 impl From<UniversalIoError> for OperationError {
     fn from(err: UniversalIoError) -> Self {
         match err {
-            UniversalIoError::Io(err) => OperationError::from(err),
-            UniversalIoError::Mmap(err) => OperationError::from(err),
+            UniversalIoError::Io(err) => Self::from(err),
+            UniversalIoError::Mmap(err) => Self::from(err),
 
             UniversalIoError::IoUringNotSupported(_)
             | UniversalIoError::NotFound { .. }
             | UniversalIoError::OutOfBounds { .. }
-            | UniversalIoError::InvalidFileIndex { .. } => {
-                OperationError::service_error(err.to_string())
-            }
-            UniversalIoError::BytemuckCast(_) => OperationError::service_error(err.to_string()),
-            UniversalIoError::Uninitialized { .. } => {
-                OperationError::service_error(err.to_string())
-            }
+            | UniversalIoError::InvalidFileIndex { .. } => Self::service_error(err.to_string()),
+            UniversalIoError::BytemuckCast(_) => Self::service_error(err.to_string()),
+            UniversalIoError::Uninitialized { .. } => Self::service_error(err.to_string()),
         }
     }
 }
 
 impl From<serde_cbor::Error> for OperationError {
     fn from(err: serde_cbor::Error) -> Self {
-        OperationError::service_error(format!("Failed to parse data: {err}"))
+        Self::service_error(format!("Failed to parse data: {err}"))
     }
 }
 
 impl<E> From<AtomicIoError<E>> for OperationError {
     fn from(err: AtomicIoError<E>) -> Self {
         match err {
-            AtomicIoError::Internal(io_err) => OperationError::from(io_err),
-            AtomicIoError::User(_user_err) => {
-                OperationError::service_error("Unknown atomic write error")
-            }
+            AtomicIoError::Internal(io_err) => Self::from(io_err),
+            AtomicIoError::User(_user_err) => Self::service_error("Unknown atomic write error"),
         }
     }
 }
@@ -202,31 +193,31 @@ impl From<IoError> for OperationError {
         match err.kind() {
             ErrorKind::OutOfMemory => {
                 let free_memory = Mem::new().available_memory_bytes();
-                OperationError::OutOfMemory {
+                Self::OutOfMemory {
                     description: format!("IO Error: {err}"),
                     free: free_memory,
                 }
             }
-            _ => OperationError::service_error(format!("IO Error: {err}")),
+            _ => Self::service_error(format!("IO Error: {err}")),
         }
     }
 }
 
 impl From<serde_json::Error> for OperationError {
     fn from(err: serde_json::Error) -> Self {
-        OperationError::service_error(format!("Json error: {err}"))
+        Self::service_error(format!("Json error: {err}"))
     }
 }
 
 impl From<fs_extra::error::Error> for OperationError {
     fn from(err: fs_extra::error::Error) -> Self {
-        OperationError::service_error(format!("File system error: {err}"))
+        Self::service_error(format!("File system error: {err}"))
     }
 }
 
 impl From<geohash::GeohashError> for OperationError {
     fn from(err: geohash::GeohashError) -> Self {
-        OperationError::service_error(format!("Geohash error: {err}"))
+        Self::service_error(format!("Geohash error: {err}"))
     }
 }
 
@@ -236,11 +227,11 @@ impl From<quantization::EncodingError> for OperationError {
             quantization::EncodingError::IOError(err)
             | quantization::EncodingError::EncodingError(err)
             | quantization::EncodingError::ArgumentsError(err) => {
-                OperationError::service_error(format!("Quantization encoding error: {err}"))
+                Self::service_error(format!("Quantization encoding error: {err}"))
             }
-            quantization::EncodingError::Stopped => OperationError::Cancelled {
-                description: PROCESS_CANCELLED_BY_SERVICE_MESSAGE.to_string(),
-            },
+            quantization::EncodingError::Stopped => {
+                Self::cancelled(PROCESS_CANCELLED_BY_SERVICE_MESSAGE)
+            }
         }
     }
 }
@@ -248,7 +239,7 @@ impl From<quantization::EncodingError> for OperationError {
 impl From<TryReserveError> for OperationError {
     fn from(err: TryReserveError) -> Self {
         let free_memory = Mem::new().available_memory_bytes();
-        OperationError::OutOfMemory {
+        Self::OutOfMemory {
             description: format!("Failed to reserve memory: {err}"),
             free: free_memory,
         }
@@ -261,9 +252,7 @@ impl From<GridstoreError> for OperationError {
             GridstoreError::ServiceError { description } => {
                 Self::service_error(format!("Gridstore error: {description}"))
             }
-            GridstoreError::FlushCancelled => Self::Cancelled {
-                description: "Gridstore flushing was cancelled".to_string(),
-            },
+            GridstoreError::FlushCancelled => Self::cancelled("Gridstore flushing was cancelled"),
             GridstoreError::Io(_) | GridstoreError::Mmap(_) | GridstoreError::SerdeJson(_) => {
                 Self::service_error(err.to_string())
             }
@@ -302,9 +291,7 @@ pub type CancellableResult<T> = Result<T, CancelledError>;
 
 impl From<CancelledError> for OperationError {
     fn from(CancelledError: CancelledError) -> Self {
-        OperationError::Cancelled {
-            description: PROCESS_CANCELLED_BY_SERVICE_MESSAGE.to_string(),
-        }
+        Self::cancelled(PROCESS_CANCELLED_BY_SERVICE_MESSAGE)
     }
 }
 

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -276,18 +276,16 @@ pub struct TypedMultiDenseVector<T> {
 impl<T> TypedMultiDenseVector<T> {
     pub fn try_from_flatten(vectors: Vec<T>, dim: usize) -> Result<Self, OperationError> {
         if dim == 0 {
-            return Err(OperationError::ValidationError {
-                description: "MultiDenseVector cannot have zero dimension".to_string(),
-            });
+            return Err(OperationError::validation_error(
+                "MultiDenseVector cannot have zero dimension",
+            ));
         }
         if !vectors.len().is_multiple_of(dim) || vectors.is_empty() {
-            return Err(OperationError::ValidationError {
-                description: format!(
-                    "Invalid multi-vector length: {}, expected multiple of {}",
-                    vectors.len(),
-                    dim
-                ),
-            });
+            return Err(OperationError::validation_error(format!(
+                "Invalid multi-vector length: {}, expected multiple of {}",
+                vectors.len(),
+                dim
+            )));
         }
 
         Ok(TypedMultiDenseVector {
@@ -298,15 +296,15 @@ impl<T> TypedMultiDenseVector<T> {
 
     pub fn try_from_matrix(matrix: Vec<Vec<T>>) -> Result<Self, OperationError> {
         if matrix.is_empty() {
-            return Err(OperationError::ValidationError {
-                description: "MultiDenseVector cannot be empty".to_string(),
-            });
+            return Err(OperationError::validation_error(
+                "MultiDenseVector cannot be empty",
+            ));
         }
         let dim = matrix[0].len();
         if dim == 0 {
-            return Err(OperationError::ValidationError {
-                description: "MultiDenseVector cannot have zero dimension".to_string(),
-            });
+            return Err(OperationError::validation_error(
+                "MultiDenseVector cannot have zero dimension",
+            ));
         }
         // assert all vectors have the same dimension
         if let Some(bad_vec) = matrix.iter().find(|v| v.len() != dim) {

--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -282,9 +282,8 @@ impl<T> TypedMultiDenseVector<T> {
         }
         if !vectors.len().is_multiple_of(dim) || vectors.is_empty() {
             return Err(OperationError::validation_error(format!(
-                "Invalid multi-vector length: {}, expected multiple of {}",
-                vectors.len(),
-                dim
+                "Invalid multi-vector length: {}, expected multiple of {dim}",
+                vectors.len()
             )));
         }
 

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -182,11 +182,8 @@ where
             length: std::mem::size_of::<Header>() as u64,
         })?;
 
-        let (header, _) = Header::read_from_prefix(&header_bytes).map_err(|_| {
-            OperationError::InconsistentStorage {
-                description: NOT_ENOUGH_BYTES_ERROR_MESSAGE.to_owned(),
-            }
-        })?;
+        let (header, _) = Header::read_from_prefix(&header_bytes)
+            .map_err(|_| OperationError::inconsistent_storage(NOT_ENOUGH_BYTES_ERROR_MESSAGE))?;
 
         Ok(Self {
             file_name,

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -322,11 +322,9 @@ pub(crate) fn create_sparse_vector_index(
         args.config.datatype.unwrap_or_default(),
         sparse_vector_index::USE_COMPRESSED,
     ) {
-        (_, a @ (VectorStorageDatatype::Float16 | VectorStorageDatatype::Uint8), false) => {
-            Err(OperationError::ValidationError {
-                description: format!("{a:?} datatype is not supported"),
-            })?
-        }
+        (_, a @ (VectorStorageDatatype::Float16 | VectorStorageDatatype::Uint8), false) => Err(
+            OperationError::validation_error(format!("{a:?} datatype is not supported")),
+        )?,
 
         (SparseIndexType::MutableRam, _, _) => {
             VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?)

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2931,23 +2931,19 @@ pub struct GeoPolygon {
 impl GeoPolygon {
     pub fn validate_line_string(line: &GeoLineString) -> OperationResult<()> {
         if line.points.len() <= 3 {
-            return Err(OperationError::ValidationError {
-                description: format!(
-                    "polygon invalid, the size must be at least 4, got {}",
-                    line.points.len()
-                ),
-            });
+            return Err(OperationError::validation_error(format!(
+                "polygon invalid, the size must be at least 4, got {}",
+                line.points.len()
+            )));
         }
 
         if let (Some(first), Some(last)) = (line.points.first(), line.points.last())
             && ((first.lat - last.lat).abs() > f64::EPSILON
                 || (first.lon - last.lon).abs() > f64::EPSILON)
         {
-            return Err(OperationError::ValidationError {
-                description: String::from(
-                    "polygon invalid, the first and the last points should be the same to form a closed line",
-                ),
-            });
+            return Err(OperationError::validation_error(
+                "polygon invalid, the first and the last points should be the same to form a closed line",
+            ));
         }
 
         Ok(())

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -109,9 +109,9 @@ pub fn process_payload_operation(
                 set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
-                Err(OperationError::ValidationError {
-                    description: "No points or filter specified".to_string(),
-                })
+                Err(OperationError::validation_error(
+                    "No points or filter specified",
+                ))
             }
         }
         PayloadOps::DeletePayload(dp) => {
@@ -121,9 +121,9 @@ pub fn process_payload_operation(
                 delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
-                Err(OperationError::ValidationError {
-                    description: "No points or filter specified".to_string(),
-                })
+                Err(OperationError::validation_error(
+                    "No points or filter specified",
+                ))
             }
         }
         PayloadOps::ClearPayload { ref points, .. } => {
@@ -140,9 +140,9 @@ pub fn process_payload_operation(
                 overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
-                Err(OperationError::ValidationError {
-                    description: "No points or filter specified".to_string(),
-                })
+                Err(OperationError::validation_error(
+                    "No points or filter specified",
+                ))
             }
         }
     }


### PR DESCRIPTION
Replaced the use of direct `OperationError` creation with special functions for creating `OperationError`