### PR TITLE
Immutable storage for mmap numeric index

### DIFF
--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -25,6 +25,14 @@ pub struct TypedStorage<S, T> {
     _phantom: PhantomData<T>,
 }
 
+impl<S, T> TypedStorage<S, T> {
+    /// Approximate RAM usage in bytes. IO-backed storage has no significant
+    /// heap allocations; on-disk data is accounted via `files()`.
+    pub fn ram_usage_bytes(&self) -> usize {
+        0
+    }
+}
+
 impl<S: UniversalRead<T>, T: Copy + 'static> UniversalReadFileOps for TypedStorage<S, T> {
     #[inline]
     fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {

--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
 use rand::{RngExt, SeedableRng};
 use segment::common::operation_error::OperationResult;
+use segment::id_tracker::{IdTracker, IdTrackerEnum};
 use segment::index::field_index::numeric_index::mmap_numeric_index::MmapNumericIndex;
 use segment::index::field_index::numeric_index::mutable_numeric_index::InMemoryNumericIndex;
 use tempfile::Builder;
@@ -32,6 +36,16 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
     let mut group = c.benchmark_group("numeric-check-values");
 
     let payloads: Vec<(PointOffsetType, f64)> = get_random_payloads(&mut rng, NUM_POINTS);
+    let mut id_tracker = IdTrackerEnum::InMemoryIdTracker(Default::default());
+    for point_id in 0..NUM_POINTS as PointOffsetType {
+        id_tracker
+            .set_link(
+                segment::types::ExtendedPointId::NumId(point_id as _),
+                point_id,
+            )
+            .unwrap();
+    }
+
     let mutable_index: InMemoryNumericIndex<f64> = payloads
         .into_iter()
         .map(Ok)
@@ -51,7 +65,8 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
         })
     });
 
-    let mmap_index = MmapNumericIndex::build(mutable_index, dir.path(), false).unwrap();
+    let mmap_index =
+        MmapNumericIndex::build(mutable_index, dir.path(), false, &id_tracker).unwrap();
 
     group.bench_function("mmap-numeric-index", |b| {
         b.iter(|| {

--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -1,10 +1,10 @@
+use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::prelude::StdRng;
 use rand::{RngExt, SeedableRng};
 use segment::common::operation_error::OperationResult;
-use segment::id_tracker::{IdTracker, IdTrackerEnum};
 use segment::index::field_index::numeric_index::mmap_numeric_index::MmapNumericIndex;
 use segment::index::field_index::numeric_index::mutable_numeric_index::InMemoryNumericIndex;
 use tempfile::Builder;
@@ -33,15 +33,8 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
     let mut group = c.benchmark_group("numeric-check-values");
 
     let payloads: Vec<(PointOffsetType, f64)> = get_random_payloads(&mut rng, NUM_POINTS);
-    let mut id_tracker = IdTrackerEnum::InMemoryIdTracker(Default::default());
-    for point_id in 0..NUM_POINTS as PointOffsetType {
-        id_tracker
-            .set_link(
-                segment::types::ExtendedPointId::NumId(point_id.into()),
-                point_id,
-            )
-            .unwrap();
-    }
+    // No deletions in this benchmark — sized generously to cover the whole point set.
+    let deleted_points = BitVec::repeat(false, NUM_POINTS);
 
     let mutable_index: InMemoryNumericIndex<f64> = payloads
         .into_iter()
@@ -63,7 +56,7 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
     });
 
     let mmap_index =
-        MmapNumericIndex::build(mutable_index, dir.path(), false, &id_tracker).unwrap();
+        MmapNumericIndex::build(mutable_index, dir.path(), false, &deleted_points).unwrap();
 
     group.bench_function("mmap-numeric-index", |b| {
         b.iter(|| {

--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-
-use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -40,7 +37,7 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
     for point_id in 0..NUM_POINTS as PointOffsetType {
         id_tracker
             .set_link(
-                segment::types::ExtendedPointId::NumId(point_id as _),
+                segment::types::ExtendedPointId::NumId(point_id.into()),
                 point_id,
             )
             .unwrap();

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use gridstore::Blob;
 
 use super::bool_index::BoolIndex;
@@ -14,6 +16,7 @@ use super::stored_point_to_values::StoredValue;
 use super::{FieldIndexBuilder, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::index::TextIndexParams;
+use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::FieldIndex;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
@@ -45,6 +48,7 @@ pub struct IndexSelectorGridstore<'a> {
 
 impl IndexSelector<'_> {
     /// Loads the correct index based on `index_type`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_index_with_type(
         &self,
         field: &JsonPath,
@@ -53,6 +57,7 @@ impl IndexSelector<'_> {
         path: &Path,
         total_point_count: usize,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<FieldIndex>> {
         let index = match (&index_type.index_type, payload_schema.expand().as_ref()) {
             (PayloadIndexType::IntIndex, PayloadSchemaParams::Integer(params)) => {
@@ -66,7 +71,7 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                self.numeric_new(field, create_if_missing)?
+                self.numeric_new(field, create_if_missing, id_tracker)?
                     .map(FieldIndex::IntIndex)
             }
             (PayloadIndexType::IntMapIndex, PayloadSchemaParams::Integer(params)) => {
@@ -84,7 +89,7 @@ impl IndexSelector<'_> {
                     .map(FieldIndex::IntMapIndex)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(FieldIndex::DatetimeIndex),
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => self
@@ -92,7 +97,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::KeywordIndex),
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(FieldIndex::FloatIndex),
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => self
@@ -139,6 +144,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<Vec<FieldIndex>>> {
         let indexes = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => self
@@ -157,7 +163,7 @@ impl IndexSelector<'_> {
                     None
                 };
                 let range = if use_range {
-                    match self.numeric_new(field, create_if_missing)? {
+                    match self.numeric_new(field, create_if_missing, id_tracker)? {
                         Some(index) => Some(FieldIndex::IntIndex(index)),
                         None => return Ok(None),
                     }
@@ -168,7 +174,7 @@ impl IndexSelector<'_> {
                 Some(lookup.into_iter().chain(range).collect())
             }
             PayloadSchemaParams::Float(_) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(|index| vec![FieldIndex::FloatIndex(index)]),
             PayloadSchemaParams::Geo(_) => self
                 .geo_new(field, create_if_missing)?
@@ -180,7 +186,7 @@ impl IndexSelector<'_> {
                 .bool_new(field, create_if_missing)?
                 .map(|index| vec![FieldIndex::BoolIndex(index)]),
             PayloadSchemaParams::Datetime(_) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
             PayloadSchemaParams::Uuid(_) => self
                 .map_new(field, create_if_missing)?
@@ -195,6 +201,7 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     ) -> OperationResult<Vec<FieldIndexBuilder>> {
         let builders = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => {
@@ -223,6 +230,7 @@ impl IndexSelector<'_> {
                         field,
                         FieldIndexBuilder::IntMmapIndex,
                         FieldIndexBuilder::IntGridstoreIndex,
+                        id_tracker,
                     ))
                 } else {
                     None
@@ -235,6 +243,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::FloatMmapIndex,
                     FieldIndexBuilder::FloatGridstoreIndex,
+                    id_tracker,
                 )]
             }
             PayloadSchemaParams::Geo(_) => {
@@ -255,6 +264,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::DatetimeMmapIndex,
                     FieldIndexBuilder::DatetimeGridstoreIndex,
+                    id_tracker,
                 )]
             }
             PayloadSchemaParams::Uuid(_) => {
@@ -310,13 +320,14 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<NumericIndex<T, P>>>
     where
         Vec<T>: Blob,
     {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
@@ -329,6 +340,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(NumericIndexMmapBuilder<T, P>) -> FieldIndexBuilder,
         make_gridstore: fn(NumericIndexGridstoreBuilder<T, P>) -> FieldIndexBuilder,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     ) -> FieldIndexBuilder
     where
         NumericIndex<T, P>: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -336,7 +348,7 @@ impl IndexSelector<'_> {
     {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
-                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk),
+                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker),
             ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
+use common::bitvec::BitSlice;
 use gridstore::Blob;
 
 use super::bool_index::BoolIndex;
@@ -16,7 +15,6 @@ use super::stored_point_to_values::StoredValue;
 use super::{FieldIndexBuilder, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::index::TextIndexParams;
-use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::FieldIndex;
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::geo_index::GeoMapIndex;
@@ -57,7 +55,7 @@ impl IndexSelector<'_> {
         path: &Path,
         total_point_count: usize,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<FieldIndex>> {
         let index = match (&index_type.index_type, payload_schema.expand().as_ref()) {
             (PayloadIndexType::IntIndex, PayloadSchemaParams::Integer(params)) => {
@@ -71,7 +69,7 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                self.numeric_new(field, create_if_missing, id_tracker)?
+                self.numeric_new(field, create_if_missing, deleted_points)?
                     .map(FieldIndex::IntIndex)
             }
             (PayloadIndexType::IntMapIndex, PayloadSchemaParams::Integer(params)) => {
@@ -89,7 +87,7 @@ impl IndexSelector<'_> {
                     .map(FieldIndex::IntMapIndex)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::DatetimeIndex),
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => self
@@ -97,7 +95,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::KeywordIndex),
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::FloatIndex),
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => self
@@ -144,7 +142,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Vec<FieldIndex>>> {
         let indexes = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => self
@@ -163,7 +161,7 @@ impl IndexSelector<'_> {
                     None
                 };
                 let range = if use_range {
-                    match self.numeric_new(field, create_if_missing, id_tracker)? {
+                    match self.numeric_new(field, create_if_missing, deleted_points)? {
                         Some(index) => Some(FieldIndex::IntIndex(index)),
                         None => return Ok(None),
                     }
@@ -174,7 +172,7 @@ impl IndexSelector<'_> {
                 Some(lookup.into_iter().chain(range).collect())
             }
             PayloadSchemaParams::Float(_) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::FloatIndex(index)]),
             PayloadSchemaParams::Geo(_) => self
                 .geo_new(field, create_if_missing)?
@@ -186,7 +184,7 @@ impl IndexSelector<'_> {
                 .bool_new(field, create_if_missing)?
                 .map(|index| vec![FieldIndex::BoolIndex(index)]),
             PayloadSchemaParams::Datetime(_) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
             PayloadSchemaParams::Uuid(_) => self
                 .map_new(field, create_if_missing)?
@@ -201,7 +199,7 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Vec<FieldIndexBuilder>> {
         let builders = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => {
@@ -230,7 +228,7 @@ impl IndexSelector<'_> {
                         field,
                         FieldIndexBuilder::IntMmapIndex,
                         FieldIndexBuilder::IntGridstoreIndex,
-                        id_tracker,
+                        deleted_points,
                     ))
                 } else {
                     None
@@ -243,7 +241,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::FloatMmapIndex,
                     FieldIndexBuilder::FloatGridstoreIndex,
-                    id_tracker,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Geo(_) => {
@@ -264,7 +262,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::DatetimeMmapIndex,
                     FieldIndexBuilder::DatetimeGridstoreIndex,
-                    id_tracker,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Uuid(_) => {
@@ -320,14 +318,14 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<NumericIndex<T, P>>>
     where
         Vec<T>: Blob,
     {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker)?
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
@@ -340,7 +338,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(NumericIndexMmapBuilder<T, P>) -> FieldIndexBuilder,
         make_gridstore: fn(NumericIndexGridstoreBuilder<T, P>) -> FieldIndexBuilder,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> FieldIndexBuilder
     where
         NumericIndex<T, P>: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -348,7 +346,7 @@ impl IndexSelector<'_> {
     {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
-                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker),
+                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points),
             ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -109,7 +109,12 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::FullTextIndex),
 
             (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self
-                .bool_new(field, create_if_missing, deleted_points, index_type.mutability)?
+                .bool_new(
+                    field,
+                    create_if_missing,
+                    deleted_points,
+                    index_type.mutability,
+                )?
                 .map(FieldIndex::BoolIndex),
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => self
@@ -520,8 +525,9 @@ impl IndexSelector<'_> {
                 // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
                 // format; stored mutability picks which in-memory wrapper to build.
                 match mutability {
-                    IndexMutability::Immutable => ImmutableBoolIndex::open(&dir, deleted_points)?
-                        .map(BoolIndex::Immutable),
+                    IndexMutability::Immutable => {
+                        ImmutableBoolIndex::open(&dir, deleted_points)?.map(BoolIndex::Immutable)
+                    }
                     IndexMutability::Mutable => {
                         MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
                     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
+use common::bitvec::BitSlice;
 use gridstore::Blob;
 
 use super::bool_index::BoolIndex;
@@ -58,6 +57,7 @@ impl IndexSelector<'_> {
         index_type: &FullPayloadIndexType,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<FieldIndex>> {
         let index = match (&index_type.index_type, payload_schema.expand().as_ref()) {
             (PayloadIndexType::IntIndex, PayloadSchemaParams::Integer(params)) => {
@@ -71,7 +71,7 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                self.numeric_new(field, create_if_missing, id_tracker)?
+                self.numeric_new(field, create_if_missing, deleted_points)?
                     .map(FieldIndex::IntIndex)
             }
             (PayloadIndexType::IntMapIndex, PayloadSchemaParams::Integer(params)) => {
@@ -89,7 +89,7 @@ impl IndexSelector<'_> {
                     .map(FieldIndex::IntMapIndex)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::DatetimeIndex),
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => self
@@ -97,7 +97,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::KeywordIndex),
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::FloatIndex),
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => self
@@ -109,7 +109,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::FullTextIndex),
 
             (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self
-                .bool_new(field, create_if_missing, id_tracker, index_type.mutability)?
+                .bool_new(field, create_if_missing, deleted_points, index_type.mutability)?
                 .map(FieldIndex::BoolIndex),
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => self
@@ -141,7 +141,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Vec<FieldIndex>>> {
         let indexes = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => self
@@ -160,7 +160,7 @@ impl IndexSelector<'_> {
                     None
                 };
                 let range = if use_range {
-                    match self.numeric_new(field, create_if_missing, id_tracker)? {
+                    match self.numeric_new(field, create_if_missing, deleted_points)? {
                         Some(index) => Some(FieldIndex::IntIndex(index)),
                         None => return Ok(None),
                     }
@@ -171,7 +171,7 @@ impl IndexSelector<'_> {
                 Some(lookup.into_iter().chain(range).collect())
             }
             PayloadSchemaParams::Float(_) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::FloatIndex(index)]),
             PayloadSchemaParams::Geo(_) => self
                 .geo_new(field, create_if_missing)?
@@ -183,12 +183,12 @@ impl IndexSelector<'_> {
                 .bool_new(
                     field,
                     create_if_missing,
-                    id_tracker,
+                    deleted_points,
                     self.default_mutability(),
                 )?
                 .map(|index| vec![FieldIndex::BoolIndex(index)]),
             PayloadSchemaParams::Datetime(_) => self
-                .numeric_new(field, create_if_missing, id_tracker)?
+                .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
             PayloadSchemaParams::Uuid(_) => self
                 .map_new(field, create_if_missing)?
@@ -203,7 +203,7 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Vec<FieldIndexBuilder>> {
         let builders = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => {
@@ -232,7 +232,7 @@ impl IndexSelector<'_> {
                         field,
                         FieldIndexBuilder::IntMmapIndex,
                         FieldIndexBuilder::IntGridstoreIndex,
-                        id_tracker,
+                        deleted_points,
                     ))
                 } else {
                     None
@@ -245,7 +245,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::FloatMmapIndex,
                     FieldIndexBuilder::FloatGridstoreIndex,
-                    id_tracker,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Geo(_) => {
@@ -266,7 +266,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::DatetimeMmapIndex,
                     FieldIndexBuilder::DatetimeGridstoreIndex,
-                    id_tracker,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Uuid(_) => {
@@ -322,14 +322,14 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<NumericIndex<T, P>>>
     where
         Vec<T>: Blob,
     {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker)?
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
@@ -342,7 +342,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(NumericIndexMmapBuilder<T, P>) -> FieldIndexBuilder,
         make_gridstore: fn(NumericIndexGridstoreBuilder<T, P>) -> FieldIndexBuilder,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> FieldIndexBuilder
     where
         NumericIndex<T, P>: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -350,7 +350,7 @@ impl IndexSelector<'_> {
     {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
-                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker),
+                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points),
             ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))
@@ -511,7 +511,7 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
         mutability: IndexMutability,
     ) -> OperationResult<Option<BoolIndex>> {
         Ok(match self {
@@ -520,10 +520,8 @@ impl IndexSelector<'_> {
                 // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
                 // format; stored mutability picks which in-memory wrapper to build.
                 match mutability {
-                    IndexMutability::Immutable => {
-                        ImmutableBoolIndex::open(&dir, id_tracker.deleted_point_bitslice())?
-                            .map(BoolIndex::Immutable)
-                    }
+                    IndexMutability::Immutable => ImmutableBoolIndex::open(&dir, deleted_points)?
+                        .map(BoolIndex::Immutable),
                     IndexMutability::Mutable => {
                         MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
                     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use gridstore::Blob;
 
 use super::bool_index::BoolIndex;
@@ -69,7 +71,7 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                self.numeric_new(field, create_if_missing)?
+                self.numeric_new(field, create_if_missing, id_tracker)?
                     .map(FieldIndex::IntIndex)
             }
             (PayloadIndexType::IntMapIndex, PayloadSchemaParams::Integer(params)) => {
@@ -87,7 +89,7 @@ impl IndexSelector<'_> {
                     .map(FieldIndex::IntMapIndex)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(FieldIndex::DatetimeIndex),
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => self
@@ -95,7 +97,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::KeywordIndex),
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(FieldIndex::FloatIndex),
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => self
@@ -158,7 +160,7 @@ impl IndexSelector<'_> {
                     None
                 };
                 let range = if use_range {
-                    match self.numeric_new(field, create_if_missing)? {
+                    match self.numeric_new(field, create_if_missing, id_tracker)? {
                         Some(index) => Some(FieldIndex::IntIndex(index)),
                         None => return Ok(None),
                     }
@@ -169,7 +171,7 @@ impl IndexSelector<'_> {
                 Some(lookup.into_iter().chain(range).collect())
             }
             PayloadSchemaParams::Float(_) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(|index| vec![FieldIndex::FloatIndex(index)]),
             PayloadSchemaParams::Geo(_) => self
                 .geo_new(field, create_if_missing)?
@@ -186,7 +188,7 @@ impl IndexSelector<'_> {
                 )?
                 .map(|index| vec![FieldIndex::BoolIndex(index)]),
             PayloadSchemaParams::Datetime(_) => self
-                .numeric_new(field, create_if_missing)?
+                .numeric_new(field, create_if_missing, id_tracker)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
             PayloadSchemaParams::Uuid(_) => self
                 .map_new(field, create_if_missing)?
@@ -201,6 +203,7 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     ) -> OperationResult<Vec<FieldIndexBuilder>> {
         let builders = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => {
@@ -229,6 +232,7 @@ impl IndexSelector<'_> {
                         field,
                         FieldIndexBuilder::IntMmapIndex,
                         FieldIndexBuilder::IntGridstoreIndex,
+                        id_tracker,
                     ))
                 } else {
                     None
@@ -241,6 +245,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::FloatMmapIndex,
                     FieldIndexBuilder::FloatGridstoreIndex,
+                    id_tracker,
                 )]
             }
             PayloadSchemaParams::Geo(_) => {
@@ -261,6 +266,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::DatetimeMmapIndex,
                     FieldIndexBuilder::DatetimeGridstoreIndex,
+                    id_tracker,
                 )]
             }
             PayloadSchemaParams::Uuid(_) => {
@@ -316,13 +322,14 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<NumericIndex<T, P>>>
     where
         Vec<T>: Blob,
     {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk)?
+                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
@@ -335,6 +342,7 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(NumericIndexMmapBuilder<T, P>) -> FieldIndexBuilder,
         make_gridstore: fn(NumericIndexGridstoreBuilder<T, P>) -> FieldIndexBuilder,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     ) -> FieldIndexBuilder
     where
         NumericIndex<T, P>: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -342,7 +350,7 @@ impl IndexSelector<'_> {
     {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
-                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk),
+                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, id_tracker),
             ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -10,7 +10,7 @@ use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, UniversalRead};
