### PR TITLE
A few improvements for parallel runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: uv --project tests run bash ./tests/integration-tests.sh distributed
         shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: uv --project tests run pytest -n auto --dist=loadfile tests/consensus_tests --durations=10
+        run: uv --project tests run pytest -n auto --dist=loadfile -v tests/consensus_tests --durations=10
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: uv --project tests run bash ./tests/integration-tests.sh distributed
         shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: uv --project tests run pytest -n auto --dist=loadfile -v tests/consensus_tests --durations=10
+        run: uv --project tests run pytest -n 2 --dist=loadfile -v tests/consensus_tests --durations=10
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: uv --project tests run bash ./tests/integration-tests.sh distributed
         shell: bash
       - name: Run integration tests - multiple peers - pytest
-        run: uv --project tests run pytest -n 2 --dist=loadfile -v tests/consensus_tests --durations=10
+        run: uv --project tests run pytest -n auto --dist=loadfile -v tests/consensus_tests --durations=10
         timeout-minutes: 60
       - name: upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/consensus_tests/auth_tests/test_audit_telemetry.py
+++ b/tests/consensus_tests/auth_tests/test_audit_telemetry.py
@@ -8,8 +8,6 @@ import requests
 from consensus_tests import fixtures
 from consensus_tests.utils import kill_all_processes, wait_for
 
-pytestmark = pytest.mark.xdist_group("auth")
-
 from .utils import (
     API_KEY_HEADERS,
     READ_ONLY_API_KEY,

--- a/tests/consensus_tests/auth_tests/test_jwt_access.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_access.py
@@ -11,8 +11,6 @@ from consensus_tests import fixtures
 from consensus_tests.utils import PROJECT_ROOT
 from grpc_interceptor import ClientCallDetails, ClientInterceptor
 
-pytestmark = pytest.mark.xdist_group("auth")
-
 from .utils import (
     API_KEY_HEADERS,
     API_KEY_METADATA,

--- a/tests/consensus_tests/auth_tests/test_jwt_validation.py
+++ b/tests/consensus_tests/auth_tests/test_jwt_validation.py
@@ -2,8 +2,6 @@ import pytest
 import requests
 from consensus_tests import fixtures
 
-pytestmark = pytest.mark.xdist_group("auth")
-
 from .utils import API_KEY_HEADERS, READ_ONLY_API_KEY, REST_URI, SECRET, encode_jwt, ALT_SECRET
 
 COLL_NAME = "jwt_test_collection"

--- a/tests/consensus_tests/auth_tests/utils.py
+++ b/tests/consensus_tests/auth_tests/utils.py
@@ -1,10 +1,15 @@
+import os
 import random
 import string
 
 import jwt
 from consensus_tests.utils import start_cluster
 
-PORT_SEED = 10000
+# Each pytest-xdist worker gets its own 100-port window so auth test files can
+# run in parallel on different workers without binding the same port.
+_worker_id = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+_worker_num = int(_worker_id[2:]) if _worker_id.startswith("gw") and _worker_id[2:].isdigit() else 0
+PORT_SEED = 10000 + _worker_num * 100
 REST_URI = f"http://127.0.0.1:{PORT_SEED + 2}"
 GRPC_URI = f"127.0.0.1:{PORT_SEED + 1}"
 

--- a/tests/consensus_tests/test_named_vector_crud.py
+++ b/tests/consensus_tests/test_named_vector_crud.py
@@ -224,6 +224,7 @@ def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
 
     # Kill the last peer
     killed_peer = processes.pop()
+    restart_port = killed_peer.p2p_port
     killed_peer.kill()
     print(f"Killed peer at port {killed_peer.http_port}")
 
@@ -283,7 +284,7 @@ def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
 
     # Restart the killed peer — it should recover via consensus snapshot
     new_url = start_peer(
-        peer_dirs[-1], "peer_restarted.log", bootstrap_uri, extra_env=env
+        peer_dirs[-1], "peer_restarted.log", bootstrap_uri, port=restart_port, extra_env=env
     )
     peer_api_uris[-1] = new_url
 

--- a/tests/consensus_tests/test_recovery_mode.py
+++ b/tests/consensus_tests/test_recovery_mode.py
@@ -38,10 +38,11 @@ def test_upserts_in_recovery_mode(tmp_path: pathlib.Path):
         "QDRANT__STORAGE__RECOVERY_MODE": "Custom recovery msg"
     }
     p = processes.pop()
+    restart_port = p.p2p_port
     p.kill()
     peer_api_uris[-1] = start_peer(
         peer_dirs[-1], f"peer_{N_PEERS}_restarted.log", bootstrap_uri,
-        extra_env=extra_env
+        port=restart_port, extra_env=extra_env
     )
 
     # Qdrant loads a dummy shard but doesn't try to recover it from other replicas by default

--- a/tests/consensus_tests/test_snapshot_recovery_kill.py
+++ b/tests/consensus_tests/test_snapshot_recovery_kill.py
@@ -80,7 +80,6 @@ def test_snapshot_restore_kill_during_partial(tmp_path: Path, every_test):
     # Kill target peer
     recovery_url = peer_urls[2]
     recovery_dir = Path(peer_dirs[2])
-    recovery_port = processes[2].http_port
 
     monitor = PartialMonitor(recovery_url)
     monitor.start()
@@ -96,7 +95,7 @@ def test_snapshot_restore_kill_during_partial(tmp_path: Path, every_test):
         pytest.fail("Partial state not detected")
 
     # Restart again
-    restarted = start_peer(recovery_dir, "peer_restarted.log", bootstrap, port=recovery_port, extra_env=env)
+    restarted = start_peer(recovery_dir, "peer_restarted.log", bootstrap, extra_env=env)
 
     # This checks `/readyz` which is supposed to return 200, as there will be no automatic recovery
     wait_for_peer_online(restarted)

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -86,7 +86,7 @@ def test_triple_replication(tmp_path: pathlib.Path):
                     print(count)
 
                 # Make sure there are no stale updates
-                upsert_random_points(peer_api_uris[0], 1, COLLECTION_NAME, offset=100_000, wait=True)
+                upsert_random_points(peer_api_uris[0], 1, COLLECTION_NAME, offset=100_000, wait="true")
 
                 for peer_api_uri in peer_api_uris:
                     count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)

