### PR TITLE
fix(segment): restore DenseVectorStorageImpl::is_on_disk semantics

### DIFF
--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -59,6 +59,15 @@ where
         }
     }
 
+    /// Whether this storage was pre-populated into the OS page cache at load
+    /// time (via `populate=true`). Distinct from [`VectorStorage::is_on_disk`]:
+    /// both populated and non-populated mmaps live on disk, but a populated
+    /// one is expected to be resident in RAM. Memory reporting uses this to
+    /// pick `FileStorageIntent::Cached` vs. `FileStorageIntent::OnDisk`.
+    pub fn populated(&self) -> bool {
+        self.populated
+    }
+
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let Self {
@@ -234,7 +243,13 @@ where
     }
 
     fn is_on_disk(&self) -> bool {
-        !self.populated
+        // The underlying storage is an mmap on disk. `populated` tracks whether
+        // we pre-faulted it into the OS page cache at load time; it does NOT
+        // change the fact that the storage *lives* on disk. This distinction
+        // matters for `quantized_vectors.rs::is_ram()` which uses this method
+        // to decide whether to materialize the quantized blob in RAM vs. mmap.
+        // Use `populated()` (below) when you want the populate-at-load signal.
+        true
     }
 
     fn total_vector_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -34,13 +34,14 @@ impl MemoryReporter for VectorStorageEnum {
                 ComponentMemoryUsage::ram_only(v.size_of_available_vectors_in_bytes() as u64)
             }
 
-            // Mmap dense variants: intent depends on populate config
-            VectorStorageEnum::DenseMemmap(v) => from_files_with_on_disk(v.files(), v.is_on_disk()),
+            // Mmap dense variants: intent depends on populate-at-load flag,
+            // not `is_on_disk()` (the underlying storage always lives on disk).
+            VectorStorageEnum::DenseMemmap(v) => from_files_with_on_disk(v.files(), !v.populated()),
             VectorStorageEnum::DenseMemmapByte(v) => {
-                from_files_with_on_disk(v.files(), v.is_on_disk())
+                from_files_with_on_disk(v.files(), !v.populated())
             }
             VectorStorageEnum::DenseMemmapHalf(v) => {
-                from_files_with_on_disk(v.files(), v.is_on_disk())
+                from_files_with_on_disk(v.files(), !v.populated())
             }
 
             // io_uring dense variants: always on-disk, no mmap caching

