### PR TITLE
[UIO] Migrate numeric index

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -671,19 +671,20 @@ impl<'a> StreamRange<OrderValue> for NumericFieldIndex<'a> {
     fn stream_range(
         &self,
         range: &RangeInterface,
-    ) -> Box<dyn DoubleEndedIterator<Item = (OrderValue, PointOffsetType)> + 'a> {
-        match self {
+    ) -> OperationResult<Box<dyn DoubleEndedIterator<Item = (OrderValue, PointOffsetType)> + 'a>>
+    {
+        Ok(match self {
             NumericFieldIndex::IntIndex(index) => Box::new(
                 index
-                    .stream_range(range)
+                    .stream_range(range)?
                     .map(|(v, p)| (OrderValue::from(v), p)),
             ),
             NumericFieldIndex::FloatIndex(index) => Box::new(
                 index
-                    .stream_range(range)
+                    .stream_range(range)?
                     .map(|(v, p)| (OrderValue::from(v), p)),
             ),
-        }
+        })
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -11,7 +11,7 @@ use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
 use fs_err as fs;
-use itertools::Itertools;
+use itertools::Either;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
 
@@ -51,50 +51,6 @@ pub(super) struct Storage<
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MmapNumericIndexConfig {
     max_values_per_point: usize,
-}
-
-pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
-    pairs_front: Box<dyn Iterator<Item = OperationResult<Point<T>>> + 'a>,
-    pairs_back: Box<dyn Iterator<Item = OperationResult<Point<T>>> + 'a>,
-    deleted: &'a BufferedUpdateBitSlice<MmapFile>,
-}
-
-impl<T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'_, T> {
-    type Item = OperationResult<Point<T>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        for result in self.pairs_front.by_ref() {
-            let key = match result {
-                Ok(pair) => pair,
-                Err(e) => return Some(Err(e)),
-            };
-            let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
-            if deleted {
-                continue;
-            }
-            return Some(Ok(key));
-        }
-
-        None
-    }
-}
-
-impl<T: Encodable + Numericable> DoubleEndedIterator for NumericIndexPairsIterator<'_, T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        for result in self.pairs_back.by_ref() {
-            let key = match result {
-                Ok(pair) => pair,
-                Err(e) => return Some(Err(e)),
-            };
-            let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
-            if deleted {
-                continue;
-            }
-            return Some(Ok(key));
-        }
-
-        None
-    }
 }
 
 impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNumericIndex<T> {
@@ -293,12 +249,12 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> OperationResult<impl Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<impl Iterator<Item = PointOffsetType> + 'a> {
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
         Ok(self
             .values_range_iterator(start_bound, end_bound)?
-            .map_ok(|point| point.idx)
+            .map(|point| point.idx)
             .measure_hw_with_condition_cell(hw_counter, size_of::<Point<T>>(), |i| {
                 i.payload_index_io_read_counter()
             }))
@@ -308,11 +264,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> OperationResult<impl DoubleEndedIterator<Item = OperationResult<(T, PointOffsetType)>> + '_>
-    {
+    ) -> OperationResult<impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
         Ok(self
             .values_range_iterator(start_bound, end_bound)?
-            .map_ok(|Point { val, idx, .. }| (val, idx)))
+            .map(|Point { val, idx, .. }| (val, idx)))
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
@@ -410,42 +365,31 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
     }
 
     /// Returns an iterator over non-deleted pairs.
+    ///
+    /// This will read the entire range upfront if it was not already cached.
     fn values_range_iterator(
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> OperationResult<NumericIndexPairsIterator<'_, T>> {
+    ) -> OperationResult<impl DoubleEndedIterator<Item = Point<T>> + '_> {
         let (start_pos, end_pos) = self.values_range_bounds(start_bound, end_bound)?;
+        let count = end_pos - start_pos;
 
