### PR TITLE
Fix flaky test_deferred_points_dedup_after_optimization

### DIFF
--- a/lib/collection/src/tests/deferred_points_dedup.rs
+++ b/lib/collection/src/tests/deferred_points_dedup.rs
@@ -118,12 +118,17 @@ async fn wait_optimization(shard: &LocalShard, timeout: Duration) {
     let start = std::time::Instant::now();
     loop {
         let (status, _) = shard.local_shard_status().await;
-        if status == ShardStatus::Green {
+        let has_proxy = shard
+            .segments()
+            .read()
+            .iter()
+            .any(|(_, segment)| !segment.is_original());
+        if status == ShardStatus::Green && !has_proxy {
             return;
         }
         assert!(
             start.elapsed() < timeout,
-            "Timeout waiting for optimizations to finish (status: {status:?})",
+            "Timeout waiting for optimizations to finish (status: {status:?}, has_proxy: {has_proxy})",
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }


### PR DESCRIPTION
 Addresses #8504

`wait_optimization` only checked for `ShardStatus::Green`, which can be true briefly before proxy segments are fully removed, causing the test to access an unimplemented proxy method.