+use common::universal_io::{MmapFile, OpenOptions, UniversalRead};
 use fs_err as fs;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
@@ -19,11 +19,13 @@ use super::Encodable;
 use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::stored_bitslice::MmapBitSlice;
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
 
 const PAIRS_PATH: &str = "data.bin";
+const DELETED_PATH: &str = "deleted.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue + 'static> {
@@ -99,6 +101,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         fs::create_dir_all(path)?;
 
         let pairs_path = path.join(PAIRS_PATH);
+        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -131,6 +134,27 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             }
         }
 
+        {
+            let deleted_flags_count = in_memory_index.point_to_values.len();
+            let _ = create_and_ensure_length(
+                &deleted_path,
+                deleted_flags_count
+                    .div_ceil(u8::BITS as usize)
+                    .next_multiple_of(size_of::<u64>()),
+            )?;
+
+            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+            deleted.set_ascending_bits_batch(
+                in_memory_index
+                    .point_to_values
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, values)| values.is_empty())
+                    .map(|(idx, _)| (idx as u64, true)),
+            )?;
+            deleted.flusher()()?;
+        }
+
         Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
@@ -143,6 +167,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
+        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         // If config doesn't exist, assume the index doesn't exist on disk
@@ -162,12 +187,12 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         };
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
-        let mut deleted = BitVec::repeat(false, point_to_values.len());
-        for idx in 0..point_to_values.len() {
-            let deleted_payload = point_to_values.get_values_count(idx as _)?.unwrap_or(0) == 0;
-            let deleted_point = id_tracker.is_deleted_point(idx as PointOffsetType);
-            if deleted_payload || deleted_point {
-                deleted.set(idx, true);
+        let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let mut deleted = id_tracker.deleted_point_bitslice().to_owned();
+        for idx in 0..deleted_mmap.element_len() {
+            let deleted_payload = deleted_mmap.get_bit(idx)?.unwrap_or(false);
+            if deleted_payload {
+                deleted.set(idx as usize, true);
             }
         }
         let deleted_count = deleted.count_ones();
@@ -199,14 +224,22 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
+        let mut files = vec![
+            self.path.join(PAIRS_PATH),
+            self.path.join(DELETED_PATH),
+            self.path.join(CONFIG_PATH),
+        ];
         files.extend(self.storage.point_to_values.files());
         files.extend(Histogram::<T>::files(&self.path));
         files
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
+        let mut files = vec![
+            self.path.join(PAIRS_PATH),
+            self.path.join(DELETED_PATH),
+            self.path.join(CONFIG_PATH),
+        ];
         files.extend(self.storage.point_to_values.immutable_files());
         files.extend(Histogram::<T>::immutable_files(&self.path));
         files
@@ -386,8 +419,10 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let pairs_path = self.path.join(PAIRS_PATH);
+        let deleted_path = self.path.join(DELETED_PATH);
 
         clear_disk_cache(&pairs_path)?;
+        clear_disk_cache(&deleted_path)?;
 
         self.storage.point_to_values.clear_cache()?;
 

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -1,5 +1,5 @@
 use std::borrow::Borrow;
-use std::ops::Bound;
+use std::ops::{BitOrAssign, Bound};
 use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitSliceExt, BitVec};
@@ -20,7 +20,6 @@ use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
 
@@ -96,7 +95,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
@@ -155,7 +154,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             deleted.flusher()()?;
         }
 
-        Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
     }
@@ -164,7 +163,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     pub fn open(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
         let deleted_path = path.join(DELETED_PATH);
@@ -186,15 +185,18 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             )?)?
         };
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
+        let mut deleted = deleted_points.to_owned();
 
         let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let mut deleted = id_tracker.deleted_point_bitslice().to_owned();
-        for idx in 0..deleted_mmap.element_len() {
-            let deleted_payload = deleted_mmap.get_bit(idx)?.unwrap_or(false);
-            if deleted_payload {
-                deleted.set(idx as usize, true);
-            }
+        let stored_bitslice = deleted_mmap.read_all()?;
+
+        if deleted.len() < stored_bitslice.len() {
+            // There are points in id_tracker, which was not constructed with payload index
+            // Assume they don't exist in payload index
+            deleted.resize(stored_bitslice.len(), true);
         }
+
+        deleted.bitor_assign(stored_bitslice.as_ref());
         let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 
+use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -9,7 +10,7 @@ use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, UniversalRead};
+use common::universal_io::{MmapFile, UniversalRead};
 use fs_err as fs;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
@@ -17,14 +18,12 @@ use serde::{Deserialize, Serialize};
 use super::Encodable;
 use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::stored_bitslice::MmapBitSlice;
+use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
 
 const PAIRS_PATH: &str = "data.bin";