-        let pos_to_read_range = |pos: usize| {
-            let range = ReadRange {
-                byte_offset: (pos * size_of::<Point<T>>()) as u64,
-                length: 1,
-            };
-            ((), range)
+        let iter = if count > 0 {
+            match self.storage.pairs.read::<Random>(ReadRange {
+                byte_offset: (start_pos * size_of::<Point<T>>()) as u64,
+                length: count as u64,
+            })? {
+                Cow::Borrowed(slice) => Either::Left(slice.iter().copied()),
+                Cow::Owned(vec) => Either::Right(vec.into_iter()),
+            }
+        } else {
+            Either::Right(Vec::new().into_iter())
         };
-        let map_read = |result: Result<((), Cow<'_, [Point<T>]>), _>| -> OperationResult<_> {
-            let ((), cow) = result?;
-            Ok(cow[0])
-        };
-        let pairs_front = Box::new(
-            self.storage
-                .pairs
-                .read_iter::<Random, ()>((start_pos..end_pos).map(pos_to_read_range))?
-                .map(map_read),
-        );
-        let pairs_back = Box::new(
-            self.storage
-                .pairs
-                .read_iter::<Random, ()>((start_pos..end_pos).rev().map(pos_to_read_range))?
-                .map(map_read),
-        );
 
-        Ok(NumericIndexPairsIterator {
-            pairs_front,
-            pairs_back,
-            deleted: &self.storage.deleted,
-        })
+        let deleted = &self.storage.deleted;
+
+        Ok(iter.filter(move |point| !deleted.get(point.idx as usize).unwrap_or(true)))
     }
 
     fn make_conditioned_counter<'a>(

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -9,7 +9,9 @@ use common::fs::{atomic_save_json, read_json};
 use common::generic_consts::Random;
 use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
+use common::universal_io::{
+    MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead, UniversalWrite,
+};
 use fs_err as fs;
 use itertools::Either;
 use memmap2::MmapMut;
@@ -40,9 +42,9 @@ pub struct MmapNumericIndex<T: Encodable + Numericable + Default + StoredValue +
 
 pub(super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
-    S: UniversalRead<u8>,
+    S: UniversalWrite<u64> + UniversalRead<Point<T>> + UniversalRead<u8>,
 > {
-    deleted: BufferedUpdateBitSlice<MmapFile>,
+    deleted: BufferedUpdateBitSlice<S>,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pairs: TypedStorage<S, Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 
@@ -6,11 +6,12 @@ use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::fs::{atomic_save_json, read_json};
-use common::mmap;
-use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
+use common::generic_consts::Random;
+use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, UniversalRead};
+use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
 use fs_err as fs;
+use itertools::Itertools;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
 
@@ -43,7 +44,7 @@ pub(super) struct Storage<
 > {
     deleted: BufferedUpdateBitSlice<MmapFile>,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
-    pairs: MmapSlice<Point<T>>,
+    pairs: TypedStorage<S, Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,
 }
 
@@ -53,45 +54,50 @@ struct MmapNumericIndexConfig {
 }
 
 pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
-    pairs: &'a [Point<T>],
+    pairs_front: Box<dyn Iterator<Item = OperationResult<Point<T>>> + 'a>,
+    pairs_back: Box<dyn Iterator<Item = OperationResult<Point<T>>> + 'a>,
     deleted: &'a BufferedUpdateBitSlice<MmapFile>,
-    start_index: usize,
-    end_index: usize,
 }
 
 impl<T: Encodable + Numericable> Iterator for NumericIndexPairsIterator<'_, T> {
-    type Item = Point<T>;
+    type Item = OperationResult<Point<T>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.start_index < self.end_index {
-            let key = self.pairs[self.start_index];
+        for result in self.pairs_front.by_ref() {
+            let key = match result {
+                Ok(pair) => pair,
+                Err(e) => return Some(Err(e)),
+            };
             let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
-            self.start_index += 1;
             if deleted {
                 continue;
             }
-            return Some(key);
+            return Some(Ok(key));
         }
+
         None
     }
 }
 
 impl<T: Encodable + Numericable> DoubleEndedIterator for NumericIndexPairsIterator<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        while self.start_index < self.end_index {
-            let key = self.pairs[self.end_index - 1];
+        for result in self.pairs_back.by_ref() {
+            let key = match result {
+                Ok(pair) => pair,
+                Err(e) => return Some(Err(e)),
+            };
             let deleted = self.deleted.get(key.idx as usize).unwrap_or(true);
-            self.end_index -= 1;
             if deleted {
                 continue;
             }
-            return Some(key);
+            return Some(Ok(key));
         }
+
         None
     }
 }
 
-impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
+impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNumericIndex<T> {
     pub fn build(
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
@@ -175,19 +181,23 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         let deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
         let deleted_count = deleted.count_ones()?;
         let do_populate = !is_on_disk;
-        let map = unsafe {
-            MmapSlice::try_from(mmap::open_write_mmap(
-                &pairs_path,
-                AdviceSetting::Global,
-                do_populate,
-            )?)?
+
+        let pairs_options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            disk_parallel: None,
+            populate: Some(do_populate),
+            advice: None,
+            prevent_caching: None,
         };
+        let pairs = TypedStorage::open(pairs_path, pairs_options)?;
+
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
-                pairs: map,
+                pairs,
                 deleted: BufferedUpdateBitSlice::new(deleted),
                 point_to_values,
             },
@@ -274,8 +284,8 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
 
     /// Returns the number of key-value pairs in the index.
     /// Note that is doesn't count deleted pairs.
-    pub(super) fn total_unique_values_count(&self) -> usize {
-        self.storage.pairs.len()
+    pub(super) fn total_unique_values_count(&self) -> OperationResult<usize> {
+        Ok(self.storage.pairs.len()? as usize)
     }
 
     pub(super) fn values_range<'a>(
@@ -283,23 +293,26 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> impl Iterator<Item = PointOffsetType> + 'a {
+    ) -> OperationResult<impl Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
-        self.values_range_iterator(start_bound, end_bound)
-            .map(|Point { idx, .. }| idx)
+        Ok(self
+            .values_range_iterator(start_bound, end_bound)?
+            .map_ok(|point| point.idx)
             .measure_hw_with_condition_cell(hw_counter, size_of::<Point<T>>(), |i| {
                 i.payload_index_io_read_counter()
-            })
+            }))
     }
 
     pub(super) fn orderable_values_range(
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> impl DoubleEndedIterator<Item = (T, PointOffsetType)> + '_ {
-        self.values_range_iterator(start_bound, end_bound)
-            .map(|Point { val, idx, .. }| (val, idx))
+    ) -> OperationResult<impl DoubleEndedIterator<Item = OperationResult<(T, PointOffsetType)>> + '_>
+    {
+        Ok(self
+            .values_range_iterator(start_bound, end_bound)?
+            .map_ok(|Point { val, idx, .. }| (val, idx)))
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) {
@@ -326,58 +339,113 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> usize {
-        let iter = self.values_range_iterator(start_bound, end_bound);
-        iter.end_index - iter.start_index
+    ) -> OperationResult<usize> {
+        let (start, end) = self.values_range_bounds(start_bound, end_bound)?;
+        Ok(end - start)
     }
 
-    // get iterator
-    fn values_range_iterator(
+    /// Binary search within `[lo, hi)` range of `pairs` storage.
+    ///
+    /// Returns `Ok(index)` if the element is found, `Err(index)` if not
+    /// (where `index` is where the element would be inserted).
+    fn binary_search_pairs(
+        &self,
+        bound: &Point<T>,
+        lo: usize,
+        hi: usize,
+    ) -> OperationResult<Result<usize, usize>> {
+        let mut left = lo;
+        let mut right = hi;
+        while left < right {
+            let mid = left + (right - left) / 2;
+            // TODO(luis): use read_one
+            let elem = self.storage.pairs.read::<Random>(ReadRange {
+                byte_offset: (mid * size_of::<Point<T>>()) as u64,
+                length: 1,
+            })?;
+            match elem[0].cmp(bound) {
+                std::cmp::Ordering::Less => left = mid + 1,
+                std::cmp::Ordering::Equal => return Ok(Ok(mid)),
+                std::cmp::Ordering::Greater => right = mid,
+            }
+        }
+        Ok(Err(left))
+    }
+
+    /// Find the `[start_index, end_index)` range for the given bounds.
+    fn values_range_bounds(
         &self,
         start_bound: Bound<Point<T>>,
         end_bound: Bound<Point<T>>,
-    ) -> NumericIndexPairsIterator<'_, T> {
+    ) -> OperationResult<(usize, usize)> {
+        let len = self.storage.pairs.len()? as usize;
+
         let start_index = match start_bound {
             Bound::Included(bound) => self
-                .storage
-                .pairs
-                .binary_search(&bound)
+                .binary_search_pairs(&bound, 0, len)?
                 .unwrap_or_else(|idx| idx),
-            Bound::Excluded(bound) => match self.storage.pairs.binary_search(&bound) {
+            Bound::Excluded(bound) => match self.binary_search_pairs(&bound, 0, len)? {
                 Ok(idx) => idx + 1,
                 Err(idx) => idx,
             },
             Bound::Unbounded => 0,
         };
 
-        if start_index >= self.storage.pairs.len() {
-            return NumericIndexPairsIterator {
-                pairs: &self.storage.pairs,
-                deleted: &self.storage.deleted,
-                start_index: self.storage.pairs.len(),
-                end_index: self.storage.pairs.len(),
-            };
+        if start_index >= len {
+            return Ok((len, len));
         }
 
         let end_index = match end_bound {
-            Bound::Included(bound) => match self.storage.pairs[start_index..].binary_search(&bound)
-            {
-                Ok(idx) => idx + 1 + start_index,
-                Err(idx) => idx + start_index,
+            Bound::Included(bound) => match self.binary_search_pairs(&bound, start_index, len)? {
+                Ok(idx) => idx + 1,
+                Err(idx) => idx,
             },
-            Bound::Excluded(bound) => {
-                let end_bound = self.storage.pairs[start_index..].binary_search(&bound);
-                end_bound.unwrap_or_else(|idx| idx) + start_index
-            }
-            Bound::Unbounded => self.storage.pairs.len(),
+            Bound::Excluded(bound) => self
+                .binary_search_pairs(&bound, start_index, len)?
+                .unwrap_or_else(|idx| idx),
+            Bound::Unbounded => len,
         };
 
-        NumericIndexPairsIterator {
-            pairs: &self.storage.pairs,
+        Ok((start_index, end_index))
+    }
+
+    /// Returns an iterator over non-deleted pairs.
+    fn values_range_iterator(
+        &self,
+        start_bound: Bound<Point<T>>,
+        end_bound: Bound<Point<T>>,
+    ) -> OperationResult<NumericIndexPairsIterator<'_, T>> {
+        let (start_pos, end_pos) = self.values_range_bounds(start_bound, end_bound)?;
+
+        let pos_to_read_range = |pos: usize| {
+            let range = ReadRange {
+                byte_offset: (pos * size_of::<Point<T>>()) as u64,
+                length: 1,
+            };
+            ((), range)
+        };
+        let map_read = |result: Result<((), Cow<'_, [Point<T>]>), _>| -> OperationResult<_> {
+            let ((), cow) = result?;
+            Ok(cow[0])
+        };
+        let pairs_front = Box::new(
+            self.storage
+                .pairs
+                .read_iter::<Random, ()>((start_pos..end_pos).map(pos_to_read_range))?
+                .map(map_read),
+        );
+        let pairs_back = Box::new(
+            self.storage
+                .pairs
+                .read_iter::<Random, ()>((start_pos..end_pos).rev().map(pos_to_read_range))?
+                .map(map_read),
+        );
+
+        Ok(NumericIndexPairsIterator {
+            pairs_front,
+            pairs_back,
             deleted: &self.storage.deleted,
-            start_index,
-            end_index,
-        }
+        })
     }
 
     fn make_conditioned_counter<'a>(
@@ -414,7 +482,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             pairs,
             point_to_values,
         } = storage;
-        pairs.clear_cache()?;
+        pairs.clear_ram_cache()?;
         deleted.clear_cache()?;
         point_to_values.clear_cache()?;
         Ok(())

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -394,11 +394,7 @@ where
         Ok(match &self {
             NumericIndexInner::Mutable(mutable) => Box::new(mutable.values_range(start, end)),
             NumericIndexInner::Immutable(immutable) => Box::new(immutable.values_range(start, end)),
-            NumericIndexInner::Mmap(mmap) => Box::new(
-                mmap.values_range(start, end, hw_counter)?
-                    // TODO: propagate error through iterator
-                    .filter_map(Result::ok),
-            ),
+            NumericIndexInner::Mmap(mmap) => Box::new(mmap.values_range(start, end, hw_counter)?),
         })
     }
 
@@ -825,6 +821,7 @@ where
             NumericIndexInner::Mmap(index) => Box::new(
                 index
                     .values_range(start_bound, end_bound, hw_counter)
+                    .map(|iter| iter.map(Ok))
                     .into_result_iter(),
             ),
         })
