### PR TITLE
Clamp float32 cosine similarity to [-1.0, 1.0]

### DIFF
--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -4,20 +4,124 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal};
-use segment::types::{PointIdType, WithPayloadInterface, WithVector};
+use segment::data_types::vectors::{
+    DEFAULT_VECTOR_NAME, NamedQuery, VectorInternal, VectorStructInternal,
+};
+use segment::types::{Distance, PointIdType, SearchParams, WithPayloadInterface, WithVector};
 use shard::query::query_enum::QueryEnum;
+use shard::search::CoreSearchRequestBatch;
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
-use crate::operations::types::CollectionError;
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+};
+use crate::operations::types::{CollectionError, CoreSearchRequest, VectorsConfig};
 use crate::operations::universal_query::shard_query::{
     FusionInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
+use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shard_query_cosine_threshold_one_filters_identical_vector() {
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let mut config = create_collection_config_with_dim(2);
+    config.params.vectors =
+        VectorsConfig::Single(VectorParamsBuilder::new(2, Distance::Cosine).build());
+
+    let collection_name = "test".to_string();
+    let current_runtime: Handle = Handle::current();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        current_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    let vector = vec![0.5111364722251892_f32, 0.26978665590286255_f32];
+    let upsert_ops = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(vec![PointStructPersisted {
+            id: segment::types::ExtendedPointId::NumId(1),
+            vector: VectorStructInternal::from(vector.clone()).into(),
+            payload: None,
+        }]),
+    ));
+    shard
+        .update(
+            upsert_ops.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let request = CoreSearchRequest {
+        query: QueryEnum::Nearest(NamedQuery::default_dense(vector)),
+        filter: None,
+        params: Some(SearchParams {
+            exact: true,
+            ..Default::default()
+        }),
+        limit: 1,
+        offset: 0,
+        with_payload: None,
+        with_vector: None,
+        score_threshold: None,
+    };
+
+    let result = shard
+        .do_search(
+            Arc::new(CoreSearchRequestBatch {
+                searches: vec![request.clone()],
+            }),
+            &current_runtime,
+            std::time::Duration::from_secs(5),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result[0].len(), 1);
+    assert_eq!(result[0][0].id, PointIdType::NumId(1));
+
+    let result = shard
+        .do_search(
+            Arc::new(CoreSearchRequestBatch {
+                searches: vec![CoreSearchRequest {
+                    score_threshold: Some(1.0),
+                    ..request
+                }],
+            }),
+            &current_runtime,
+            std::time::Duration::from_secs(5),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result[0].is_empty());
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_shard_query_rrf_rescoring() {

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -172,7 +172,7 @@ impl Metric<VectorElementType> for CosineMetric {
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
-        DotProductMetric::similarity(v1, v2)
+        DotProductMetric::similarity(v1, v2).clamp(-1.0, 1.0)
     }
 
     fn preprocess(vector: DenseVector) -> DenseVector {

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -141,7 +141,7 @@ pub fn is_read_with_prefetch_efficient<O: VectorOffset>(ids: &[O]) -> bool {
 mod tests {
     use super::*;
     use crate::data_types::vectors::MultiDenseVectorInternal;
-    use crate::spaces::simple::EuclidMetric;
+    use crate::spaces::simple::{CosineMetric, EuclidMetric};
 
     #[test]
     fn test_check_ids_rather_contiguous() {
@@ -178,5 +178,13 @@ mod tests {
         let score = score_max_similarity::<f32, EuclidMetric>((&a).into(), (&b).into());
         // proper value according to theory should be `5.9777255` but we do not apply post-processing step
         assert_eq!(score, -19.);
+    }
+
+    #[test]
+    fn test_score_multi_cosine_can_exceed_one() {
+        let a = MultiDenseVectorInternal::try_from(vec![vec![1.0, 0.0], vec![0.0, 1.0]]).unwrap();
+        let score = score_max_similarity::<f32, CosineMetric>((&a).into(), (&a).into());
+
+        assert_eq!(score, 2.0);
     }
 }

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -27,6 +27,28 @@ use segment::types::{
 use tempfile::Builder;
 
 #[test]
+fn exact_cosine_self_score_is_bounded() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vector = vec![0.5111364722251892_f32, 0.26978665590286255_f32];
+    let query = vector.clone().into();
+
+    let mut segment = build_simple_segment(dir.path(), 2, Distance::Cosine).unwrap();
+    segment
+        .upsert_point(1, 1.into(), only_default_vector(&vector), &hw_counter)
+        .unwrap();
+
+    let result = segment.vector_data[DEFAULT_VECTOR_NAME]
+        .vector_index
+        .borrow()
+        .search(&[&query], None, 1, None, &Default::default())
+        .unwrap();
+
+    assert_eq!(result[0][0].score, 1.0);
+}
+
+#[test]
 fn exact_search_test() {
     let stopped = AtomicBool::new(false);
 


### PR DESCRIPTION
Fixes #8688.

Plain `f32` cosine can return a score slightly above `1.0`, which can let identical hits pass `score_threshold = 1.0`.

This clamps the `f32` cosine similarity to `[-1.0, 1.0]`. Generic score postprocessing stays unchanged, since multivector MaxSim can validly exceed `1.0`.

Adds regression coverage for the self-score bound, the threshold case, and the multivector MaxSim guardrail.