-const DELETED_PATH: &str = "deleted.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue + 'static> {
@@ -40,7 +39,7 @@ pub(super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
     S: UniversalRead<u8>,
 > {
-    deleted: MmapBitSliceBufferedUpdateWrapper,
+    deleted: BitVec,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pairs: MmapSlice<Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,
@@ -53,7 +52,7 @@ struct MmapNumericIndexConfig {
 
 pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
     pairs: &'a [Point<T>],
-    deleted: &'a MmapBitSliceBufferedUpdateWrapper,
+    deleted: &'a BitSlice,
     start_index: usize,
     end_index: usize,
 }
@@ -64,7 +63,7 @@ impl<T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'_, T> {
     fn next(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.pairs[self.start_index].clone();
-            let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
+            let deleted = self.deleted.get_bit(key.idx as usize).unwrap_or(true);
             self.start_index += 1;
             if deleted {
                 continue;
@@ -79,7 +78,7 @@ impl<T: Encodable + Numericable> DoubleEndedIterator for NumericIndexPairsIterat
     fn next_back(&mut self) -> Option<Self::Item> {
         while self.start_index < self.end_index {
             let key = self.pairs[self.end_index - 1].clone();
-            let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
+            let deleted = self.deleted.get_bit(key.idx as usize).unwrap_or(true);
             self.end_index -= 1;
             if deleted {
                 continue;
@@ -95,11 +94,11 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
         is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -132,36 +131,18 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             }
         }
 
-        {
-            let deleted_flags_count = in_memory_index.point_to_values.len();
-            let _ = create_and_ensure_length(
-                &deleted_path,
-                deleted_flags_count
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-
-            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-            deleted.set_ascending_bits_batch(
-                in_memory_index
-                    .point_to_values
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, values)| values.is_empty())
-                    .map(|(idx, _)| (idx as u64, true)),
-            )?;
-            deleted.flusher()()?;
-        }
-
-        Self::open(path, is_on_disk)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
     }
 
     /// Open and load mmap numeric index from the given path
-    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn open(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         // If config doesn't exist, assume the index doesn't exist on disk
@@ -171,8 +152,6 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
 
         let histogram = Histogram::<T>::load(path)?;
         let config: MmapNumericIndexConfig = read_json(&config_path)?;
-        let deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let deleted_count = deleted.count_ones()?;
         let do_populate = !is_on_disk;
         let map = unsafe {
             MmapSlice::try_from(mmap::open_write_mmap(
@@ -183,11 +162,21 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         };
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
+        let mut deleted = BitVec::repeat(false, point_to_values.len());
+        for idx in 0..point_to_values.len() {
+            let deleted_payload = point_to_values.get_values_count(idx as _)?.unwrap_or(0) == 0;
+            let deleted_point = id_tracker.is_deleted_point(idx as PointOffsetType);
+            if deleted_payload || deleted_point {
+                deleted.set(idx, true);
+            }
+        }
+        let deleted_count = deleted.count_ones();
+
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
                 pairs: map,
-                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                deleted,
                 point_to_values,
             },
             histogram,
@@ -210,11 +199,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
-        let mut files = vec![
-            self.path.join(PAIRS_PATH),
-            self.path.join(DELETED_PATH),
-            self.path.join(CONFIG_PATH),
-        ];
+        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
         files.extend(self.storage.point_to_values.files());
         files.extend(Histogram::<T>::files(&self.path));
         files
@@ -228,7 +213,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+        Box::new(|| Ok(()))
     }
 
     pub fn check_values_any(
@@ -239,7 +224,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     ) -> OperationResult<bool> {
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             self.storage
                 .point_to_values
                 .check_values_any(idx, |v| check_fn(v), &hw_counter)
@@ -249,7 +234,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             Some(Box::new(
                 self.storage
                     .point_to_values
@@ -264,7 +249,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             self.storage.point_to_values.get_values_count(idx).ok()?
         } else {
             None
@@ -303,7 +288,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
         let idx = idx as usize;
-        if idx < self.storage.deleted.len() && !self.storage.deleted.get(idx).unwrap_or(true) {
+        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
             self.storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
@@ -401,10 +386,8 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let pairs_path = self.path.join(PAIRS_PATH);
-        let deleted_path = self.path.join(DELETED_PATH);
 
         clear_disk_cache(&pairs_path)?;
-        clear_disk_cache(&deleted_path)?;
 
         self.storage.point_to_values.clear_cache()?;
 

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -187,16 +187,14 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let stored_bitslice = deleted_mmap.read_all()?;
+        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
-        if deleted.len() < stored_bitslice.len() {
-            // There are points in id_tracker, which was not constructed with payload index
-            // Assume they don't exist in payload index
-            deleted.resize(stored_bitslice.len(), true);
-        }
+        // The `id_tracker`'s deleted mask can be shorter or longer, but `deleted` length must match the
+        // `point_to_values` length because it only tracks the index's contents.
+        deleted.resize(point_to_values.len(), true);
+        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        deleted.bitor_assign(stored_bitslice.as_ref());
         let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -6,9 +6,10 @@ use common::bitvec::{BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
-use common::fs::{atomic_save_json, read_json};
+use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::generic_consts::Random;
 use common::mmap::{MmapSlice, create_and_ensure_length};
+use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
 use fs_err as fs;
@@ -26,6 +27,7 @@ use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
 
 const PAIRS_PATH: &str = "data.bin";
+const DELETED_PATH: &str = "deleted.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue + 'static> {
@@ -62,6 +64,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         fs::create_dir_all(path)?;
 
         let pairs_path = path.join(PAIRS_PATH);
+        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -94,6 +97,27 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             }
         }
 
+        {
+            let deleted_flags_count = in_memory_index.point_to_values.len();
+            let _ = create_and_ensure_length(
+                &deleted_path,
+                deleted_flags_count
+                    .div_ceil(u8::BITS as usize)
+                    .next_multiple_of(size_of::<u64>()),
+            )?;
+
+            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+            deleted.set_ascending_bits_batch(
+                in_memory_index
+                    .point_to_values
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, values)| values.is_empty())
+                    .map(|(idx, _)| (idx as u64, true)),
+            )?;
+            deleted.flusher()()?;
+        }
+
         Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
@@ -106,6 +130,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
+        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         // If config doesn't exist, assume the index doesn't exist on disk
@@ -129,12 +154,12 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
 
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
-        let mut deleted = BitVec::repeat(false, point_to_values.len());
-        for idx in 0..point_to_values.len() {
-            let deleted_payload = point_to_values.get_values_count(idx as _)?.unwrap_or(0) == 0;
-            let deleted_point = id_tracker.is_deleted_point(idx as PointOffsetType);
-            if deleted_payload || deleted_point {
-                deleted.set(idx, true);
+        let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let mut deleted = id_tracker.deleted_point_bitslice().to_owned();
+        for idx in 0..deleted_mmap.element_len() {
+            let deleted_payload = deleted_mmap.get_bit(idx)?.unwrap_or(false);
+            if deleted_payload {
+                deleted.set(idx as usize, true);
             }
         }
         let deleted_count = deleted.count_ones();
@@ -166,14 +191,22 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
+        let mut files = vec![
+            self.path.join(PAIRS_PATH),
+            self.path.join(DELETED_PATH),
+            self.path.join(CONFIG_PATH),
+        ];
         files.extend(self.storage.point_to_values.files());
         files.extend(Histogram::<T>::files(&self.path));
         files
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
+        let mut files = vec![
+            self.path.join(PAIRS_PATH),
+            self.path.join(DELETED_PATH),
+            self.path.join(CONFIG_PATH),
+        ];
         files.extend(self.storage.point_to_values.immutable_files());
         files.extend(Histogram::<T>::immutable_files(&self.path));
         files
@@ -399,7 +432,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let Self {
-            path: _,
+            path,
             storage,
             histogram: _,
             deleted_count: _,
@@ -412,6 +445,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             point_to_values,
         } = storage;
         pairs.clear_ram_cache()?;
+        clear_disk_cache(&path.join(DELETED_PATH))?;
         point_to_values.clear_cache()?;
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -2,17 +2,15 @@ use std::borrow::{Borrow, Cow};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 
+use common::bitvec::{BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::fs::{atomic_save_json, read_json};
 use common::generic_consts::Random;
 use common::mmap::{MmapSlice, create_and_ensure_length};
-use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{
-    MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead, UniversalWrite,
-};
+use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
 use fs_err as fs;
 use itertools::Either;
 use memmap2::MmapMut;
@@ -21,14 +19,13 @@ use serde::{Deserialize, Serialize};
 use super::Encodable;
 use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
-use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
 
 const PAIRS_PATH: &str = "data.bin";
-const DELETED_PATH: &str = "deleted.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue + 'static> {
@@ -42,9 +39,9 @@ pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue +
 
 pub(super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
-    S: UniversalWrite<u64> + UniversalRead<Point<T>> + UniversalRead<u8>,
+    S: UniversalRead<Point<T>> + UniversalRead<u8>,
 > {
-    deleted: BufferedUpdateBitSlice<S>,
+    deleted: BitVec,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pairs: TypedStorage<S, Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,
@@ -60,11 +57,11 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
         is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -97,36 +94,18 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             }
         }
 
-        {
-            let deleted_flags_count = in_memory_index.point_to_values.len();
-            let _ = create_and_ensure_length(
-                &deleted_path,
-                deleted_flags_count
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-
-            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-            deleted.set_ascending_bits_batch(
-                in_memory_index
-                    .point_to_values
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, values)| values.is_empty())
-                    .map(|(idx, _)| (idx as u64, true)),
-            )?;
-            deleted.flusher()()?;
-        }
-
-        Self::open(path, is_on_disk)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
     }
 
     /// Open and load mmap numeric index from the given path
-    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn open(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         // If config doesn't exist, assume the index doesn't exist on disk
@@ -136,8 +115,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
 
         let histogram = Histogram::<T>::load(path)?;
         let config: MmapNumericIndexConfig = read_json(&config_path)?;
-        let deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let deleted_count = deleted.count_ones()?;
         let do_populate = !is_on_disk;
 
         let pairs_options = OpenOptions {
@@ -152,11 +129,21 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
 
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
+        let mut deleted = BitVec::repeat(false, point_to_values.len());
+        for idx in 0..point_to_values.len() {
+            let deleted_payload = point_to_values.get_values_count(idx as _)?.unwrap_or(0) == 0;
+            let deleted_point = id_tracker.is_deleted_point(idx as PointOffsetType);
+            if deleted_payload || deleted_point {
+                deleted.set(idx, true);
+            }
+        }
+        let deleted_count = deleted.count_ones();
+
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
+                deleted,
                 pairs,
-                deleted: BufferedUpdateBitSlice::new(deleted),
                 point_to_values,
             },
             histogram,
@@ -179,11 +166,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
-        let mut files = vec![
-            self.path.join(PAIRS_PATH),
-            self.path.join(DELETED_PATH),
-            self.path.join(CONFIG_PATH),
-        ];
+        let mut files = vec![self.path.join(PAIRS_PATH), self.path.join(CONFIG_PATH)];
         files.extend(self.storage.point_to_values.files());
         files.extend(Histogram::<T>::files(&self.path));
         files
@@ -197,7 +180,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+        Box::new(|| Ok(()))
     }
 
     pub fn check_values_any(
@@ -208,7 +191,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     ) -> OperationResult<bool> {
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             self.storage
                 .point_to_values
                 .check_values_any(idx, |v| check_fn(v), &hw_counter)
@@ -218,7 +201,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             Some(Box::new(
                 self.storage
                     .point_to_values
@@ -233,7 +216,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.storage.deleted.get(idx as usize) == Some(false) {
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             self.storage.point_to_values.get_values_count(idx).ok()?
         } else {
             None
@@ -274,7 +257,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
         let idx = idx as usize;
-        if idx < self.storage.deleted.len() && !self.storage.deleted.get(idx).unwrap_or(true) {
+        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
             self.storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
@@ -391,7 +374,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
 
         let deleted = &self.storage.deleted;
 
-        Ok(iter.filter(move |point| !deleted.get(point.idx as usize).unwrap_or(true)))
+        Ok(iter.filter(move |point| !deleted.get_bit(point.idx as usize).unwrap_or(true)))
     }
 
     fn make_conditioned_counter<'a>(
@@ -424,12 +407,11 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             is_on_disk: _,
         } = self;
         let Storage {
-            deleted,
+            deleted: _,
             pairs,
             point_to_values,
         } = storage;
         pairs.clear_ram_cache()?;
-        deleted.clear_cache()?;
         point_to_values.clear_cache()?;
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -175,9 +175,12 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
-        // The `id_tracker`'s deleted mask can be shorter or longer, but `deleted` length must match the
-        // `point_to_values` length because it only tracks the index's contents.
-        deleted.resize(point_to_values.len(), true);
+        // `deleted` length must match `point_to_values.len()` because it only
+        // tracks the index's contents. The id-tracker's deleted mask can be
+        // shorter or longer; if shorter, the missing entries default to live
+        // (the id-tracker is the source of truth for deletions, and a shorter
+        // mask just means it doesn't yet know about those higher offsets).
+        deleted.resize(point_to_values.len(), false);
         deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
         let deleted_count = deleted.count_ones();

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -29,6 +29,17 @@ const PAIRS_PATH: &str = "data.bin";
 const DELETED_PATH: &str = "deleted.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
+/// Mmap-backed immutable numeric index.
+///
+/// On-disk state (`data.bin`, `deleted.bin`, `point_to_values.*`, etc.) is
+/// written once during [`Self::build`] and not mutated afterwards: `deleted.bin`
+/// records only the points whose payload was empty at build time.
+///
+/// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
+/// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
+/// only updates the in-memory bitvec. Callers must re-supply the authoritative
+/// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
+/// `deleted_points` argument to [`Self::open`] on reload.
 pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue + 'static> {
     path: PathBuf,
     pub(super) storage: Storage<T, MmapFile>,
@@ -233,6 +244,8 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         files
     }
 
+    /// No-op flusher: the on-disk state is build-time only. See the type-level
+    /// docs on [`MmapNumericIndex`] for the deletion durability contract.
     pub fn flusher(&self) -> Flusher {
         Box::new(|| Ok(()))
     }
@@ -309,6 +322,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             .map(|Point { val, idx, .. }| (val, idx)))
     }
 
+    /// Marks `idx` as deleted in the in-memory deletion bitvec.
+    ///
+    /// Not persisted: on reopen, deletions must be re-supplied via the
+    /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
         let idx = idx as usize;
         if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -48,6 +48,24 @@ pub(super) struct Storage<
     pub(super) point_to_values: StoredPointToValues<T, S>,
 }
 
+impl<
+    T: Encodable + Numericable + Default + StoredValue + 'static,
+    S: UniversalRead<Point<T>> + UniversalRead<u8>,
+> Storage<T, S>
+{
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            deleted,
+            pairs,
+            point_to_values,
+        } = self;
+
+        deleted.capacity().div_ceil(u8::BITS as usize)
+            + pairs.ram_usage_bytes()
+            + point_to_values.ram_usage_bytes()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MmapNumericIndexConfig {
     max_values_per_point: usize,
@@ -448,5 +466,18 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         clear_disk_cache(&path.join(DELETED_PATH))?;
         point_to_values.clear_cache()?;
         Ok(())
+    }
+
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            path: _,
+            storage,
+            histogram,
+            deleted_count: _,
+            max_values_per_point: _,
+            is_on_disk: _,
+        } = self;
+
+        histogram.ram_usage_bytes() + storage.ram_usage_bytes()
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -154,16 +154,14 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let stored_bitslice = deleted_mmap.read_all()?;
+        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
-        if deleted.len() < stored_bitslice.len() {
-            // There are points in id_tracker, which was not constructed with payload index
-            // Assume they don't exist in payload index
-            deleted.resize(stored_bitslice.len(), true);
-        }
+        // The `id_tracker`'s deleted mask can be shorter or longer, but `deleted` length must match the
+        // `point_to_values` length because it only tracks the index's contents.
+        deleted.resize(point_to_values.len(), true);
+        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        deleted.bitor_assign(stored_bitslice.as_ref());
         let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -1,8 +1,8 @@
 use std::borrow::{Borrow, Cow};
-use std::ops::Bound;
+use std::ops::{BitOrAssign, Bound};
 use std::path::{Path, PathBuf};
 
-use common::bitvec::{BitSliceExt, BitVec};
+use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -21,7 +21,6 @@ use super::Encodable;
 use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, StoredValue};
@@ -59,7 +58,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
@@ -118,7 +117,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
             deleted.flusher()()?;
         }
 
-        Self::open(path, is_on_disk, id_tracker)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapNumericIndex after building it")
         })
     }
