### PR TITLE
audit logging telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12240,6 +12240,16 @@
             "type": "boolean",
             "nullable": true
           },
+          "audit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AuditTelemetry"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
           "startup": {
             "type": "string",
             "format": "date-time"
@@ -12389,6 +12399,41 @@
         "properties": {
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "AuditTelemetry": {
+        "type": "object",
+        "required": [
+          "dir",
+          "log_api",
+          "max_log_files",
+          "rotation",
+          "trust_forwarded_headers"
+        ],
+        "properties": {
+          "dir": {
+            "type": "string"
+          },
+          "rotation": {
+            "type": "string"
+          },
+          "max_log_files": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "trust_forwarded_headers": {
+            "type": "boolean"
+          },
+          "log_api": {
+            "type": "boolean"
+          },
+          "dir_size_bytes": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
           }
         }
       },

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -171,6 +171,18 @@ impl MetricsProvider for AppBuildTelemetry {
         self.features
             .iter()
             .for_each(|f| f.add_metrics(metrics, prefix));
+
+        if let Some(audit) = &self.audit
+            && let Some(size) = audit.dir_size_bytes
+        {
+            metrics.push_metric(metric_family(
+                "audit_log_dir_size_bytes",
+                "size of the audit log directory on disk in bytes",
+                MetricType::GAUGE,
+                vec![gauge(size as f64, &[])],
+                prefix,
+            ));
+        }
     }
 }
 

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -125,7 +125,11 @@ fn collect_audit_telemetry(
 ) -> Option<AuditTelemetry> {
     let config = audit.filter(|c| c.enabled)?;
     let dir_size_bytes = (detail.level > DetailsLevel::Level2)
-        .then(|| common::disk::dir_disk_size(&config.dir).ok().map(|v| v as usize))
+        .then(|| {
+            common::disk::dir_disk_size(&config.dir)
+                .ok()
+                .map(|v| v as usize)
+        })
         .flatten();
     let rotation = match config.rotation {
         AuditRotation::Daily => "daily",

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -8,6 +8,7 @@ use segment::common::anonymize::Anonymize;
 use segment::types::HnswGlobalConfig;
 use serde::Serialize;
 
+use crate::common::audit::{AuditConfig, AuditRotation};
 use crate::settings::Settings;
 
 pub struct AppBuildTelemetryCollector {
@@ -52,6 +53,19 @@ pub struct RunningEnvironmentTelemetry {
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
+pub struct AuditTelemetry {
+    #[anonymize(false)]
+    pub dir: String,
+    #[anonymize(false)]
+    pub rotation: String,
+    pub max_log_files: usize,
+    pub trust_forwarded_headers: bool,
+    pub log_api: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dir_size_bytes: Option<usize>,
+}
+
+#[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
 pub struct AppBuildTelemetry {
     #[anonymize(false)]
     pub name: String,
@@ -70,6 +84,8 @@ pub struct AppBuildTelemetry {
     pub jwt_rbac: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_jwt_dashboard: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audit: Option<AuditTelemetry>,
     pub startup: DateTime<Utc>,
 }
 
@@ -97,9 +113,32 @@ impl AppBuildTelemetry {
             system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
             jwt_rbac: settings.service.jwt_rbac,
             hide_jwt_dashboard: settings.service.hide_jwt_dashboard,
+            audit: collect_audit_telemetry(settings.audit.as_ref(), detail),
             startup: collector.startup,
         }
     }
+}
+
+fn collect_audit_telemetry(
+    audit: Option<&AuditConfig>,
+    detail: TelemetryDetail,
+) -> Option<AuditTelemetry> {
+    let config = audit.filter(|c| c.enabled)?;
+    let dir_size_bytes = (detail.level > DetailsLevel::Level2)
+        .then(|| common::disk::dir_disk_size(&config.dir).ok().map(|v| v as usize))
+        .flatten();
+    let rotation = match config.rotation {
+        AuditRotation::Daily => "daily",
+        AuditRotation::Hourly => "hourly",
+    };
+    Some(AuditTelemetry {
+        dir: config.dir.display().to_string(),
+        rotation: rotation.to_string(),
+        max_log_files: config.max_log_files,
+        trust_forwarded_headers: config.trust_forwarded_headers,
+        log_api: config.log_api,
+        dir_size_bytes,
+    })
 }
 
 fn get_system_data() -> RunningEnvironmentTelemetry {

--- a/src/common/telemetry_ops/conversions.rs
+++ b/src/common/telemetry_ops/conversions.rs
@@ -37,6 +37,7 @@ impl TryFrom<grpc::AppTelemetry> for AppBuildTelemetry {
             system: None,
             jwt_rbac: None,
             hide_jwt_dashboard: None,
+            audit: None,
             startup: DateTime::from_timestamp_secs(startup)
                 .ok_or_else(|| Status::internal("startup time is out-of-range"))?,
         })
@@ -54,6 +55,7 @@ impl From<AppBuildTelemetry> for grpc::AppTelemetry {
             system: _,
             jwt_rbac: _,
             hide_jwt_dashboard: _,
+            audit: _,
             startup,
         } = value;
 


### PR DESCRIPTION
```
Update telemetry: if audit logging is enabled, telemetry should report audit logging configuration. Additionally, it should report on-disk size of the audit log directory (if details level > 2). Additionally, log audit logging         
directory size in /metrics, if audit logging is enabled
```