### PR TITLE
Add regression test for optimizer config refresh

### DIFF
--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -90,3 +90,68 @@ impl LocalShard {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::budget::ResourceBudget;
+    use common::save_on_disk::SaveOnDisk;
+    use tempfile::Builder;
+    use tokio::runtime::Handle;
+    use tokio::sync::RwLock;
+
+    use super::LocalShard;
+    use crate::shards::shard_trait::ShardOperation;
+    use crate::tests::fixtures::create_collection_config;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn optimizer_config_update_refreshes_prevent_unoptimized_flag() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+        let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+        let mut config = create_collection_config();
+        config.optimizer_config.prevent_unoptimized = Some(false);
+
+        let current_runtime: Handle = Handle::current();
+        let shard = LocalShard::build(
+            0,
+            "test".to_string(),
+            collection_dir.path(),
+            Arc::new(RwLock::new(config.clone())),
+            Arc::new(Default::default()),
+            payload_index_schema,
+            current_runtime.clone(),
+            current_runtime.clone(),
+            ResourceBudget::default(),
+            config.optimizer_config.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!shard.update_handler.lock().await.prevent_unoptimized);
+
+        {
+            let mut shard_config = shard.collection_config.write().await;
+            shard_config.optimizer_config.prevent_unoptimized = Some(true);
+        }
+
+        shard.on_optimizer_config_update().await.unwrap();
+
+        assert!(shard.update_handler.lock().await.prevent_unoptimized);
+
+        {
+            let mut shard_config = shard.collection_config.write().await;
+            shard_config.optimizer_config.prevent_unoptimized = Some(false);
+        }
+
+        shard.on_optimizer_config_update().await.unwrap();
+
+        assert!(!shard.update_handler.lock().await.prevent_unoptimized);
+
+        shard.stop_gracefully().await;
+    }
+}


### PR DESCRIPTION
Fixes #5341

## Summary
- add a regression test covering live optimizer config refresh on a local shard
- verify `prevent_unoptimized` updates are applied after `on_optimizer_config_update()`
- keep the PR aligned with current `dev`, where the runtime logic has already been refactored

## Why this PR is test-only
The original local fix was created against an older `dev` snapshot. Current `qdrant/dev` now updates the live `UpdateHandler` through a newer `prevent_unoptimized` path, so the old patch conflicts cleanly with upstream refactors. This PR keeps the useful part: a regression test that proves the current runtime behavior stays correct.

## Testing
- `cargo test -p collection optimizer_config_update_refreshes_prevent_unoptimized_flag -- --nocapture`