@@ -1129,12 +1126,9 @@ where
             NumericIndexInner::Immutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
-            NumericIndexInner::Mmap(index) => Box::new(
-                index
-                    .orderable_values_range(start_bound, end_bound)?
-                    // TODO: propagate error through iterator
-                    .filter_map(Result::ok),
-            ),
+            NumericIndexInner::Mmap(index) => {
+                Box::new(index.orderable_values_range(start_bound, end_bound)?)
+            }
         })
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 
 use chrono::DateTime;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::iterator_ext::TransposeResultIter;
 use common::types::PointOffsetType;
 use delegate::delegate;
 use gridstore::Blob;
@@ -55,7 +56,7 @@ pub trait StreamRange<T> {
     fn stream_range(
         &self,
         range: &RangeInterface,
-    ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_>;
+    ) -> OperationResult<Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_>>;
 }
 
 pub trait Encodable: Copy + Serialize + DeserializeOwned + 'static {
@@ -211,12 +212,12 @@ where
         }
     }
 
-    fn total_unique_values_count(&self) -> usize {
-        match self {
+    fn total_unique_values_count(&self) -> OperationResult<usize> {
+        Ok(match self {
             NumericIndexInner::Mutable(index) => index.total_unique_values_count(),
             NumericIndexInner::Immutable(index) => index.total_unique_values_count(),
-            NumericIndexInner::Mmap(index) => index.total_unique_values_count(),
-        }
+            NumericIndexInner::Mmap(index) => index.total_unique_values_count()?,
+        })
     }
 
     pub fn flusher(&self) -> Flusher {
@@ -297,10 +298,10 @@ where
         }
     }
 
