### PR TITLE
Add optional `api` field to audit log events

### DIFF
--- a/lib/storage/src/audit.rs
+++ b/lib/storage/src/audit.rs
@@ -34,6 +34,9 @@ static AUDIT_LOGGER: OnceLock<AuditLogger> = OnceLock::new();
 /// Stored separately so it can be queried before/without an active logger.
 static TRUST_FORWARDED_HEADERS: OnceLock<bool> = OnceLock::new();
 
+/// Whether the audit logger should log the API method path.
+static LOG_API: OnceLock<bool> = OnceLock::new();
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -63,6 +66,11 @@ pub struct AuditConfig {
     /// Default: false
     #[serde(default)]
     pub trust_forwarded_headers: bool,
+
+    /// If true, log the API method path (REST path or gRPC method) in addition
+    /// to the internal operation name.  Default: false.
+    #[serde(default)]
+    pub log_api: bool,
 }
 
 fn default_audit_dir() -> PathBuf {
@@ -98,8 +106,14 @@ pub enum AuditResult {
 pub struct AuditEvent {
     /// ISO‑8601 timestamp.
     pub timestamp: DateTime<Utc>,
-    /// The API method / handler name.
-    pub method: String,
+    /// The internal operation name (e.g. `upsert_points`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// The API method path (REST path or gRPC method name).
+    /// Populated when the `log_api` audit config option is enabled,
+    /// or for denied authentication requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api: Option<String>,
     /// How the request was authenticated.
     pub auth_type: AuthType,
     /// The `subject` field from the JWT (if any).
@@ -200,9 +214,10 @@ pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<
         return Ok(None);
     }
 
-    // Persist the forwarded-headers flag so it is available globally even
-    // outside the audit logger itself (e.g. in auth middleware).
+    // Persist flags so they are available globally even outside the audit
+    // logger itself (e.g. in auth middleware).
     let _ = TRUST_FORWARDED_HEADERS.set(config.trust_forwarded_headers);
+    let _ = LOG_API.set(config.log_api);
 
     let (logger, guard) = AuditLogger::new(config)?;
     AUDIT_LOGGER
@@ -231,4 +246,9 @@ pub fn is_audit_enabled() -> bool {
 /// headers (`X-Forwarded-For`) for determining the client address.
 pub fn audit_trust_forwarded_headers() -> bool {
     TRUST_FORWARDED_HEADERS.get().copied().unwrap_or(false)
+}
+
+/// Returns `true` if the audit logger is configured to log API method paths.
+pub fn audit_log_api() -> bool {
+    LOG_API.get().copied().unwrap_or(false)
 }

--- a/lib/storage/src/audit.rs
+++ b/lib/storage/src/audit.rs
@@ -145,9 +145,18 @@ struct AuditLogger {
 
 impl AuditLogger {
     fn new(config: &AuditConfig) -> anyhow::Result<(Self, WorkerGuard)> {
-        fs_err::create_dir_all(&config.dir)?;
+        let AuditConfig {
+            enabled: _,
+            dir,
+            rotation,
+            max_log_files,
+            trust_forwarded_headers: _,
+            log_api: _,
+        } = config;
 
-        let rotation = match config.rotation {
+        fs_err::create_dir_all(dir)?;
+
+        let rotation = match rotation {
             AuditRotation::Daily => Rotation::DAILY,
             AuditRotation::Hourly => Rotation::HOURLY,
         };
@@ -156,8 +165,8 @@ impl AuditLogger {
             .rotation(rotation)
             .filename_prefix("audit")
             .filename_suffix("log")
-            .max_log_files(config.max_log_files.max(1))
-            .build(&config.dir)
+            .max_log_files((*max_log_files).max(1))
+            .build(dir)
             .map_err(|err| anyhow::anyhow!("Failed to create audit log appender: {err}"))?;
 
         // Wrap the appender in a non-blocking writer.  The actual file I/O is
@@ -210,21 +219,30 @@ pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<
         return Ok(None);
     };
 
-    if !config.enabled {
+    let AuditConfig {
+        enabled,
+        dir,
+        rotation: _,
+        max_log_files: _,
+        trust_forwarded_headers,
+        log_api,
+    } = config;
+
+    if !enabled {
         return Ok(None);
     }
 
     // Persist flags so they are available globally even outside the audit
     // logger itself (e.g. in auth middleware).
-    let _ = TRUST_FORWARDED_HEADERS.set(config.trust_forwarded_headers);
-    let _ = LOG_API.set(config.log_api);
+    let _ = TRUST_FORWARDED_HEADERS.set(*trust_forwarded_headers);
+    let _ = LOG_API.set(*log_api);
 
     let (logger, guard) = AuditLogger::new(config)?;
     AUDIT_LOGGER
         .set(logger)
         .map_err(|_| anyhow::anyhow!("Audit logger already initialised"))?;
 
-    log::info!("Audit logging enabled, writing to {}", config.dir.display());
+    log::info!("Audit logging enabled, writing to {}", dir.display());
 
     Ok(Some(guard))
 }

--- a/lib/storage/src/audit_reader.rs
+++ b/lib/storage/src/audit_reader.rs
@@ -288,6 +288,7 @@ fn event_field_matches(event: &AuditEvent, key: &str, expected: &str) -> Option<
     let AuditEvent {
         timestamp: _, // filtered separately via time_from/time_to
         method,
+        api,
         auth_type,
         subject,
         remote,
@@ -298,7 +299,8 @@ fn event_field_matches(event: &AuditEvent, key: &str, expected: &str) -> Option<
     } = event;
 
     match key {
-        "method" => Some(method == expected),
+        "method" => Some(method.as_deref() == Some(expected)),
+        "api" => Some(api.as_deref() == Some(expected)),
         "auth_type" => {
             // Compare against the serde-serialized form of the enum variant.
             let serialized = serde_json::to_value(auth_type).ok()?;
@@ -326,7 +328,8 @@ mod tests {
     fn make_event() -> AuditEvent {
         AuditEvent {
             timestamp: "2024-06-15T10:30:00Z".parse().unwrap(),
-            method: "upsert_points".to_string(),
+            method: Some("upsert_points".to_string()),
+            api: None,
             auth_type: AuthType::ApiKey,
             subject: None,
             remote: None,
@@ -423,6 +426,7 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: AuditEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.method, event.method);
+        assert_eq!(deserialized.api, event.api);
         assert_eq!(deserialized.timestamp, event.timestamp);
         assert_eq!(deserialized.auth_type, event.auth_type);
         assert_eq!(deserialized.result, event.result);

--- a/lib/storage/src/rbac/auth.rs
+++ b/lib/storage/src/rbac/auth.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 
 use super::{Access, AccessRequirements, AuthType, CollectionMultipass, CollectionPass};
-use crate::audit::{AuditEvent, AuditResult, audit_log, is_audit_enabled};
+use crate::audit::{AuditEvent, AuditResult, audit_log, audit_log_api, is_audit_enabled};
 use crate::content_manager::errors::StorageError;
 
 /// Per-request authentication context.
@@ -17,6 +17,8 @@ pub struct Auth {
     remote: Option<String>,
     auth_type: AuthType,
     tracing_id: Option<String>,
+    /// The API method path (REST path or gRPC method name).
+    api: Option<String>,
 }
 
 impl Auth {
@@ -33,7 +35,13 @@ impl Auth {
             remote,
             auth_type,
             tracing_id,
+            api: None,
         }
+    }
+
+    pub fn with_api(mut self, api: String) -> Self {
+        self.api = Some(api);
+        self
     }
 
     pub const fn new_internal(access: Access) -> Self {
@@ -43,6 +51,7 @@ impl Auth {
             remote: None,
             auth_type: AuthType::Internal,
             tracing_id: None,
+            api: None,
         }
     }
 
@@ -112,9 +121,16 @@ impl Auth {
             Err(e) => (AuditResult::Denied, Some(e.to_string())),
         };
 
+        let api = if audit_log_api() {
+            self.api.clone()
+        } else {
+            None
+        };
+
         audit_log(AuditEvent {
             timestamp: Utc::now(),
-            method: method.to_string(),
+            method: Some(method.to_string()),
+            api,
             auth_type: self.auth_type.clone(),
             subject: self.subject.clone(),
             remote: self.remote.clone(),

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -140,7 +140,9 @@ where
                 .await
             {
                 Ok((access, inference_token, auth_type, subject)) => {
-                    let auth = Auth::new(access, subject, remote, auth_type, tracing_id);
+                    let api_path = req.path().to_string();
+                    let auth = Auth::new(access, subject, remote, auth_type, tracing_id)
+                        .with_api(api_path);
                     let previous = req.extensions_mut().insert(auth);
                     req.extensions_mut().insert(inference_token);
                     debug_assert!(

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -68,7 +68,7 @@ impl Display for AuthError {
 /// Log a denied authentication attempt to the audit log when audit is enabled.
 /// Used by both REST (actix) and gRPC (tonic) auth middlewares.
 pub fn log_denied_auth(
-    method: &str,
+    api: &str,
     remote: Option<String>,
     tracing_id: Option<String>,
     error: &AuthError,
@@ -76,7 +76,8 @@ pub fn log_denied_auth(
     if is_audit_enabled() {
         audit_log(AuditEvent {
             timestamp: Utc::now(),
-            method: method.to_string(),
+            method: None,
+            api: Some(api.to_string()),
             auth_type: AuthType::None,
             subject: None,
             remote,

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -75,8 +75,7 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
             }
         })?;
 
-    let auth = Auth::new(access, subject, remote, auth_type, tracing_id)
-        .with_api(path.to_string());
+    let auth = Auth::new(access, subject, remote, auth_type, tracing_id).with_api(path.to_string());
 
     let previous = req.extensions_mut().insert(auth);
 

--- a/src/tonic/auth.rs
+++ b/src/tonic/auth.rs
@@ -75,7 +75,8 @@ async fn check(auth_keys: Arc<AuthKeys>, mut req: Request) -> Result<Request, St
             }
         })?;
 
-    let auth = Auth::new(access, subject, remote, auth_type, tracing_id);
+    let auth = Auth::new(access, subject, remote, auth_type, tracing_id)
+        .with_api(path.to_string());
 
     let previous = req.extensions_mut().insert(auth);
 

--- a/tests/consensus_tests/auth_tests/test_audit_telemetry.py
+++ b/tests/consensus_tests/auth_tests/test_audit_telemetry.py
@@ -23,13 +23,15 @@ TOKEN_COLL_R = encode_jwt(
 )
 
 
-def read_audit_methods(peer_dir: Path) -> list[str]:
+def read_audit_methods(peer_dir: Path) -> list[str | None]:
     methods = []
     for log_file in sorted((peer_dir / "storage" / "audit").glob("audit.*.log")):
         for line in log_file.read_text().splitlines():
             if not line.strip():
                 continue
-            methods.append(json.loads(line)["method"])
+            # `method` is omitted for denied auth entries, where the middleware
+            # has no internal operation name yet — use .get() to tolerate this.
+            methods.append(json.loads(line).get("method"))
     return methods
 
 


### PR DESCRIPTION
## Summary
- Adds a new optional `api` field to audit log entries that records the API method path (REST path or gRPC method name)
- Controlled by the new `log_api` audit config option (default: `false`)
- For denied auth requests, `api` is always populated and `method` is now omitted (made optional), since there is no internal operation name available at that point
- Adds `api` as a supported filter key in audit log queries

## Test plan
- [x] `cargo check` passes
- [x] All audit reader unit tests pass
- [ ] Verify audit log output with `log_api: true` — events should include both `method` and `api`
- [ ] Verify audit log output with `log_api: false` (default) — events should only include `method`, no `api`
- [ ] Verify denied auth requests log `api` but not `method` regardless of setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)