### PR TITLE
Fix grpc stop words

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -568,16 +568,10 @@ impl TryFrom<StopwordsSet> for segment::data_types::index::StopwordsInterface {
             )
         };
 
-        let result_custom = if custom.is_empty() {
-            None
-        } else {
-            Some(custom.into_iter().map(|word| word.to_lowercase()).collect())
-        };
-
         Ok(segment::data_types::index::StopwordsInterface::Set(
             segment::data_types::index::StopwordsSet {
                 languages: result_languages,
-                custom: result_custom,
+                custom: (!custom.is_empty()).then_some(custom.into_iter().collect()),
             },
         ))
     }

--- a/tests/openapi/test_stopwords.py
+++ b/tests/openapi/test_stopwords.py
@@ -1,0 +1,102 @@
+"""Regression test for https://github.com/qdrant/qdrant/issues/8724.
+
+With `lowercase=false` and a mixed-case custom stopword list, the gRPC path
+unconditionally lowercased custom stopwords while REST preserved them verbatim,
+so the two transports stored different stopword sets on disk and disagreed on
+identical MatchText queries.
+"""
+
+import pytest
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import (
+    Distance,
+    FieldCondition,
+    Filter,
+    MatchText,
+    PointStruct,
+    StopwordsSet,
+    TextIndexParams,
+    TextIndexType,
+    TokenizerType,
+    VectorParams,
+)
+
+
+def _build_client(prefer_grpc: bool) -> QdrantClient:
+    return QdrantClient(
+        host="127.0.0.1",
+        port=6333,
+        grpc_port=6334,
+        prefer_grpc=prefer_grpc,
+        timeout=30,
+    )
+
+
+def _points():
+    return [
+        PointStruct(
+            id=1,
+            vector=[1.0, 0.0],
+            payload={"title": "The quick brown fox jumps over the lazy dog"},
+        ),
+        PointStruct(
+            id=2,
+            vector=[0.0, 1.0],
+            payload={"title": "LAZY sentinel"},
+        ),
+    ]
+
+
+def _scroll_ids(client: QdrantClient, collection: str, term: str):
+    points, _ = client.scroll(
+        collection_name=collection,
+        scroll_filter=Filter(
+            must=[FieldCondition(key="title", match=MatchText(text=term))]
+        ),
+        limit=32,
+        with_payload=False,
+        with_vectors=False,
+    )
+    return sorted(int(p.id) for p in points)
+
+
+def _run(prefer_grpc: bool):
+    collection = f"stopwords_repro_{'grpc' if prefer_grpc else 'rest'}"
+    client = _build_client(prefer_grpc)
+    try:
+        if client.collection_exists(collection):
+            client.delete_collection(collection)
+        client.create_collection(
+            collection_name=collection,
+            vectors_config=VectorParams(size=2, distance=Distance.DOT),
+        )
+        client.upsert(collection_name=collection, points=_points(), wait=True)
+        client.create_payload_index(
+            collection_name=collection,
+            field_name="title",
+            field_schema=TextIndexParams(
+                type=TextIndexType.TEXT,
+                tokenizer=TokenizerType.WORD,
+                lowercase=False,
+                stopwords=StopwordsSet(custom=["the", "The", "LAZY"]),
+            ),
+            wait=True,
+        )
+        return {term: _scroll_ids(client, collection, term) for term in ("lazy", "The", "LAZY")}
+    finally:
+        if client.collection_exists(collection):
+            client.delete_collection(collection)
+        client.close()
+
+
+@pytest.mark.parametrize("prefer_grpc", [False, True], ids=["rest", "grpc"])
+def test_custom_stopwords_case_sensitive(prefer_grpc):
+    """With lowercase=false and stopwords {"the","The","LAZY"}:
+    - "lazy" is not a stopword -> matches point 1
+    - "The" and "LAZY" are stopwords -> filtered from query -> []
+
+    Before the fix, the gRPC parametrization failed: custom stopwords were
+    lowercased during conversion, so the set was stored as {"the","lazy"}.
+    """
+    results = _run(prefer_grpc)
+    assert results == {"lazy": [1], "The": [], "LAZY": []}


### PR DESCRIPTION
Fixes #8724

## Root cause
**GRPC** on dev [currently unconditionally converts all stopwords to lower-case](https://github.com/qdrant/qdrant/blob/8c72d3b12f7074925110044e5229881ad3be345f/lib/api/src/grpc/conversions.rs#L574) and then converts the request into our internal type `StopwordsInterface` (during field-index creation).

The **REST** path however directly deserializes the request into the internal `StopwordsInterface`, without any preprocessing.

This inconsistency causes `lowercase: false` to filter out different words, depending on which API was used to create the index. 

## The fix

This PR removes this unconditional conversion on the GRPC side to make it match with the REST API.
Our `StopwordsFilter` converts the provided stopwords to lower-case, [if required](https://github.com/qdrant/qdrant/blob/9940a4b27286b156ab46ce13d0ada711662e463f/lib/segment/src/index/field_index/full_text_index/stop_words/mod.rs#L109) .

This means that now on `lowercase: false` the case of stop words is preserved and have to match the case of the tokens in order to get filtered out.

## Controversial points
This change is **breaking**, regardless of how we fix it. 
The only option would be to make stopwords always get filtered out, even if the case doesn't match. Then we could migrate existing persisted stop words by making them all lower-case on load. 
However, this would be still a breaking change as read-operations (search,count,...) will still return different results between versions.