### PR TITLE
Immutable storage null index

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -13,6 +13,7 @@ use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextGridstoreIndexBuilder, FullTextIndex};
 use super::geo_index::{GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
 use super::map_index::{MapIndex, MapIndexGridstoreBuilder, MapIndexMmapBuilder};
+use super::null_index::immutable_null_index::ImmutableNullIndexBuilder;
 use super::numeric_index::{
     NumericIndex, NumericIndexGridstoreBuilder, NumericIndexMmapBuilder, StreamRange,
 };
@@ -20,7 +21,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::geo_index::GeoMapIndex;
-use crate::index::field_index::null_index::MutableNullIndex;
+use crate::index::field_index::null_index::NullIndex;
 use crate::index::field_index::null_index::mutable_null_index::MutableNullIndexBuilder;
 use crate::index::field_index::numeric_index::NumericIndexInner;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
@@ -136,7 +137,7 @@ pub enum FieldIndex {
     BoolIndex(BoolIndex),
     UuidIndex(NumericIndex<UuidIntType, UuidPayloadType>),
     UuidMapIndex(MapIndex<UuidIntType>),
-    NullIndex(MutableNullIndex),
+    NullIndex(NullIndex),
 }
 
 impl std::fmt::Debug for FieldIndex {
@@ -562,7 +563,8 @@ pub enum FieldIndexBuilder {
     BoolGridstoreIndex(MutableBoolIndexBuilder),
     UuidMmapIndex(MapIndexMmapBuilder<UuidIntType>),
     UuidGridstoreIndex(MapIndexGridstoreBuilder<UuidIntType>),
-    NullIndex(MutableNullIndexBuilder),
+    MutableNullIndex(MutableNullIndexBuilder),
+    ImmutableNullIndex(ImmutableNullIndexBuilder),
 }
 
 impl FieldIndexBuilderTrait for FieldIndexBuilder {
@@ -588,7 +590,8 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FullTextGridstoreIndex(builder) => builder.init(),
             Self::UuidMmapIndex(index) => index.init(),
             Self::UuidGridstoreIndex(index) => index.init(),
-            Self::NullIndex(index) => index.init(),
+            Self::MutableNullIndex(index) => index.init(),
+            Self::ImmutableNullIndex(index) => index.init(),
         }
     }
 
@@ -621,7 +624,8 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             }
             Self::UuidMmapIndex(index) => index.add_point(id, payload, hw_counter),
             Self::UuidGridstoreIndex(index) => index.add_point(id, payload, hw_counter),
-            Self::NullIndex(index) => index.add_point(id, payload, hw_counter),
+            Self::MutableNullIndex(index) => index.add_point(id, payload, hw_counter),
+            Self::ImmutableNullIndex(index) => index.add_point(id, payload, hw_counter),
         }
     }
 
@@ -647,7 +651,12 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FullTextGridstoreIndex(builder) => FieldIndex::FullTextIndex(builder.finalize()?),
             Self::UuidMmapIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
             Self::UuidGridstoreIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
-            Self::NullIndex(index) => FieldIndex::NullIndex(index.finalize()?),
+            Self::MutableNullIndex(index) => {
+                FieldIndex::NullIndex(NullIndex::from(index.finalize()?))
+            }
+            Self::ImmutableNullIndex(index) => {
+                FieldIndex::NullIndex(NullIndex::from(index.finalize()?))
+            }
         })
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -13,6 +13,7 @@ use super::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use super::full_text_index::text_index::{FullTextGridstoreIndexBuilder, FullTextIndex};
 use super::geo_index::{GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
 use super::map_index::{MapIndex, MapIndexGridstoreBuilder, MapIndexMmapBuilder};
+use super::null_index::immutable_null_index::ImmutableNullIndexBuilder;
 use super::numeric_index::{
     NumericIndex, NumericIndexGridstoreBuilder, NumericIndexMmapBuilder, StreamRange,
 };
@@ -20,7 +21,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::order_by::OrderValue;
 use crate::index::field_index::geo_index::GeoMapIndex;
-use crate::index::field_index::null_index::MutableNullIndex;
+use crate::index::field_index::null_index::NullIndex;
 use crate::index::field_index::null_index::mutable_null_index::MutableNullIndexBuilder;
 use crate::index::field_index::numeric_index::NumericIndexInner;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
@@ -136,7 +137,7 @@ pub enum FieldIndex {
     BoolIndex(BoolIndex),
     UuidIndex(NumericIndex<UuidIntType, UuidPayloadType>),
     UuidMapIndex(MapIndex<UuidIntType>),
-    NullIndex(MutableNullIndex),
+    NullIndex(NullIndex),
 }
 
 impl std::fmt::Debug for FieldIndex {
@@ -579,7 +580,8 @@ pub enum FieldIndexBuilder {
     BoolGridstoreIndex(MutableBoolIndexBuilder),
     UuidMmapIndex(MapIndexMmapBuilder<UuidIntType>),
     UuidGridstoreIndex(MapIndexGridstoreBuilder<UuidIntType>),
-    NullIndex(MutableNullIndexBuilder),
+    MutableNullIndex(MutableNullIndexBuilder),
+    ImmutableNullIndex(ImmutableNullIndexBuilder),
 }
 
 impl FieldIndexBuilderTrait for FieldIndexBuilder {
@@ -605,7 +607,8 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FullTextGridstoreIndex(builder) => builder.init(),
             Self::UuidMmapIndex(index) => index.init(),
             Self::UuidGridstoreIndex(index) => index.init(),
-            Self::NullIndex(index) => index.init(),
+            Self::MutableNullIndex(index) => index.init(),
+            Self::ImmutableNullIndex(index) => index.init(),
         }
     }
 
@@ -638,7 +641,8 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             }
             Self::UuidMmapIndex(index) => index.add_point(id, payload, hw_counter),
             Self::UuidGridstoreIndex(index) => index.add_point(id, payload, hw_counter),
-            Self::NullIndex(index) => index.add_point(id, payload, hw_counter),
+            Self::MutableNullIndex(index) => index.add_point(id, payload, hw_counter),
+            Self::ImmutableNullIndex(index) => index.add_point(id, payload, hw_counter),
         }
     }
 
