### PR TITLE
fix(segment): check bottom_right lon for NaN in circle_hashes

### DIFF
--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -421,7 +421,7 @@ pub fn circle_hashes(circle: &GeoRadius, max_regions: usize) -> OperationResult<
     if geo_bounding_box.top_left.lat.is_nan()
         || geo_bounding_box.top_left.lon.is_nan()
         || geo_bounding_box.bottom_right.lat.is_nan()
-        || geo_bounding_box.bottom_right.lat.is_nan()
+        || geo_bounding_box.bottom_right.lon.is_nan()
     {
         return Err(OperationError::service_error("Invalid circle"));
     }


### PR DESCRIPTION
## Summary
In `circle_hashes`, the bounding-box NaN guard used `bottom_right.lat.is_nan()` twice. Validate `bottom_right.lon` instead so circles with NaN longitude are rejected.