### PR TITLE
Interrupt subgraph_connectivity if it makes no progress

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -989,5 +989,8 @@ mod tests {
             handle.is_finished(),
             "subgraph_connectivity hung on an isolated entry point",
         );
+        handle
+            .join()
+            .expect("subgraph_connectivity thread panicked");
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -952,27 +952,33 @@ mod tests {
     /// entry point has no outgoing links on any of its layers. In that case the
     /// inner BFS iterates zero edges, so `spent_budget` stays at 0 and the
     /// retry `loop` never observes `spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET`.
+    ///
+    /// The state is reachable through normal graph construction: the very first
+    /// point inserted via `link_new_point` has no pre-existing neighbors, so it
+    /// is registered in `EntryPoints` with empty `links_layers` on every layer.
     #[test]
     fn test_subgraph_connectivity_isolated_entry_point_does_not_hang() {
         use std::sync::Arc;
         use std::thread;
         use std::time::{Duration, Instant};
 
-        // Points exist at level 0 but no edges have been inserted yet.
-        const NUM_POINTS: PointOffsetType = 4;
-        let mut builder =
-            GraphLayersBuilder::new(NUM_POINTS as usize, HnswM::new2(M), 16, 10, false);
-        for idx in 0..NUM_POINTS {
-            builder.set_levels(idx, 0);
-        }
+        const DIM: usize = 4;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // Build a one-point graph the normal way. `link_new_point` sees an
+        // empty entry-points list, takes the "new empty entry" branch, and
+        // registers point 0 with no outgoing links on any of its layers.
+        let vector_holder = TestRawScorerProducer::new(DIM, Distance::Cosine, 1, false, &mut rng);
+        let mut builder = GraphLayersBuilder::new(1, HnswM::new2(M), 16, 10, false);
+        let level = builder.get_random_layer(&mut rng);
+        builder.set_levels(0, level);
+        builder.link_new_point(0, vector_holder.internal_scorer(0));
         let builder = Arc::new(builder);
-        let points: Vec<PointOffsetType> = (0..NUM_POINTS).collect();
 
         // Run on a background thread so the test can bound wall-clock time
         // rather than hanging the whole test runner.
         let builder_clone = Arc::clone(&builder);
-        let points_clone = points.clone();
-        let handle = thread::spawn(move || builder_clone.subgraph_connectivity(&points_clone, 0.5));
+        let handle = thread::spawn(move || builder_clone.subgraph_connectivity(&[0], 0.5));
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while !handle.is_finished() && Instant::now() < deadline {

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -153,6 +153,7 @@ impl GraphLayersBuilder {
 
         // Retry loop, in case some budget is left.
         loop {
+            let budget_before_iteration = spent_budget;
             visited.set(entry_point as usize, true);
 
             // Points visited in the previous layer (Get used as entry point in the iteration over the next layer)
@@ -189,8 +190,12 @@ impl GraphLayersBuilder {
                 }
             }
 
-            // Budget exhausted, don't retry.
-            if spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET {
+            // Budget exhausted, don't retry. Also stop if this iteration made no
+            // progress: BFS traversed zero edges, so retrying cannot discover more
+            // (the graph is immutable and coin flips only gate enumerated links).
+            if spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET
+                || spent_budget == budget_before_iteration
+            {
                 break;
             }
 
@@ -941,5 +946,42 @@ mod tests {
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
         eprintln!("avg_connectivity = {avg_connectivity:#?}");
+    }
+
+    /// Regression test: `subgraph_connectivity` must not hang when the chosen
+    /// entry point has no outgoing links on any of its layers. In that case the
+    /// inner BFS iterates zero edges, so `spent_budget` stays at 0 and the
+    /// retry `loop` never observes `spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET`.
+    #[test]
+    fn test_subgraph_connectivity_isolated_entry_point_does_not_hang() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        // Points exist at level 0 but no edges have been inserted yet.
+        const NUM_POINTS: PointOffsetType = 4;
+        let mut builder =
+            GraphLayersBuilder::new(NUM_POINTS as usize, HnswM::new2(M), 16, 10, false);
+        for idx in 0..NUM_POINTS {
+            builder.set_levels(idx, 0);
+        }
+        let builder = Arc::new(builder);
+        let points: Vec<PointOffsetType> = (0..NUM_POINTS).collect();
+
+        // Run on a background thread so the test can bound wall-clock time
+        // rather than hanging the whole test runner.
+        let builder_clone = Arc::clone(&builder);
+        let points_clone = points.clone();
+        let handle = thread::spawn(move || builder_clone.subgraph_connectivity(&points_clone, 0.5));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_finished() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(20));
+        }
+
+        assert!(
+            handle.is_finished(),
+            "subgraph_connectivity hung on an isolated entry point",
+        );
     }
 }


### PR DESCRIPTION
  - Fix infinite loop in `GraphLayersBuilder::subgraph_connectivity` when the selected entry point has no outgoing links on any layer. `spent_budget` is only incremented while iterating a point's outgoing links,
   so an isolated entry point leaves it stuck at `0` forever — the retry `loop` never observes `spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET`. This was seen in production: the HNSW build thread spinning
  inside `subgraph_connectivity` → `HNSWIndex::build` → `SegmentOptimizer::optimize`, which in turn blocked the consensus thread (`apply_entries` waiting on the collection lock held by the optimizer), hanging
  the whole node.
  - Break the retry loop when an iteration consumes zero budget. Sound because the graph is immutable across retries and the coin flip only gates *following* enumerated links, not *enumerating* them — if BFS
  enumerated zero edges once, it will every time. Return value in that case is `1.0 / points.len()`, truthfully reflecting an isolated entry point.
  - Add regression test `test_subgraph_connectivity_isolated_entry_point_does_not_hang`. Runs the call on a background thread with a 2s deadline so the test runner isn't wedged if the bug regresses. Fails in ~2s
   on the old code, passes in ~0.02s with the fix.

  ## Test plan

  - [x] New regression test passes (`cargo test -p segment --lib test_subgraph_connectivity_isolated_entry_point_does_not_hang`)
  - [x] Full `hnsw_index::` test suite passes (38/38), including `test_graph_connectivity` which exercises the normal, non-isolated path
  - [ ] Manually verify on the affected deployment that optimizer-driven HNSW builds no longer hang