### PR TITLE
fix: enable Windows ARM64 f16 NEON build

### DIFF
--- a/lib/quantization/build.rs
+++ b/lib/quantization/build.rs
@@ -29,13 +29,20 @@ fn main() {
             builder.flag("-march=haswell");
         }
 
-        // O3 optimization level
-        builder.flag("-O3");
-        // Use popcnt instruction
-        builder.flag("-mpopcnt");
+        if builder.get_compiler().is_like_msvc() {
+            builder.flag("/O2");
+        } else {
+            builder.flag("-O3");
+            builder.flag("-mpopcnt");
+        }
     } else if target_arch == "aarch64" && target_feature.split(',').any(|feat| feat == "neon") {
         builder.file("cpp/neon.c");
-        builder.flag("-O3");
+
+        if builder.get_compiler().is_like_msvc() {
+            builder.flag("/O2");
+        } else {
+            builder.flag("-O3");
+        }
     }
 
     builder.compile("simd_utils");

--- a/lib/segment/build.rs
+++ b/lib/segment/build.rs
@@ -1,8 +1,13 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/spaces/metric_f16/cpp/neon.c");
+
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH env-var is not defined or is not UTF-8");
+    if target_arch != "aarch64" {
+        return;
+    }
 
     // TODO: Is `CARGO_CFG_TARGET_FEATURE` *always* defined?
     //
@@ -12,12 +17,20 @@ fn main() {
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html (Ctrl-F CARGO_CFG_<cfg>)
     let target_feature = env::var("CARGO_CFG_TARGET_FEATURE")
         .expect("CARGO_CFG_TARGET_FEATURE env-var is not defined or is not UTF-8");
+    if !target_feature.split(',').any(|feat| feat == "neon") {
+        return;
+    }
 
-    if target_arch == "aarch64" && target_feature.split(',').any(|feat| feat == "neon") {
-        let mut builder = cc::Build::new();
-        builder.file("src/spaces/metric_f16/cpp/neon.c");
+    let mut builder = cc::Build::new();
+    builder.file("src/spaces/metric_f16/cpp/neon.c");
+
+    if builder.get_compiler().is_like_msvc() {
+        builder.flag("/O2");
+        builder.flag("/Zc:arm64-aliased-neon-types");
+    } else {
         builder.flag("-O3");
         builder.flag("-march=armv8.2-a+fp16");
-        builder.compile("simd_utils");
     }
+
+    builder.compile("simd_utils");
 }

--- a/lib/segment/src/spaces/metric_f16/cpp/neon.c
+++ b/lib/segment/src/spaces/metric_f16/cpp/neon.c
@@ -1,23 +1,65 @@
-#if !defined PC_VER
+#if defined(_MSC_VER)
+#include <arm64_neon.h>
+#define QDRANT_FP16_NEON_ENABLED 1
+#else
 #include <arm_neon.h>
-#endif
-
 #ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
 #include <arm_fp16.h>
-float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
+#define QDRANT_FP16_NEON_ENABLED 1
+#endif
+#endif
+
+#ifdef QDRANT_FP16_NEON_ENABLED
+#if defined(_MSC_VER)
+#define QDRANT_F16_STORAGE uint16_t
+#define QDRANT_F16_ZERO() vreinterpretq_f16_u16(vdupq_n_u16(0))
+#define QDRANT_F16_LOAD(ptr) vreinterpretq_f16_u16(vld1q_u16((const uint16_t*)(ptr)))
+
+static inline float16x4_t qdrant_f16_splat(uint16_t bits)
+{
+    return vreinterpret_f16_u16(vdup_n_u16(bits));
+}
+
+static inline float qdrant_f16_lane_to_f32(float16x4_t value)
+{
+    return vgetq_lane_f32(vcvt_f32_f16(value), 0);
+}
+
+static inline float qdrant_mulf_f16(uint16_t lhs, uint16_t rhs)
+{
+    return qdrant_f16_lane_to_f32(vmul_f16(qdrant_f16_splat(lhs), qdrant_f16_splat(rhs)));
+}
+
+static inline float qdrant_sqdiff_f16(uint16_t lhs, uint16_t rhs)
+{
+    float16x4_t diff = vsub_f16(qdrant_f16_splat(lhs), qdrant_f16_splat(rhs));
+    return qdrant_f16_lane_to_f32(vmul_f16(diff, diff));
+}
+
+static inline float qdrant_absdiff_f16(uint16_t lhs, uint16_t rhs)
+{
+    return qdrant_f16_lane_to_f32(vabd_f16(qdrant_f16_splat(lhs), qdrant_f16_splat(rhs)));
+}
+#else
+#define QDRANT_F16_STORAGE float16_t
+#define QDRANT_F16_ZERO() vdupq_n_f16(0.0f)
+#define QDRANT_F16_LOAD(ptr) vld1q_f16(ptr)
+#endif
+
+float32_t dotProduct_half_4x4(const QDRANT_F16_STORAGE* pSrcA, const QDRANT_F16_STORAGE* pSrcB, uint32_t blockSize)
 {
     float32_t dotProduct = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
+    float16x8_t sum1 = QDRANT_F16_ZERO();
+    float16x8_t sum2 = QDRANT_F16_ZERO();
+    float16x8_t sum3 = QDRANT_F16_ZERO();
+    float16x8_t sum4 = QDRANT_F16_ZERO();
 
     for(uint32_t i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sum1 = vfmaq_f16(sum1, vld1q_f16(pSrcA), vld1q_f16(pSrcB));
-        sum2 = vfmaq_f16(sum2, vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8));
-        sum3 = vfmaq_f16(sum3, vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16));
-        sum4 = vfmaq_f16(sum4, vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24));
+        sum1 = vfmaq_f16(sum1, QDRANT_F16_LOAD(pSrcA), QDRANT_F16_LOAD(pSrcB));
+        sum2 = vfmaq_f16(sum2, QDRANT_F16_LOAD(pSrcA+8), QDRANT_F16_LOAD(pSrcB+8));
+        sum3 = vfmaq_f16(sum3, QDRANT_F16_LOAD(pSrcA+16), QDRANT_F16_LOAD(pSrcB+16));
+        sum4 = vfmaq_f16(sum4, QDRANT_F16_LOAD(pSrcA+24), QDRANT_F16_LOAD(pSrcB+24));
 
         pSrcA += 32;
         pSrcB += 32;
