### PR TITLE
Fix IsEmpty condition on null rebuilt index

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -375,10 +375,15 @@ impl IndexSelector<'_> {
         }
     }
 
-    pub fn null_builder(dir: &Path, field: &JsonPath) -> OperationResult<FieldIndexBuilder> {
+    pub fn null_builder(
+        dir: &Path,
+        field: &JsonPath,
+        total_point_count: usize,
+    ) -> OperationResult<FieldIndexBuilder> {
         // null index is always on disk and appendable
         Ok(FieldIndexBuilder::NullIndex(MutableNullIndex::builder(
             &null_dir(dir, field),
+            total_point_count,
         )?))
     }
 

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -307,7 +307,7 @@ impl PayloadFieldIndex for MutableNullIndex {
                 } else {
                     // Return points that don't have null values
                     Some(Box::new(self.storage.is_null_flags.iter_falses().chain({
-                        let end = self.storage.has_values_flags.len() as PointOffsetType;
+                        let end = self.storage.is_null_flags.len() as PointOffsetType;
                         end..self.total_point_count as u32
                     })))
                 }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -36,9 +36,12 @@ struct Storage {
 }
 
 impl MutableNullIndex {
-    pub fn builder(path: &Path) -> OperationResult<MutableNullIndexBuilder> {
+    pub fn builder(
+        path: &Path,
+        total_point_count: usize,
+    ) -> OperationResult<MutableNullIndexBuilder> {
         Ok(MutableNullIndexBuilder(
-            Self::open(path, 0, true)?.ok_or_else(|| {
+            Self::open(path, total_point_count, true)?.ok_or_else(|| {
                 OperationError::service_error(format!(
                     "Failed to create and open mutable null index at path: {}",
                     path.display(),
@@ -76,11 +79,20 @@ impl MutableNullIndex {
         })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
-        let has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
+        let mut has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
+        // Expand flags so `iter_falses()` covers every point in the segment, including
+        // those without a payload storage entry (e.g. after `clear_payload`).
+        // Bug: <https://github.com/qdrant/qdrant/issues/8723>
+        if has_values_mmap.len() < total_point_count {
+            has_values_mmap.set_len(total_point_count)?;
+        }
         let has_values_flags = RoaringFlags::new(has_values_mmap);
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
-        let is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
+        let mut is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
+        if is_null_mmap.len() < total_point_count {
+            is_null_mmap.set_len(total_point_count)?;
+        }
         let is_null_flags = RoaringFlags::new(is_null_mmap);
 
         let storage = Storage {
@@ -421,9 +433,9 @@ mod tests {
         let null_value_in_array =
             Value::Array(vec![Value::String("test".to_string()), Value::Null]);
 
-        let mut builder = MutableNullIndex::builder(dir.path()).unwrap();
+        let n: PointOffsetType = 100;
 
-        let n = 100;
+        let mut builder = MutableNullIndex::builder(dir.path(), n as usize).unwrap();
 
         let hw_counter = HardwareCounterCell::new();
 
@@ -534,7 +546,7 @@ mod tests {
     #[test]
     fn test_manual_buffer_flushing() {
         let dir = TempDir::with_prefix("test_manual_buffer_flushing").unwrap();
-        let mut index = MutableNullIndex::builder(dir.path()).unwrap().0;
+        let mut index = MutableNullIndex::builder(dir.path(), 10).unwrap().0;
 
         let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -79,20 +79,11 @@ impl MutableNullIndex {
         })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
-        let mut has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
-        // Expand flags so `iter_falses()` covers every point in the segment, including
-        // those without a payload storage entry (e.g. after `clear_payload`).
-        // Bug: <https://github.com/qdrant/qdrant/issues/8723>
-        if has_values_mmap.len() < total_point_count {
-            has_values_mmap.set_len(total_point_count)?;
-        }
+        let has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
         let has_values_flags = RoaringFlags::new(has_values_mmap);
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
-        let mut is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
-        if is_null_mmap.len() < total_point_count {
-            is_null_mmap.set_len(total_point_count)?;
-        }
+        let is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
         let is_null_flags = RoaringFlags::new(is_null_mmap);
 
         let storage = Storage {
@@ -299,7 +290,12 @@ impl PayloadFieldIndex for MutableNullIndex {
             if let Some(is_empty) = is_empty {
                 if *is_empty {
                     // Return points that don't have values
-                    Some(Box::new(self.storage.has_values_flags.iter_falses()))
+                    Some(Box::new(self.storage.has_values_flags.iter_falses().chain(
+                        {
+                            let end = self.storage.has_values_flags.len() as PointOffsetType;
+                            end..self.total_point_count as u32
+                        },
+                    )))
                 } else {
                     // Return points that have values
                     Some(Box::new(self.storage.has_values_flags.iter_trues()))
@@ -310,7 +306,10 @@ impl PayloadFieldIndex for MutableNullIndex {
                     Some(Box::new(self.storage.is_null_flags.iter_trues()))
                 } else {
                     // Return points that don't have null values
-                    Some(Box::new(self.storage.is_null_flags.iter_falses()))
+                    Some(Box::new(self.storage.is_null_flags.iter_falses().chain({
+                        let end = self.storage.has_values_flags.len() as PointOffsetType;
+                        end..self.total_point_count as u32
+                    })))
                 }
             } else {
                 None

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -323,8 +323,12 @@ impl StructPayloadIndex {
             .selector(payload_schema)
             .index_builder(field, payload_schema)?;
 
-        // Special null index complements every index.
-        let null_index = IndexSelector::null_builder(&self.path, field)?;
+        // Special null index complements every index. Seed it with the segment's total
+        // point count so `iter_falses()` returns points that are missing from payload
+        // storage (e.g. after `clear_payload`), matching the regular "no value" points.
+        // Bug: <https://github.com/qdrant/qdrant/issues/8723>
+        let total_point_count = self.id_tracker.borrow().total_point_count();
+        let null_index = IndexSelector::null_builder(&self.path, field, total_point_count)?;
         builders.push(null_index);
 
         for index in &mut builders {

--- a/tests/openapi/test_filter_is_empty.py
+++ b/tests/openapi/test_filter_is_empty.py
@@ -97,3 +97,105 @@ def test_filter_is_empty(collection_name):
 
     json = response.json()
     assert len(json['result']['points']) == 2, json
+
+
+def _scroll_is_empty(collection_name, key):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {"must": [{"is_empty": {"key": key}}]},
+            "limit": 10,
+            "with_payload": False,
+            "with_vector": False,
+        }
+    )
+    assert response.ok
+    return sorted(p['id'] for p in response.json()['result']['points'])
+
+
+def test_filter_is_empty_after_clear_and_rebuild():
+    """
+    Bug: <https://github.com/qdrant/qdrant/issues/8723>
+
+    After `clear_payload` on a point and a subsequent delete+recreate of the payload
+    index, `is_empty` must still return points whose payload no longer contains the
+    field, regardless of whether the field was previously present or not.
+    """
+    name = "test_filter_is_empty_after_clear_and_rebuild"
+
+    drop_collection(name)
+
+    # Create collection with a keyword payload index on "status".
+    assert request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': name},
+        body={"vectors": {"size": 2, "distance": "Dot"}},
+    ).ok
+
+    assert request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "status",
+            "field_schema": {"type": "keyword", "on_disk": True},
+        },
+    ).ok
+
+    # Point 1 has an explicit null, point 2 has no payload, point 3 has a value.
+    # Keep the value on the highest-ID point so the rebuild bug (len not covering
+    # cleared points with higher IDs) gets exercised when point 1 is later cleared.
+    assert request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {"id": 1, "vector": [1.0, 0.0], "payload": {"status": None}},
+                {"id": 2, "vector": [0.0, 1.0], "payload": {}},
+                {"id": 3, "vector": [1.0, 1.0], "payload": {"status": "live"}},
+            ],
+        },
+    ).ok
+
+    assert _scroll_is_empty(name, "status") == [1, 2]
+
+    # Clear the payload of point 1: it should now behave like point 2 (missing field).
+    assert request_with_validation(
+        api='/collections/{collection_name}/points/payload/clear',
+        method="POST",
+        path_params={'collection_name': name},
+        query_params={'wait': 'true'},
+        body={"points": [1]},
+    ).ok
+
+    assert _scroll_is_empty(name, "status") == [1, 2]
+
+    # Delete + recreate the payload index. Post-rebuild, cleared points must still
+    # match `is_empty`, just like points that never had the field.
+    assert request_with_validation(
+        api='/collections/{collection_name}/index/{field_name}',
+        method="DELETE",
+        path_params={'collection_name': name, 'field_name': 'status'},
+        query_params={'wait': 'true'},
+    ).ok
+
+    assert request_with_validation(
+        api='/collections/{collection_name}/index',
+        method="PUT",
+        path_params={'collection_name': name},
+        query_params={'wait': 'true'},
+        body={
+            "field_name": "status",
+            "field_schema": {"type": "keyword", "on_disk": True},
+        },
+    ).ok
+
+    assert _scroll_is_empty(name, "status") == [1, 2]
+
+    drop_collection(name)


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/8723>

AI summary:

Root cause (issue #8723): During build_field_indexes on payload-index rebuild, the null index's internal mmap flags track len from explicit `set()` calls. Points missing from payload storage (e.g., after `clear_payload`) never got an `add_point` call, so their IDs fell outside the flags' range — `iter_falses()` skipped them. Behavior was intermittent because it depended on where cleared points' internal IDs landed relative to the remaining points' IDs.

Fix: Thread `total_point_count` from the ID tracker into `MutableNullIndex::builder` → `open_or_create`, and pre-expand the `has_values` and `is_null` mmap flags to that length. This guarantees `iter_falses()` reports every segment point — cleared points included.

Files changed:
- `lib/segment/src/index/field_index/null_index/mutable_null_index.rs` — builder accepts `total_point_count`; `open_or_create` expands flags.
- `lib/segment/src/index/field_index/index_selector.rs` — null_builder threads the count.
- `lib/segment/src/index/struct_payload_index.rs` — build_field_indexes fetches the count from `id_tracker`.
- `tests/openapi/test_filter_is_empty.py` — regression test replicating the issue's reproducer.

Unit tests (`cargo test -p segment --lib -- null_index payload_index`) and the full-workspace cargo check `--all-targets` both pass.


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
