### PR TITLE
[UIO] BufferedUpdateBitSlice

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -196,7 +196,7 @@ name = "in_memory_id_tracker"
 harness = false
 
 [[bench]]
-name = "mmap_bitslice_buffered_update_wrapper"
+name = "buffered_update_bitslice"
 harness = false
 
 [[bench]]

--- a/lib/segment/benches/buffered_update_bitslice.rs
+++ b/lib/segment/benches/buffered_update_bitslice.rs
@@ -6,7 +6,7 @@ use common::universal_io::OpenOptions;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::prelude::*;
 use rand::rngs::StdRng;
-use segment::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use segment::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use segment::common::stored_bitslice::MmapBitSlice;
 use tempfile::tempdir;
 
@@ -14,10 +14,10 @@ const SIZE: usize = 4 * 1024 * 1024;
 const FLAG_COUNT: usize = 1_000_000;
 const LOOKUP_COUNT: usize = 1_000_000;
 
-fn mmap_bitslice_buffered_update_wrapper(c: &mut Criterion) {
+fn buffered_update_bitslice(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let dir = tempdir().unwrap();
-    let path = dir.path().join("bitslice.mmap");
+    let path = dir.path().join("bitslice.bin");
 
     let _ = create_and_ensure_length(
         &path,
@@ -27,17 +27,15 @@ fn mmap_bitslice_buffered_update_wrapper(c: &mut Criterion) {
     .unwrap();
 
     let bitslice_storage = MmapBitSlice::open(&path, OpenOptions::default()).unwrap();
-    let mmap_bitslice_buffered_update_wrapper =
-        MmapBitSliceBufferedUpdateWrapper::new(bitslice_storage);
+    let buffered_update_bitslice = BufferedUpdateBitSlice::new(bitslice_storage);
 
     // Set random flags and persist
     for _ in 0..FLAG_COUNT {
-        mmap_bitslice_buffered_update_wrapper
-            .set(rng.random::<u64>() as usize % SIZE, rng.random());
+        buffered_update_bitslice.set(rng.random::<u64>() as usize % SIZE, rng.random());
     }
-    mmap_bitslice_buffered_update_wrapper.flusher()().unwrap();
+    buffered_update_bitslice.flusher()().unwrap();
 
-    let mut group = c.benchmark_group("mmap-bitslice-buffered-update-wrapper");
+    let mut group = c.benchmark_group("buffered-update-bitslice");
 
     let lookups: Vec<_> = iter::repeat_with(|| rng.random::<u64>() as usize % SIZE)
         .take(LOOKUP_COUNT)
@@ -46,21 +44,20 @@ fn mmap_bitslice_buffered_update_wrapper(c: &mut Criterion) {
     group.bench_function("lookup-without-pending-changes", |b| {
         b.iter(|| {
             for lookup in &lookups {
-                black_box(mmap_bitslice_buffered_update_wrapper.get(*lookup).unwrap());
+                black_box(buffered_update_bitslice.get(*lookup).unwrap());
             }
         });
     });
 
     // Set random flags and keep them in pending changes list
     for _ in 0..FLAG_COUNT {
-        mmap_bitslice_buffered_update_wrapper
-            .set(rng.random::<u64>() as usize % SIZE, rng.random());
+        buffered_update_bitslice.set(rng.random::<u64>() as usize % SIZE, rng.random());
     }
 
     group.bench_function("lookup-with-pending-changes", |b| {
         b.iter(|| {
             for lookup in &lookups {
-                black_box(mmap_bitslice_buffered_update_wrapper.get(*lookup).unwrap());
+                black_box(buffered_update_bitslice.get(*lookup).unwrap());
             }
         });
     });
@@ -69,7 +66,7 @@ fn mmap_bitslice_buffered_update_wrapper(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = mmap_bitslice_buffered_update_wrapper
+    targets = buffered_update_bitslice
 }
 
 criterion_main!(benches);

--- a/lib/segment/src/common/buffered_update_bitslice.rs
+++ b/lib/segment/src/common/buffered_update_bitslice.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use common::universal_io::UniversalWrite;
 use itertools::Itertools;
 use parking_lot::RwLock;
 
@@ -12,7 +13,7 @@ use crate::common::stored_bitslice::MmapBitSlice;
 /// until they get flushed manually.
 /// This expects the underlying storage not to grow in size.
 #[derive(Debug)]
-pub struct MmapBitSliceBufferedUpdateWrapper {
+pub struct BufferedUpdateBitSlice {
     bitslice: Arc<RwLock<MmapBitSlice>>,
     len: usize,
     pending_updates: Arc<RwLock<AHashMap<usize, bool>>>,
@@ -20,7 +21,7 @@ pub struct MmapBitSliceBufferedUpdateWrapper {
     is_alive_flush_lock: common::is_alive_lock::IsAliveLock,
 }
 
-impl MmapBitSliceBufferedUpdateWrapper {
+impl BufferedUpdateBitSlice {
     pub fn new(bitslice: MmapBitSlice) -> Self {
         let len = bitslice.bit_len() as usize;
         Self {

--- a/lib/segment/src/common/buffered_update_bitslice.rs
+++ b/lib/segment/src/common/buffered_update_bitslice.rs
@@ -7,22 +7,22 @@ use parking_lot::RwLock;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::common::stored_bitslice::MmapBitSlice;
+use crate::common::stored_bitslice::StoredBitSlice;
 
-/// A wrapper around [`MmapBitSliceStorage`] that delays writing changes to the underlying file
+/// A wrapper around [`StoredBitSlice`] that delays writing changes to the underlying storage
 /// until they get flushed manually.
 /// This expects the underlying storage not to grow in size.
 #[derive(Debug)]
-pub struct BufferedUpdateBitSlice {
-    bitslice: Arc<RwLock<MmapBitSlice>>,
+pub struct BufferedUpdateBitSlice<S> {
+    bitslice: Arc<RwLock<StoredBitSlice<S>>>,
     len: usize,
     pending_updates: Arc<RwLock<AHashMap<usize, bool>>>,
     /// Lock to prevent concurrent flush and drop
     is_alive_flush_lock: common::is_alive_lock::IsAliveLock,
 }
 
-impl BufferedUpdateBitSlice {
-    pub fn new(bitslice: MmapBitSlice) -> Self {
+impl<S: UniversalWrite<u64> + Send + Sync + 'static> BufferedUpdateBitSlice<S> {
+    pub fn new(bitslice: StoredBitSlice<S>) -> Self {
         let len = bitslice.bit_len() as usize;
         Self {
             bitslice: Arc::new(RwLock::new(bitslice)),
@@ -110,9 +110,9 @@ impl BufferedUpdateBitSlice {
                 pending_updates_weak.upgrade(),
             ) else {
                 // Already dropped, skip flush
-                log::trace!("MmapBitsliceBuffered was dropped, cancelling flush");
+                log::trace!("BufferedUpdateBitSlice was dropped, cancelling flush");
                 return Err(OperationError::cancelled(
-                    "Aborted flushing on a dropped MmapBitSliceBufferedUpdateWrapper instance",
+                    "Aborted flushing on a dropped BufferedUpdateBitSlice instance",
                 ));
             };
 

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -1,9 +1,9 @@
 pub mod anonymize;
+pub mod buffered_update_bitslice;
 pub mod error_logging;
 pub mod flags;
 pub mod macros;
 pub mod memory_usage;
-pub mod mmap_bitslice_buffered_update_wrapper;
 pub mod operation_error;
 pub mod operation_time_statistics;
 pub mod reciprocal_rank_fusion;

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -57,7 +57,7 @@ impl ExternalIdType {
 pub struct ImmutableIdTracker {
     path: PathBuf,
 
-    deleted_wrapper: BufferedUpdateBitSlice,
+    deleted_wrapper: BufferedUpdateBitSlice<MmapFile>,
 
     internal_to_version: CompressedVersions,
     internal_to_version_wrapper: SliceBufferedUpdateWrapper<MmapFile, SeqNumberType>,

--- a/lib/segment/src/id_tracker/immutable_id_tracker.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker.rs
@@ -13,7 +13,7 @@ use fs_err::File;
 use uuid::Uuid;
 
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
@@ -57,7 +57,7 @@ impl ExternalIdType {
 pub struct ImmutableIdTracker {
     path: PathBuf,
 
-    deleted_wrapper: MmapBitSliceBufferedUpdateWrapper,
+    deleted_wrapper: BufferedUpdateBitSlice,
 
     internal_to_version: CompressedVersions,
     internal_to_version_wrapper: SliceBufferedUpdateWrapper<MmapFile, SeqNumberType>,
@@ -273,7 +273,7 @@ impl ImmutableIdTracker {
         let mut deleted_bitvec = BitVec::new();
         deleted_bitvec.extend_from_bitslice(deleted_storage.read_all()?.as_ref());
 
-        let deleted_wrapper = MmapBitSliceBufferedUpdateWrapper::new(deleted_storage);
+        let deleted_wrapper = BufferedUpdateBitSlice::new(deleted_storage);
 
         let internal_to_version_file = TypedStorage::<MmapFile, SeqNumberType>::open(
             Self::version_mapping_file_path(segment_path),
@@ -334,7 +334,7 @@ impl ImmutableIdTracker {
 
         deleted_storage.flusher()()?;
 
-        let deleted_wrapper = MmapBitSliceBufferedUpdateWrapper::new(deleted_storage);
+        let deleted_wrapper = BufferedUpdateBitSlice::new(deleted_storage);
 
         // Create mmap file for internal-to-version list
         let version_filepath = Self::version_mapping_file_path(path);

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -19,7 +19,7 @@ use super::postings_iterator::{
 };
 use super::{InvertedIndex, ParsedQuery, TokenId, TokenSet};
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
 use crate::index::field_index::full_text_index::inverted_index::Document;
@@ -48,7 +48,7 @@ pub(in crate::index::field_index::full_text_index) struct Storage {
     pub(in crate::index::field_index::full_text_index) vocab: MmapHashMap<str, TokenId>,
     pub(in crate::index::field_index::full_text_index) point_to_tokens_count: MmapSlice<usize>,
     pub(in crate::index::field_index::full_text_index) deleted_points:
-        MmapBitSliceBufferedUpdateWrapper,
+        BufferedUpdateBitSlice,
 }
 
 impl MmapInvertedIndex {
@@ -151,7 +151,7 @@ impl MmapInvertedIndex {
             },
         )?;
         let num_deleted_points = deleted.count_ones()?;
-        let deleted_points = MmapBitSliceBufferedUpdateWrapper::new(deleted);
+        let deleted_points = BufferedUpdateBitSlice::new(deleted);
         let points_count = point_to_tokens_count.len() - num_deleted_points;
 
         Ok(Some(Self {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::{self, AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::mmap_hashmap::{MmapHashMap, READ_ENTRY_OVERHEAD};
 use common::types::PointOffsetType;
-use common::universal_io::OpenOptions;
+use common::universal_io::{MmapFile, OpenOptions};
 use itertools::Either;
 use mmap_postings::{MmapPostingValue, MmapPostings};
 
@@ -48,7 +48,7 @@ pub(in crate::index::field_index::full_text_index) struct Storage {
     pub(in crate::index::field_index::full_text_index) vocab: MmapHashMap<str, TokenId>,
     pub(in crate::index::field_index::full_text_index) point_to_tokens_count: MmapSlice<usize>,
     pub(in crate::index::field_index::full_text_index) deleted_points:
-        BufferedUpdateBitSlice,
+        BufferedUpdateBitSlice<MmapFile>,
 }
 
 impl MmapInvertedIndex {

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -98,7 +98,7 @@ pub(super) struct Storage<S: StoredGeoMapIndexStorage> {
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
     pub(super) point_to_values: StoredPointToValues<GeoPoint, S>,
     /// Deleted flags for each PointOffsetType
-    pub(super) deleted: BufferedUpdateBitSlice,
+    pub(super) deleted: BufferedUpdateBitSlice<MmapFile>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use super::mutable_geo_index::InMemoryGeoMapIndex;
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
 use crate::index::field_index::geo_hash::{GeoHash, GeoHashRaw};
@@ -98,7 +98,7 @@ pub(super) struct Storage<S: StoredGeoMapIndexStorage> {
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
     pub(super) point_to_values: StoredPointToValues<GeoPoint, S>,
     /// Deleted flags for each PointOffsetType
-    pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
+    pub(super) deleted: BufferedUpdateBitSlice,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -269,7 +269,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                 points_map,
                 points_map_ids,
                 point_to_values,
-                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                deleted: BufferedUpdateBitSlice::new(deleted),
             },
             deleted_count,
             points_values_count: stats.points_values_count,

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -38,7 +38,7 @@ pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
 pub(super) struct Storage<N: MapIndexKey + Key + ?Sized> {
     pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
     point_to_values: StoredPointToValues<N, MmapFile>,
-    pub(super) deleted: BufferedUpdateBitSlice,
+    pub(super) deleted: BufferedUpdateBitSlice<MmapFile>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{IdIter, MapIndexKey};
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
 use crate::index::field_index::stored_point_to_values::StoredPointToValues;
@@ -38,7 +38,7 @@ pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
 pub(super) struct Storage<N: MapIndexKey + Key + ?Sized> {
     pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
     point_to_values: StoredPointToValues<N, MmapFile>,
-    pub(super) deleted: MmapBitSliceBufferedUpdateWrapper,
+    pub(super) deleted: BufferedUpdateBitSlice,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,7 +79,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             storage: Storage {
                 value_to_points: hashmap,
                 point_to_values,
-                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                deleted: BufferedUpdateBitSlice::new(deleted),
             },
             deleted_count,
             total_key_value_pairs: config.total_key_value_pairs,

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use super::Encodable;
 use super::mutable_numeric_index::InMemoryNumericIndex;
 use crate::common::Flusher;
-use crate::common::mmap_bitslice_buffered_update_wrapper::MmapBitSliceBufferedUpdateWrapper;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::stored_bitslice::MmapBitSlice;
 use crate::index::field_index::histogram::{Histogram, Numericable, Point};
@@ -40,7 +40,7 @@ pub(super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
     S: UniversalRead<u8>,
 > {
-    deleted: MmapBitSliceBufferedUpdateWrapper,
+    deleted: BufferedUpdateBitSlice,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pairs: MmapSlice<Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,
@@ -53,7 +53,7 @@ struct MmapNumericIndexConfig {
 
 pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
     pairs: &'a [Point<T>],
-    deleted: &'a MmapBitSliceBufferedUpdateWrapper,
+    deleted: &'a BufferedUpdateBitSlice,
     start_index: usize,
     end_index: usize,
 }
@@ -187,7 +187,7 @@ impl<T: Encodable + Numericable + Default + StoredValue> MmapNumericIndex<T> {
             path: path.to_path_buf(),
             storage: Storage {
                 pairs: map,
-                deleted: MmapBitSliceBufferedUpdateWrapper::new(deleted),
+                deleted: BufferedUpdateBitSlice::new(deleted),
                 point_to_values,
             },
             histogram,

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -40,7 +40,7 @@ pub(super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
     S: UniversalRead<u8>,
 > {
-    deleted: BufferedUpdateBitSlice,
+    deleted: BufferedUpdateBitSlice<MmapFile>,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pairs: MmapSlice<Point<T>>,
     pub(super) point_to_values: StoredPointToValues<T, S>,
@@ -53,7 +53,7 @@ struct MmapNumericIndexConfig {
 
 pub(super) struct NumericIndexPairsIterator<'a, T: Encodable + Numericable> {
     pairs: &'a [Point<T>],
-    deleted: &'a BufferedUpdateBitSlice,
+    deleted: &'a BufferedUpdateBitSlice<MmapFile>,
     start_index: usize,
     end_index: usize,
 }


### PR DESCRIPTION
Migrates the usage of `MmapBitSliceBufferedUpdateWrapper` into `BufferedUpdateBitSlice`. 

The inner bitslice type that was used was already migrated, so this PR only renames and propagates the generic to the wrapper type.