@@ -127,7 +126,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     pub fn open(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
         let deleted_path = path.join(DELETED_PATH);
@@ -153,15 +152,18 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         let pairs = TypedStorage::open(pairs_path, pairs_options)?;
 
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
+        let mut deleted = deleted_points.to_owned();
 
         let deleted_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
-        let mut deleted = id_tracker.deleted_point_bitslice().to_owned();
-        for idx in 0..deleted_mmap.element_len() {
-            let deleted_payload = deleted_mmap.get_bit(idx)?.unwrap_or(false);
-            if deleted_payload {
-                deleted.set(idx as usize, true);
-            }
+        let stored_bitslice = deleted_mmap.read_all()?;
+
+        if deleted.len() < stored_bitslice.len() {
+            // There are points in id_tracker, which was not constructed with payload index
+            // Assume they don't exist in payload index
+            deleted.resize(stored_bitslice.len(), true);
         }
+
+        deleted.bitor_assign(stored_bitslice.as_ref());
         let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -11,10 +11,9 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use chrono::DateTime;
+use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use delegate::delegate;
@@ -34,7 +33,6 @@ use super::stored_point_to_values::StoredValue;
 use super::utils::{check_boundaries, value_to_integer};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::histogram::{Histogram, Numericable};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
@@ -179,9 +177,9 @@ where
     pub fn new_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let Some(mmap_index) = MmapNumericIndex::open(path, is_on_disk, id_tracker)? else {
+        let Some(mmap_index) = MmapNumericIndex::open(path, is_on_disk, deleted_points)? else {
             // Files don't exist, cannot load
             return Ok(None);
         };
@@ -499,9 +497,9 @@ where
     pub fn new_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let index = NumericIndexInner::new_mmap(path, is_on_disk, id_tracker)?;
+        let index = NumericIndexInner::new_mmap(path, is_on_disk, deleted_points)?;
 
         Ok(index.map(|inner| Self {
             inner,
@@ -521,7 +519,7 @@ where
     pub fn builder_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> NumericIndexMmapBuilder<T, P>
     where
         Self: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -530,7 +528,7 @@ where
             path: path.to_owned(),
             in_memory_index: InMemoryNumericIndex::default(),
             is_on_disk,
-            id_tracker,
+            deleted_points: deleted_points.to_owned(),
             _phantom: PhantomData,
         }
     }
@@ -630,7 +628,7 @@ where
     path: PathBuf,
     in_memory_index: InMemoryNumericIndex<T>,
     is_on_disk: bool,
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+    deleted_points: BitVec,
     _phantom: PhantomData<P>,
 }
 
@@ -676,7 +674,7 @@ where
             self.in_memory_index,
             &self.path,
             self.is_on_disk,
-            &self.id_tracker.borrow(),
+            &self.deleted_points,
         )?;
         Ok(NumericIndex {
             inner: NumericIndexInner::Mmap(inner),

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -11,7 +11,9 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use chrono::DateTime;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -32,6 +34,7 @@ use super::stored_point_to_values::StoredValue;
 use super::utils::{check_boundaries, value_to_integer};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::histogram::{Histogram, Numericable};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
@@ -173,8 +176,12 @@ where
     Vec<T>: Blob,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
-        let Some(mmap_index) = MmapNumericIndex::open(path, is_on_disk)? else {
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
+        let Some(mmap_index) = MmapNumericIndex::open(path, is_on_disk, id_tracker)? else {
             // Files don't exist, cannot load
             return Ok(None);
         };
@@ -489,8 +496,12 @@ where
     Vec<T>: Blob,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
-        let index = NumericIndexInner::new_mmap(path, is_on_disk)?;
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
+        let index = NumericIndexInner::new_mmap(path, is_on_disk, id_tracker)?;
 
         Ok(index.map(|inner| Self {
             inner,
@@ -507,7 +518,11 @@ where
         }))
     }
 
-    pub fn builder_mmap(path: &Path, is_on_disk: bool) -> NumericIndexMmapBuilder<T, P>
+    pub fn builder_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+    ) -> NumericIndexMmapBuilder<T, P>
     where
         Self: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
     {
@@ -515,6 +530,7 @@ where
             path: path.to_owned(),
             in_memory_index: InMemoryNumericIndex::default(),
             is_on_disk,
+            id_tracker,
             _phantom: PhantomData,
         }
     }
@@ -614,6 +630,7 @@ where
     path: PathBuf,
     in_memory_index: InMemoryNumericIndex<T>,
     is_on_disk: bool,
+    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     _phantom: PhantomData<P>,
 }
 
@@ -655,7 +672,12 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        let inner = MmapNumericIndex::build(self.in_memory_index, &self.path, self.is_on_disk)?;
+        let inner = MmapNumericIndex::build(
+            self.in_memory_index,
+            &self.path,
+            self.is_on_disk,
+            &self.id_tracker.borrow(),
+        )?;
         Ok(NumericIndex {
             inner: NumericIndexInner::Mmap(inner),
             _phantom: PhantomData,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -11,10 +11,9 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use chrono::DateTime;
+use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use gridstore::Blob;
@@ -32,7 +31,6 @@ use super::stored_point_to_values::StoredValue;
 use super::utils::{check_boundaries, value_to_integer};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -178,7 +176,7 @@ where
     pub fn new_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
         // pure-mmap `Storage` variant at load time. Files are shared between
@@ -187,7 +185,7 @@ where
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = MmapNumericIndex::open(path, effective_is_on_disk, id_tracker)?
+        let Some(mmap_index) = MmapNumericIndex::open(path, effective_is_on_disk, deleted_points)?
         else {
             // Files don't exist, cannot load
             return Ok(None);
@@ -519,9 +517,9 @@ where
     pub fn new_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: &IdTrackerEnum,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let index = NumericIndexInner::new_mmap(path, is_on_disk, id_tracker)?;
+        let index = NumericIndexInner::new_mmap(path, is_on_disk, deleted_points)?;
 
         Ok(index.map(|inner| Self {
             inner,
@@ -541,7 +539,7 @@ where
     pub fn builder_mmap(
         path: &Path,
         is_on_disk: bool,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        deleted_points: &BitSlice,
     ) -> NumericIndexMmapBuilder<T, P>
     where
         Self: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
@@ -550,7 +548,7 @@ where
             path: path.to_owned(),
             in_memory_index: InMemoryNumericIndex::default(),
             is_on_disk,
-            id_tracker,
+            deleted_points: deleted_points.to_owned(),
             _phantom: PhantomData,
         }
     }
@@ -677,7 +675,7 @@ where
     path: PathBuf,
     in_memory_index: InMemoryNumericIndex<T>,
     is_on_disk: bool,
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+    deleted_points: BitVec,
     _phantom: PhantomData<P>,
 }
 
@@ -723,7 +721,7 @@ where
             self.in_memory_index,
             &self.path,
             self.is_on_disk,
-            &self.id_tracker.borrow(),
+            &self.deleted_points,
         )?;
         Ok(NumericIndex {
             inner: NumericIndexInner::Mmap(inner),

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -11,7 +11,9 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
 use chrono::DateTime;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -30,6 +32,7 @@ use super::stored_point_to_values::StoredValue;
 use super::utils::{check_boundaries, value_to_integer};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::IdTrackerEnum;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -172,7 +175,11 @@ where
     Vec<T>: Blob,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
         // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
         // pure-mmap `Storage` variant at load time. Files are shared between
         // variants; the persisted `is_on_disk` flag in `mmap_index` is
@@ -180,7 +187,8 @@ where
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = MmapNumericIndex::open(path, effective_is_on_disk)? else {
+        let Some(mmap_index) = MmapNumericIndex::open(path, effective_is_on_disk, id_tracker)?
+        else {
             // Files don't exist, cannot load
             return Ok(None);
         };
@@ -508,8 +516,12 @@ where
     Vec<T>: Blob,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
-        let index = NumericIndexInner::new_mmap(path, is_on_disk)?;
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: &IdTrackerEnum,
+    ) -> OperationResult<Option<Self>> {
+        let index = NumericIndexInner::new_mmap(path, is_on_disk, id_tracker)?;
 
         Ok(index.map(|inner| Self {
             inner,
@@ -526,7 +538,11 @@ where
         }))
     }
 
-    pub fn builder_mmap(path: &Path, is_on_disk: bool) -> NumericIndexMmapBuilder<T, P>
+    pub fn builder_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+    ) -> NumericIndexMmapBuilder<T, P>
     where
         Self: ValueIndexer<ValueType = P> + NumericIndexIntoInnerValue<T, P>,
     {
@@ -534,6 +550,7 @@ where
             path: path.to_owned(),
             in_memory_index: InMemoryNumericIndex::default(),
             is_on_disk,
+            id_tracker,
             _phantom: PhantomData,
         }
     }
@@ -660,6 +677,7 @@ where
     path: PathBuf,
     in_memory_index: InMemoryNumericIndex<T>,
     is_on_disk: bool,
+    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     _phantom: PhantomData<P>,
 }
 
@@ -701,7 +719,12 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        let inner = MmapNumericIndex::build(self.in_memory_index, &self.path, self.is_on_disk)?;
+        let inner = MmapNumericIndex::build(
+            self.in_memory_index,
+            &self.path,
+            self.is_on_disk,
+            &self.id_tracker.borrow(),
+        )?;
         Ok(NumericIndex {
             inner: NumericIndexInner::Mmap(inner),
             _phantom: PhantomData,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -461,7 +461,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.ram_usage_bytes(),
             NumericIndexInner::Immutable(index) => index.ram_usage_bytes(),
-            NumericIndexInner::Mmap(_) => 0, // mmap-backed, accounted via files
+            NumericIndexInner::Mmap(index) => index.ram_usage_bytes(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,9 +6,28 @@ use rstest::rstest;
 use tempfile::{Builder, TempDir};
 
 use super::*;
-use crate::id_tracker::id_tracker_base::IdTracker;
 use crate::json_path::JsonPath;
-use crate::types::ExtendedPointId;
+
+/// Generous default size for the deleted-points bitslice used in tests.
+///
+/// Must be larger than the stored mmap deletion bitslice for any test in this
+/// file (which is sized to the highest point id, rounded up to a `u64`
+/// boundary). 4096 bits comfortably covers all current tests.
+const TEST_DELETED_BITS: usize = 4096;
+
+/// All-zero deletion bitslice for tests that don't care about deletions.
+fn empty_deleted() -> BitVec {
+    BitVec::repeat(false, TEST_DELETED_BITS)
+}
+
+/// Deletion bitslice with specific points marked as deleted.
+fn deleted_with(points: &[PointOffsetType]) -> BitVec {
+    let mut v = empty_deleted();
+    for &p in points {
+        v.set(p as usize, true);
+    }
+    v
+}
 
 #[derive(Clone, Copy)]
 enum IndexType {
@@ -43,12 +62,7 @@ impl IndexBuilder {
     }
 }
 
-fn get_index_builder(
-    index_type: IndexType,
-) -> (TempDir, IndexBuilder, Arc<AtomicRefCell<IdTrackerEnum>>) {
-    let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
-        Default::default(),
-    )));
+fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
     let temp_dir = Builder::new()
         .prefix("test_numeric_index")
         .tempdir()
@@ -66,29 +80,29 @@ fn get_index_builder(
         >::builder_mmap(
             temp_dir.path(),
             false,
-            id_tracker.clone(),
+            &empty_deleted(),
         )),
     };
     match &mut builder {
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         IndexBuilder::Mmap(builder) => builder.init().unwrap(),
     }
-    (temp_dir, builder, id_tracker)
+    (temp_dir, builder)
 }
 
 fn open_index_from_disk(
     temp_dir: &Path,
     index_type: IndexType,
-    id_tracker: &IdTrackerEnum,
+    deleted: &BitSlice,
 ) -> NumericIndex<FloatPayloadType, FloatPayloadType> {
     match index_type {
         IndexType::MutableGridstore => NumericIndex::new_gridstore(temp_dir.to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, id_tracker)
+        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, deleted)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, id_tracker)
+        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, deleted)
             .unwrap()
             .unwrap(),
     }