@@ -34,7 +76,11 @@ float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, ui
 
     dotProduct = vaddvq_f32(sum);
     for (uint32_t i=0; i < (blockSize % 32); i++) {
+#if defined(_MSC_VER)
+        dotProduct += qdrant_mulf_f16(*pSrcA, *pSrcB);
+#else
         dotProduct += (float32_t)((*pSrcA)*(*pSrcB));
+#endif
         pSrcA += 1;
         pSrcB += 1;
     }
@@ -42,30 +88,30 @@ float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, ui
     return dotProduct;
 }
 
-float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
+float32_t euclideanDist_half_4x4(const QDRANT_F16_STORAGE* pSrcA, const QDRANT_F16_STORAGE* pSrcB, uint32_t blockSize)
 {
     float32_t euclideanDistance = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sub1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sub2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sub3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
-    float16x8_t sub4 = vdupq_n_f16(0.0f);
+    float16x8_t sum1 = QDRANT_F16_ZERO();
+    float16x8_t sub1 = QDRANT_F16_ZERO();
+    float16x8_t sum2 = QDRANT_F16_ZERO();
+    float16x8_t sub2 = QDRANT_F16_ZERO();
+    float16x8_t sum3 = QDRANT_F16_ZERO();
+    float16x8_t sub3 = QDRANT_F16_ZERO();
+    float16x8_t sum4 = QDRANT_F16_ZERO();
+    float16x8_t sub4 = QDRANT_F16_ZERO();
 
     for(uint32_t i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sub1 = vsubq_f16(vld1q_f16(pSrcA), vld1q_f16(pSrcB));
+        sub1 = vsubq_f16(QDRANT_F16_LOAD(pSrcA), QDRANT_F16_LOAD(pSrcB));
         sum1 = vfmaq_f16(sum1, sub1, sub1);
 
-        sub2 = vsubq_f16(vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8));
+        sub2 = vsubq_f16(QDRANT_F16_LOAD(pSrcA+8), QDRANT_F16_LOAD(pSrcB+8));
         sum2 = vfmaq_f16(sum2, sub2, sub2);
 
-        sub3 = vsubq_f16(vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16));
+        sub3 = vsubq_f16(QDRANT_F16_LOAD(pSrcA+16), QDRANT_F16_LOAD(pSrcB+16));
         sum3 = vfmaq_f16(sum3, sub3, sub3);
 
-        sub4 = vsubq_f16(vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24));
+        sub4 = vsubq_f16(QDRANT_F16_LOAD(pSrcA+24), QDRANT_F16_LOAD(pSrcB+24));
         sum4 = vfmaq_f16(sum4, sub4, sub4);
 
         pSrcA += 32;
