### PR TITLE
Make subgraph_connectivity deterministic

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -107,7 +107,12 @@ impl GraphLayersBuilder {
     ///  - Return the fraction of reachable nodes to the total number of nodes in the sub-graph.
     ///
     /// Coin probability `q` is a parameter of this function. By default, it is 0.5.
-    pub fn subgraph_connectivity(&self, points: &[PointOffsetType], q: f32) -> f32 {
+    pub fn subgraph_connectivity<R: Rng + ?Sized>(
+        &self,
+        rng: &mut R,
+        points: &[PointOffsetType],
+        q: f32,
+    ) -> f32 {
         if points.is_empty() {
             return 1.0;
         }
@@ -121,14 +126,12 @@ impl GraphLayersBuilder {
             point_selection.set(*point_id as usize, true);
         }
 
-        let mut rnd = rand::rng();
-
         // Try to get entry point from the entry points list
         // If not found, select the point with the highest level
         let entry_point = self
             .entry_points
             .lock()
-            .get_random_entry_point(&mut rnd, |point_id| {
+            .get_random_entry_point(rng, |point_id| {
                 point_selection.get_bit(point_id as usize).unwrap_or(false)
             })
             .map(|ep| ep.point_id);
@@ -172,7 +175,7 @@ impl GraphLayersBuilder {
                         spent_budget += 1;
 
                         // Flip a coin to decide if the edge is removed or not
-                        let coin_flip = rnd.random_range(0.0..1.0);
+                        let coin_flip = rng.random_range(0.0..1.0);
                         if coin_flip < q {
                             continue;
                         }

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -981,7 +981,10 @@ mod tests {
         // Run on a background thread so the test can bound wall-clock time
         // rather than hanging the whole test runner.
         let builder_clone = Arc::clone(&builder);
-        let handle = thread::spawn(move || builder_clone.subgraph_connectivity(&[0], 0.5));
+        let handle = thread::spawn(move || {
+            let mut rng = rand::rng();
+            builder_clone.subgraph_connectivity(&mut rng, &[0], 0.5)
+        });
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while !handle.is_finished() && Instant::now() < deadline {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -529,9 +529,9 @@ impl HNSWIndex {
 
             let required_connectivity = if average_links_per_0_level_int >= 4 {
                 let global_graph_connectivity = [
-                    graph_layers_builder.subgraph_connectivity(&all_points, percolation),
-                    graph_layers_builder.subgraph_connectivity(&all_points, percolation),
-                    graph_layers_builder.subgraph_connectivity(&all_points, percolation),
+                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
+                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
+                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
                 ];
 
                 debug!("graph connectivity: {global_graph_connectivity:?} @ {percolation}");
@@ -625,8 +625,11 @@ impl HNSWIndex {
                         && let Some(required_connectivity) = required_connectivity
                     {
                         // Always build for tenants
-                        let graph_connectivity = graph_layers_builder
-                            .subgraph_connectivity(&points_to_index, percolation);
+                        let graph_connectivity = graph_layers_builder.subgraph_connectivity(
+                            rng,
+                            &points_to_index,
+                            percolation,
+                        );
 
                         if graph_connectivity >= required_connectivity {
                             trace!(


### PR DESCRIPTION
No need to create a new `rand::rng();` as the caller has one at hand to ensure determinism.