### PR TITLE
Add consistency to `test_resharding_deferred`

### DIFF
--- a/tests/consensus_tests/test_resharding_deferred.py
+++ b/tests/consensus_tests/test_resharding_deferred.py
@@ -307,8 +307,8 @@ def test_resharding_transfer_deferred_points(tmp_path: pathlib.Path, direction: 
                     }
                 },
             )
-        assert_http_ok(resp)
-        time.sleep(1)
+            assert_http_ok(resp)
+            time.sleep(1)
 
     # Complete resharding: commit hash rings and finish.
     resp = commit_read_hashring(peer_api_uris[0])

--- a/tests/consensus_tests/test_resharding_deferred.py
+++ b/tests/consensus_tests/test_resharding_deferred.py
@@ -308,7 +308,7 @@ def test_resharding_transfer_deferred_points(tmp_path: pathlib.Path, direction: 
                 },
             )
             assert_http_ok(resp)
-            time.sleep(1)
+        time.sleep(1)
 
     # Complete resharding: commit hash rings and finish.
     resp = commit_read_hashring(peer_api_uris[0])

--- a/tests/consensus_tests/test_resharding_deferred.py
+++ b/tests/consensus_tests/test_resharding_deferred.py
@@ -293,6 +293,22 @@ def test_resharding_transfer_deferred_points(tmp_path: pathlib.Path, direction: 
         )
         assert_http_ok(resp)
         time.sleep(1)
+    else:
+        # Without this, the replicas stays in "ReshardingScaleDown" state
+        for shard_id in range(target_shard_id):
+            peer_id, _ = find_replica(shard_id, info, peer_api_uris, peer_ids)
+
+            resp = requests.post(
+                f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster",
+                json={
+                    "finish_migrating_points": {
+                        "peer_id": peer_id,
+                        "shard_id": shard_id,
+                    }
+                },
+            )
+        assert_http_ok(resp)
+        time.sleep(1)
 
     # Complete resharding: commit hash rings and finish.
     resp = commit_read_hashring(peer_api_uris[0])


### PR DESCRIPTION
Add consistency to the `test_resharding_transfer_deferred_points` test, which puts shards in the `Active` state from the `ReshardingScaleDown` state