### PR TITLE
Exclude down resharded shards during select

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -639,6 +639,20 @@ impl ShardHolder {
                         continue;
                     }
 
+                    // Skip shard being removed by resharding down once the write
+                    // hash ring is committed. The shard is logically gone at this
+                    // point; querying it on a remote peer that already applied
+                    // `finish_resharding` would return a "shard not found" error.
+                    let resharding_removing_down =
+                        self.resharding_state.read().clone().is_some_and(|state| {
+                            state.direction == ReshardingDirection::Down
+                                && state.shard_id == shard_id
+                                && state.stage >= ReshardingStage::WriteHashRingCommitted
+                        });
+                    if resharding_removing_down {
+                        continue;
+                    }
+
                     // Technically, we could skip inactive shards regardless of sharding method,
                     // as we do not expect that shard id can even become inactive on all replicas.
                     // (if it happens, means there is a bug)

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -626,15 +626,16 @@ impl ShardHolder {
                     ShardingMethod::Custom => true,
                 };
 
+                let resharding_state = self.resharding_state.read().clone();
+
                 for (&shard_id, shard) in self.shards.iter() {
                     // Ignore a new resharding shard until it completed point migration
                     // The shard will be marked as active at the end of the migration stage
-                    let resharding_migrating_up =
-                        self.resharding_state.read().clone().is_some_and(|state| {
-                            state.direction == ReshardingDirection::Up
-                                && state.shard_id == shard_id
-                                && state.stage < ReshardingStage::ReadHashRingCommitted
-                        });
+                    let resharding_migrating_up = resharding_state.as_ref().is_some_and(|state| {
+                        state.direction == ReshardingDirection::Up
+                            && state.shard_id == shard_id
+                            && state.stage < ReshardingStage::ReadHashRingCommitted
+                    });
                     if resharding_migrating_up {
                         continue;
                     }
@@ -643,12 +644,11 @@ impl ShardHolder {
                     // hash ring is committed. The shard is logically gone at this
                     // point; querying it on a remote peer that already applied
                     // `finish_resharding` would return a "shard not found" error.
-                    let resharding_removing_down =
-                        self.resharding_state.read().clone().is_some_and(|state| {
-                            state.direction == ReshardingDirection::Down
-                                && state.shard_id == shard_id
-                                && state.stage >= ReshardingStage::WriteHashRingCommitted
-                        });
+                    let resharding_removing_down = resharding_state.as_ref().is_some_and(|state| {
+                        state.direction == ReshardingDirection::Down
+                            && state.shard_id == shard_id
+                            && state.stage >= ReshardingStage::WriteHashRingCommitted
+                    });
                     if resharding_removing_down {
                         continue;
                     }


### PR DESCRIPTION
  ## Summary
  - When resharding down, skip the shard being removed from `select_shards(All)` once the write hash ring is committed
  - Fixes a race window where a slow peer (still processing the `finish_resharding` consensus entry) would try to query a remote peer that already dropped the shard, resulting in a 404 "shard not found" error

  ## Details
  After `finish_resharding` is proposed through Raft, each peer applies the shard removal independently.

During the propagation window, peer A may still have shard 2 in its local shard map while peer B has already removed it. Any read operation (info, count, search, scroll) on peer A going through `select_shards(All)` would include shard 2, send a gRPC request to peer B, and get back a non-transient `NotFound` error that fails the entire request.

The fix mirrors the existing `Up` direction filter: once the write hash ring is committed, the shard is logically gone and should be excluded from read operations.

 Maybe fixes #8593

  ## Test plan
  - [ ] Verify `test_resharding_deferred.py::test_resharding_transfer_deferred_points[down]` is no longer flaky
  - [x] Run full resharding test suite to check for regressions