-    fn range_cardinality(&self, range: &RangeInterface) -> CardinalityEstimation {
+    fn range_cardinality(&self, range: &RangeInterface) -> OperationResult<CardinalityEstimation> {
         let max_values_per_point = self.max_values_per_point();
         if max_values_per_point == 0 {
-            return CardinalityEstimation::exact(0);
+            return Ok(CardinalityEstimation::exact(0));
         }
 
         let range = match range {
@@ -330,7 +331,7 @@ where
         let min_estimation = histogram_estimation.0;
         let max_estimation = histogram_estimation.2;
 
-        let total_values = self.total_unique_values_count();
+        let total_values = self.total_unique_values_count()?;
         // Example: points_count = 1000, total values = 2000, values_count = 500
         // min = max(1, 500 - (2000 - 1000)) = 1
         // exp = 500 / (2000 / 1000) = 250
@@ -357,12 +358,12 @@ where
         )
         .round() as usize;
 
-        CardinalityEstimation {
+        Ok(CardinalityEstimation {
             primary_clauses: vec![],
             min: expected_min,
             exp: min(expected_max, max(estimation, expected_min)),
             max: expected_max,
-        }
+        })
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -387,33 +388,35 @@ where
         &'a self,
         value: T,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         let start = Bound::Included(Point::new(value, PointOffsetType::MIN));
         let end = Bound::Included(Point::new(value, PointOffsetType::MAX));
-        match &self {
-            NumericIndexInner::Mutable(mutable) => {
-                Box::new(mutable.values_range(start, end).map(Ok))
-            }
-            NumericIndexInner::Immutable(immutable) => {
-                Box::new(immutable.values_range(start, end).map(Ok))
-            }
-            NumericIndexInner::Mmap(mmap) => {
-                Box::new(mmap.values_range(start, end, hw_counter).map(Ok))
-            }
-        }
+        Ok(match &self {
+            NumericIndexInner::Mutable(mutable) => Box::new(mutable.values_range(start, end)),
+            NumericIndexInner::Immutable(immutable) => Box::new(immutable.values_range(start, end)),
+            NumericIndexInner::Mmap(mmap) => Box::new(
+                mmap.values_range(start, end, hw_counter)?
+                    // TODO: propagate error through iterator
+                    .filter_map(Result::ok),
+            ),
+        })
     }
 
     /// Tries to estimate the amount of points for a given key.
-    pub fn estimate_points(&self, value: &T, hw_counter: &HardwareCounterCell) -> usize {
+    pub fn estimate_points(
+        &self,
+        value: &T,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<usize> {
         let start = Bound::Included(Point::new(*value, PointOffsetType::MIN));
         let end = Bound::Included(Point::new(*value, PointOffsetType::MAX));
 
         hw_counter
             .payload_index_io_read_counter()
             // We have to do 2 times binary search in mmap and immutable storage.
-            .incr_delta(2 * ((self.total_unique_values_count() as f32).log2().ceil() as usize));
+            .incr_delta(2 * ((self.total_unique_values_count()? as f32).log2().ceil() as usize));
 
-        match &self {
+        Ok(match &self {
             NumericIndexInner::Mutable(mutable) => {
                 let mut iter = mutable.map().range((start, end));
                 let first = iter.next();
@@ -428,22 +431,22 @@ where
             NumericIndexInner::Immutable(immutable) => {
                 let range_size = immutable.values_range_size(start, end);
                 if range_size == 0 {
-                    return 0;
+                    return Ok(0);
                 }
                 let avg_values_per_point =
-                    self.total_unique_values_count() as f32 / self.get_points_count() as f32;
+                    self.total_unique_values_count()? as f32 / self.get_points_count() as f32;
                 (range_size as f32 / avg_values_per_point).max(1.0).round() as usize
             }
             NumericIndexInner::Mmap(mmap) => {
-                let range_size = mmap.values_range_size(start, end);
+                let range_size = mmap.values_range_size(start, end)?;
                 if range_size == 0 {
-                    return 0;
+                    return Ok(0);
                 }
                 let avg_values_per_point =
-                    self.total_unique_values_count() as f32 / self.get_points_count() as f32;
+                    self.total_unique_values_count()? as f32 / self.get_points_count() as f32;
                 (range_size as f32 / avg_values_per_point).max(1.0).round() as usize
             }
-        }
+        })
     }
 
     /// Approximate RAM usage in bytes for in-memory structures.
@@ -788,7 +791,11 @@ where
 
             if let Ok(uuid) = Uuid::from_str(keyword) {
                 let value = T::from_u128(uuid.as_u128());
-                return Some(self.point_ids_by_value(value, hw_counter));
+                return Some(Box::new(
+                    self.point_ids_by_value(value, hw_counter)
+                        .map(|iter| iter.map(Ok))
+                        .into_result_iter(),
+                ));
             }
         }
 
@@ -818,7 +825,7 @@ where
             NumericIndexInner::Mmap(index) => Box::new(
                 index
                     .values_range(start_bound, end_bound, hw_counter)
-                    .map(Ok),
+                    .into_result_iter(),
             ),
         })
     }
