### PR TITLE
fix: Payload range filtering misbehaves at float32 minimum finite value (FLT_MIN), with inconsistent results between gRPC and REST (#8617)

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2033,26 +2033,30 @@ mod tests {
     #[test]
     fn float_min_boundary_grpc_range_round_trip() {
         let float_min = f64::from(f32::MIN);
+        let neg_one = f64::from(-1.0_f32);
+        let pos_one = f64::from(1.0_f32);
+        let float_max = f64::from(f32::MAX);
         let grpc = Range {
             lt: Some(float_min),
-            gt: Some(float_min),
-            gte: Some(float_min),
-            lte: Some(float_min),
+            gt: Some(neg_one),
+            gte: Some(pos_one),
+            lte: Some(float_max),
         };
 
-        let segment_range = segment::types::Range::<OrderedFloat<FloatPayloadType>>::from(grpc.clone());
+        let segment_range =
+            segment::types::Range::<OrderedFloat<FloatPayloadType>>::from(grpc.clone());
 
         assert_eq!(segment_range.lt, Some(OrderedFloat(float_min)));
-        assert_eq!(segment_range.gt, Some(OrderedFloat(float_min)));
-        assert_eq!(segment_range.gte, Some(OrderedFloat(float_min)));
-        assert_eq!(segment_range.lte, Some(OrderedFloat(float_min)));
+        assert_eq!(segment_range.gt, Some(OrderedFloat(neg_one)));
+        assert_eq!(segment_range.gte, Some(OrderedFloat(pos_one)));
+        assert_eq!(segment_range.lte, Some(OrderedFloat(float_max)));
 
         let grpc_round_trip = Range::from(segment_range);
 
         assert_eq!(grpc_round_trip.lt, Some(float_min));
-        assert_eq!(grpc_round_trip.gt, Some(float_min));
-        assert_eq!(grpc_round_trip.gte, Some(float_min));
-        assert_eq!(grpc_round_trip.lte, Some(float_min));
+        assert_eq!(grpc_round_trip.gt, Some(neg_one));
+        assert_eq!(grpc_round_trip.gte, Some(pos_one));
+        assert_eq!(grpc_round_trip.lte, Some(float_max));
     }
 }
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1995,18 +1995,19 @@ impl From<segment::types::GeoLineString> for GeoLineString {
 impl From<Range> for segment::types::Range<OrderedFloat<FloatPayloadType>> {
     fn from(value: Range) -> Self {
         let Range { lt, gt, gte, lte } = value;
-        Self {
+        segment::types::Range {
             lt: lt.map(OrderedFloat::from),
             gt: gt.map(OrderedFloat::from),
             gte: gte.map(OrderedFloat::from),
             lte: lte.map(OrderedFloat::from),
         }
+        .normalized_to_stored_precision()
     }
 }
 
 impl From<segment::types::Range<OrderedFloat<FloatPayloadType>>> for Range {
     fn from(value: segment::types::Range<OrderedFloat<FloatPayloadType>>) -> Self {
-        let segment::types::Range { lt, gt, gte, lte } = value;
+        let segment::types::Range { lt, gt, gte, lte } = value.normalized_to_stored_precision();
         Self {
             lt: lt.map(FloatPayloadType::from),
             gt: gt.map(FloatPayloadType::from),
@@ -2018,7 +2019,40 @@ impl From<segment::types::Range<OrderedFloat<FloatPayloadType>>> for Range {
 
 impl From<Range> for segment::types::RangeInterface {
     fn from(value: Range) -> Self {
-        Self::Float(value.into())
+        Self::Float(segment::types::Range::from(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ordered_float::OrderedFloat;
+    use segment::types::FloatPayloadType;
+
+    use crate::grpc::qdrant::Range;
+
+    #[test]
+    fn float_min_boundary_grpc_range_round_trip() {
+        let float_min = f64::from(f32::MIN);
+        let grpc = Range {
+            lt: Some(float_min),
+            gt: Some(float_min),
+            gte: Some(float_min),
+            lte: Some(float_min),
+        };
+
+        let segment_range = segment::types::Range::<OrderedFloat<FloatPayloadType>>::from(grpc.clone());
+
+        assert_eq!(segment_range.lt, Some(OrderedFloat(float_min)));
+        assert_eq!(segment_range.gt, Some(OrderedFloat(float_min)));
+        assert_eq!(segment_range.gte, Some(OrderedFloat(float_min)));
+        assert_eq!(segment_range.lte, Some(OrderedFloat(float_min)));
+
+        let grpc_round_trip = Range::from(segment_range);
+
+        assert_eq!(grpc_round_trip.lt, Some(float_min));
+        assert_eq!(grpc_round_trip.gt, Some(float_min));
+        assert_eq!(grpc_round_trip.gte, Some(float_min));
+        assert_eq!(grpc_round_trip.lte, Some(float_min));
     }
 }
 

--- a/lib/edge/src/reexports.rs
+++ b/lib/edge/src/reexports.rs
@@ -75,7 +75,5 @@ pub mod internal {
 
 /// Re-export from external crates used by Qdrant.
 pub mod external {
-    pub use ordered_float;
-    pub use serde_json;
-    pub use uuid;
+    pub use {ordered_float, serde_json, uuid};
 }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -317,7 +317,9 @@ where
         }
 
         let range = match range {
-            RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+            RangeInterface::Float(float_range) => float_range
+                .normalized_to_stored_precision()
+                .map(|float| T::from_f64(float.0)),
             RangeInterface::DateTime(datetime_range) => {
                 datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
             }
@@ -1158,7 +1160,9 @@ where
         range: &RangeInterface,
     ) -> OperationResult<impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
         let range = match range {
-            RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+            RangeInterface::Float(float_range) => float_range
+                .normalized_to_stored_precision()
+                .map(|float| T::from_f64(float.0)),
             RangeInterface::DateTime(datetime_range) => {
                 datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
             }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -850,12 +850,14 @@ where
         };
 
         let (start_bound, end_bound) = match range_cond {
-            RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
-            RangeInterface::DateTime(datetime_range) => {
-                datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
-            }
-        }
-        .as_index_key_bounds();
+            RangeInterface::Float(float_range) => float_range
+                .normalized_to_stored_precision()
+                .map(|float| T::from_f64(float.0))
+                .as_index_key_bounds(),
+            RangeInterface::DateTime(datetime_range) => datetime_range
+                .map(|dt| T::from_u128(dt.timestamp() as u128))
+                .as_index_key_bounds(),
+        };
 
         // map.range
         // Panics if range start > end. Panics if range start == end and both bounds are Excluded.

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -183,6 +183,39 @@ fn cardinality_request(
     estimation
 }
 
+#[rstest]
+#[cfg_attr(feature = "rocksdb", case(IndexType::Mutable))]
+#[case(IndexType::MutableGridstore)]
+#[cfg_attr(feature = "rocksdb", case(IndexType::Immutable))]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_float_min_boundary(#[case] index_type: IndexType) {
+    let (_temp_dir, mut index_builder) = get_index_builder(index_type);
+    let hw_counter = HardwareCounterCell::new();
+    let float_min = f64::from(f32::MIN);
+    let payload = serde_json::json!(float_min);
+    index_builder.add_point(1, &[&payload], &hw_counter).unwrap();
+    let index = index_builder.finalize().unwrap();
+
+    let query = |range: Range<OrderedFloat<FloatPayloadType>>| {
+        index
+            .inner()
+            .filter(
+                &FieldCondition::new_range(JsonPath::new("test"), range),
+                &hw_counter,
+            )
+            .unwrap()
+            .collect_vec()
+    };
+
+    let bound = OrderedFloat(float_min);
+    assert_eq!(query(Range { lt: None, gt: None, gte: None, lte: Some(bound) }), vec![1]);
+    assert_eq!(query(Range { lt: Some(bound), gt: None, gte: None, lte: None }), Vec::<PointOffsetType>::new());
+    assert_eq!(query(Range { lt: None, gt: None, gte: Some(bound), lte: None }), vec![1]);
+    assert_eq!(query(Range { lt: None, gt: Some(bound), gte: None, lte: None }), Vec::<PointOffsetType>::new());
+    assert_eq!(query(Range { lt: None, gt: None, gte: Some(bound), lte: Some(bound) }), vec![1]);
+}
+
 #[test]
 fn test_set_empty_payload() {
     let (_temp_dir, mut index) = random_index(1000, 1, IndexType::MutableGridstore);

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -184,9 +184,7 @@ fn cardinality_request(
 }
 
 #[rstest]
-#[cfg_attr(feature = "rocksdb", case(IndexType::Mutable))]
 #[case(IndexType::MutableGridstore)]
-#[cfg_attr(feature = "rocksdb", case(IndexType::Immutable))]
 #[case(IndexType::Mmap)]
 #[case(IndexType::RamMmap)]
 fn test_float_min_boundary(#[case] index_type: IndexType) {
@@ -194,8 +192,20 @@ fn test_float_min_boundary(#[case] index_type: IndexType) {
     let hw_counter = HardwareCounterCell::new();
     let float_min = f64::from(f32::MIN);
     let payload = serde_json::json!(float_min);
-    index_builder.add_point(1, &[&payload], &hw_counter).unwrap();
-    let index = index_builder.finalize().unwrap();
+    index_builder
+        .add_point(1, &[&payload], &hw_counter)
+        .unwrap();
+    let mut index = index_builder.finalize().unwrap();
+
+    if matches!(index_type, IndexType::RamMmap) {
+        let NumericIndexInner::Mmap(mmap_index) = index.inner else {
+            panic!("Expected mmap index");
+        };
+        index = NumericIndex {
+            inner: NumericIndexInner::Immutable(ImmutableNumericIndex::open_mmap(mmap_index)),
+            _phantom: Default::default(),
+        };
+    }
 
     let query = |range: Range<OrderedFloat<FloatPayloadType>>| {
         index
@@ -205,15 +215,56 @@ fn test_float_min_boundary(#[case] index_type: IndexType) {
                 &hw_counter,
             )
             .unwrap()
+            .unwrap()
             .collect_vec()
     };
 
     let bound = OrderedFloat(float_min);
-    assert_eq!(query(Range { lt: None, gt: None, gte: None, lte: Some(bound) }), vec![1]);
-    assert_eq!(query(Range { lt: Some(bound), gt: None, gte: None, lte: None }), Vec::<PointOffsetType>::new());
-    assert_eq!(query(Range { lt: None, gt: None, gte: Some(bound), lte: None }), vec![1]);
-    assert_eq!(query(Range { lt: None, gt: Some(bound), gte: None, lte: None }), Vec::<PointOffsetType>::new());
-    assert_eq!(query(Range { lt: None, gt: None, gte: Some(bound), lte: Some(bound) }), vec![1]);
+    assert_eq!(
+        query(Range {
+            lt: None,
+            gt: None,
+            gte: None,
+            lte: Some(bound)
+        }),
+        vec![1]
+    );
+    assert_eq!(
+        query(Range {
+            lt: Some(bound),
+            gt: None,
+            gte: None,
+            lte: None
+        }),
+        Vec::<PointOffsetType>::new()
+    );
+    assert_eq!(
+        query(Range {
+            lt: None,
+            gt: None,
+            gte: Some(bound),
+            lte: None
+        }),
+        vec![1]
+    );
+    assert_eq!(
+        query(Range {
+            lt: None,
+            gt: Some(bound),
+            gte: None,
+            lte: None
+        }),
+        Vec::<PointOffsetType>::new()
+    );
+    assert_eq!(
+        query(Range {
+            lt: None,
+            gt: None,
+            gte: Some(bound),
+            lte: Some(bound)
+        }),
+        vec![1]
+    );
 }
 
 #[test]

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -223,10 +223,11 @@ impl ValueChecker for Match {
 
 impl ValueChecker for Range<OrderedFloat<FloatPayloadType>> {
     fn check_match(&self, payload: &Value) -> bool {
+        let normalized = self.normalized_to_stored_precision();
         match payload {
             Value::Number(num) => num
                 .as_f64()
-                .map(|number| self.check_range(OrderedFloat(number)))
+                .map(|number| normalized.check_range(OrderedFloat(number)))
                 .unwrap_or(false),
             _ => false,
         }
@@ -315,7 +316,7 @@ mod tests {
 
     use super::*;
     use crate::json_path::JsonPath;
-    use crate::types::GeoPoint;
+    use crate::types::{FloatPayloadType, GeoPoint};
 
     #[test]
     fn test_geo_matching() {
@@ -475,5 +476,49 @@ mod tests {
         assert!(is_not_null.check(&string));
         assert!(is_not_null.check(&number));
         assert!(is_not_null.check(&bool));
+    }
+
+    #[test]
+    fn test_float_min_boundary_without_payload_index() {
+        let float_min = f64::from(f32::MIN);
+        let payload = json!(float_min);
+        let bound = OrderedFloat::<FloatPayloadType>(float_min);
+
+        let lte = Range {
+            lt: None,
+            gt: None,
+            gte: None,
+            lte: Some(bound),
+        };
+        let lt = Range {
+            lt: Some(bound),
+            gt: None,
+            gte: None,
+            lte: None,
+        };
+        let gte = Range {
+            lt: None,
+            gt: None,
+            gte: Some(bound),
+            lte: None,
+        };
+        let gt = Range {
+            lt: None,
+            gt: Some(bound),
+            gte: None,
+            lte: None,
+        };
+        let eq = Range {
+            lt: None,
+            gt: None,
+            gte: Some(bound),
+            lte: Some(bound),
+        };
+
+        assert!(lte.check_match(&payload));
+        assert!(!lt.check_match(&payload));
+        assert!(gte.check_match(&payload));
+        assert!(!gt.check_match(&payload));
+        assert!(eq.check_match(&payload));
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2819,7 +2819,9 @@ impl<T: Copy + PartialOrd> Range<T> {
 }
 
 impl Range<OrderedFloat<FloatPayloadType>> {
-    fn normalize_float_bound(bound: OrderedFloat<FloatPayloadType>) -> OrderedFloat<FloatPayloadType> {
+    fn normalize_float_bound(
+        bound: OrderedFloat<FloatPayloadType>,
+    ) -> OrderedFloat<FloatPayloadType> {
         let value = bound.0;
         let rounded = value as f32;
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2818,6 +2818,29 @@ impl<T: Copy + PartialOrd> Range<T> {
     }
 }
 
+impl Range<OrderedFloat<FloatPayloadType>> {
+    fn normalize_float_bound(bound: OrderedFloat<FloatPayloadType>) -> OrderedFloat<FloatPayloadType> {
+        let value = bound.0;
+        let rounded = value as f32;
+
+        if rounded.is_finite() && FloatPayloadType::from(rounded) == value {
+            OrderedFloat(FloatPayloadType::from(rounded))
+        } else {
+            bound
+        }
+    }
+
+    pub fn normalized_to_stored_precision(&self) -> Self {
+        let Self { lt, gt, gte, lte } = *self;
+        Self {
+            lt: lt.map(Self::normalize_float_bound),
+            gt: gt.map(Self::normalize_float_bound),
+            gte: gte.map(Self::normalize_float_bound),
+            lte: lte.map(Self::normalize_float_bound),
+        }
+    }
+}
+
 /// Values count filter request
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -5,7 +5,6 @@ use ::common::tempfile_ext::MaybeTempPath;
 use actix_multipart::form::MultipartForm;
 use actix_multipart::form::tempfile::TempFile;
 use actix_web::{Responder, Result, delete, get, post, put, web};
-use actix_web_validator as valid;
 use collection::common::file_utils::move_file;
 use collection::common::sha_256;
 use collection::common::snapshot_stream::SnapshotStream;
@@ -15,7 +14,6 @@ use collection::operations::snapshot_ops::{
 use collection::operations::types::CollectionError;
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::shard_holder::shard_not_found_error;
-use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use futures::{FutureExt as _, StreamExt as _, TryFutureExt as _};
 use reqwest::Url;
@@ -36,6 +34,7 @@ use storage::rbac::AccessRequirements;
 use tokio::io::AsyncWriteExt as _;
 use uuid::Uuid;
 use validator::Validate;
+use {actix_web_validator as valid, fs_err as fs};
 
 use super::{
     CollectionPath, CollectionShardPath, CollectionShardSnapshotPath, CollectionSnapshotPath,


### PR DESCRIPTION
Fixes #8617

## Summary

Addresses #8617 by addressing payload range filtering misbehaves at float32 minimum finite value (FLT_MIN), with inconsistent results between gRPC and REST.

## Problem

Current Behavior.

## What changed

- lib/api/src/grpc/conversions.rs
- lib/segment/src/index/field_index/numeric_index/mod.rs
- lib/segment/src/index/field_index/numeric_index/tests.rs
- lib/segment/src/types.rs

## Solution

Apply focused code changes in `lib/api/src/grpc/conversions.rs`, `lib/segment/src/index/field_index/numeric_index/mod.rs`, `lib/segment/src/index/field_index/numeric_index/tests.rs` to remove the reported behavior from #8617.

## Why

Payload float values are effectively stored/indexed at float32 precision, but range bounds were kept as raw f64s.

## Tests

- `cargo test -p segment float_min_boundary -- --nocapture`
- `cargo test -p api float_min_boundary_grpc -- --nocapture`

## Scope

- Changed files (4): `lib/api/src/grpc/conversions.rs`, `lib/segment/src/index/field_index/numeric_index/mod.rs`, `lib/segment/src/index/field_index/numeric_index/tests.rs`, `lib/segment/src/types.rs`
- Root-cause gate verdict: `confirmed`
- Replay stability: `not_run`

## Validation

- Local validation gate verdict: `confirmed` (risk: `low`).
- Successful repair test: `cargo test -p segment float_min_boundary -- --nocapture`
- Successful repair test: `cargo test -p api float_min_boundary_grpc -- --nocapture`
- Successful build check: `cargo check -p api && cargo check -p segment`

## Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