--- a/tests/consensus_tests/test_triple_replication.py
+++ b/tests/consensus_tests/test_triple_replication.py
@@ -55,11 +55,12 @@ def test_triple_replication(tmp_path: pathlib.Path):
 
     upload_process.kill()
 
+    # Active state doesn't imply async replication of in-flight writes is done;
+    # wait for counts to match too.
+    converged = False
     timeout = 10
-    while True:
-        if timeout < 0:
-            raise Exception("Timeout waiting for all replicas to be active")
-
+    points_counts = set()
+    while timeout >= 0:
         all_active = True
         points_counts = set()
         for peer_api_uri in peer_api_uris:
@@ -70,30 +71,32 @@ def test_triple_replication(tmp_path: pathlib.Path):
             if res['state'] != 'Active':
                 all_active = False
 
-        if all_active:
-            if len(points_counts) != 1:
-                with open("test_triple_replication.log", "w") as f:
-                    for peer_api_uri in peer_api_uris:
-                        collection_name = COLLECTION_NAME
-                        res = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster", timeout=10)
-                        f.write(f"{peer_api_uri} {res.json()['result']}\n")
-                    for peer_api_uri in peer_api_uris:
-                        res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
-                        f.write(f"{peer_api_uri} {res.json()['result']}\n")
-
-                for peer_api_uri in peer_api_uris:
-                    count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
-                    print(count)
-
-                # Make sure there are no stale updates
-                upsert_random_points(peer_api_uris[0], 1, COLLECTION_NAME, offset=100_000, wait="true")
-
-                for peer_api_uri in peer_api_uris:
-                    count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
-                    print(count)
-
-                assert False, f"Points count is not equal on all peers: {points_counts}"
+        if all_active and len(points_counts) == 1:
+            converged = True
             break
 
         time.sleep(1)
         timeout -= 1
