### PR TITLE
Toc has deterministic collections iteration

### DIFF
--- a/lib/storage/src/content_manager/collections_ops.rs
+++ b/lib/storage/src/content_manager/collections_ops.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use collection::collection::Collection;
@@ -6,7 +6,9 @@ use collection::shards::CollectionId;
 
 use crate::content_manager::errors::StorageError;
 
-pub type Collections = HashMap<CollectionId, Arc<Collection>>;
+/// `BTreeMap` for deterministic iteration order by `CollectionId` — iteration is externally
+/// observable (list API, consensus state apply, snapshot enumeration, telemetry).
+pub type Collections = BTreeMap<CollectionId, Arc<Collection>>;
 
 pub trait Checker {
     fn collection_exists(&self, collection_name: &str) -> bool;

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -258,8 +258,7 @@ impl TableOfContent {
             }
 
             // Collect names of collections that are present locally
-            let mut collection_names: Vec<_> = existing_collections.keys().cloned().collect();
-            collection_names.sort_unstable();
+            let collection_names: Vec<_> = existing_collections.keys().cloned().collect();
 
             // Drop `collections` lock
             drop(existing_collections);

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -198,7 +198,7 @@ impl TableOfContent {
                 .get(),
         );
 
-        let mut collections: HashMap<String, Arc<Collection>> = Default::default();
+        let mut collections: Collections = Default::default();
         general_runtime.block_on(async {
             while let Some((collection_name, collection)) = collection_stream.next().await {
                 collections.insert(collection_name, Arc::new(collection));


### PR DESCRIPTION
Similar rational as https://github.com/qdrant/qdrant/pull/8708

 ## Gains

 Every collection-walking path now produces the same sequence across runs given the same input. Direct consequences:

  - **`GET /collections` REST endpoint** (`src/actix/api/collections_api.rs:45` → `do_list_collections`) and the **gRPC `Collections::List`** RPC (`src/tonic/api/collections_api.rs:94`) return collection names
  in `CollectionId` order.
  - **Telemetry response** (`TableOfContent::get_telemetry_data`) — per-collection telemetry entries are emitted in stable order.
  - **Consensus snapshot build** (`collections_snapshot`) — per-collection `collection.state().await` calls fire in `CollectionId` order; the resulting inserts into the snapshot map happen in stable sequence, so
   log output during snapshotting is reproducible.
  - **Consensus state apply reconciliation** (`collection_container`) — the loop that deletes locally-present collections missing from the Raft snapshot runs in `CollectionId` order. The manual `sort_unstable`
  added in #8706 is now redundant and removed.
  - **Peer lifecycle operations** — `TableOfContent::cancel_related_transfers` emits abort-transfer consensus operations in stable order, and `remove_shards_at_peer` tears down per-collection peer state in
  stable sequence.
  - **Shard-presence scan** (`peer_has_shards`) — early-return `.any()` is commutative so the result is unchanged, but which collection is inspected first and the log trace are now stable.
  - **Startup and health-check listings** (`all_collections_sync` at `toc/mod.rs:304`, used by startup in `main.rs` and by the `/health` path in `common/health.rs:312`) — return collection IDs in stable order.
  - **Tests and CI** get stable log interleaving and `{:?}` output across collections — fewer flakes, cleaner golden-file diffs.