@@ -98,30 +112,20 @@ fn random_index(
     num_points: usize,
     values_per_point: usize,
     index_type: IndexType,
-) -> (
-    TempDir,
-    NumericIndex<FloatPayloadType, FloatPayloadType>,
-    Arc<AtomicRefCell<IdTrackerEnum>>,
-) {
+) -> (TempDir, NumericIndex<FloatPayloadType, FloatPayloadType>) {
     let mut rng = StdRng::seed_from_u64(42);
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let hw_counter = HardwareCounterCell::new();
 
-    {
-        for i in 0..num_points {
-            let values = (0..values_per_point)
-                .map(|_| Value::from(rng.random_range(0.0..100.0)))
-                .collect_vec();
-            let values = values.iter().collect_vec();
-            id_tracker
-                .borrow_mut()
-                .set_link(ExtendedPointId::NumId(i as _), i as _)
-                .unwrap();
-            index_builder
-                .add_point(i as PointOffsetType, &values, &hw_counter)
-                .unwrap();
-        }
+    for i in 0..num_points {
+        let values = (0..values_per_point)
+            .map(|_| Value::from(rng.random_range(0.0..100.0)))
+            .collect_vec();
+        let values = values.iter().collect_vec();
+        index_builder
+            .add_point(i as PointOffsetType, &values, &hw_counter)
+            .unwrap();
     }
     let mut index = index_builder.finalize().unwrap();
 
@@ -135,7 +139,7 @@ fn random_index(
         };
     }
 
-    (temp_dir, index, id_tracker)
+    (temp_dir, index)
 }
 
 fn cardinality_request(
@@ -180,7 +184,7 @@ fn cardinality_request(
 
 #[test]
 fn test_set_empty_payload() {
-    let (_temp_dir, mut index, id_tracker) = random_index(1000, 1, IndexType::MutableGridstore);
+    let (_temp_dir, mut index) = random_index(1000, 1, IndexType::MutableGridstore);
 
     let point_id = 42;
 
@@ -191,10 +195,6 @@ fn test_set_empty_payload() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = serde_json::json!(null);
-    id_tracker
-        .borrow_mut()
-        .set_link(ExtendedPointId::NumId(point_id.into()), point_id as _)
-        .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
     let values_count = index.inner().get_values(point_id).unwrap().count();
@@ -207,7 +207,7 @@ fn test_set_empty_payload() {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_cardinality_exp(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 1, index_type);
+    let (_temp_dir, index) = random_index(1000, 1, index_type);
 
     cardinality_request(
         &index,
@@ -230,7 +230,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
+    let (_temp_dir, index) = random_index(1000, 2, index_type);
     cardinality_request(
         &index,
         Range {
@@ -280,7 +280,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
+    let (_temp_dir, index) = random_index(1000, 2, index_type);
     let threshold = 100;
     let blocks = index
         .inner()
@@ -323,7 +323,7 @@ fn test_payload_blocks(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks_small(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
     let threshold = 4;
     let values = vec![
         vec![1.0],
@@ -343,10 +343,6 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_id = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_id.into()), new_id)
-            .unwrap();
         index_builder
             .add_point(new_id, &values, &hw_counter)
             .unwrap();
@@ -366,7 +362,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -386,10 +382,6 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -398,7 +390,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 
     drop(index);
 
-    let id_tracker = id_tracker.borrow();
+    let deleted = empty_deleted();
     let new_index = match index_type {
         IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
             temp_dir.path().to_path_buf(),
@@ -407,12 +399,12 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         .unwrap()
         .unwrap(),
         IndexType::Mmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &id_tracker)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &deleted)
                 .unwrap()
                 .unwrap()
         }
         IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &id_tracker)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &deleted)
                 .unwrap()
                 .unwrap()
         }
@@ -435,7 +427,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -455,10 +447,6 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -521,11 +509,8 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     );
 
     // Remove some points
-    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
-    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
-    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
 
     test_cond(
@@ -589,7 +574,7 @@ fn test_numeric_index(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_reload(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -609,10 +594,6 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -675,17 +656,20 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
     );
 
     // Remove some points
-    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
-    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
-    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
     index.inner().flusher()().unwrap();
 
     // Reload!
+    //
+    // Note: `MmapNumericIndex::remove_point` is in-memory only — it doesn't
+    // persist to the on-disk deletion bitslice. The reload path picks up
+    // deletions from the `&BitSlice` argument, so for this test we have to
+    // re-supply the same set of removed points here.
     drop(index);
-    let index = open_index_from_disk(temp_dir.path(), index_type, &id_tracker.borrow());
+    let deleted = deleted_with(&[1, 2, 5]);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &deleted);
 
     test_cond(
         index.inner(),
@@ -778,7 +762,7 @@ fn test_cond<
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_empty_cardinality(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(0, 1, index_type);
+    let (_temp_dir, index) = random_index(0, 1, index_type);
     cardinality_request(
         &index,
         Range {
@@ -790,7 +774,7 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index, _id_tracker) = random_index(0, 0, index_type);
+    let (_temp_dir, index) = random_index(0, 0, index_type);
     cardinality_request(
         &index,
         Range {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,7 +6,9 @@ use rstest::rstest;
 use tempfile::{Builder, TempDir};
 
 use super::*;
+use crate::id_tracker::id_tracker_base::IdTracker;
 use crate::json_path::JsonPath;
+use crate::types::ExtendedPointId;
 
 #[derive(Clone, Copy)]
 enum IndexType {
@@ -41,7 +43,12 @@ impl IndexBuilder {
     }
 }
 
-fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
+fn get_index_builder(
+    index_type: IndexType,
+) -> (TempDir, IndexBuilder, Arc<AtomicRefCell<IdTrackerEnum>>) {
+    let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
+        Default::default(),
+    )));
     let temp_dir = Builder::new()
         .prefix("test_numeric_index")
         .tempdir()
@@ -57,36 +64,47 @@ fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
             FloatPayloadType,
             FloatPayloadType,
         >::builder_mmap(
-            temp_dir.path(), false
+            temp_dir.path(),
+            false,
+            id_tracker.clone(),
         )),
     };
     match &mut builder {
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         IndexBuilder::Mmap(builder) => builder.init().unwrap(),
     }
-    (temp_dir, builder)
+    (temp_dir, builder, id_tracker)
 }
 
 fn random_index(
     num_points: usize,
     values_per_point: usize,
     index_type: IndexType,
-) -> (TempDir, NumericIndex<FloatPayloadType, FloatPayloadType>) {
+) -> (
+    TempDir,
+    NumericIndex<FloatPayloadType, FloatPayloadType>,
+    Arc<AtomicRefCell<IdTrackerEnum>>,
+) {
     let mut rng = StdRng::seed_from_u64(42);
-    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let hw_counter = HardwareCounterCell::new();
 
-    for i in 0..num_points {
-        let values = (0..values_per_point)
-            .map(|_| Value::from(rng.random_range(0.0..100.0)))
-            .collect_vec();
-        let values = values.iter().collect_vec();
-        index_builder
-            .add_point(i as PointOffsetType, &values, &hw_counter)
-            .unwrap();
+    {
+        for i in 0..num_points {
+            let values = (0..values_per_point)
+                .map(|_| Value::from(rng.random_range(0.0..100.0)))
+                .collect_vec();
+            let values = values.iter().collect_vec();
+            id_tracker
+                .borrow_mut()
+                .set_link(ExtendedPointId::NumId(i as _), i as _)
+                .unwrap();
+            index_builder
+                .add_point(i as PointOffsetType, &values, &hw_counter)
+                .unwrap();
+        }
     }
-
     let mut index = index_builder.finalize().unwrap();
 
     if matches!(index_type, IndexType::RamMmap) {
@@ -99,7 +117,7 @@ fn random_index(
         };
     }
 
-    (temp_dir, index)
+    (temp_dir, index, id_tracker)
 }
 
 fn cardinality_request(
@@ -133,14 +151,18 @@ fn cardinality_request(
 
     eprintln!("estimation = {estimation:#?}");
     eprintln!("result.len() = {:#?}", result.len());
-    assert!(estimation.min <= result.len());
+    assert!(
+        estimation.min <= result.len(),
+        "{estimation:#?} should be less than or equal to {:#?}",
+        result.len()
+    );
     assert!(estimation.max >= result.len());
     estimation
 }
 
 #[test]
 fn test_set_empty_payload() {
-    let (_temp_dir, mut index) = random_index(1000, 1, IndexType::MutableGridstore);
+    let (_temp_dir, mut index, id_tracker) = random_index(1000, 1, IndexType::MutableGridstore);
 
     let point_id = 42;
 
@@ -151,6 +173,10 @@ fn test_set_empty_payload() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = serde_json::json!(null);
+    id_tracker
+        .borrow_mut()
+        .set_link(ExtendedPointId::NumId(point_id as _), point_id as _)
+        .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
     let values_count = index.inner().get_values(point_id).unwrap().count();
@@ -163,7 +189,7 @@ fn test_set_empty_payload() {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_cardinality_exp(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(1000, 1, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 1, index_type);
 
     cardinality_request(
         &index,
@@ -186,7 +212,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index) = random_index(1000, 2, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
     cardinality_request(
         &index,
         Range {
@@ -236,7 +262,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(1000, 2, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
     let threshold = 100;
     let blocks = index
         .inner()
@@ -279,7 +305,7 @@ fn test_payload_blocks(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks_small(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
     let threshold = 4;
     let values = vec![
         vec![1.0],
@@ -298,8 +324,13 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_id = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_id as _), new_id)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_id, &values, &hw_counter)
             .unwrap();
     });
     let index = index_builder.finalize().unwrap();
@@ -317,7 +348,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -336,14 +367,20 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_idx, &values, &hw_counter)
             .unwrap();
     });
     let index = index_builder.finalize().unwrap();
 
     drop(index);
 
+    let id_tracker = id_tracker.borrow();
     let new_index = match index_type {
         IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
             temp_dir.path().to_path_buf(),
@@ -351,11 +388,13 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         )
         .unwrap()
         .unwrap(),
-        IndexType::Mmap => NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true)
-            .unwrap()
-            .unwrap(),
+        IndexType::Mmap => {
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &id_tracker)
+                .unwrap()
+                .unwrap()
+        }
         IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &id_tracker)
                 .unwrap()
                 .unwrap()
         }
@@ -378,7 +417,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -397,8 +436,13 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_idx, &values, &hw_counter)
             .unwrap();
     });
     let mut index = index_builder.finalize().unwrap();
