### PR TITLE
Fix flaky test_collection_recovery_user_requests_above_limit

### DIFF
--- a/tests/consensus_tests/test_collection_recovery_limits.py
+++ b/tests/consensus_tests/test_collection_recovery_limits.py
@@ -154,13 +154,16 @@ def test_collection_recovery_user_requests_above_limit(tmp_path: pathlib.Path):
     # Restart the peer, wait unil it is up
     peer_url = start_peer(killed_peer_dir, "peer_0_restarted.log", bootstrap_url)
     wait_for_peer_online(peer_url)
+    recovering_peer_id = get_cluster_info(peer_url)["peer_id"]
 
     # We must see N_SHARDS transfers on our new node
     # WARN: this check is disabled, as it's not guaranteed that we are lucky enough to see 3 transfers in our check interval
     # wait_for(transfers_reached_threshold, peer_urls[-1], wait_for_interval=0.1, transfer_threshold=N_SHARDS, transfer_limit=N_SHARDS + 1)
 
     # Wait until all shards are active on our recovering node, never allow more than 1 shard transfers
-    wait_for(transfers_below_limit_or_done, peer_url, wait_for_interval=0.1, transfer_limit=1)
+    # Only count transfers involving the recovering peer — concurrent user-requested transfers
+    # between other peers are not subject to the automatic transfer limit.
+    wait_for(transfers_below_limit_or_done, peer_url, wait_for_interval=0.1, transfer_limit=1, involves_peer_id=recovering_peer_id)
 
     # Wait until all shards are active on our new node we replicated to
     wait_for(all_collection_shards_are_active, peer_urls[-1], COLLECTION_NAME)
@@ -182,9 +185,13 @@ def transfers_reached_threshold(peer_url, transfer_threshold=1, transfer_limit =
     return transfer_count >= transfer_threshold
 
 
-def transfers_below_limit_or_done(peer_url, transfer_limit = 1):
+def transfers_below_limit_or_done(peer_url, transfer_limit = 1, involves_peer_id = None):
     # Ongoing transfers must be below limit
-    transfer_count = get_shard_transfer_count(peer_url, COLLECTION_NAME)
+    info = get_collection_cluster_info(peer_url, COLLECTION_NAME)
+    transfers = info["shard_transfers"]
+    if involves_peer_id is not None:
+        transfers = [t for t in transfers if t["from"] == involves_peer_id or t["to"] == involves_peer_id]
+    transfer_count = len(transfers)
     if transfer_count > transfer_limit:
         raise Exception(f"Number of shard transfers in collection {COLLECTION_NAME} is above our limit ({transfer_count}/{transfer_limit})")
 


### PR DESCRIPTION
This is an AI analisis of 

```
FAILED consensus_tests/test_collection_recovery_limits.py::test_collection_recovery_user_requests_above_limit - Exception: Number of shard transfers in collection test_collection is above our limit (3/1)
```

which I reproduced locally


---

## Summary

`test_collection_recovery_user_requests_above_limit` can fail with:

```
Exception: Number of shard transfers in collection test_collection is above our limit (3/1)
```

### Root cause

The test:
1. kills the last peer;
2. adds a new peer and issues **3 user-requested** `replicate_shard` operations from `peer[0]` → new peer;
3. restarts the killed peer;
4. asserts `transfers_below_limit_or_done(peer_url, transfer_limit=1)` on the recovering peer.

`transfers_below_limit_or_done` calls `GET /collections/<name>/cluster`, whose `shard_transfers` field is the **collection-wide** transfer set — every peer sees every transfer. So the 3 user-initiated transfers between `peer[0]` and the new peer get counted against the automatic-recovery limit of 1, and the assertion fires immediately.

This is independent of the actual server-side behavior: user transfers intentionally bypass the automatic limit. The limit is only consulted when proposing *new* automatic transfers, via `check_auto_shard_transfer_limit` (`lib/collection/src/collection/shard_transfer.rs:559`) called from `sync_local_state` at `lib/collection/src/collection/mod.rs:{787,833}` using `count_shard_transfer_io(peer_id)` — it's per-peer, not global.

### Fix

Filter `shard_transfers` to those involving the recovering peer (either `from` or `to` == recovering peer id) before comparing against the limit. Unrelated user transfers no longer count.

## Test plan

- [x] `pytest tests/consensus_tests/test_collection_recovery_limits.py::test_collection_recovery_user_requests_above_limit`
- [ ] Other two tests in the same file still pass (they don't use the new `involves_peer_id` argument and fall back to the previous counting behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)