+
+    if not converged:
+        with open("test_triple_replication.log", "w") as f:
+            for peer_api_uri in peer_api_uris:
+                collection_name = COLLECTION_NAME
+                res = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster", timeout=10)
+                f.write(f"{peer_api_uri} {res.json()['result']}\n")
+            for peer_api_uri in peer_api_uris:
+                res = requests.get(f"{peer_api_uri}/cluster", timeout=10)
+                f.write(f"{peer_api_uri} {res.json()['result']}\n")
+
+        for peer_api_uri in peer_api_uris:
+            count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
+            print(count)
+
+        # Make sure there are no stale updates
+        upsert_random_points(peer_api_uris[0], 1, COLLECTION_NAME, offset=100_000, wait="true")
+
+        for peer_api_uri in peer_api_uris:
+            count = get_collection_point_count(peer_api_uri, COLLECTION_NAME, exact=True)
+            print(count)
+
+        assert False, f"Cluster did not converge: points_counts={points_counts}"

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -122,10 +122,8 @@ def get_qdrant_exec() -> str:
     return str(qdrant_exec)
 
 def get_llvm_profile_file() -> str:
-    # %m: keep merging results from each test into the same file
-    # If you have multiple tests running in parallel, you can use -%p OR -%{thread_count}m to have different files
-    # Not using -%p since each test will generate a new file
-    llvm_profile_file = PROJECT_ROOT / "target" / "llvm-cov-target" / "qdrant-consensus-tests-%m.profraw"
+    # %p (per-PID) avoids %m's partial-merge corruption when peers are SIGKILLed under -n auto.
+    llvm_profile_file = PROJECT_ROOT / "target" / "llvm-cov-target" / "qdrant-consensus-tests-%p.profraw"
     return str(llvm_profile_file)
 
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -1,8 +1,10 @@
+import ctypes
 import json
 import os
 import re
 import shutil
 import signal
+import sys
 from subprocess import Popen
 import time
 from typing import Tuple, Callable, Dict, List, Optional
@@ -17,6 +19,14 @@ from .assertions import assert_http_ok
 WAIT_TIME_SEC = 30
 RETRY_INTERVAL_SEC = 0.2
 PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+# Kernel SIGKILLs the child if the xdist worker dies abnormally, preventing orphaned peers.
+def _set_pdeathsig_sigkill():
+    if sys.platform != "linux":
+        return
+    PR_SET_PDEATHSIG = 1
+    ctypes.CDLL("libc.so.6", use_errno=True).prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
 
 # Tracks processes that need to be killed at the end of the test
 processes: List['PeerProcess'] = []
@@ -175,7 +185,7 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, ext
     # Wrap with systemd-run to throttle CPU to investigate issues
     # wrapped_cmd = ["systemd-run", "--user", "--scope", "-p", "CPUQuota=20%", "--"] + args
     # proc = Popen(wrapped_cmd, env=env, cwd=peer_dir, stdout=log_file)
-    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file)
+    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file, preexec_fn=_set_pdeathsig_sigkill)
     processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port)
 
@@ -215,7 +225,7 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None, extra_env=None, r
     # Wrap with systemd-run to throttle CPU to investigate issues
     # wrapped_cmd = ["systemd-run", "--user", "--scope", "-p", "CPUQuota=20%", "--"] + args
     # proc = Popen(wrapped_cmd, env=env, cwd=peer_dir, stdout=log_file)
-    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file)
+    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file, preexec_fn=_set_pdeathsig_sigkill)
     processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port), bootstrap_uri
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -26,7 +26,7 @@ def _set_pdeathsig_sigkill():
     if sys.platform != "linux":
         return
     PR_SET_PDEATHSIG = 1
-    ctypes.CDLL("libc.so.6", use_errno=True).prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
+    ctypes.CDLL("libc.so.6").prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
 
 # Tracks processes that need to be killed at the end of the test
 processes: List['PeerProcess'] = []

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -70,6 +70,9 @@ def kill_all_processes():
 
 @pytest.fixture(autouse=True)
 def every_test():
+    if processes:
+        print(f"WARN: {len(processes)} leaked peer processes from previous test, cleaning")
+        kill_all_processes()
     yield
     kill_all_processes()
 

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -34,20 +34,16 @@ class PeerProcess:
     def kill(self):
         self.proc.kill()
         self.proc.wait()