@@ -459,8 +503,11 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     );
 
     // Remove some points
+    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
+    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
+    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
 
     test_cond(
@@ -552,7 +599,7 @@ fn test_cond<
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_empty_cardinality(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(0, 1, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(0, 1, index_type);
     cardinality_request(
         &index,
         Range {
@@ -564,7 +611,7 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index) = random_index(0, 0, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(0, 0, index_type);
     cardinality_request(
         &index,
         Range {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -193,7 +193,7 @@ fn test_set_empty_payload() {
     let payload = serde_json::json!(null);
     id_tracker
         .borrow_mut()
-        .set_link(ExtendedPointId::NumId(point_id as _), point_id as _)
+        .set_link(ExtendedPointId::NumId(point_id.into()), point_id as _)
         .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
@@ -345,7 +345,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
         let new_id = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_id as _), new_id)
+            .set_link(ExtendedPointId::NumId(new_id.into()), new_id)
             .unwrap();
         index_builder
             .add_point(new_id, &values, &hw_counter)
@@ -388,7 +388,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
@@ -457,7 +457,7 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
@@ -611,7 +611,7 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -76,6 +76,24 @@ fn get_index_builder(
     (temp_dir, builder, id_tracker)
 }
 
+fn open_index_from_disk(
+    temp_dir: &Path,
+    index_type: IndexType,
+    id_tracker: &IdTrackerEnum,
+) -> NumericIndex<FloatPayloadType, FloatPayloadType> {
+    match index_type {
+        IndexType::MutableGridstore => NumericIndex::new_gridstore(temp_dir.to_path_buf(), true)
+            .unwrap()
+            .unwrap(),
+        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, id_tracker)
+            .unwrap()
+            .unwrap(),
+        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, id_tracker)
+            .unwrap()
+            .unwrap(),
+    }
+}
+
 fn random_index(
     num_points: usize,
     values_per_point: usize,
@@ -564,6 +582,167 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         },
         vec![6, 7, 8],
     );
+}
+
+#[rstest]
+#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_numeric_index_reload(#[case] index_type: IndexType) {
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+
+    let values = vec![
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![2.0],
+        vec![2.5],
+        vec![2.6],
+        vec![3.0],
+    ];
+
+    let hw_counter = HardwareCounterCell::new();
+
+    values.into_iter().enumerate().for_each(|(idx, values)| {
+        let values = values.iter().map(|v| Value::from(*v)).collect_vec();
+        let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
+        index_builder
+            .add_point(new_idx, &values, &hw_counter)
+            .unwrap();
+    });
+    let mut index = index_builder.finalize().unwrap();
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: Some(1.0),
+            gte: None,
+            lt: None,
+            lte: None,
+        },
+        vec![6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: Some(2.6),
+            lte: None,
+        },
+        vec![1, 2, 3, 4, 5, 6, 7],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![1, 2, 3, 4, 5, 6, 7, 8],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(2.0),
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![6, 7, 8],
+    );
+
+    // Remove some points
+    id_tracker.borrow_mut().drop_internal(1).unwrap();
+    index.remove_point(1).unwrap();
+    id_tracker.borrow_mut().drop_internal(2).unwrap();
+    index.remove_point(2).unwrap();
+    id_tracker.borrow_mut().drop_internal(5).unwrap();
+    index.remove_point(5).unwrap();
+    index.inner().flusher()().unwrap();
+
+    // Reload!
+    drop(index);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &id_tracker.borrow());
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: Some(1.0),
+            gte: None,
+            lt: None,
+            lte: None,
+        },
+        vec![6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![3, 4, 6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: Some(2.6),
+            lte: None,
+        },
+        vec![3, 4, 6, 7],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![3, 4, 6, 7, 8],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(2.0),
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![6, 7, 8],
+    );
+
+    assert_eq!(index.inner().get_points_count(), 6);
 }
 
 fn test_cond<

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -728,6 +728,64 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
     assert_eq!(index.inner().get_points_count(), 6);
 }
 
+/// Regression test: when reloading an mmap numeric index with a `deleted_points`
+/// bitslice shorter than `point_to_values.len()`, missing entries must default
+/// to live, not deleted. Empty-payload bits from the on-disk `deleted.bin` and
+/// any deletions encoded inside the short bitslice must still be honored.
+#[rstest]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_numeric_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+
+    // 9 points with ids 1..=9 → point_to_values.len() == 10.
+    // Point 4 has an empty payload, so build-time `deleted.bin` will mark it.
+    let values: Vec<Vec<f64>> = vec![
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![], // empty payload at id 4
+        vec![1.0],
+        vec![2.0],
+        vec![2.5],
+        vec![2.6],
+        vec![3.0],
+    ];
+
+    let hw_counter = HardwareCounterCell::new();
+    values.into_iter().enumerate().for_each(|(idx, values)| {
+        let values = values.iter().map(|v| Value::from(*v)).collect_vec();
+        let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        index_builder
+            .add_point(new_idx, &values, &hw_counter)
+            .unwrap();
+    });
+    let index = index_builder.finalize().unwrap();
+    drop(index);
+
+    // Reload with a bitslice shorter than `point_to_values.len()` that still
+    // marks point 1 as deleted. Models an id-tracker whose internal range
+    // hasn't yet caught up to the index's highest internal id.
+    let mut short_deleted = BitVec::repeat(false, 3);
+    short_deleted.set(1, true);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &short_deleted);
+
+    // Expect: id 1 deleted (from short bitslice), id 4 deleted (from build-time
+    // empty payload), every other id live including those beyond the bitslice.
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![2, 3, 5, 6, 7, 8, 9],
+    );
+    assert_eq!(index.inner().get_points_count(), 7);
+}
+
 fn test_cond<
     T: Encodable + Numericable + PartialOrd + Clone + StoredValue + Send + Sync + Default + 'static,
 >(

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -76,6 +76,24 @@ fn get_index_builder(
     (temp_dir, builder, id_tracker)
 }
 
+fn open_index_from_disk(
+    temp_dir: &Path,
+    index_type: IndexType,
+    id_tracker: &IdTrackerEnum,
+) -> NumericIndex<FloatPayloadType, FloatPayloadType> {
+    match index_type {
+        IndexType::MutableGridstore => NumericIndex::new_gridstore(temp_dir.to_path_buf(), true)
+            .unwrap()
+            .unwrap(),
+        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, id_tracker)
+            .unwrap()
+            .unwrap(),
+        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, id_tracker)
+            .unwrap()
+            .unwrap(),
+    }
+}
+
 fn random_index(
     num_points: usize,
     values_per_point: usize,
@@ -563,6 +581,167 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         },
         vec![6, 7, 8],
     );
+}
+
+#[rstest]
+#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_numeric_index_reload(#[case] index_type: IndexType) {
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+
+    let values = vec![
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![2.0],
+        vec![2.5],
+        vec![2.6],
+        vec![3.0],
+    ];
+
+    let hw_counter = HardwareCounterCell::new();
+
+    values.into_iter().enumerate().for_each(|(idx, values)| {
+        let values = values.iter().map(|v| Value::from(*v)).collect_vec();
+        let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
+        index_builder
+            .add_point(new_idx, &values, &hw_counter)
+            .unwrap();
+    });
+    let mut index = index_builder.finalize().unwrap();
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: Some(1.0),
+            gte: None,
+            lt: None,
+            lte: None,
+        },
+        vec![6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: Some(2.6),
+            lte: None,
+        },
+        vec![1, 2, 3, 4, 5, 6, 7],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![1, 2, 3, 4, 5, 6, 7, 8],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(2.0),
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![6, 7, 8],
+    );
+
+    // Remove some points
+    id_tracker.borrow_mut().drop_internal(1).unwrap();
+    index.remove_point(1).unwrap();
+    id_tracker.borrow_mut().drop_internal(2).unwrap();
+    index.remove_point(2).unwrap();
+    id_tracker.borrow_mut().drop_internal(5).unwrap();
+    index.remove_point(5).unwrap();
+    index.inner().flusher()().unwrap();
+
+    // Reload!
+    drop(index);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &id_tracker.borrow());
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: Some(1.0),
+            gte: None,
+            lt: None,
+            lte: None,
+        },
+        vec![6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![3, 4, 6, 7, 8, 9],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: Some(2.6),
+            lte: None,
+        },
+        vec![3, 4, 6, 7],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: None,
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![3, 4, 6, 7, 8],
+    );
+
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(2.0),
+            lt: None,
+            lte: Some(2.6),
+        },
+        vec![6, 7, 8],
+    );
+
+    assert_eq!(index.inner().get_points_count(), 6);
 }
 
 fn test_cond<

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,7 +6,9 @@ use rstest::rstest;
 use tempfile::{Builder, TempDir};
 
 use super::*;
+use crate::id_tracker::id_tracker_base::IdTracker;
 use crate::json_path::JsonPath;
+use crate::types::ExtendedPointId;
 
 #[derive(Clone, Copy)]
 enum IndexType {
@@ -41,7 +43,12 @@ impl IndexBuilder {
     }
 }
 
-fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
+fn get_index_builder(
+    index_type: IndexType,
+) -> (TempDir, IndexBuilder, Arc<AtomicRefCell<IdTrackerEnum>>) {
+    let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
+        Default::default(),
+    )));
     let temp_dir = Builder::new()
         .prefix("test_numeric_index")
         .tempdir()
@@ -57,36 +64,47 @@ fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
             FloatPayloadType,
             FloatPayloadType,
         >::builder_mmap(
-            temp_dir.path(), false
+            temp_dir.path(),
+            false,
+            id_tracker.clone(),
         )),
     };
     match &mut builder {
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         IndexBuilder::Mmap(builder) => builder.init().unwrap(),
     }
