### PR TITLE
ShardHolder has deterministic shard iteration

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -2,7 +2,7 @@ mod resharding;
 pub(crate) mod shard_mapping;
 pub mod shared_shard_holder;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -63,7 +63,9 @@ const RESHARDING_STATE_FILE: &str = "resharding_state.json";
 pub const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
 
 pub struct ShardHolder {
-    shards: AHashMap<ShardId, ShardReplicaSet>,
+    /// `BTreeMap` for deterministic iteration order by `ShardId` — iteration is externally
+    /// observable (fan-out, telemetry, consensus state apply).
+    shards: BTreeMap<ShardId, ShardReplicaSet>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
     pub(crate) shard_transfer_changes: broadcast::Sender<ShardTransferChange>,
     pub(crate) resharding_state: SaveOnDisk<Option<ReshardState>>,
@@ -113,7 +115,7 @@ impl ShardHolder {
         let (shard_transfer_changes, _) = broadcast::channel(64);
 
         Ok(Self {
-            shards: AHashMap::new(),
+            shards: BTreeMap::new(),
             shard_transfers,
             shard_transfer_changes,
             resharding_state,
@@ -126,10 +128,9 @@ impl ShardHolder {
     }
 
     pub async fn stop_gracefully(&mut self) {
-        let futures = self
-            .shards
-            .drain()
-            .map(|(_, shard)| shard.stop_gracefully());
+        let futures = std::mem::take(&mut self.shards)
+            .into_values()
+            .map(|shard| shard.stop_gracefully());
         futures::future::join_all(futures).await;
     }
 
@@ -343,8 +344,7 @@ impl ShardHolder {
             }
         }
 
-        let mut all_shard_ids: Vec<ShardId> = self.shards.keys().copied().collect();
-        all_shard_ids.sort_unstable();
+        let all_shard_ids: Vec<ShardId> = self.shards.keys().copied().collect();
 
         self.set_shard_key_mappings(shard_key_mapping)?;
 


### PR DESCRIPTION
 Switch `ShardHolder.shards` from `AHashMap<ShardId, ShardReplicaSet>` to `BTreeMap<ShardId, ShardReplicaSet>`. 

Every iteration over the shard set becomes deterministic by `ShardId` without touching any caller.

 ## Why

 `AHashMap` has a randomized seed, iteration order changes across process restarts and propagates into any code path that walks the map. 

Deployments have in general a small number of shards, let's assume less than 1000 for the sake of sizing.

On `u32` keys at this size, there is effectively no perf cost to switching, the BTreeMap's O(log n) lookup (and O(n) iteration, same as AHashMap) is dominated by the network + HNSW work that each shard handles.

 ## Gains

Every shard-walking path now produces the same sequence across runs given the same input. Direct consequences:
  - **`trigger_optimizers`** fires per-shard in `ShardId` order — reproducible log/trace output.
  - **`stop_gracefully`** tears shards down in `ShardId` order.
  - **`all_shards` / `all_shards_mut` / `get_shards`** hand callers sorted iterators, making several user-visible behaviours deterministic in one stroke:
    - **Telemetry** (`Collection::get_telemetry_data`) — shard entries in the API response are emitted in `ShardId` order.
    - **`get_local_shards()`** — the returned `Vec<ShardId>` is sorted.
    - **Snapshot creation** (`Collection::create_snapshot`) — per-shard snapshot futures are dispatched in `ShardId` order.
    - **Config propagation** (`on_strict_mode_config_update`, `on_optimizer_config_update`) — per-shard update futures are dispatched in `ShardId` order.
    - **Local state sync** (`sync_local_state`) and **peer removal** (`remove_shards_at_peer`) — sequential per-shard loops run in stable order.
    - **Payload-schema merging** (`common_payload_index_schema`) — the first-shard seeding and early-break condition walk shards in stable order; the warning-log sequence on schema extraction errors is
  reproducible.
    - **Cluster-info counts** (`count_local` per shard) — the ordering of per-shard count requests against remote peers is stable.
  - **Resharding state walks and cluster health scans** iterate shards in stable order.
  - **`apply_shards_state`** drops extra shards in `ShardId` order intrinsically — the manual `sort_unstable` from #8706 is gone.
  - **Tests and CI** get stable log interleaving and `{:?}` output across shards — fewer flakes, cleaner golden-file diffs.