-
-        # remove allocated ports from the dictionary
-        # so they can be used afterwards
-        del busy_ports[self.http_port]
-        del busy_ports[self.grpc_port]
-        del busy_ports[self.p2p_port]
+        busy_ports.pop(self.http_port, None)
+        busy_ports.pop(self.grpc_port, None)
+        busy_ports.pop(self.p2p_port, None)
 
     def interrupt(self):
         self.proc.send_signal(signal.SIGINT)
         self.proc.wait()
-
-        del busy_ports[self.http_port]
-        del busy_ports[self.grpc_port]
-        del busy_ports[self.p2p_port]
+        busy_ports.pop(self.http_port, None)
+        busy_ports.pop(self.grpc_port, None)
+        busy_ports.pop(self.p2p_port, None)
 
 
 def _occupy_port(port):
@@ -61,12 +57,15 @@ def kill_all_processes():
     print()
     while len(processes) > 0:
         p = processes.pop(0)
-        if is_coverage_mode():
-            print(f"Interrupting {p.pid}")
-            p.interrupt()
-        else:
-            print(f"Killing {p.pid}")
-            p.kill()
+        try:
+            if is_coverage_mode():
+                print(f"Interrupting {p.pid}")
+                p.interrupt()
+            else:
+                print(f"Killing {p.pid}")
+                p.kill()
+        except Exception as e:
+            print(f"Cleanup error for {p.pid}: {e}")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -1,10 +1,8 @@
-import ctypes
 import json
 import os
 import re
 import shutil
 import signal
-import sys
 from subprocess import Popen
 import time
 from typing import Tuple, Callable, Dict, List, Optional
@@ -19,14 +17,6 @@ from .assertions import assert_http_ok
 WAIT_TIME_SEC = 30
 RETRY_INTERVAL_SEC = 0.2
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-
-
-# Kernel SIGKILLs the child if the xdist worker dies abnormally, preventing orphaned peers.
-def _set_pdeathsig_sigkill():
-    if sys.platform != "linux":
-        return
-    PR_SET_PDEATHSIG = 1
-    ctypes.CDLL("libc.so.6").prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
 
 # Tracks processes that need to be killed at the end of the test
 processes: List['PeerProcess'] = []
@@ -185,7 +175,7 @@ def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, ext
     # Wrap with systemd-run to throttle CPU to investigate issues
     # wrapped_cmd = ["systemd-run", "--user", "--scope", "-p", "CPUQuota=20%", "--"] + args
     # proc = Popen(wrapped_cmd, env=env, cwd=peer_dir, stdout=log_file)
-    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file, preexec_fn=_set_pdeathsig_sigkill)
+    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file)
     processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port)
 
@@ -225,7 +215,7 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None, extra_env=None, r
     # Wrap with systemd-run to throttle CPU to investigate issues
     # wrapped_cmd = ["systemd-run", "--user", "--scope", "-p", "CPUQuota=20%", "--"] + args
     # proc = Popen(wrapped_cmd, env=env, cwd=peer_dir, stdout=log_file)
-    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file, preexec_fn=_set_pdeathsig_sigkill)
+    proc = Popen(args, env=env, cwd=peer_dir, stdout=log_file)
     processes.append(PeerProcess(proc, http_port, grpc_port, p2p_port))
     return get_uri(http_port), bootstrap_uri
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -29,6 +29,8 @@ markers = [
     "longrunning: marks tests as long-running (deselect with '-m \"not longrunning\"')",
     "xdist_group: group tests to run on the same worker (for pytest-xdist)",
 ]
+# Surface hangs at 30 min with a traceback instead of the 60 min job kill.
+timeout = 1800
 addopts = """
     --dist=loadgroup
 """


### PR DESCRIPTION
- Fix auth test port collisions under pytest-xdist --dist=loadfile: derive PORT_SEED from PYTEST_XDIST_WORKER in auth_tests/utils.py, remove now-inert xdist_group("auth") markers.
- Add -v to the CI pytest invocation so xdist tags per-test output with [gwN], making interleaved output and failure sites attributable to a worker.
- Add global timeout = 1800 (pytest-timeout) so a hung test fails with a traceback at 30 min instead of being masked by the 60-min job timeout.
- Switch LLVM_PROFILE_FILE from %m to %p so parallel COVERAGE=1 runs don't risk partial-merge corruption when peers are SIGKILLed.
- Kill leaked peer processes in every_test fixture

Example run: https://github.com/qdrant/qdrant/actions/runs/24710655731