-    (temp_dir, builder)
+    (temp_dir, builder, id_tracker)
 }
 
 fn random_index(
     num_points: usize,
     values_per_point: usize,
     index_type: IndexType,
-) -> (TempDir, NumericIndex<FloatPayloadType, FloatPayloadType>) {
+) -> (
+    TempDir,
+    NumericIndex<FloatPayloadType, FloatPayloadType>,
+    Arc<AtomicRefCell<IdTrackerEnum>>,
+) {
     let mut rng = StdRng::seed_from_u64(42);
-    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let hw_counter = HardwareCounterCell::new();
 
-    for i in 0..num_points {
-        let values = (0..values_per_point)
-            .map(|_| Value::from(rng.random_range(0.0..100.0)))
-            .collect_vec();
-        let values = values.iter().collect_vec();
-        index_builder
-            .add_point(i as PointOffsetType, &values, &hw_counter)
-            .unwrap();
+    {
+        for i in 0..num_points {
+            let values = (0..values_per_point)
+                .map(|_| Value::from(rng.random_range(0.0..100.0)))
+                .collect_vec();
+            let values = values.iter().collect_vec();
+            id_tracker
+                .borrow_mut()
+                .set_link(ExtendedPointId::NumId(i as _), i as _)
+                .unwrap();
+            index_builder
+                .add_point(i as PointOffsetType, &values, &hw_counter)
+                .unwrap();
+        }
     }
-
     let mut index = index_builder.finalize().unwrap();
 
     if matches!(index_type, IndexType::RamMmap) {
@@ -99,7 +117,7 @@ fn random_index(
         };
     }
 
-    (temp_dir, index)
+    (temp_dir, index, id_tracker)
 }
 
 fn cardinality_request(
@@ -134,14 +152,18 @@ fn cardinality_request(
 
     eprintln!("estimation = {estimation:#?}");
     eprintln!("result.len() = {:#?}", result.len());
-    assert!(estimation.min <= result.len());
+    assert!(
+        estimation.min <= result.len(),
+        "{estimation:#?} should be less than or equal to {:#?}",
+        result.len()
+    );
     assert!(estimation.max >= result.len());
     estimation
 }
 
 #[test]
 fn test_set_empty_payload() {
-    let (_temp_dir, mut index) = random_index(1000, 1, IndexType::MutableGridstore);
+    let (_temp_dir, mut index, id_tracker) = random_index(1000, 1, IndexType::MutableGridstore);
 
     let point_id = 42;
 
@@ -152,6 +174,10 @@ fn test_set_empty_payload() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = serde_json::json!(null);
+    id_tracker
+        .borrow_mut()
+        .set_link(ExtendedPointId::NumId(point_id as _), point_id as _)
+        .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
     let values_count = index.inner().get_values(point_id).unwrap().count();
@@ -164,7 +190,7 @@ fn test_set_empty_payload() {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_cardinality_exp(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(1000, 1, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 1, index_type);
 
     cardinality_request(
         &index,
@@ -187,7 +213,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index) = random_index(1000, 2, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
     cardinality_request(
         &index,
         Range {
@@ -237,7 +263,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(1000, 2, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
     let collect_blocks = |index: &NumericIndexInner<_>, threshold| {
         let mut blocks = Vec::new();
         index
@@ -275,7 +301,7 @@ fn test_payload_blocks(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks_small(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
     let threshold = 4;
     let values = vec![
         vec![1.0],
@@ -294,8 +320,13 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_id = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_id as _), new_id)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_id, &values, &hw_counter)
             .unwrap();
     });
     let index = index_builder.finalize().unwrap();
@@ -316,7 +347,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -335,14 +366,20 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_idx, &values, &hw_counter)
             .unwrap();
     });
     let index = index_builder.finalize().unwrap();
 
     drop(index);
 
+    let id_tracker = id_tracker.borrow();
     let new_index = match index_type {
         IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
             temp_dir.path().to_path_buf(),
@@ -350,11 +387,13 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         )
         .unwrap()
         .unwrap(),
-        IndexType::Mmap => NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true)
-            .unwrap()
-            .unwrap(),
+        IndexType::Mmap => {
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &id_tracker)
+                .unwrap()
+                .unwrap()
+        }
         IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &id_tracker)
                 .unwrap()
                 .unwrap()
         }
@@ -377,7 +416,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -396,8 +435,13 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     values.into_iter().enumerate().for_each(|(idx, values)| {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .unwrap();
         index_builder
-            .add_point(idx as PointOffsetType + 1, &values, &hw_counter)
+            .add_point(new_idx, &values, &hw_counter)
             .unwrap();
     });
     let mut index = index_builder.finalize().unwrap();
@@ -458,8 +502,11 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     );
 
     // Remove some points
+    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
+    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
+    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
 
     test_cond(
@@ -551,7 +598,7 @@ fn test_cond<
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_empty_cardinality(#[case] index_type: IndexType) {
-    let (_temp_dir, index) = random_index(0, 1, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(0, 1, index_type);
     cardinality_request(
         &index,
         Range {
@@ -563,7 +610,7 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index) = random_index(0, 0, index_type);
+    let (_temp_dir, index, _id_tracker) = random_index(0, 0, index_type);
     cardinality_request(
         &index,
         Range {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -194,7 +194,7 @@ fn test_set_empty_payload() {
     let payload = serde_json::json!(null);
     id_tracker
         .borrow_mut()
-        .set_link(ExtendedPointId::NumId(point_id as _), point_id as _)
+        .set_link(ExtendedPointId::NumId(point_id.into()), point_id as _)
         .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
@@ -341,7 +341,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
         let new_id = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_id as _), new_id)
+            .set_link(ExtendedPointId::NumId(new_id.into()), new_id)
             .unwrap();
         index_builder
             .add_point(new_id, &values, &hw_counter)
@@ -387,7 +387,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
@@ -456,7 +456,7 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
@@ -610,7 +610,7 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
         let new_idx = idx as PointOffsetType + 1;
         id_tracker
             .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx as _), new_idx)
+            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
             .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -6,9 +6,28 @@ use rstest::rstest;
 use tempfile::{Builder, TempDir};
 
 use super::*;
-use crate::id_tracker::id_tracker_base::IdTracker;
 use crate::json_path::JsonPath;
-use crate::types::ExtendedPointId;
+
+/// Generous default size for the deleted-points bitslice used in tests.
+///
+/// Must be larger than the stored mmap deletion bitslice for any test in this
+/// file (which is sized to the highest point id, rounded up to a `u64`
+/// boundary). 4096 bits comfortably covers all current tests.
+const TEST_DELETED_BITS: usize = 4096;
+
+/// All-zero deletion bitslice for tests that don't care about deletions.
+fn empty_deleted() -> BitVec {
+    BitVec::repeat(false, TEST_DELETED_BITS)
+}
+
+/// Deletion bitslice with specific points marked as deleted.
+fn deleted_with(points: &[PointOffsetType]) -> BitVec {
+    let mut v = empty_deleted();
+    for &p in points {
+        v.set(p as usize, true);
+    }
+    v
+}
 
 #[derive(Clone, Copy)]
 enum IndexType {
@@ -43,12 +62,7 @@ impl IndexBuilder {
     }
 }
 
-fn get_index_builder(
-    index_type: IndexType,
-) -> (TempDir, IndexBuilder, Arc<AtomicRefCell<IdTrackerEnum>>) {
-    let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
-        Default::default(),
-    )));
+fn get_index_builder(index_type: IndexType) -> (TempDir, IndexBuilder) {
     let temp_dir = Builder::new()
         .prefix("test_numeric_index")
         .tempdir()
@@ -66,29 +80,29 @@ fn get_index_builder(
         >::builder_mmap(
             temp_dir.path(),
             false,
-            id_tracker.clone(),
+            &empty_deleted(),
         )),
     };
     match &mut builder {
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         IndexBuilder::Mmap(builder) => builder.init().unwrap(),
     }
-    (temp_dir, builder, id_tracker)
+    (temp_dir, builder)
 }
 
 fn open_index_from_disk(
     temp_dir: &Path,
     index_type: IndexType,
-    id_tracker: &IdTrackerEnum,
+    deleted: &BitSlice,
 ) -> NumericIndex<FloatPayloadType, FloatPayloadType> {
     match index_type {
         IndexType::MutableGridstore => NumericIndex::new_gridstore(temp_dir.to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, id_tracker)
+        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, deleted)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, id_tracker)
+        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, deleted)
             .unwrap()
             .unwrap(),
     }
@@ -98,30 +112,20 @@ fn random_index(
     num_points: usize,
     values_per_point: usize,
     index_type: IndexType,
-) -> (
-    TempDir,
-    NumericIndex<FloatPayloadType, FloatPayloadType>,
-    Arc<AtomicRefCell<IdTrackerEnum>>,
-) {
+) -> (TempDir, NumericIndex<FloatPayloadType, FloatPayloadType>) {
     let mut rng = StdRng::seed_from_u64(42);
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let hw_counter = HardwareCounterCell::new();
 
-    {
-        for i in 0..num_points {
-            let values = (0..values_per_point)
-                .map(|_| Value::from(rng.random_range(0.0..100.0)))
-                .collect_vec();
-            let values = values.iter().collect_vec();
-            id_tracker
-                .borrow_mut()
-                .set_link(ExtendedPointId::NumId(i as _), i as _)
-                .unwrap();
-            index_builder
-                .add_point(i as PointOffsetType, &values, &hw_counter)
-                .unwrap();
-        }
+    for i in 0..num_points {
+        let values = (0..values_per_point)
+            .map(|_| Value::from(rng.random_range(0.0..100.0)))
+            .collect_vec();
+        let values = values.iter().collect_vec();
+        index_builder
+            .add_point(i as PointOffsetType, &values, &hw_counter)
+            .unwrap();
     }
     let mut index = index_builder.finalize().unwrap();
 
@@ -135,7 +139,7 @@ fn random_index(
         };
     }
 
-    (temp_dir, index, id_tracker)
+    (temp_dir, index)
 }
 
 fn cardinality_request(
@@ -181,7 +185,7 @@ fn cardinality_request(
 
 #[test]
 fn test_set_empty_payload() {
-    let (_temp_dir, mut index, id_tracker) = random_index(1000, 1, IndexType::MutableGridstore);
+    let (_temp_dir, mut index) = random_index(1000, 1, IndexType::MutableGridstore);
 
     let point_id = 42;
 
@@ -192,10 +196,6 @@ fn test_set_empty_payload() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = serde_json::json!(null);
-    id_tracker
-        .borrow_mut()
-        .set_link(ExtendedPointId::NumId(point_id.into()), point_id as _)
-        .unwrap();
     index.add_point(point_id, &[&payload], &hw_counter).unwrap();
 
     let values_count = index.inner().get_values(point_id).unwrap().count();
@@ -208,7 +208,7 @@ fn test_set_empty_payload() {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_cardinality_exp(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 1, index_type);
+    let (_temp_dir, index) = random_index(1000, 1, index_type);
 
     cardinality_request(
         &index,
@@ -231,7 +231,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
+    let (_temp_dir, index) = random_index(1000, 2, index_type);
     cardinality_request(
         &index,
         Range {
@@ -281,7 +281,7 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(1000, 2, index_type);
+    let (_temp_dir, index) = random_index(1000, 2, index_type);
     let collect_blocks = |index: &NumericIndexInner<_>, threshold| {
         let mut blocks = Vec::new();
         index
@@ -319,7 +319,7 @@ fn test_payload_blocks(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks_small(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
     let threshold = 4;
     let values = vec![
         vec![1.0],
@@ -339,10 +339,6 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_id = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_id.into()), new_id)
-            .unwrap();
         index_builder
             .add_point(new_id, &values, &hw_counter)
             .unwrap();
@@ -365,7 +361,7 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -385,10 +381,6 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -397,7 +389,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 
     drop(index);
 
-    let id_tracker = id_tracker.borrow();
+    let deleted = empty_deleted();
     let new_index = match index_type {
         IndexType::MutableGridstore => NumericIndexInner::<FloatPayloadType>::new_gridstore(
             temp_dir.path().to_path_buf(),
@@ -406,12 +398,12 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         .unwrap()
         .unwrap(),
         IndexType::Mmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &id_tracker)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &deleted)
                 .unwrap()
                 .unwrap()
         }
         IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &id_tracker)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &deleted)
                 .unwrap()
                 .unwrap()
         }
@@ -434,7 +426,7 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index(#[case] index_type: IndexType) {
-    let (_temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -454,10 +446,6 @@ fn test_numeric_index(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -520,11 +508,8 @@ fn test_numeric_index(#[case] index_type: IndexType) {
     );
 
     // Remove some points
-    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
-    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
-    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
 
     test_cond(
@@ -588,7 +573,7 @@ fn test_numeric_index(#[case] index_type: IndexType) {
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_numeric_index_reload(#[case] index_type: IndexType) {
-    let (temp_dir, mut index_builder, id_tracker) = get_index_builder(index_type);
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
 
     let values = vec![
         vec![1.0],
@@ -608,10 +593,6 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
         let values = values.iter().map(|v| Value::from(*v)).collect_vec();
         let values = values.iter().collect_vec();
         let new_idx = idx as PointOffsetType + 1;
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(new_idx.into()), new_idx)
-            .unwrap();
         index_builder
             .add_point(new_idx, &values, &hw_counter)
             .unwrap();
@@ -674,17 +655,20 @@ fn test_numeric_index_reload(#[case] index_type: IndexType) {
     );
 
     // Remove some points
-    id_tracker.borrow_mut().drop_internal(1).unwrap();
     index.remove_point(1).unwrap();
-    id_tracker.borrow_mut().drop_internal(2).unwrap();
     index.remove_point(2).unwrap();
-    id_tracker.borrow_mut().drop_internal(5).unwrap();
     index.remove_point(5).unwrap();
     index.inner().flusher()().unwrap();
 
     // Reload!
+    //
+    // Note: `MmapNumericIndex::remove_point` is in-memory only — it doesn't
+    // persist to the on-disk deletion bitslice. The reload path picks up
+    // deletions from the `&BitSlice` argument, so for this test we have to
+    // re-supply the same set of removed points here.
     drop(index);
-    let index = open_index_from_disk(temp_dir.path(), index_type, &id_tracker.borrow());
+    let deleted = deleted_with(&[1, 2, 5]);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &deleted);
 
     test_cond(
         index.inner(),
@@ -777,7 +761,7 @@ fn test_cond<
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_empty_cardinality(#[case] index_type: IndexType) {
-    let (_temp_dir, index, _id_tracker) = random_index(0, 1, index_type);
+    let (_temp_dir, index) = random_index(0, 1, index_type);
     cardinality_request(
         &index,
         Range {
@@ -789,7 +773,7 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 
-    let (_temp_dir, index, _id_tracker) = random_index(0, 0, index_type);
+    let (_temp_dir, index) = random_index(0, 0, index_type);
     cardinality_request(
         &index,
         Range {

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -258,6 +258,19 @@ where
         self.header.points_count as usize
     }
 
+    /// Approximate RAM usage in bytes. Data is mmap-backed, so no significant
+    /// heap allocations; on-disk data is accounted via `files()`.
+    pub fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            file_name: _,
+            store: _,
+            header: _,
+            phantom: _,
+        } = self;
+        0
+    }
+
+
     fn get_range(&self, point_id: PointOffsetType) -> OperationResult<Option<MmapRange>> {
         if point_id < self.header.points_count as PointOffsetType {
             let range_offset = (self.header.ranges_start as usize)

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -270,7 +270,6 @@ where
         0
     }
 
-
     fn get_range(&self, point_id: PointOffsetType) -> OperationResult<Option<MmapRange>> {
         if point_id < self.header.points_count as PointOffsetType {
             let range_offset = (self.header.ranges_start as usize)

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -232,6 +232,7 @@ mod tests {
     use serde_json::{Value, from_value, json};
 
     use crate::common::utils::MultiValue;
+    use crate::id_tracker::{IdTracker, IdTrackerEnum};
     use crate::index::field_index::geo_index::GeoMapIndex;
     use crate::index::field_index::numeric_index::NumericIndex;
     use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait};
@@ -239,7 +240,7 @@ mod tests {
     use crate::index::query_optimization::rescore_formula::value_retriever::variable_retriever;
     use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
     use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-    use crate::types::Payload;
+    use crate::types::{ExtendedPointId, Payload};
 
     pub fn fixture_payload_provider() -> PayloadProvider {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
@@ -345,12 +346,27 @@ mod tests {
             PayloadStorageEnum::InMemoryPayloadStorage(InMemoryPayloadStorage::default()),
         )));
         let hw_counter = HardwareCounterCell::new();
+        let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
+            Default::default(),
+        )));
 
         // Create a field index for a number.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false);
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(0), 0)
+            .unwrap();
         builder.add_point(0, &[&42.into()], &hw_counter).unwrap();
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(1), 1)
+            .unwrap();
         builder.add_point(1, &[], &hw_counter).unwrap();
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(2), 2)
+            .unwrap();
         builder
             .add_point(2, &[&99.into(), &55.into()], &hw_counter)
             .unwrap();
@@ -373,7 +389,7 @@ mod tests {
 
         // Create a field index for datetime
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false);
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
 
         builder
             .add_point(0, &[&json!("2023-01-01T00:00:00Z")], &hw_counter)

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -228,11 +228,11 @@ mod tests {
     use std::sync::Arc;
 
     use atomic_refcell::AtomicRefCell;
+    use common::bitvec::BitVec;
     use common::counter::hardware_counter::HardwareCounterCell;
     use serde_json::{Value, from_value, json};
 
     use crate::common::utils::MultiValue;
-    use crate::id_tracker::{IdTracker, IdTrackerEnum};
     use crate::index::field_index::geo_index::GeoMapIndex;
     use crate::index::field_index::numeric_index::NumericIndex;
     use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait};
@@ -240,7 +240,7 @@ mod tests {
     use crate::index::query_optimization::rescore_formula::value_retriever::variable_retriever;
     use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
     use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-    use crate::types::{ExtendedPointId, Payload};
+    use crate::types::Payload;
 
     pub fn fixture_payload_provider() -> PayloadProvider {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
@@ -346,27 +346,15 @@ mod tests {
             PayloadStorageEnum::InMemoryPayloadStorage(InMemoryPayloadStorage::default()),
         )));
         let hw_counter = HardwareCounterCell::new();
-        let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
-            Default::default(),
-        )));
+        // No deletions in this test — sized to comfortably exceed the
+        // stored deletion bitslice for the few points added below.
+        let deleted_points = BitVec::repeat(false, 64);
 
         // Create a field index for a number.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(0), 0)
-            .unwrap();
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, &deleted_points);
         builder.add_point(0, &[&42.into()], &hw_counter).unwrap();
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(1), 1)
-            .unwrap();
         builder.add_point(1, &[], &hw_counter).unwrap();
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(2), 2)
-            .unwrap();
         builder
             .add_point(2, &[&99.into(), &55.into()], &hw_counter)
             .unwrap();
@@ -389,7 +377,7 @@ mod tests {
 
         // Create a field index for datetime
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, &deleted_points);
 
         builder
             .add_point(0, &[&json!("2023-01-01T00:00:00Z")], &hw_counter)

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -227,11 +227,11 @@ mod tests {
     use std::sync::Arc;
 
     use atomic_refcell::AtomicRefCell;
+    use common::bitvec::BitVec;
     use common::counter::hardware_counter::HardwareCounterCell;
     use serde_json::{Value, from_value, json};
 
     use crate::common::utils::MultiValue;
-    use crate::id_tracker::{IdTracker, IdTrackerEnum};
     use crate::index::field_index::geo_index::GeoMapIndex;
     use crate::index::field_index::numeric_index::NumericIndex;
     use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait};
@@ -239,7 +239,7 @@ mod tests {
     use crate::index::query_optimization::rescore_formula::value_retriever::variable_retriever;
     use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
     use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-    use crate::types::{ExtendedPointId, Payload};
+    use crate::types::Payload;
 
     pub fn fixture_payload_provider() -> PayloadProvider {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
@@ -345,27 +345,15 @@ mod tests {
             PayloadStorageEnum::InMemoryPayloadStorage(InMemoryPayloadStorage::default()),
         )));
         let hw_counter = HardwareCounterCell::new();
-        let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
-            Default::default(),
-        )));
+        // No deletions in this test — sized to comfortably exceed the
+        // stored deletion bitslice for the few points added below.
+        let deleted_points = BitVec::repeat(false, 64);
 
         // Create a field index for a number.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(0), 0)
-            .unwrap();
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, &deleted_points);
         builder.add_point(0, &[&42.into()], &hw_counter).unwrap();
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(1), 1)
-            .unwrap();
         builder.add_point(1, &[], &hw_counter).unwrap();
