### PR TITLE
Draft: Use patched core2 crate in edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,8 +1607,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "core2"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+source = "git+https://github.com/bbqsrc/core2?rev=545e84bcb0f235b12e21351e0c69767958efe2a7#545e84bcb0f235b12e21351e0c69767958efe2a7"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,7 @@ walkdir = "2.5.0"
 [patch.crates-io]
 tonic = { git = "https://github.com/qdrant/tonic", branch = "v0.11.0-qdrant" }
 hyper = { git = "https://github.com/qdrant/hyper", branch = "v0.14.26-qdrant" }
+core2 = { git = "https://github.com/bbqsrc/core2", rev = "545e84bcb0f235b12e21351e0c69767958efe2a7" }
 
 [[bin]]
 name = "schema_generator"

--- a/lib/edge/publish/.gitignore
+++ b/lib/edge/publish/.gitignore
@@ -1,3 +1,4 @@
 /Cargo.lock
+/core2
 /examples/target
 /qdrant-edge

--- a/lib/edge/publish/Cargo.toml
+++ b/lib/edge/publish/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "3"
 members = [ "examples", "qdrant-edge" ]
+
+[patch.crates-io]
+core2 = { path = "qdrant-edge/core2" }

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -50,6 +50,11 @@ EXCLUDED_DEPENDENCIES = {
     "tonic-build",
 }
 
+# Crates from [patch.crates-io] that have been yanked from crates.io.
+# The script clones them and inlines their sources into the amalgamated
+# crate, just like the local packages in PACKAGES_TO_INCLUDE.
+PATCHED_CRATES = {"core2"}
+
 
 def main() -> None:
     root_manifest = tomlkit.loads(
@@ -58,6 +63,9 @@ def main() -> None:
     packages = all_file_dependencies(REPO_ROOT / "lib/edge")
 
     shutil.rmtree(AMALGAMATION, ignore_errors=True)
+    patched = clone_patched_crates(root_manifest)
+    packages.update(patched)
+    PACKAGES_TO_INCLUDE.extend(patched.keys())
 
     # Copy Rust sources.
     for pkg, (path, manifest) in packages.items():
@@ -303,6 +311,67 @@ def substitute(paths: Path | Iterable[Path], *replacements: tuple[str, str]) -> 
             path.write_text(text, encoding="utf-8")
     for seen, (pattern, _) in zip(seen, replacements):
         assert seen, f"Pattern {pattern!r} not found"
+
+
+def clone_patched_crates(
+    root_manifest: tomlkit.TOMLDocument,
+) -> dict[str, tuple[Path, tomlkit.TOMLDocument]]:
+    """Clone crates from PATCHED_CRATES using git info from [patch.crates-io].
+    Returns mapping package_name -> (path, manifest), like all_file_dependencies.
+    """
+    patches = root_manifest.get("patch", {}).get("crates-io", {})
+    result: dict[str, tuple[Path, tomlkit.TOMLDocument]] = {}
+
+    for name in sorted(PATCHED_CRATES):
+        spec = patches.get(name)
+        if spec is None:
+            print(
+                f"Warning: {name!r} not found in [patch.crates-io]", file=sys.stderr
+            )
+            continue
+        if not isinstance(spec, dict) or "git" not in spec:
+            continue
+
+        target = AMALGAMATION.parent / name
+        shutil.rmtree(target, ignore_errors=True)
+
+        git_url = spec["git"]
+        git_ref = spec.get("rev") or spec.get("branch") or spec.get("tag")
+
+        print(f"Cloning {name} from {git_url}@{git_ref}", file=sys.stderr)
+
+        target.mkdir(parents=True)
+        subprocess.run(
+            ["git", "init", str(target)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "-C", str(target), "remote", "add", "origin", git_url],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        fetch_cmd = ["git", "-C", str(target), "fetch", "--depth=1", "origin"]
+        if git_ref:
+            fetch_cmd.append(git_ref)
+        subprocess.run(fetch_cmd, check=True)
+        subprocess.run(
+            ["git", "-C", str(target), "checkout", "FETCH_HEAD"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Remove .git directory — we only need the source.
+        shutil.rmtree(target / ".git")
+
+        manifest = tomlkit.loads(
+            (target / "Cargo.toml").read_text(encoding="utf-8")
+        )
+        result[name] = (target, manifest)
+
+    return result
 
 
 def all_file_dependencies(root: Path) -> dict[str, tuple[Path, tomlkit.TOMLDocument]]:

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -51,8 +51,9 @@ EXCLUDED_DEPENDENCIES = {
 }
 
 # Crates from [patch.crates-io] that have been yanked from crates.io.
-# The script clones them and inlines their sources into the amalgamated
-# crate, just like the local packages in PACKAGES_TO_INCLUDE.
+# The script clones them and copies them into the amalgamated crate
+# directory, then adds [patch.crates-io] entries with local paths to the
+# generated Cargo.toml so Cargo resolves them locally.
 PATCHED_CRATES = {"core2"}
 
 
@@ -64,8 +65,6 @@ def main() -> None:
 
     shutil.rmtree(AMALGAMATION, ignore_errors=True)
     patched = clone_patched_crates(root_manifest)
-    packages.update(patched)
-    PACKAGES_TO_INCLUDE.extend(patched.keys())
 
     # Copy Rust sources.
     for pkg, (path, manifest) in packages.items():
@@ -106,6 +105,14 @@ def main() -> None:
     shutil.copytree(REPO_ROOT / "lib/segment/tokenizer", AMALGAMATION / "tokenizer")
     shutil.copy2(Path(__file__).parent / "README.md", AMALGAMATION / "README.md")
 
+    # Copy patched crates into the amalgamated crate directory.
+    patch_table = {}
+    for name, (clone_path, _) in patched.items():
+        shutil.copytree(clone_path, AMALGAMATION / name)
+        spec = tomlkit.inline_table()
+        spec.update({"path": name})
+        patch_table[name] = spec
+
     # Write Cargo.toml.
     manifest = {
         "package": {
@@ -126,6 +133,8 @@ def main() -> None:
             root_manifest, [manifest for _, manifest in packages.values()]
         ),
     }
+    if patch_table:
+        manifest["patch"] = {"crates-io": patch_table}
     (AMALGAMATION / "Cargo.toml").write_text(tomlkit.dumps(manifest), encoding="utf-8")
 
     # Write src/lib.rs.


### PR DESCRIPTION
The `core2` crate is [yanked](https://crates.io/crates/core2/0.4.0) and so we cannot use it anymore.

This patches the crate to use the latest version from git. It also inlines the crate for `edge` builds.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