@@ -82,10 +128,13 @@ float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
     sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum4)));
 
     euclideanDistance = vaddvq_f32(sum);
-    float16_t tmp = 0.0f;
     for (uint32_t i=0; i < (blockSize % 32); i++) {
-        tmp = (*pSrcA - *pSrcB);
+#if defined(_MSC_VER)
+        euclideanDistance += qdrant_sqdiff_f16(*pSrcA, *pSrcB);
+#else
+        float16_t tmp = (*pSrcA - *pSrcB);
         euclideanDistance += (float32_t)(tmp * tmp);
+#endif
         pSrcA += 1;
         pSrcB += 1;
     }
@@ -93,24 +142,24 @@ float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
     return euclideanDistance;
 }
 
-float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
+float32_t manhattanDist_half_4x4(const QDRANT_F16_STORAGE* pSrcA, const QDRANT_F16_STORAGE* pSrcB, uint32_t blockSize)
 {
     float32_t manhattanDistance = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
+    float16x8_t sum1 = QDRANT_F16_ZERO();
+    float16x8_t sum2 = QDRANT_F16_ZERO();
+    float16x8_t sum3 = QDRANT_F16_ZERO();
+    float16x8_t sum4 = QDRANT_F16_ZERO();
     uint32_t i = 0;
 
     for(i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sum1 = vaddq_f16(sum1, vabdq_f16(vld1q_f16(pSrcA), vld1q_f16(pSrcB)));
+        sum1 = vaddq_f16(sum1, vabdq_f16(QDRANT_F16_LOAD(pSrcA), QDRANT_F16_LOAD(pSrcB)));
 
-        sum2 = vaddq_f16(sum2, vabdq_f16(vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8)));
+        sum2 = vaddq_f16(sum2, vabdq_f16(QDRANT_F16_LOAD(pSrcA+8), QDRANT_F16_LOAD(pSrcB+8)));
 
-        sum3 = vaddq_f16(sum3, vabdq_f16(vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16)));
+        sum3 = vaddq_f16(sum3, vabdq_f16(QDRANT_F16_LOAD(pSrcA+16), QDRANT_F16_LOAD(pSrcB+16)));
 
-        sum4 = vaddq_f16(sum4, vabdq_f16(vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24)));
+        sum4 = vaddq_f16(sum4, vabdq_f16(QDRANT_F16_LOAD(pSrcA+24), QDRANT_F16_LOAD(pSrcB+24)));
 
         pSrcA += 32;
         pSrcB += 32;
@@ -127,7 +176,11 @@ float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
 
     manhattanDistance = vaddvq_f32(sum);
     for (i=0; i < (blockSize % 32); i++) {
+#if defined(_MSC_VER)
+        manhattanDistance += qdrant_absdiff_f16(*pSrcA, *pSrcB);
+#else
         manhattanDistance += (float32_t)(vabsh_f16(*pSrcA - *pSrcB));
+#endif
         pSrcA += 1;
         pSrcB += 1;
     }

--- a/lib/segment/src/spaces/metric_f16/mod.rs
+++ b/lib/segment/src/spaces/metric_f16/mod.rs
@@ -6,7 +6,7 @@ pub mod simple_manhattan;
 #[cfg(target_arch = "x86_64")]
 pub mod avx;
 
-#[cfg(all(target_arch = "aarch64", not(windows)))]
+#[cfg(target_arch = "aarch64")]
 pub mod neon;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/lib/segment/src/spaces/metric_f16/neon/dot.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/dot.rs
@@ -1,5 +1,6 @@
 #[cfg(target_feature = "neon")]
 use common::types::ScoreType;
+#[cfg(all(target_feature = "neon", not(target_env = "msvc")))]
 use half::f16;
 
 #[cfg(target_feature = "neon")]
