### PR TITLE
[#8734] Alternative fix

### DIFF
--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -79,20 +79,11 @@ impl MutableNullIndex {
         })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
-        let mut has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
-        // Expand flags so `iter_falses()` covers every point in the segment, including
-        // those without a payload storage entry (e.g. after `clear_payload`).
-        // Bug: <https://github.com/qdrant/qdrant/issues/8723>
-        if has_values_mmap.len() < total_point_count {
-            has_values_mmap.set_len(total_point_count)?;
-        }
+        let has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
         let has_values_flags = RoaringFlags::new(has_values_mmap);
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
-        let mut is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
-        if is_null_mmap.len() < total_point_count {
-            is_null_mmap.set_len(total_point_count)?;
-        }
+        let is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
         let is_null_flags = RoaringFlags::new(is_null_mmap);
 
         let storage = Storage {

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -290,7 +290,12 @@ impl PayloadFieldIndex for MutableNullIndex {
             if let Some(is_empty) = is_empty {
                 if *is_empty {
                     // Return points that don't have values
-                    Some(Box::new(self.storage.has_values_flags.iter_falses()))
+                    Some(Box::new(self.storage.has_values_flags.iter_falses().chain(
+                        {
+                            let end = self.storage.has_values_flags.len() as PointOffsetType;
+                            end..self.total_point_count as u32
+                        },
+                    )))
                 } else {
                     // Return points that have values
                     Some(Box::new(self.storage.has_values_flags.iter_trues()))
@@ -301,7 +306,10 @@ impl PayloadFieldIndex for MutableNullIndex {
                     Some(Box::new(self.storage.is_null_flags.iter_trues()))
                 } else {
                     // Return points that don't have null values
-                    Some(Box::new(self.storage.is_null_flags.iter_falses()))
+                    Some(Box::new(self.storage.is_null_flags.iter_falses().chain({
+                        let end = self.storage.has_values_flags.len() as PointOffsetType;
+                        end..self.total_point_count as u32
+                    })))
                 }
             } else {
                 None


### PR DESCRIPTION
While reviewing I noticed that, while the #8734 fix works nicely, it can be possible to avoid growing the mmap for untracked points, if we know the total amount of points in the segment in advance.

This PR is just a suggestion as an alternative, which keeps the semantics of "any id that is not tracked by a bitslice should return `false`", and avoids growing the mmap just for `false` flags.