### PR TITLE
[IoUringReadIter] Buffer out-of-order items

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/read_iter.rs
+++ b/lib/common/common/src/universal_io/io_uring/read_iter.rs
@@ -2,12 +2,16 @@ use std::iter;
 use std::marker::PhantomData;
 
 use ::io_uring::types::Fd;
+use ahash::AHashMap;
 
 use super::*;
 
 pub struct IoUringReadIter<T: 'static, Meta, I: Iterator> {
     ranges: iter::Peekable<I>,
-    runtime: IoUringRuntime<'static, T, Meta>,
+    runtime: IoUringRuntime<'static, T, (usize, Meta)>,
+    next_submit_seq: usize,
+    next_seq: usize,
+    buffer: AHashMap<usize, (Meta, Vec<T>)>,
     _phantom: PhantomData<*const ()>, // `!Send + !Sync`
 }
 
@@ -20,6 +24,9 @@ where
         let iter = Self {
             ranges: ranges.peekable(),
             runtime: IoUringRuntime::new()?,
+            next_submit_seq: 0,
+            next_seq: 0,
+            buffer: Default::default(),
             _phantom: PhantomData,
         };
 
@@ -27,28 +34,45 @@ where
     }
 
     fn next_impl(&mut self) -> Result<Option<(Meta, Vec<T>)>> {
-        if self.runtime.completion_is_empty()
-            && (self.ranges.peek().is_some() || self.runtime.in_progress > 0)
-        {
+        loop {
+            // If the next expected item is already buffered, return it.
+            if let Some(item) = self.buffer.remove(&self.next_seq) {
+                self.next_seq += 1;
+                return Ok(Some(item));
+            }
+
+            // Nothing left to process — we're done.
+            if self.ranges.peek().is_none() && self.runtime.in_progress == 0 {
+                debug_assert!(self.buffer.is_empty());
+                return Ok(None);
+            }
+
+            // Saturate the submission queue with new requests.
             self.runtime.enqueue_while(|state| {
                 let Some((meta, fd, direct_io, range)) = self.ranges.next() else {
                     return Ok(None);
                 };
-                let entry = state.read(meta, fd, range, direct_io);
+                let seq = self.next_submit_seq;
+                self.next_submit_seq += 1;
+                let entry = state.read((seq, meta), fd, range, direct_io);
                 Ok(Some(entry))
             })?;
 
+            // Wait for at least one completion.
             self.runtime.submit_and_wait(1)?;
+
+            // Drain all available completions into the buffer.
+            for result in self.runtime.completed() {
+                let ((seq, meta), resp) = result?;
+                if seq == self.next_seq {
+                    // This is the next expected item, return it immediately.
+                    self.next_seq += 1;
+                    return Ok(Some((meta, resp.expect_read())));
+                } else {
+                    self.buffer.insert(seq, (meta, resp.expect_read()));
+                }
+            }
         }
-
-        let next = self
-            .runtime
-            .completed()
-            .next()
-            .transpose()?
-            .map(|(meta, resp)| (meta, resp.expect_read()));
-
-        Ok(next)
     }
 }
 

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -27,8 +27,8 @@ impl<'data, T, Meta> IoUringRuntime<'data, T, Meta> {
         Ok(rt)
     }
 
-    /// Push entries into Submission Queue while `entries` returns `Ok(Something)`
-    /// or the queue is full.
+    /// Push entries into Submission Queue while `entries` returns `Ok(Some(thing))`
+    /// or until the queue is full.
     pub fn enqueue_while<F>(&mut self, mut entries: F) -> Result<()>
     where
         F: FnMut(&mut IoUringState<'data, T, Meta>) -> Result<Option<squeue::Entry>>,
@@ -48,10 +48,6 @@ impl<'data, T, Meta> IoUringRuntime<'data, T, Meta> {
         }
 
         Ok(())
-    }
-
-    pub fn completion_is_empty(&mut self) -> bool {
-        self.io_uring.completion().is_empty()
     }
 
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {


### PR DESCRIPTION
**Disclaimer**: I know I know. We want to reduce the number of allocations as much as possible. This PR introduces a bit of overhead by using a hashmap as buffer, but I don't think it is that bad because:
- Shares the same hashmap for the iterator, so no new allocations unless we grow it.
- Uring already allocates a vector, in this case we are moving the pointer to the hashmap (I think?).
- Even though we are introducing hashing, the hashed type is `usize`, so should be quick, and IO costs a lot more anyway.

Returning things out-of-order makes handling the iterator a lot more complex ([example](https://github.com/qdrant/qdrant/pull/8507/changes#diff-1eb15cd42d6e7ef826b617ff2534202007c861edbe53969478b6828d5bd970bcR444-R532)), and makes users of UniversalRead iterator having to handle the special case of IoUring for every case.

For iterators, we almost always have to wait until the next sequential item, even if we are capable of processing others in the meantime. So I think there is no big benefit of complicating the callsites everywhere, when we can contain it to the read iterator itself.

This PR ensures items are in order by:
- always draining the completion queue.
- checking if the next sequential item is there.
- saturating the submission queue with more items.