-        id_tracker
-            .borrow_mut()
-            .set_link(ExtendedPointId::NumId(2), 2)
-            .unwrap();
         builder
             .add_point(2, &[&99.into(), &55.into()], &hw_counter)
             .unwrap();
@@ -388,7 +376,7 @@ mod tests {
 
         // Create a field index for datetime
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, &deleted_points);
 
         builder
             .add_point(0, &[&json!("2023-01-01T00:00:00Z")], &hw_counter)

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -231,6 +231,7 @@ mod tests {
     use serde_json::{Value, from_value, json};
 
     use crate::common::utils::MultiValue;
+    use crate::id_tracker::{IdTracker, IdTrackerEnum};
     use crate::index::field_index::geo_index::GeoMapIndex;
     use crate::index::field_index::numeric_index::NumericIndex;
     use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait};
@@ -238,7 +239,7 @@ mod tests {
     use crate::index::query_optimization::rescore_formula::value_retriever::variable_retriever;
     use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
     use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-    use crate::types::Payload;
+    use crate::types::{ExtendedPointId, Payload};
 
     pub fn fixture_payload_provider() -> PayloadProvider {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
@@ -344,12 +345,27 @@ mod tests {
             PayloadStorageEnum::InMemoryPayloadStorage(InMemoryPayloadStorage::default()),
         )));
         let hw_counter = HardwareCounterCell::new();
+        let id_tracker = Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
+            Default::default(),
+        )));
 
         // Create a field index for a number.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false);
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(0), 0)
+            .unwrap();
         builder.add_point(0, &[&42.into()], &hw_counter).unwrap();
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(1), 1)
+            .unwrap();
         builder.add_point(1, &[], &hw_counter).unwrap();
+        id_tracker
+            .borrow_mut()
+            .set_link(ExtendedPointId::NumId(2), 2)
+            .unwrap();
         builder
             .add_point(2, &[&99.into(), &55.into()], &hw_counter)
             .unwrap();
@@ -372,7 +388,7 @@ mod tests {
 
         // Create a field index for datetime
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = NumericIndex::builder_mmap(dir.path(), false);
+        let mut builder = NumericIndex::builder_mmap(dir.path(), false, id_tracker.clone());
 
         builder
             .add_point(0, &[&json!("2023-01-01T00:00:00Z")], &hw_counter)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -172,6 +172,7 @@ impl StructPayloadIndex {
                 field,
                 &payload_schema.schema,
                 create_if_missing,
+                &self.id_tracker.borrow(),
             )?;
 
             if let Some(mut indexes) = indexes {
@@ -215,6 +216,7 @@ impl StructPayloadIndex {
                             &self.path,
                             total_point_count,
                             create_if_missing,
+                            &self.id_tracker.borrow(),
                         )
                     })
                 })
@@ -298,9 +300,11 @@ impl StructPayloadIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
-        let mut builders = self
-            .selector(payload_schema)
-            .index_builder(field, payload_schema)?;
+        let mut builders = self.selector(payload_schema).index_builder(
+            field,
+            payload_schema,
+            self.id_tracker.clone(),
+        )?;
 
         // Special null index complements every index.
         let null_index = IndexSelector::null_builder(&self.path, field)?;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -167,12 +167,15 @@ impl StructPayloadIndex {
         let mut rebuild = false;
         let mut is_dirty = false;
 
+        let id_tracker = self.id_tracker.borrow();
+        let deleted_points = id_tracker.deleted_point_bitslice();
+
         let mut indexes = if payload_schema.types.is_empty() {
             let indexes = self.selector(&payload_schema.schema).new_index(
                 field,
                 &payload_schema.schema,
                 create_if_missing,
-                &self.id_tracker.borrow(),
+                deleted_points,
             )?;
 
             if let Some(mut indexes) = indexes {
@@ -216,7 +219,7 @@ impl StructPayloadIndex {
                             &self.path,
                             total_point_count,
                             create_if_missing,
-                            &self.id_tracker.borrow(),
+                            deleted_points,
                         )
                     })
                 })
@@ -300,11 +303,14 @@ impl StructPayloadIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
-        let mut builders = self.selector(payload_schema).index_builder(
-            field,
-            payload_schema,
-            self.id_tracker.clone(),
-        )?;
+        let mut builders = {
+            let id_tracker = self.id_tracker.borrow();
+            self.selector(payload_schema).index_builder(
+                field,
+                payload_schema,
+                id_tracker.deleted_point_bitslice(),
+            )?
+        };
 
         // Special null index complements every index.
         let null_index = IndexSelector::null_builder(&self.path, field)?;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -321,7 +321,8 @@ impl StructPayloadIndex {
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
         let selector = self.selector(payload_schema);
-        let mut builders = selector.index_builder(field, payload_schema)?;
+        let mut builders =
+            selector.index_builder(field, payload_schema, self.id_tracker.clone())?;
 
         // Special null index complements every index. Seed it with the segment's total
         // point count so `iter_falses()` returns points that are missing from payload

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -163,6 +163,7 @@ impl StructPayloadIndex {
         create_if_missing: bool,
     ) -> OperationResult<(Vec<FieldIndex>, bool)> {
         let id_tracker_borrow = self.id_tracker.borrow();
+        let deleted_points = id_tracker_borrow.deleted_point_bitslice();
         let mut rebuild = false;
         let mut is_dirty = false;
 
@@ -172,7 +173,7 @@ impl StructPayloadIndex {
                 field,
                 &payload_schema.schema,
                 create_if_missing,
-                &id_tracker_borrow,
+                deleted_points,
             )?;
 
             if let Some(mut indexes) = indexes {
@@ -215,6 +216,7 @@ impl StructPayloadIndex {
                             index,
                             create_if_missing,
                             &id_tracker_borrow,
+                            deleted_points,
                         )
                     })
                 })
@@ -320,9 +322,13 @@ impl StructPayloadIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
+        let id_tracker_borrow = self.id_tracker.borrow();
         let selector = self.selector(payload_schema);
-        let mut builders =
-            selector.index_builder(field, payload_schema, self.id_tracker.clone())?;
+        let mut builders = selector.index_builder(
+            field,
+            payload_schema,
+            id_tracker_borrow.deleted_point_bitslice(),
+        )?;
 
         // Special null index complements every index. Seed it with the segment's total
         // point count so `iter_falses()` returns points that are missing from payload


### PR DESCRIPTION
Do not use a deleted mmap-ed storage, instead, reconstruct a bitmask from the index and segment-level deleted mask.  It effectively makes the mmap numeric index storage immutable, and immutable numeric index storage too as it delegates to mmap numeric index.

It would reduce IO at Qdrant serverless instances.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