@@ -664,7 +668,12 @@ impl FieldIndexBuilderTrait for FieldIndexBuilder {
             Self::FullTextGridstoreIndex(builder) => FieldIndex::FullTextIndex(builder.finalize()?),
             Self::UuidMmapIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
             Self::UuidGridstoreIndex(index) => FieldIndex::UuidMapIndex(index.finalize()?),
-            Self::NullIndex(index) => FieldIndex::NullIndex(index.finalize()?),
+            Self::MutableNullIndex(index) => {
+                FieldIndex::NullIndex(NullIndex::from(index.finalize()?))
+            }
+            Self::ImmutableNullIndex(index) => {
+                FieldIndex::NullIndex(NullIndex::from(index.finalize()?))
+            }
         })
     }
 }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -8,6 +8,7 @@ use super::bool_index::mutable_bool_index::MutableBoolIndex;
 use super::geo_index::{GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
 use super::histogram::Numericable;
 use super::map_index::{MapIndex, MapIndexGridstoreBuilder, MapIndexKey, MapIndexMmapBuilder};
+use super::null_index::{ImmutableNullIndex, NullIndex};
 use super::numeric_index::{
     Encodable, NumericIndexGridstoreBuilder, NumericIndexIntoInnerValue, NumericIndexMmapBuilder,
 };
@@ -53,8 +54,6 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
         index_type: &FullPayloadIndexType,
-        path: &Path,
-        total_point_count: usize,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<FieldIndex>> {
@@ -118,13 +117,6 @@ impl IndexSelector<'_> {
             (PayloadIndexType::UuidMapIndex, PayloadSchemaParams::Uuid(_)) => self
                 .map_new(field, create_if_missing)?
                 .map(FieldIndex::UuidMapIndex),
-
-            (PayloadIndexType::NullIndex, _) => MutableNullIndex::open(
-                &null_dir(path, field),
-                total_point_count,
-                create_if_missing,
-            )?
-            .map(FieldIndex::NullIndex),
 
             // Storage inconsistency. Should never happen.
             (index_type, schema) => {
@@ -380,24 +372,42 @@ impl IndexSelector<'_> {
         }
     }
 
-    pub fn null_builder(dir: &Path, field: &JsonPath) -> OperationResult<FieldIndexBuilder> {
-        // null index is always on disk and appendable
-        Ok(FieldIndexBuilder::NullIndex(MutableNullIndex::builder(
-            &null_dir(dir, field),
-        )?))
+    pub fn null_builder(&self, dir: &Path, field: &JsonPath) -> OperationResult<FieldIndexBuilder> {
+        let builder = match self {
+            IndexSelector::Mmap(_) => FieldIndexBuilder::ImmutableNullIndex(
+                ImmutableNullIndex::builder(&null_dir(dir, field))?,
+            ),
+            IndexSelector::Gridstore(_) => FieldIndexBuilder::MutableNullIndex(
+                MutableNullIndex::builder(&null_dir(dir, field))?,
+            ),
+        };
+        Ok(builder)
     }
 
     pub fn new_null_index(
+        &self,
         dir: &Path,
         field: &JsonPath,
-        total_point_count: usize,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<FieldIndex>> {
-        // null index is always on disk and is appendable
-        Ok(
-            MutableNullIndex::open(&null_dir(dir, field), total_point_count, create_if_missing)?
-                .map(FieldIndex::NullIndex),
-        )
+        let total_point_count = id_tracker.total_point_count();
+        match self {
+            IndexSelector::Mmap(_) => Ok(ImmutableNullIndex::open(
+                &null_dir(dir, field),
+                total_point_count,
+                id_tracker.deleted_point_bitslice(),
+            )?
+            .map(NullIndex::Immutable)
+            .map(FieldIndex::NullIndex)),
+            IndexSelector::Gridstore(_) => Ok(MutableNullIndex::open(
+                &null_dir(dir, field),
+                total_point_count,
+                create_if_missing,
+            )?
+            .map(NullIndex::Mutable)
+            .map(FieldIndex::NullIndex)),
+        }
     }
 
     fn text_new(

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -120,7 +120,7 @@ impl IndexSelector<'_> {
 
             (PayloadIndexType::NullIndex, _) => {
                 let dir = match self {
-                    IndexSelector::Mmap(IndexSelectorMmap { dir, .. }) => *dir,
+                    IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => *dir,
                     IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => *dir,
                 };
                 self.new_null_index(
@@ -418,29 +418,26 @@ impl IndexSelector<'_> {
     ) -> OperationResult<Option<FieldIndex>> {
         let total_point_count = id_tracker.total_point_count();
         let null_dir = null_dir(dir, field);
-        let open_mutable = || -> OperationResult<Option<FieldIndex>> {
-            Ok(
-                MutableNullIndex::open(&null_dir, total_point_count, create_if_missing)?
-                    .map(NullIndex::Mutable)
-                    .map(FieldIndex::NullIndex),
-            )
-        };
-        match self {
-            // `MutableNullIndex` and `ImmutableNullIndex` share the same on-disk
-            // format; stored mutability picks which in-memory wrapper to build.
-            IndexSelector::Mmap(_) => match mutability {
-                IndexMutability::Immutable => Ok(ImmutableNullIndex::open(
-                    &null_dir,
-                    total_point_count,
-                    id_tracker.deleted_point_bitslice(),
-                )?
-                .map(NullIndex::Immutable)
-                .map(FieldIndex::NullIndex)),
-                IndexMutability::Mutable => open_mutable(),
-            },
-            // Gridstore segments are always appendable, so the null index is
-            // always mutable regardless of the stored mutability marker.
-            IndexSelector::Gridstore(_) => open_mutable(),
+        // `MutableNullIndex` and `ImmutableNullIndex` share the same on-disk
+        // format; stored mutability picks which in-memory wrapper to build.
+        // Gridstore segments are always appendable, so the null index is
+        // always mutable regardless of the stored mutability marker.
+        match (self, mutability) {
+            (IndexSelector::Mmap(_), IndexMutability::Immutable) => Ok(ImmutableNullIndex::open(
+                &null_dir,
+                total_point_count,
+                id_tracker.deleted_point_bitslice(),
+            )?
+            .map(NullIndex::Immutable)
+            .map(FieldIndex::NullIndex)),
+            (IndexSelector::Mmap(_), IndexMutability::Mutable)
+            | (IndexSelector::Gridstore(_), _) => {
+                Ok(
+                    MutableNullIndex::open(&null_dir, total_point_count, create_if_missing)?
+                        .map(NullIndex::Mutable)
+                        .map(FieldIndex::NullIndex),
+                )
+            }
         }
     }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -177,14 +177,14 @@ impl IndexSelector<'_> {
             PayloadSchemaParams::Text(text_index_params) => self
                 .text_new(field, text_index_params.clone(), create_if_missing)?
                 .map(|index| vec![FieldIndex::FullTextIndex(index)]),
-            PayloadSchemaParams::Bool(_) => {
-                let mutability = match self {
-                    IndexSelector::Mmap(_) => IndexMutability::Immutable,
-                    IndexSelector::Gridstore(_) => IndexMutability::Mutable,
-                };
-                self.bool_new(field, create_if_missing, id_tracker, mutability)?
-                    .map(|index| vec![FieldIndex::BoolIndex(index)])
-            }
+            PayloadSchemaParams::Bool(_) => self
+                .bool_new(
+                    field,
+                    create_if_missing,
+                    id_tracker,
+                    self.default_mutability(),
+                )?
+                .map(|index| vec![FieldIndex::BoolIndex(index)]),
             PayloadSchemaParams::Datetime(_) => self
                 .numeric_new(field, create_if_missing)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
@@ -385,6 +385,16 @@ impl IndexSelector<'_> {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => dir,
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => dir,
+        }
+    }
+
+    /// Default mutability for indexes that share an on-disk format across
+    /// mutability variants (e.g. bool, null): Mmap segments are immutable,
+    /// Gridstore segments are appendable/mutable.
+    pub fn default_mutability(&self) -> IndexMutability {
+        match self {
+            IndexSelector::Mmap(_) => IndexMutability::Immutable,
+            IndexSelector::Gridstore(_) => IndexMutability::Mutable,
         }
     }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -7,6 +7,7 @@ use super::bool_index::immutable_bool_index::ImmutableBoolIndex;
 use super::bool_index::mutable_bool_index::MutableBoolIndex;
 use super::geo_index::{GeoMapIndexGridstoreBuilder, GeoMapIndexMmapBuilder};
 use super::map_index::{MapIndex, MapIndexGridstoreBuilder, MapIndexKey, MapIndexMmapBuilder};
+use super::null_index::{ImmutableNullIndex, NullIndex};
 use super::numeric_index::{
     Encodable, NumericIndexGridstoreBuilder, NumericIndexIntoInnerValue, NumericIndexMmapBuilder,
 };
@@ -53,8 +54,6 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,
         index_type: &FullPayloadIndexType,
-        path: &Path,
-        total_point_count: usize,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<FieldIndex>> {
@@ -118,13 +117,6 @@ impl IndexSelector<'_> {
             (PayloadIndexType::UuidMapIndex, PayloadSchemaParams::Uuid(_)) => self
                 .map_new(field, create_if_missing)?
                 .map(FieldIndex::UuidMapIndex),
-
-            (PayloadIndexType::NullIndex, _) => MutableNullIndex::open(
-                &null_dir(path, field),
-                total_point_count,
-                create_if_missing,
-            )?
-            .map(FieldIndex::NullIndex),
 
             // Storage inconsistency. Should never happen.
             (index_type, schema) => {
@@ -386,28 +378,46 @@ impl IndexSelector<'_> {
     }
 
     pub fn null_builder(
+        &self,
         dir: &Path,
         field: &JsonPath,
         total_point_count: usize,
     ) -> OperationResult<FieldIndexBuilder> {
-        // null index is always on disk and appendable
-        Ok(FieldIndexBuilder::NullIndex(MutableNullIndex::builder(
-            &null_dir(dir, field),
-            total_point_count,
-        )?))
+        let builder = match self {
+            IndexSelector::Mmap(_) => FieldIndexBuilder::ImmutableNullIndex(
+                ImmutableNullIndex::builder(&null_dir(dir, field), total_point_count)?,
+            ),
+            IndexSelector::Gridstore(_) => FieldIndexBuilder::MutableNullIndex(
+                MutableNullIndex::builder(&null_dir(dir, field), total_point_count)?,
+            ),
+        };
+        Ok(builder)
     }
 
     pub fn new_null_index(
+        &self,
         dir: &Path,
         field: &JsonPath,
-        total_point_count: usize,
         create_if_missing: bool,
+        id_tracker: &IdTrackerEnum,
     ) -> OperationResult<Option<FieldIndex>> {
-        // null index is always on disk and is appendable
-        Ok(
-            MutableNullIndex::open(&null_dir(dir, field), total_point_count, create_if_missing)?
-                .map(FieldIndex::NullIndex),
-        )
+        let total_point_count = id_tracker.total_point_count();
+        match self {
+            IndexSelector::Mmap(_) => Ok(ImmutableNullIndex::open(
+                &null_dir(dir, field),
+                total_point_count,
+                id_tracker.deleted_point_bitslice(),
+            )?
+            .map(NullIndex::Immutable)
+            .map(FieldIndex::NullIndex)),
+            IndexSelector::Gridstore(_) => Ok(MutableNullIndex::open(
+                &null_dir(dir, field),
+                total_point_count,
+                create_if_missing,
+            )?
+            .map(NullIndex::Mutable)
+            .map(FieldIndex::NullIndex)),
+        }
     }
 
     fn text_new(

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -118,6 +118,20 @@ impl IndexSelector<'_> {
                 .map_new(field, create_if_missing)?
                 .map(FieldIndex::UuidMapIndex),
 
+            (PayloadIndexType::NullIndex, _) => {
+                let dir = match self {
+                    IndexSelector::Mmap(IndexSelectorMmap { dir, .. }) => *dir,
+                    IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => *dir,
+                };
+                self.new_null_index(
+                    dir,
+                    field,
+                    create_if_missing,
+                    id_tracker,
+                    index_type.mutability,
+                )?
+            }
+
             // Storage inconsistency. Should never happen.
             (index_type, schema) => {
                 return Err(OperationError::service_error(format!(
@@ -400,23 +414,33 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
+        mutability: IndexMutability,
     ) -> OperationResult<Option<FieldIndex>> {
         let total_point_count = id_tracker.total_point_count();
+        let null_dir = null_dir(dir, field);
+        let open_mutable = || -> OperationResult<Option<FieldIndex>> {
+            Ok(
+                MutableNullIndex::open(&null_dir, total_point_count, create_if_missing)?
+                    .map(NullIndex::Mutable)
+                    .map(FieldIndex::NullIndex),
+            )
+        };
         match self {
-            IndexSelector::Mmap(_) => Ok(ImmutableNullIndex::open(
-                &null_dir(dir, field),
-                total_point_count,
-                id_tracker.deleted_point_bitslice(),
-            )?
-            .map(NullIndex::Immutable)
-            .map(FieldIndex::NullIndex)),
-            IndexSelector::Gridstore(_) => Ok(MutableNullIndex::open(
-                &null_dir(dir, field),
-                total_point_count,
-                create_if_missing,
-            )?
-            .map(NullIndex::Mutable)
-            .map(FieldIndex::NullIndex)),
+            // `MutableNullIndex` and `ImmutableNullIndex` share the same on-disk
+            // format; stored mutability picks which in-memory wrapper to build.
+            IndexSelector::Mmap(_) => match mutability {
+                IndexMutability::Immutable => Ok(ImmutableNullIndex::open(
+                    &null_dir,
+                    total_point_count,
+                    id_tracker.deleted_point_bitslice(),
+                )?
+                .map(NullIndex::Immutable)
+                .map(FieldIndex::NullIndex)),
+                IndexMutability::Mutable => open_mutable(),
+            },
+            // Gridstore segments are always appendable, so the null index is
+            // always mutable regardless of the stored mutability marker.
+            IndexSelector::Gridstore(_) => open_mutable(),
         }
     }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -119,17 +119,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::UuidMapIndex),
 
             (PayloadIndexType::NullIndex, _) => {
-                let dir = match self {
-                    IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => *dir,
-                    IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => *dir,
-                };
-                self.new_null_index(
-                    dir,
-                    field,
-                    create_if_missing,
-                    id_tracker,
-                    index_type.mutability,
-                )?
+                self.new_null_index(field, create_if_missing, id_tracker, index_type.mutability)?
             }
 
             // Storage inconsistency. Should never happen.
@@ -391,18 +381,25 @@ impl IndexSelector<'_> {
         }
     }
 
+    fn dir(&self) -> &Path {
+        match self {
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => dir,
+            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => dir,
+        }
+    }
+
     pub fn null_builder(
         &self,
-        dir: &Path,
         field: &JsonPath,
         total_point_count: usize,
     ) -> OperationResult<FieldIndexBuilder> {
+        let null_dir = null_dir(self.dir(), field);
         let builder = match self {
             IndexSelector::Mmap(_) => FieldIndexBuilder::ImmutableNullIndex(
-                ImmutableNullIndex::builder(&null_dir(dir, field), total_point_count)?,
+                ImmutableNullIndex::builder(&null_dir, total_point_count)?,
             ),
             IndexSelector::Gridstore(_) => FieldIndexBuilder::MutableNullIndex(
-                MutableNullIndex::builder(&null_dir(dir, field), total_point_count)?,
+                MutableNullIndex::builder(&null_dir, total_point_count)?,
             ),
         };
         Ok(builder)
@@ -410,14 +407,13 @@ impl IndexSelector<'_> {
 
     pub fn new_null_index(
         &self,
-        dir: &Path,
         field: &JsonPath,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
         mutability: IndexMutability,
     ) -> OperationResult<Option<FieldIndex>> {
         let total_point_count = id_tracker.total_point_count();
-        let null_dir = null_dir(dir, field);
+        let null_dir = null_dir(self.dir(), field);
         // `MutableNullIndex` and `ImmutableNullIndex` share the same on-disk
         // format; stored mutability picks which in-memory wrapper to build.
         // Gridstore segments are always appendable, so the null index is

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -46,8 +46,6 @@ impl ImmutableNullIndex {
     // N.B.: these operations are immutable.
     delegate! {
         to self.0 {
-            // TODO telemetry should overwrite a text tag.
-            pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn values_count(&self, point_id: PointOffsetType) -> usize;
             pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
             pub fn values_is_null(&self, id: PointOffsetType) -> bool;
@@ -55,6 +53,18 @@ impl ImmutableNullIndex {
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
             pub fn get_storage_type(&self) -> StorageType;
+        }
+    }
+
+    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        let points_count = self.count_indexed_points();
+
+        PayloadIndexTelemetry {
+            field_name: None,
+            points_count,
+            points_values_count: points_count,
+            histogram_bucket_size: None,
+            index_type: "immutable_null_index",
         }
     }
 }

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -1,0 +1,387 @@
+use std::path::{Path, PathBuf};
+
+use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use delegate::delegate;
+
+use super::mutable_null_index::MutableNullIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use crate::telemetry::PayloadIndexTelemetry;
+
+pub struct ImmutableNullIndex(MutableNullIndex);
+
+impl ImmutableNullIndex {
+    pub fn builder(
+        path: &Path,
+        total_point_count: usize,
+    ) -> OperationResult<ImmutableNullIndexBuilder> {
+        Ok(ImmutableNullIndexBuilder(
+            MutableNullIndex::open(path, total_point_count, true)?.ok_or_else(|| {
+                OperationError::service_error("Failed to create and open MutableNullIndex")
+            })?,
+        ))
+    }
+
+    pub fn from_mutable(mutable_index: MutableNullIndex) -> OperationResult<Self> {
+        mutable_index.flusher()()?;
+        Ok(Self(mutable_index))
+    }
+
+    pub fn open(
+        path: &Path,
+        total_point_count: usize,
+        deleted: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
+        Ok(MutableNullIndex::open_immutable(path, total_point_count, deleted)?.map(Self))
+    }
+
+    #[inline]
+    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        self.0.remove_point_immutable(id)
+    }
+}
+
+impl ImmutableNullIndex {
+    // N.B.: these operations are immutable.
+    delegate! {
+        to self.0 {
+            pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+            pub fn values_count(&self, point_id: PointOffsetType) -> usize;
+            pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
+            pub fn values_is_null(&self, id: PointOffsetType) -> bool;
+            pub fn is_on_disk(&self) -> bool;
+            pub fn populate(&self) -> OperationResult<()>;
+            pub fn clear_cache(&self) -> OperationResult<()>;
+        }
+    }
+}
+
+impl PayloadFieldIndex for ImmutableNullIndex {
+    delegate! {
+        to self.0 {
+            fn count_indexed_points(&self) -> usize;
+            fn wipe(self) -> OperationResult<()>;
+            fn files(&self) -> Vec<PathBuf>;
+            fn filter<'a>(
+                    &'a self,
+                    condition: &'a crate::types::FieldCondition,
+                    hw_counter: &'a HardwareCounterCell,
+            ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
+            fn estimate_cardinality(
+                    &self,
+                    condition: &crate::types::FieldCondition,
+                    hw_counter: &HardwareCounterCell,
+            ) -> OperationResult<Option<crate::index::field_index::CardinalityEstimation>>;
+            fn payload_blocks(
+                    &self,
+                    threshold: usize,
+                    key: crate::types::PayloadKeyType,
+            ) -> Box<dyn Iterator<Item = OperationResult<crate::index::field_index::PayloadBlockCondition>> + '_>;
+        }
+    }
+
+    #[inline]
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        self.files() // All the files are immutable in this index.
+    }
+
+    #[inline]
+    fn flusher(&self) -> crate::common::Flusher {
+        Box::new(|| Ok(())) // No op for an immutable index.
+    }
+}
+
+pub struct ImmutableNullIndexBuilder(MutableNullIndex);
+
+impl FieldIndexBuilderTrait for ImmutableNullIndexBuilder {
+    type FieldIndexType = ImmutableNullIndex;
+
+    fn init(&mut self) -> OperationResult<()> {
+        // After Self is created, it is already initialized
+        Ok(())
+    }
+
+    fn add_point(
+        &mut self,
+        id: PointOffsetType,
+        payload: &[&serde_json::Value],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.0.add_point(id, payload, hw_counter)
+    }
+
+    fn finalize(self) -> OperationResult<Self::FieldIndexType> {
+        self.0.flusher()()?; // Immutable index has noop flusher, so we have to ensure the data is flushed now.
+        Ok(ImmutableNullIndex(self.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::bitvec::BitVec;
+    use itertools::Itertools as _;
+    use serde_json::{Value, json};
+    use tempfile::TempDir;
+
+    use crate::{json_path::JsonPath, types::FieldCondition};
+
+    use super::*;
+
+    #[test]
+    fn test_remove_idempotent() {
+        let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let null_value = Value::Null;
+        let null_value_in_array =
+            Value::Array(vec![Value::String("test".to_string()), Value::Null]);
+
+        for i in 0..4 {
+            match i % 4 {
+                0 => builder.add_point(i, &[&null_value], &hw_counter).unwrap(),
+                1 => builder
+                    .add_point(i, &[&null_value_in_array], &hw_counter)
+                    .unwrap(),
+                2 => builder.add_point(i, &[], &hw_counter).unwrap(),
+                3 => builder
+                    .add_point(i, &[&Value::Bool(true)], &hw_counter)
+                    .unwrap(),
+                _ => unreachable!(),
+            }
+        }
+
+        let mut index = builder.finalize().unwrap();
+
+        let key = JsonPath::new("test");
+
+        let filter_is_null = FieldCondition::new_is_null(key.clone(), true);
+
+        let filter_is_not_empty = FieldCondition {
+            key: key.clone(),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(false),
+            is_null: None,
+        };
+
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0, 1],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![1, 3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            2,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            2,
+        );
+
+
+        index.remove_point(1).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+
+        index.remove_point(1).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+
+        index.remove_point(3).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec()
+                .is_empty(),
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            0,
+        );
+
+        index.remove_point(3).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec()
+                .is_empty(),
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_remove_reopen() {
+        let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+        builder.add_point(0, &[&json!(true)], &hw_counter).unwrap();
+        builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();
+        builder.add_point(2, &[&json!(false)], &hw_counter).unwrap();
+
+        let mut index = builder.finalize().unwrap();
+
+        let mut deleted = BitVec::repeat(false, 3);
+        deleted.set(1, true);
+        index.remove_point(1).unwrap();
+        drop(index);
+
+        let reopened_index = ImmutableNullIndex::open(dir.path(), 3, &deleted)
+            .unwrap()
+            .unwrap();
+
+        let filter_is_not_empty = FieldCondition {
+            key: JsonPath::new("test"),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(false),
+            is_null: None,
+        };
+
+        assert_eq!(
+            reopened_index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0, 2],
+        );
+        assert_eq!(reopened_index.count_indexed_points(), 3);
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -8,17 +8,15 @@ use delegate::delegate;
 use super::mutable_null_index::MutableNullIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use crate::index::payload_config::StorageType;
 use crate::telemetry::PayloadIndexTelemetry;
 
 pub struct ImmutableNullIndex(MutableNullIndex);
 
 impl ImmutableNullIndex {
-    pub fn builder(
-        path: &Path,
-        total_point_count: usize,
-    ) -> OperationResult<ImmutableNullIndexBuilder> {
+    pub fn builder(path: &Path) -> OperationResult<ImmutableNullIndexBuilder> {
         Ok(ImmutableNullIndexBuilder(
-            MutableNullIndex::open(path, total_point_count, true)?.ok_or_else(|| {
+            MutableNullIndex::open(path, 0, true)?.ok_or_else(|| {
                 OperationError::service_error("Failed to create and open MutableNullIndex")
             })?,
         ))
@@ -39,7 +37,8 @@ impl ImmutableNullIndex {
 
     #[inline]
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        self.0.remove_point_immutable(id)
+        self.0.remove_point_immutable(id);
+        Ok(())
     }
 }
 
@@ -47,6 +46,7 @@ impl ImmutableNullIndex {
     // N.B.: these operations are immutable.
     delegate! {
         to self.0 {
+            // TODO telemetry should overwrite a text tag.
             pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn values_count(&self, point_id: PointOffsetType) -> usize;
             pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
@@ -54,6 +54,7 @@ impl ImmutableNullIndex {
             pub fn is_on_disk(&self) -> bool;
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
+            pub fn get_storage_type(&self) -> StorageType;
         }
     }
 }
@@ -125,14 +126,14 @@ mod tests {
     use serde_json::{Value, json};
     use tempfile::TempDir;
 
-    use crate::{json_path::JsonPath, types::FieldCondition};
-
     use super::*;
+    use crate::json_path::JsonPath;
+    use crate::types::FieldCondition;
 
     #[test]
     fn test_remove_idempotent() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
         let hw_counter = HardwareCounterCell::new();
 
         let null_value = Value::Null;
@@ -203,7 +204,6 @@ mod tests {
                 .exp,
             2,
         );
-
 
         index.remove_point(1).unwrap();
         assert_eq!(
@@ -345,7 +345,7 @@ mod tests {
     #[test]
     fn test_remove_reopen() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
         let hw_counter = HardwareCounterCell::new();
         builder.add_point(0, &[&json!(true)], &hw_counter).unwrap();
         builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -409,11 +409,10 @@ mod tests {
         builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();
         builder.add_point(2, &[&json!(false)], &hw_counter).unwrap();
 
-        let mut index = builder.finalize().unwrap();
+        let index = builder.finalize().unwrap();
 
         let mut deleted = BitVec::repeat(false, 3);
         deleted.set(1, true);
-        index.remove_point(1).unwrap();
         drop(index);
 
         let reopened_index = ImmutableNullIndex::open(dir.path(), 3, &deleted)

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -8,6 +8,7 @@ use delegate::delegate;
 use super::mutable_null_index::MutableNullIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use crate::index::payload_config::StorageType;
 use crate::telemetry::PayloadIndexTelemetry;
 
 pub struct ImmutableNullIndex(MutableNullIndex);
@@ -39,7 +40,8 @@ impl ImmutableNullIndex {
 
     #[inline]
     pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
-        self.0.remove_point_immutable(id)
+        self.0.remove_point_immutable(id);
+        Ok(())
     }
 }
 
@@ -47,6 +49,7 @@ impl ImmutableNullIndex {
     // N.B.: these operations are immutable.
     delegate! {
         to self.0 {
+            // TODO telemetry should overwrite a text tag.
             pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn values_count(&self, point_id: PointOffsetType) -> usize;
             pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
@@ -54,6 +57,7 @@ impl ImmutableNullIndex {
             pub fn is_on_disk(&self) -> bool;
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
+            pub fn get_storage_type(&self) -> StorageType;
         }
     }
 }
@@ -132,7 +136,7 @@ mod tests {
     #[test]
     fn test_remove_idempotent() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
         let hw_counter = HardwareCounterCell::new();
 
         let null_value = Value::Null;
@@ -344,7 +348,7 @@ mod tests {
     #[test]
     fn test_remove_reopen() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
         let hw_counter = HardwareCounterCell::new();
         builder.add_point(0, &[&json!(true)], &hw_counter).unwrap();
         builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -54,6 +54,7 @@ impl ImmutableNullIndex {
             pub fn values_is_null(&self, id: PointOffsetType) -> bool;
             pub fn is_on_disk(&self) -> bool;
             pub fn populate(&self) -> OperationResult<()>;
+            pub fn ram_usage_bytes(&self) -> usize;
             pub fn clear_cache(&self) -> OperationResult<()>;
             pub fn get_storage_type(&self) -> StorageType;
         }

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -154,19 +154,14 @@ mod tests {
         let null_value_in_array =
             Value::Array(vec![Value::String("test".to_string()), Value::Null]);
 
-        for i in 0..4 {
-            match i % 4 {
-                0 => builder.add_point(i, &[&null_value], &hw_counter).unwrap(),
-                1 => builder
-                    .add_point(i, &[&null_value_in_array], &hw_counter)
-                    .unwrap(),
-                2 => builder.add_point(i, &[], &hw_counter).unwrap(),
-                3 => builder
-                    .add_point(i, &[&Value::Bool(true)], &hw_counter)
-                    .unwrap(),
-                _ => unreachable!(),
-            }
-        }
+        builder.add_point(0, &[&null_value], &hw_counter).unwrap();
+        builder
+            .add_point(1, &[&null_value_in_array], &hw_counter)
+            .unwrap();
+        builder.add_point(2, &[], &hw_counter).unwrap();
+        builder
+            .add_point(3, &[&Value::Bool(true)], &hw_counter)
+            .unwrap();
 
         let mut index = builder.finalize().unwrap();
 

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_remove_idempotent() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
         let hw_counter = HardwareCounterCell::new();
 
         let null_value = Value::Null;
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn test_remove_reopen() {
         let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
-        let mut builder = ImmutableNullIndex::builder(dir.path()).unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
         let hw_counter = HardwareCounterCell::new();
         builder.add_point(0, &[&json!(true)], &hw_counter).unwrap();
         builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -1,0 +1,386 @@
+use std::path::{Path, PathBuf};
+
+use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use delegate::delegate;
+
+use super::mutable_null_index::MutableNullIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use crate::telemetry::PayloadIndexTelemetry;
+
+pub struct ImmutableNullIndex(MutableNullIndex);
+
+impl ImmutableNullIndex {
+    pub fn builder(
+        path: &Path,
+        total_point_count: usize,
+    ) -> OperationResult<ImmutableNullIndexBuilder> {
+        Ok(ImmutableNullIndexBuilder(
+            MutableNullIndex::open(path, total_point_count, true)?.ok_or_else(|| {
+                OperationError::service_error("Failed to create and open MutableNullIndex")
+            })?,
+        ))
+    }
+
+    pub fn from_mutable(mutable_index: MutableNullIndex) -> OperationResult<Self> {
+        mutable_index.flusher()()?;
+        Ok(Self(mutable_index))
+    }
+
+    pub fn open(
+        path: &Path,
+        total_point_count: usize,
+        deleted: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
+        Ok(MutableNullIndex::open_immutable(path, total_point_count, deleted)?.map(Self))
+    }
+
+    #[inline]
+    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        self.0.remove_point_immutable(id)
+    }
+}
+
+impl ImmutableNullIndex {
+    // N.B.: these operations are immutable.
+    delegate! {
+        to self.0 {
+            pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+            pub fn values_count(&self, point_id: PointOffsetType) -> usize;
+            pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
+            pub fn values_is_null(&self, id: PointOffsetType) -> bool;
+            pub fn is_on_disk(&self) -> bool;
+            pub fn populate(&self) -> OperationResult<()>;
+            pub fn clear_cache(&self) -> OperationResult<()>;
+        }
+    }
+}
+
+impl PayloadFieldIndex for ImmutableNullIndex {
+    delegate! {
+        to self.0 {
+            fn count_indexed_points(&self) -> usize;
+            fn wipe(self) -> OperationResult<()>;
+            fn files(&self) -> Vec<PathBuf>;
+            fn filter<'a>(
+                    &'a self,
+                    condition: &'a crate::types::FieldCondition,
+                    hw_counter: &'a HardwareCounterCell,
+            ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
+            fn estimate_cardinality(
+                    &self,
+                    condition: &crate::types::FieldCondition,
+                    hw_counter: &HardwareCounterCell,
+            ) -> OperationResult<Option<crate::index::field_index::CardinalityEstimation>>;
+            fn payload_blocks(
+                    &self,
+                    threshold: usize,
+                    key: crate::types::PayloadKeyType,
+            ) -> Box<dyn Iterator<Item = OperationResult<crate::index::field_index::PayloadBlockCondition>> + '_>;
+        }
+    }
+
+    #[inline]
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        self.files() // All the files are immutable in this index.
+    }
+
+    #[inline]
+    fn flusher(&self) -> crate::common::Flusher {
+        Box::new(|| Ok(())) // No op for an immutable index.
+    }
+}
+
+pub struct ImmutableNullIndexBuilder(MutableNullIndex);
+
+impl FieldIndexBuilderTrait for ImmutableNullIndexBuilder {
+    type FieldIndexType = ImmutableNullIndex;
+
+    fn init(&mut self) -> OperationResult<()> {
+        // After Self is created, it is already initialized
+        Ok(())
+    }
+
+    fn add_point(
+        &mut self,
+        id: PointOffsetType,
+        payload: &[&serde_json::Value],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.0.add_point(id, payload, hw_counter)
+    }
+
+    fn finalize(self) -> OperationResult<Self::FieldIndexType> {
+        self.0.flusher()()?; // Immutable index has noop flusher, so we have to ensure the data is flushed now.
+        Ok(ImmutableNullIndex(self.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::bitvec::BitVec;
+    use itertools::Itertools as _;
+    use serde_json::{Value, json};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::json_path::JsonPath;
+    use crate::types::FieldCondition;
+
+    #[test]
+    fn test_remove_idempotent() {
+        let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let null_value = Value::Null;
+        let null_value_in_array =
+            Value::Array(vec![Value::String("test".to_string()), Value::Null]);
+
+        for i in 0..4 {
+            match i % 4 {
+                0 => builder.add_point(i, &[&null_value], &hw_counter).unwrap(),
+                1 => builder
+                    .add_point(i, &[&null_value_in_array], &hw_counter)
+                    .unwrap(),
+                2 => builder.add_point(i, &[], &hw_counter).unwrap(),
+                3 => builder
+                    .add_point(i, &[&Value::Bool(true)], &hw_counter)
+                    .unwrap(),
+                _ => unreachable!(),
+            }
+        }
+
+        let mut index = builder.finalize().unwrap();
+
+        let key = JsonPath::new("test");
+
+        let filter_is_null = FieldCondition::new_is_null(key.clone(), true);
+
+        let filter_is_not_empty = FieldCondition {
+            key: key.clone(),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(false),
+            is_null: None,
+        };
+
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0, 1],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![1, 3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            2,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            2,
+        );
+
+        index.remove_point(1).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+
+        index.remove_point(1).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert_eq!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![3],
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+
+        index.remove_point(3).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec()
+                .is_empty(),
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            0,
+        );
+
+        index.remove_point(3).unwrap();
+        assert_eq!(
+            index
+                .filter(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0],
+        );
+        assert!(
+            index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec()
+                .is_empty(),
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_null, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            1,
+        );
+        assert_eq!(
+            index
+                .estimate_cardinality(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .exp,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_remove_reopen() {
+        let dir = TempDir::with_prefix("test_immutable_null_index").unwrap();
+        let mut builder = ImmutableNullIndex::builder(dir.path(), 0).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+        builder.add_point(0, &[&json!(true)], &hw_counter).unwrap();
+        builder.add_point(1, &[&json!(true)], &hw_counter).unwrap();
+        builder.add_point(2, &[&json!(false)], &hw_counter).unwrap();
+
+        let mut index = builder.finalize().unwrap();
+
+        let mut deleted = BitVec::repeat(false, 3);
+        deleted.set(1, true);
+        index.remove_point(1).unwrap();
+        drop(index);
+
+        let reopened_index = ImmutableNullIndex::open(dir.path(), 3, &deleted)
+            .unwrap()
+            .unwrap();
+
+        let filter_is_not_empty = FieldCondition {
+            key: JsonPath::new("test"),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(false),
+            is_null: None,
+        };
+
+        assert_eq!(
+            reopened_index
+                .filter(&filter_is_not_empty, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0, 2],
+        );
+        assert_eq!(reopened_index.count_indexed_points(), 3);
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -3,13 +3,15 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use delegate::delegate;
 
 use super::mutable_null_index::MutableNullIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex};
+use crate::index::field_index::{
+    CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
+};
 use crate::index::payload_config::StorageType;
 use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, PayloadKeyType};
 
 pub struct ImmutableNullIndex(MutableNullIndex);
 
@@ -47,17 +49,45 @@ impl ImmutableNullIndex {
 
 impl ImmutableNullIndex {
     // N.B.: these operations are immutable.
-    delegate! {
-        to self.0 {
-            pub fn values_count(&self, point_id: PointOffsetType) -> usize;
-            pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
-            pub fn values_is_null(&self, id: PointOffsetType) -> bool;
-            pub fn is_on_disk(&self) -> bool;
-            pub fn populate(&self) -> OperationResult<()>;
-            pub fn ram_usage_bytes(&self) -> usize;
-            pub fn clear_cache(&self) -> OperationResult<()>;
-            pub fn get_storage_type(&self) -> StorageType;
-        }
+
+    #[inline]
+    pub fn values_count(&self, point_id: PointOffsetType) -> usize {
+        self.0.values_count(point_id)
+    }
+
+    #[inline]
+    pub fn values_is_empty(&self, id: PointOffsetType) -> bool {
+        self.0.values_is_empty(id)
+    }
+
+    #[inline]
+    pub fn values_is_null(&self, id: PointOffsetType) -> bool {
+        self.0.values_is_null(id)
+    }
+
+    #[inline]
+    pub fn is_on_disk(&self) -> bool {
+        self.0.is_on_disk()
+    }
+
+    #[inline]
+    pub fn populate(&self) -> OperationResult<()> {
+        self.0.populate()
+    }
+
+    #[inline]
+    pub fn ram_usage_bytes(&self) -> usize {
+        self.0.ram_usage_bytes()
+    }
+
+    #[inline]
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.0.clear_cache()
+    }
+
+    #[inline]
+    pub fn get_storage_type(&self) -> StorageType {
+        self.0.get_storage_type()
     }
 
     pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
@@ -74,27 +104,46 @@ impl ImmutableNullIndex {
 }
 
 impl PayloadFieldIndex for ImmutableNullIndex {
-    delegate! {
-        to self.0 {
-            fn count_indexed_points(&self) -> usize;
-            fn wipe(self) -> OperationResult<()>;
-            fn files(&self) -> Vec<PathBuf>;
-            fn filter<'a>(
-                    &'a self,
-                    condition: &'a crate::types::FieldCondition,
-                    hw_counter: &'a HardwareCounterCell,
-            ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
-            fn estimate_cardinality(
-                    &self,
-                    condition: &crate::types::FieldCondition,
-                    hw_counter: &HardwareCounterCell,
-            ) -> OperationResult<Option<crate::index::field_index::CardinalityEstimation>>;
-            fn payload_blocks(
-                    &self,
-                    threshold: usize,
-                    key: crate::types::PayloadKeyType,
-            ) -> Box<dyn Iterator<Item = OperationResult<crate::index::field_index::PayloadBlockCondition>> + '_>;
-        }
+    #[inline]
+    fn count_indexed_points(&self) -> usize {
+        self.0.count_indexed_points()
+    }
+
+    #[inline]
+    fn wipe(self) -> OperationResult<()> {
+        self.0.wipe()
+    }
+
+    #[inline]
+    fn files(&self) -> Vec<PathBuf> {
+        self.0.files()
+    }
+
+    #[inline]
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        self.0.filter(condition, hw_counter)
+    }
+
+    #[inline]
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        self.0.estimate_cardinality(condition, hw_counter)
+    }
+
+    #[inline]
+    fn payload_blocks(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        self.0.payload_blocks(threshold, key)
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -49,8 +49,6 @@ impl ImmutableNullIndex {
     // N.B.: these operations are immutable.
     delegate! {
         to self.0 {
-            // TODO telemetry should overwrite a text tag.
-            pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
             pub fn values_count(&self, point_id: PointOffsetType) -> usize;
             pub fn values_is_empty(&self, id: PointOffsetType) -> bool;
             pub fn values_is_null(&self, id: PointOffsetType) -> bool;
@@ -58,6 +56,18 @@ impl ImmutableNullIndex {
             pub fn populate(&self) -> OperationResult<()>;
             pub fn clear_cache(&self) -> OperationResult<()>;
             pub fn get_storage_type(&self) -> StorageType;
+        }
+    }
+
+    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        let points_count = self.count_indexed_points();
+
+        PayloadIndexTelemetry {
+            field_name: None,
+            points_count,
+            points_values_count: points_count,
+            histogram_bucket_size: None,
+            index_type: "immutable_null_index",
         }
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -1,3 +1,5 @@
 pub mod mutable_null_index;
+pub mod immutable_null_index;
 
 pub use mutable_null_index::MutableNullIndex;
+pub use immutable_null_index::ImmutableNullIndex;

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -1,5 +1,188 @@
-pub mod mutable_null_index;
 pub mod immutable_null_index;
+pub mod mutable_null_index;
 
-pub use mutable_null_index::MutableNullIndex;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
 pub use immutable_null_index::ImmutableNullIndex;
+pub use mutable_null_index::MutableNullIndex;
+use serde_json::Value;
+
+use super::PayloadFieldIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::payload_config::{IndexMutability, StorageType};
+use crate::telemetry::PayloadIndexTelemetry;
+
+pub enum NullIndex {
+    Mutable(MutableNullIndex),
+    Immutable(ImmutableNullIndex),
+}
+
+impl From<MutableNullIndex> for NullIndex {
+    fn from(value: MutableNullIndex) -> Self {
+        NullIndex::Mutable(value)
+    }
+}
+
+impl From<ImmutableNullIndex> for NullIndex {
+    fn from(value: ImmutableNullIndex) -> Self {
+        NullIndex::Immutable(value)
+    }
+}
+
+impl NullIndex {
+    pub fn add_point(
+        &mut self,
+        id: PointOffsetType,
+        payload: &[&Value],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.add_point(id, payload, hw_counter),
+            NullIndex::Immutable(_immutable) => Err(OperationError::service_error(
+                "Can't add values to immutable null index",
+            )),
+        }
+    }
+
+    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.remove_point(id),
+            NullIndex::Immutable(immutable) => immutable.remove_point(id),
+        }
+    }
+
+    pub fn values_count(&self, id: PointOffsetType) -> usize {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_count(id),
+            NullIndex::Immutable(immutable) => immutable.values_count(id),
+        }
+    }
+
+    pub fn values_is_empty(&self, id: PointOffsetType) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_is_empty(id),
+            NullIndex::Immutable(immutable) => immutable.values_is_empty(id),
+        }
+    }
+
+    pub fn values_is_null(&self, id: PointOffsetType) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_is_null(id),
+            NullIndex::Immutable(immutable) => immutable.values_is_null(id),
+        }
+    }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.populate(),
+            NullIndex::Immutable(immutable) => immutable.populate(),
+        }
+    }
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.is_on_disk(),
+            NullIndex::Immutable(immutable) => immutable.is_on_disk(),
+        }
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.clear_cache(),
+            NullIndex::Immutable(immutable) => immutable.clear_cache(),
+        }
+    }
+    pub fn get_mutability_type(&self) -> IndexMutability {
+        match self {
+            NullIndex::Mutable(_) => IndexMutability::Mutable,
+            NullIndex::Immutable(_) => IndexMutability::Immutable,
+        }
+    }
+
+    pub fn get_storage_type(&self) -> StorageType {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.get_storage_type(),
+            NullIndex::Immutable(immutable) => immutable.get_storage_type(),
+        }
+    }
+
+    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.get_telemetry_data(),
+            NullIndex::Immutable(immutable) => immutable.get_telemetry_data(),
+        }
+    }
+}
+
+impl PayloadFieldIndex for NullIndex {
+    fn count_indexed_points(&self) -> usize {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.count_indexed_points(),
+            NullIndex::Immutable(immutable) => immutable.count_indexed_points(),
+        }
+    }
+
+    fn wipe(self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.wipe(),
+            NullIndex::Immutable(immutable) => immutable.wipe(),
+        }
+    }
+
+    fn flusher(&self) -> crate::common::Flusher {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.flusher(),
+            NullIndex::Immutable(immutable) => immutable.flusher(),
+        }
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.files(),
+            NullIndex::Immutable(immutable) => immutable.files(),
+        }
+    }
+
+    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.immutable_files(),
+            NullIndex::Immutable(immutable) => immutable.immutable_files(),
+        }
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a crate::types::FieldCondition,
+        hw_counter: &'a common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.filter(condition, hw_counter),
+            NullIndex::Immutable(immutable) => immutable.filter(condition, hw_counter),
+        }
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &crate::types::FieldCondition,
+        hw_counter: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Option<super::CardinalityEstimation>> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.estimate_cardinality(condition, hw_counter),
+            NullIndex::Immutable(immutable) => {
+                immutable.estimate_cardinality(condition, hw_counter)
+            }
+        }
+    }
+
+    fn payload_blocks(
+        &self,
+        threshold: usize,
+        key: crate::types::PayloadKeyType,
+    ) -> Box<dyn Iterator<Item = OperationResult<super::PayloadBlockCondition>> + '_> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.payload_blocks(threshold, key),
+            NullIndex::Immutable(immutable) => immutable.payload_blocks(threshold, key),
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -79,6 +79,14 @@ impl NullIndex {
         }
     }
 
+    /// Approximate RAM usage in bytes.
+    pub fn ram_usage_bytes(&self) -> usize {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.ram_usage_bytes(),
+            NullIndex::Immutable(immutable) => immutable.ram_usage_bytes(),
+        }
+    }
+
     pub fn is_on_disk(&self) -> bool {
         match self {
             NullIndex::Mutable(mutable) => mutable.is_on_disk(),

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -1,3 +1,5 @@
+pub mod immutable_null_index;
 pub mod mutable_null_index;
 
+pub use immutable_null_index::ImmutableNullIndex;
 pub use mutable_null_index::MutableNullIndex;

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -1,5 +1,188 @@
 pub mod immutable_null_index;
 pub mod mutable_null_index;
 
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
 pub use immutable_null_index::ImmutableNullIndex;
 pub use mutable_null_index::MutableNullIndex;
+use serde_json::Value;
+
+use super::PayloadFieldIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::payload_config::{IndexMutability, StorageType};
+use crate::telemetry::PayloadIndexTelemetry;
+
+pub enum NullIndex {
+    Mutable(MutableNullIndex),
+    Immutable(ImmutableNullIndex),
+}
+
+impl From<MutableNullIndex> for NullIndex {
+    fn from(value: MutableNullIndex) -> Self {
+        NullIndex::Mutable(value)
+    }
+}
+
+impl From<ImmutableNullIndex> for NullIndex {
+    fn from(value: ImmutableNullIndex) -> Self {
+        NullIndex::Immutable(value)
+    }
+}
+
+impl NullIndex {
+    pub fn add_point(
+        &mut self,
+        id: PointOffsetType,
+        payload: &[&Value],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.add_point(id, payload, hw_counter),
+            NullIndex::Immutable(_immutable) => Err(OperationError::service_error(
+                "Can't add values to immutable null index",
+            )),
+        }
+    }
+
+    pub fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.remove_point(id),
+            NullIndex::Immutable(immutable) => immutable.remove_point(id),
+        }
+    }
+
+    pub fn values_count(&self, id: PointOffsetType) -> usize {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_count(id),
+            NullIndex::Immutable(immutable) => immutable.values_count(id),
+        }
+    }
+
+    pub fn values_is_empty(&self, id: PointOffsetType) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_is_empty(id),
+            NullIndex::Immutable(immutable) => immutable.values_is_empty(id),
+        }
+    }
+
+    pub fn values_is_null(&self, id: PointOffsetType) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.values_is_null(id),
+            NullIndex::Immutable(immutable) => immutable.values_is_null(id),
+        }
+    }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.populate(),
+            NullIndex::Immutable(immutable) => immutable.populate(),
+        }
+    }
+
+    pub fn is_on_disk(&self) -> bool {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.is_on_disk(),
+            NullIndex::Immutable(immutable) => immutable.is_on_disk(),
+        }
+    }
+
+    /// Drop disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.clear_cache(),
+            NullIndex::Immutable(immutable) => immutable.clear_cache(),
+        }
+    }
+    pub fn get_mutability_type(&self) -> IndexMutability {
+        match self {
+            NullIndex::Mutable(_) => IndexMutability::Mutable,
+            NullIndex::Immutable(_) => IndexMutability::Immutable,
+        }
+    }
+
+    pub fn get_storage_type(&self) -> StorageType {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.get_storage_type(),
+            NullIndex::Immutable(immutable) => immutable.get_storage_type(),
+        }
+    }
+
+    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.get_telemetry_data(),
+            NullIndex::Immutable(immutable) => immutable.get_telemetry_data(),
+        }
+    }
+}
+
+impl PayloadFieldIndex for NullIndex {
+    fn count_indexed_points(&self) -> usize {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.count_indexed_points(),
+            NullIndex::Immutable(immutable) => immutable.count_indexed_points(),
+        }
+    }
+
+    fn wipe(self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.wipe(),
+            NullIndex::Immutable(immutable) => immutable.wipe(),
+        }
+    }
+
+    fn flusher(&self) -> crate::common::Flusher {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.flusher(),
+            NullIndex::Immutable(immutable) => immutable.flusher(),
+        }
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.files(),
+            NullIndex::Immutable(immutable) => immutable.files(),
+        }
+    }
+
+    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.immutable_files(),
+            NullIndex::Immutable(immutable) => immutable.immutable_files(),
+        }
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a crate::types::FieldCondition,
+        hw_counter: &'a common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.filter(condition, hw_counter),
+            NullIndex::Immutable(immutable) => immutable.filter(condition, hw_counter),
+        }
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &crate::types::FieldCondition,
+        hw_counter: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<Option<super::CardinalityEstimation>> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.estimate_cardinality(condition, hw_counter),
+            NullIndex::Immutable(immutable) => {
+                immutable.estimate_cardinality(condition, hw_counter)
+            }
+        }
+    }
+
+    fn payload_blocks(
+        &self,
+        threshold: usize,
+        key: crate::types::PayloadKeyType,
+    ) -> Box<dyn Iterator<Item = OperationResult<super::PayloadBlockCondition>> + '_> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.payload_blocks(threshold, key),
+            NullIndex::Immutable(immutable) => immutable.payload_blocks(threshold, key),
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -77,13 +77,14 @@ impl MutableNullIndex {
         let has_values_dir = path.join(HAS_VALUES_DIRNAME);
 
         // If has values directory doesn't exist, assume the index doesn't exist on disk
-        if !has_values_dir.is_dir()  {
+        if !has_values_dir.is_dir() {
             return Ok(None);
         }
 
+        // TODO should be an error if it doesn't exist.
         let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
         for pos in deleted.iter_ones() {
-            mutable_null_index.remove_point_immutable(pos as PointOffsetType)?;
+            mutable_null_index.remove_point_immutable(pos as PointOffsetType);
         }
         Ok(Some(mutable_null_index))
     }
@@ -186,7 +187,7 @@ impl MutableNullIndex {
         Ok(())
     }
 
-    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) -> OperationResult<()> {
+    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) {
         // Update bitmaps immediately
         self.storage.has_values_flags.set_immutable(id, false);
         self.storage.is_null_flags.set_immutable(id, false);
@@ -199,10 +200,7 @@ impl MutableNullIndex {
         self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
 
         // N.B. No I/O, do not update hw_counter.
-
-        Ok(())
     }
-
 
     pub fn values_count(&self, id: PointOffsetType) -> usize {
         usize::from(self.storage.has_values_flags.get(id))

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -74,19 +74,16 @@ impl MutableNullIndex {
         total_point_count: usize,
         deleted: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let has_values_dir = path.join(HAS_VALUES_DIRNAME);
-
-        // If has values directory doesn't exist, assume the index doesn't exist on disk
-        if !has_values_dir.is_dir() {
-            return Ok(None);
+        let mutable_null_index = Self::open(path, total_point_count, false)?;
+        match mutable_null_index {
+            Some(mut mutable_null_index) => {
+                for pos in deleted.iter_ones() {
+                    mutable_null_index.remove_point_immutable(pos as PointOffsetType);
+                }
+                Ok(Some(mutable_null_index))
+            }
+            None => Ok(None),
         }
-
-        // TODO should be an error if it doesn't exist.
-        let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
-        for pos in deleted.iter_ones() {
-            mutable_null_index.remove_point_immutable(pos as PointOffsetType);
-        }
-        Ok(Some(mutable_null_index))
     }
 
     fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
@@ -192,12 +189,8 @@ impl MutableNullIndex {
         self.storage.has_values_flags.set_immutable(id, false);
         self.storage.is_null_flags.set_immutable(id, false);
 
-        // Bump total points
-        // We MUST bump the total point count when removing a point too
-        // On upsert without this respective field, remove point is called rather than add point
-        // Bumping the total point count ensures we correctly estimate the number of points
-        // Bug: <https://github.com/qdrant/qdrant/pull/6882>
-        self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
+        // N.B. We do not update total_point_count because it comes from the id tracker and is not not changed
+        // in non-appendable segments.
 
         // N.B. No I/O, do not update hw_counter.
     }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use fs_err as fs;
@@ -66,6 +67,25 @@ impl MutableNullIndex {
         }
 
         Ok(Some(Self::open_or_create(path, total_point_count)?))
+    }
+
+    pub(super) fn open_immutable(
+        path: &Path,
+        total_point_count: usize,
+        deleted: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
+        let has_values_dir = path.join(HAS_VALUES_DIRNAME);
+
+        // If has values directory doesn't exist, assume the index doesn't exist on disk
+        if !has_values_dir.is_dir()  {
+            return Ok(None);
+        }
+
+        let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
+        for pos in deleted.iter_ones() {
+            mutable_null_index.remove_point_immutable(pos as PointOffsetType)?;
+        }
+        Ok(Some(mutable_null_index))
     }
 
     fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
@@ -165,6 +185,24 @@ impl MutableNullIndex {
 
         Ok(())
     }
+
+    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        // Update bitmaps immediately
+        self.storage.has_values_flags.set_immutable(id, false);
+        self.storage.is_null_flags.set_immutable(id, false);
+
+        // Bump total points
+        // We MUST bump the total point count when removing a point too
+        // On upsert without this respective field, remove point is called rather than add point
+        // Bumping the total point count ensures we correctly estimate the number of points
+        // Bug: <https://github.com/qdrant/qdrant/pull/6882>
+        self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
+
+        // N.B. No I/O, do not update hw_counter.
+
+        Ok(())
+    }
+
 
     pub fn values_count(&self, id: PointOffsetType) -> usize {
         usize::from(self.storage.has_values_flags.get(id))

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -77,19 +77,16 @@ impl MutableNullIndex {
         total_point_count: usize,
         deleted: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let has_values_dir = path.join(HAS_VALUES_DIRNAME);
-
-        // If has values directory doesn't exist, assume the index doesn't exist on disk
-        if !has_values_dir.is_dir() {
-            return Ok(None);
+        let mutable_null_index = Self::open(path, total_point_count, false)?;
+        match mutable_null_index {
+            Some(mut mutable_null_index) => {
+                for pos in deleted.iter_ones() {
+                    mutable_null_index.remove_point_immutable(pos as PointOffsetType);
+                }
+                Ok(Some(mutable_null_index))
+            }
+            None => Ok(None),
         }
-
-        // TODO should be an error if it doesn't exist.
-        let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
-        for pos in deleted.iter_ones() {
-            mutable_null_index.remove_point_immutable(pos as PointOffsetType);
-        }
-        Ok(Some(mutable_null_index))
     }
 
     fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
@@ -195,12 +192,8 @@ impl MutableNullIndex {
         self.storage.has_values_flags.set_immutable(id, false);
         self.storage.is_null_flags.set_immutable(id, false);
 
-        // Bump total points
-        // We MUST bump the total point count when removing a point too
-        // On upsert without this respective field, remove point is called rather than add point
-        // Bumping the total point count ensures we correctly estimate the number of points
-        // Bug: <https://github.com/qdrant/qdrant/pull/6882>
-        self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
+        // N.B. We do not update total_point_count because it comes from the id tracker and is not not changed
+        // in non-appendable segments.
 
         // N.B. No I/O, do not update hw_counter.
     }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use fs_err as fs;
@@ -69,6 +70,25 @@ impl MutableNullIndex {
         }
 
         Ok(Some(Self::open_or_create(path, total_point_count)?))
+    }
+
+    pub(super) fn open_immutable(
+        path: &Path,
+        total_point_count: usize,
+        deleted: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
+        let has_values_dir = path.join(HAS_VALUES_DIRNAME);
+
+        // If has values directory doesn't exist, assume the index doesn't exist on disk
+        if !has_values_dir.is_dir() {
+            return Ok(None);
+        }
+
+        let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
+        for pos in deleted.iter_ones() {
+            mutable_null_index.remove_point_immutable(pos as PointOffsetType)?;
+        }
+        Ok(Some(mutable_null_index))
     }
 
     fn open_or_create(path: &Path, total_point_count: usize) -> OperationResult<Self> {
@@ -165,6 +185,23 @@ impl MutableNullIndex {
         // Account for I/O cost as if we were writing to disk now
         let hw_counter = HardwareCounterCell::disposable();
         hw_counter.payload_index_io_write_counter().incr_delta(2);
+
+        Ok(())
+    }
+
+    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) -> OperationResult<()> {
+        // Update bitmaps immediately
+        self.storage.has_values_flags.set_immutable(id, false);
+        self.storage.is_null_flags.set_immutable(id, false);
+
+        // Bump total points
+        // We MUST bump the total point count when removing a point too
+        // On upsert without this respective field, remove point is called rather than add point
+        // Bumping the total point count ensures we correctly estimate the number of points
+        // Bug: <https://github.com/qdrant/qdrant/pull/6882>
+        self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
+
+        // N.B. No I/O, do not update hw_counter.
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -84,9 +84,10 @@ impl MutableNullIndex {
             return Ok(None);
         }
 
+        // TODO should be an error if it doesn't exist.
         let mut mutable_null_index = Self::open_or_create(path, total_point_count)?;
         for pos in deleted.iter_ones() {
-            mutable_null_index.remove_point_immutable(pos as PointOffsetType)?;
+            mutable_null_index.remove_point_immutable(pos as PointOffsetType);
         }
         Ok(Some(mutable_null_index))
     }
@@ -189,7 +190,7 @@ impl MutableNullIndex {
         Ok(())
     }
 
-    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) -> OperationResult<()> {
+    pub(super) fn remove_point_immutable(&mut self, id: PointOffsetType) {
         // Update bitmaps immediately
         self.storage.has_values_flags.set_immutable(id, false);
         self.storage.is_null_flags.set_immutable(id, false);
@@ -202,8 +203,6 @@ impl MutableNullIndex {
         self.total_point_count = std::cmp::max(self.total_point_count, id as usize + 1);
 
         // N.B. No I/O, do not update hw_counter.
-
-        Ok(())
     }
 
     pub fn values_count(&self, id: PointOffsetType) -> usize {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::id_tracker::IdTracker;
 use crate::index::field_index::FieldIndex;
-use crate::index::field_index::null_index::MutableNullIndex;
+use crate::index::field_index::null_index::NullIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -400,10 +400,8 @@ pub fn get_datetime_range_checkers(
     }
 }
 
-fn get_is_empty_indexes(
-    indexes: &[FieldIndex],
-) -> (Option<&MutableNullIndex>, Option<&FieldIndex>) {
-    let mut primary_null_index: Option<&MutableNullIndex> = None;
+fn get_is_empty_indexes(indexes: &[FieldIndex]) -> (Option<&NullIndex>, Option<&FieldIndex>) {
+    let mut primary_null_index: Option<&NullIndex> = None;
     let mut fallback_index: Option<&FieldIndex> = None;
 
     for index in indexes {
@@ -421,7 +419,7 @@ fn get_is_empty_indexes(
 }
 
 fn get_null_index_is_empty_checker(
-    null_index: &MutableNullIndex,
+    null_index: &NullIndex,
     is_empty: bool,
 ) -> ConditionCheckerFn<'_> {
     Box::new(move |point_id: PointOffsetType| null_index.values_is_empty(point_id) == is_empty)

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -163,12 +163,13 @@ impl StructPayloadIndex {
         payload_schema: &mut PayloadFieldSchemaWithIndexType,
         create_if_missing: bool,
     ) -> OperationResult<(Vec<FieldIndex>, bool)> {
-        let total_point_count = self.id_tracker.borrow().total_point_count();
+        let id_tracker_borrow = self.id_tracker.borrow();
         let mut rebuild = false;
         let mut is_dirty = false;
 
         let mut indexes = if payload_schema.types.is_empty() {
-            let indexes = self.selector(&payload_schema.schema).new_index(
+            let selector = self.selector(&payload_schema.schema);
+            let indexes = selector.new_index(
                 field,
                 &payload_schema.schema,
                 create_if_missing,
@@ -184,11 +185,11 @@ impl StructPayloadIndex {
                 );
 
                 // Special null index complements every index.
-                if let Some(null_index) = IndexSelector::new_null_index(
+                if let Some(null_index) = selector.new_null_index(
                     &self.path,
                     field,
-                    total_point_count,
                     create_if_missing,
+                    &id_tracker_borrow,
                 )? {
                     indexes.push(null_index);
                 }
@@ -214,8 +215,6 @@ impl StructPayloadIndex {
                             field,
                             &payload_schema.schema,
                             index,
-                            &self.path,
-                            total_point_count,
                             create_if_missing,
                             &id_tracker_borrow,
                         )
@@ -301,12 +300,11 @@ impl StructPayloadIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
-        let mut builders = self
-            .selector(payload_schema)
-            .index_builder(field, payload_schema)?;
+        let selector = self.selector(payload_schema);
+        let mut builders = selector.index_builder(field, payload_schema)?;
 
         // Special null index complements every index.
-        let null_index = IndexSelector::null_builder(&self.path, field)?;
+        let null_index = selector.null_builder(&self.path, field)?;
         builders.push(null_index);
 
         for index in &mut builders {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -162,12 +162,13 @@ impl StructPayloadIndex {
         payload_schema: &mut PayloadFieldSchemaWithIndexType,
         create_if_missing: bool,
     ) -> OperationResult<(Vec<FieldIndex>, bool)> {
-        let total_point_count = self.id_tracker.borrow().total_point_count();
+        let id_tracker_borrow = self.id_tracker.borrow();
         let mut rebuild = false;
         let mut is_dirty = false;
 
         let mut indexes = if payload_schema.types.is_empty() {
-            let indexes = self.selector(&payload_schema.schema).new_index(
+            let selector = self.selector(&payload_schema.schema);
+            let indexes = selector.new_index(
                 field,
                 &payload_schema.schema,
                 create_if_missing,
@@ -183,11 +184,11 @@ impl StructPayloadIndex {
                 );
 
                 // Special null index complements every index.
-                if let Some(null_index) = IndexSelector::new_null_index(
+                if let Some(null_index) = selector.new_null_index(
                     &self.path,
                     field,
-                    total_point_count,
                     create_if_missing,
+                    &id_tracker_borrow,
                 )? {
                     indexes.push(null_index);
                 }
@@ -213,8 +214,6 @@ impl StructPayloadIndex {
                             field,
                             &payload_schema.schema,
                             index,
-                            &self.path,
-                            total_point_count,
                             create_if_missing,
                             &id_tracker_borrow,
                         )
@@ -322,16 +321,16 @@ impl StructPayloadIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
         let payload_storage = self.payload.borrow();
-        let mut builders = self
-            .selector(payload_schema)
-            .index_builder(field, payload_schema)?;
+        let selector = self.selector(payload_schema);
+        let mut builders = selector.index_builder(field, payload_schema)?;
 
         // Special null index complements every index. Seed it with the segment's total
         // point count so `iter_falses()` returns points that are missing from payload
         // storage (e.g. after `clear_payload`), matching the regular "no value" points.
         // Bug: <https://github.com/qdrant/qdrant/issues/8723>
         let total_point_count = self.id_tracker.borrow().total_point_count();
-        let null_index = IndexSelector::null_builder(&self.path, field, total_point_count)?;
+        // Special null index complements every index.
+        let null_index = selector.null_builder(&self.path, field, total_point_count)?;
         builders.push(null_index);
 
         for index in &mut builders {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -174,7 +174,7 @@ impl StructPayloadIndex {
                 field,
                 &payload_schema.schema,
                 create_if_missing,
-                &self.id_tracker.borrow(),
+                &id_tracker_borrow,
             )?;
 
             if let Some(mut indexes) = indexes {
@@ -191,7 +191,6 @@ impl StructPayloadIndex {
                     IndexSelector::Gridstore(_) => IndexMutability::Mutable,
                 };
                 if let Some(null_index) = selector.new_null_index(
-                    &self.path,
                     field,
                     create_if_missing,
                     &id_tracker_borrow,
@@ -210,7 +209,6 @@ impl StructPayloadIndex {
                 vec![]
             }
         } else {
-            let id_tracker_borrow = self.id_tracker.borrow();
             payload_schema
                 .types
                 .iter()
@@ -336,8 +334,7 @@ impl StructPayloadIndex {
         // storage (e.g. after `clear_payload`), matching the regular "no value" points.
         // Bug: <https://github.com/qdrant/qdrant/issues/8723>
         let total_point_count = self.id_tracker.borrow().total_point_count();
-        // Special null index complements every index.
-        let null_index = selector.null_builder(&self.path, field, total_point_count)?;
+        let null_index = selector.null_builder(field, total_point_count)?;
         builders.push(null_index);
 
         for index in &mut builders {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -19,7 +19,9 @@ use super::field_index::index_selector::{
     IndexSelector, IndexSelectorGridstore, IndexSelectorMmap,
 };
 use super::field_index::{FieldIndexBuilderTrait as _, ResolvedHasId};
-use super::payload_config::{FullPayloadIndexType, PayloadFieldSchemaWithIndexType};
+use super::payload_config::{
+    FullPayloadIndexType, IndexMutability, PayloadFieldSchemaWithIndexType,
+};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::IndexesMap;
@@ -184,11 +186,16 @@ impl StructPayloadIndex {
                 );
 
                 // Special null index complements every index.
+                let null_mutability = match &selector {
+                    IndexSelector::Mmap(_) => IndexMutability::Immutable,
+                    IndexSelector::Gridstore(_) => IndexMutability::Mutable,
+                };
                 if let Some(null_index) = selector.new_null_index(
                     &self.path,
                     field,
                     create_if_missing,
                     &id_tracker_borrow,
+                    null_mutability,
                 )? {
                     indexes.push(null_index);
                 }

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -19,9 +19,7 @@ use super::field_index::index_selector::{
     IndexSelector, IndexSelectorGridstore, IndexSelectorMmap,
 };
 use super::field_index::{FieldIndexBuilderTrait as _, ResolvedHasId};
-use super::payload_config::{
-    FullPayloadIndexType, IndexMutability, PayloadFieldSchemaWithIndexType,
-};
+use super::payload_config::{FullPayloadIndexType, PayloadFieldSchemaWithIndexType};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::IndexesMap;
@@ -186,15 +184,11 @@ impl StructPayloadIndex {
                 );
 
                 // Special null index complements every index.
-                let null_mutability = match &selector {
-                    IndexSelector::Mmap(_) => IndexMutability::Immutable,
-                    IndexSelector::Gridstore(_) => IndexMutability::Mutable,
-                };
                 if let Some(null_index) = selector.new_null_index(
                     field,
                     create_if_missing,
                     &id_tracker_borrow,
-                    null_mutability,
+                    selector.default_mutability(),
                 )? {
                     indexes.push(null_index);
                 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1311,6 +1311,87 @@ fn test_bool_index_appendable_reopen_accepts_updates() {
     assert_eq!(bool_index.count_indexed_points(), 2);
 }
 
+/// An appendable segment with a payload field index carries a companion null
+/// index in its persisted `types`. On reopen that null index must be loaded
+/// from disk (not silently rebuilt from payload storage) and must accept
+/// subsequent updates.
+#[test]
+fn test_null_index_appendable_reopen_loads_and_accepts_updates() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let field = JsonPath::new("name");
+    let hw_counter = HardwareCounterCell::new();
+
+    {
+        let mut payload_storage = InMemoryPayloadStorage::default();
+        payload_storage
+            .set(0, &payload_json! {"name": "foo"}, &hw_counter)
+            .unwrap();
+
+        let payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
+        let id_tracker = Arc::new(AtomicRefCell::new(create_id_tracker_fixture(2)));
+
+        let mut index = StructPayloadIndex::open(
+            payload_storage,
+            id_tracker,
+            HashMap::new(),
+            dir.path(),
+            true,
+            true,
+        )
+        .unwrap();
+
+        index
+            .set_indexed(&field, FieldType(Keyword), &hw_counter)
+            .unwrap();
+
+        for field_index in index.field_indexes.get(&field).unwrap() {
+            field_index.flusher()().unwrap();
+        }
+    }
+
+    // Reopen with a fresh (empty) payload storage — same pattern as the bool
+    // test above.
+    let payload_storage = Arc::new(AtomicRefCell::new(InMemoryPayloadStorage::default().into()));
+    let id_tracker = Arc::new(AtomicRefCell::new(create_id_tracker_fixture(2)));
+    let mut index = StructPayloadIndex::open(
+        payload_storage,
+        id_tracker,
+        HashMap::new(),
+        dir.path(),
+        true,
+        false,
+    )
+    .unwrap();
+
+    // The null index is persisted with `{ mutability: Mutable, storage_type:
+    // Mmap }` because `MutableNullIndex` and `ImmutableNullIndex` share the
+    // same on-disk format. If the reload dispatched on storage_type alone, it
+    // would open `ImmutableNullIndex` and this write would fail with "Can't
+    // add values to immutable null index" (same class of bug as #8785 for the
+    // bool index).
+    index
+        .set_payload(1, &payload_json! {"name": "bar"}, &None, &hw_counter)
+        .expect("update on reopened null index must succeed");
+
+    let field_indexes = index.field_indexes.get(&field).unwrap();
+    let null_index = field_indexes
+        .iter()
+        .find(|fi| matches!(fi, FieldIndex::NullIndex(_)))
+        .expect("null index present after reopen");
+
+    let not_empty = FieldCondition::new_is_empty(field.clone(), false);
+    let with_values: Vec<_> = null_index
+        .filter(&not_empty, &hw_counter)
+        .unwrap()
+        .expect("null index must answer is_empty filter")
+        .collect();
+    assert_eq!(
+        with_values,
+        vec![0, 1],
+        "null index must retain point 0 from before reopen and include point 1 from after",
+    );
+}
+
 fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Result<()> {
     let keywords: IndexSet<String, FnvBuildHasher> = ["value1", "value2"]
         .iter()


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/8625>

Add `ImmutableNullIndex` type that uses immutable storage and segment's deleted bitmask.

It would reduce IO on serverless Qdrant instances.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/8625>
- [x] Rebase on dev
- [x] Undraft

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
