### PR TITLE
Misc clippy fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,12 +3023,8 @@ checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
  "ash",
  "log",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
 ]
 
 [[package]]
@@ -4709,37 +4705,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
 ]
 
 [[package]]
@@ -4750,17 +4721,6 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
 ]
 
 [[package]]

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use common::generic_consts::{Random, Sequential};
-use common::universal_io::{IoUringFile, MmapFile, OpenOptions, ReadRange, UniversalRead};
+#[cfg(target_os = "linux")]
+use common::universal_io::IoUringFile;
+use common::universal_io::{MmapFile, OpenOptions, ReadRange, UniversalRead};
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
 use rand::rngs::StdRng;

--- a/lib/gpu/Cargo.toml
+++ b/lib/gpu/Cargo.toml
@@ -20,7 +20,7 @@ testing = []
 
 [dependencies]
 ash = { version = "0.38.0", optional = true, default-features = false, features = ["loaded", "debug"] }
-gpu-allocator = { version = "0.28.0", optional = true }
+gpu-allocator = { version = "0.28.0", optional = true, default-features = false, features = ["std", "vulkan"] }
 shaderc = { version = "0.10.1", optional = true, features = ["build-from-source"]}
 zerocopy = { workspace = true }
 


### PR DESCRIPTION
On macos, there were two clippy lints happening:
1. Infinite recursion error when trying to check bounds for some `objc2` types, which were introduced by #8583. `objc2` is used only by `gpu-allocator` only for Metal backend, but we only use Vulkan. As a quick patch, we can just use the `"vulkan"` feature flag on `gpu-allocator` directly.
2. Ungated `IoUringFile` usage, needed to be gated by `target_os = "linux"`
