### PR TITLE
Disable CI for edge examples due to yanked core2

### DIFF
--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -80,14 +80,17 @@ jobs:
         run: just prepare-data
 
       - name: 🦀 Check Rust
+        if: false # TODO: re-enable once core2 0.4.0 yank (libflate transitive dep) is resolved
         working-directory: lib/edge
         run: just rs-check
 
       - name: 🦀 Build Rust examples
+        if: false # TODO: re-enable once core2 0.4.0 yank (libflate transitive dep) is resolved
         working-directory: lib/edge
         run: just rs-examples-build
 
       - name: 🦀 Run Rust examples
+        if: false # TODO: re-enable once core2 0.4.0 yank (libflate transitive dep) is resolved
         working-directory: lib/edge
         run: just rs-examples
 


### PR DESCRIPTION
## Summary

  Temporarily disable the three Rust steps in the `edge-test` CI workflow (`🦀 Check Rust`, `🦀 Build Rust examples`, `🦀 Run Rust examples`) while we work around the upstream `core2 0.4.0` yank.

  ## Context

  `core2 0.4.0` was yanked from crates.io by its author, and no other `^0.4` version exists. It reaches us transitively through:

  ```
  qdrant-edge → charabia → jieba-rs → include-flate → libflate → core2 ^0.4
  ```

  The `examples` workspace under `lib/edge/publish/examples` has no committed `Cargo.lock`, so every CI run resolves fresh and fails with:

  ```
  error: failed to select a version for the requirement `core2 = "^0.4"`
    version 0.4.0 is yanked
  ```

  This blocks unrelated PRs from going green.

  ## Change

  Added `if: false` to each of the three Rust steps in `.github/workflows/edge-test.yml`, with a TODO comment referencing the yank. Python steps are untouched and still run.

  ## Follow-up

  Re-enable these steps once one of the following lands:
  - upstream `libflate` cuts a release that drops the `core2` dep, or
  - we add a `[patch.crates-io]` override + commit a `Cargo.lock` for the examples workspace.

  ## Test plan

  - [ ] CI on this PR shows `edge-test` passing (Rust steps skipped, Python steps run)
  - [ ] Confirm skipped steps appear as "skipped" (not failed) in the Actions UI