### PR TITLE
TurboQuant hadamard Rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5926,6 +5926,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "static_assertions",
  "strum",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5926,7 +5926,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "static_assertions",
  "strum",
  "tempfile",
 ]

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -56,3 +56,7 @@ harness = false
 [[bench]]
 name = "p_square"
 harness = false
+
+[[bench]]
+name = "hadamard"
+harness = false

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -31,6 +31,7 @@ bytemuck = { workspace = true }
 parking_lot = { workspace = true }
 ordered-float = { workspace = true }
 arrayvec = "0.7.6"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 fs-err = { workspace = true, features = ["debug"] }

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -31,7 +31,6 @@ bytemuck = { workspace = true }
 parking_lot = { workspace = true }
 ordered-float = { workspace = true }
 arrayvec = "0.7.6"
-static_assertions = "1.1.0"
 
 [dev-dependencies]
 fs-err = { workspace = true, features = ["debug"] }

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -1,39 +1,23 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use quantization::turboquant::rotation::{
-    HadamardRotation, compute_chunk_sizes, in_place_walsh_hadamard_transform,
-};
+use quantization::turboquant::rotation::HadamardRotation;
 
 const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];
-
-fn bench_wht(c: &mut Criterion) {
-    let mut group = c.benchmark_group("walsh_hadamard_transform");
-
-    for &dim in DIMS {
-        let chunk_size = *compute_chunk_sizes(dim).first().unwrap();
-        let mut data: Vec<f64> = (0..chunk_size).map(|i| i as f64 * 0.01).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| {
-                in_place_walsh_hadamard_transform(black_box(&mut data));
-            });
-        });
-    }
-
-    group.finish();
-}
 
 fn bench_apply(c: &mut Criterion) {
     let mut group = c.benchmark_group("hadamard_apply");
 
     for &dim in DIMS {
         let rot = HadamardRotation::new(dim);
-        let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
-        let mut buf = vec![0.0f64; dim];
+        let input: Vec<f64> = (0..dim).map(|i| (i as f64) * 0.1).collect();
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| black_box(rot.apply(black_box(&input), &mut buf)));
+            b.iter_batched(
+                || input.clone(),
+                |mut data| rot.apply(black_box(&mut data)),
+                criterion::BatchSize::SmallInput,
+            );
         });
     }
 
@@ -45,16 +29,20 @@ fn bench_apply_inverse(c: &mut Criterion) {
 
     for &dim in DIMS {
         let rot = HadamardRotation::new(dim);
-        let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
-        let mut buf = vec![0.0f64; dim];
-        let rotated = rot.apply(&input, &mut buf);
+        let input: Vec<f64> = (0..dim).map(|i| (i as f64) * 0.1).collect();
+        let mut rotated = input.clone();
+        rot.apply(&mut rotated);
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated), &mut buf)));
+            b.iter_batched(
+                || rotated.clone(),
+                |mut data| rot.apply_inverse(black_box(&mut data)),
+                criterion::BatchSize::SmallInput,
+            );
         });
     }
 
     group.finish();
 }
-criterion_group!(benches, bench_wht, bench_apply, bench_apply_inverse,);
+criterion_group!(benches, bench_apply, bench_apply_inverse,);
 criterion_main!(benches);

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -28,7 +28,7 @@ fn bench_apply(c: &mut Criterion) {
     let mut group = c.benchmark_group("hadamard_apply");
 
     for &dim in DIMS {
-        let rot = HadamardRotation::new(42, dim);
+        let rot = HadamardRotation::new(dim);
         let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
@@ -43,7 +43,7 @@ fn bench_apply_inverse(c: &mut Criterion) {
     let mut group = c.benchmark_group("hadamard_apply_inverse");
 
     for &dim in DIMS {
-        let rot = HadamardRotation::new(42, dim);
+        let rot = HadamardRotation::new(dim);
         let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
         let rotated = rot.apply(&input);
 

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use quantization::turboquant::rotation::{
-    HadamardRotation, get_chunk_size, in_place_walsh_hadamard_transform,
+    HadamardRotation, compute_chunk_sizes, in_place_walsh_hadamard_transform,
 };
 
 const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];
@@ -11,7 +11,7 @@ fn bench_wht(c: &mut Criterion) {
     let mut group = c.benchmark_group("walsh_hadamard_transform");
 
     for &dim in DIMS {
-        let chunk_size = get_chunk_size(dim);
+        let chunk_size = *compute_chunk_sizes(dim).first().unwrap();
         let mut data: Vec<f64> = (0..chunk_size).map(|i| i as f64 * 0.01).collect();
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
@@ -48,7 +48,7 @@ fn bench_apply_inverse(c: &mut Criterion) {
         let rotated = rot.apply(&input);
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated), dim)));
+            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated))));
         });
     }
 

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -1,0 +1,58 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use quantization::turboquant::rotation::{
+    get_chunk_size, in_place_walsh_hadamard_transform, HadamardRotation,
+};
+
+const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];
+
+fn bench_wht(c: &mut Criterion) {
+    let mut group = c.benchmark_group("walsh_hadamard_transform");
+
+    for &dim in DIMS {
+        let chunk_size = get_chunk_size(dim);
+        let mut data: Vec<f64> = (0..chunk_size).map(|i| i as f64 * 0.01).collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
+            b.iter(|| {
+                in_place_walsh_hadamard_transform(black_box(&mut data));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_apply(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hadamard_apply");
+
+    for &dim in DIMS {
+        let rot = HadamardRotation::new(42, dim);
+        let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
+            b.iter(|| black_box(rot.apply(black_box(&input))));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_apply_inverse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hadamard_apply_inverse");
+
+    for &dim in DIMS {
+        let rot = HadamardRotation::new(42, dim);
+        let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
+        let rotated = rot.apply(&input);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
+            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated), dim)));
+        });
+    }
+
+    group.finish();
+}
+criterion_group!(benches, bench_wht, bench_apply, bench_apply_inverse,);
+criterion_main!(benches);

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -30,9 +30,10 @@ fn bench_apply(c: &mut Criterion) {
     for &dim in DIMS {
         let rot = HadamardRotation::new(dim);
         let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
+        let mut buf = vec![0.0f64; dim];
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| black_box(rot.apply(black_box(&input))));
+            b.iter(|| black_box(rot.apply(black_box(&input), &mut buf)));
         });
     }
 
@@ -45,10 +46,11 @@ fn bench_apply_inverse(c: &mut Criterion) {
     for &dim in DIMS {
         let rot = HadamardRotation::new(dim);
         let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
-        let rotated = rot.apply(&input);
+        let mut buf = vec![0.0f64; dim];
+        let rotated = rot.apply(&input, &mut buf);
 
         group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
-            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated))));
+            b.iter(|| black_box(rot.apply_inverse(black_box(&rotated), &mut buf)));
         });
     }
 

--- a/lib/quantization/benches/hadamard.rs
+++ b/lib/quantization/benches/hadamard.rs
@@ -1,8 +1,8 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use quantization::turboquant::rotation::{
-    get_chunk_size, in_place_walsh_hadamard_transform, HadamardRotation,
+    HadamardRotation, get_chunk_size, in_place_walsh_hadamard_transform,
 };
 
 const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -1,3 +1,5 @@
+pub mod rotation;
+
 use std::alloc::Layout;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -1,3 +1,4 @@
+mod permutation;
 pub mod rotation;
 
 use std::alloc::Layout;

