### PR TITLE
Sort HashMap keys for deterministic iteration

### DIFF
--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -226,7 +226,8 @@ impl Collection {
                         .await?;
                 }
                 None => {
-                    let shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
+                    let mut shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
+                    shard_replicas.sort_unstable();
                     let mut replica_set = self
                         .create_replica_set(shard_id, shard_key.clone(), &shard_replicas, None)
                         .await?;

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -343,7 +343,8 @@ impl ShardHolder {
             }
         }
 
-        let all_shard_ids = self.shards.keys().cloned().collect::<HashSet<_>>();
+        let mut all_shard_ids: Vec<ShardId> = self.shards.keys().copied().collect();
+        all_shard_ids.sort_unstable();
 
         self.set_shard_key_mappings(shard_key_mapping)?;
 

--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -262,7 +262,9 @@ impl Persistent {
     }
 
     pub fn get_cluster_metadata_keys(&self) -> Vec<String> {
-        self.cluster_metadata.keys().cloned().collect()
+        let mut keys: Vec<String> = self.cluster_metadata.keys().cloned().collect();
+        keys.sort_unstable();
+        keys
     }
 
     pub fn get_cluster_metadata_key(&self, key: &str) -> serde_json::Value {

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -258,7 +258,8 @@ impl TableOfContent {
             }
 
             // Collect names of collections that are present locally
-            let collection_names: Vec<_> = existing_collections.keys().cloned().collect();
+            let mut collection_names: Vec<_> = existing_collections.keys().cloned().collect();
+            collection_names.sort_unstable();
 
             // Drop `collections` lock
             drop(existing_collections);

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -116,7 +116,9 @@ pub async fn handle_existing_collections(
 
                     for shard_id in shard_ids {
                         let shard_info = shards.get(shard_id).unwrap();
-                        placement.push(shard_info.replicas.keys().copied().collect());
+                        let mut replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
+                        replicas.sort_unstable();
+                        placement.push(replicas);
                     }
 
                     consensus_operations.push(CollectionMetaOperations::CreateShardKey(


### PR DESCRIPTION
Sort `HashMap` / `AHashMap` keys at five call sites where randomized iteration order was leaking into HTTP responses, consensus operations, and ordered side-effects. 

Each fix collects into a `Vec` and calls  `sort_unstable()` before the existing usage.

## Changes

  - **`persistent.rs`** — `get_cluster_metadata_keys()` is served directly over `GET /cluster/metadata/keys`; response order was random.
  - **`collection_container.rs`** — during consensus-snapshot reconciliation, `delete_collection(...)` was invoked in random order over locally-existing collections.
  - **`shard_holder/mod.rs`** — resharding state-apply dropped extra shards in random order; the intermediate `HashSet` was never used for membership, replaced with a sorted `Vec<ShardId>`.
  - **`single_to_cluster.rs`** — replica peers per shard were pushed into the `placement` vector of a `CreateShardKey` consensus op in random order.
  - **`state_management.rs`** — `apply_shard_info` passed `shard_info.replicas.keys()` to `create_replica_set(...)` in random order.

## Future work

Further determinism candidates were found but I want to keep this PR small and not controversial.