@@ -836,7 +843,7 @@ where
             if let Ok(uuid) = Uuid::from_str(keyword) {
                 let key = T::from_u128(uuid.as_u128());
 
-                let estimated_count = self.estimate_points(&key, hw_counter);
+                let estimated_count = self.estimate_points(&key, hw_counter)?;
                 return Ok(Some(
                     CardinalityEstimation::exact(estimated_count).with_primary_clause(
                         PrimaryCondition::Condition(Box::new(condition.clone())),
@@ -845,13 +852,17 @@ where
             }
         }
 
-        Ok(condition.range.as_ref().map(|range| {
-            let mut cardinality = self.range_cardinality(range);
-            cardinality
-                .primary_clauses
-                .push(PrimaryCondition::Condition(Box::new(condition.clone())));
-            cardinality
-        }))
+        condition
+            .range
+            .as_ref()
+            .map(|range| {
+                let mut cardinality = self.range_cardinality(range)?;
+                cardinality
+                    .primary_clauses
+                    .push(PrimaryCondition::Condition(Box::new(condition.clone())));
+                Ok(cardinality)
+            })
+            .transpose()
     }
 
     fn payload_blocks(
@@ -859,70 +870,77 @@ where
         threshold: usize,
         key: PayloadKeyType,
     ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        let mut lower_bound = Unbounded;
-        let mut pre_lower_bound: Option<Bound<T>> = None;
-        let mut payload_conditions = Vec::new();
+        let inner = || -> OperationResult<Vec<PayloadBlockCondition>> {
+            let mut lower_bound = Unbounded;
+            let mut pre_lower_bound: Option<Bound<T>> = None;
+            let mut payload_conditions = Vec::new();
 
-        let value_per_point =
-            self.total_unique_values_count() as f64 / self.get_points_count() as f64;
-        let effective_threshold = (threshold as f64 * value_per_point) as usize;
+            let value_per_point =
+                self.total_unique_values_count()? as f64 / self.get_points_count() as f64;
+            let effective_threshold = (threshold as f64 * value_per_point) as usize;
 
-        loop {
-            let upper_bound = self
-                .get_histogram()
-                .get_range_by_size(lower_bound, effective_threshold / 2);
+            loop {
+                let upper_bound = self
+                    .get_histogram()
+                    .get_range_by_size(lower_bound, effective_threshold / 2);
 
-            if let Some(pre_lower_bound) = pre_lower_bound {
-                let range = Range {
-                    lt: match upper_bound {
-                        Excluded(val) => Some(OrderedFloat(val.to_f64())),
-                        _ => None,
-                    },
-                    gt: match pre_lower_bound {
-                        Excluded(val) => Some(OrderedFloat(val.to_f64())),
-                        _ => None,
-                    },
-                    gte: match pre_lower_bound {
-                        Included(val) => Some(OrderedFloat(val.to_f64())),
-                        _ => None,
-                    },
-                    lte: match upper_bound {
-                        Included(val) => Some(OrderedFloat(val.to_f64())),
-                        _ => None,
-                    },
-                };
-                let cardinality = self.range_cardinality(&RangeInterface::Float(range));
-                let condition = PayloadBlockCondition {
-                    condition: FieldCondition::new_range(key.clone(), range),
-                    cardinality: cardinality.exp,
-                };
-
-                payload_conditions.push(condition);
-            } else if upper_bound == Unbounded {
-                // One block covers all points
-                payload_conditions.push(PayloadBlockCondition {
-                    condition: FieldCondition::new_range(
-                        key.clone(),
-                        Range {
-                            gte: None,
-                            lte: None,
-                            lt: None,
-                            gt: None,
+                if let Some(pre_lower_bound) = pre_lower_bound {
+                    let range = Range {
+                        lt: match upper_bound {
+                            Excluded(val) => Some(OrderedFloat(val.to_f64())),
+                            _ => None,
                         },
-                    ),
-                    cardinality: self.get_points_count(),
-                });
+                        gt: match pre_lower_bound {
+                            Excluded(val) => Some(OrderedFloat(val.to_f64())),
+                            _ => None,
+                        },
+                        gte: match pre_lower_bound {
+                            Included(val) => Some(OrderedFloat(val.to_f64())),
+                            _ => None,
+                        },
+                        lte: match upper_bound {
+                            Included(val) => Some(OrderedFloat(val.to_f64())),
+                            _ => None,
+                        },
+                    };
+                    let cardinality = self.range_cardinality(&RangeInterface::Float(range))?;
+                    let condition = PayloadBlockCondition {
+                        condition: FieldCondition::new_range(key.clone(), range),
+                        cardinality: cardinality.exp,
+                    };
+
+                    payload_conditions.push(condition);
+                } else if upper_bound == Unbounded {
+                    // One block covers all points
+                    payload_conditions.push(PayloadBlockCondition {
+                        condition: FieldCondition::new_range(
+                            key.clone(),
+                            Range {
+                                gte: None,
+                                lte: None,
+                                lt: None,
+                                gt: None,
+                            },
+                        ),
+                        cardinality: self.get_points_count(),
+                    });
+                }
+
+                pre_lower_bound = Some(lower_bound);
+
+                lower_bound = match upper_bound {
+                    Included(val) => Excluded(val),
+                    Excluded(val) => Excluded(val),
+                    Unbounded => break,
+                };
             }
+            Ok(payload_conditions)
+        };
 
-            pre_lower_bound = Some(lower_bound);
-
-            lower_bound = match upper_bound {
-                Included(val) => Excluded(val),
-                Excluded(val) => Excluded(val),
-                Unbounded => break,
-            };
+        match inner() {
+            Ok(conditions) => Box::new(conditions.into_iter().map(Ok)),
+            Err(err) => Box::new(std::iter::once(Err(err))),
         }
-        Box::new(payload_conditions.into_iter().map(Ok))
     }
 }
 
@@ -1089,7 +1107,7 @@ where
     fn stream_range(
         &self,
         range: &RangeInterface,
-    ) -> Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_> {
+    ) -> OperationResult<Box<dyn DoubleEndedIterator<Item = (T, PointOffsetType)> + '_>> {
         let range = match range {
             RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
             RangeInterface::DateTime(datetime_range) => {
@@ -1101,19 +1119,22 @@ where
         // map.range
         // Panics if range start > end. Panics if range start == end and both bounds are Excluded.
         if !check_boundaries(&start_bound, &end_bound) {
-            return Box::new(std::iter::empty());
+            return Ok(Box::new(std::iter::empty()));
         }
 
-        match self {
+        Ok(match self {
             NumericIndexInner::Mutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound))
             }
-            NumericIndexInner::Mmap(index) => {
-                Box::new(index.orderable_values_range(start_bound, end_bound))
-            }
-        }
+            NumericIndexInner::Mmap(index) => Box::new(
+                index
+                    .orderable_values_range(start_bound, end_bound)?
+                    // TODO: propagate error through iterator
+                    .filter_map(Result::ok),
+            ),
+        })
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -118,7 +118,8 @@ fn cardinality_request(
 
     let estimation = index
         .inner()
-        .range_cardinality(&RangeInterface::Float(ordered_range));
+        .range_cardinality(&RangeInterface::Float(ordered_range))
+        .unwrap();
 
     let result = index
         .inner()

--- a/lib/segment/src/segment/order_by.rs
+++ b/lib/segment/src/segment/order_by.rs
@@ -113,7 +113,7 @@ impl Segment {
             })?;
 
         let range_iter = numeric_index
-            .stream_range(&order_by.as_range())
+            .stream_range(&order_by.as_range())?
             // We can't early stop the iterator for deferred points because the items are sorted lexicographically by type `(T, internalID)`.
             .filter(|&(_, internal_id)| {
                 deferred_behavior.include_all_points()


### PR DESCRIPTION
Builds on top of #8668 

Migrates the numeric index to use universal io infrastructure.

Specifically, it finishes the migration of `pairs` and `deleted` fields.
