### PR TITLE
Send batches from futures stream, use buffering to prefetch reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,6 +1324,7 @@ dependencies = [
  "api",
  "approx",
  "arc-swap",
+ "async-stream",
  "async-trait",
  "atomicwrites",
  "bytemuck",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -66,6 +66,7 @@ http = { workspace = true }
 actix-web-validator = { workspace = true }
 actix-web = { workspace = true }
 actix-files = { workspace = true }
+async-stream = "0.3"
 
 common = { path = "../common/common" }
 cancel = { path = "../common/cancel" }

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -1,3 +1,4 @@
+use std::future::ready;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -7,6 +8,7 @@ use async_trait::async_trait;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::tar_ext;
 use common::types::{DeferredBehavior, TelemetryDetail};
+use futures::{Stream, StreamExt};
 use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::index::field_index::CardinalityEstimation;
@@ -547,45 +549,28 @@ impl Inner {
     /// likely won't be updated. In the worst case this might cause double sending operations.
     /// This should be fine as operations are idempotent.
     pub async fn transfer_all_missed_updates(&self) -> CollectionResult<()> {
+        let mut stream = self
+            .stream_read_wal_batch()
+            .map(ready)
+            // Buffer to prefetch batches
+            .buffered(2);
         let mut update_lock = None;
-        // First read not under `update_lock`
-        let mut batch = self
-            .read_wal_batch(self.transfer_from.load(Ordering::Relaxed))
-            .await?;
 
-        loop {
-            // Before exiting on an empty read, acquire `update_lock` and re-read to confirm.
-            // Without the lock, a concurrent write could have committed between our read and
-            // our return, leaving entries behind.
-            if batch.batch.is_empty() && update_lock.is_none() {
+        while let Some(wal_batch) = stream.next().await {
+            let wal_batch = wal_batch?;
+
+            // Once reaching last batch, hold update lock to prevent new writes accumulating on WAL
+            let is_last = wal_batch.reached_end || wal_batch.batch.is_empty();
+            if is_last && update_lock.is_none() {
                 update_lock = Some(self.update_lock.lock().await);
-                batch = self
-                    .read_wal_batch(self.transfer_from.load(Ordering::Relaxed))
-                    .await?;
             }
 
-            if batch.batch.is_empty() {
+            // Once next batch is empty and we hold the update lock, we're done
+            if wal_batch.batch.is_empty() && update_lock.is_some() {
                 break;
             }
 
-            // Once we see a batch that reaches the end of the WAL, hold `update_lock` for the rest
-            // of the transfer so no new writes can accumulate. Acquiring the lock synchronously
-            // before the `tokio::join!` guarantees the next read runs under the lock.
-            if batch.reached_end && update_lock.is_none() {
-                update_lock = Some(self.update_lock.lock().await);
-            }
-
-            // Send the current batch and prefetch the next one concurrently. This overlaps the
-            // network round-trip with the WAL read for the next batch.
-            // Note: this temporarily holds two batches in memory (~2x MAX_BATCH_BYTES).
-            let is_last = batch.reached_end;
-            let next_from = batch.batch.last().unwrap().0 + 1;
-            let (send_result, read_result) = tokio::join!(
-                self.send_wal_batch(&batch, is_last),
-                self.read_wal_batch(next_from),
-            );
-            send_result?;
-            batch = read_result?;
+            self.send_wal_batch(&wal_batch, is_last).await?;
         }
 
         // Set the WAL version to keep to the next item we should transfer
@@ -593,6 +578,28 @@ impl Inner {
         self.set_wal_keep_from(Some(transfer_from));
 
         Ok(())
+    }
+
+    /// Create stream that reads all WAL delta items in batches starting from `transfer_from`.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    fn stream_read_wal_batch(&self) -> impl Stream<Item = CollectionResult<WalBatch>> {
+        async_stream::try_stream! {
+            let mut next_from = self.transfer_from.load(Ordering::Relaxed);
+
+            loop {
+                let wal_batch = self.read_wal_batch(next_from).await?;
+
+                if let Some((idx, _)) = wal_batch.batch.last() {
+                    next_from = *idx + 1;
+                }
+
+                yield wal_batch;
+            }
+        }
+        .boxed()
     }
 
     /// Read a batch of WAL entries starting from `from`.


### PR DESCRIPTION
Improvement suggestion for <https://github.com/qdrant/qdrant/pull/8656>

I find the branching in the original approach a little bit confusing.

This moves to a futures stream for reading batches, clearly separating the read and send stages. Buffering is used to prefetch reads.

Please feel free to pick which ever you like best.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?