@@ -7,6 +8,10 @@ use crate::data_types::vectors::VectorElementTypeHalf;
 
 #[cfg(target_feature = "neon")]
 unsafe extern "C" {
+    #[cfg(target_env = "msvc")]
+    fn dotProduct_half_4x4(v1: *const u16, v2: *const u16, n: i32) -> f32;
+
+    #[cfg(not(target_env = "msvc"))]
     fn dotProduct_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
@@ -17,6 +22,12 @@ pub unsafe fn neon_dot_similarity_half(
     v2: &[VectorElementTypeHalf],
 ) -> ScoreType {
     let n: i32 = v1.len().try_into().unwrap();
+    #[cfg(target_env = "msvc")]
+    unsafe {
+        dotProduct_half_4x4(v1.as_ptr().cast::<u16>(), v2.as_ptr().cast::<u16>(), n)
+    }
+
+    #[cfg(not(target_env = "msvc"))]
     unsafe { dotProduct_half_4x4(v1.as_ptr(), v2.as_ptr(), n) }
 }
 

--- a/lib/segment/src/spaces/metric_f16/neon/euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/euclid.rs
@@ -1,5 +1,6 @@
 #[cfg(target_feature = "neon")]
 use common::types::ScoreType;
+#[cfg(all(target_feature = "neon", not(target_env = "msvc")))]
 use half::f16;
 
 #[cfg(target_feature = "neon")]
@@ -7,6 +8,10 @@ use crate::data_types::vectors::VectorElementTypeHalf;
 
 #[cfg(target_feature = "neon")]
 unsafe extern "C" {
+    #[cfg(target_env = "msvc")]
+    fn euclideanDist_half_4x4(v1: *const u16, v2: *const u16, n: i32) -> f32;
+
+    #[cfg(not(target_env = "msvc"))]
     fn euclideanDist_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
@@ -17,6 +22,16 @@ pub unsafe fn neon_euclid_similarity_half(
     v2: &[VectorElementTypeHalf],
 ) -> ScoreType {
     let n = v1.len();
+    #[cfg(target_env = "msvc")]
+    unsafe {
+        -euclideanDist_half_4x4(
+            v1.as_ptr().cast::<u16>(),
+            v2.as_ptr().cast::<u16>(),
+            n.try_into().unwrap(),
+        )
+    }
+
+    #[cfg(not(target_env = "msvc"))]
     unsafe { -euclideanDist_half_4x4(v1.as_ptr(), v2.as_ptr(), n.try_into().unwrap()) }
 }
 

--- a/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
@@ -1,5 +1,6 @@
 #[cfg(target_feature = "neon")]
 use common::types::ScoreType;
+#[cfg(all(target_feature = "neon", not(target_env = "msvc")))]
 use half::f16;
 
 #[cfg(target_feature = "neon")]
@@ -7,6 +8,10 @@ use crate::data_types::vectors::VectorElementTypeHalf;
 
 #[cfg(target_feature = "neon")]
 unsafe extern "C" {
+    #[cfg(target_env = "msvc")]
+    fn manhattanDist_half_4x4(v1: *const u16, v2: *const u16, n: i32) -> f32;
+
+    #[cfg(not(target_env = "msvc"))]
     fn manhattanDist_half_4x4(v1: *const f16, v2: *const f16, n: i32) -> f32;
 }
 
@@ -17,6 +22,16 @@ pub unsafe fn neon_manhattan_similarity_half(
     v2: &[VectorElementTypeHalf],
 ) -> ScoreType {
     let n = v1.len();
+    #[cfg(target_env = "msvc")]
+    unsafe {
+        -manhattanDist_half_4x4(
+            v1.as_ptr().cast::<u16>(),
+            v2.as_ptr().cast::<u16>(),
+            n.try_into().unwrap(),
+        )
+    }
+
+    #[cfg(not(target_env = "msvc"))]
     unsafe { -manhattanDist_half_4x4(v1.as_ptr(), v2.as_ptr(), n.try_into().unwrap()) }
 }
 

--- a/lib/segment/src/spaces/metric_f16/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_cosine.rs
@@ -5,7 +5,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::dot::avx_dot_similarity_half;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::spaces::metric_f16::neon::dot::neon_dot_similarity_half;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::spaces::metric_f16::sse::dot::sse_dot_similarity_half;
@@ -14,7 +14,7 @@ use crate::spaces::simple::MIN_DIM_SIZE_AVX;
 use crate::spaces::simple::{CosineMetric, MIN_DIM_SIZE_SIMD, cosine_preprocess};
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::simple_avx::*;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::spaces::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::spaces::simple_sse::*;
@@ -44,7 +44,7 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon")
                 && std::arch::is_aarch64_feature_detected!("fp16")
@@ -75,7 +75,7 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon") && vector.len() >= MIN_DIM_SIZE_SIMD
             {

--- a/lib/segment/src/spaces/metric_f16/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_dot.rs
@@ -5,7 +5,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::dot::avx_dot_similarity_half;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::spaces::metric_f16::neon::dot::neon_dot_similarity_half;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::spaces::metric_f16::sse::dot::sse_dot_similarity_half;
@@ -38,7 +38,7 @@ impl Metric<VectorElementTypeHalf> for DotProductMetric {
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon")
                 && std::arch::is_aarch64_feature_detected!("fp16")

--- a/lib/segment/src/spaces/metric_f16/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_euclid.rs
@@ -6,7 +6,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::euclid::avx_euclid_similarity_half;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::spaces::metric_f16::neon::euclid::neon_euclid_similarity_half;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::spaces::metric_f16::sse::euclid::sse_euclid_similarity_half;
@@ -39,7 +39,7 @@ impl Metric<VectorElementTypeHalf> for EuclidMetric {
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon")
                 && std::arch::is_aarch64_feature_detected!("fp16")

--- a/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
@@ -6,7 +6,7 @@ use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::manhattan::avx_manhattan_similarity_half;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::spaces::metric_f16::neon::manhattan::neon_manhattan_similarity_half;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::spaces::metric_f16::sse::manhattan::sse_manhattan_similarity_half;
@@ -39,7 +39,7 @@ impl Metric<VectorElementTypeHalf> for ManhattanMetric {
             }
         }
 
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", not(windows)))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             if std::arch::is_aarch64_feature_detected!("neon")
                 && std::arch::is_aarch64_feature_detected!("fp16")


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

Fixes #7718

This PR enables the existing `metric_f16` NEON path on `aarch64-pc-windows-msvc` and fixes the native build/runtime path so Qdrant builds and uses the NEON implementation on Windows ARM64 on real hardware.

What changed:
- removed the Windows gate from the `aarch64` `metric_f16` NEON module and from the NEON dispatch call sites, so the accelerated path can actually be selected on Windows ARM64
- updated `lib/segment/build.rs` to compile the f16 NEON C code only on `aarch64 + neon`, and to use MSVC-compatible optimization flags
- updated `lib/quantization/build.rs` to avoid passing GCC/Clang-only flags to `cl.exe`
- adjusted `lib/segment/src/spaces/metric_f16/cpp/neon.c` for MSVC ARM64:
  - use `<arm64_neon.h>` on MSVC
  - keep the vectorized FP16 NEON code paths
  - avoid relying on scalar `float16_t` in C mode, which is not available in MSVC headers
  - use an explicit non-MSVC fallback branch instead of the accidental `PC_VER` check
  - use scalar half-to-f32 conversion only in the remainder loop on MSVC

Why this is needed:
- issue #7718 asks to restore f16 NEON support on Windows ARM
- the previous Windows ARM64 failure was a combination of:
  - the NEON module and dispatch path being disabled on Windows
  - GCC-style flags being passed into MSVC builds
  - MSVC ARM64 C headers not exposing scalar `float16_t` the same way as Clang/GCC

Validation performed on live Windows ARM64 hardware:
- `cargo check -p qdrant`
- `cargo clippy --workspace --all-features`
- `cargo build --profile perf --bin qdrant`
- verified `target/perf/qdrant.exe --help`

Test environment:
- OS: Windows 11 Pro ARM64, version 10.0.28000 aka 26H1 (build 28000)
- Device: Microsoft Surface Pro with 5G, 11th Edition
- CPU: Qualcomm Snapdragon X 12-core X1E80100 @ 3.40 GHz
- Rust host: `aarch64-pc-windows-msvc`
- Rust toolchain used for validation: `rustc 1.94.1`

Notes:
- I built and validated this on an actual Windows ARM64 machine rather than via cross-compilation only.
- I kept this PR scoped to the ARM64/MSVC f16 NEON build/runtime path relevant to #7718.
- I did not add a new automated test here because the main gap was access to live Windows ARM64 hardware/tooling rather than missing Rust-side logic coverage.
- I could not run `cargo +nightly fmt --all` in this environment because this machine does not have `rustup`/nightly installed; I did run `cargo fmt --all` successfully, but it ignores the nightly-only rustfmt options from the repo config.
- On this specific device, a full `cargo build --release --bin qdrant` currently runs into LLVM out-of-memory at the final `qdrant` crate under the repository's `profile.release` settings (`lto = "fat"`, `codegen-units = 1`). The Windows ARM64-specific code path fixed in this PR is validated via `cargo check`, `clippy`, and a successful optimized `profile perf` binary build/run on the same machine.

AI disclosure:
- [AI] de17b2dc6fbe9452613d21a3064a01783709a532 fix: enable Windows ARM64 f16 NEON build

Initial prompt:
- "Build Qdrant natively for Windows ARM64, use PR #7832 as prior context, validate on live Windows ARM64 hardware, and fix the remaining native build issues needed to get Qdrant building."
