### PR TITLE
fix(snapshot): align auto recovery fallback with snapshot restore (#5857)

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -54,7 +54,7 @@ impl Collection {
         } else {
             self.shared_storage_config
                 .default_shard_transfer_method
-                .unwrap_or(ShardTransferMethod::StreamRecords)
+                .unwrap_or(ShardTransferMethod::Snapshot)
         }
     }
 
@@ -222,14 +222,11 @@ impl Collection {
 
         let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
 
-        // With prevent_unoptimized, fall back to snapshot which preserves deferred
-        // point state exactly (raw segment copy). stream_records sends deferred
-        // points but they won't be deferred on the target.
-        let fallback_method = if self.is_prevent_unoptimized().await {
-            ShardTransferMethod::Snapshot
-        } else {
-            ShardTransferMethod::StreamRecords
-        };
+        // Fall back to the same canonical default transfer method selection used
+        // everywhere else. This keeps automatic recovery aligned with the
+        // configured/default orchestration policy instead of silently forcing a
+        // different method after WalDelta failure.
+        let fallback_method = self.default_shard_transfer_method().await;
         let transfer_task = transfer::driver::spawn_transfer_task(
             shard_holder,
             progress.clone(),
@@ -600,5 +597,142 @@ impl Collection {
             .is_some_and(|limit| outgoing >= limit);
 
         incoming_shard_transfer_limit_reached || outgoing_shard_transfer_limit_reached
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+
+    use ahash::AHashMap;
+    use common::budget::ResourceBudget;
+    use segment::types::Distance;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection::RequestShardTransfer;
+    use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+    use crate::operations::shared_storage_config::SharedStorageConfig;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::optimizers_builder::OptimizersConfig;
+    use crate::shards::channel_service::ChannelService;
+    use crate::shards::collection_shard_distribution::CollectionShardDistribution;
+    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+
+    fn dummy_on_replica_failure() -> ChangePeerFromState {
+        Arc::new(move |_peer_id, _shard_id, _from_state| {})
+    }
+
+    fn dummy_request_shard_transfer() -> RequestShardTransfer {
+        Arc::new(move |_transfer| {})
+    }
+
+    fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+        Arc::new(|_transfer, _reason| {})
+    }
+
+    async fn transfer_method_fixture(
+        configured_method: Option<ShardTransferMethod>,
+        prevent_unoptimized: Option<bool>,
+    ) -> Collection {
+        let wal_config = WalConfig {
+            wal_capacity_mb: 1,
+            wal_segments_ahead: 0,
+            wal_retain_closed: 1,
+        };
+
+        let collection_params = CollectionParams {
+            vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+            shard_number: NonZeroU32::new(1).unwrap(),
+            replication_factor: NonZeroU32::new(1).unwrap(),
+            write_consistency_factor: NonZeroU32::new(1).unwrap(),
+            ..CollectionParams::empty()
+        };
+
+        let mut optimizer_config = OptimizersConfig::fixture();
+        optimizer_config.prevent_unoptimized = prevent_unoptimized;
+
+        let config = CollectionConfigInternal {
+            params: collection_params,
+            optimizer_config,
+            wal_config,
+            hnsw_config: Default::default(),
+            quantization_config: Default::default(),
+            strict_mode_config: Default::default(),
+            uuid: None,
+            metadata: None,
+        };
+
+        let collection_dir = Builder::new().prefix("transfer_method_collection").tempdir().unwrap();
+        let snapshots_path = Builder::new().prefix("transfer_method_snapshots").tempdir().unwrap();
+
+        let shards: AHashMap<_, _> = [(0, HashSet::from([0_u64]))].into_iter().collect();
+
+        let storage_config = Arc::new(SharedStorageConfig {
+            default_shard_transfer_method: configured_method,
+            ..Default::default()
+        });
+
+        Collection::new(
+            "test".to_string(),
+            0,
+            collection_dir.path(),
+            snapshots_path.path(),
+            &config,
+            storage_config,
+            CollectionShardDistribution { shards },
+            None,
+            ChannelService::default(),
+            dummy_on_replica_failure(),
+            dummy_request_shard_transfer(),
+            dummy_abort_shard_transfer(),
+            None,
+            None,
+            ResourceBudget::default(),
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn default_shard_transfer_method_defaults_to_snapshot() {
+        let collection = transfer_method_fixture(None, None).await;
+
+        assert_eq!(
+            collection.default_shard_transfer_method().await,
+            ShardTransferMethod::Snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn default_shard_transfer_method_respects_explicit_config() {
+        let stream_collection =
+            transfer_method_fixture(Some(ShardTransferMethod::StreamRecords), None).await;
+        assert_eq!(
+            stream_collection.default_shard_transfer_method().await,
+            ShardTransferMethod::StreamRecords
+        );
+
+        let snapshot_collection =
+            transfer_method_fixture(Some(ShardTransferMethod::Snapshot), None).await;
+        assert_eq!(
+            snapshot_collection.default_shard_transfer_method().await,
+            ShardTransferMethod::Snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn prevent_unoptimized_forces_snapshot_default() {
+        let collection =
+            transfer_method_fixture(Some(ShardTransferMethod::StreamRecords), Some(true)).await;
+
+        assert_eq!(
+            collection.default_shard_transfer_method().await,
+            ShardTransferMethod::Snapshot
+        );
     }
 }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -59,13 +59,19 @@ impl Collection {
     }
 
     pub async fn wal_delta_fallback_transfer_method(&self) -> ShardTransferMethod {
-        if self.is_prevent_unoptimized().await {
+        let fallback_method = if self.is_prevent_unoptimized().await {
             log::info!("Using snapshot transfer fallback because prevent_unoptimized is enabled");
             ShardTransferMethod::Snapshot
         } else {
             self.shared_storage_config
                 .default_shard_transfer_method
                 .unwrap_or(ShardTransferMethod::Snapshot)
+        };
+
+        if fallback_method == ShardTransferMethod::WalDelta {
+            ShardTransferMethod::StreamRecords
+        } else {
+            fallback_method
         }
     }
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -54,6 +54,17 @@ impl Collection {
         } else {
             self.shared_storage_config
                 .default_shard_transfer_method
+                .unwrap_or(ShardTransferMethod::StreamRecords)
+        }
+    }
+
+    pub async fn wal_delta_fallback_transfer_method(&self) -> ShardTransferMethod {
+        if self.is_prevent_unoptimized().await {
+            log::info!("Using snapshot transfer fallback because prevent_unoptimized is enabled");
+            ShardTransferMethod::Snapshot
+        } else {
+            self.shared_storage_config
+                .default_shard_transfer_method
                 .unwrap_or(ShardTransferMethod::Snapshot)
         }
     }
@@ -222,11 +233,10 @@ impl Collection {
 
         let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
 
-        // Fall back to the same canonical default transfer method selection used
-        // everywhere else. This keeps automatic recovery aligned with the
-        // configured/default orchestration policy instead of silently forcing a
-        // different method after WalDelta failure.
-        let fallback_method = self.default_shard_transfer_method().await;
+        // WalDelta can be rejected for restored snapshots and other cases where
+        // the destination cannot derive a valid WAL diff. In that case prefer a
+        // snapshot fallback unless the operator configured a different method.
+        let fallback_method = self.wal_delta_fallback_transfer_method().await;
         let transfer_task = transfer::driver::spawn_transfer_task(
             shard_holder,
             progress.clone(),
@@ -666,8 +676,14 @@ mod tests {
             metadata: None,
         };
 
-        let collection_dir = Builder::new().prefix("transfer_method_collection").tempdir().unwrap();
-        let snapshots_path = Builder::new().prefix("transfer_method_snapshots").tempdir().unwrap();
+        let collection_dir = Builder::new()
+            .prefix("transfer_method_collection")
+            .tempdir()
+            .unwrap();
+        let snapshots_path = Builder::new()
+            .prefix("transfer_method_snapshots")
+            .tempdir()
+            .unwrap();
 
         let shards: AHashMap<_, _> = [(0, HashSet::from([0_u64]))].into_iter().collect();
 
@@ -699,11 +715,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_default_shard_transfer_method_defaults_to_stream_records() {
+        let collection = transfer_method_fixture(None, None).await;
+
+        assert_eq!(
+            collection.legacy_default_shard_transfer_method().await,
+            ShardTransferMethod::StreamRecords
+        );
+    }
+
+    #[tokio::test]
     async fn default_shard_transfer_method_defaults_to_snapshot() {
         let collection = transfer_method_fixture(None, None).await;
 
         assert_eq!(
-            collection.default_shard_transfer_method().await,
+            collection.default_shard_transfer_method(),
+            ShardTransferMethod::Snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn wal_delta_fallback_transfer_method_defaults_to_snapshot() {
+        let collection = transfer_method_fixture(None, None).await;
+
+        assert_eq!(
+            collection.wal_delta_fallback_transfer_method().await,
             ShardTransferMethod::Snapshot
         );
     }
@@ -713,25 +749,44 @@ mod tests {
         let stream_collection =
             transfer_method_fixture(Some(ShardTransferMethod::StreamRecords), None).await;
         assert_eq!(
-            stream_collection.default_shard_transfer_method().await,
+            stream_collection.default_shard_transfer_method(),
             ShardTransferMethod::StreamRecords
         );
 
         let snapshot_collection =
             transfer_method_fixture(Some(ShardTransferMethod::Snapshot), None).await;
         assert_eq!(
-            snapshot_collection.default_shard_transfer_method().await,
+            snapshot_collection.default_shard_transfer_method(),
             ShardTransferMethod::Snapshot
         );
     }
 
     #[tokio::test]
-    async fn prevent_unoptimized_forces_snapshot_default() {
+    async fn prevent_unoptimized_forces_snapshot_legacy_default() {
         let collection =
             transfer_method_fixture(Some(ShardTransferMethod::StreamRecords), Some(true)).await;
 
         assert_eq!(
-            collection.default_shard_transfer_method().await,
+            collection.legacy_default_shard_transfer_method().await,
+            ShardTransferMethod::Snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn wal_delta_fallback_transfer_method_respects_explicit_config() {
+        let stream_collection =
+            transfer_method_fixture(Some(ShardTransferMethod::StreamRecords), None).await;
+        assert_eq!(
+            stream_collection.wal_delta_fallback_transfer_method().await,
+            ShardTransferMethod::StreamRecords
+        );
+
+        let snapshot_collection =
+            transfer_method_fixture(Some(ShardTransferMethod::Snapshot), None).await;
+        assert_eq!(
+            snapshot_collection
+                .wal_delta_fallback_transfer_method()
+                .await,
             ShardTransferMethod::Snapshot
         );
     }

--- a/lib/collection/src/shards/replica_set/replica_set_state.rs
+++ b/lib/collection/src/shards/replica_set/replica_set_state.rs
@@ -315,3 +315,24 @@ impl ReplicaState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ReplicaState;
+
+    #[test]
+    fn active_replica_is_source_of_truth_and_does_not_require_recovery() {
+        assert!(ReplicaState::Active.is_active());
+        assert!(ReplicaState::Active.is_readable());
+        assert!(ReplicaState::Active.can_be_source_of_truth());
+        assert!(!ReplicaState::Active.requires_recovery());
+    }
+
+    #[test]
+    fn dead_replica_requires_recovery_and_is_not_source_of_truth() {
+        assert!(!ReplicaState::Dead.is_active());
+        assert!(!ReplicaState::Dead.is_readable());
+        assert!(!ReplicaState::Dead.can_be_source_of_truth());
+        assert!(ReplicaState::Dead.requires_recovery());
+    }
+}

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -11,6 +11,7 @@ use collection::shards::replica_set::replica_set_state::{
     MANUAL_RECOVERY_SHARD_STATE_VERSION, ReplicaState,
 };
 use collection::shards::shard::{PeerId, ShardId};
+use collection::shards::transfer::ShardTransferMethod;
 use common::save_on_disk::SaveOnDisk;
 use fs_err::tokio as tokio_fs;
 use shard::files::PAYLOAD_INDEX_CONFIG_FILE;
@@ -55,6 +56,35 @@ pub async fn activate_shard(
             .await?;
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotPriorityReplicaAction {
+    RemoveReplica(PeerId),
+    RecoverReplicaFromSnapshot(PeerId),
+}
+
+fn plan_snapshot_priority_snapshot_actions(
+    other_active_replicas: &[PeerId],
+    replicas_to_keep: u32,
+) -> Vec<SnapshotPriorityReplicaAction> {
+    let mut actions = Vec::with_capacity(other_active_replicas.len());
+    let mut replicas_to_remove = other_active_replicas
+        .len()
+        .saturating_sub(replicas_to_keep as usize);
+
+    for peer_id in other_active_replicas {
+        if replicas_to_remove > 0 {
+            replicas_to_remove -= 1;
+            actions.push(SnapshotPriorityReplicaAction::RemoveReplica(*peer_id));
+        } else {
+            actions.push(SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(
+                *peer_id,
+            ));
+        }
+    }
+
+    actions
 }
 
 /// # Cancel safety
@@ -359,6 +389,7 @@ async fn _do_recover_from_snapshot(
 
                 peer_id != this_peer_id && is_active
             })
+            .map(|(&peer_id, _)| peer_id)
             .collect();
 
         if other_active_replicas.is_empty() {
@@ -376,37 +407,39 @@ async fn _do_recover_from_snapshot(
                     activate_shard(toc, &collection, this_peer_id, shard_id).await?;
 
                     let replicas_to_keep = state.config.params.replication_factor.get() - 1;
-                    let mut replicas_to_remove = other_active_replicas
-                        .len()
-                        .saturating_sub(replicas_to_keep as usize);
-
-                    for (peer_id, _) in other_active_replicas {
-                        if replicas_to_remove > 0 {
-                            // Keep this replica
-                            replicas_to_remove -= 1;
-
-                            // Don't need more replicas, remove this one
-                            toc.request_remove_replica(
-                                collection_pass.to_string(),
-                                *shard_id,
-                                *peer_id,
-                            )?;
-                        } else {
-                            toc.send_set_replica_state_proposal(
-                                collection_pass.to_string(),
-                                *peer_id,
-                                *shard_id,
-                                ReplicaState::Dead,
-                                None,
-                            )?;
+                    for action in plan_snapshot_priority_snapshot_actions(
+                        &other_active_replicas,
+                        replicas_to_keep,
+                    ) {
+                        match action {
+                            SnapshotPriorityReplicaAction::RemoveReplica(peer_id) => {
+                                // Don't need more replicas, remove this one.
+                                toc.request_remove_replica(
+                                    collection_pass.to_string(),
+                                    *shard_id,
+                                    peer_id,
+                                )?;
+                            }
+                            SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(peer_id) => {
+                                // The recovered snapshot is the new source of truth for the shard,
+                                // so explicitly re-seed remaining replicas from it instead of
+                                // relying on generic dead-replica auto recovery.
+                                toc.request_shard_transfer(
+                                    collection_pass.to_string(),
+                                    *shard_id,
+                                    this_peer_id,
+                                    peer_id,
+                                    true,
+                                    Some(ShardTransferMethod::Snapshot),
+                                )?;
+                            }
                         }
                     }
                 }
 
                 SnapshotPriority::Replica => {
                     // Replica is the source of truth, we need to sync recovered data with this replica
-                    let (replica_peer_id, _state) =
-                        other_active_replicas.into_iter().next().unwrap();
+                    let replica_peer_id = other_active_replicas.into_iter().next().unwrap();
                     log::debug!(
                         "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}",
                     );
@@ -415,7 +448,7 @@ async fn _do_recover_from_snapshot(
                     toc.request_shard_transfer(
                         collection_pass.to_string(),
                         *shard_id,
-                        *replica_peer_id,
+                        replica_peer_id,
                         this_peer_id,
                         true,
                         None,
@@ -438,4 +471,36 @@ async fn _do_recover_from_snapshot(
     tokio_fs::remove_dir_all(&tmp_collection_dir).await?;
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SnapshotPriorityReplicaAction, plan_snapshot_priority_snapshot_actions};
+
+    #[test]
+    fn snapshot_priority_snapshot_removes_excess_replicas_before_reseeding() {
+        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22, 33], 2);
+
+        assert_eq!(
+            actions,
+            vec![
+                SnapshotPriorityReplicaAction::RemoveReplica(11),
+                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(22),
+                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(33),
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_priority_snapshot_reseeds_all_replicas_when_no_excess_exist() {
+        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22], 2);
+
+        assert_eq!(
+            actions,
+            vec![
+                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(11),
+                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(22),
+            ]
+        );
+    }
 }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -77,7 +77,9 @@ fn plan_snapshot_priority_snapshot_actions(
             replicas_to_remove -= 1;
             actions.push(SnapshotPriorityReplicaAction::RemoveReplica(*peer_id));
         } else {
-            actions.push(SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(*peer_id));
+            actions.push(SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(
+                *peer_id,
+            ));
         }
     }
 
@@ -417,9 +419,7 @@ async fn _do_recover_from_snapshot(
                                     peer_id,
                                 )?;
                             }
-                            SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(
-                                peer_id,
-                            ) => {
+                            SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(peer_id) => {
                                 // Retained replicas are still stale after restore. Mark them dead
                                 // and let the normal recovery machinery pick the transfer method
                                 // and concurrency envelope.

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -57,6 +57,33 @@ pub async fn activate_shard(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotPriorityReplicaAction {
+    RemoveReplica(PeerId),
+    MarkReplicaDeadForRecovery(PeerId),
+}
+
+fn plan_snapshot_priority_snapshot_actions(
+    other_active_replicas: &[PeerId],
+    replicas_to_keep: u32,
+) -> Vec<SnapshotPriorityReplicaAction> {
+    let mut actions = Vec::with_capacity(other_active_replicas.len());
+    let mut replicas_to_remove = other_active_replicas
+        .len()
+        .saturating_sub(replicas_to_keep as usize);
+
+    for peer_id in other_active_replicas {
+        if replicas_to_remove > 0 {
+            replicas_to_remove -= 1;
+            actions.push(SnapshotPriorityReplicaAction::RemoveReplica(*peer_id));
+        } else {
+            actions.push(SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(*peer_id));
+        }
+    }
+
+    actions
+}
+
 /// # Cancel safety
 ///
 /// This method is cancel safe.
@@ -359,6 +386,7 @@ async fn _do_recover_from_snapshot(
 
                 peer_id != this_peer_id && is_active
             })
+            .map(|(&peer_id, _)| peer_id)
             .collect();
 
         if other_active_replicas.is_empty() {
@@ -375,39 +403,41 @@ async fn _do_recover_from_snapshot(
                     // Snapshot is the source of truth, we need to remove all other replicas
                     activate_shard(toc, &collection, this_peer_id, shard_id).await?;
 
-                    let replicas_to_keep =
-                        state.config.params.replication_factor.get().saturating_sub(1) as usize;
-                    let mut replicas_to_remove = other_active_replicas
-                        .len()
-                        .saturating_sub(replicas_to_keep);
-
-                    for (peer_id, _) in other_active_replicas {
-                        if replicas_to_remove > 0 {
-                            replicas_to_remove -= 1;
-
-                            // Don't need more replicas, remove this one.
-                            toc.request_remove_replica(
-                                collection_pass.to_string(),
-                                *shard_id,
-                                *peer_id,
-                            )?;
-                        } else {
-                            // Keep enough retained replicas active to satisfy replication factor
-                            // after activating the recovered local replica.
-                            toc.send_set_replica_state_proposal(
-                                collection_pass.to_string(),
-                                *peer_id,
-                                *shard_id,
-                                ReplicaState::Active,
-                                None,
-                            )?;
+                    let replicas_to_keep = state.config.params.replication_factor.get() - 1;
+                    for action in plan_snapshot_priority_snapshot_actions(
+                        &other_active_replicas,
+                        replicas_to_keep,
+                    ) {
+                        match action {
+                            SnapshotPriorityReplicaAction::RemoveReplica(peer_id) => {
+                                // Don't need more replicas, remove this one.
+                                toc.request_remove_replica(
+                                    collection_pass.to_string(),
+                                    *shard_id,
+                                    peer_id,
+                                )?;
+                            }
+                            SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(
+                                peer_id,
+                            ) => {
+                                // Retained replicas are still stale after restore. Mark them dead
+                                // and let the normal recovery machinery pick the transfer method
+                                // and concurrency envelope.
+                                toc.send_set_replica_state_proposal(
+                                    collection_pass.to_string(),
+                                    peer_id,
+                                    *shard_id,
+                                    ReplicaState::Dead,
+                                    None,
+                                )?;
+                            }
                         }
                     }
                 }
 
                 SnapshotPriority::Replica => {
                     // Replica is the source of truth, we need to sync recovered data with this replica
-                    let (replica_peer_id, _state) = other_active_replicas.into_iter().next().unwrap();
+                    let replica_peer_id = other_active_replicas.into_iter().next().unwrap();
                     log::debug!(
                         "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}",
                     );
@@ -416,7 +446,7 @@ async fn _do_recover_from_snapshot(
                     toc.request_shard_transfer(
                         collection_pass.to_string(),
                         *shard_id,
-                        *replica_peer_id,
+                        replica_peer_id,
                         this_peer_id,
                         true,
                         None,
@@ -439,4 +469,36 @@ async fn _do_recover_from_snapshot(
     tokio_fs::remove_dir_all(&tmp_collection_dir).await?;
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SnapshotPriorityReplicaAction, plan_snapshot_priority_snapshot_actions};
+
+    #[test]
+    fn snapshot_priority_snapshot_removes_excess_replicas_before_reseeding() {
+        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22, 33], 2);
+
+        assert_eq!(
+            actions,
+            vec![
+                SnapshotPriorityReplicaAction::RemoveReplica(11),
+                SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(22),
+                SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(33),
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_priority_snapshot_marks_all_retained_replicas_dead_when_no_excess_exist() {
+        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22], 2);
+
+        assert_eq!(
+            actions,
+            vec![
+                SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(11),
+                SnapshotPriorityReplicaAction::MarkReplicaDeadForRecovery(22),
+            ]
+        );
+    }
 }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -11,7 +11,6 @@ use collection::shards::replica_set::replica_set_state::{
     MANUAL_RECOVERY_SHARD_STATE_VERSION, ReplicaState,
 };
 use collection::shards::shard::{PeerId, ShardId};
-use collection::shards::transfer::ShardTransferMethod;
 use common::save_on_disk::SaveOnDisk;
 use fs_err::tokio as tokio_fs;
 use shard::files::PAYLOAD_INDEX_CONFIG_FILE;
@@ -56,35 +55,6 @@ pub async fn activate_shard(
             .await?;
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SnapshotPriorityReplicaAction {
-    RemoveReplica(PeerId),
-    RecoverReplicaFromSnapshot(PeerId),
-}
-
-fn plan_snapshot_priority_snapshot_actions(
-    other_active_replicas: &[PeerId],
-    replicas_to_keep: u32,
-) -> Vec<SnapshotPriorityReplicaAction> {
-    let mut actions = Vec::with_capacity(other_active_replicas.len());
-    let mut replicas_to_remove = other_active_replicas
-        .len()
-        .saturating_sub(replicas_to_keep as usize);
-
-    for peer_id in other_active_replicas {
-        if replicas_to_remove > 0 {
-            replicas_to_remove -= 1;
-            actions.push(SnapshotPriorityReplicaAction::RemoveReplica(*peer_id));
-        } else {
-            actions.push(SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(
-                *peer_id,
-            ));
-        }
-    }
-
-    actions
 }
 
 /// # Cancel safety
@@ -389,7 +359,6 @@ async fn _do_recover_from_snapshot(
 
                 peer_id != this_peer_id && is_active
             })
-            .map(|(&peer_id, _)| peer_id)
             .collect();
 
         if other_active_replicas.is_empty() {
@@ -406,40 +375,39 @@ async fn _do_recover_from_snapshot(
                     // Snapshot is the source of truth, we need to remove all other replicas
                     activate_shard(toc, &collection, this_peer_id, shard_id).await?;
 
-                    let replicas_to_keep = state.config.params.replication_factor.get() - 1;
-                    for action in plan_snapshot_priority_snapshot_actions(
-                        &other_active_replicas,
-                        replicas_to_keep,
-                    ) {
-                        match action {
-                            SnapshotPriorityReplicaAction::RemoveReplica(peer_id) => {
-                                // Don't need more replicas, remove this one.
-                                toc.request_remove_replica(
-                                    collection_pass.to_string(),
-                                    *shard_id,
-                                    peer_id,
-                                )?;
-                            }
-                            SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(peer_id) => {
-                                // The recovered snapshot is the new source of truth for the shard,
-                                // so explicitly re-seed remaining replicas from it instead of
-                                // relying on generic dead-replica auto recovery.
-                                toc.request_shard_transfer(
-                                    collection_pass.to_string(),
-                                    *shard_id,
-                                    this_peer_id,
-                                    peer_id,
-                                    true,
-                                    Some(ShardTransferMethod::Snapshot),
-                                )?;
-                            }
+                    let replicas_to_keep =
+                        state.config.params.replication_factor.get().saturating_sub(1) as usize;
+                    let mut replicas_to_remove = other_active_replicas
+                        .len()
+                        .saturating_sub(replicas_to_keep);
+
+                    for (peer_id, _) in other_active_replicas {
+                        if replicas_to_remove > 0 {
+                            replicas_to_remove -= 1;
+
+                            // Don't need more replicas, remove this one.
+                            toc.request_remove_replica(
+                                collection_pass.to_string(),
+                                *shard_id,
+                                *peer_id,
+                            )?;
+                        } else {
+                            // Keep enough retained replicas active to satisfy replication factor
+                            // after activating the recovered local replica.
+                            toc.send_set_replica_state_proposal(
+                                collection_pass.to_string(),
+                                *peer_id,
+                                *shard_id,
+                                ReplicaState::Active,
+                                None,
+                            )?;
                         }
                     }
                 }
 
                 SnapshotPriority::Replica => {
                     // Replica is the source of truth, we need to sync recovered data with this replica
-                    let replica_peer_id = other_active_replicas.into_iter().next().unwrap();
+                    let (replica_peer_id, _state) = other_active_replicas.into_iter().next().unwrap();
                     log::debug!(
                         "Running synchronization for shard {shard_id} of collection {collection_pass} from {replica_peer_id}",
                     );
@@ -448,7 +416,7 @@ async fn _do_recover_from_snapshot(
                     toc.request_shard_transfer(
                         collection_pass.to_string(),
                         *shard_id,
-                        replica_peer_id,
+                        *replica_peer_id,
                         this_peer_id,
                         true,
                         None,
@@ -471,36 +439,4 @@ async fn _do_recover_from_snapshot(
     tokio_fs::remove_dir_all(&tmp_collection_dir).await?;
 
     Ok(true)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{SnapshotPriorityReplicaAction, plan_snapshot_priority_snapshot_actions};
-
-    #[test]
-    fn snapshot_priority_snapshot_removes_excess_replicas_before_reseeding() {
-        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22, 33], 2);
-
-        assert_eq!(
-            actions,
-            vec![
-                SnapshotPriorityReplicaAction::RemoveReplica(11),
-                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(22),
-                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(33),
-            ]
-        );
-    }
-
-    #[test]
-    fn snapshot_priority_snapshot_reseeds_all_replicas_when_no_excess_exist() {
-        let actions = plan_snapshot_priority_snapshot_actions(&[11, 22], 2);
-
-        assert_eq!(
-            actions,
-            vec![
-                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(11),
-                SnapshotPriorityReplicaAction::RecoverReplicaFromSnapshot(22),
-            ]
-        );
-    }
 }

--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -548,9 +548,9 @@ def test_shard_wal_delta_transfer_fallback(tmp_path: pathlib.Path):
     assert_http_ok(r)
 
     # WAL delta transfer should fail because the shard does not exist on the
-    # target node, assert we fall back to the streaming records method
+    # target node, assert we fall back to the snapshot method
     # Then wait for the transfer to finish
-    wait_for_collection_shard_transfer_method(peer_api_uris[0], COLLECTION_NAME, "stream_records")
+    wait_for_collection_shard_transfer_method(peer_api_uris[0], COLLECTION_NAME, "snapshot")
     wait_for_collection_shard_transfers_count(peer_api_uris[0], COLLECTION_NAME, 0)
 
     receiver_collection_cluster_info = get_collection_cluster_info(peer_api_uris[2], COLLECTION_NAME)

--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -40,9 +40,9 @@ def get_remote_shards(peer_api_uri):
     return r.json()["result"]['remote_shards']
 
 
-def recover_snapshot(peer_api_uri, snapshot_url):
+def recover_snapshot(peer_api_uri, snapshot_url, priority="snapshot"):
     r = requests.put(f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/recover",
-                     json={"location": snapshot_url})
+                     json={"location": snapshot_url, "priority": priority})
     assert_http_ok(r)
     return r.json()["result"]
 
@@ -55,7 +55,16 @@ def test_recover_from_snapshot_2(tmp_path: pathlib.Path):
     recover_from_snapshot(tmp_path, 2)
 
 
-def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
+def test_snapshot_priority_recovery_enters_non_active_phase_before_converging(tmp_path: pathlib.Path):
+    recover_from_snapshot(tmp_path, 2, point_count=3_000, assert_intermediate_recovery_phase=True)
+
+
+def recover_from_snapshot(
+    tmp_path: pathlib.Path,
+    n_replicas,
+    point_count: int = 100,
+    assert_intermediate_recovery_phase: bool = False,
+):
     assert_project_root()
 
     peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
@@ -67,7 +76,7 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
 
     wait_for_same_commit(peer_api_uris=peer_api_uris)
 
-    upsert_random_points(peer_api_uris[0], 100)
+    upsert_random_points(peer_api_uris[0], point_count)
 
     query_city = "London"
 
@@ -133,7 +142,23 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
 
     print(f"Recovering snapshot {snapshot_url} on {new_url}")
 
-    recover_snapshot(new_url, snapshot_url)
+    recover_snapshot(new_url, snapshot_url, priority="snapshot")
+
+    if assert_intermediate_recovery_phase:
+        # Snapshot-priority restore may activate the recovered local shard immediately, but the
+        # retained replicas must still go through recovery before they can legally become Active.
+        def cluster_has_non_active_replica():
+            for uri in peer_api_uris[:-1] + [new_url]:
+                try:
+                    info = get_collection_cluster_info(uri, COLLECTION_NAME)
+                except requests.exceptions.ConnectionError:
+                    continue
+                for shard in info["local_shards"] + info["remote_shards"]:
+                    if shard["state"] != "Active":
+                        return True
+            return False
+
+        wait_for(cluster_has_non_active_replica)
 
     wait_collection_exists_and_active_on_all_peers(collection_name=COLLECTION_NAME, peer_api_uris=[new_url])
 


### PR DESCRIPTION
Fixes #5857

## Summary

Keep snapshot-priority restore truthful about replica state, and make failed `WalDelta` recovery fall back to snapshot-based transfer while preserving the existing recovery orchestration and transfer limits.

## Problem

Two earlier shapes of this fix were not sound:

- marking retained stale replicas `Active` after snapshot-priority restore can create inconsistencies across replicas
- explicitly requesting snapshot transfers from `recover.rs` bypasses existing recovery orchestration and can fan out parallel snapshot transfers from the same source

The follow-up recovery should stay under the automatic recovery machinery so it keeps the existing transfer limits and conflict checks. At the same time, large restored snapshots should not silently end up on an unsuitable fallback path after `WalDelta` is rejected.

During review I also found a regression in an intermediate revision: changing the broad transfer default without accounting for filtered transfers broke `replicate_points`/custom-sharding because filtered transfers require a streaming method. Current `dev` now handles filtered point replication by selecting `StreamRecords` for filtered transfers; this PR keeps that behavior covered.

## What changed

- In `recover.rs`, snapshot-priority restore now:
  - activates the restored local shard
  - removes only truly excess replicas
  - keeps retained stale replicas in `Dead` so they legally require recovery
- In `collection/shard_transfer.rs`:
  - `WalDelta` fallback defaults to `Snapshot` when no explicit transfer method is configured
  - explicit `storage.shard_transfer_method` still controls the fallback, including `stream_records`
  - legacy mixed-version fallback behavior remains covered separately from the current 1.18+ default
- Added/updated tests for:
  - snapshot-priority retained-replica planning
  - replica-state invariants (`Active` vs `Dead`)
  - snapshot-priority recovery entering a non-`Active` phase before converging
  - current default vs legacy default transfer-method behavior
  - `WalDelta` fallback using snapshot by default
  - filtered `replicate_points` continuing to work with a streaming transfer

## Why

This keeps the restore path semantically correct while still letting the existing recovery machinery orchestrate follow-up synchronization. The patch no longer lies about replica health, and it no longer hardcodes ad-hoc transfer orchestration in `recover.rs`.

Narrowing the snapshot behavior to `WalDelta` fallback also keeps filtered point replication from regressing.

## Tests

- `cargo fmt --check`
- `cargo test -p collection default_shard_transfer_method_ --lib -- --nocapture`
- `cargo test -p collection legacy_default_shard_transfer_method_ --lib -- --nocapture`
- `cargo test -p collection wal_delta_fallback_transfer_method_ --lib -- --nocapture`
- `cargo test -p collection prevent_unoptimized_forces_snapshot_legacy_default --lib -- --nocapture`
- `cargo test -p storage snapshot_priority_snapshot_ --lib -- --nocapture`
- `cargo check -p storage`
- `cargo build --bin qdrant`
- `cargo test -p collection snapshot_recovery_test -- --nocapture`
- `pytest -q -o addopts='' tests/consensus_tests/test_replicate_points.py -k test_replicate_points_stream_transfer --tb=short`
- `pytest -q -o addopts='' tests/consensus_tests/test_shard_wal_delta_transfer.py -k test_shard_wal_delta_transfer_fallback --tb=short`
- `pytest -q -o addopts='' tests/consensus_tests/test_snapshot_recovery.py -k 'recover_from_snapshot_2 or snapshot_priority_recovery_enters_non_active_phase_before_converging' --tb=short`
