### PR TITLE
simplify uio geo index

### DIFF
--- a/lib/common/common/src/iterator_ext/mod.rs
+++ b/lib/common/common/src/iterator_ext/mod.rs
@@ -11,6 +11,7 @@ pub(super) mod on_final_count;
 
 mod check_stopped;
 mod fallible;
+pub mod ordering_iterator;
 pub mod stoppable_iter;
 
 pub use fallible::{FallibleIteratorExt, TransposeResultIter};

--- a/lib/common/common/src/iterator_ext/ordering_iterator.rs
+++ b/lib/common/common/src/iterator_ext/ordering_iterator.rs
@@ -1,0 +1,263 @@
+use std::collections::BTreeMap;
+use std::convert::Infallible;
+
+/// Trait that abstracts over the item type of [`OrderingIterator`], allowing it
+/// to accept both plain `(usize, T)` items and `Result<(usize, T), E>` items
+/// from a single implementation.
+///
+/// Errors produced by the upstream iterator bypass the ordering buffer and are
+/// forwarded immediately in the order they were observed.
+pub trait OrderedItem: Sized {
+    type Value;
+    type Error;
+
+    fn split(self) -> Result<(usize, Self::Value), Self::Error>;
+    fn from_value(idx: usize, value: Self::Value) -> Self;
+    fn from_error(error: Self::Error) -> Self;
+}
+
+impl<T> OrderedItem for (usize, T) {
+    type Value = T;
+    type Error = Infallible;
+
+    fn split(self) -> Result<(usize, T), Infallible> {
+        Ok(self)
+    }
+
+    fn from_value(idx: usize, value: T) -> Self {
+        (idx, value)
+    }
+
+    fn from_error(error: Infallible) -> Self {
+        match error {}
+    }
+}
+
+impl<T, E> OrderedItem for Result<(usize, T), E> {
+    type Value = T;
+    type Error = E;
+
+    fn split(self) -> Result<(usize, T), E> {
+        self
+    }
+
+    fn from_value(idx: usize, value: T) -> Self {
+        Ok((idx, value))
+    }
+
+    fn from_error(error: E) -> Self {
+        Err(error)
+    }
+}
+
+/// An iterator adapter that takes an iterator of `(idx: usize, element: T)`
+/// items — optionally wrapped in `Result` — and yields them in order of
+/// ascending `idx`, starting from `0`.
+///
+/// This is useful when the incoming iterator has local ordering inconsistencies
+/// but does not require the whole iterator to be consumed before emitting the
+/// first result.
+///
+/// Out-of-order elements are buffered in a [`BTreeMap`] until their turn comes.
+/// If there are gaps in the id sequence (missing ids), the iterator skips over
+/// them once it has confirmed the gap by exhausting its input, advancing to the
+/// next smallest buffered id.
+///
+/// If the upstream iterator yields errors (i.e. `Item = Result<_, _>`), the
+/// errors are forwarded immediately in the order they were observed and do not
+/// participate in the ordering.
+///
+/// The input ids are assumed to be unique; behavior is unspecified if the same
+/// id is produced more than once.
+pub struct OrderingIterator<I>
+where
+    I: Iterator,
+    I::Item: OrderedItem,
+{
+    iter: I,
+    next_id: usize,
+    buffer: BTreeMap<usize, <I::Item as OrderedItem>::Value>,
+}
+
+impl<I> OrderingIterator<I>
+where
+    I: Iterator,
+    I::Item: OrderedItem,
+{
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            next_id: 0,
+            buffer: BTreeMap::new(),
+        }
+    }
+}
+
+impl<I> Iterator for OrderingIterator<I>
+where
+    I: Iterator,
+    I::Item: OrderedItem,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(value) = self.buffer.remove(&self.next_id) {
+                let idx = self.next_id;
+                self.next_id += 1;
+                return Some(I::Item::from_value(idx, value));
+            }
+
+            let Some(item) = self.iter.next() else {
+                // Upstream iterator is exhausted: drain the buffer in ascending
+                // order, skipping over any gaps between ids.
+                let (idx, value) = self.buffer.pop_first()?;
+                self.next_id = idx + 1;
+                return Some(I::Item::from_value(idx, value));
+            };
+
+            match item.split() {
+                Ok((idx, value)) => {
+                    if idx == self.next_id {
+                        self.next_id += 1;
+                        return Some(I::Item::from_value(idx, value));
+                    }
+                    self.buffer.insert(idx, value);
+                }
+                Err(error) => {
+                    return Some(I::Item::from_error(error));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect<I: IntoIterator<Item = (usize, char)>>(input: I) -> Vec<(usize, char)> {
+        OrderingIterator::new(input.into_iter()).collect()
+    }
+
+    fn collect_res<I, E>(input: I) -> Vec<Result<(usize, char), E>>
+    where
+        I: IntoIterator<Item = Result<(usize, char), E>>,
+    {
+        OrderingIterator::new(input.into_iter()).collect()
+    }
+
+    #[test]
+    fn already_ordered() {
+        let input = vec![(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd')];
+        assert_eq!(collect(input), vec![(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd')],);
+    }
+
+    #[test]
+    fn reversed() {
+        let input = vec![(3, 'd'), (2, 'c'), (1, 'b'), (0, 'a')];
+        assert_eq!(collect(input), vec![(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd')],);
+    }
+
+    #[test]
+    fn shuffled() {
+        let input = vec![(2, 'c'), (0, 'a'), (3, 'd'), (1, 'b')];
+        assert_eq!(collect(input), vec![(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd')],);
+    }
+
+    #[test]
+    fn drains_buffer_after_exhaustion() {
+        let input = vec![(0, 'a'), (3, 'd'), (2, 'c'), (1, 'b')];
+        assert_eq!(collect(input), vec![(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd')],);
+    }
+
+    #[test]
+    fn empty() {
+        let input: Vec<(usize, char)> = vec![];
+        assert!(collect(input).is_empty());
+    }
+
+    #[test]
+    fn single_element() {
+        assert_eq!(collect(vec![(0, 'a')]), vec![(0, 'a')]);
+    }
+
+    #[test]
+    fn does_not_start_at_zero() {
+        let input = vec![(5, 'a'), (6, 'b'), (7, 'c')];
+        assert_eq!(collect(input), vec![(5, 'a'), (6, 'b'), (7, 'c')],);
+    }
+
+    #[test]
+    fn large_gap_in_the_middle() {
+        let input = vec![(0, 'a'), (1, 'b'), (1_000_000, 'c'), (1_000_001, 'd')];
+        assert_eq!(
+            collect(input),
+            vec![(0, 'a'), (1, 'b'), (1_000_000, 'c'), (1_000_001, 'd')],
+        );
+    }
+
+    #[test]
+    fn large_gap_with_local_disorder() {
+        let input = vec![
+            (1000, 'b'),
+            (1, 'a'),
+            (1_000_001, 'd'),
+            (1_000_000, 'c'),
+            (2_000_000, 'e'),
+        ];
+        assert_eq!(
+            collect(input),
+            vec![
+                (1, 'a'),
+                (1000, 'b'),
+                (1_000_000, 'c'),
+                (1_000_001, 'd'),
+                (2_000_000, 'e'),
+            ],
+        );
+    }
+
+    #[test]
+    fn multiple_gaps() {
+        let input = vec![(0, 'a'), (10, 'b'), (20, 'c'), (21, 'd'), (30, 'e')];
+        assert_eq!(
+            collect(input),
+            vec![(0, 'a'), (10, 'b'), (20, 'c'), (21, 'd'), (30, 'e')],
+        );
+    }
+
+    #[test]
+    fn result_items_reordered() {
+        let input: Vec<Result<(usize, char), &str>> =
+            vec![Ok((2, 'c')), Ok((0, 'a')), Ok((3, 'd')), Ok((1, 'b'))];
+        assert_eq!(
+            collect_res(input),
+            vec![Ok((0, 'a')), Ok((1, 'b')), Ok((2, 'c')), Ok((3, 'd'))],
+        );
+    }
+
+    #[test]
+    fn result_items_error_passes_through_in_observed_order() {
+        // Errors are yielded immediately and do not participate in reordering.
+        // The Ok items are still reordered around them.
+        let input: Vec<Result<(usize, char), &str>> =
+            vec![Ok((1, 'b')), Err("boom"), Ok((0, 'a')), Ok((2, 'c'))];
+        assert_eq!(
+            collect_res(input),
+            vec![Err("boom"), Ok((0, 'a')), Ok((1, 'b')), Ok((2, 'c'))],
+        );
+    }
+
+    #[test]
+    fn result_items_error_before_ready_value() {
+        // The error is observed while we're still buffering; it should be
+        // yielded as soon as it's seen, then ordering resumes.
+        let input: Vec<Result<(usize, char), i32>> =
+            vec![Ok((2, 'c')), Err(42), Ok((0, 'a')), Ok((1, 'b'))];
+        assert_eq!(
+            collect_res(input),
+            vec![Err(42), Ok((0, 'a')), Ok((1, 'b')), Ok((2, 'c'))],
+        );
+    }
+}

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -43,43 +43,6 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
             .map(move |(meta, range)| self.read::<P>(range).map(|data| (meta, data))))
     }
 
-    /// Iterates over the provided ranges, reading a few elements at a time,
-    /// but returning in a per-element basis.
-    ///
-    /// The provided ranges can span many elements, they will be auto-chunked
-    /// by this function to ensure each read is not too big. The argument is an
-    /// iterator just so that it is possible to read from non-contiguous regions
-    /// in the same output iterator.
-    fn read_iter_autobatched(
-        &self,
-        ranges: impl IntoIterator<Item = ReadRange>,
-    ) -> Result<impl Iterator<Item = Result<T>>> {
-        let ranges = ranges
-            .into_iter()
-            .flat_map(|range| range.iter_autochunks::<T>())
-            .map(|chunk| ((), chunk));
-        let mut iter = self.read_iter::<Sequential, _>(ranges)?;
-        let mut current_chunk: Cow<'_, [T]> = Cow::Borrowed(&[]);
-        let mut current_chunk_pos = 0;
-        Ok(std::iter::from_fn(move || {
-            loop {
-                if current_chunk_pos < current_chunk.len() {
-                    let pos = current_chunk_pos;
-                    current_chunk_pos += 1;
-                    return Some(Ok(current_chunk[pos]));
-                }
-                match iter.next() {
-                    Some(Ok(((), next_chunk))) => {
-                        current_chunk = next_chunk;
-                        current_chunk_pos = 0;
-                    }
-                    Some(Err(e)) => return Some(Err(e)),
-                    None => return None,
-                }
-            }
-        }))
-    }
-
     fn len(&self) -> Result<u64>;
 
     /// Fill RAM cache with related data, if applicable for this implementation.

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -156,7 +156,7 @@ impl PayloadFieldIndex for BoolIndex {
         &'a self,
         condition: &'a crate::types::FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         match self {
             BoolIndex::Mmap(index) => index.filter(condition, hw_counter),
         }
@@ -317,8 +317,8 @@ mod tests {
         let count = index
             .filter(&match_bool(match_on), &hw_counter)
             .unwrap()
-            .process_results(|it| it.count())
-            .unwrap();
+            .unwrap()
+            .count();
 
         assert_eq!(count, expected_count);
     }
@@ -378,14 +378,14 @@ mod tests {
         let point_offsets = new_index
             .filter(&match_bool(false), &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![1, 2, 3, 5, 6, 10]);
 
         let point_offsets = new_index
             .filter(&match_bool(true), &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![0, 2, 3, 4, 6, 11]);
 
@@ -415,7 +415,7 @@ mod tests {
         let point_offsets = index
             .filter(&match_bool(false), &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![idx]);
 
@@ -424,13 +424,13 @@ mod tests {
         let point_offsets = index
             .filter(&match_bool(true), &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![idx]);
         let point_offsets = index
             .filter(&match_bool(false), &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert!(point_offsets.is_empty());
     }

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -392,7 +392,7 @@ impl PayloadFieldIndex for MutableBoolIndex {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         match &condition.r#match {
             Some(Match::Value(MatchValue {
                 value: ValueVariants::Bool(value),
@@ -405,11 +405,10 @@ impl PayloadFieldIndex for MutableBoolIndex {
                         hw_counter.new_accumulator(),
                         u8::BITS as usize,
                         |i| i.payload_index_io_read_counter(),
-                    )
-                    .map(Ok);
-                Some(Box::new(iter))
+                    );
+                Ok(Some(Box::new(iter)))
             }
-            _ => None,
+            _ => Ok(None),
         }
     }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -52,7 +52,7 @@ pub trait PayloadFieldIndex {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>>;
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
 
     /// Return estimation of amount of points which satisfy given condition.
     /// Returns `Ok(None)` if the condition does not match the index type
@@ -245,7 +245,7 @@ impl FieldIndex {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         self.get_payload_field_index().filter(condition, hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -262,11 +262,11 @@ impl InvertedIndex for ImmutableInvertedIndex {
         &'a self,
         query: ParsedQuery,
         _hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match query {
-            ParsedQuery::AllTokens(tokens) => Box::new(self.filter_has_all(tokens).map(Ok)),
-            ParsedQuery::Phrase(tokens) => Box::new(self.filter_has_phrase(tokens).map(Ok)),
-            ParsedQuery::AnyTokens(tokens) => Box::new(self.filter_has_any(tokens).map(Ok)),
+            ParsedQuery::AllTokens(tokens) => Ok(Box::new(self.filter_has_all(tokens))),
+            ParsedQuery::Phrase(tokens) => Ok(Box::new(self.filter_has_phrase(tokens))),
+            ParsedQuery::AnyTokens(tokens) => Ok(Box::new(self.filter_has_any(tokens))),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -189,7 +189,7 @@ impl MmapInvertedIndex {
     pub fn filter_has_all<'a>(
         &'a self,
         tokens: TokenSet,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         // in case of mmap immutable index, deleted points are still in the postings
         let filter = move |idx| self.is_active(idx);
 
@@ -197,7 +197,7 @@ impl MmapInvertedIndex {
             postings: &'a MmapPostings<V>,
             tokens: TokenSet,
             filter: impl Fn(u32) -> bool + 'a,
-        ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+        ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
             let postings_opt: Option<Vec<_>> = tokens
                 .tokens()
                 .iter()
@@ -214,7 +214,10 @@ impl MmapInvertedIndex {
                 return Box::new(std::iter::empty());
             }
 
-            Box::new(intersect_compressed_postings_iterator(posting_readers, filter).map(Ok))
+            Box::new(intersect_compressed_postings_iterator(
+                posting_readers,
+                filter,
+            ))
         }
 
         match &self.storage.postings {
@@ -463,11 +466,11 @@ impl InvertedIndex for MmapInvertedIndex {
         &'a self,
         query: ParsedQuery,
         _hw_counter: &HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match query {
-            ParsedQuery::AllTokens(tokens) => self.filter_has_all(tokens),
-            ParsedQuery::Phrase(phrase) => Box::new(self.filter_has_phrase(phrase).map(Ok)),
-            ParsedQuery::AnyTokens(tokens) => Box::new(self.filter_has_any(tokens).map(Ok)),
+            ParsedQuery::AllTokens(tokens) => Ok(self.filter_has_all(tokens)),
+            ParsedQuery::Phrase(phrase) => Ok(Box::new(self.filter_has_phrase(phrase))),
+            ParsedQuery::AnyTokens(tokens) => Ok(Box::new(self.filter_has_any(tokens))),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -228,7 +228,7 @@ pub trait InvertedIndex {
         &'a self,
         query: ParsedQuery,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>;
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>>;
 
     fn get_posting_len(&self, token_id: TokenId, hw_counter: &HardwareCounterCell)
     -> Option<usize>;
@@ -711,15 +711,15 @@ mod tests {
             };
             let mut_filtered = mut_index
                 .filter(mut_query, hw_counter)
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect::<Vec<_>>();
             let imm_filtered = mmap_index
                 .filter(imm_query, hw_counter)
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect::<Vec<_>>();
             let imm_mmap_filtered = imm_mmap_index
                 .filter(imm_mmap_query, hw_counter)
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect::<Vec<_>>();
 
             assert_eq!(mut_filtered, imm_filtered);

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
@@ -214,11 +214,11 @@ impl InvertedIndex for MutableInvertedIndex {
         &self,
         query: ParsedQuery,
         _hw_counter: &HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + '_> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
         match query {
-            ParsedQuery::AllTokens(tokens) => Box::new(self.filter_has_all(tokens).map(Ok)),
-            ParsedQuery::Phrase(phrase) => Box::new(self.filter_has_phrase(phrase).map(Ok)),
-            ParsedQuery::AnyTokens(tokens) => Box::new(self.filter_has_any(tokens).map(Ok)),
+            ParsedQuery::AllTokens(tokens) => Ok(Box::new(self.filter_has_all(tokens))),
+            ParsedQuery::Phrase(phrase) => Ok(Box::new(self.filter_has_phrase(phrase))),
+            ParsedQuery::AnyTokens(tokens) => Ok(Box::new(self.filter_has_any(tokens))),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -351,7 +351,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![0, 4]);
 
@@ -359,7 +359,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![2]);
 
@@ -367,7 +367,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![4]);
 
@@ -379,7 +379,7 @@ mod tests {
                 index
                     .filter(&filter_condition, &hw_counter)
                     .unwrap()
-                    .map(|r| r.unwrap())
+                    .unwrap()
                     .next()
                     .is_none()
             );
@@ -417,7 +417,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![0]);
 
@@ -425,7 +425,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![0, 1, 3, 4]);
 
@@ -435,7 +435,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert!(search_res.is_empty());
             assert_eq!(index.count_indexed_points(), 3);
@@ -445,7 +445,7 @@ mod tests {
             let search_res: Vec<_> = index
                 .filter(&filter_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect();
             assert_eq!(search_res, vec![1, 4]);
             assert_eq!(index.count_indexed_points(), 2);

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -183,10 +183,7 @@ fn test_prefix_search() {
             .unwrap();
     }
 
-    let res: Vec<_> = index
-        .query("ROBO", &hw_counter)
-        .map(|r| r.unwrap())
-        .collect();
+    let res: Vec<_> = index.query("ROBO", &hw_counter).unwrap().collect();
 
     let query = index.parse_text_query("ROBO", &hw_counter).unwrap();
 
@@ -196,10 +193,7 @@ fn test_prefix_search() {
 
     assert_eq!(res.len(), 3);
 
-    let res: Vec<_> = index
-        .query("q231", &hw_counter)
-        .map(|r| r.unwrap())
-        .collect();
+    let res: Vec<_> = index.query("q231", &hw_counter).unwrap().collect();
     assert!(res.is_empty());
 
     assert!(index.parse_text_query("q231", &hw_counter).is_none());
@@ -265,7 +259,7 @@ fn test_phrase_matching() {
 
         let text_results: Vec<_> = index
             .filter_query(text_query, &hw_counter)
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
 
         // Should match documents 0, 1, and 2 (all contain "quick", "brown", "fox")
@@ -283,7 +277,7 @@ fn test_phrase_matching() {
 
         let phrase_results: Vec<_> = index
             .filter_query(phrase_query, &hw_counter)
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
 
         // Should only match documents 0 and 2 (contain "quick brown fox" in that exact order)
@@ -298,7 +292,7 @@ fn test_phrase_matching() {
             .unwrap();
         let missing_results: Vec<_> = index
             .filter_query(missing_query, &hw_counter)
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
 
         // Should match no documents (no document contains this exact phrase)
@@ -318,7 +312,7 @@ fn test_phrase_matching() {
         // Should only match document 4
         let filter_results: Vec<_> = index
             .filter_query(phrase_query, &hw_counter)
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
         assert_eq!(filter_results.len(), 1);
         assert!(filter_results.contains(&4));
@@ -388,7 +382,7 @@ fn test_ascii_folding_in_full_text_index_word() {
 
     let results_enabled: Vec<_> = index_enabled
         .filter_query(query_enabled, &hw_counter)
-        .map(|r| r.unwrap())
+        .unwrap()
         .collect();
     assert!(results_enabled.contains(&0));
 
@@ -397,7 +391,7 @@ fn test_ascii_folding_in_full_text_index_word() {
     if let Some(query_disabled) = query_disabled_opt {
         let results_disabled: Vec<_> = index_disabled
             .filter_query(query_disabled, &hw_counter)
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
         assert!(!results_disabled.contains(&0));
     }
@@ -407,7 +401,7 @@ fn test_ascii_folding_in_full_text_index_word() {
     assert!(index_enabled.check_match(&query_acento, 0));
     let results_acento: Vec<_> = index_enabled
         .filter_query(query_acento, &hw_counter)
-        .map(|r| r.unwrap())
+        .unwrap()
         .collect();
     assert!(results_acento.contains(&0));
 
@@ -416,7 +410,7 @@ fn test_ascii_folding_in_full_text_index_word() {
         .unwrap();
     let results_acento2: Vec<_> = index_disabled
         .filter_query(query_acento2, &hw_counter)
-        .map(|r| r.unwrap())
+        .unwrap()
         .collect();
     assert!(results_acento2.contains(&0));
 }

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -352,11 +352,11 @@ fn test_congruence(
             assert_eq!(
                 index_a
                     .filter_query(parsed_query_a, &hw_counter)
-                    .map(|r| r.unwrap())
+                    .unwrap()
                     .collect::<HashSet<_>>(),
                 index_b
                     .filter_query(parsed_query_b, &hw_counter)
-                    .map(|r| r.unwrap())
+                    .unwrap()
                     .collect::<HashSet<_>>(),
             );
         }
@@ -396,11 +396,11 @@ fn test_congruence(
                 assert_eq!(
                     index_a
                         .filter_query(parsed_query_a, &hw_counter)
-                        .map(|r| r.unwrap())
+                        .unwrap()
                         .collect::<HashSet<_>>(),
                     index_b
                         .filter_query(parsed_query_b, &hw_counter)
-                        .map(|r| r.unwrap())
+                        .unwrap()
                         .collect::<HashSet<_>>(),
                 );
             }
@@ -457,7 +457,7 @@ fn check_phrase<const KEYWORD_COUNT: usize>(
 
             let result = index
                 .filter_query(parsed_query, &hw_counter)
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect::<HashSet<_>>();
 
             assert!(!result.is_empty());

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -114,7 +114,7 @@ impl FullTextIndex {
         &'a self,
         query: ParsedQuery,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         match self {
             Self::Mutable(index) => index.inverted_index.filter(query, hw_counter),
             Self::Immutable(index) => index.inverted_index.filter(query, hw_counter),
@@ -303,9 +303,9 @@ impl FullTextIndex {
         &'a self,
         query: &'a str,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
         let Some(parsed_query) = self.parse_text_query(query, hw_counter) else {
-            return Box::new(std::iter::empty());
+            return Ok(Box::new(std::iter::empty()));
         };
         self.filter_query(parsed_query, hw_counter)
     }
@@ -478,20 +478,20 @@ impl PayloadFieldIndex for FullTextIndex {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         let parsed_query_opt = match &condition.r#match {
             Some(Match::Text(MatchText { text })) => self.parse_text_query(text, hw_counter),
             Some(Match::Phrase(MatchPhrase { phrase })) => {
                 self.parse_phrase_query(phrase, hw_counter)
             }
-            _ => return None,
+            _ => return Ok(None),
         };
 
         let Some(parsed_query) = parsed_query_opt else {
-            return Some(Box::new(std::iter::empty()));
+            return Ok(Some(Box::new(std::iter::empty())));
         };
 
-        Some(self.filter_query(parsed_query, hw_counter))
+        Ok(Some(self.filter_query(parsed_query, hw_counter)?))
     }
 
     fn estimate_cardinality(

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
-use std::iter::once;
 use std::path::{Path, PathBuf};
 
-use bitvec::vec::BitVec;
+use ahash::AHashSet;
 use common::binary_search::binary_search_by;
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::{atomic_save_json, read_json};
 use common::generic_consts::{Random, Sequential};
+use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
@@ -318,18 +318,20 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
 
     pub(super) fn points_per_hash(
         &self,
-    ) -> OperationResult<impl Iterator<Item = OperationResult<(GeoHash, usize)>> + '_> {
-        Ok(self
-            .storage
-            .counts_per_hash
-            .read_iter_autobatched(once(ReadRange {
-                byte_offset: 0,
-                length: self.storage.counts_per_hash.len()?,
-            }))?
-            .map(|c| match c {
-                Ok(c) => Ok((c.hash.normalize(), c.points as usize)),
-                Err(e) => Err(OperationError::from(e)),
-            }))
+        filter: impl Fn(&(GeoHash, usize)) -> bool,
+    ) -> OperationResult<Vec<(GeoHash, usize)>> {
+        let counts = self.storage.counts_per_hash.read::<Sequential>(ReadRange {
+            byte_offset: 0,
+            length: self.storage.counts_per_hash.len()?,
+        })?;
+        let mut results = Vec::with_capacity(counts.len());
+        for count in counts.iter() {
+            let pair = (count.hash.normalize(), count.points as usize);
+            if filter(&pair) {
+                results.push(pair);
+            }
+        }
+        Ok(results)
     }
 
     pub fn points_of_hash(
@@ -433,57 +435,56 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         }
     }
 
-    /// Returns an iterator over all point IDs which have the geohash prefix.
-    /// Note. Point ID may be repeated multiple times in the iterator.
-    pub(super) fn stored_sub_regions(
+    /// Return all unique point IDs which have any of the geo-hash prefixes.
+    pub(super) fn all_points(
         &self,
-        geohash_prefix: GeoHash,
-    ) -> OperationResult<impl Iterator<Item = OperationResult<PointOffsetType>> + '_> {
+        mut geo_hashes: Vec<GeoHash>,
+    ) -> OperationResult<AHashSet<PointOffsetType>> {
+        if geo_hashes.is_empty() {
+            return Ok(AHashSet::default());
+        }
+
         let len = self.storage.points_map.len()?;
 
-        // The `points_map` file is sorted by heohash. That means, we need to
-        // find this range `start..end`, where
-        // - `start` is the first entry which geohash is >= geohash_prefix.
-        // - `end` is the first entry past the start which geohash is not within
-        //    the geohash_prefix.
-        // 0                             start      end                    EOF
-        // ├───────────────────────────────┼─────────┼──────────────────────┤
-        // │<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<│.........│>>>>>>>>>>>>>>>>>>>>>>│
-        // │ entries < geohash_prefix      │ result  │ entries past the end │
-        // └───────────────────────────────┴─────────┴──────────────────────┘
+        geo_hashes.sort_unstable();
+        geo_hashes.dedup();
+        // Drop any prefix that is already subsumed by an earlier (shorter)
+        // one. After this pass the remaining prefixes are pairwise
+        // incomparable — no prefix is a prefix of another — so at most one of
+        // them can match any given entry.
+        geo_hashes.dedup_by(|later, earlier| later.starts_with(*earlier));
+
+        let smallest_hash = *geo_hashes.first().unwrap();
+
+        // The `points_map` file is sorted by geohash. We want to collect every
+        // entry whose hash has any of `geo_hashes` as a prefix. Since entries
+        // are sorted, the matching entries live between:
+        // - `start`: the first entry with geohash >= smallest_hash, and
+        // - `end`:   the first entry whose geohash is strictly greater than
+        //            the last prefix and is not covered by it.
+        //
+        // Non-matching entries may be interleaved with matching ones when
+        // multiple disjoint prefixes are requested, so we must check each
+        // entry individually instead of stopping at the first miss.
+        //
+        // 0                             start                end           EOF
+        // ├───────────────────────────────┼───────────────────┼─────────────┤
+        // │<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<│..m..m.mm.....m.mmm│>>>>>>>>>>>>>│
+        // │ entries < smallest_hash       │ m = matching      │ past end    │
+        // └───────────────────────────────┴───────────────────┴─────────────┘
 
         // Step 1: binary search to find the index of the `start` entry.
         let start_idx = binary_search_by(0..len, |idx| {
             let range = ReadRange::one(idx * size_of::<PointKeyValue>() as u64);
             let value = self.storage.points_map.read::<Random>(range)?;
-            OperationResult::Ok(value[0].hash.normalize().cmp(&geohash_prefix))
+            OperationResult::Ok(value[0].hash.normalize().cmp(&smallest_hash))
         })?
         .unwrap_or_else(|index| index);
 
-        // Step 2: Read entries in chunks starting from `start` until we stumble
-        // into a chunk with an `end` entry.
-        //
-        //     start                                 end
-        // ─────┬┴──────┬───────┬───────┬───────┬─────┴─┬───────┬───────┬───────
-        // …<<<<│.......│.......│.......│.......│.....>>│>>>>>>>│>>>>>>>│>>>>>>…
-        // ─────┴── 0 ──┴── 1 ──┴── 2 ──┴── 3 ──┴── 4 ──┴── 5 ──┴── 6 ──┴── 7 ──
-        //
-        // The problem is that UniversalRead iterator gives us chunks in an
-        // arbitrary order, and we don't know where `end` is.
-        // Suppose chunks arrived in this order:
-        //
-        // ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐
-        // │.......│ │>>>>>>>│ │.......│ │.....>>│ │.......│ │.......│ │>>>>>>>│
-        // └── 0 ──┘ └── 6 ──┘ └── 1 ──┘ └── 4 ──┘ └── 3 ──┘ └── 2 ──┘ └── 5 ──┘
-        //              (a)                 (b)                 (c)
-        //
-        // (a) When we see chunk 6, we know that it's past the end, but we still
-        //     need to wait for chunks 0..5 to be completed.
-        // (b) Similar, but now we know we need to wait for chunks 0..3.
-        // (c) Only at this point we received all "good" chunks, so we can stop
-        //     here.
-        //
-        // TODO: make this step lazy/merge into the next step.
+        // Step 2: read entries in chunks starting from `start`. Chunks may
+        // arrive out of order from the underlying IO, so we reorder them with
+        // `OrderingIterator` before inspecting their contents; this lets us
+        // stop reading as soon as we walk past the last prefix.
         let chunks = self.storage.points_map.read_iter::<Sequential, _>(
             ReadRange {
                 byte_offset: start_idx * size_of::<PointKeyValue>() as u64,
@@ -493,56 +494,55 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
             .enumerate(),
         )?;
 
+        let ordered_chunks = OrderingIterator::new(chunks);
+
         // 128 - Guesstimate to avoid extra allocations on first iterations
         let mut point_map_ranges: Vec<ReadRange> = Vec::with_capacity(128);
-        let mut end_chunk_idx = None;
-        let mut received_chunks = BitVec::<usize>::EMPTY;
 
-        for chunk_result in chunks {
-            let (chunk_idx, entries) = chunk_result?;
-            if end_chunk_idx.is_some_and(|end_chunk| chunk_idx > end_chunk) {
-                continue;
-            }
+        // `prefix_cursor` tracks the largest prefix <= current entry's hash.
+        // Since entries are processed in sorted order and prefixes are sorted
+        // and pairwise incomparable, the cursor only ever moves forward,
+        // giving amortized O(1) matching per entry instead of O(|prefixes|).
+        let mut prefix_cursor = 0usize;
 
-            // Mark chunk as received.
-            if chunk_idx >= received_chunks.len() {
-                received_chunks.resize(chunk_idx + 1, false);
-            }
-            received_chunks.set(chunk_idx, true);
+        'outer: for chunk_result in ordered_chunks {
+            let (_chunk_idx, entries) = chunk_result?;
+            for entry in entries.iter() {
+                let hash = entry.hash.normalize();
 
-            for &entry in entries.iter() {
-                if entry.hash.normalize().starts_with(geohash_prefix) {
+                while prefix_cursor + 1 < geo_hashes.len() && geo_hashes[prefix_cursor + 1] <= hash
+                {
+                    prefix_cursor += 1;
+                }
+
+                let current_prefix = geo_hashes[prefix_cursor];
+
+                if hash.starts_with(current_prefix) {
                     point_map_ranges.push(ReadRange {
                         byte_offset: u64::from(entry.ids_start)
                             * size_of::<PointOffsetType>() as u64,
                         length: u64::from(entry.ids_end.saturating_sub(entry.ids_start)),
                     });
-                } else {
-                    end_chunk_idx =
-                        Some(end_chunk_idx.map_or(chunk_idx, |end_chunk| end_chunk.min(chunk_idx)));
-                    break;
+                } else if prefix_cursor + 1 == geo_hashes.len() {
+                    // Past the last prefix with no match: no further entry
+                    // can start with any prefix, so we're done.
+                    break 'outer;
                 }
-            }
-
-            if let Some(end_chunk_idx) = end_chunk_idx
-                && received_chunks[..end_chunk_idx].all()
-            {
-                break;
             }
         }
 
-        // Step 3: read ranges from `point_map_ranges`.
-        Ok(self
-            .storage
-            .points_map_ids
-            .read_iter_autobatched(point_map_ranges)?
-            .filter_map(|res| match res {
-                Ok(point_id) if !self.storage.deleted.get(point_id as usize).unwrap_or(true) => {
-                    Some(Ok(point_id))
-                }
-                Ok(_) => None,
-                Err(e) => Some(Err(OperationError::from(e))),
-            }))
+        // Step 3: read the collected ranges and accumulate unique,
+        // non-deleted point ids.
+        let mut points = AHashSet::new();
+        self.storage.points_map_ids.read_batch::<Random, _>(
+            point_map_ranges.into_iter().enumerate(),
+            |_idx, values| {
+                points.extend(values.iter().copied());
+                Ok(())
+            },
+        )?;
+
+        Ok(points)
     }
 
     pub fn points_count(&self) -> usize {

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -447,8 +447,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         let len = self.storage.points_map.len()?;
 
         geo_hashes.sort_unstable();
-        geo_hashes.dedup();
-        // Drop any prefix that is already subsumed by an earlier (shorter)
+        // Drop any prefix that is already subsumed by or equal to an earlier (shorter)
         // one. After this pass the remaining prefixes are pairwise
         // incomparable — no prefix is a prefix of another — so at most one of
         // them can match any given entry.

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -537,7 +537,12 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         self.storage.points_map_ids.read_batch::<Random, _>(
             point_map_ranges.into_iter().enumerate(),
             |_idx, values| {
-                points.extend(values.iter().copied());
+                points.extend(
+                    values
+                        .iter()
+                        .copied()
+                        .filter(|&id| !self.storage.deleted.get(id as usize).unwrap_or(true)),
+                );
                 Ok(())
             },
         )?;

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1,7 +1,6 @@
 use std::cmp::{max, min};
 use std::path::{Path, PathBuf};
 
-use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::MmapFile;
@@ -246,13 +245,7 @@ impl GeoMapIndex {
                     .unique(),
             ))),
             GeoMapIndex::Storage(index) => {
-                let mut result = AHashSet::new();
-                for top_geo_hash in values {
-                    for point in index.stored_sub_regions(top_geo_hash)? {
-                        let point = point?;
-                        result.insert(point);
-                    }
-                }
+                let result = index.all_points(values)?;
                 Ok(Either::Right(result.into_iter()))
             }
         }
@@ -274,9 +267,7 @@ impl GeoMapIndex {
                 .points_per_hash()
                 .filter(filter_condition)
                 .collect_vec(),
-            GeoMapIndex::Storage(index) => index
-                .points_per_hash()?
-                .process_results(|iter| iter.filter(filter_condition).collect_vec())?,
+            GeoMapIndex::Storage(index) => index.points_per_hash(filter_condition)?,
         };
 
         // smallest regions first

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1704,8 +1704,7 @@ mod tests {
             build_random_index(POINT_COUNT, 20, IndexType::MutableGridstore);
         let (immutable_index, _immutable_tmp, _) =
             build_random_index(POINT_COUNT, 20, IndexType::RamMmap);
-        let (mmap_index, _mmap_tmp, _) =
-            build_random_index(POINT_COUNT, 20, IndexType::Mmap);
+        let (mmap_index, _mmap_tmp, _) = build_random_index(POINT_COUNT, 20, IndexType::Mmap);
 
         let GeoMapIndex::Storage(storage_index) = &mmap_index else {
             panic!("expected Mmap variant to build into Storage");
@@ -1778,15 +1777,11 @@ mod tests {
         ];
 
         for (name, hashes) in cases {
-            let mutable_result: HashSet<PointOffsetType> = mutable_index
-                .iterator(hashes.clone())
-                .unwrap()
-                .collect();
+            let mutable_result: HashSet<PointOffsetType> =
+                mutable_index.iterator(hashes.clone()).unwrap().collect();
 
-            let immutable_result: HashSet<PointOffsetType> = immutable_index
-                .iterator(hashes.clone())
-                .unwrap()
-                .collect();
+            let immutable_result: HashSet<PointOffsetType> =
+                immutable_index.iterator(hashes.clone()).unwrap().collect();
 
             let all_points_result: HashSet<PointOffsetType> = storage_index
                 .all_points(hashes)

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1691,4 +1691,117 @@ mod tests {
             }
         }
     }
+
+    /// Cross-check that [`StoredGeoMapIndex::all_points`] produces the same
+    /// point set as the mutable and immutable index implementations for a
+    /// variety of prefix configurations (single region, disjoint regions,
+    /// overlapping ancestor/descendant prefixes).
+    #[test]
+    fn test_all_points_congruence() {
+        const POINT_COUNT: usize = 500;
+
+        let (mutable_index, _mutable_tmp, _) =
+            build_random_index(POINT_COUNT, 20, IndexType::MutableGridstore);
+        let (immutable_index, _immutable_tmp, _) =
+            build_random_index(POINT_COUNT, 20, IndexType::RamMmap);
+        let (mmap_index, _mmap_tmp, _) =
+            build_random_index(POINT_COUNT, 20, IndexType::Mmap);
+
+        let GeoMapIndex::Storage(storage_index) = &mmap_index else {
+            panic!("expected Mmap variant to build into Storage");
+        };
+
+        // Case 1: single contiguous region (Europe-ish polygon).
+        let europe_polygon = GeoPolygon {
+            exterior: GeoLineString {
+                points: vec![
+                    GeoPoint::new_unchecked(19.415558242000287, 69.18533258102943),
+                    GeoPoint::new_unchecked(2.4664944437317615, 61.852748225727254),
+                    GeoPoint::new_unchecked(2.713789718828849, 51.80793869181895),
+                    GeoPoint::new_unchecked(19.415558242000287, 69.18533258102943),
+                ],
+            },
+            interiors: None,
+        };
+        let europe_hashes = polygon_hashes(&europe_polygon, GEO_QUERY_MAX_REGION).unwrap();
+
+        // Case 2: two disjoint regions (NYC + Tokyo). Forces the prefix
+        // cursor inside `all_points` to traverse non-matching entries
+        // between the two prefix groups.
+        let nyc_circle = GeoRadius {
+            center: NYC,
+            radius: OrderedFloat(300_000.0),
+        };
+        let tokyo_circle = GeoRadius {
+            center: TOKYO,
+            radius: OrderedFloat(300_000.0),
+        };
+        let mut disjoint_hashes = circle_hashes(&nyc_circle, GEO_QUERY_MAX_REGION).unwrap();
+        disjoint_hashes.extend(circle_hashes(&tokyo_circle, GEO_QUERY_MAX_REGION).unwrap());
+
+        // Case 3: same set as Case 1 but with every prefix duplicated and
+        // with a shorter ancestor prefix added for the first hash. This
+        // exercises both the exact-duplicate `dedup()` and the
+        // ancestor-subsumption `dedup_by` paths in `all_points`.
+        let mut overlapping_hashes = europe_hashes.clone();
+        overlapping_hashes.extend(europe_hashes.iter().copied());
+        if let Some(first) = europe_hashes.first() {
+            let len = first.len();
+            if len > 2 {
+                overlapping_hashes.push(first.truncate(len - 1));
+                overlapping_hashes.push(first.truncate(len - 2));
+            }
+        }
+
+        // Case 4: a very large region (global-ish polygon) to stress the
+        // full-range traversal path where the cursor reaches the last
+        // prefix and keeps scanning deep into the points_map.
+        let global_polygon = GeoPolygon {
+            exterior: GeoLineString {
+                points: vec![
+                    GeoPoint::new_unchecked(-170.0, -80.0),
+                    GeoPoint::new_unchecked(170.0, -80.0),
+                    GeoPoint::new_unchecked(170.0, 80.0),
+                    GeoPoint::new_unchecked(-170.0, 80.0),
+                    GeoPoint::new_unchecked(-170.0, -80.0),
+                ],
+            },
+            interiors: None,
+        };
+        let global_hashes = polygon_hashes(&global_polygon, GEO_QUERY_MAX_REGION).unwrap();
+
+        let cases: Vec<(&str, Vec<GeoHash>)> = vec![
+            ("europe_single_region", europe_hashes),
+            ("nyc_plus_tokyo_disjoint", disjoint_hashes),
+            ("overlapping_and_duplicated", overlapping_hashes),
+            ("global_large_region", global_hashes),
+        ];
+
+        for (name, hashes) in cases {
+            let mutable_result: HashSet<PointOffsetType> = mutable_index
+                .iterator(hashes.clone())
+                .unwrap()
+                .collect();
+
+            let immutable_result: HashSet<PointOffsetType> = immutable_index
+                .iterator(hashes.clone())
+                .unwrap()
+                .collect();
+
+            let all_points_result: HashSet<PointOffsetType> = storage_index
+                .all_points(hashes)
+                .unwrap()
+                .into_iter()
+                .collect();
+
+            assert_eq!(
+                mutable_result, immutable_result,
+                "case `{name}`: mutable vs immutable differ",
+            );
+            assert_eq!(
+                mutable_result, all_points_result,
+                "case `{name}`: mutable vs all_points differ",
+            );
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -649,6 +649,7 @@ mod tests {
     use std::ops::Range;
 
     use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use common::universal_io::MmapFile;
     use itertools::Itertools;
     use ordered_float::OrderedFloat;
     use rand::SeedableRng;
@@ -1700,11 +1701,11 @@ mod tests {
     fn test_all_points_congruence() {
         const POINT_COUNT: usize = 500;
 
-        let (mutable_index, _mutable_tmp, _) =
+        let (mut mutable_index, _mutable_tmp, _) =
             build_random_index(POINT_COUNT, 20, IndexType::MutableGridstore);
-        let (immutable_index, _immutable_tmp, _) =
+        let (mut immutable_index, _immutable_tmp, _) =
             build_random_index(POINT_COUNT, 20, IndexType::RamMmap);
-        let (mmap_index, _mmap_tmp, _) = build_random_index(POINT_COUNT, 20, IndexType::Mmap);
+        let (mut mmap_index, _mmap_tmp, _) = build_random_index(POINT_COUNT, 20, IndexType::Mmap);
 
         let GeoMapIndex::Storage(storage_index) = &mmap_index else {
             panic!("expected Mmap variant to build into Storage");
@@ -1776,27 +1777,62 @@ mod tests {
             ("global_large_region", global_hashes),
         ];
 
-        for (name, hashes) in cases {
-            let mutable_result: HashSet<PointOffsetType> =
-                mutable_index.iterator(hashes.clone()).unwrap().collect();
+        let assert_all_points_match =
+            |mutable_index: &GeoMapIndex,
+             immutable_index: &GeoMapIndex,
+             storage_index: &super::mmap_geo_index::StoredGeoMapIndex<MmapFile>,
+             cases: &[(&str, Vec<GeoHash>)],
+             phase: &str| {
+                for (name, hashes) in cases {
+                    let hashes = hashes.clone();
+                    let mutable_result: HashSet<PointOffsetType> =
+                        mutable_index.iterator(hashes.clone()).unwrap().collect();
 
-            let immutable_result: HashSet<PointOffsetType> =
-                immutable_index.iterator(hashes.clone()).unwrap().collect();
+                    let immutable_result: HashSet<PointOffsetType> =
+                        immutable_index.iterator(hashes.clone()).unwrap().collect();
 
-            let all_points_result: HashSet<PointOffsetType> = storage_index
-                .all_points(hashes)
-                .unwrap()
-                .into_iter()
-                .collect();
+                    let all_points_result: HashSet<PointOffsetType> = storage_index
+                        .all_points(hashes)
+                        .unwrap()
+                        .into_iter()
+                        .collect();
 
-            assert_eq!(
-                mutable_result, immutable_result,
-                "case `{name}`: mutable vs immutable differ",
-            );
-            assert_eq!(
-                mutable_result, all_points_result,
-                "case `{name}`: mutable vs all_points differ",
-            );
+                    assert_eq!(
+                        mutable_result, immutable_result,
+                        "{phase}: case `{name}`: mutable vs immutable differ",
+                    );
+                    assert_eq!(
+                        mutable_result, all_points_result,
+                        "{phase}: case `{name}`: mutable vs all_points differ",
+                    );
+                }
+            };
+
+        assert_all_points_match(
+            &mutable_index,
+            &immutable_index,
+            storage_index,
+            &cases,
+            "baseline",
+        );
+
+        const DELETED_POINT_IDS: &[PointOffsetType] = &[10, 11, 12, 100, 150];
+        for &id in DELETED_POINT_IDS {
+            mutable_index.remove_point(id).unwrap();
+            immutable_index.remove_point(id).unwrap();
+            mmap_index.remove_point(id).unwrap();
         }
+
+        let GeoMapIndex::Storage(storage_index) = &mmap_index else {
+            panic!("expected Mmap variant to build into Storage");
+        };
+
+        assert_all_points_match(
+            &mutable_index,
+            &immutable_index,
+            storage_index,
+            &cases,
+            "after point deletions",
+        );
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1,6 +1,7 @@
 use std::cmp::{max, min};
 use std::path::{Path, PathBuf};
 
+use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::MmapFile;
@@ -245,14 +246,11 @@ impl GeoMapIndex {
                     .unique(),
             ))),
             GeoMapIndex::Storage(index) => {
-                let mut seen = std::collections::HashSet::new();
-                let mut result: Vec<PointOffsetType> = Vec::new();
+                let mut result = AHashSet::new();
                 for top_geo_hash in values {
                     for point in index.stored_sub_regions(top_geo_hash)? {
                         let point = point?;
-                        if seen.insert(point) {
-                            result.push(point);
-                        }
+                        result.insert(point);
                     }
                 }
                 Ok(Either::Right(result.into_iter()))

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -2,10 +2,9 @@ use std::cmp::{max, min};
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::iterator_ext::{FallibleIteratorExt as _, TransposeResultIter as _};
 use common::types::PointOffsetType;
 use common::universal_io::MmapFile;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use mutable_geo_index::InMemoryGeoMapIndex;
 use serde_json::Value;
 
@@ -231,30 +230,33 @@ impl GeoMapIndex {
     fn iterator(
         &self,
         values: Vec<GeoHash>,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + '_> {
+    ) -> OperationResult<impl Iterator<Item = PointOffsetType> + '_> {
         match self {
-            GeoMapIndex::Mutable(index) => Box::new(
+            GeoMapIndex::Mutable(index) => Ok(Either::Left(Either::Right(
                 values
                     .into_iter()
                     .flat_map(|top_geo_hash| index.stored_sub_regions(top_geo_hash))
-                    .unique()
-                    .map(Ok),
-            ),
-            GeoMapIndex::Immutable(index) => Box::new(
+                    .unique(),
+            ))),
+            GeoMapIndex::Immutable(index) => Ok(Either::Left(Either::Left(
                 values
                     .into_iter()
                     .flat_map(|top_geo_hash| index.stored_sub_regions(top_geo_hash))
-                    .unique()
-                    .map(Ok),
-            ),
-            GeoMapIndex::Storage(index) => Box::new(
-                values
-                    .into_iter()
-                    .flat_map(|top_geo_hash| {
-                        index.stored_sub_regions(top_geo_hash).into_result_iter()
-                    })
-                    .unique_ok(),
-            ),
+                    .unique(),
+            ))),
+            GeoMapIndex::Storage(index) => {
+                let mut seen = std::collections::HashSet::new();
+                let mut result: Vec<PointOffsetType> = Vec::new();
+                for top_geo_hash in values {
+                    for point in index.stored_sub_regions(top_geo_hash)? {
+                        let point = point?;
+                        if seen.insert(point) {
+                            result.push(point);
+                        }
+                    }
+                }
+                Ok(Either::Right(result.into_iter()))
+            }
         }
     }
 
@@ -534,47 +536,44 @@ impl PayloadFieldIndex for GeoMapIndex {
         &'a self,
         condition: &FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         if let Some(geo_bounding_box) = &condition.geo_bounding_box {
-            let geo_hashes = rectangle_hashes(geo_bounding_box, GEO_QUERY_MAX_REGION).ok()?;
+            let geo_hashes = rectangle_hashes(geo_bounding_box, GEO_QUERY_MAX_REGION)?;
             let geo_condition_copy = *geo_bounding_box;
-            return Some(Box::new(self.iterator(geo_hashes).filter_map_ok(
-                move |point| {
+            return Ok(Some(Box::new(self.iterator(geo_hashes)?.filter(
+                move |&point| {
                     self.check_values_any(point, hw_counter, |geo_point| {
                         geo_condition_copy.check_point(geo_point)
                     })
-                    .then_some(point)
                 },
-            )));
+            ))));
         }
 
         if let Some(geo_radius) = &condition.geo_radius {
-            let geo_hashes = circle_hashes(geo_radius, GEO_QUERY_MAX_REGION).ok()?;
+            let geo_hashes = circle_hashes(geo_radius, GEO_QUERY_MAX_REGION)?;
             let geo_condition_copy = *geo_radius;
-            return Some(Box::new(self.iterator(geo_hashes).filter_map_ok(
-                move |point| {
+            return Ok(Some(Box::new(self.iterator(geo_hashes)?.filter(
+                move |&point| {
                     self.check_values_any(point, hw_counter, |geo_point| {
                         geo_condition_copy.check_point(geo_point)
                     })
-                    .then_some(point)
                 },
-            )));
+            ))));
         }
 
         if let Some(geo_polygon) = &condition.geo_polygon {
-            let geo_hashes = polygon_hashes(geo_polygon, GEO_QUERY_MAX_REGION).ok()?;
+            let geo_hashes = polygon_hashes(geo_polygon, GEO_QUERY_MAX_REGION)?;
             let geo_condition_copy = geo_polygon.convert();
-            return Some(Box::new(self.iterator(geo_hashes).filter_map_ok(
-                move |point| {
+            return Ok(Some(Box::new(self.iterator(geo_hashes)?.filter(
+                move |&point| {
                     self.check_values_any(point, hw_counter, |geo_point| {
                         geo_condition_copy.check_point(geo_point)
                     })
-                    .then_some(point)
                 },
-            )));
+            ))));
         }
 
-        None
+        Ok(None)
     }
 
     fn estimate_cardinality(
@@ -847,10 +846,7 @@ mod tests {
             index_type: IndexType,
         ) {
             let (field_index, _, _) = build_random_index(500, 20, index_type);
-            let exact_points_for_hashes = field_index
-                .iterator(hashes)
-                .map(|r| r.unwrap())
-                .collect_vec();
+            let exact_points_for_hashes = field_index.iterator(hashes).unwrap().collect_vec();
             let real_cardinality = exact_points_for_hashes.len();
 
             let hw_counter = HardwareCounterCell::new();
@@ -924,10 +920,7 @@ mod tests {
             index_type: IndexType,
         ) {
             let (field_index, _, _) = build_random_index(500, 20, index_type);
-            let exact_points_for_hashes = field_index
-                .iterator(hashes)
-                .map(|r| r.unwrap())
-                .collect_vec();
+            let exact_points_for_hashes = field_index.iterator(hashes).unwrap().collect_vec();
             let real_cardinality = exact_points_for_hashes.len();
 
             let hw_counter = HardwareCounterCell::new();
@@ -1002,7 +995,7 @@ mod tests {
             let mut indexed_matched_points = field_index
                 .filter(&field_condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect_vec();
 
             matched_points.sort_unstable();
@@ -1065,7 +1058,7 @@ mod tests {
             let block_points = field_index
                 .filter(&block.condition, &hw_counter)
                 .unwrap()
-                .map(|r| r.unwrap())
+                .unwrap()
                 .collect_vec();
             assert_eq!(block_points.len(), block.cardinality);
         });
@@ -1273,7 +1266,7 @@ mod tests {
         let point_offsets = new_index
             .filter(&field_condition, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![1]);
 
@@ -1285,7 +1278,7 @@ mod tests {
         let point_offsets = new_index
             .filter(&field_condition, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(point_offsets, vec![1]);
     }
@@ -1477,7 +1470,7 @@ mod tests {
         let point_offsets = new_index
             .filter(&field_condition, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         // Only LOS_ANGELES is in the bounding box
         assert_eq!(point_offsets, vec![2]);
@@ -1536,7 +1529,7 @@ mod tests {
         let results = index
             .filter(&field_condition, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(results, vec![1]);
 
@@ -1592,7 +1585,7 @@ mod tests {
         let results = index
             .filter(&field_condition, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect_vec();
         assert_eq!(results, vec![0]);
 
@@ -1678,11 +1671,11 @@ mod tests {
             assert_eq!(
                 indices[0]
                     .iterator(hashes.clone())
-                    .map(|r| r.unwrap())
+                    .unwrap()
                     .collect::<HashSet<_>>(),
                 index
                     .iterator(hashes.clone())
-                    .map(|r| r.unwrap())
+                    .unwrap()
                     .collect::<HashSet<_>>(),
             );
             for point_id in 0..POINT_COUNT {

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -484,7 +484,7 @@ where
         &'a self,
         excluded: &'a IndexSet<K, A>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>
+    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>
     where
         A: BuildHasher,
         K: Borrow<N> + Hash + Eq,
@@ -493,8 +493,7 @@ where
             self.iter_values()
                 .filter(|key| !excluded.contains((*key).borrow()))
                 .flat_map(move |key| self.get_iterator(key.borrow(), hw_counter))
-                .unique()
-                .map(Ok),
+                .unique(),
         )
     }
 
@@ -746,12 +745,14 @@ impl PayloadFieldIndex for MapIndex<str> {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
-        match &condition.r#match {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> = match &condition
+            .r#match
+        {
             Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(keyword) => Some(Box::new(
-                    self.get_iterator(keyword.as_str(), hw_counter).map(Ok),
-                )),
+                ValueVariants::String(keyword) => {
+                    Some(Box::new(self.get_iterator(keyword.as_str(), hw_counter)))
+                }
                 ValueVariants::Integer(_) => None,
                 ValueVariants::Bool(_) => None,
             },
@@ -760,8 +761,7 @@ impl PayloadFieldIndex for MapIndex<str> {
                     keywords
                         .iter()
                         .flat_map(move |keyword| self.get_iterator(keyword.as_str(), hw_counter))
-                        .unique()
-                        .map(Ok),
+                        .unique(),
                 )),
                 AnyVariants::Integers(integers) => {
                     if integers.is_empty() {
@@ -782,7 +782,9 @@ impl PayloadFieldIndex for MapIndex<str> {
                 }
             },
             _ => None,
-        }
+        };
+
+        Ok(result)
     }
 
     fn estimate_cardinality(
@@ -896,67 +898,72 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
-        match &condition.r#match {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(uuid_string) => {
-                    let uuid = Uuid::from_str(uuid_string).ok()?;
-                    Some(Box::new(
-                        self.get_iterator(&uuid.as_u128(), hw_counter).map(Ok),
-                    ))
-                }
-                ValueVariants::Integer(_) => None,
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                AnyVariants::Strings(uuids_string) => {
-                    let uuids: IndexSet<u128> = uuids_string
-                        .iter()
-                        .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                        .collect::<Result<_, _>>()
-                        .ok()?;
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> =
+            match &condition.r#match {
+                Some(Match::Value(MatchValue { value })) => match value {
+                    ValueVariants::String(uuid_string) => {
+                        let Ok(uuid) = Uuid::from_str(uuid_string) else {
+                            return Ok(None);
+                        };
+                        Some(Box::new(self.get_iterator(&uuid.as_u128(), hw_counter)))
+                    }
+                    ValueVariants::Integer(_) => None,
+                    ValueVariants::Bool(_) => None,
+                },
+                Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+                    AnyVariants::Strings(uuids_string) => {
+                        let Ok(uuids) = uuids_string
+                            .iter()
+                            .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                            .collect::<Result<IndexSet<u128>, _>>()
+                        else {
+                            return Ok(None);
+                        };
 
-                    Some(Box::new(
-                        uuids
-                            .into_iter()
-                            .flat_map(move |uuid| self.get_iterator(&uuid, hw_counter))
-                            .unique()
-                            .map(Ok),
-                    ))
-                }
-                AnyVariants::Integers(integers) => {
-                    if integers.is_empty() {
-                        Some(Box::new(iter::empty()))
-                    } else {
-                        None
+                        Some(Box::new(
+                            uuids
+                                .into_iter()
+                                .flat_map(move |uuid| self.get_iterator(&uuid, hw_counter))
+                                .unique(),
+                        ))
                     }
-                }
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(uuids_string) => {
-                    let excluded_uuids: IndexSet<u128> = uuids_string
-                        .iter()
-                        .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                        .collect::<Result<_, _>>()
-                        .ok()?;
-                    Some(Box::new(
-                        self.iter_values()
-                            .filter(move |key| !excluded_uuids.contains(*key))
-                            .flat_map(move |key| self.get_iterator(key, hw_counter))
-                            .unique()
-                            .map(Ok),
-                    ))
-                }
-                AnyVariants::Integers(other) => {
-                    if other.is_empty() {
-                        Some(Box::new(iter::empty()))
-                    } else {
-                        None
+                    AnyVariants::Integers(integers) => {
+                        if integers.is_empty() {
+                            Some(Box::new(iter::empty()))
+                        } else {
+                            None
+                        }
                     }
-                }
-            },
-            _ => None,
-        }
+                },
+                Some(Match::Except(MatchExcept { except })) => match except {
+                    AnyVariants::Strings(uuids_string) => {
+                        let Ok(excluded_uuids) = uuids_string
+                            .iter()
+                            .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                            .collect::<Result<IndexSet<u128>, _>>()
+                        else {
+                            return Ok(None);
+                        };
+                        Some(Box::new(
+                            self.iter_values()
+                                .filter(move |key| !excluded_uuids.contains(*key))
+                                .flat_map(move |key| self.get_iterator(key, hw_counter))
+                                .unique(),
+                        ))
+                    }
+                    AnyVariants::Integers(other) => {
+                        if other.is_empty() {
+                            Some(Box::new(iter::empty()))
+                        } else {
+                            None
+                        }
+                    }
+                },
+                _ => None,
+            };
+
+        Ok(result)
     }
 
     fn estimate_cardinality(
@@ -1094,43 +1101,45 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         &'a self,
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
-        match &condition.r#match {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(_) => None,
-                ValueVariants::Integer(integer) => {
-                    Some(Box::new(self.get_iterator(integer, hw_counter).map(Ok)))
-                }
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                AnyVariants::Strings(keywords) => {
-                    if keywords.is_empty() {
-                        Some(Box::new(std::iter::empty()))
-                    } else {
-                        None
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> =
+            match &condition.r#match {
+                Some(Match::Value(MatchValue { value })) => match value {
+                    ValueVariants::String(_) => None,
+                    ValueVariants::Integer(integer) => {
+                        Some(Box::new(self.get_iterator(integer, hw_counter)))
                     }
-                }
-                AnyVariants::Integers(integers) => Some(Box::new(
-                    integers
-                        .iter()
-                        .flat_map(move |integer| self.get_iterator(integer, hw_counter))
-                        .unique()
-                        .map(Ok),
-                )),
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(other) => {
-                    if other.is_empty() {
-                        Some(Box::new(iter::empty()))
-                    } else {
-                        None
+                    ValueVariants::Bool(_) => None,
+                },
+                Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+                    AnyVariants::Strings(keywords) => {
+                        if keywords.is_empty() {
+                            Some(Box::new(std::iter::empty()))
+                        } else {
+                            None
+                        }
                     }
-                }
-                AnyVariants::Integers(integers) => Some(self.except_set(integers, hw_counter)),
-            },
-            _ => None,
-        }
+                    AnyVariants::Integers(integers) => Some(Box::new(
+                        integers
+                            .iter()
+                            .flat_map(move |integer| self.get_iterator(integer, hw_counter))
+                            .unique(),
+                    )),
+                },
+                Some(Match::Except(MatchExcept { except })) => match except {
+                    AnyVariants::Strings(other) => {
+                        if other.is_empty() {
+                            Some(Box::new(iter::empty()))
+                        } else {
+                            None
+                        }
+                    }
+                    AnyVariants::Integers(integers) => Some(self.except_set(integers, hw_counter)),
+                },
+                _ => None,
+            };
+
+        Ok(result)
     }
 
     fn estimate_cardinality(

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -269,7 +269,7 @@ impl PayloadFieldIndex for MutableNullIndex {
         &'a self,
         condition: &'a FieldCondition,
         _hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         let FieldCondition {
             key: _,
             r#match: _,
@@ -282,27 +282,28 @@ impl PayloadFieldIndex for MutableNullIndex {
             is_null,
         } = condition;
 
-        if let Some(is_empty) = is_empty {
-            if *is_empty {
-                // Return points that don't have values
-                Some(Box::new(
-                    self.storage.has_values_flags.iter_falses().map(Ok),
-                ))
+        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> =
+            if let Some(is_empty) = is_empty {
+                if *is_empty {
+                    // Return points that don't have values
+                    Some(Box::new(self.storage.has_values_flags.iter_falses()))
+                } else {
+                    // Return points that have values
+                    Some(Box::new(self.storage.has_values_flags.iter_trues()))
+                }
+            } else if let Some(is_null) = is_null {
+                if *is_null {
+                    // Return points that have null values
+                    Some(Box::new(self.storage.is_null_flags.iter_trues()))
+                } else {
+                    // Return points that don't have null values
+                    Some(Box::new(self.storage.is_null_flags.iter_falses()))
+                }
             } else {
-                // Return points that have values
-                Some(Box::new(self.storage.has_values_flags.iter_trues().map(Ok)))
-            }
-        } else if let Some(is_null) = is_null {
-            if *is_null {
-                // Return points that have null values
-                Some(Box::new(self.storage.is_null_flags.iter_trues().map(Ok)))
-            } else {
-                // Return points that don't have null values
-                Some(Box::new(self.storage.is_null_flags.iter_falses().map(Ok)))
-            }
-        } else {
-            None
-        }
+                None
+            };
+
+        Ok(result)
     }
 
     fn estimate_cardinality(
@@ -462,12 +463,12 @@ mod tests {
         let is_null_values: Vec<_> = null_index
             .filter(&filter_is_null, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
         let not_empty_values: Vec<_> = null_index
             .filter(&filter_is_not_empty, &hw_counter)
             .unwrap()
-            .map(|r| r.unwrap())
+            .unwrap()
             .collect();
 
         let is_empty_values: Vec<_> = (0..n)

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -14,7 +14,6 @@ use std::str::FromStr;
 
 use chrono::DateTime;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::iterator_ext::TransposeResultIter;
 use common::types::PointOffsetType;
 use delegate::delegate;
 use gridstore::Blob;
@@ -778,7 +777,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         if let Some(Match::Value(MatchValue {
             value: ValueVariants::String(keyword),
         })) = &condition.r#match
@@ -787,15 +786,13 @@ where
 
             if let Ok(uuid) = Uuid::from_str(keyword) {
                 let value = T::from_u128(uuid.as_u128());
-                return Some(Box::new(
-                    self.point_ids_by_value(value, hw_counter)
-                        .map(|iter| iter.map(Ok))
-                        .into_result_iter(),
-                ));
+                return Ok(Some(self.point_ids_by_value(value, hw_counter)?));
             }
         }
 
-        let range_cond = condition.range.as_ref()?;
+        let Some(range_cond) = condition.range.as_ref() else {
+            return Ok(None);
+        };
 
         let (start_bound, end_bound) = match range_cond {
             RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
@@ -808,23 +805,23 @@ where
         // map.range
         // Panics if range start > end. Panics if range start == end and both bounds are Excluded.
         if !check_boundaries(&start_bound, &end_bound) {
-            return Some(Box::new(std::iter::empty()));
+            return Ok(Some(Box::new(std::iter::empty())));
         }
 
-        Some(match self {
+        let result: Box<dyn Iterator<Item = PointOffsetType> + 'a> = match self {
             NumericIndexInner::Mutable(index) => {
-                Box::new(index.values_range(start_bound, end_bound).map(Ok))
+                Box::new(index.values_range(start_bound, end_bound))
             }
             NumericIndexInner::Immutable(index) => {
-                Box::new(index.values_range(start_bound, end_bound).map(Ok))
+                Box::new(index.values_range(start_bound, end_bound))
             }
-            NumericIndexInner::Mmap(index) => Box::new(
-                index
-                    .values_range(start_bound, end_bound, hw_counter)
-                    .map(|iter| iter.map(Ok))
-                    .into_result_iter(),
-            ),
-        })
+
+            NumericIndexInner::Mmap(index) => {
+                Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
+            }
+        };
+
+        Ok(Some(result))
     }
 
     fn estimate_cardinality(

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -128,7 +128,7 @@ fn cardinality_request(
             &hw_counter,
         )
         .unwrap()
-        .map(|r| r.unwrap())
+        .unwrap()
         .unique()
         .collect_vec();
 
@@ -542,7 +542,7 @@ fn test_cond<
     let offsets = index
         .filter(&condition, &hw_counter)
         .unwrap()
-        .map(|r| r.unwrap())
+        .unwrap()
         .collect_vec();
     assert_eq!(offsets, result);
 }

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -14,7 +14,7 @@ use common::flags::FeatureFlags;
 use common::progress_tracker::ProgressTracker;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use fs_err as fs;
-use itertools::{EitherOrBoth, Itertools};
+use itertools::EitherOrBoth;
 use log::{debug, trace};
 use parking_lot::Mutex;
 use rand::Rng;
@@ -753,7 +753,7 @@ impl HNSWIndex {
             payload_index.estimate_cardinality(&filter, &disposed_hw_counter)?;
         let point_mappings = id_tracker.point_mappings();
 
-        payload_index
+        Ok(payload_index
             .iter_filtered_points(
                 &filter,
                 id_tracker,
@@ -763,8 +763,8 @@ impl HNSWIndex {
                 stopped,
                 None,
             )?
-            .filter_ok(|&point_id| !deleted_bitslice.get_bit(point_id as usize).unwrap_or(false))
-            .collect()
+            .filter(|&point_id| !deleted_bitslice.get_bit(point_id as usize).unwrap_or(false))
+            .collect())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1209,7 +1209,7 @@ impl HNSWIndex {
     fn search_plain_iterator_batched(
         &self,
         query_vectors: &[&QueryVector],
-        points: impl Iterator<Item = OperationResult<PointOffsetType>>,
+        points: impl Iterator<Item = PointOffsetType>,
         top: usize,
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
@@ -1254,7 +1254,7 @@ impl HNSWIndex {
     fn search_plain_batched(
         &self,
         vectors: &[&QueryVector],
-        filtered_points: impl Iterator<Item = OperationResult<PointOffsetType>>,
+        filtered_points: impl Iterator<Item = PointOffsetType>,
         top: usize,
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
@@ -1276,7 +1276,7 @@ impl HNSWIndex {
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         let id_tracker = self.id_tracker.borrow();
-        let ids_iterator = id_tracker.point_mappings().iter_internal().map(Ok);
+        let ids_iterator = id_tracker.point_mappings().iter_internal();
         self.search_plain_iterator_batched(vectors, ids_iterator, top, params, vector_query_context)
     }
 

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -360,8 +360,7 @@ impl<'a> BatchFilteredSearcher<'a> {
             .take_while(|&point_id| {
                 // Early exit if we hit the max point ID (e.g. a deferred point).
                 point_id < deferred_internal_id.unwrap_or(PointOffsetType::MAX)
-            })
-            .map(Ok);
+            });
 
         self.peek_top_iter(iter, is_stopped)
     }
@@ -369,7 +368,7 @@ impl<'a> BatchFilteredSearcher<'a> {
     /// This function expects deferred points to be already filtered from the iterator.
     pub fn peek_top_iter(
         mut self,
-        mut points: impl Iterator<Item = OperationResult<PointOffsetType>>,
+        mut points: impl Iterator<Item = PointOffsetType>,
         is_stopped: &AtomicBool,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         // Reuse the same buffer for all chunks, to avoid reallocation
@@ -380,9 +379,8 @@ impl<'a> BatchFilteredSearcher<'a> {
             check_process_stopped(is_stopped)?;
 
             let mut chunk_size = 0;
-            for point_result in &mut points {
+            for point_id in &mut points {
                 check_process_stopped(is_stopped)?;
-                let point_id = point_result?;
 
                 if !self.filters.check_vector(point_id) {
                     continue;

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -144,8 +144,7 @@ impl VectorIndex for PlainVectorIndex {
                     &is_stopped,
                     deferred_internal_id,
                 )?;
-                batch_searcher
-                    .peek_top_iter(filtered_ids_vec.iter().copied().map(Ok), &is_stopped)?
+                batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
             }
             None => batch_searcher.peek_top_all(&is_stopped, deferred_internal_id)?,
         };

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -334,7 +334,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                         prefiltered_points.as_ref().unwrap().iter().copied()
                     }
                 };
-                searcher.peek_top_iter(filtered_points.map(Ok), &is_stopped)?
+                searcher.peek_top_iter(filtered_points, &is_stopped)?
             }
             None => {
                 searcher.peek_top_all(&is_stopped, vector_query_context.deferred_internal_id())?

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -12,7 +12,6 @@ use common::either_variant::EitherVariant;
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use fs_err as fs;
-use itertools::Itertools;
 use schemars::_serde_json::Value;
 
 use super::field_index::facet_index::FacetIndexEnum;
@@ -101,19 +100,23 @@ impl StructPayloadIndex {
         &'a self,
         condition: &'a PrimaryCondition,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = OperationResult<PointOffsetType>> + 'a>> {
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         match condition {
             PrimaryCondition::Condition(field_condition) => {
-                let field_key = &field_condition.key;
-                let field_indexes = self.field_indexes.get(field_key)?;
+                let Some(field_indexes) = self.field_indexes.get(&field_condition.key) else {
+                    return Ok(None);
+                };
                 field_indexes
                     .iter()
-                    .find_map(|field_index| field_index.filter(field_condition, hw_counter))
+                    .find_map(|field_index| {
+                        field_index.filter(field_condition, hw_counter).transpose()
+                    })
+                    .transpose()
             }
             PrimaryCondition::Ids(ids) => {
-                Some(Box::new(ids.resolved_point_offsets.iter().copied().map(Ok)))
+                Ok(Some(Box::new(ids.resolved_point_offsets.iter().copied())))
             }
-            PrimaryCondition::HasVector(_) => None,
+            PrimaryCondition::HasVector(_) => Ok(None),
         }
     }
 
@@ -478,7 +481,7 @@ impl StructPayloadIndex {
         hw_counter: &'a HardwareCounterCell,
         is_stopped: &'a AtomicBool,
         deferred_internal_id: Option<PointOffsetType>,
-    ) -> OperationResult<impl Iterator<Item = OperationResult<PointOffsetType>> + 'a> {
+    ) -> OperationResult<impl Iterator<Item = PointOffsetType> + 'a> {
         if query_cardinality.primary_clauses.is_empty() {
             let full_scan_iterator = point_mappings.iter_internal_visible(deferred_internal_id);
 
@@ -486,8 +489,7 @@ impl StructPayloadIndex {
             // Worst case: query expected to return few matches, but index can't be used
             let matched_points = full_scan_iterator
                 .stop_if(is_stopped)
-                .filter(move |i| struct_filtered_context.check(*i))
-                .map(Ok);
+                .filter(move |i| struct_filtered_context.check(*i));
 
             Ok(EitherVariant::A(matched_points))
         } else {
@@ -496,13 +498,13 @@ impl StructPayloadIndex {
 
             // If even one iterator is None, we should replace the whole thing with
             // an iterator over all ids.
-            let primary_clause_iterators: Option<Vec<_>> = query_cardinality
+            let primary_clause_iterators: OperationResult<Option<Vec<_>>> = query_cardinality
                 .primary_clauses
                 .iter()
                 .map(|clause| self.query_field(clause, hw_counter))
                 .collect();
 
-            if let Some(primary_iterators) = primary_clause_iterators {
+            if let Some(primary_iterators) = primary_clause_iterators? {
                 let all_conditions_are_primary = filter
                     .iter_conditions()
                     .all(|condition| query_cardinality.is_primary(condition));
@@ -512,7 +514,7 @@ impl StructPayloadIndex {
                     // Filter out deferred points.
                     // This iterator (and each primary iterator too) can yield items in non sorted order, depending on the type of index and primary condition.
                     .flatten()
-                    .filter_ok(move |&internal_id| {
+                    .filter(move |&internal_id| {
                         internal_id < deferred_internal_id.unwrap_or(PointOffsetType::MAX)
                     })
                     .stop_if(is_stopped);
@@ -521,13 +523,13 @@ impl StructPayloadIndex {
                     // All conditions are primary clauses,
                     // We can avoid post-filtering
                     let iter = joined_primary_iterator
-                        .filter_ok(move |&id| !visited_list.check_and_update_visited(id));
+                        .filter(move |&id| !visited_list.check_and_update_visited(id));
                     EitherVariant::B(iter)
                 } else {
                     // Some conditions are primary clauses, some are not
                     let struct_filtered_context =
                         self.struct_filtered_context(filter, hw_counter)?;
-                    let iter = joined_primary_iterator.filter_ok(move |&id| {
+                    let iter = joined_primary_iterator.filter(move |&id| {
                         !visited_list.check_and_update_visited(id)
                             && struct_filtered_context.check(id)
                     });
@@ -548,8 +550,7 @@ impl StructPayloadIndex {
                 })
                 .filter(move |&id| {
                     !visited_list.check_and_update_visited(id) && struct_filtered_context.check(id)
-                })
-                .map(Ok);
+                });
 
             Ok(EitherVariant::D(iter))
         }
@@ -779,16 +780,18 @@ impl PayloadIndex for StructPayloadIndex {
         let query_cardinality = self.estimate_cardinality(filter, hw_counter)?;
         let id_tracker = self.id_tracker.borrow();
         let point_mappings = id_tracker.point_mappings();
-        self.iter_filtered_points(
-            filter,
-            &id_tracker,
-            &point_mappings,
-            &query_cardinality,
-            hw_counter,
-            is_stopped,
-            deferred_internal_id,
-        )?
-        .collect()
+        let result = self
+            .iter_filtered_points(
+                filter,
+                &id_tracker,
+                &point_mappings,
+                &query_cardinality,
+                hw_counter,
+                is_stopped,
+                deferred_internal_id,
+            )?
+            .collect();
+        Ok(result)
     }
 
     fn indexed_points(&self, field: PayloadKeyTypeRef) -> usize {

--- a/lib/segment/src/segment/facet.rs
+++ b/lib/segment/src/segment/facet.rs
@@ -62,20 +62,16 @@ impl Segment {
                         is_stopped,
                         self.deferred_internal_id(),
                     )?
-                    .filter_ok(|&point_id| !id_tracker.is_deleted_point(point_id))
-                    .try_fold(
-                        HashMap::new(),
-                        |mut map, point_result| -> OperationResult<_> {
-                            let point_id = point_result?;
-                            facet_index
-                                .get_point_values(point_id, hw_counter)
-                                .unique()
-                                .for_each(|value| {
-                                    *map.entry(value).or_insert(0) += 1;
-                                });
-                            Ok(map)
-                        },
-                    )?
+                    .filter(|&point_id| !id_tracker.is_deleted_point(point_id))
+                    .fold(HashMap::new(), |mut map, point_id| {
+                        facet_index
+                            .get_point_values(point_id, hw_counter)
+                            .unique()
+                            .for_each(|value| {
+                                *map.entry(value).or_insert(0) += 1;
+                            });
+                        map
+                    })
                     .into_iter()
                     .map(|(value, count)| FacetHit { value, count });
 
@@ -163,15 +159,11 @@ impl Segment {
                     is_stopped,
                     self.deferred_internal_id(),
                 )?
-                .filter_ok(|&point_id| !id_tracker.is_deleted_point(point_id))
-                .try_fold(
-                    BTreeSet::new(),
-                    |mut set, point_result| -> OperationResult<_> {
-                        let point_id = point_result?;
-                        set.extend(facet_index.get_point_values(point_id, hw_counter));
-                        Ok(set)
-                    },
-                )?
+                .filter(|&point_id| !id_tracker.is_deleted_point(point_id))
+                .fold(BTreeSet::new(), |mut set, point_id| {
+                    set.extend(facet_index.get_point_values(point_id, hw_counter));
+                    set
+                })
                 .into_iter()
                 .map(|value| value.to_owned())
                 .collect()

--- a/lib/segment/src/segment/order_by.rs
+++ b/lib/segment/src/segment/order_by.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType};
-use itertools::{Either, Itertools};
+use itertools::Either;
 
 use super::Segment;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -53,27 +53,24 @@ impl Segment {
                 is_stopped,
                 effective_deferred_id,
             )?
-            .flat_map(|point_result| match point_result {
-                Err(e) => Either::Left(std::iter::once(Err(e))),
-                Ok(internal_id) => Either::Right(
-                    // Repeat a point for as many values as it has
-                    numeric_index
-                        .get_ordering_values(internal_id)
-                        // But only those which start from `start_from`
-                        .filter(|value| match order_by.direction() {
-                            Direction::Asc => value >= &start_from,
-                            Direction::Desc => value <= &start_from,
-                        })
-                        .map(move |ordering_value| Ok((ordering_value, internal_id))),
-                ),
+            .flat_map(|internal_id| {
+                // Repeat a point for as many values as it has
+                numeric_index
+                    .get_ordering_values(internal_id)
+                    // But only those which start from `start_from`
+                    .filter(|value| match order_by.direction() {
+                        Direction::Asc => value >= &start_from,
+                        Direction::Desc => value <= &start_from,
+                    })
+                    .map(move |ordering_value| (ordering_value, internal_id))
             })
-            .filter_map_ok(|(value, internal_id)| {
+            .filter_map(|(value, internal_id)| {
                 id_tracker
                     .external_id(internal_id)
                     .map(|external_id| (value, external_id))
             });
 
-        values_ids_iterator.process_results(|values_ids_iterator| match order_by.direction() {
+        Ok(match order_by.direction() {
             Direction::Asc => {
                 let mut page = match limit {
                     Some(limit) => peek_top_smallest_iterable(values_ids_iterator, limit),

--- a/lib/segment/src/segment/sampling.rs
+++ b/lib/segment/src/segment/sampling.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
-use itertools::Itertools;
 use rand::seq::{IteratorRandom, SliceRandom};
 
 use super::Segment;
@@ -34,14 +33,12 @@ impl Segment {
                 is_stopped,
                 self.deferred_internal_id(),
             )?
-            .filter_map_ok(|internal_id| id_tracker.external_id(internal_id));
+            .filter_map(|internal_id| id_tracker.external_id(internal_id));
 
         let mut rng = rand::rng();
-        ids_iterator.process_results(|iter| {
-            let mut shuffled = iter.sample(&mut rng, limit);
-            shuffled.shuffle(&mut rng);
-            shuffled
-        })
+        let mut shuffled = ids_iterator.sample(&mut rng, limit);
+        shuffled.shuffle(&mut rng);
+        Ok(shuffled)
     }
 
     pub fn filtered_read_by_random_stream(

--- a/lib/segment/src/segment/scroll.rs
+++ b/lib/segment/src/segment/scroll.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::DeferredBehavior;
-use itertools::Itertools;
 
 use super::Segment;
 use crate::common::operation_error::OperationResult;
@@ -130,7 +129,7 @@ impl Segment {
                 is_stopped,
                 effective_deferred_id,
             )?
-            .filter_map_ok(|internal_id| {
+            .filter_map(|internal_id| {
                 let external_id = id_tracker.external_id(internal_id)?;
                 match offset {
                     Some(offset) if external_id < offset => None,
@@ -138,13 +137,11 @@ impl Segment {
                 }
             });
 
-        ids_iterator.process_results(|iter| {
-            let mut page = match limit {
-                Some(limit) => peek_top_smallest_iterable(iter, limit),
-                None => iter.collect(),
-            };
-            page.sort_unstable();
-            page
-        })
+        let mut page = match limit {
+            Some(limit) => peek_top_smallest_iterable(ids_iterator, limit),
+            None => ids_iterator.collect(),
+        };
+        page.sort_unstable();
+        Ok(page)
     }
 }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -513,7 +513,7 @@ mod tests {
             2,
         );
         let res = searcher
-            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
             .unwrap()
             .into_iter()
             .exactly_one()
@@ -585,7 +585,7 @@ mod tests {
         );
 
         let closest = searcher
-            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
             .unwrap()
             .into_iter()
             .exactly_one()
@@ -614,7 +614,7 @@ mod tests {
             5,
         );
         let closest = searcher
-            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
             .unwrap()
             .into_iter()
             .exactly_one()
@@ -703,7 +703,7 @@ mod tests {
             5,
         );
         let closest = searcher
-            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+            .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
             .unwrap()
             .into_iter()
             .exactly_one()

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -62,7 +62,7 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()
@@ -90,7 +90,7 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()
@@ -175,7 +175,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()
@@ -223,7 +223,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
         2,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()
@@ -262,7 +262,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
     )
     .unwrap();
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -129,7 +129,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .pop()
         .unwrap();
@@ -156,7 +156,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .pop()
         .unwrap();
@@ -244,7 +244,7 @@ fn do_test_update_from_delete_points(
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .pop()
         .unwrap();

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -80,7 +80,7 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         5,
     );
     let closest = searcher
-        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap()
         .into_iter()
         .exactly_one()
@@ -172,7 +172,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
         5,
     );
     let results = searcher
-        .peek_top_iter([0, 1, 2, 3, 4, 5].iter().cloned().map(Ok), &DEFAULT_STOPPED)
+        .peek_top_iter([0, 1, 2, 3, 4, 5].iter().cloned(), &DEFAULT_STOPPED)
         .unwrap();
 
     let closest = results.into_iter().exactly_one().unwrap();


### PR DESCRIPTION
This PR proposes an alternative to returning actual lazy iterators from payload indexes.

Reasons:

- code is very complex. Auto-batching/chunking logic on top of CoWs e.t.c. makes it really hard to read or write UIO migrations for payload indexes.
- Lazy iterators froces `Item=Result<...>`, which might be a performance concern, which affects all types of indexes, even in-memory ones
- Pre-load is supposed to be better for latency. Lazy iterators are by definition doing sequential IO, and it requires a lot of extra processing to make this sequential IO efficient. With full prefetching - efficient  batched IO is easier. 


