### PR TITLE
perf(neon): optimize reduction tree for similarity metrics

### DIFF
--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -42,7 +42,7 @@ pub(crate) unsafe fn euclid_similarity_neon(
             ptr2 = ptr2.add(16);
             i += 16;
         }
-        let mut result = vaddvq_f32(sum1) + vaddvq_f32(sum2) + vaddvq_f32(sum3) + vaddvq_f32(sum4);
+        let mut result = vaddvq_f32(vaddq_f32(vaddq_f32(sum1, sum2), vaddq_f32(sum3, sum4)));
         for i in 0..n - m {
             result += (*ptr1.add(i) - *ptr2.add(i)).powi(2);
         }
@@ -83,7 +83,7 @@ pub(crate) unsafe fn manhattan_similarity_neon(
             ptr2 = ptr2.add(16);
             i += 16;
         }
-        let mut result = vaddvq_f32(sum1) + vaddvq_f32(sum2) + vaddvq_f32(sum3) + vaddvq_f32(sum4);
+        let mut result = vaddvq_f32(vaddq_f32(vaddq_f32(sum1, sum2), vaddq_f32(sum3, sum4)));
         for i in 0..n - m {
             result += (*ptr1.add(i) - *ptr2.add(i)).abs();
         }
@@ -186,7 +186,7 @@ pub(crate) unsafe fn dot_similarity_neon(
             ptr2 = ptr2.add(16);
             i += 16;
         }
-        let mut result = vaddvq_f32(sum1) + vaddvq_f32(sum2) + vaddvq_f32(sum3) + vaddvq_f32(sum4);
+        let mut result = vaddvq_f32(vaddq_f32(vaddq_f32(sum1, sum2), vaddq_f32(sum3, sum4)));
         for i in 0..n - m {
             result += (*ptr1.add(i)) * (*ptr2.add(i));
         }


### PR DESCRIPTION
## Summary

Optimized the NEON SIMD implementations for `euclid`, `manhattan`,  and `dot` similarity metrics on `aarch64` targets. Refining the reduction phase to minimize instruction latency.

## What Changed

Following up on the pattern established in [8640](https://github.com/qdrant/qdrant/pull/8640), I have updated the final summation logic for all similarity metrics in `simple_neon.rs`. 

The change from:

$$vaddvq(sum1) + vaddvq(sum2) + vaddvq(sum3) + vaddvq(sum4)$$

to:

$$vaddvq(vaddq(vaddq(sum1, sum2), vaddq(sum3, sum4)))$$

leverages the fact that vertical additions (`vaddq_f32`) are significantly faster than across-lane (`vaddvq_f32`) on modern `aarch64` cores. By performing as many additions as possible within the SIMD registers before extracting the scalar, we minimize cross-lane stalls and reduce the overall latency of the reduction step.

### Metrics Optimized

The following functions were updated with the improved reduction tree:

- `euclid_similarity_neon`
- `manhattan_similarity_neon`
- `dot_similarity_neon`

## Performance Impact

| Task | Baseline | Proposed | Speedup |
| --- | --- | --- | --- |
| Horizontal Sum | 1.73 ns | **1.57 ns** | ~9% |

**Hardware:** Apple M1 (16 GB RAM)

## Reproducibility

To verify these results, I have established a dedicated benchmark laboratory comparing the baseline scalar implementation against this optimization.

**Benchmark Repository:** [qdrant-performance-sandbox](https://github.com/98prabowo/qdrant-performance-sandbox)