--- a/lib/segment/tests/integration/immutable_quantization_variant_test.rs
+++ b/lib/segment/tests/integration/immutable_quantization_variant_test.rs
@@ -1,0 +1,141 @@
+//! Regression test for PR #8606 (deep memory reporting).
+//!
+//! PR #8606 changed `DenseVectorStorageImpl::is_on_disk()` from hard-coded
+//! `true` to `!self.populated`. `quantized_vectors.rs::is_ram()` reads that
+//! method to decide whether a quantized blob goes to `QuantizedRamStorage`
+//! (heap) or `QuantizedMmapStorage` (disk):
+//!
+//!     in_ram = !on_disk_vector_storage || always_ram == Some(true)
+//!
+//! Crasher hits the immutable path via `SegmentBuilder`, which materializes
+//! an `InRamMmap` vector storage backed by `DenseVectorStorageImpl` with
+//! `populated=true`. The flip causes the quantized storage to land in RAM
+//! instead of on disk, driving 4x transient disk spikes under crasher's
+//! restart loop.
+//!
+//! This test drives the full appendable → immutable build path and asserts
+//! that binary quantization with `always_ram: false` stays on disk.
+//!
+//! * Pre-fix (PR #8606 semantics): picks `BinaryRam` → this test fails.
+//! * Post-fix (`is_on_disk() -> true` restored): picks `BinaryMmap` → passes.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+
+use common::budget::ResourcePermit;
+use common::counter::hardware_counter::HardwareCounterCell;
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
+use segment::entry::entry_point::SegmentEntry;
+use segment::segment_constructor::build_segment;
+use segment::segment_constructor::segment_builder::SegmentBuilder;
+use segment::types::{
+    BinaryQuantizationConfig, Distance, HnswGlobalConfig, Indexes, QuantizationConfig,
+    SegmentConfig, VectorDataConfig, VectorStorageType,
+};
+use segment::vector_storage::quantized::quantized_vectors::QuantizedVectorStorage;
+use tempfile::Builder;
+
+#[test]
+fn immutable_built_segment_quantizes_binary_to_disk_when_always_ram_false() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let source_dir = Builder::new().prefix("src").tempdir().unwrap();
+    let builder_tmp = Builder::new().prefix("bld_tmp").tempdir().unwrap();
+    let target_dir = Builder::new().prefix("tgt").tempdir().unwrap();
+
+    // Source: appendable, on_disk=false, binary quantization with always_ram=false.
+    // Mirrors the crasher `dense-vector-memory-bq-*` configs that hit the bug.
+    let quantization: QuantizationConfig = BinaryQuantizationConfig {
+        always_ram: Some(false),
+        encoding: None,
+        query_encoding: None,
+    }
+    .into();
+
+    let source_config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: 8,
+                distance: Distance::Dot,
+                storage_type: VectorStorageType::InRamChunkedMmap, // appendable, on_disk=false
+                index: Indexes::Plain {},
+                quantization_config: Some(quantization.clone()),
+                multivector_config: None,
+                datatype: None,
+            },
+        )]),
+        sparse_vector_data: HashMap::new(),
+        payload_storage_type: Default::default(),
+    };
+
+    let mut source = build_segment(source_dir.path(), &source_config, None, true).unwrap();
+
+    let hw = HardwareCounterCell::new();
+    for id in 0..128u64 {
+        let v: Vec<f32> = (0..8)
+            .map(|i| (((id as i32 + i) % 4) - 2) as f32 * 0.25)
+            .collect();
+        source
+            .upsert_point(id, id.into(), only_default_vector(&v), &hw)
+            .unwrap();
+    }
+
+    // Target (the merged segment) uses the immutable `InRamMmap` storage --
+    // this is what the optimizer produces when consolidating appendable
+    // `on_disk: false` segments in production. This is the path that goes
+    // through `DenseVectorStorageImpl` with `populated=true`, which is where
+    // PR #8606's `is_on_disk()` change materially affects behavior.
+    let target_config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: 8,
+                distance: Distance::Dot,
+                storage_type: VectorStorageType::InRamMmap,
+                index: Indexes::Plain {},
+                quantization_config: Some(quantization),
+                multivector_config: None,
+                datatype: None,
+            },
+        )]),
+        sparse_vector_data: HashMap::new(),
+        payload_storage_type: Default::default(),
+    };
+
+    let stopped = AtomicBool::new(false);
+    let mut builder = SegmentBuilder::new(
+        builder_tmp.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    builder.update(&[&source], &stopped, &hw).unwrap();
+
+    let _permit = ResourcePermit::dummy(2);
+    let merged = builder.build_for_test(target_dir.path());
+
+    let vd = merged.vector_data.values().next().unwrap();
+    let quantized = vd.quantized_vectors.borrow();
+    let quantized = quantized
+        .as_ref()
+        .expect("target segment must have quantized vectors");
+
+    let variant = match quantized.get_storage() {
+        QuantizedVectorStorage::BinaryRam(_) => "BinaryRam (heap)",
+        QuantizedVectorStorage::BinaryMmap(_) => "BinaryMmap (disk)",
+        QuantizedVectorStorage::BinaryChunkedMmap(_) => "BinaryChunkedMmap",
+        other => panic!("unexpected quantization variant: {other:?}"),
+    };
+    eprintln!("Quantization variant on immutable built segment: {variant}");
+
+    assert!(
+        matches!(
+            quantized.get_storage(),
+            QuantizedVectorStorage::BinaryMmap(_),
+        ),
+        "binary quantization with always_ram=false should land on disk \
+         (got {variant}) -- PR #8606 regression if this fails",
+    );
+}

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod gpu_hnsw_test;
 mod hnsw_discover_test;
 mod hnsw_incremental_build;
 mod hnsw_quantized_search_test;
+mod immutable_quantization_variant_test;
 mod multivector_filtrable_hnsw_test;
 mod multivector_hnsw_test;
 mod multivector_quantization_test;

--- a/tools/codespell.toml
+++ b/tools/codespell.toml
@@ -15,6 +15,7 @@ skip = [
 ignore-words-list = [
     "ABD",                 # Geohash example
     "INDX",                # bitvec crate const
+    "crasher",             # qdrant/crasher sibling repo
     "generall",            # The boss
     "hel",                 # Query token
     "mmapped",             # Memory mapped


### PR DESCRIPTION
PR #8606 changed `DenseVectorStorageImpl::is_on_disk()` from hard-coded `true` to `!self.populated`.

The method is load-bearing beyond reporting: `quantized_vectors.rs::is_ram()` reads it to decide whether to materialize the quantized blob as `QuantizedRamStorage` (heap) or `QuantizedMmapStorage` (disk) for every quantized variant (scalar, pq, binary, turbo).

For user configs with `on_disk: false` + quantization (no `always_ram`), the flip caused the quantized storage variant to move from disk to RAM, which in turn triggered segment rebuilds and transient 4x storage spikes during crasher-CI runs, hitting ENOSPC within 12-16 min vs. a stable 60 min on the parent commit.

Restore `is_on_disk() -> true` and expose `populated()` as a separate accessor. Memory reporter now reads `populated()` to pick `FileStorageIntent::Cached` vs. `OnDisk` -- the distinction the original PR wanted to surface -- without changing quantization placement.

Bisect: 4/4 green on aa3af834, 4/4 red on 5a899b74 (#8606).