--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -1,0 +1,135 @@
+use rand::RngExt;
+use rand::prelude::StdRng;
+
+/// A random permutation of indices `[0, dim)` and its precomputed inverse.
+///
+/// Used by [`HadamardRotation`](super::rotation::HadamardRotation) to shuffle
+/// dimensions between Walsh-Hadamard transforms, breaking alignment between
+/// the chunk boundaries and the original coordinate axes.
+pub struct Permutation {
+    /// Maps original index → permuted index.
+    forward: Vec<usize>,
+
+    /// Maps permuted index → original index (inverse of `forward`).
+    backward: Vec<usize>,
+}
+
+impl Permutation {
+    /// Create a new random permutation of `dim` elements using Fisher-Yates shuffle.
+    pub fn new(rng: &mut StdRng, dim: usize) -> Self {
+        let (forward, backward) = Self::generate_permutation(rng, dim);
+        Self { forward, backward }
+    }
+
+    /// Reorder `buf` according to the forward or backward permutation.
+    ///
+    /// `tmp` is a scratch buffer that must be the same length as `buf`.
+    pub fn apply(&self, buf: &mut [f64], tmp: &mut [f64], forward: bool) {
+        let permutation = if forward {
+            &self.forward
+        } else {
+            &self.backward
+        };
+
+        Self::apply_permutation(buf, tmp, permutation);
+    }
+
+    /// Generate a random permutation and its inverse using Fisher-Yates shuffle.
+    fn generate_permutation(rng: &mut StdRng, n: usize) -> (Vec<usize>, Vec<usize>) {
+        let mut perm: Vec<usize> = (0..n).collect();
+        for i in (1..n).rev() {
+            let j = rng.random_range(0..=i);
+            perm.swap(i, j);
+        }
+        let mut inv = vec![0usize; n];
+        for (i, &p) in perm.iter().enumerate() {
+            inv[p] = i;
+        }
+        (perm, inv)
+    }
+
+    /// Apply a permutation out-of-place: element at index `i` moves to `perm[i]`.
+    fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
+        debug_assert_eq!(tmp.len(), buf.len());
+        for (i, &p) in perm.iter().enumerate() {
+            tmp[p] = buf[i];
+        }
+        buf.copy_from_slice(tmp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+
+    use super::*;
+
+    #[test]
+    fn forward_backward_are_valid_permutations() {
+        for dim in [1, 2, 5, 64, 300] {
+            let mut rng = StdRng::seed_from_u64(42);
+            let perm = Permutation::new(&mut rng, dim);
+
+            // Both should contain each index exactly once.
+            for (label, mapping) in [("forward", &perm.forward), ("backward", &perm.backward)] {
+                let mut sorted = mapping.clone();
+                sorted.sort();
+                assert_eq!(
+                    sorted,
+                    (0..dim).collect::<Vec<_>>(),
+                    "{label} is not a valid permutation for dim={dim}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn forward_and_backward_are_inverses() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let perm = Permutation::new(&mut rng, 128);
+
+        for i in 0..128 {
+            assert_eq!(perm.backward[perm.forward[i]], i);
+            assert_eq!(perm.forward[perm.backward[i]], i);
+        }
+    }
+
+    #[test]
+    fn apply_roundtrip() {
+        let dim = 64;
+        let mut rng = StdRng::seed_from_u64(42);
+        let perm = Permutation::new(&mut rng, dim);
+
+        let original: Vec<f64> = (0..dim).map(|i| i as f64).collect();
+        let mut buf = original.clone();
+        let mut tmp = vec![0.0; dim];
+
+        // Forward then backward should recover the original.
+        perm.apply(&mut buf, &mut tmp, true);
+        assert_ne!(buf, original, "forward permutation should shuffle");
+        perm.apply(&mut buf, &mut tmp, false);
+        assert_eq!(buf, original, "roundtrip should recover original");
+    }
+
+    #[test]
+    fn deterministic_with_same_seed() {
+        let dim = 100;
+        let mut rng1 = StdRng::seed_from_u64(42);
+        let mut rng2 = StdRng::seed_from_u64(42);
+
+        let p1 = Permutation::new(&mut rng1, dim);
+        let p2 = Permutation::new(&mut rng2, dim);
+
+        assert_eq!(p1.forward, p2.forward);
+        assert_eq!(p1.backward, p2.backward);
+    }
+
+    #[test]
+    fn dim_one_is_identity() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let perm = Permutation::new(&mut rng, 1);
+
+        assert_eq!(perm.forward, vec![0]);
+        assert_eq!(perm.backward, vec![0]);
+    }
+}

--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -21,20 +21,24 @@ impl ReversibleLcg {
     fn new(seed: u64) -> Self {
         Self { state: seed }
     }
+}
 
-    /// Advance the generator and return the new state.
+impl Iterator for ReversibleLcg {
+    type Item = u64;
+
     #[inline]
-    fn next(&mut self) -> u64 {
+    fn next(&mut self) -> Option<Self::Item> {
         self.state = self.state.wrapping_mul(Self::A).wrapping_add(Self::C);
-        self.state
+        Some(self.state)
     }
+}
 
-    /// Return the current state and step the generator backward.
+impl DoubleEndedIterator for ReversibleLcg {
     #[inline]
-    fn prev(&mut self) -> u64 {
+    fn next_back(&mut self) -> Option<Self::Item> {
         let val = self.state;
         self.state = self.state.wrapping_sub(Self::C).wrapping_mul(Self::A_INV);
-        val
+        Some(val)
     }
 }
 
@@ -70,9 +74,9 @@ impl Permutation {
     /// Apply the forward permutation in-place (Fisher-Yates replay).
     pub fn permute(&self, arr: &mut [f64]) {
         debug_assert_eq!(arr.len(), self.count);
-        let mut rng = ReversibleLcg::new(self.seed);
-        for i in (1..self.count).rev() {
-            let j = Self::bounded_rand(rng.next(), i as u64 + 1) as usize;
+        let rng = ReversibleLcg::new(self.seed);
+        for (i, rand) in ((1..self.count).rev()).zip(rng) {
+            let j = Self::bounded_rand(rand, i as u64 + 1) as usize;
             arr.swap(i, j);
         }
     }
@@ -80,11 +84,9 @@ impl Permutation {
     /// Apply the inverse permutation in-place (reversed Fisher-Yates).
     pub fn unpermute(&self, arr: &mut [f64]) {
         debug_assert_eq!(arr.len(), self.count);
-        let mut rng = ReversibleLcg {
-            state: self.end_state,
-        };
-        for i in 1..self.count {
-            let j = Self::bounded_rand(rng.prev(), i as u64 + 1) as usize;
+        let rng = ReversibleLcg::new(self.end_state);
+        for (i, rand) in (1..self.count).zip(rng.rev()) {
+            let j = Self::bounded_rand(rand, i as u64 + 1) as usize;
             arr.swap(i, j);
         }
     }
@@ -106,11 +108,11 @@ mod tests {
     #[test]
     fn lcg_reversibility() {
         let mut rng = ReversibleLcg::new(12345);
-        let values: Vec<u64> = (0..100).map(|_| rng.next()).collect();
+        let values: Vec<u64> = (0..100).map(|_| rng.next().unwrap()).collect();
 
         // Walking backward should recover every value in reverse order.
         for v in values.iter().rev() {
-            assert_eq!(rng.prev(), *v);
+            assert_eq!(rng.next_back().unwrap(), *v);
         }
     }
 

--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -1,135 +1,242 @@
-use rand::RngExt;
-use rand::prelude::StdRng;
-
-/// A random permutation of indices `[0, dim)` and its precomputed inverse.
+/// A reversible Linear Congruential Generator (LCG).
 ///
-/// Used by [`HadamardRotation`](super::rotation::HadamardRotation) to shuffle
-/// dimensions between Walsh-Hadamard transforms, breaking alignment between
-/// the chunk boundaries and the original coordinate axes.
-pub struct Permutation {
-    /// Maps original index → permuted index.
-    forward: Vec<usize>,
+/// Uses Knuth's MMIX constants. The forward recurrence is:
+///   state_{n+1} = A * state_n + C  (mod 2^64)
+///
+/// Because A is odd (coprime with 2^64), the modular multiplicative
+/// inverse A_INV exists, allowing backward stepping:
+///   state_n = A_INV * (state_{n+1} - C)  (mod 2^64)
+struct ReversibleLcg {
+    state: u64,
+}
 
-    /// Maps permuted index → original index (inverse of `forward`).
-    backward: Vec<usize>,
+impl ReversibleLcg {
+    /// Knuth's MMIX multiplier.
+    const A: u64 = 6_364_136_223_846_793_005;
+    /// Knuth's MMIX increment.
+    const C: u64 = 1_442_695_040_888_963_407;
+    /// Modular multiplicative inverse of A mod 2^64: A * A_INV ≡ 1 (mod 2^64).
+    const A_INV: u64 = 13_877_824_140_714_322_085;
+
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    /// Advance the generator and return the new state.
+    #[inline]
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_mul(Self::A).wrapping_add(Self::C);
+        self.state
+    }
+
+    /// Return the current state and step the generator backward.
+    #[inline]
+    fn prev(&mut self) -> u64 {
+        let val = self.state;
+        self.state = self.state.wrapping_sub(Self::C).wrapping_mul(Self::A_INV);
+        val
+    }
+}
+
+/// A random permutation that operates in-place without storing index maps.
+///
+/// Uses a Fisher-Yates shuffle driven by a [`ReversibleLcg`]. Forward
+/// permutation replays the shuffle; backward permutation reverses it by
+/// running the LCG in reverse.
+///
+/// Memory: O(1) per permutation (three scalars) instead of O(n) for index maps.
+pub struct Permutation {
+    seed: u64,
+    count: usize,
+    /// LCG state after all forward-pass random draws, used as starting
+    /// point for the reverse pass.
+    end_state: u64,
 }
 
 impl Permutation {
-    /// Create a new random permutation of `dim` elements using Fisher-Yates shuffle.
-    pub fn new(rng: &mut StdRng, dim: usize) -> Self {
-        let (forward, backward) = Self::generate_permutation(rng, dim);
-        Self { forward, backward }
+    /// Create a new permutation for `count` elements seeded by `seed`.
+    pub fn new(seed: u64, count: usize) -> Self {
+        let mut rng = ReversibleLcg::new(seed);
+        for _ in 1..count {
+            rng.next();
+        }
+        Self {
+            seed,
+            count,
+            end_state: rng.state,
+        }
     }
 
-    /// Reorder `buf` according to the forward or backward permutation.
-    ///
-    /// `tmp` is a scratch buffer that must be the same length as `buf`.
-    pub fn apply(&self, buf: &mut [f64], tmp: &mut [f64], forward: bool) {
-        let permutation = if forward {
-            &self.forward
-        } else {
-            &self.backward
+    /// Apply the forward permutation in-place (Fisher-Yates replay).
+    pub fn permute(&self, arr: &mut [f64]) {
+        debug_assert_eq!(arr.len(), self.count);
+        let mut rng = ReversibleLcg::new(self.seed);
+        for i in (1..self.count).rev() {
+            let j = Self::bounded_rand(rng.next(), i as u64 + 1) as usize;
+            arr.swap(i, j);
+        }
+    }
+
+    /// Apply the inverse permutation in-place (reversed Fisher-Yates).
+    pub fn unpermute(&self, arr: &mut [f64]) {
+        debug_assert_eq!(arr.len(), self.count);
+        let mut rng = ReversibleLcg {
+            state: self.end_state,
         };
-
-        Self::apply_permutation(buf, tmp, permutation);
+        for i in 1..self.count {
+            let j = Self::bounded_rand(rng.prev(), i as u64 + 1) as usize;
+            arr.swap(i, j);
+        }
     }
 
-    /// Generate a random permutation and its inverse using Fisher-Yates shuffle.
-    fn generate_permutation(rng: &mut StdRng, n: usize) -> (Vec<usize>, Vec<usize>) {
-        let mut perm: Vec<usize> = (0..n).collect();
-        for i in (1..n).rev() {
-            let j = rng.random_range(0..=i);
-            perm.swap(i, j);
-        }
-        let mut inv = vec![0usize; n];
-        for (i, &p) in perm.iter().enumerate() {
-            inv[p] = i;
-        }
-        (perm, inv)
-    }
-
-    /// Apply a permutation out-of-place: element at index `i` moves to `perm[i]`.
-    fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
-        debug_assert_eq!(tmp.len(), buf.len());
-        for (i, &p) in perm.iter().enumerate() {
-            tmp[p] = buf[i];
-        }
-        buf.copy_from_slice(tmp);
+    /// Map a 64-bit LCG output to `[0, bound)` using the upper 32 bits.
+    ///
+    /// The low bits of an LCG have short periods (bit k has period 2^k),
+    /// so bare `% bound` produces degenerate permutations. Using the
+    /// upper half avoids this.
+    fn bounded_rand(val: u64, bound: u64) -> u64 {
+        (val >> 32) % bound
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use rand::SeedableRng;
-
     use super::*;
 
     #[test]
-    fn forward_backward_are_valid_permutations() {
-        for dim in [1, 2, 5, 64, 300] {
-            let mut rng = StdRng::seed_from_u64(42);
-            let perm = Permutation::new(&mut rng, dim);
+    fn lcg_reversibility() {
+        let mut rng = ReversibleLcg::new(12345);
+        let values: Vec<u64> = (0..100).map(|_| rng.next()).collect();
 
-            // Both should contain each index exactly once.
-            for (label, mapping) in [("forward", &perm.forward), ("backward", &perm.backward)] {
-                let mut sorted = mapping.clone();
-                sorted.sort();
-                assert_eq!(
-                    sorted,
-                    (0..dim).collect::<Vec<_>>(),
-                    "{label} is not a valid permutation for dim={dim}"
-                );
+        // Walking backward should recover every value in reverse order.
+        for v in values.iter().rev() {
+            assert_eq!(rng.prev(), *v);
+        }
+    }
+
+    #[test]
+    fn permute_unpermute_roundtrip() {
+        for &count in &[2, 5, 64, 128, 300, 1000, 1024, 2048] {
+            let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
+            let perm = Permutation::new(42, count);
+
+            let mut arr = original.clone();
+            perm.permute(&mut arr);
+
+            // For large arrays the probability of identity is negligible.
+            if count >= 5 {
+                assert_ne!(arr, original, "count={count}: permute should shuffle");
             }
+
+            perm.unpermute(&mut arr);
+            assert_eq!(
+                arr, original,
+                "count={count}: roundtrip should recover original"
+            );
         }
     }
 
     #[test]
-    fn forward_and_backward_are_inverses() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let perm = Permutation::new(&mut rng, 128);
+    fn different_seeds_produce_different_permutations() {
+        let count = 64;
+        let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
 
-        for i in 0..128 {
-            assert_eq!(perm.backward[perm.forward[i]], i);
-            assert_eq!(perm.forward[perm.backward[i]], i);
-        }
+        let p1 = Permutation::new(1, count);
+        let p2 = Permutation::new(2, count);
+
+        let mut a = original.clone();
+        let mut b = original.clone();
+        p1.permute(&mut a);
+        p2.permute(&mut b);
+
+        assert_ne!(a, b, "different seeds should yield different permutations");
     }
 
     #[test]
-    fn apply_roundtrip() {
-        let dim = 64;
-        let mut rng = StdRng::seed_from_u64(42);
-        let perm = Permutation::new(&mut rng, dim);
+    fn edge_case_count_zero() {
+        let perm = Permutation::new(0, 0);
+        let mut arr = vec![];
+        perm.permute(&mut arr);
+        assert!(arr.is_empty());
+        perm.unpermute(&mut arr);
+        assert!(arr.is_empty());
+    }
 
-        let original: Vec<f64> = (0..dim).map(|i| i as f64).collect();
-        let mut buf = original.clone();
-        let mut tmp = vec![0.0; dim];
+    #[test]
+    fn edge_case_count_one() {
+        let perm = Permutation::new(0, 1);
+        let mut arr = vec![42.0];
+        perm.permute(&mut arr);
+        assert_eq!(arr, vec![42.0]);
+        perm.unpermute(&mut arr);
+        assert_eq!(arr, vec![42.0]);
+    }
 
-        // Forward then backward should recover the original.
-        perm.apply(&mut buf, &mut tmp, true);
-        assert_ne!(buf, original, "forward permutation should shuffle");
-        perm.apply(&mut buf, &mut tmp, false);
-        assert_eq!(buf, original, "roundtrip should recover original");
+    #[test]
+    fn edge_case_count_two() {
+        let original = vec![1.0, 2.0];
+        let perm = Permutation::new(99, 2);
+        let mut arr = original.clone();
+        perm.permute(&mut arr);
+        perm.unpermute(&mut arr);
+        assert_eq!(arr, original);
+    }
+
+    #[test]
+    fn permute_is_a_valid_permutation() {
+        let count = 100;
+        let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
+        let perm = Permutation::new(42, count);
+
+        let mut arr = original.clone();
+        perm.permute(&mut arr);
+
+        // Every element should appear exactly once.
+        let mut sorted = arr.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(sorted, original);
+    }
+
+    /// Regression test: with bare `% bound` on raw LCG state, the lowest bit
+    /// strictly alternates (A and C are both odd), making the i=1 Fisher-Yates
+    /// step deterministic on seed parity. This halved the reachable permutation
+    /// space — e.g. only 12/24 permutations for count=4.
+    ///
+    /// The fix uses the upper 32 bits (`>> 32`) which have much longer periods.
+    #[test]
+    fn all_small_permutations_reachable() {
+        use std::collections::HashSet;
+
+        let count = 4;
+        let mut seen = HashSet::new();
+        for seed in 0..10_000u64 {
+            let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
+            let perm = Permutation::new(seed, count);
+            let mut arr = original;
+            perm.permute(&mut arr);
+            seen.insert(arr.iter().map(|&v| v as u32).collect::<Vec<_>>());
+        }
+        assert_eq!(
+            seen.len(),
+            24,
+            "expected all 4!=24 permutations reachable, got {}",
+            seen.len()
+        );
     }
 
     #[test]
     fn deterministic_with_same_seed() {
-        let dim = 100;
-        let mut rng1 = StdRng::seed_from_u64(42);
-        let mut rng2 = StdRng::seed_from_u64(42);
+        let count = 100;
+        let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
 
-        let p1 = Permutation::new(&mut rng1, dim);
-        let p2 = Permutation::new(&mut rng2, dim);
+        let p1 = Permutation::new(42, count);
+        let p2 = Permutation::new(42, count);
 
-        assert_eq!(p1.forward, p2.forward);
-        assert_eq!(p1.backward, p2.backward);
-    }
+        let mut a = original.clone();
+        let mut b = original.clone();
+        p1.permute(&mut a);
+        p2.permute(&mut b);
 
-    #[test]
-    fn dim_one_is_identity() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let perm = Permutation::new(&mut rng, 1);
-
-        assert_eq!(perm.forward, vec![0]);
-        assert_eq!(perm.backward, vec![0]);
+        assert_eq!(a, b, "same seed should produce identical permutations");
     }
 }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
+use rand::RngExt;
 use rand::prelude::StdRng;
-use rand::{RngExt, SeedableRng};
 
 use crate::turboquant::permutation::Permutation;
 
@@ -24,7 +24,7 @@ pub struct HadamardRotation {
 }
 
 impl HadamardRotation {
-    pub fn new(seed: u64, dim: usize) -> Self {
+    pub fn new(dim: usize) -> Self {
         let chunk_sizes = compute_chunk_sizes(dim);
 
         let chunk_norms: Vec<f64> = chunk_sizes
@@ -32,10 +32,8 @@ impl HadamardRotation {
             .map(|&s| 1.0 / (s as f64).sqrt())
             .collect();
 
-        let mut rng = StdRng::seed_from_u64(seed);
-
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|_| Permutation::new(&mut rng, dim));
+            std::array::from_fn(|index| Permutation::new(index as u64 + 42, dim));
 
         Self {
             permutations,
@@ -53,12 +51,9 @@ impl HadamardRotation {
         // Apply WHT + normalize to each variable-size chunk.
         self.wht_normalized_chunks(&mut buf);
 
-        // Temp vector for `apply_permutation`.
-        let mut tmp = vec![0.0f64; buf.len()];
-
         // Permute then WHT+normalize for each permutation.
         for permutation in &self.permutations {
-            permutation.apply(&mut buf, &mut tmp, true);
+            permutation.permute(&mut buf);
             self.wht_normalized_chunks(&mut buf);
         }
 
@@ -73,12 +68,9 @@ impl HadamardRotation {
         // WHT + normalize
         self.wht_normalized_chunks(&mut buf);
 
-        // Temp vector for `apply_permutation`.
-        let mut tmp = vec![0.0f64; buf.len()];
-
         // Apply inverse permutations backwards.
         for permutation in self.permutations.iter().rev() {
-            permutation.apply(&mut buf, &mut tmp, false);
+            permutation.unpermute(&mut buf);
             self.wht_normalized_chunks(&mut buf);
         }
 
@@ -161,7 +153,7 @@ fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -202,7 +194,7 @@ mod test {
 
         for dim in [100, 300, 384, 512, 1024, 1586] {
             let n_vectors = 200;
-            let rot = HadamardRotation::new(42, dim);
+            let rot = HadamardRotation::new(dim);
 
             // Generate distorted vectors: energy concentrated in first few dims.
             let mut rng = StdRng::seed_from_u64(42);
@@ -281,7 +273,7 @@ mod test {
 
         for &dim in dim_iter {
             for seed in [0, 10, 42, 100] {
-                let rot = HadamardRotation::new(seed, dim);
+                let rot = HadamardRotation::new(dim);
                 let mut rng = StdRng::seed_from_u64(seed);
 
                 let input: Vec<f32> = (0..dim)

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -18,11 +18,19 @@ pub struct HadamardRotation {
     /// Sequence of power-of-2 chunk sizes that exactly cover `dim`.
     /// Produced by greedily taking the largest power-of-2 that fits the remainder.
     chunk_sizes: Vec<usize>,
+
+    /// Precomputed normalization factors: `1.0 / sqrt(chunk_size)` for each chunk.
+    chunk_norms: Vec<f64>,
 }
 
 impl HadamardRotation {
     pub fn new(seed: u64, dim: usize) -> Self {
         let chunk_sizes = compute_chunk_sizes(dim);
+
+        let chunk_norms: Vec<f64> = chunk_sizes
+            .iter()
+            .map(|&s| 1.0 / (s as f64).sqrt())
+            .collect();
 
         let mut rng = StdRng::seed_from_u64(seed);
 
@@ -33,6 +41,7 @@ impl HadamardRotation {
             permutations,
             dim,
             chunk_sizes,
+            chunk_norms,
         }
     }
 
@@ -79,10 +88,9 @@ impl HadamardRotation {
     /// Apply WHT + normalization to variable-size chunks.
     fn wht_normalized_chunks(&self, buf: &mut [f64]) {
         let mut offset = 0;
-        for &size in &self.chunk_sizes {
+        for (&size, &norm) in self.chunk_sizes.iter().zip(&self.chunk_norms) {
             let chunk = &mut buf[offset..offset + size];
             in_place_walsh_hadamard_transform(chunk);
-            let norm = 1.0 / (size as f64).sqrt();
             for v in chunk.iter_mut() {
                 *v *= norm;
             }
@@ -131,9 +139,9 @@ pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
     let mut sizes = Vec::with_capacity(dim.count_ones() as usize);
     let mut bits = dim;
     while bits != 0 {
-        let highest = 1 << (usize::BITS - 1 - bits.leading_zeros());
+        let highest = 1 << bits.ilog2();
         sizes.push(highest);
-        bits ^= highest; // clear that bit
+        bits ^= highest;
     }
     sizes
 }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -9,9 +9,6 @@ const N_PERMUTATIONS: usize = 3;
 
 /// Hadamard rotation implementation customized for TurboQuant.
 pub struct HadamardRotation {
-    /// Random signs applied before the rotation
-    signs1: Vec<f64>,
-
     /// Random (but shared) permutations.
     permutations: [Permutation; N_PERMUTATIONS],
 
@@ -29,13 +26,10 @@ impl HadamardRotation {
 
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let signs = generate_signs(&mut rng, dim);
-
         let permutations: [_; N_PERMUTATIONS] =
             std::array::from_fn(|_| Permutation::new(&mut rng, dim));
 
         Self {
-            signs1: signs,
             permutations,
             dim,
             chunk_sizes,
@@ -45,11 +39,7 @@ impl HadamardRotation {
     pub fn apply(&self, x: &[f32]) -> Vec<f32> {
         debug_assert_eq!(x.len(), self.dim);
 
-        let mut buf: Vec<f64> = x
-            .iter()
-            .zip(&self.signs1)
-            .map(|(&v, &s)| f64::from(v) * s)
-            .collect();
+        let mut buf: Vec<f64> = x.iter().map(|&v| f64::from(v)).collect();
 
         // Apply WHT + normalize to each variable-size chunk.
         self.wht_normalized_chunks(&mut buf);
@@ -83,11 +73,7 @@ impl HadamardRotation {
             self.wht_normalized_chunks(&mut buf);
         }
 
-        buf[..self.dim]
-            .iter()
-            .zip(&self.signs1)
-            .map(|(&v, &sign)| (v * sign) as f32)
-            .collect()
+        buf[..self.dim].iter().map(|&v| v as f32).collect()
     }
 
     /// Apply WHT + normalization to variable-size chunks.
@@ -142,17 +128,12 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
 /// ```
 pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
     debug_assert!(dim > 0);
-    let mut sizes = Vec::with_capacity(1);
-    let mut remaining = dim;
-    while remaining > 0 {
-        let next_pow2 = remaining.next_power_of_two();
-        let chunk = if next_pow2 == remaining {
-            remaining
-        } else {
-            next_pow2 >> 1
-        };
-        sizes.push(chunk);
-        remaining -= chunk;
+    let mut sizes = Vec::with_capacity(dim.count_ones() as usize);
+    let mut bits = dim;
+    while bits != 0 {
+        let highest = 1 << (usize::BITS - 1 - bits.leading_zeros());
+        sizes.push(highest);
+        bits ^= highest; // clear that bit
     }
     sizes
 }
@@ -288,7 +269,6 @@ mod test {
     fn hadamard_roundtrip() {
         let power_of_two_dims = [128, 512, 1024, 4096];
         let rand_dims = [50, 127, 300, 500, 1025];
-
         let dim_iter = power_of_two_dims.iter().chain(&rand_dims);
 
         for &dim in dim_iter {

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
-use rand::RngExt;
-use rand::prelude::StdRng;
-
 use crate::turboquant::permutation::Permutation;
 
 const N_PERMUTATIONS: usize = 3;
+
+/// Random seeds for Permutation. The values were picked arbitrarily, but they must not be changed.
+const PERMUTATION_SEEDS: [u64; 3] = [654605292835415893, 8636605637963351413, 1775280196666917949];
 
 /// Hadamard rotation implementation customized for TurboQuant.
 pub struct HadamardRotation {
@@ -33,7 +33,7 @@ impl HadamardRotation {
             .collect();
 
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|index| Permutation::new(index as u64, dim));
+            std::array::from_fn(|index| Permutation::new(PERMUTATION_SEEDS[index], dim));
 
         Self {
             permutations,
@@ -43,38 +43,44 @@ impl HadamardRotation {
         }
     }
 
-    pub fn apply(&self, x: &[f32]) -> Vec<f32> {
+    pub fn apply(&self, x: &[f32], buf: &mut [f64]) -> Vec<f32> {
         debug_assert_eq!(x.len(), self.dim);
+        debug_assert_eq!(self.dim, buf.len());
 
-        let mut buf: Vec<f64> = x.iter().map(|&v| f64::from(v)).collect();
+        for (idx, &component) in x.iter().enumerate() {
+            buf[idx] = f64::from(component);
+        }
 
         // Apply WHT + normalize to each variable-size chunk.
-        self.wht_normalized_chunks(&mut buf);
+        self.wht_normalized_chunks(buf);
 
         // Permute then WHT+normalize for each permutation.
         for permutation in &self.permutations {
-            permutation.permute(&mut buf);
-            self.wht_normalized_chunks(&mut buf);
+            permutation.permute(buf);
+            self.wht_normalized_chunks(buf);
         }
 
         buf.iter().map(|&v| v as f32).collect()
     }
 
-    pub fn apply_inverse(&self, y: &[f32]) -> Vec<f32> {
+    pub fn apply_inverse(&self, y: &[f32], buf: &mut [f64]) -> Vec<f32> {
         debug_assert_eq!(y.len(), self.dim);
+        debug_assert_eq!(self.dim, buf.len());
 
-        let mut buf: Vec<f64> = y.iter().map(|&v| f64::from(v)).collect();
+        for (idx, &component) in y.iter().enumerate() {
+            buf[idx] = f64::from(component);
+        }
 
         // WHT + normalize
-        self.wht_normalized_chunks(&mut buf);
+        self.wht_normalized_chunks(buf);
 
         // Apply inverse permutations backwards.
         for permutation in self.permutations.iter().rev() {
-            permutation.unpermute(&mut buf);
-            self.wht_normalized_chunks(&mut buf);
+            permutation.unpermute(buf);
+            self.wht_normalized_chunks(buf);
         }
 
-        buf[..self.dim].iter().map(|&v| v as f32).collect()
+        buf.iter().map(|&v| v as f32).collect()
     }
 
     /// Apply WHT + normalization to variable-size chunks.
@@ -138,22 +144,10 @@ pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
     sizes
 }
 
-/// Generate a random sign vector (±1.0).
-fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
-    (0..n)
-        .map(|_| {
-            if rng.random::<bool>() {
-                1.0f64
-            } else {
-                -1.0f64
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod test {
-    use rand::{Rng, SeedableRng};
+    use rand::prelude::StdRng;
+    use rand::{Rng, RngExt, SeedableRng};
 
     use super::*;
 
@@ -210,7 +204,9 @@ mod test {
                 })
                 .collect();
 
-            let rotated: Vec<Vec<f32>> = vectors.iter().map(|v| rot.apply(v)).collect();
+            let mut buf = vec![0.0f64; dim];
+
+            let rotated: Vec<Vec<f32>> = vectors.iter().map(|v| rot.apply(v, &mut buf)).collect();
 
             let mut params = VectorParameters {
                 dim,
@@ -280,7 +276,8 @@ mod test {
                     .map(|_| ((rng.next_u32() % 1_000) as f32) / 100.0)
                     .collect();
 
-                let recovered = rot.apply_inverse(&rot.apply(&input));
+                let mut buf = vec![0.0f64; dim];
+                let recovered = rot.apply_inverse(&rot.apply(&input, &mut buf), &mut buf);
 
                 // Original input and recovered should be the same.
                 for (orig, recovered) in input.iter().zip(recovered.iter()) {

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -51,12 +51,11 @@ impl HadamardRotation {
 
     pub fn apply(&self, x: &[f32]) -> Vec<f32> {
         debug_assert!(x.len() <= self.padded_dim);
-        // TODO: Can we use f32?
 
         let mut buf = Vec::with_capacity(self.padded_dim);
 
         // Update `buf` with the vector and signs applied.
-        buf.extend(x.iter().zip(&self.signs1).map(|(&v, &s)| v as f64 * s));
+        buf.extend(x.iter().zip(&self.signs1).map(|(&v, &s)| f64::from(v) * s));
 
         buf.resize(self.padded_dim, 0.0);
 
@@ -97,7 +96,7 @@ impl HadamardRotation {
         buf.extend(
             y.iter()
                 .zip(&self.signs2)
-                .map(|(&v, &s)| v as f64 * s * norm),
+                .map(|(&v, &s)| f64::from(v) * s * norm),
         );
 
         buf.resize(self.padded_dim, 0.0);
@@ -161,12 +160,12 @@ pub fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
     for (i, &p) in perm.iter().enumerate() {
         tmp[p] = buf[i];
     }
-    buf.copy_from_slice(&tmp);
+    buf.copy_from_slice(tmp);
 }
 
 /// Round up to the nearest multiple of `chunk_size`.
 pub fn compute_padded_dim(dim: usize, chunk_size: usize) -> usize {
-    (dim + chunk_size - 1) / chunk_size * chunk_size
+    dim.div_ceil(chunk_size) * chunk_size
 }
 
 /// Pick a power-of-two chunk size for block-wise Hadamard rotation.
@@ -216,6 +215,8 @@ pub fn generate_permutation(rng: &mut StdRng, n: usize) -> (Vec<usize>, Vec<usiz
 
 #[cfg(test)]
 mod test {
+    use rand::Rng;
+
     use super::*;
 
     #[test]
@@ -241,7 +242,7 @@ mod test {
         use crate::VectorParameters;
         use crate::vector_stats::VectorStats;
 
-        for dim in [100, 300, 384, 1024, 1586] {
+        for dim in [100, 300, 384, 512, 1024, 1586] {
             let n_vectors = 200;
             let rot = HadamardRotation::new(42, dim);
 
@@ -315,18 +316,29 @@ mod test {
 
     #[test]
     fn hadamard_roundtrip() {
-        for dim in [50, 127, 128, 500, 1024, 1025] {
-            let rot = HadamardRotation::new(42, dim);
-            let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
-            let transformed = rot.apply(&input);
-            let recovered = rot.apply_inverse(&transformed, dim);
-            for (a, b) in input.iter().zip(recovered.iter()) {
-                assert!(
-                    (a - b).abs() < 1e-5,
-                    "hadamard roundtrip failed: {} vs {}",
-                    a,
-                    b
-                );
+        let power_of_two_dims = [128, 512, 1024, 4096];
+        let rand_dims = [50, 127, 300, 500, 1025];
+
+        let dim_iter = power_of_two_dims.iter().chain(&rand_dims);
+
+        for &dim in dim_iter {
+            for seed in [0, 10, 42, 100] {
+                let rot = HadamardRotation::new(seed, dim);
+                let mut rng = StdRng::seed_from_u64(seed);
+
+                let input: Vec<f32> = (0..dim)
+                    .map(|_| ((rng.next_u32() % 1_000) as f32) / 100.0)
+                    .collect();
+
+                let recovered = rot.apply_inverse(&rot.apply(&input), dim);
+
+                // Original input and recovered should be the same.
+                for (orig, recovered) in input.iter().zip(recovered.iter()) {
+                    assert!(
+                        (orig - recovered).abs() < 1e-5,
+                        "hadamard roundtrip failed: {orig} vs {recovered}",
+                    );
+                }
             }
         }
     }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -54,13 +54,11 @@ impl HadamardRotation {
         // TODO: Can we use f32?
 
         let mut buf = Vec::with_capacity(self.padded_dim);
-        buf.extend(x.iter().map(|&v| v as f64));
-        buf.resize(self.padded_dim, 0.0);
 
-        // Apply random signs
-        for (b, &s) in buf.iter_mut().zip(self.signs1.iter()) {
-            *b *= s;
-        }
+        // Update `buf` with the vector and signs applied.
+        buf.extend(x.iter().zip(&self.signs1).map(|(&v, &s)| v as f64 * s));
+
+        buf.resize(self.padded_dim, 0.0);
 
         // Apply hadamard
         for chunk in buf.chunks_mut(self.chunk_size) {
@@ -78,24 +76,31 @@ impl HadamardRotation {
             }
         }
 
-        // Apply second random signs.
-        for (b, &s) in buf.iter_mut().zip(self.signs2.iter()) {
-            *b *= s;
-        }
+        // Merge second random signs and normalization.
+        let norm = self.normalization_factor();
+        let signs_and_norm_iter = self.signs2.iter().map(|&s| s * norm);
 
-        buf.iter().map(|&v| v as f32).collect()
+        buf.iter()
+            // Apply merged signs and norm.
+            .zip(signs_and_norm_iter)
+            .map(|(&v, sn)| (v * sn) as f32)
+            .collect()
     }
 
     pub fn apply_inverse(&self, y: &[f32], original_dim: usize) -> Vec<f32> {
         debug_assert!(original_dim <= self.padded_dim);
-        let mut buf = Vec::with_capacity(self.padded_dim);
-        buf.extend(y.iter().map(|&v| v as f64));
-        buf.resize(self.padded_dim, 0.0);
 
-        // Apply signs 2
-        for (b, &s) in buf.iter_mut().zip(self.signs2.iter()) {
-            *b *= s;
-        }
+        let mut buf = Vec::with_capacity(self.padded_dim);
+
+        // Apply second random signs, normalization, and f32->f64 conversion in one pass.
+        let norm = self.normalization_factor();
+        buf.extend(
+            y.iter()
+                .zip(&self.signs2)
+                .map(|(&v, &s)| v as f64 * s * norm),
+        );
+
+        buf.resize(self.padded_dim, 0.0);
 
         // First hadamard
         for chunk in buf.chunks_mut(self.chunk_size) {
@@ -114,16 +119,24 @@ impl HadamardRotation {
             }
         }
 
-        // Apply signs 1
-        for (b, &s) in buf.iter_mut().zip(self.signs1.iter()) {
-            *b *= s;
-        }
+        buf[..original_dim]
+            .iter()
+            // Apply signs 1
+            .zip(&self.signs1)
+            .map(|(&v, &sign)| (v * sign) as f32)
+            .collect()
+    }
 
-        buf[..original_dim].iter().map(|&v| v as f32).collect()
+    /// Combined normalization for 4 unnormalized WHTs: 1 / sqrt(n)^4 = 1 / n^2.
+    fn normalization_factor(&self) -> f64 {
+        // 1 initial WHT + N_PERMUTATIONS = 4 total. Update exponent if this changes.
+        static_assertions::const_assert_eq!(N_PERMUTATIONS, 3);
+        1.0 / (self.chunk_size * self.chunk_size) as f64
     }
 }
 
-/// In-place normalized Walsh-Hadamard Transform in f64. Self-inverse: WHT(WHT(x)) = x.
+/// In-place unnormalized Walsh-Hadamard Transform in f64.
+/// Normalization is applied externally in `apply`/`apply_inverse`.
 /// Input length must be a power of 2.
 pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
     let n = x.len();
@@ -139,10 +152,6 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
             }
         }
         h *= 2;
-    }
-    let norm = (n as f64).sqrt();
-    for val in x.iter_mut() {
-        *val /= norm;
     }
 }
 

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -12,9 +12,6 @@ pub struct HadamardRotation {
     /// Random signs applied before the rotation
     signs1: Vec<f64>,
 
-    /// Random signs applied after the rotation
-    signs2: Vec<f64>,
-
     /// Random (but shared) permutations.
     permutations: [Permutation; N_PERMUTATIONS],
 
@@ -32,15 +29,13 @@ impl HadamardRotation {
 
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let signs1 = generate_signs(&mut rng, dim);
-        let signs2 = generate_signs(&mut rng, dim);
+        let signs = generate_signs(&mut rng, dim);
 
         let permutations: [_; N_PERMUTATIONS] =
             std::array::from_fn(|_| Permutation::new(&mut rng, dim));
 
         Self {
-            signs1,
-            signs2,
+            signs1: signs,
             permutations,
             dim,
             chunk_sizes,
@@ -68,20 +63,13 @@ impl HadamardRotation {
             self.wht_normalized_chunks(&mut buf);
         }
 
-        buf.iter()
-            .zip(&self.signs2)
-            .map(|(&v, &s)| (v * s) as f32)
-            .collect()
+        buf.iter().map(|&v| v as f32).collect()
     }
 
     pub fn apply_inverse(&self, y: &[f32]) -> Vec<f32> {
         debug_assert_eq!(y.len(), self.dim);
 
-        let mut buf: Vec<f64> = y
-            .iter()
-            .zip(&self.signs2)
-            .map(|(&v, &s)| f64::from(v) * s)
-            .collect();
+        let mut buf: Vec<f64> = y.iter().map(|&v| f64::from(v)).collect();
 
         // WHT + normalize
         self.wht_normalized_chunks(&mut buf);
@@ -231,12 +219,13 @@ mod test {
             let mut rng = StdRng::seed_from_u64(42);
             let vectors: Vec<Vec<f32>> = (0..n_vectors)
                 .map(|_| {
-                    (0..dim)
+                    let random_vector: Vec<f32> = (0..dim)
                         .map(|d| {
                             let scale = if d < 5 { 100.0 } else { 0.01 };
                             rng.random_range(-1.0f32..1.0) * scale
                         })
-                        .collect()
+                        .collect();
+                    cosine_preprocess(random_vector)
                 })
                 .collect();
 
@@ -322,5 +311,18 @@ mod test {
                 }
             }
         }
+    }
+
+    fn is_length_zero_or_normalized(length: f32) -> bool {
+        length < f32::EPSILON || (length - 1.0).abs() <= 1.0e-6
+    }
+
+    fn cosine_preprocess(vector: Vec<f32>) -> Vec<f32> {
+        let mut length: f32 = vector.iter().map(|x| x * x).sum();
+        if is_length_zero_or_normalized(length) {
+            return vector;
+        }
+        length = length.sqrt();
+        vector.iter().map(|x| x / length).collect()
     }
 }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -46,44 +46,30 @@ impl HadamardRotation {
         }
     }
 
-    pub fn apply(&self, x: &[f32], buf: &mut [f64]) -> Vec<f32> {
+    pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
-        debug_assert_eq!(self.dim, buf.len());
-
-        for (idx, &component) in x.iter().enumerate() {
-            buf[idx] = f64::from(component);
-        }
 
         // Apply WHT + normalize to each variable-size chunk.
-        self.wht_normalized_chunks(buf);
+        self.wht_normalized_chunks(x);
 
         // Permute then WHT+normalize for each permutation.
         for permutation in &self.permutations {
-            permutation.permute(buf);
-            self.wht_normalized_chunks(buf);
+            permutation.permute(x);
+            self.wht_normalized_chunks(x);
         }
-
-        buf.iter().map(|&v| v as f32).collect()
     }
 
-    pub fn apply_inverse(&self, y: &[f32], buf: &mut [f64]) -> Vec<f32> {
+    pub fn apply_inverse(&self, y: &mut [f64]) {
         debug_assert_eq!(y.len(), self.dim);
-        debug_assert_eq!(self.dim, buf.len());
-
-        for (idx, &component) in y.iter().enumerate() {
-            buf[idx] = f64::from(component);
-        }
 
         // WHT + normalize
-        self.wht_normalized_chunks(buf);
+        self.wht_normalized_chunks(y);
 
         // Apply inverse permutations backwards.
         for permutation in self.permutations.iter().rev() {
-            permutation.unpermute(buf);
-            self.wht_normalized_chunks(buf);
+            permutation.unpermute(y);
+            self.wht_normalized_chunks(y);
         }
-
-        buf.iter().map(|&v| v as f32).collect()
     }
 
     /// Apply WHT + normalization to variable-size chunks.
@@ -198,21 +184,32 @@ mod test {
 
             // Generate distorted vectors: energy concentrated in first few dims.
             let mut rng = StdRng::seed_from_u64(42);
-            let vectors: Vec<Vec<f32>> = (0..n_vectors)
+            let vectors: Vec<Vec<f64>> = (0..n_vectors)
                 .map(|_| {
-                    let random_vector: Vec<f32> = (0..dim)
+                    let random_vector: Vec<f64> = (0..dim)
                         .map(|d| {
                             let scale = if d < 5 { 100.0 } else { 0.01 };
-                            rng.random_range(-1.0f32..1.0) * scale
+                            rng.random_range(-1.0f64..1.0) * scale
                         })
                         .collect();
                     cosine_preprocess(random_vector)
                 })
                 .collect();
 
-            let mut buf = vec![0.0f64; dim];
+            let mut rotated = vectors.clone();
+            for vector in rotated.iter_mut() {
+                rot.apply(vector);
+            }
 
-            let rotated: Vec<Vec<f32>> = vectors.iter().map(|v| rot.apply(v, &mut buf)).collect();
+            let rotated: Vec<_> = rotated
+                .into_iter()
+                .map(|v| v.into_iter().map(|i| i as f32).collect::<Vec<_>>())
+                .collect();
+
+            let vectors: Vec<_> = vectors
+                .into_iter()
+                .map(|v| v.into_iter().map(|i| i as f32).collect::<Vec<_>>())
+                .collect();
 
             let mut params = VectorParameters {
                 dim,
@@ -278,15 +275,16 @@ mod test {
                 let rot = HadamardRotation::new(dim);
                 let mut rng = StdRng::seed_from_u64(seed);
 
-                let input: Vec<f32> = (0..dim)
-                    .map(|_| ((rng.next_u32() % 1_000) as f32) / 100.0)
+                let input: Vec<f64> = (0..dim)
+                    .map(|_| f64::from(rng.next_u32() % 1_000) / 100.0)
                     .collect();
 
-                let mut buf = vec![0.0f64; dim];
-                let recovered = rot.apply_inverse(&rot.apply(&input, &mut buf), &mut buf);
+                let mut rotated = input.clone();
+                rot.apply(&mut rotated);
+                rot.apply_inverse(&mut rotated);
 
                 // Original input and recovered should be the same.
-                for (orig, recovered) in input.iter().zip(recovered.iter()) {
+                for (orig, recovered) in input.iter().zip(rotated.iter()) {
                     assert!(
                         (orig - recovered).abs() < 1e-5,
                         "hadamard roundtrip failed: {orig} vs {recovered}",
@@ -296,12 +294,12 @@ mod test {
         }
     }
 
-    fn is_length_zero_or_normalized(length: f32) -> bool {
-        length < f32::EPSILON || (length - 1.0).abs() <= 1.0e-6
+    fn is_length_zero_or_normalized(length: f64) -> bool {
+        length < f64::EPSILON || (length - 1.0).abs() <= 1.0e-6
     }
 
-    fn cosine_preprocess(vector: Vec<f32>) -> Vec<f32> {
-        let mut length: f32 = vector.iter().map(|x| x * x).sum();
+    fn cosine_preprocess(vector: Vec<f64>) -> Vec<f64> {
+        let mut length: f64 = vector.iter().map(|x| x * x).sum();
         if is_length_zero_or_normalized(length) {
             return vector;
         }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -33,7 +33,7 @@ impl HadamardRotation {
             .collect();
 
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|index| Permutation::new(index as u64 + 42, dim));
+            std::array::from_fn(|index| Permutation::new(index as u64, dim));
 
         Self {
             permutations,

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -12,125 +12,111 @@ pub struct HadamardRotation {
 
     permutations: [(Vec<usize>, Vec<usize>); N_PERMUTATIONS],
 
-    /// Rotated dimension.
-    padded_dim: usize,
+    /// Original dimension.
+    dim: usize,
 
-    /// Size of each chunk depending on the original dimension.
-    chunk_size: usize,
+    /// Sequence of power-of-2 chunk sizes that exactly cover `dim`.
+    /// Produced by greedily taking the largest power-of-2 that fits the remainder.
+    chunk_sizes: Vec<usize>,
 }
 
 impl HadamardRotation {
     pub fn new(seed: u64, dim: usize) -> Self {
-        let chunk_size = get_chunk_size(dim);
-        let padded_dim = compute_padded_dim(dim, chunk_size);
+        let chunk_sizes = compute_chunk_sizes(dim);
 
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let signs1 = generate_signs(&mut rng, padded_dim);
-        let signs2 = generate_signs(&mut rng, padded_dim);
+        let signs1 = generate_signs(&mut rng, dim);
+        let signs2 = generate_signs(&mut rng, dim);
 
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|_| generate_permutation(&mut rng, padded_dim));
+            std::array::from_fn(|_| generate_permutation(&mut rng, dim));
 
         Self {
             signs1,
             signs2,
             permutations,
-            padded_dim,
-            chunk_size,
+            dim,
+            chunk_sizes,
         }
     }
 
-    pub fn padded_dim(&self) -> usize {
-        self.padded_dim
+    pub fn dim(&self) -> usize {
+        self.dim
     }
 
-    pub fn chunk_size(&self) -> usize {
-        self.chunk_size
+    pub fn chunk_sizes(&self) -> &[usize] {
+        &self.chunk_sizes
     }
 
     pub fn apply(&self, x: &[f32]) -> Vec<f32> {
-        debug_assert!(x.len() <= self.padded_dim);
+        debug_assert_eq!(x.len(), self.dim);
 
-        let mut buf = Vec::with_capacity(self.padded_dim);
+        let mut buf: Vec<f64> = x
+            .iter()
+            .zip(&self.signs1)
+            .map(|(&v, &s)| f64::from(v) * s)
+            .collect();
 
-        // Update `buf` with the vector and signs applied.
-        buf.extend(x.iter().zip(&self.signs1).map(|(&v, &s)| f64::from(v) * s));
-
-        buf.resize(self.padded_dim, 0.0);
-
-        // Apply hadamard
-        for chunk in buf.chunks_mut(self.chunk_size) {
-            in_place_walsh_hadamard_transform(chunk);
-        }
+        // Apply WHT + normalize to each variable-size chunk.
+        self.wht_normalized_chunks(&mut buf);
 
         // Temp vector for `apply_permutation`.
         let mut tmp = vec![0.0f64; buf.len()];
 
-        // Apply hadamard for each permutation.
+        // Permute then WHT+normalize for each permutation.
         for perm in &self.permutations {
             apply_permutation(&mut buf, &mut tmp, &perm.0);
-            for chunk in buf.chunks_mut(self.chunk_size) {
-                in_place_walsh_hadamard_transform(chunk);
-            }
+            self.wht_normalized_chunks(&mut buf);
         }
 
-        // Merge second random signs and normalization.
-        let norm = self.normalization_factor();
-        let signs_and_norm_iter = self.signs2.iter().map(|&s| s * norm);
-
         buf.iter()
-            // Apply merged signs and norm.
-            .zip(signs_and_norm_iter)
-            .map(|(&v, sn)| (v * sn) as f32)
+            .zip(&self.signs2)
+            .map(|(&v, &s)| (v * s) as f32)
             .collect()
     }
 
-    pub fn apply_inverse(&self, y: &[f32], original_dim: usize) -> Vec<f32> {
-        debug_assert!(original_dim <= self.padded_dim);
+    pub fn apply_inverse(&self, y: &[f32]) -> Vec<f32> {
+        debug_assert_eq!(y.len(), self.dim);
 
-        let mut buf = Vec::with_capacity(self.padded_dim);
+        let mut buf: Vec<f64> = y
+            .iter()
+            .zip(&self.signs2)
+            .map(|(&v, &s)| f64::from(v) * s)
+            .collect();
 
-        // Apply second random signs, normalization, and f32->f64 conversion in one pass.
-        let norm = self.normalization_factor();
-        buf.extend(
-            y.iter()
-                .zip(&self.signs2)
-                .map(|(&v, &s)| f64::from(v) * s * norm),
-        );
-
-        buf.resize(self.padded_dim, 0.0);
-
-        // First hadamard
-        for chunk in buf.chunks_mut(self.chunk_size) {
-            in_place_walsh_hadamard_transform(chunk);
-        }
+        // WHT + normalize
+        self.wht_normalized_chunks(&mut buf);
 
         // Temp vector for `apply_permutation`.
         let mut tmp = vec![0.0f64; buf.len()];
 
-        // Apply permutations (backwards)
+        // Apply inverse permutations backwards.
         for perm in self.permutations.iter().rev() {
             apply_permutation(&mut buf, &mut tmp, &perm.1);
-
-            for chunk in buf.chunks_mut(self.chunk_size) {
-                in_place_walsh_hadamard_transform(chunk);
-            }
+            self.wht_normalized_chunks(&mut buf);
         }
 
-        buf[..original_dim]
+        buf[..self.dim]
             .iter()
-            // Apply signs 1
             .zip(&self.signs1)
             .map(|(&v, &sign)| (v * sign) as f32)
             .collect()
     }
 
-    /// Combined normalization for 4 unnormalized WHTs: 1 / sqrt(n)^4 = 1 / n^2.
-    fn normalization_factor(&self) -> f64 {
-        // 1 initial WHT + N_PERMUTATIONS = 4 total. Update exponent if this changes.
-        static_assertions::const_assert_eq!(N_PERMUTATIONS, 3);
-        1.0 / (self.chunk_size * self.chunk_size) as f64
+    /// Apply WHT + normalization to variable-size chunks.
+    fn wht_normalized_chunks(&self, buf: &mut [f64]) {
+        let mut offset = 0;
+        for &size in &self.chunk_sizes {
+            let chunk = &mut buf[offset..offset + size];
+            in_place_walsh_hadamard_transform(chunk);
+            let norm = 1.0 / (size as f64).sqrt();
+            for v in chunk.iter_mut() {
+                *v *= norm;
+            }
+            offset += size;
+        }
+        debug_assert_eq!(offset, buf.len());
     }
 }
 
@@ -163,27 +149,35 @@ pub fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
     buf.copy_from_slice(tmp);
 }
 
-/// Round up to the nearest multiple of `chunk_size`.
-pub fn compute_padded_dim(dim: usize, chunk_size: usize) -> usize {
-    dim.div_ceil(chunk_size) * chunk_size
-}
-
-/// Pick a power-of-two chunk size for block-wise Hadamard rotation.
-/// Divides dim by 4 and rounds up to the next power of two, yielding ~3-5 chunks.
+/// Decompose `dim` into a sequence of decreasing power-of-2 chunk sizes
+/// that sum to exactly `dim`. No padding is needed.
 ///
-///  dim  | chunk | padded | #chunks | overhead
-/// ------|-------|--------|---------|----------
-///   128 |    32 |    128 |       4 |     0.0%
-///   300 |   128 |    384 |       3 |    28.0%
-///   384 |   128 |    384 |       3 |     0.0%
-///   768 |   256 |    768 |       3 |     0.0%
-///  1024 |   256 |   1024 |       4 |     0.0%
-///  1280 |   512 |   1536 |       3 |    20.0%
-///  1536 |   512 |   1536 |       3 |     0.0%
-///  3072 |  1024 |   3072 |       3 |     0.0%
-///  4096 |  1024 |   4096 |       4 |     0.0%
-pub fn get_chunk_size(dim: usize) -> usize {
-    (dim >> 2).next_power_of_two()
+/// Greedily takes the largest power-of-2 that fits the remaining length.
+///
+/// ```text
+///  dim  | chunks
+/// ------|--------
+///   128 | [128]
+///   300 | [256, 32, 8, 4]
+///   700 | [512, 128, 32, 16, 8, 4]
+///  1536 | [1024, 512]
+///  4096 | [4096]
+/// ```
+pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
+    debug_assert!(dim > 0);
+    let mut sizes = Vec::with_capacity(1);
+    let mut remaining = dim;
+    while remaining > 0 {
+        let next_pow2 = remaining.next_power_of_two();
+        let chunk = if next_pow2 == remaining {
+            remaining
+        } else {
+            next_pow2 >> 1
+        };
+        sizes.push(chunk);
+        remaining -= chunk;
+    }
+    sizes
 }
 
 /// Generate a random sign vector (±1.0).
@@ -220,19 +214,31 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_picking_chunk_size() {
-        for i in [5, 128, 129, 712, 1536] {
-            assert!(get_chunk_size(i).is_power_of_two());
+    fn test_compute_chunk_sizes() {
+        // All chunks must be powers of two.
+        for dim in [5, 128, 129, 300, 700, 712, 1536, 4096] {
+            let sizes = compute_chunk_sizes(dim);
+            assert!(
+                sizes.iter().all(|s| s.is_power_of_two()),
+                "dim={dim}: not all power-of-2: {sizes:?}"
+            );
+            assert_eq!(
+                sizes.iter().sum::<usize>(),
+                dim,
+                "dim={dim}: chunks don't sum to dim: {sizes:?}"
+            );
+            // Chunks should be in decreasing order.
+            assert!(
+                sizes.windows(2).all(|w| w[0] >= w[1]),
+                "dim={dim}: not decreasing: {sizes:?}"
+            );
         }
 
-        assert_eq!(get_chunk_size(5), 1);
-        assert_eq!(get_chunk_size(100), 32);
-        assert_eq!(get_chunk_size(128), 32);
-        assert_eq!(get_chunk_size(129), 32);
-        assert_eq!(get_chunk_size(300), 128);
-        assert_eq!(get_chunk_size(712), 256);
-        assert_eq!(get_chunk_size(1536), 512);
-        assert_eq!(get_chunk_size(4096), 1024);
+        // Specific cases.
+        assert_eq!(compute_chunk_sizes(128), vec![128]);
+        assert_eq!(compute_chunk_sizes(700), vec![512, 128, 32, 16, 8, 4]);
+        assert_eq!(compute_chunk_sizes(1536), vec![1024, 512]);
+        assert_eq!(compute_chunk_sizes(4096), vec![4096]);
     }
 
     /// Test that Hadamard rotation spreads energy across dimensions,
@@ -270,7 +276,7 @@ mod test {
 
             let stats_before = VectorStats::build(vectors.iter(), &params);
 
-            params.dim = rot.padded_dim;
+            params.dim = rot.dim();
             let stats_after = VectorStats::build(rotated.iter(), &params);
 
             // Measure how uniform the per-dimension stddevs are by looking at
@@ -330,7 +336,7 @@ mod test {
                     .map(|_| ((rng.next_u32() % 1_000) as f32) / 100.0)
                     .collect();
 
-                let recovered = rot.apply_inverse(&rot.apply(&input), dim);
+                let recovered = rot.apply_inverse(&rot.apply(&input));
 
                 // Original input and recovered should be the same.
                 for (orig, recovered) in input.iter().zip(recovered.iter()) {

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -3,14 +3,20 @@
 use rand::prelude::StdRng;
 use rand::{RngExt, SeedableRng};
 
+use crate::turboquant::permutation::Permutation;
+
 const N_PERMUTATIONS: usize = 3;
 
 /// Hadamard rotation implementation customized for TurboQuant.
 pub struct HadamardRotation {
+    /// Random signs applied before the rotation
     signs1: Vec<f64>,
+
+    /// Random signs applied after the rotation
     signs2: Vec<f64>,
 
-    permutations: [(Vec<usize>, Vec<usize>); N_PERMUTATIONS],
+    /// Random (but shared) permutations.
+    permutations: [Permutation; N_PERMUTATIONS],
 
     /// Original dimension.
     dim: usize,
@@ -30,7 +36,7 @@ impl HadamardRotation {
         let signs2 = generate_signs(&mut rng, dim);
 
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|_| generate_permutation(&mut rng, dim));
+            std::array::from_fn(|_| Permutation::new(&mut rng, dim));
 
         Self {
             signs1,
@@ -39,14 +45,6 @@ impl HadamardRotation {
             dim,
             chunk_sizes,
         }
-    }
-
-    pub fn dim(&self) -> usize {
-        self.dim
-    }
-
-    pub fn chunk_sizes(&self) -> &[usize] {
-        &self.chunk_sizes
     }
 
     pub fn apply(&self, x: &[f32]) -> Vec<f32> {
@@ -65,8 +63,8 @@ impl HadamardRotation {
         let mut tmp = vec![0.0f64; buf.len()];
 
         // Permute then WHT+normalize for each permutation.
-        for perm in &self.permutations {
-            apply_permutation(&mut buf, &mut tmp, &perm.0);
+        for permutation in &self.permutations {
+            permutation.apply(&mut buf, &mut tmp, true);
             self.wht_normalized_chunks(&mut buf);
         }
 
@@ -92,8 +90,8 @@ impl HadamardRotation {
         let mut tmp = vec![0.0f64; buf.len()];
 
         // Apply inverse permutations backwards.
-        for perm in self.permutations.iter().rev() {
-            apply_permutation(&mut buf, &mut tmp, &perm.1);
+        for permutation in self.permutations.iter().rev() {
+            permutation.apply(&mut buf, &mut tmp, false);
             self.wht_normalized_chunks(&mut buf);
         }
 
@@ -140,15 +138,6 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
     }
 }
 
-/// Apply a permutation out-of-place: element at index `i` moves to `perm[i]`.
-pub fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
-    debug_assert_eq!(tmp.len(), buf.len());
-    for (i, &p) in perm.iter().enumerate() {
-        tmp[p] = buf[i];
-    }
-    buf.copy_from_slice(tmp);
-}
-
 /// Decompose `dim` into a sequence of decreasing power-of-2 chunk sizes
 /// that sum to exactly `dim`. No padding is needed.
 ///
@@ -181,7 +170,7 @@ pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
 }
 
 /// Generate a random sign vector (±1.0).
-pub fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
+fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
     (0..n)
         .map(|_| {
             if rng.random::<bool>() {
@@ -191,20 +180,6 @@ pub fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
             }
         })
         .collect()
-}
-
-/// Generate a random permutation and its inverse using Fisher-Yates shuffle.
-pub fn generate_permutation(rng: &mut StdRng, n: usize) -> (Vec<usize>, Vec<usize>) {
-    let mut perm: Vec<usize> = (0..n).collect();
-    for i in (1..n).rev() {
-        let j = rng.random_range(0..=i);
-        perm.swap(i, j);
-    }
-    let mut inv = vec![0usize; n];
-    for (i, &p) in perm.iter().enumerate() {
-        inv[p] = i;
-    }
-    (perm, inv)
 }
 
 #[cfg(test)]
@@ -276,7 +251,7 @@ mod test {
 
             let stats_before = VectorStats::build(vectors.iter(), &params);
 
-            params.dim = rot.dim();
+            params.dim = rot.dim;
             let stats_after = VectorStats::build(rotated.iter(), &params);
 
             // Measure how uniform the per-dimension stddevs are by looking at

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -1,0 +1,324 @@
+#![allow(dead_code)]
+
+use rand::prelude::StdRng;
+use rand::{RngExt, SeedableRng};
+
+const N_PERMUTATIONS: usize = 3;
+
+/// Hadamard rotation implementation customized for TurboQuant.
+pub struct HadamardRotation {
+    signs1: Vec<f64>,
+    signs2: Vec<f64>,
+
+    permutations: [(Vec<usize>, Vec<usize>); N_PERMUTATIONS],
+
+    /// Rotated dimension.
+    padded_dim: usize,
+
+    /// Size of each chunk depending on the original dimension.
+    chunk_size: usize,
+}
+
+impl HadamardRotation {
+    pub fn new(seed: u64, dim: usize) -> Self {
+        let chunk_size = get_chunk_size(dim);
+        let padded_dim = compute_padded_dim(dim, chunk_size);
+
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let signs1 = generate_signs(&mut rng, padded_dim);
+        let signs2 = generate_signs(&mut rng, padded_dim);
+
+        let permutations: [_; N_PERMUTATIONS] =
+            std::array::from_fn(|_| generate_permutation(&mut rng, padded_dim));
+
+        Self {
+            signs1,
+            signs2,
+            permutations,
+            padded_dim,
+            chunk_size,
+        }
+    }
+
+    pub fn padded_dim(&self) -> usize {
+        self.padded_dim
+    }
+
+    pub fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    pub fn apply(&self, x: &[f32]) -> Vec<f32> {
+        debug_assert!(x.len() <= self.padded_dim);
+        // TODO: Can we use f32?
+
+        let mut buf = Vec::with_capacity(self.padded_dim);
+        buf.extend(x.iter().map(|&v| v as f64));
+        buf.resize(self.padded_dim, 0.0);
+
+        // Apply random signs
+        for (b, &s) in buf.iter_mut().zip(self.signs1.iter()) {
+            *b *= s;
+        }
+
+        // Apply hadamard
+        for chunk in buf.chunks_mut(self.chunk_size) {
+            in_place_walsh_hadamard_transform(chunk);
+        }
+
+        // Temp vector for `apply_permutation`.
+        let mut tmp = vec![0.0f64; buf.len()];
+
+        // Apply hadamard for each permutation.
+        for perm in &self.permutations {
+            apply_permutation(&mut buf, &mut tmp, &perm.0);
+            for chunk in buf.chunks_mut(self.chunk_size) {
+                in_place_walsh_hadamard_transform(chunk);
+            }
+        }
+
+        // Apply second random signs.
+        for (b, &s) in buf.iter_mut().zip(self.signs2.iter()) {
+            *b *= s;
+        }
+
+        buf.iter().map(|&v| v as f32).collect()
+    }
+
+    pub fn apply_inverse(&self, y: &[f32], original_dim: usize) -> Vec<f32> {
+        debug_assert!(original_dim <= self.padded_dim);
+        let mut buf = Vec::with_capacity(self.padded_dim);
+        buf.extend(y.iter().map(|&v| v as f64));
+        buf.resize(self.padded_dim, 0.0);
+
+        // Apply signs 2
+        for (b, &s) in buf.iter_mut().zip(self.signs2.iter()) {
+            *b *= s;
+        }
+
+        // First hadamard
+        for chunk in buf.chunks_mut(self.chunk_size) {
+            in_place_walsh_hadamard_transform(chunk);
+        }
+
+        // Temp vector for `apply_permutation`.
+        let mut tmp = vec![0.0f64; buf.len()];
+
+        // Apply permutations (backwards)
+        for perm in self.permutations.iter().rev() {
+            apply_permutation(&mut buf, &mut tmp, &perm.1);
+
+            for chunk in buf.chunks_mut(self.chunk_size) {
+                in_place_walsh_hadamard_transform(chunk);
+            }
+        }
+
+        // Apply signs 1
+        for (b, &s) in buf.iter_mut().zip(self.signs1.iter()) {
+            *b *= s;
+        }
+
+        buf[..original_dim].iter().map(|&v| v as f32).collect()
+    }
+}
+
+/// In-place normalized Walsh-Hadamard Transform in f64. Self-inverse: WHT(WHT(x)) = x.
+/// Input length must be a power of 2.
+pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
+    let n = x.len();
+    debug_assert!(n.is_power_of_two(), "WHT requires power-of-2 length");
+    let mut h = 1;
+    while h < n {
+        for i in (0..n).step_by(h * 2) {
+            for j in i..i + h {
+                let a = x[j];
+                let b = x[j + h];
+                x[j] = a + b;
+                x[j + h] = a - b;
+            }
+        }
+        h *= 2;
+    }
+    let norm = (n as f64).sqrt();
+    for val in x.iter_mut() {
+        *val /= norm;
+    }
+}
+
+/// Apply a permutation out-of-place: element at index `i` moves to `perm[i]`.
+pub fn apply_permutation(buf: &mut [f64], tmp: &mut [f64], perm: &[usize]) {
+    debug_assert_eq!(tmp.len(), buf.len());
+    for (i, &p) in perm.iter().enumerate() {
+        tmp[p] = buf[i];
+    }
+    buf.copy_from_slice(&tmp);
+}
+
+/// Round up to the nearest multiple of `chunk_size`.
+pub fn compute_padded_dim(dim: usize, chunk_size: usize) -> usize {
+    (dim + chunk_size - 1) / chunk_size * chunk_size
+}
+
+/// Pick a power-of-two chunk size for block-wise Hadamard rotation.
+/// Divides dim by 4 and rounds up to the next power of two, yielding ~3-5 chunks.
+///
+///  dim  | chunk | padded | #chunks | overhead
+/// ------|-------|--------|---------|----------
+///   128 |    32 |    128 |       4 |     0.0%
+///   300 |   128 |    384 |       3 |    28.0%
+///   384 |   128 |    384 |       3 |     0.0%
+///   768 |   256 |    768 |       3 |     0.0%
+///  1024 |   256 |   1024 |       4 |     0.0%
+///  1280 |   512 |   1536 |       3 |    20.0%
+///  1536 |   512 |   1536 |       3 |     0.0%
+///  3072 |  1024 |   3072 |       3 |     0.0%
+///  4096 |  1024 |   4096 |       4 |     0.0%
+pub fn get_chunk_size(dim: usize) -> usize {
+    (dim >> 2).next_power_of_two()
+}
+
+/// Generate a random sign vector (±1.0).
+pub fn generate_signs(rng: &mut StdRng, n: usize) -> Vec<f64> {
+    (0..n)
+        .map(|_| {
+            if rng.random::<bool>() {
+                1.0f64
+            } else {
+                -1.0f64
+            }
+        })
+        .collect()
+}
+
+/// Generate a random permutation and its inverse using Fisher-Yates shuffle.
+pub fn generate_permutation(rng: &mut StdRng, n: usize) -> (Vec<usize>, Vec<usize>) {
+    let mut perm: Vec<usize> = (0..n).collect();
+    for i in (1..n).rev() {
+        let j = rng.random_range(0..=i);
+        perm.swap(i, j);
+    }
+    let mut inv = vec![0usize; n];
+    for (i, &p) in perm.iter().enumerate() {
+        inv[p] = i;
+    }
+    (perm, inv)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_picking_chunk_size() {
+        for i in [5, 128, 129, 712, 1536] {
+            assert!(get_chunk_size(i).is_power_of_two());
+        }
+
+        assert_eq!(get_chunk_size(5), 1);
+        assert_eq!(get_chunk_size(100), 32);
+        assert_eq!(get_chunk_size(128), 32);
+        assert_eq!(get_chunk_size(129), 32);
+        assert_eq!(get_chunk_size(300), 128);
+        assert_eq!(get_chunk_size(712), 256);
+        assert_eq!(get_chunk_size(1536), 512);
+        assert_eq!(get_chunk_size(4096), 1024);
+    }
+
+    /// Test that Hadamard rotation spreads energy across dimensions,
+    /// reducing distortion in vectors where energy is concentrated.
+    #[test]
+    fn hadamard_reduces_distortion() {
+        use crate::VectorParameters;
+        use crate::vector_stats::VectorStats;
+
+        for dim in [100, 300, 384, 1024, 1586] {
+            let n_vectors = 200;
+            let rot = HadamardRotation::new(42, dim);
+
+            // Generate distorted vectors: energy concentrated in first few dims.
+            let mut rng = StdRng::seed_from_u64(42);
+            let vectors: Vec<Vec<f32>> = (0..n_vectors)
+                .map(|_| {
+                    (0..dim)
+                        .map(|d| {
+                            let scale = if d < 5 { 100.0 } else { 0.01 };
+                            rng.random_range(-1.0f32..1.0) * scale
+                        })
+                        .collect()
+                })
+                .collect();
+
+            let rotated: Vec<Vec<f32>> = vectors.iter().map(|v| rot.apply(v)).collect();
+
+            let mut params = VectorParameters {
+                dim,
+                distance_type: crate::DistanceType::Dot,
+                invert: false,
+                deprecated_count: None,
+            };
+
+            let stats_before = VectorStats::build(vectors.iter(), &params);
+
+            params.dim = rot.padded_dim;
+            let stats_after = VectorStats::build(rotated.iter(), &params);
+
+            // Measure how uniform the per-dimension stddevs are by looking at
+            // the ratio between max and min stddev across dimensions.
+            let stddevs_before: Vec<f32> = stats_before
+                .elements_stats
+                .iter()
+                .map(|s| s.stddev)
+                .collect();
+
+            let stddevs_after: Vec<f32> = stats_after
+                .elements_stats
+                .iter()
+                .map(|s| s.stddev)
+                .collect();
+
+            let ratio = |s: &[f32]| {
+                let max = s.iter().copied().fold(f32::MIN, f32::max);
+                let min = s.iter().copied().fold(f32::MAX, f32::min);
+                max / min
+            };
+
+            let ratio_before = ratio(&stddevs_before);
+            let ratio_after = ratio(&stddevs_after);
+
+            // Allow ratio to have a ratio of max 0.2% of the original ratio.
+            let allowed_ratio_ratio = 0.002;
+
+            // Before rotation: huge spread (some dims have 100x scale).
+            assert!(
+                ratio_before > 1000.0,
+                "expected distorted input, got ratio {ratio_before}"
+            );
+
+            // After rotation: stddevs should be much more uniform.
+            assert!(
+                ratio_after <= ratio_before * allowed_ratio_ratio,
+                "rotation didn't spread energy enough, stddev ratio {ratio_after} ({})",
+                ratio_after / ratio_before
+            );
+        }
+    }
+
+    #[test]
+    fn hadamard_roundtrip() {
+        for dim in [50, 127, 128, 500, 1024, 1025] {
+            let rot = HadamardRotation::new(42, dim);
+            let input: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.1).collect();
+            let transformed = rot.apply(&input);
+            let recovered = rot.apply_inverse(&transformed, dim);
+            for (a, b) in input.iter().zip(recovered.iter()) {
+                assert!(
+                    (a - b).abs() < 1e-5,
+                    "hadamard roundtrip failed: {} vs {}",
+                    a,
+                    b
+                );
+            }
+        }
+    }
+}

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -4,7 +4,10 @@ use crate::turboquant::permutation::Permutation;
 
 const N_PERMUTATIONS: usize = 3;
 
-/// Random seeds for Permutation. The values were picked arbitrarily, but they must not be changed.
+/// Random seeds for Permutation. The values were picked arbitrarily.
+///
+/// WARNING: DO NOT CHANGE THESE VALUES. They are baked into the encoding of every quantized vector.
+/// Changing them would silently corrupt all existing quantized vectors.
 const PERMUTATION_SEEDS: [u64; 3] = [654605292835415893, 8636605637963351413, 1775280196666917949];
 
 /// Hadamard rotation implementation customized for TurboQuant.
@@ -99,7 +102,10 @@ impl HadamardRotation {
 }
 
 /// In-place unnormalized Walsh-Hadamard Transform in f64.
+///
+/// The transform is its own inverse: calling it twice recovers the original data (up to a scale factor).
 /// Normalization is applied externally in `apply`/`apply_inverse`.
+///
 /// Input length must be a power of 2.
 pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
     let n = x.len();
@@ -132,7 +138,7 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
 ///  1536 | [1024, 512]
 ///  4096 | [4096]
 /// ```
-pub fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
+fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
     debug_assert!(dim > 0);
     let mut sizes = Vec::with_capacity(dim.count_ones() as usize);
     let mut bits = dim;


### PR DESCRIPTION
Implements Hadamard rotation required for the TurboQuant implementation.


# Statistics
Below are two important statistics collected from dbpedia vectors, showing that the rotation from this PR properly relaxes the distributions.

## Energy distribution
Max component value of each vector. Rotated vectors are tightly clustered around 0.1, meaning that max values of the previously non-rotated vectors (blue) are properly distributed upon the other coordinates.

<img width="1750" height="1874" alt="image" src="https://github.com/user-attachments/assets/6e842f9d-99f4-414b-8d84-858f9dcbd6b1" />

## Excess Kurtosis

Measurement of how heavy-tailed / peaked the distribution of components is. Rotated vectors show a very small value, making the individual coordinates/components distribution much more uniform.

<img width="1802" height="1780" alt="image" src="https://github.com/user-attachments/assets/3c6e653d-1bc0-4f54-b739-48c752b2d8d8" />

# Performance
Performance of the current implementation (not vectorized with SIMD).

<img width="1200" height="750" alt="image" src="https://github.com/user-attachments/assets/0addc5e8-74db-42e0-ad2f-fbceeb356612" />