### PR TITLE
Fix flaky test_wait_for_condition_change

### DIFF
--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -83,8 +83,12 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     where
         F: Fn(&T) -> bool,
     {
-        let start = std::time::Instant::now();
-        while start.elapsed() < timeout {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
             let mut data_read_guard = self.data.read();
             if check(&data_read_guard) {
                 return true;
@@ -94,10 +98,9 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             RwLockReadGuard::unlocked(&mut data_read_guard, || {
                 // Move the guard in so it gets unlocked before we re-lock the RwLock read guard
                 let mut guard = notification_guard;
-                self.change_notification.wait_for(&mut guard, timeout);
+                self.change_notification.wait_for(&mut guard, remaining);
             });
         }
-        false
     }
 
     /// Perform an operation over the stored data,


### PR DESCRIPTION
Closes #7114

`SaveOnDisk::wait_for` passes the full `timeout` to `Condvar::wait_for` on every iteration instead of the remaining time, causing it to overshoot the deadline after a notification.

