### PR TITLE
TQ Scoring

### DIFF
--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -55,5 +55,69 @@ fn bench_quantize(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_quantize);
+fn bench_dot(c: &mut Criterion) {
+    let bit_widths: &[(TQBits, &str)] = &[
+        (TQBits::Bits1, "1bit"),
+        (TQBits::Bits2, "2bit"),
+        (TQBits::Bits4, "4bit"),
+    ];
+
+    for &(bits, bits_name) in bit_widths {
+        let mut group = c.benchmark_group(format!("turboquant_dot_{bits_name}"));
+
+        for &dim in DIMS {
+            let tq = make_tq(dim, bits);
+            let mut rng = StdRng::seed_from_u64(42);
+
+            // Pre-quantize a vector so the bench measures only the dot path.
+            let mut buf = vec![0.0f64; dim];
+            let vec = random_vector(dim, &mut rng);
+            let packed = tq.quantize(&vec, &mut buf);
+
+            group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
+                b.iter_batched(
+                    || random_vector(dim, &mut rng),
+                    |query| tq.dot_asymmetric(black_box(&query), black_box(&packed)),
+                    criterion::BatchSize::SmallInput,
+                );
+            });
+        }
+
+        group.finish();
+    }
+}
+
+fn bench_dot_precomputed(c: &mut Criterion) {
+    let bit_widths: &[(TQBits, &str)] = &[
+        (TQBits::Bits1, "1bit"),
+        (TQBits::Bits2, "2bit"),
+        (TQBits::Bits4, "4bit"),
+    ];
+
+    for &(bits, bits_name) in bit_widths {
+        let mut group = c.benchmark_group(format!("turboquant_dot_precomputed_{bits_name}"));
+
+        for &dim in DIMS {
+            let tq = make_tq(dim, bits);
+            let mut rng = StdRng::seed_from_u64(42);
+
+            // Pre-quantize a vector so the bench measures only the dot path.
+            let mut buf = vec![0.0f64; dim];
+            let vec = random_vector(dim, &mut rng);
+            let packed = tq.quantize(&vec, &mut buf);
+
+            group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
+                b.iter_batched(
+                    || tq.precompute_query(&random_vector(dim, &mut rng)),
+                    |query| tq.dot_precomputed(black_box(&query), black_box(&packed)),
+                    criterion::BatchSize::SmallInput,
+                );
+            });
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_quantize, bench_dot, bench_dot_precomputed);
 criterion_main!(benches);

--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -77,7 +77,12 @@ fn bench_dot(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
                 b.iter_batched(
                     || random_vector(dim, &mut rng),
-                    |query| tq.dot_asymmetric(black_box(&query), black_box(&packed)),
+                    |query| {
+                        tq.score_precomputed(
+                            black_box(&tq.precompute_query(&query)),
+                            black_box(&packed),
+                        )
+                    },
                     criterion::BatchSize::SmallInput,
                 );
             });
@@ -109,7 +114,7 @@ fn bench_dot_precomputed(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
                 b.iter_batched(
                     || tq.precompute_query(&random_vector(dim, &mut rng)),
-                    |query| tq.dot_precomputed(black_box(&query), black_box(&packed)),
+                    |query| tq.score_precomputed(black_box(&query), black_box(&packed)),
                     criterion::BatchSize::SmallInput,
                 );
             });

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -10,12 +10,13 @@ use crate::EncodingError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DistanceType {
+    Cosine,
     Dot,
     L1,
     L2,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct VectorParameters {
     pub dim: usize,
     pub distance_type: DistanceType,
@@ -90,7 +91,7 @@ pub trait EncodedVectors: Sized {
 impl DistanceType {
     pub fn distance(&self, a: &[f32], b: &[f32]) -> f32 {
         match self {
-            DistanceType::Dot => a.iter().zip(b).map(|(a, b)| a * b).sum(),
+            DistanceType::Dot | DistanceType::Cosine => a.iter().zip(b).map(|(a, b)| a * b).sum(),
             DistanceType::L1 => a.iter().zip(b).map(|(a, b)| (a - b).abs()).sum(),
             DistanceType::L2 => a.iter().zip(b).map(|(a, b)| (a - b) * (a - b)).sum(),
         }

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -10,7 +10,15 @@ use crate::EncodingError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DistanceType {
+    // Warning!
+    // Old Qdrant versions used `Dot` for both Cosine and Dot (since their implementations were equal).
+    // However, TurboQuant needs to know the exact distance type and can't treat Cosine and Dot equally.
+    // Because this distinction was introduced together with TQ, quantization storages created prior to
+    // TQ might still store `Dot` even though the original vectors use `Cosine`.
+    // Therefore, we can't rely on the exact type for any quantization storage other than TQ, and must *always* treat
+    // Cosine and Dot the same for quantization types that were implemented prior to TQ.
     Cosine,
+
     Dot,
     L1,
     L2,

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -472,7 +472,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             .map_err(|e| EncodingError::EncodingError(format!("Failed to build storage: {e}",)))?;
 
         let metadata = Metadata {
-            vector_parameters: vector_parameters.clone(),
+            vector_parameters: *vector_parameters,
             encoding,
             query_encoding,
             vector_stats,
@@ -796,8 +796,8 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             self.metadata.vector_parameters.invert,
         ) {
             // So if `invert` is true we return XOR, otherwise we return (dim - XOR)
-            (DistanceType::Dot, true) => xor_product - zeros_count,
-            (DistanceType::Dot, false) => zeros_count - xor_product,
+            (DistanceType::Dot | DistanceType::Cosine, true) => xor_product - zeros_count,
+            (DistanceType::Dot | DistanceType::Cosine, false) => zeros_count - xor_product,
             // This also results in exact ordering as L1 and L2 but reversed.
             (DistanceType::L1 | DistanceType::L2, true) => zeros_count - xor_product,
             (DistanceType::L1 | DistanceType::L2, false) => xor_product - zeros_count,

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -107,7 +107,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         let metadata = Metadata {
             centroids,
             vector_division,
-            vector_parameters: vector_parameters.clone(),
+            vector_parameters: *vector_parameters,
         };
         if let Some(meta_path) = meta_path {
             meta_path

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -118,7 +118,7 @@ impl MetadataInt8 {
         // this a^2 is returned here
         // L2 is handled the same way as Dot here
         let shift = match self.vector_parameters.distance_type {
-            DistanceType::Dot | DistanceType::L2 => {
+            DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
                 self.actual_dim as f32 * self.offset * self.offset
             }
             DistanceType::L1 => 0.0,
@@ -156,7 +156,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 alpha: 0.0,
                 offset: 0.0,
                 multiplier: 0.0,
-                vector_parameters: vector_parameters.clone(),
+                vector_parameters: *vector_parameters,
             });
             if let Some(meta_path) = meta_path {
                 meta_path
@@ -207,7 +207,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         let multiplier = match vector_parameters.distance_type {
             // (alpha*x - offset) * (alpha*y - offset) = alpha^2*x*y - alpha*offset*x - alpha*offset*y + offset^2
             // multiplier is applied to xy term only, so we need to multiply score by alpha^2
-            DistanceType::Dot => alpha * alpha,
+            DistanceType::Dot | DistanceType::Cosine => alpha * alpha,
             // |(alpha*x - offset) - (alpha*y - offset)| = alpha*|x - y|
             // multiplier is applied to |x - y| term only, so we need to multiply score by alpha
             DistanceType::L1 => alpha,
@@ -243,7 +243,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
             if !vector_parameters.dim.is_multiple_of(ALIGNMENT) {
                 for _ in 0..(ALIGNMENT - vector_parameters.dim % ALIGNMENT) {
                     let placeholder = match vector_parameters.distance_type {
-                        DistanceType::Dot => 0.0,
+                        DistanceType::Dot | DistanceType::Cosine => 0.0,
                         DistanceType::L1 | DistanceType::L2 => offset,
                     };
                     let encoded = metadata.encode_value(placeholder);
@@ -251,7 +251,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 }
             }
             let vector_offset = match vector_parameters.distance_type {
-                DistanceType::Dot => {
+                DistanceType::Dot | DistanceType::Cosine => {
                     let elements_sum = encoded_vector.iter().map(|&x| f32::from(x)).sum::<f32>();
                     elements_sum * alpha * offset
                 }
@@ -330,7 +330,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let q_ptr = query.encoded_query.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
                         impl_score_dot(q_ptr, v_ptr, metadata.actual_dim)
                     }
                     DistanceType::L1 => impl_score_l1(q_ptr, v_ptr, metadata.actual_dim),
@@ -348,7 +348,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let (query_offset, q_ptr) = self.get_vec_ptr(i);
                 let (vector_offset, v_ptr) = self.get_vec_ptr(j);
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
                         impl_score_dot(q_ptr, v_ptr, metadata.actual_dim)
                     }
                     DistanceType::L1 => impl_score_l1(q_ptr, v_ptr, metadata.actual_dim),
@@ -367,7 +367,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let q_ptr = query.encoded_query.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_neon(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -388,7 +388,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let (vector_offset, v_ptr) = self.get_vec_ptr(j);
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_neon(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -409,7 +409,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let q_ptr = query.encoded_query.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_sse(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -430,7 +430,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let (vector_offset, v_ptr) = self.get_vec_ptr(j);
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_sse(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -451,7 +451,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let q_ptr = query.encoded_query.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_avx(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -472,7 +472,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 let (vector_offset, v_ptr) = self.get_vec_ptr(j);
 
                 let score = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot | DistanceType::L2 => unsafe {
+                    DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
                         impl_score_dot_avx(q_ptr, v_ptr, metadata.actual_dim as u32)
                     },
                     DistanceType::L1 => unsafe {
@@ -556,7 +556,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         if !dim.is_multiple_of(ALIGNMENT) {
             for _ in 0..(ALIGNMENT - dim % ALIGNMENT) {
                 let placeholder = match metadata.vector_parameters.distance_type {
-                    DistanceType::Dot => 0.0,
+                    DistanceType::Dot | DistanceType::Cosine => 0.0,
                     DistanceType::L1 | DistanceType::L2 => metadata.offset,
                 };
                 let encoded = metadata.encode_value(placeholder);
@@ -564,7 +564,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
             }
         }
         let offset = match metadata.vector_parameters.distance_type {
-            DistanceType::Dot => {
+            DistanceType::Dot | DistanceType::Cosine => {
                 let query_elements_sum = query.iter().map(|&x| f32::from(x)).sum::<f32>();
                 query_elements_sum * metadata.alpha * metadata.offset
             }

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -226,7 +226,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
             alpha,
             offset,
             multiplier,
-            vector_parameters: vector_parameters.clone(),
+            vector_parameters: *vector_parameters,
         };
 
         for vector in orig_data {

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -31,17 +31,24 @@ impl TqVectorExtras {
 }
 
 impl TurboQuantizer {
-    /// Bit-pack an iterator of centroid indices into a compact byte vector.
-    pub(super) fn pack_vector<I>(&self, centroids: I, extras: TqVectorExtras) -> Vec<u8>
+    /// Bit-pack a sequence of rotated, Lloyd-Max-scaled values into a compact
+    /// byte vector. Each value is mapped to its nearest centroid index via the
+    /// bit-width's decision boundaries before packing.
+    ///
+    /// Symmetric inverse of [`Self::unpack_vector`]: feeding its yielded f64s
+    /// back through `pack_vector` reproduces the same byte layout.
+    pub(super) fn pack_vector<I>(&self, scaled: I, extras: TqVectorExtras) -> Vec<u8>
     where
-        I: Iterator<Item = u8>,
+        I: IntoIterator<Item = f64>,
     {
         let mut out = Vec::with_capacity(self.quantized_size());
         let mut bit_writer = BitWriter::new(&mut out);
 
+        let boundaries = self.bits.get_centroid_boundaries();
         let bits = self.bits.bit_size();
-        for item in centroids {
-            bit_writer.write(item, bits);
+        for val in scaled {
+            let idx = boundaries.partition_point(|&b| (val as f32) > b) as u8;
+            bit_writer.write(idx, bits);
         }
         bit_writer.finish();
         self.pack_extras_into(&extras, &mut out);
@@ -57,16 +64,12 @@ impl TurboQuantizer {
     ///
     /// Does not apply the inverse rotation — the iterator yields values in the
     /// rotated space.
-    pub fn unpack_vector<'a>(
-        &'a self,
-        vec: &'a [u8],
-    ) -> (Option<TqVectorExtras>, impl Iterator<Item = f64> + 'a) {
+    pub fn unpack_vector(&self, vec: &[u8]) -> (TqVectorExtras, impl Iterator<Item = f64>) {
         let extra_len = TqVectorExtras::size_for(self.bits, self.distance, self.mode);
 
-        let dim_part = &vec[..vec.len() - extra_len];
-        let extra_part = &vec[vec.len() - extra_len..];
+        let (dim_part, extra_part) = vec.split_at(vec.len() - extra_len);
 
-        let extras = (!extra_part.is_empty()).then(|| self.unpack_extras_from(extra_part));
+        let extras = self.unpack_extras_from(extra_part);
 
         let centroids = self.bits.get_centroids();
         let mut reader = BitReader::new(dim_part);
@@ -144,15 +147,22 @@ impl TurboQuantizer {
     ///
     /// This function requires `src` to have extra data encoded.
     fn unpack_extras_from(&self, src: &[u8]) -> TqVectorExtras {
-        debug_assert!(!src.is_empty());
+        debug_assert_eq!(
+            src.len(),
+            TqVectorExtras::size_for(self.bits, self.distance, self.mode),
+            "src must contain encoded extras data of the expected size"
+        );
 
         let mut extras = TqVectorExtras::default();
 
         // Additional l2 for dot vectors.
-        if matches!(self.distance, DistanceType::Dot) {
-            debug_assert_eq!(src.len(), size_of::<f32>());
-            let l2_bytes: [u8; 4] = src[..4].try_into().unwrap(); // TODO(turbo): maybe add error handling.
-            extras.l2_length = Some(f32::from_le_bytes(l2_bytes));
+        match self.distance {
+            DistanceType::Dot => {
+                let l2_bytes: [u8; 4] = src[..4].try_into().unwrap(); // TODO(turbo): maybe add error handling.
+                extras.l2_length = Some(f32::from_le_bytes(l2_bytes));
+            }
+            DistanceType::Cosine => {}
+            DistanceType::L1 | DistanceType::L2 => unreachable!(),
         }
 
         extras

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -37,32 +37,36 @@ impl TurboQuantizer {
         out
     }
 
-    /// Unpacks `vec` into `out` and returns `Extras`.
+    /// Unpacks `vec` into an iterator of `dim` centroid values and returns any
+    /// `Extras` stored alongside.
     ///
-    /// `out` must have length equal to the quantizer's `dim`; one centroid
-    /// value is written per slot.
+    /// The iterator lazily decodes one centroid per step, so callers scoring a
+    /// vector can `zip` it with a query and compute the dot in a single pass
+    /// without materializing an intermediate buffer.
     ///
-    /// Does not apply the inverse rotation — `out` holds values in the
+    /// Does not apply the inverse rotation — the iterator yields values in the
     /// rotated space.
-    pub fn unpack_vector(&self, vec: &[u8], out: &mut [f64]) -> Option<TqVectorExtras> {
+    pub fn unpack_vector<'a>(
+        &'a self,
+        vec: &'a [u8],
+    ) -> (Option<TqVectorExtras>, impl Iterator<Item = f64> + 'a) {
         let extra_len = TqVectorExtras::size_for(self.bits, self.distance, self.mode);
 
         let dim_part = &vec[..vec.len() - extra_len];
         let extra_part = &vec[vec.len() - extra_len..];
 
-        debug_assert_eq!(out.len(), self.rotation.dim());
+        let extras = (!extra_part.is_empty()).then(|| self.unpack_extras_from(extra_part));
 
-        // Unpack dimensions.
         let centroids = self.bits.get_centroids();
         let mut reader = BitReader::new(dim_part);
         reader.set_bits(self.bits.bit_size());
-        for slot in out.iter_mut() {
-            let idx: u8 = reader.read();
-            *slot = f64::from(centroids[idx as usize]);
-        }
 
-        // Unpack and return extras if available.
-        (!extra_part.is_empty()).then(|| self.unpack_extras_from(extra_part))
+        let iter = (0..self.rotation.dim()).map(move |_| {
+            let idx: u8 = reader.read();
+            f64::from(centroids[idx as usize])
+        });
+
+        (extras, iter)
     }
 
     /// Size in bytes of a vector quantized by this quantizer.

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -1,6 +1,6 @@
 use common::bitpacking::{BitReader, BitWriter};
 
-use crate::DistanceType;
+use crate::encoded_vectors::DistanceType;
 use crate::turboquant::quantization::TurboQuantizer;
 use crate::turboquant::{TQBits, TQMode};
 
@@ -8,14 +8,25 @@ use crate::turboquant::{TQBits, TQMode};
 #[derive(Default, Copy, Clone)]
 pub struct TqVectorExtras {
     // TODO(turbo): add all fields.
-    // l2_length: Option<f32>,
+    pub(super) l2_length: Option<f32>,
 }
 
 impl TqVectorExtras {
     /// Returns the size (in bytes) required for the extras.
-    pub(super) fn size_for(_bits: TQBits, _distance: DistanceType, _mode: TQMode) -> usize {
-        // TODO(turbo): fully implement
-        0
+    pub(super) fn size_for(_bits: TQBits, distance: DistanceType, _mode: TQMode) -> usize {
+        let mut size = 0;
+
+        match distance {
+            DistanceType::Dot => {
+                // For Dot product we need to additionally store the original vectors l2.
+                size += size_of::<f32>();
+            }
+            DistanceType::Cosine => {}
+            DistanceType::L1 => unimplemented!("L1 metric not yet implemented"),
+            DistanceType::L2 => unimplemented!("L2 metric not yet implemented"),
+        }
+
+        size
     }
 }
 
@@ -98,31 +109,128 @@ impl TurboQuantizer {
     /// This depends on the  metadata of the `TurboQuantizer`, such as distance-type or TQ-Mode.
     ///
     /// Not all configurations need extras.
-    pub(super) fn calculate_extras(&self, _rotated_vec: &[f64]) -> TqVectorExtras {
+    pub(super) fn calculate_extras(&self, rotated_vec: &[f64]) -> TqVectorExtras {
         // TODO(turbo): fully implement
         Self::assert_supported_distance(self.distance);
 
-        TqVectorExtras::default()
-    }
+        let mut extras = TqVectorExtras::default();
 
-    /// Decodes `src` containing encoded 'extra'-data and returns the decoded `Extras`.
-    #[allow(clippy::unused_self)]
-    fn unpack_extras_from(&self, _src: &[u8]) -> TqVectorExtras {
-        // TODO(turbo): implement unpacking of extras.
-        todo!()
+        // Additional l2 for dot vectors.
+        if matches!(self.distance, DistanceType::Dot) {
+            extras.l2_length = Some(rotated_vec.iter().map(|&i| i * i).sum::<f64>().sqrt() as f32);
+        }
+
+        extras
     }
 
     /// Packs (encodes) the extras into the given buffer.
-    #[allow(clippy::unused_self)]
-    fn pack_extras_into(&self, _extras: &TqVectorExtras, _buf: &mut Vec<u8>) {
-        // TODO(turbo): implement packing of extras.
+    fn pack_extras_into(&self, extras: &TqVectorExtras, buf: &mut Vec<u8>) {
+        let extra_len =
+            Self::quantized_size_for(self.rotation.dim(), self.bits, self.distance, self.mode);
+
+        if extra_len == 0 {
+            return;
+        }
+
+        buf.reserve(extra_len);
+
+        // Additional l2 for dot vectors.
+        if let Some(l2) = extras.l2_length {
+            buf.extend(&l2.to_le_bytes());
+        }
+    }
+
+    /// Decodes `src` containing encoded 'extra'-data and returns the decoded `Extras`.
+    ///
+    /// This function requires `src` to have extra data encoded.
+    fn unpack_extras_from(&self, src: &[u8]) -> TqVectorExtras {
+        debug_assert!(!src.is_empty());
+
+        let mut extras = TqVectorExtras::default();
+
+        // Additional l2 for dot vectors.
+        if matches!(self.distance, DistanceType::Dot) {
+            debug_assert_eq!(src.len(), size_of::<f32>());
+            let l2_bytes: [u8; 4] = src[..4].try_into().unwrap(); // TODO(turbo): maybe add error handling.
+            extras.l2_length = Some(f32::from_le_bytes(l2_bytes));
+        }
+
+        extras
     }
 
     /// TODO(turbo): remove once all distance have been implemented.
-    fn assert_supported_distance(distance: DistanceType) {
-        if !matches!(distance, DistanceType::Dot) {
+    pub(super) fn assert_supported_distance(distance: DistanceType) {
+        if !matches!(distance, DistanceType::Dot | DistanceType::Cosine) {
             // TODO(turbo): implement for other metrics too.
-            unimplemented!("Quantization currently only implemented for dot product");
+            unimplemented!("Quantization currently only implemented for cosine and dot product");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bit widths exercised by the extras tests. `Bits1_5` is excluded: its
+    /// `bit_size` is not yet implemented and panics.
+    const SUPPORTED_BITS: &[TQBits] = &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4];
+    /// Distances exercised by the extras tests. `L1`/`L2` are excluded: their
+    /// `size_for` arms panic with `unimplemented!`.
+    const SUPPORTED_DISTANCES: &[DistanceType] = &[DistanceType::Dot, DistanceType::Cosine];
+    const ALL_MODES: &[TQMode] = &[TQMode::Normal, TQMode::Plus];
+
+    fn example_extras(distance: DistanceType) -> TqVectorExtras {
+        match distance {
+            DistanceType::Dot => TqVectorExtras {
+                l2_length: Some(1.25),
+            },
+            DistanceType::Cosine => TqVectorExtras { l2_length: None },
+            DistanceType::L1 | DistanceType::L2 => {
+                unreachable!("unsupported distance in test")
+            }
+        }
+    }
+
+    /// For every supported (bits, mode, distance) combo, assert:
+    ///   1. `pack_extras_into` writes exactly `size_for` bytes.
+    ///   2. `unpack_extras_from` recovers the packed extras field-for-field.
+    ///
+    /// Unpacking uses a destructuring pattern so adding a new field to
+    /// `TqVectorExtras` will force this test to be updated.
+    #[test]
+    fn extras_size_matches_pack_and_roundtrips_unpack() {
+        let dim = 64;
+
+        for &bits in SUPPORTED_BITS {
+            for &mode in ALL_MODES {
+                for &distance in SUPPORTED_DISTANCES {
+                    let predicted_extra_size = TqVectorExtras::size_for(bits, distance, mode);
+
+                    let tq = TurboQuantizer::new(dim, bits, mode, distance);
+                    let expected = example_extras(distance);
+
+                    let mut buf = Vec::new();
+                    tq.pack_extras_into(&expected, &mut buf);
+                    assert_eq!(
+                        buf.len(),
+                        predicted_extra_size,
+                        "pack size mismatch (bits={bits:?}, mode={mode:?}, distance={distance:?})",
+                    );
+
+                    if predicted_extra_size == 0 {
+                        continue;
+                    }
+
+                    let TqVectorExtras { l2_length } = tq.unpack_extras_from(&buf);
+                    let TqVectorExtras {
+                        l2_length: expected_l2,
+                    } = expected;
+                    assert_eq!(
+                        l2_length, expected_l2,
+                        "l2_length roundtrip (bits={bits:?}, mode={mode:?}, distance={distance:?})",
+                    );
+                }
+            }
         }
     }
 }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -106,7 +106,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         debug_assert!(validate_vector_parameters(data.clone(), vector_parameters).is_ok());
 
         let metadata = Metadata {
-            vector_parameters: vector_parameters.clone(),
+            vector_parameters: *vector_parameters,
             bits,
             mode,
         };
@@ -251,7 +251,7 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
 
         hw_counter.vector_io_read().incr_delta(v1.len() + v2.len());
 
-        self.quantizer.dot_symmetric(&v1, &v2)
+        self.quantizer.score_symmetric(&v1, &v2)
     }
 
     fn quantized_vector_size(&self) -> usize {
@@ -318,6 +318,7 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         hw_counter: &HardwareCounterCell,
     ) -> f32 {
         hw_counter.cpu_counter().incr_delta(bytes.len());
-        self.quantizer.dot_precomputed(&query.rotated_query, bytes)
+        self.quantizer
+            .score_precomputed(&query.rotated_query, bytes)
     }
 }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::EncodingError;
 use crate::encoded_storage::{EncodedStorage, EncodedStorageBuilder};
 use crate::encoded_vectors::{EncodedVectors, VectorParameters, validate_vector_parameters};
-use crate::turboquant::quantization::TurboQuantizer;
+use crate::turboquant::quantization::{Precomputed, TurboQuantizer};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -58,10 +58,15 @@ pub struct EncodedVectorsTQ<TStorage: EncodedStorage> {
     metadata: Metadata,
     metadata_path: Option<PathBuf>,
     quantizer: TurboQuantizer,
+
+    // Buffer used when encoding vectors.
+    encoding_buffer: Vec<f64>,
 }
 
 /// Encoded query type for Turbo Quant.
-pub struct EncodedQueryTQ {}
+pub struct EncodedQueryTQ {
+    rotated_query: Precomputed,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Metadata {
@@ -97,6 +102,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         meta_path: Option<&Path>,
         stopped: &AtomicBool,
     ) -> Result<Self, EncodingError> {
+        let dim = vector_parameters.dim;
         debug_assert!(validate_vector_parameters(data.clone(), vector_parameters).is_ok());
 
         let metadata = Metadata {
@@ -107,7 +113,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
 
         let quantizer = TurboQuantizer::new_from_metadata(&metadata);
 
-        let mut buf = vec![0.0f64; vector_parameters.dim];
+        let mut buf = vec![0.0f64; dim];
 
         for vector in data {
             if stopped.load(Ordering::Relaxed) {
@@ -153,6 +159,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
             metadata,
             metadata_path: meta_path.map(PathBuf::from),
             quantizer,
+            encoding_buffer: vec![0.0f64; dim],
         })
     }
 
@@ -162,11 +169,13 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
 
         let quantizer = TurboQuantizer::new_from_metadata(&metadata);
 
+        let dim = metadata.vector_parameters.dim;
         let result = Self {
             encoded_vectors,
             metadata,
             metadata_path: Some(meta_path.to_path_buf()),
             quantizer,
+            encoding_buffer: vec![0.0f64; dim],
         };
 
         Ok(result)
@@ -214,8 +223,10 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         self.encoded_vectors.is_on_disk()
     }
 
-    fn encode_query(&self, _query: &[f32]) -> EncodedQueryTQ {
-        EncodedQueryTQ {}
+    fn encode_query(&self, query: &[f32]) -> EncodedQueryTQ {
+        EncodedQueryTQ {
+            rotated_query: self.quantizer.precompute_query(query),
+        }
     }
 
     fn score_point(
@@ -240,7 +251,7 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
 
         hw_counter.vector_io_read().incr_delta(v1.len() + v2.len());
 
-        todo!()
+        self.quantizer.dot_symmetric(&v1, &v2)
     }
 
     fn quantized_vector_size(&self) -> usize {
@@ -265,8 +276,8 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         vector: &[f32],
         hw_counter: &HardwareCounterCell,
     ) -> std::io::Result<()> {
-        let mut buf = vec![0.0f64; vector.len()];
-        let encoded_vector = Self::encode_vector(vector, &self.quantizer, &mut buf);
+        let encoded_vector =
+            Self::encode_vector(vector, &self.quantizer, &mut self.encoding_buffer);
         self.encoded_vectors.upsert_vector(
             id,
             bytemuck::cast_slice(encoded_vector.as_slice()),
@@ -302,12 +313,11 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
     fn score_bytes(
         &self,
         _: Self::SupportsBytes,
-        _query: &Self::EncodedQuery,
+        query: &Self::EncodedQuery,
         bytes: &[u8],
         hw_counter: &HardwareCounterCell,
     ) -> f32 {
         hw_counter.cpu_counter().incr_delta(bytes.len());
-
-        todo!()
+        self.quantizer.dot_precomputed(&query.rotated_query, bytes)
     }
 }

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -141,6 +141,8 @@ where
 #[cfg(test)]
 mod tests {
     use common::bitpacking::BitReader;
+    use rand::prelude::StdRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
     use crate::VectorParameters;
@@ -160,11 +162,11 @@ mod tests {
         TurboQuantizer::new_from_metadata(&metadata)
     }
 
-    /// Build a pair `(a, b)` where `b = t * a + (1 - t) * noise`, so `t = 1`
-    /// means identical and `t = 0` means independent random.
-    fn generate_mixed_pair(
+    /// Build a vector pair that has a given magnitude of similarity, tuned by `similarity`.
+    /// `similarity = 1` means identical and `similarity = 0` means independent random vectors.
+    fn generate_random_vector_pair_with_similarity(
         dim: usize,
-        t: f32,
+        similarity: f32,
         rng: &mut rand::prelude::StdRng,
     ) -> (Vec<f32>, Vec<f32>) {
         use rand::RngExt;
@@ -173,16 +175,14 @@ mod tests {
         let b: Vec<f32> = a
             .iter()
             .zip(noise.iter())
-            .map(|(&x, &n)| t * x + (1.0 - t) * n)
+            .map(|(&x, &n)| similarity * x + (1.0 - similarity) * n)
             .collect();
         (a, b)
     }
 
-    fn true_dot(a: &[f32], b: &[f32]) -> f64 {
-        a.iter()
-            .zip(b)
-            .map(|(&x, &y)| f64::from(x) * f64::from(y))
-            .sum()
+    /// Build a single random vector with components uniformly in `[-1, 1]`.
+    fn random_vector(dim: usize, rng: &mut StdRng) -> Vec<f32> {
+        (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect()
     }
 
     fn l2_norm(v: &[f32]) -> f64 {
@@ -192,6 +192,7 @@ mod tests {
             .sqrt()
     }
 
+    /// Score an original vector against a quantized one.
     fn asymmetric_score_helper(tq: &TurboQuantizer, query: &[f32], vec: &[u8]) -> f32 {
         let precomputed = tq.precompute_query(query);
         tq.score_precomputed(&precomputed, vec)
@@ -199,7 +200,7 @@ mod tests {
 
     /// Normalize `v` onto the unit sphere — required input for the Cosine
     /// quantizer path.
-    fn unit_norm(v: &[f32]) -> Vec<f32> {
+    fn normalize_vector(v: &[f32]) -> Vec<f32> {
         let len = l2_norm(v) as f32;
         v.iter().map(|&x| x / len).collect()
     }
@@ -209,6 +210,15 @@ mod tests {
         let mut reader = BitReader::new(packed);
         reader.set_bits(bits.bit_size());
         (0..dim).map(|_| reader.read()).collect()
+    }
+
+    #[inline]
+    fn dot_f32_impl<I, J>(left: I, right: J) -> f32
+    where
+        I: Iterator<Item = f32>,
+        J: Iterator<Item = f32>,
+    {
+        left.zip(right).map(|(q, u)| q * u).sum::<f32>()
     }
 
     /// Extreme-magnitude inputs (including values near f32::MAX) must still
@@ -308,231 +318,6 @@ mod tests {
         }
     }
 
-    /// After rotation, each dimension is quantized independently. Verify that
-    /// the assigned centroid index is the nearest centroid for each rotated value.
-    #[test]
-    fn quantize_assigns_nearest_centroid() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let mut rng = StdRng::seed_from_u64(77);
-
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let centroids = bits.get_centroids();
-
-            for &dim in &[128, 300, 512] {
-                let mut buf = vec![0.0f64; dim];
-                let tq = make_tq(dim, bits, DistanceType::Cosine);
-                let rot = HadamardRotation::new(dim);
-                let vec_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-                let vec = unit_norm(&vec_raw);
-
-                let result = tq.quantize(&vec, &mut buf);
-                let indices = unpack_indices(&result, dim, bits);
-
-                // Reproduce rotation AND the √dim / ||v|| rescaling that
-                // `quantize` performs before partitioning against centroids.
-                let mut rotated: Vec<f64> = vec.iter().map(|&v| f64::from(v)).collect();
-                rot.apply(&mut rotated);
-                let scale = (dim as f64).sqrt();
-                for v in rotated.iter_mut() {
-                    *v *= scale;
-                }
-
-                for (d, (&idx, &val)) in indices.iter().zip(rotated.iter()).enumerate() {
-                    let assigned_centroid = f64::from(centroids[idx as usize]);
-                    let assigned_dist = (val - assigned_centroid).abs();
-
-                    // No other centroid should be strictly closer.
-                    for (j, &c) in centroids.iter().enumerate() {
-                        let dist = (val - f64::from(c)).abs();
-                        assert!(
-                            assigned_dist <= dist + 1e-9,
-                            "dim={dim}, bits={bits:?}, d={d}: index {idx} \
-                             (centroid={assigned_centroid:.4}) is farther ({assigned_dist:.6}) \
-                             than centroid[{j}]={c:.4} (dist={dist:.6}) for val={val:.6}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /// Reconstruct quantized vectors by mapping indices back to centroids and
-    /// applying inverse rotation. Verify the reconstruction is a reasonable
-    /// approximation: MSE should decrease with more bits.
-    #[test]
-    fn quantize_reconstruction_quality_improves_with_bits() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let dim = 512;
-        let n_vectors = 50;
-        let mut buf = vec![0.0f64; dim];
-        let mut rng = StdRng::seed_from_u64(99);
-        let rot = HadamardRotation::new(dim);
-
-        let vectors: Vec<Vec<f32>> = (0..n_vectors)
-            .map(|_| {
-                let raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-                unit_norm(&raw)
-            })
-            .collect();
-
-        let mut mse_per_bits = Vec::new();
-
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits, DistanceType::Cosine);
-            let centroids = bits.get_centroids();
-            let mut total_mse = 0.0f64;
-
-            for vec in &vectors {
-                let packed = tq.quantize(vec, &mut buf);
-                let indices = unpack_indices(&packed, dim, bits);
-
-                // Reconstruct: map indices → centroids, inverse rotate, then
-                // undo the √dim rescaling that `quantize` applied before
-                // partitioning (unpacked values live on the √dim × scale).
-                let inv_scale = 1.0 / (dim as f64).sqrt();
-                let mut reconstructed: Vec<f64> = indices
-                    .iter()
-                    .map(|&i| f64::from(centroids[i as usize]) * inv_scale)
-                    .collect();
-                rot.apply_inverse(&mut reconstructed);
-
-                // MSE between unit-norm original and reconstructed.
-                let mse: f64 = vec
-                    .iter()
-                    .zip(reconstructed.iter())
-                    .map(|(&orig, &recon)| {
-                        let diff = f64::from(orig) - recon;
-                        diff * diff
-                    })
-                    .sum::<f64>()
-                    / dim as f64;
-
-                total_mse += mse;
-            }
-
-            let avg_mse = total_mse / f64::from(n_vectors);
-            mse_per_bits.push((bits, avg_mse));
-        }
-
-        // More bits should give lower MSE.
-        let mse_1bit = mse_per_bits[0].1;
-        let mse_2bit = mse_per_bits[1].1;
-        let mse_4bit = mse_per_bits[2].1;
-
-        assert!(
-            mse_2bit < mse_1bit,
-            "2-bit MSE ({mse_2bit:.6}) should be less than 1-bit ({mse_1bit:.6})"
-        );
-        assert!(
-            mse_4bit < mse_2bit,
-            "4-bit MSE ({mse_4bit:.6}) should be less than 2-bit ({mse_2bit:.6})"
-        );
-    }
-
-    /// Verify that dot product ordering is approximately preserved after
-    /// quantization: if dot(q, a) > dot(q, b), the quantized approximation
-    /// should agree in the majority of cases.
-    #[test]
-    fn quantize_preserves_cosine_product_ordering() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let dim = 512;
-        let n_comparisons = 500;
-        let mut rng = StdRng::seed_from_u64(55);
-        let rot = HadamardRotation::new(dim);
-
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let centroids = TQBits::Bits4.get_centroids();
-
-        let mut concordant = 0usize;
-
-        for _ in 0..n_comparisons {
-            let query: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let vec_a_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let vec_b_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let vec_a = unit_norm(&vec_a_raw);
-            let vec_b = unit_norm(&vec_b_raw);
-
-            // True dot products (against unit-norm vectors).
-            let dot_a = true_dot(&query, &vec_a);
-            let dot_b = true_dot(&query, &vec_b);
-
-            // Approximate dot products using quantized vectors. The unpacked
-            // centroids live on the √dim × rotated(v̂) scale, so dividing
-            // the reconstructed dot by √dim recovers the original-space dot.
-            let inv_scale = 1.0 / (dim as f64).sqrt();
-            let approx_dot = |vec: &[f32]| -> f64 {
-                let mut buf = vec![0.0f64; vec.len()];
-                let packed = tq.quantize(vec, &mut buf);
-                let indices = unpack_indices(&packed, dim, TQBits::Bits4);
-                let mut recon: Vec<f64> = indices
-                    .iter()
-                    .map(|&i| f64::from(centroids[i as usize]))
-                    .collect();
-                rot.apply_inverse(&mut recon);
-                query
-                    .iter()
-                    .zip(recon.iter())
-                    .map(|(&q, &r)| f64::from(q) * r)
-                    .sum::<f64>()
-                    * inv_scale
-            };
-
-            let approx_a = approx_dot(&vec_a);
-            let approx_b = approx_dot(&vec_b);
-
-            // Check if ordering is preserved.
-            if (dot_a > dot_b) == (approx_a > approx_b) {
-                concordant += 1;
-            }
-        }
-
-        let concordance_rate = concordant as f64 / f64::from(n_comparisons);
-        // With 4 bits and 512 dimensions, ordering should be preserved
-        // in a strong majority of random comparisons.
-        assert!(
-            concordance_rate > 0.75,
-            "concordance rate {concordance_rate:.2} is too low \
-             ({concordant}/{n_comparisons})"
-        );
-    }
-
-    /// Negating all elements of a vector should mirror the centroid indices.
-    /// For symmetric centroids c_0 < c_1 < ... < c_{n-1}, negation maps
-    /// index k -> (n-1-k) because the centroids are symmetric around 0.
-    #[test]
-    fn quantize_negation_mirrors_indices() {
-        let dim = 128; // power of 2, so rotation is clean
-
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let max_index = (1u8 << bits.bit_size()) - 1;
-            let tq = make_tq(dim, bits, DistanceType::Cosine);
-
-            // Use a uniform vector so rotation doesn't scramble things.
-            let val = 0.5f32;
-            let pos_vec = vec![val; dim];
-            let neg_vec = vec![-val; dim];
-            let mut buf = vec![0.0f64; dim];
-
-            let pos_indices = unpack_indices(&tq.quantize(&pos_vec, &mut buf), dim, bits);
-            let neg_indices = unpack_indices(&tq.quantize(&neg_vec, &mut buf), dim, bits);
-
-            for (d, (&p, &n)) in pos_indices.iter().zip(neg_indices.iter()).enumerate() {
-                assert_eq!(
-                    p,
-                    max_index - n,
-                    "bits={bits:?}, d={d}: negation should mirror index \
-                     (got pos={p}, neg={n}, max_index={max_index})"
-                );
-            }
-        }
-    }
-
     /// Non-power-of-2 dimensions should work correctly (the rotation decomposes
     /// into power-of-2 chunks internally).
     #[test]
@@ -604,6 +389,341 @@ mod tests {
         }
     }
 
+    /// Quantized scores (symmetric and asymmetric paths) stay within tolerance
+    /// of the true dot/cosine similarity across a range of pair similarities.
+    #[test]
+    fn score_approximates_true_similarity() {
+        for dim in [128, 300, 512, 1000, 1024, 2000, 4000] {
+            let bits = TQBits::Bits4;
+            let mut rng = StdRng::seed_from_u64(42);
+
+            for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+                let tq = make_tq(dim, bits, distance);
+                let mut buf = vec![0.0f64; dim];
+
+                for &similarity in &[0.2f32, 0.5, 0.8] {
+                    let (a_raw, b_raw) =
+                        generate_random_vector_pair_with_similarity(dim, similarity, &mut rng);
+
+                    // Cosine path requires unit-norm inputs.
+                    let (a, b) = match distance {
+                        DistanceType::Cosine => {
+                            (normalize_vector(&a_raw), normalize_vector(&b_raw))
+                        }
+                        _ => (a_raw, b_raw),
+                    };
+
+                    let true_score = dot_f32_impl(a.iter().copied(), b.iter().copied());
+
+                    let a_q = tq.quantize(&a, &mut buf);
+                    let b_q = tq.quantize(&b, &mut buf);
+
+                    let sym = tq.score_symmetric(&a_q, &b_q);
+                    let asym = asymmetric_score_helper(&tq, &a, &b_q);
+
+                    // Cosine scores are bounded in [-1, 1]; Dot scales with ||a||*||b||.
+                    let scale = match distance {
+                        DistanceType::Cosine => 1.0,
+                        _ => (l2_norm(&a) * l2_norm(&b)) as f32,
+                    };
+                    let tol = 0.05 * scale;
+
+                    assert!(
+                        (sym - true_score).abs() < tol,
+                        "symmetric: distance={distance:?}, similarity={similarity}, \
+                     got {sym}, expected {true_score} (tol {tol})"
+                    );
+                    assert!(
+                        (asym - true_score).abs() < tol,
+                        "asymmetric: distance={distance:?}, similarity={similarity}, \
+                     got {asym}, expected {true_score} (tol {tol})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// score(v, v) must recover ‖v‖² for Dot and 1.0 for Cosine, across both
+    /// symmetric and asymmetric scoring paths.
+    #[test]
+    fn score_self_similarity() {
+        let bits = TQBits::Bits4;
+
+        for dim in [128, 300, 512, 1024, 2000] {
+            let mut rng = StdRng::seed_from_u64(42);
+
+            for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+                let tq = make_tq(dim, bits, distance);
+                let mut buf = vec![0.0f64; dim];
+
+                let raw = random_vector(dim, &mut rng);
+                let v = match distance {
+                    DistanceType::Cosine => normalize_vector(&raw),
+                    _ => raw,
+                };
+
+                let expected = match distance {
+                    DistanceType::Cosine => 1.0,
+                    _ => (l2_norm(&v) * l2_norm(&v)) as f32,
+                };
+                let tol = 0.05 * expected.abs().max(1.0);
+
+                let v_q = tq.quantize(&v, &mut buf);
+
+                let sym = tq.score_symmetric(&v_q, &v_q);
+                let asym = asymmetric_score_helper(&tq, &v, &v_q);
+
+                assert!(
+                    (sym - expected).abs() < tol,
+                    "symmetric: dim={dim}, distance={distance:?}, \
+                     got {sym}, expected {expected} (tol {tol})"
+                );
+                assert!(
+                    (asym - expected).abs() < tol,
+                    "asymmetric: dim={dim}, distance={distance:?}, \
+                     got {asym}, expected {expected} (tol {tol})"
+                );
+            }
+        }
+    }
+
+    /// score(v, -v) must recover -‖v‖² for Dot and -1.0 for Cosine across both
+    /// scoring paths — the sign correctness check on the negative end.
+    #[test]
+    fn score_antipodal_is_negative() {
+        let bits = TQBits::Bits4;
+
+        for dim in [128, 300, 512, 1024, 2000] {
+            let mut rng = StdRng::seed_from_u64(42);
+
+            for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+                let tq = make_tq(dim, bits, distance);
+                let mut buf = vec![0.0f64; dim];
+
+                let raw = random_vector(dim, &mut rng);
+                let v = match distance {
+                    DistanceType::Cosine => normalize_vector(&raw),
+                    _ => raw,
+                };
+                let neg_v: Vec<f32> = v.iter().map(|&x| -x).collect();
+
+                let expected = match distance {
+                    DistanceType::Cosine => -1.0,
+                    _ => -(l2_norm(&v) * l2_norm(&v)) as f32,
+                };
+                let tol = 0.05 * expected.abs().max(1.0);
+
+                let v_q = tq.quantize(&v, &mut buf);
+                let neg_q = tq.quantize(&neg_v, &mut buf);
+
+                let sym = tq.score_symmetric(&v_q, &neg_q);
+                let asym = asymmetric_score_helper(&tq, &v, &neg_q);
+
+                assert!(
+                    (sym - expected).abs() < tol,
+                    "symmetric: dim={dim}, distance={distance:?}, \
+                     got {sym}, expected {expected} (tol {tol})"
+                );
+                assert!(
+                    (asym - expected).abs() < tol,
+                    "asymmetric: dim={dim}, distance={distance:?}, \
+                     got {asym}, expected {expected} (tol {tol})"
+                );
+            }
+        }
+    }
+
+    /// Higher bit widths must produce lower mean-absolute scoring error:
+    /// MAE(Bits4) ≤ MAE(Bits2) ≤ MAE(Bits1) across a batch of random pairs.
+    #[test]
+    fn higher_bits_reduce_error() {
+        let dim = 512;
+        let n_pairs = 32;
+
+        for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+            let mae = |bits: TQBits| -> f32 {
+                let mut rng = StdRng::seed_from_u64(42);
+                let tq = make_tq(dim, bits, distance);
+                let mut buf = vec![0.0f64; dim];
+
+                let total: f32 = (0..n_pairs)
+                    .map(|_| {
+                        let (a_raw, b_raw) =
+                            generate_random_vector_pair_with_similarity(dim, 0.5, &mut rng);
+                        let (a, b) = match distance {
+                            DistanceType::Cosine => {
+                                (normalize_vector(&a_raw), normalize_vector(&b_raw))
+                            }
+                            _ => (a_raw, b_raw),
+                        };
+                        let truth = dot_f32_impl(a.iter().copied(), b.iter().copied());
+                        let a_q = tq.quantize(&a, &mut buf);
+                        let b_q = tq.quantize(&b, &mut buf);
+                        (tq.score_symmetric(&a_q, &b_q) - truth).abs()
+                    })
+                    .sum();
+                total / n_pairs as f32
+            };
+
+            let mae_1 = mae(TQBits::Bits1);
+            let mae_2 = mae(TQBits::Bits2);
+            let mae_4 = mae(TQBits::Bits4);
+
+            assert!(
+                mae_4 <= mae_2 && mae_2 <= mae_1,
+                "distance={distance:?}: MAE not monotonic in bits — \
+                 Bits1={mae_1}, Bits2={mae_2}, Bits4={mae_4}"
+            );
+        }
+    }
+
+    /// Scoring extreme-magnitude (but f32-in-range) vectors must produce finite
+    /// results — not NaN or ±Inf — on both symmetric and asymmetric paths.
+    #[test]
+    fn score_extreme_magnitudes_finite() {
+        let dim = 128;
+        let bits = TQBits::Bits4;
+        let mut buf = vec![0.0f64; dim];
+
+        for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+            let tq = make_tq(dim, bits, distance);
+
+            for &val in &[1000.0f32, -1000.0, 1e6, -1e6] {
+                let raw = vec![val; dim];
+                let v = match distance {
+                    DistanceType::Cosine => normalize_vector(&raw),
+                    _ => raw,
+                };
+
+                let v_q = tq.quantize(&v, &mut buf);
+                let sym = tq.score_symmetric(&v_q, &v_q);
+                let asym = asymmetric_score_helper(&tq, &v, &v_q);
+
+                assert!(
+                    sym.is_finite(),
+                    "symmetric: distance={distance:?}, val={val}: got {sym}"
+                );
+                assert!(
+                    asym.is_finite(),
+                    "asymmetric: distance={distance:?}, val={val}: got {asym}"
+                );
+            }
+        }
+    }
+
+    /// Quantized scoring preserves candidate ordering: ranking by quantized
+    /// scores matches ranking by true scores on all but a small fraction of
+    /// pairwise comparisons.
+    #[test]
+    fn rank_preservation() {
+        let dim = 512;
+        let bits = TQBits::Bits4;
+        let mut buf = vec![0.0f64; dim];
+
+        for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
+            let mut rng = StdRng::seed_from_u64(42);
+            let tq = make_tq(dim, bits, distance);
+
+            let query_raw = random_vector(dim, &mut rng);
+            let similarities: Vec<f32> = (1..=10).map(|i| i as f32 / 10.0).collect();
+            let candidates_raw: Vec<Vec<f32>> = similarities
+                .iter()
+                .map(|&s| {
+                    let noise = random_vector(dim, &mut rng);
+                    query_raw
+                        .iter()
+                        .zip(&noise)
+                        .map(|(&q, &n)| s * q + (1.0 - s) * n)
+                        .collect()
+                })
+                .collect();
+
+            let query = match distance {
+                DistanceType::Cosine => normalize_vector(&query_raw),
+                _ => query_raw,
+            };
+            let candidates: Vec<Vec<f32>> = candidates_raw
+                .iter()
+                .map(|c| match distance {
+                    DistanceType::Cosine => normalize_vector(c),
+                    _ => c.clone(),
+                })
+                .collect();
+
+            let true_scores: Vec<f32> = candidates
+                .iter()
+                .map(|c| dot_f32_impl(query.iter().copied(), c.iter().copied()))
+                .collect();
+            let quant_scores: Vec<f32> = candidates
+                .iter()
+                .map(|c| {
+                    let cq = tq.quantize(c, &mut buf);
+                    asymmetric_score_helper(&tq, &query, &cq)
+                })
+                .collect();
+
+            let n = candidates.len();
+            let mut inversions = 0;
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    let true_sign = (true_scores[i] - true_scores[j]).signum();
+                    let quant_sign = (quant_scores[i] - quant_scores[j]).signum();
+                    if true_sign != 0.0 && true_sign != quant_sign {
+                        inversions += 1;
+                    }
+                }
+            }
+            let total_pairs = n * (n - 1) / 2;
+
+            assert!(
+                inversions * 100 < 15 * total_pairs,
+                "distance={distance:?}: {inversions}/{total_pairs} pairs inverted"
+            );
+        }
+    }
+
+    /// Dot scoring scales linearly with vector magnitude:
+    /// score(q, k·v) ≈ k·⟨q,v⟩  and  score(k·q, k·v) ≈ k²·⟨q,v⟩.
+    /// Guards that the stored l2_length extras correctly restore scale.
+    /// (Cosine's contract requires unit-norm inputs, so scaling is out-of-scope.)
+    #[test]
+    fn score_linearity_dot() {
+        let dim = 512;
+        let bits = TQBits::Bits4;
+        let mut rng = StdRng::seed_from_u64(42);
+        let tq = make_tq(dim, bits, DistanceType::Dot);
+        let mut buf = vec![0.0f64; dim];
+
+        let (q, v) = generate_random_vector_pair_with_similarity(dim, 0.5, &mut rng);
+        let true_dot = dot_f32_impl(q.iter().copied(), v.iter().copied());
+
+        for &k in &[0.5f32, 2.0, 5.0] {
+            let q_scaled: Vec<f32> = q.iter().map(|&x| x * k).collect();
+            let v_scaled: Vec<f32> = v.iter().map(|&x| x * k).collect();
+
+            let q_scaled_q = tq.quantize(&q_scaled, &mut buf);
+            let v_scaled_q = tq.quantize(&v_scaled, &mut buf);
+
+            let expected_asym = k * true_dot;
+            let expected_sym = k * k * true_dot;
+
+            let asym = asymmetric_score_helper(&tq, &q, &v_scaled_q);
+            let sym = tq.score_symmetric(&q_scaled_q, &v_scaled_q);
+
+            let tol_asym = 0.05 * (l2_norm(&q) * l2_norm(&v_scaled)) as f32;
+            let tol_sym = 0.05 * (l2_norm(&q_scaled) * l2_norm(&v_scaled)) as f32;
+
+            assert!(
+                (asym - expected_asym).abs() < tol_asym,
+                "asymmetric: k={k}, got {asym}, expected {expected_asym} (tol {tol_asym})"
+            );
+            assert!(
+                (sym - expected_sym).abs() < tol_sym,
+                "symmetric: k={k}, got {sym}, expected {expected_sym} (tol {tol_sym})"
+            );
+        }
+    }
+
     /// Edge cases for the pack/unpack roundtrip: uniform all-min and all-max
     /// index patterns exercise the bit-packing boundaries.
     #[test]
@@ -628,354 +748,5 @@ mod tests {
                 }
             }
         }
-    }
-
-    /// `dot(0, vec) = 0` for any quantized vector — a rotated zero query is
-    /// still zero, so every component of the sum is zero.
-    #[test]
-    fn cosine_zero_query_returns_zero() {
-        let dim = 128;
-        let mut buf = vec![0.0f64; dim];
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits, DistanceType::Cosine);
-            let v: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin()).collect();
-            let packed = tq.quantize(&v, &mut buf);
-            let zero = vec![0.0f32; dim];
-            let result = asymmetric_score_helper(&tq, &zero, &packed);
-            assert_eq!(result, 0.0, "bits={bits:?}: dot(0, v) = {result}");
-        }
-    }
-
-    /// `dot` is linear in the query:
-    /// `dot(k*q1 + c*q2, v) = k*dot(q1, v) + c*dot(q2, v)`.
-    /// Rotation and per-component summation are both linear, so this holds
-    /// up to floating-point precision.
-    #[test]
-    fn cosine_linear_in_query() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let mut rng = StdRng::seed_from_u64(11);
-        let dim = 256;
-        let mut buf = vec![0.0f64; dim];
-
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits, DistanceType::Cosine);
-            let q1: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let q2: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v = unit_norm(&v_raw);
-            let packed = tq.quantize(&v, &mut buf);
-
-            let (k, c) = (0.7f32, -1.3f32);
-            let q_combo: Vec<f32> = q1.iter().zip(&q2).map(|(a, b)| k * a + c * b).collect();
-
-            let d_combo = asymmetric_score_helper(&tq, &q_combo, &packed);
-            let d_linear = k * asymmetric_score_helper(&tq, &q1, &packed)
-                + c * asymmetric_score_helper(&tq, &q2, &packed);
-
-            let tol = 1e-5 * d_combo.abs().max(d_linear.abs()).max(1.0);
-            assert!(
-                (d_combo - d_linear).abs() <= tol,
-                "bits={bits:?}: dot(k*q1+c*q2, v)={d_combo} vs \
-                 k*dot(q1,v)+c*dot(q2,v)={d_linear}"
-            );
-        }
-    }
-
-    /// `dot` must agree with the equivalent manual reconstruction: unpack the
-    /// vector into centroids in rotated space, apply the inverse rotation to
-    /// recover original-space values, then dot with the original query.
-    ///
-    /// The Hadamard rotation is orthogonal, so `<Rq, u> = <q, R⁻¹u>` — both
-    /// paths should agree up to floating-point precision regardless of bits/dim.
-    #[test]
-    fn cosine_matches_inverse_rotation_reconstruction() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let mut rng = StdRng::seed_from_u64(33);
-
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            for &dim in &[128, 300, 512] {
-                let tq = make_tq(dim, bits, DistanceType::Cosine);
-                let rot = HadamardRotation::new(dim);
-
-                let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-                let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-                let v = unit_norm(&v_raw);
-                let mut buf = vec![0.0f64; dim];
-                let packed = tq.quantize(&v, &mut buf);
-
-                // Manual path: unpack -> inverse rotate -> dot in original
-                // space. The unpacked centroids live on the scaled grid
-                // (√dim × rotated(v̂)), so we divide by √dim to match what
-                // `score_precomputed` compensates for internally.
-                let mut unpacked: Vec<f64> = tq.unpack_vector(&packed).1.collect();
-                rot.apply_inverse(&mut unpacked);
-                let manual: f32 = (q
-                    .iter()
-                    .zip(unpacked.iter())
-                    .map(|(&qi, &ui)| f64::from(qi) * ui)
-                    .sum::<f64>()
-                    / (dim as f64).sqrt()) as f32;
-
-                let fn_result = asymmetric_score_helper(&tq, &q, &packed);
-
-                let tol = 1e-5 * manual.abs().max(fn_result.abs()).max(1.0);
-                assert!(
-                    (manual - fn_result).abs() <= tol,
-                    "dim={dim}, bits={bits:?}: dot={fn_result}, manual={manual}"
-                );
-            }
-        }
-    }
-
-    /// For 4-bit quantization on reasonably large dimensions, the quantized
-    /// cosine score must closely approximate the true `<q, v̂>` — matching
-    /// the inner product with the unit-norm stored vector. A broken
-    /// quantizer/scoring path yields values uncorrelated with truth.
-    #[test]
-    fn cosine_approximates_true_cosine_product() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let dim = 512;
-        let n_trials = 100;
-        let mut rng = StdRng::seed_from_u64(44);
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let mut buf = vec![0.0f64; dim];
-
-        let mut total_abs_err = 0.0f64;
-        let mut total_abs_true = 0.0f64;
-
-        for _ in 0..n_trials {
-            let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v = unit_norm(&v_raw);
-
-            let truth = true_dot(&q, &v);
-
-            let packed = tq.quantize(&v, &mut buf);
-            let approx = f64::from(asymmetric_score_helper(&tq, &q, &packed));
-
-            total_abs_err += (truth - approx).abs();
-            total_abs_true += truth.abs();
-        }
-
-        let rel_mae = total_abs_err / total_abs_true;
-        assert!(
-            rel_mae < 0.15,
-            "Relative MAE {rel_mae} exceeds tolerance for Bits4, dim={dim}"
-        );
-    }
-
-    /// `score_symmetric` must (a) be commutative and (b) approximate
-    /// `<â, b̂> = cos(θ)` for unit-norm inputs.
-    #[test]
-    fn cosine_symmetric_approximates_true_cosine() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let dim = 512;
-        let n_trials = 100;
-        let mut rng = StdRng::seed_from_u64(66);
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let mut buf = vec![0.0f64; dim];
-
-        let mut total_abs_err = 0.0f64;
-        let mut total_abs_true = 0.0f64;
-
-        for _ in 0..n_trials {
-            let a_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let b_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let a = unit_norm(&a_raw);
-            let b = unit_norm(&b_raw);
-
-            let truth = true_dot(&a, &b);
-
-            let packed_a = tq.quantize(&a, &mut buf);
-            let packed_b = tq.quantize(&b, &mut buf);
-
-            let ab = tq.score_symmetric(&packed_a, &packed_b);
-            let ba = tq.score_symmetric(&packed_b, &packed_a);
-            assert_eq!(ab, ba, "dot_symmetric is not commutative: {ab} vs {ba}");
-
-            total_abs_err += (f64::from(ab) - truth).abs();
-            total_abs_true += truth.abs();
-        }
-
-        let rel_mae = total_abs_err / total_abs_true;
-        // Both sides quantized → roughly double the error vs the asymmetric case,
-        // but still well below 40% relative MAE for Bits4 at dim=512.
-        assert!(
-            rel_mae < 0.4,
-            "Relative MAE {rel_mae} exceeds tolerance for Bits4, dim={dim}"
-        );
-    }
-
-    /// `score_symmetric(Q(v̂), Q(v̂)) ≈ 1` for unit-norm `v̂` — a sharper
-    /// check than the random-pair test, since self-cosine is always 1 and
-    /// sensitive to sign errors in the unpack path.
-    #[test]
-    fn cosine_symmetric_self_cosine_approximates_one() {
-        use rand::prelude::StdRng;
-        use rand::{RngExt, SeedableRng};
-
-        let dim = 512;
-        let mut rng = StdRng::seed_from_u64(77);
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let mut buf = vec![0.0f64; dim];
-
-        for _ in 0..20 {
-            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v = unit_norm(&v_raw);
-
-            let packed = tq.quantize(&v, &mut buf);
-            let approx = f64::from(tq.score_symmetric(&packed, &packed));
-
-            let rel_err = (1.0 - approx).abs();
-            assert!(
-                rel_err < 0.15,
-                "expected ≈1 for unit self-dot, got {approx} (err {rel_err})"
-            );
-        }
-    }
-
-    // --- End-to-end tests for score_symmetric -----------------------------
-    //
-    // Each test: build a TurboQuantizer, generate random pairs at various
-    // similarity levels, compute both the original dot and the quantized
-    // score_symmetric, compare.
-    // ---------------------------------------------------------------------
-
-    /// Run pairs at 5 mixing levels from fully independent (`t = 0.0`) to
-    /// identical (`t = 1.0`). Per-trial absolute error must be small relative
-    /// to `||a|| * ||b||` — that scale-invariant bound holds uniformly even
-    /// when the raw dot product itself is near zero.
-    #[test]
-    fn end_to_end_cosine_symmetric_varied_similarity() {
-        use rand::SeedableRng;
-        use rand::prelude::StdRng;
-
-        let dim = 512;
-        let n_trials = 30;
-        let mut rng = StdRng::seed_from_u64(2024);
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let mut buf = vec![0.0f64; dim];
-
-        for &t in &[0.0f32, 0.25, 0.5, 0.75, 1.0] {
-            let mut max_err = 0.0f64;
-
-            for _ in 0..n_trials {
-                let (a_raw, b_raw) = generate_mixed_pair(dim, t, &mut rng);
-                let a = unit_norm(&a_raw);
-                let b = unit_norm(&b_raw);
-                let truth = true_dot(&a, &b); // unit × unit → cos(θ), in [-1, 1]
-
-                let packed_a = tq.quantize(&a, &mut buf);
-                let packed_b = tq.quantize(&b, &mut buf);
-                let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
-
-                max_err = max_err.max((truth - approx).abs());
-            }
-
-            assert!(max_err < 0.1, "t={t}: max |cos(θ) - approx| = {max_err}");
-        }
-    }
-
-    /// Over a shared set of varied-similarity pairs, accuracy must improve
-    /// monotonically with bit width: MAE(4b) < MAE(2b) < MAE(1b).
-    #[test]
-    fn end_to_end_cosine_symmetric_more_bits_is_better() {
-        use rand::SeedableRng;
-        use rand::prelude::StdRng;
-
-        let dim = 512;
-        let n_pairs = 80;
-        let mut rng = StdRng::seed_from_u64(2025);
-        let mut buf = vec![0.0f64; dim];
-
-        // Fixed unit-sphere pair set (varying similarity) shared across all
-        // bit widths.
-        let pairs: Vec<(Vec<f32>, Vec<f32>)> = (0..n_pairs)
-            .map(|i| {
-                let t = i as f32 / (n_pairs as f32 - 1.0);
-                let (a, b) = generate_mixed_pair(dim, t, &mut rng);
-                (unit_norm(&a), unit_norm(&b))
-            })
-            .collect();
-
-        let mut mae_by_bits = Vec::new();
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits, DistanceType::Cosine);
-            let mut total_abs_err = 0.0f64;
-            for (a, b) in &pairs {
-                let packed_a = tq.quantize(a, &mut buf);
-                let packed_b = tq.quantize(b, &mut buf);
-                let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
-                total_abs_err += (true_dot(a, b) - approx).abs();
-            }
-            mae_by_bits.push((bits, total_abs_err / f64::from(n_pairs)));
-        }
-
-        assert!(
-            mae_by_bits[1].1 < mae_by_bits[0].1,
-            "2-bit MAE {} not better than 1-bit MAE {}",
-            mae_by_bits[1].1,
-            mae_by_bits[0].1
-        );
-        assert!(
-            mae_by_bits[2].1 < mae_by_bits[1].1,
-            "4-bit MAE {} not better than 2-bit MAE {}",
-            mae_by_bits[2].1,
-            mae_by_bits[1].1
-        );
-    }
-
-    /// Rank ordering of dot products over a diverse set of pairs must be
-    /// almost fully preserved after symmetric quantization — concordance
-    /// over all pairwise comparisons should exceed 95% at 4 bits.
-    #[test]
-    fn end_to_end_cosine_symmetric_preserves_ordering() {
-        use rand::SeedableRng;
-        use rand::prelude::StdRng;
-
-        let dim = 512;
-        let n_pairs = 60;
-        let mut rng = StdRng::seed_from_u64(2026);
-        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
-        let mut buf = vec![0.0f64; dim];
-
-        let mut pairs_scored: Vec<(f64, f64)> = Vec::with_capacity(n_pairs);
-        for i in 0..n_pairs {
-            let t = i as f32 / (n_pairs as f32 - 1.0);
-            let (a_raw, b_raw) = generate_mixed_pair(dim, t, &mut rng);
-            let a = unit_norm(&a_raw);
-            let b = unit_norm(&b_raw);
-            let packed_a = tq.quantize(&a, &mut buf);
-            let packed_b = tq.quantize(&b, &mut buf);
-            let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
-            pairs_scored.push((true_dot(&a, &b), approx));
-        }
-
-        let mut concordant = 0usize;
-        let mut total = 0usize;
-        for i in 0..n_pairs {
-            for j in (i + 1)..n_pairs {
-                let true_cmp = pairs_scored[i].0 - pairs_scored[j].0;
-                let approx_cmp = pairs_scored[i].1 - pairs_scored[j].1;
-                if true_cmp.signum() == approx_cmp.signum() {
-                    concordant += 1;
-                }
-                total += 1;
-            }
-        }
-
-        let concordance = concordant as f64 / total as f64;
-        assert!(
-            concordance > 0.95,
-            "ordering concordance {concordance} below 0.95 ({concordant}/{total})"
-        );
     }
 }

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -10,6 +10,20 @@ pub struct TurboQuantizer {
     pub(super) distance: DistanceType,
 }
 
+/// A query with the Hadamard rotation already applied. Built via
+/// [`TurboQuantizer::precompute_query`] and consumed by
+/// [`TurboQuantizer::dot_precomputed`] to amortize the rotation cost across
+/// many scoring calls.
+pub struct Precomputed(Vec<f64>);
+
+impl Precomputed {
+    /// Borrow the rotated query components.
+    #[inline]
+    pub fn as_slice(&self) -> &[f64] {
+        &self.0
+    }
+}
+
 impl TurboQuantizer {
     /// Initialize a new TurboQuantizer.
     pub fn new(dim: usize, bits: TQBits, mode: TQMode, distance: DistanceType) -> Self {
@@ -59,6 +73,57 @@ impl TurboQuantizer {
         // Encode centroid indices and return packed vector.
         self.pack_vector(encoded, extras)
     }
+
+    /// Dot product between two vectors that were both encoded with this
+    /// quantizer.
+    ///
+    /// Unpacks each vector into rotated space and dots the results. The
+    /// Hadamard rotation is orthogonal, so `<Rv1, Rv2> = <v1, v2>` — no
+    /// inverse rotation is needed, and neither side plays the query role.
+    pub fn dot_symmetric(&self, v1: &[u8], v2: &[u8]) -> f32 {
+        // TODO(turbo): apply metadata from extra values.
+        let (_extra_v1, iter1) = self.unpack_vector(v1);
+        let (_extra_v2, iter2) = self.unpack_vector(v2);
+        iter1.zip(iter2).map(|(a, b)| a * b).sum::<f64>() as f32
+    }
+
+    /// Dot product between a raw `query` and a quantizer-encoded `vec`.
+    ///
+    /// The query is rotated into the same Hadamard-rotated space as the stored
+    /// vector before the dot is computed. Prefer [`Self::dot_precomputed`]
+    /// when scoring many vectors against the same query.
+    pub fn dot_asymmetric(&self, query: &[f32], vec: &[u8]) -> f32 {
+        let mut rotated_query: Vec<_> = query.iter().map(|&i| f64::from(i)).collect();
+        self.rotation.apply(&mut rotated_query);
+
+        // TODO(turbo): apply metadata from extra value.
+        let (_extra_vec, unpacked) = self.unpack_vector(vec);
+        rotated_query
+            .iter()
+            .zip(unpacked)
+            .map(|(&q, u)| q * u)
+            .sum::<f64>() as f32
+    }
+
+    /// Precompute the Hadamard rotation of `query` so subsequent
+    /// [`Self::dot_precomputed`] calls skip the per-call rotation.
+    pub fn precompute_query(&self, query: &[f32]) -> Precomputed {
+        let mut rotated: Vec<f64> = query.iter().map(|&x| f64::from(x)).collect();
+        self.rotation.apply(&mut rotated);
+        Precomputed(rotated)
+    }
+
+    /// Dot product with a query that has already been rotated via
+    /// [`Self::precompute_query`].
+    pub fn dot_precomputed(&self, query: &Precomputed, vec: &[u8]) -> f32 {
+        let (_, unpacked) = self.unpack_vector(vec);
+        query
+            .as_slice()
+            .iter()
+            .zip(unpacked)
+            .map(|(&q, u)| q * u)
+            .sum::<f64>() as f32
+    }
 }
 
 #[cfg(test)]
@@ -82,6 +147,38 @@ mod tests {
             mode: TQMode::Normal,
         };
         TurboQuantizer::new_from_metadata(&metadata)
+    }
+
+    /// Build a pair `(a, b)` where `b = t * a + (1 - t) * noise`, so `t = 1`
+    /// means identical and `t = 0` means independent random.
+    fn generate_mixed_pair(
+        dim: usize,
+        t: f32,
+        rng: &mut rand::prelude::StdRng,
+    ) -> (Vec<f32>, Vec<f32>) {
+        use rand::RngExt;
+        let a: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+        let noise: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+        let b: Vec<f32> = a
+            .iter()
+            .zip(noise.iter())
+            .map(|(&x, &n)| t * x + (1.0 - t) * n)
+            .collect();
+        (a, b)
+    }
+
+    fn true_dot(a: &[f32], b: &[f32]) -> f64 {
+        a.iter()
+            .zip(b)
+            .map(|(&x, &y)| f64::from(x) * f64::from(y))
+            .sum()
+    }
+
+    fn l2_norm(v: &[f32]) -> f64 {
+        v.iter()
+            .map(|&x| f64::from(x) * f64::from(x))
+            .sum::<f64>()
+            .sqrt()
     }
 
     /// Helper: unpack all centroid indices from a quantized byte vector.
@@ -460,8 +557,7 @@ mod tests {
 
                 let packed = tq.pack_vector(indices.iter().copied(), TqVectorExtras::default());
 
-                let mut out = vec![0.0f64; dim];
-                tq.unpack_vector(&packed, &mut out);
+                let out: Vec<f64> = tq.unpack_vector(&packed).1.collect();
 
                 for (i, (&idx, &value)) in indices.iter().zip(out.iter()).enumerate() {
                     let expected = f64::from(centroids[idx as usize]);
@@ -490,8 +586,7 @@ mod tests {
                     let indices = vec![idx; dim];
                     let packed = tq.pack_vector(indices.iter().copied(), TqVectorExtras::default());
 
-                    let mut out = vec![0.0f64; dim];
-                    tq.unpack_vector(&packed, &mut out);
+                    let out: Vec<f64> = tq.unpack_vector(&packed).1.collect();
 
                     let expected = f64::from(centroids[idx as usize]);
                     for (i, &v) in out.iter().enumerate() {
@@ -500,5 +595,353 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// `dot(0, vec) = 0` for any quantized vector — a rotated zero query is
+    /// still zero, so every component of the sum is zero.
+    #[test]
+    fn dot_zero_query_returns_zero() {
+        let dim = 128;
+        let mut buf = vec![0.0f64; dim];
+        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            let tq = make_tq(dim, bits);
+            let v: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin()).collect();
+            let packed = tq.quantize(&v, &mut buf);
+            let zero = vec![0.0f32; dim];
+            let result = tq.dot_asymmetric(&zero, &packed);
+            assert_eq!(result, 0.0, "bits={bits:?}: dot(0, v) = {result}");
+        }
+    }
+
+    /// `dot` is linear in the query:
+    /// `dot(k*q1 + c*q2, v) = k*dot(q1, v) + c*dot(q2, v)`.
+    /// Rotation and per-component summation are both linear, so this holds
+    /// up to floating-point precision.
+    #[test]
+    fn dot_linear_in_query() {
+        use rand::prelude::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(11);
+        let dim = 256;
+        let mut buf = vec![0.0f64; dim];
+
+        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            let tq = make_tq(dim, bits);
+            let q1: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let q2: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let packed = tq.quantize(&v, &mut buf);
+
+            let (k, c) = (0.7f32, -1.3f32);
+            let q_combo: Vec<f32> = q1.iter().zip(&q2).map(|(a, b)| k * a + c * b).collect();
+
+            let d_combo = tq.dot_asymmetric(&q_combo, &packed);
+            let d_linear =
+                k * tq.dot_asymmetric(&q1, &packed) + c * tq.dot_asymmetric(&q2, &packed);
+
+            let tol = 1e-5 * d_combo.abs().max(d_linear.abs()).max(1.0);
+            assert!(
+                (d_combo - d_linear).abs() <= tol,
+                "bits={bits:?}: dot(k*q1+c*q2, v)={d_combo} vs \
+                 k*dot(q1,v)+c*dot(q2,v)={d_linear}"
+            );
+        }
+    }
+
+    /// `dot` must agree with the equivalent manual reconstruction: unpack the
+    /// vector into centroids in rotated space, apply the inverse rotation to
+    /// recover original-space values, then dot with the original query.
+    ///
+    /// The Hadamard rotation is orthogonal, so `<Rq, u> = <q, R⁻¹u>` — both
+    /// paths should agree up to floating-point precision regardless of bits/dim.
+    #[test]
+    fn dot_matches_inverse_rotation_reconstruction() {
+        use rand::prelude::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(33);
+
+        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            for &dim in &[128, 300, 512] {
+                let tq = make_tq(dim, bits);
+                let rot = HadamardRotation::new(dim);
+
+                let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let mut buf = vec![0.0f64; dim];
+                let packed = tq.quantize(&v, &mut buf);
+
+                // Manual path: unpack -> inverse rotate -> dot in original space.
+                let mut unpacked: Vec<f64> = tq.unpack_vector(&packed).1.collect();
+                rot.apply_inverse(&mut unpacked);
+                let manual: f32 = q
+                    .iter()
+                    .zip(unpacked.iter())
+                    .map(|(&qi, &ui)| f64::from(qi) * ui)
+                    .sum::<f64>() as f32;
+
+                let fn_result = tq.dot_asymmetric(&q, &packed);
+
+                let tol = 1e-5 * manual.abs().max(fn_result.abs()).max(1.0);
+                assert!(
+                    (manual - fn_result).abs() <= tol,
+                    "dim={dim}, bits={bits:?}: dot={fn_result}, manual={manual}"
+                );
+            }
+        }
+    }
+
+    /// For 4-bit quantization on reasonably large dimensions, the quantized
+    /// dot product must closely approximate the true (pre-quantization) dot
+    /// product. A badly-approximating `dot` (e.g. missing the query rotation)
+    /// yields values uncorrelated with the truth and blows this bound out.
+    #[test]
+    fn dot_approximates_true_dot_product() {
+        use rand::prelude::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let dim = 512;
+        let n_trials = 100;
+        let mut rng = StdRng::seed_from_u64(44);
+        let tq = make_tq(dim, TQBits::Bits4);
+        let mut buf = vec![0.0f64; dim];
+
+        let mut total_abs_err = 0.0f64;
+        let mut total_abs_true = 0.0f64;
+
+        for _ in 0..n_trials {
+            let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+
+            let true_dot: f64 = q
+                .iter()
+                .zip(&v)
+                .map(|(&a, &b)| f64::from(a) * f64::from(b))
+                .sum();
+
+            let packed = tq.quantize(&v, &mut buf);
+            let approx = f64::from(tq.dot_asymmetric(&q, &packed));
+
+            total_abs_err += (true_dot - approx).abs();
+            total_abs_true += true_dot.abs();
+        }
+
+        let rel_mae = total_abs_err / total_abs_true;
+        assert!(
+            rel_mae < 0.15,
+            "Relative MAE {rel_mae} exceeds tolerance for Bits4, dim={dim}"
+        );
+    }
+
+    /// `dot_symmetric` must (a) be commutative and (b) approximate the true
+    /// dot product — even with quantization noise on *both* sides, the
+    /// orthogonality of the Hadamard rotation keeps the result close to
+    /// `<v1, v2>`.
+    #[test]
+    fn dot_symmetric_approximates_true_dot() {
+        use rand::prelude::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let dim = 512;
+        let n_trials = 100;
+        let mut rng = StdRng::seed_from_u64(66);
+        let tq = make_tq(dim, TQBits::Bits4);
+        let mut buf = vec![0.0f64; dim];
+
+        let mut total_abs_err = 0.0f64;
+        let mut total_abs_true = 0.0f64;
+
+        for _ in 0..n_trials {
+            let a: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let b: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+
+            let true_dot: f64 = a
+                .iter()
+                .zip(&b)
+                .map(|(&x, &y)| f64::from(x) * f64::from(y))
+                .sum();
+
+            let packed_a = tq.quantize(&a, &mut buf);
+            let packed_b = tq.quantize(&b, &mut buf);
+
+            let ab = tq.dot_symmetric(&packed_a, &packed_b);
+            let ba = tq.dot_symmetric(&packed_b, &packed_a);
+            assert_eq!(ab, ba, "dot_symmetric is not commutative: {ab} vs {ba}");
+
+            total_abs_err += (f64::from(ab) - true_dot).abs();
+            total_abs_true += true_dot.abs();
+        }
+
+        let rel_mae = total_abs_err / total_abs_true;
+        // Both sides quantized → roughly double the error vs the asymmetric case,
+        // but still well below 40% relative MAE for Bits4 at dim=512.
+        assert!(
+            rel_mae < 0.4,
+            "Relative MAE {rel_mae} exceeds tolerance for Bits4, dim={dim}"
+        );
+    }
+
+    /// `dot_symmetric(packed, packed)` approximates `||v||²` — a sharper
+    /// check than the random-pair test, since self-dot is always positive
+    /// and sensitive to sign errors in the unpack path.
+    #[test]
+    fn dot_symmetric_self_dot_approximates_norm_squared() {
+        use rand::prelude::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let dim = 512;
+        let mut rng = StdRng::seed_from_u64(77);
+        let tq = make_tq(dim, TQBits::Bits4);
+        let mut buf = vec![0.0f64; dim];
+
+        for _ in 0..20 {
+            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let norm_sq: f64 = v.iter().map(|&x| f64::from(x) * f64::from(x)).sum();
+
+            let packed = tq.quantize(&v, &mut buf);
+            let approx = f64::from(tq.dot_symmetric(&packed, &packed));
+
+            let rel_err = (norm_sq - approx).abs() / norm_sq;
+            assert!(
+                rel_err < 0.15,
+                "||v||²={norm_sq}, approx={approx}, rel_err={rel_err}"
+            );
+        }
+    }
+
+    // --- End-to-end tests for dot_symmetric -------------------------------
+    //
+    // Each test: build a TurboQuantizer, generate random pairs at various
+    // similarity levels, compute both the original dot and the quantized
+    // dot_symmetric, compare.
+    // ---------------------------------------------------------------------
+
+    /// Run pairs at 5 mixing levels from fully independent (`t = 0.0`) to
+    /// identical (`t = 1.0`). Per-trial absolute error must be small relative
+    /// to `||a|| * ||b||` — that scale-invariant bound holds uniformly even
+    /// when the raw dot product itself is near zero.
+    #[test]
+    fn end_to_end_dot_symmetric_varied_similarity() {
+        use rand::SeedableRng;
+        use rand::prelude::StdRng;
+
+        let dim = 512;
+        let n_trials = 30;
+        let mut rng = StdRng::seed_from_u64(2024);
+        let tq = make_tq(dim, TQBits::Bits4);
+        let mut buf = vec![0.0f64; dim];
+
+        for &t in &[0.0f32, 0.25, 0.5, 0.75, 1.0] {
+            let mut max_norm_err = 0.0f64;
+
+            for _ in 0..n_trials {
+                let (a, b) = generate_mixed_pair(dim, t, &mut rng);
+                let true_d = true_dot(&a, &b);
+                let scale = l2_norm(&a) * l2_norm(&b);
+
+                let packed_a = tq.quantize(&a, &mut buf);
+                let packed_b = tq.quantize(&b, &mut buf);
+                let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+
+                max_norm_err = max_norm_err.max((true_d - approx).abs() / scale);
+            }
+
+            assert!(
+                max_norm_err < 0.1,
+                "t={t}: max |true-approx|/(||a||*||b||) = {max_norm_err}"
+            );
+        }
+    }
+
+    /// Over a shared set of varied-similarity pairs, accuracy must improve
+    /// monotonically with bit width: MAE(4b) < MAE(2b) < MAE(1b).
+    #[test]
+    fn end_to_end_dot_symmetric_more_bits_is_better() {
+        use rand::SeedableRng;
+        use rand::prelude::StdRng;
+
+        let dim = 512;
+        let n_pairs = 80;
+        let mut rng = StdRng::seed_from_u64(2025);
+        let mut buf = vec![0.0f64; dim];
+
+        // Fixed pair set (varying similarity) shared across all bit widths.
+        let pairs: Vec<(Vec<f32>, Vec<f32>)> = (0..n_pairs)
+            .map(|i| {
+                let t = i as f32 / (n_pairs as f32 - 1.0);
+                generate_mixed_pair(dim, t, &mut rng)
+            })
+            .collect();
+
+        let mut mae_by_bits = Vec::new();
+        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            let tq = make_tq(dim, bits);
+            let mut total_abs_err = 0.0f64;
+            for (a, b) in &pairs {
+                let packed_a = tq.quantize(a, &mut buf);
+                let packed_b = tq.quantize(b, &mut buf);
+                let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+                total_abs_err += (true_dot(a, b) - approx).abs();
+            }
+            mae_by_bits.push((bits, total_abs_err / f64::from(n_pairs)));
+        }
+
+        assert!(
+            mae_by_bits[1].1 < mae_by_bits[0].1,
+            "2-bit MAE {} not better than 1-bit MAE {}",
+            mae_by_bits[1].1,
+            mae_by_bits[0].1
+        );
+        assert!(
+            mae_by_bits[2].1 < mae_by_bits[1].1,
+            "4-bit MAE {} not better than 2-bit MAE {}",
+            mae_by_bits[2].1,
+            mae_by_bits[1].1
+        );
+    }
+
+    /// Rank ordering of dot products over a diverse set of pairs must be
+    /// almost fully preserved after symmetric quantization — concordance
+    /// over all pairwise comparisons should exceed 95% at 4 bits.
+    #[test]
+    fn end_to_end_dot_symmetric_preserves_ordering() {
+        use rand::SeedableRng;
+        use rand::prelude::StdRng;
+
+        let dim = 512;
+        let n_pairs = 60;
+        let mut rng = StdRng::seed_from_u64(2026);
+        let tq = make_tq(dim, TQBits::Bits4);
+        let mut buf = vec![0.0f64; dim];
+
+        let mut pairs_scored: Vec<(f64, f64)> = Vec::with_capacity(n_pairs);
+        for i in 0..n_pairs {
+            let t = i as f32 / (n_pairs as f32 - 1.0);
+            let (a, b) = generate_mixed_pair(dim, t, &mut rng);
+            let packed_a = tq.quantize(&a, &mut buf);
+            let packed_b = tq.quantize(&b, &mut buf);
+            let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+            pairs_scored.push((true_dot(&a, &b), approx));
+        }
+
+        let mut concordant = 0usize;
+        let mut total = 0usize;
+        for i in 0..n_pairs {
+            for j in (i + 1)..n_pairs {
+                let true_cmp = pairs_scored[i].0 - pairs_scored[j].0;
+                let approx_cmp = pairs_scored[i].1 - pairs_scored[j].1;
+                if true_cmp.signum() == approx_cmp.signum() {
+                    concordant += 1;
+                }
+                total += 1;
+            }
+        }
+
+        let concordance = concordant as f64 / total as f64;
+        assert!(
+            concordance > 0.95,
+            "ordering concordance {concordance} below 0.95 ({concordant}/{total})"
+        );
     }
 }

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -8,11 +8,14 @@ pub struct TurboQuantizer {
     pub(super) bits: TQBits,
     pub(super) mode: TQMode,
     pub(super) distance: DistanceType,
+
+    // Pre-calculated `sqrt(dim)` used in scoring.
+    dim_sqrt: f32,
 }
 
 /// A query with the Hadamard rotation already applied. Built via
 /// [`TurboQuantizer::precompute_query`] and consumed by
-/// [`TurboQuantizer::dot_precomputed`] to amortize the rotation cost across
+/// [`TurboQuantizer::score_precomputed`] to amortize the rotation cost across
 /// many scoring calls.
 pub struct Precomputed(Vec<f64>);
 
@@ -28,11 +31,13 @@ impl TurboQuantizer {
     /// Initialize a new TurboQuantizer.
     pub fn new(dim: usize, bits: TQBits, mode: TQMode, distance: DistanceType) -> Self {
         let rotation = HadamardRotation::new(dim);
+        let dim_sqrt = (dim as f32).sqrt();
         TurboQuantizer {
             rotation,
             bits,
             mode,
             distance,
+            dim_sqrt,
         }
     }
 
@@ -48,82 +53,89 @@ impl TurboQuantizer {
 
     /// Quantize a given vector with TurboQuant.
     pub fn quantize(&self, vec: &[f32], buf: &mut [f64]) -> Vec<u8> {
-        if !matches!(self.distance, DistanceType::Dot) {
-            // TODO(turbo): implement for other metrics too.
-            unimplemented!("Quantization currently only implemented for dot product");
-        }
+        Self::assert_supported_distance(self.distance);
 
         debug_assert_eq!(vec.len(), buf.len());
 
-        // Rotate the vector
+        // Convert to f64
         for (i, &component) in vec.iter().enumerate() {
             buf[i] = f64::from(component);
         }
+
+        // Rotate the vector.
         self.rotation.apply(buf);
 
         // Calculate data that needs to be stored additionally.
         let extras = self.calculate_extras(buf);
 
-        // Find rotated vectors centroids.
-        let boundaries = self.bits.get_centroid_boundaries();
-        let encoded = buf
-            .iter()
-            .map(|&val| boundaries.partition_point(|&b| val > f64::from(b)) as u8);
+        // Rescale so per-coordinate variance is ~1 — matching the Lloyd-Max
+        // N(0, 1) centroid grid.
+        let length = f64::from(extras.l2_length.unwrap_or(1.0));
+        let scale = (self.rotation.dim() as f64).sqrt() / length;
 
-        // Encode centroid indices and return packed vector.
+        // Picking the corresponding centroid indices.
+        let boundaries = self.bits.get_centroid_boundaries();
+        let encoded = buf.iter().map(|&val| {
+            let scaled = (val * scale) as f32;
+            boundaries.partition_point(|&b| scaled > b) as u8
+        });
+
+        // Encode and return packed vector.
         self.pack_vector(encoded, extras)
     }
 
-    /// Dot product between two vectors that were both encoded with this
-    /// quantizer.
+    /// Similarity score between two vectors that were both encoded with this
+    /// quantizer. Returns an approximate `<v1, v2>` for Dot and `cos(θ)` for
+    /// Cosine.
     ///
-    /// Unpacks each vector into rotated space and dots the results. The
-    /// Hadamard rotation is orthogonal, so `<Rv1, Rv2> = <v1, v2>` — no
-    /// inverse rotation is needed, and neither side plays the query role.
-    pub fn dot_symmetric(&self, v1: &[u8], v2: &[u8]) -> f32 {
-        // TODO(turbo): apply metadata from extra values.
-        let (_extra_v1, iter1) = self.unpack_vector(v1);
-        let (_extra_v2, iter2) = self.unpack_vector(v2);
-        iter1.zip(iter2).map(|(a, b)| a * b).sum::<f64>() as f32
-    }
+    /// For asymmetric scoring (original vector against quantized vector), refer to [`Self::score_precomputed`]
+    /// and precompute the query first.
+    pub fn score_symmetric(&self, v1: &[u8], v2: &[u8]) -> f32 {
+        let (extra_v1, iter1) = self.unpack_vector(v1);
+        let (extra_v2, iter2) = self.unpack_vector(v2);
+        let raw_dot = dot_impl(iter1, iter2);
 
-    /// Dot product between a raw `query` and a quantizer-encoded `vec`.
-    ///
-    /// The query is rotated into the same Hadamard-rotated space as the stored
-    /// vector before the dot is computed. Prefer [`Self::dot_precomputed`]
-    /// when scoring many vectors against the same query.
-    pub fn dot_asymmetric(&self, query: &[f32], vec: &[u8]) -> f32 {
-        let mut rotated_query: Vec<_> = query.iter().map(|&i| f64::from(i)).collect();
-        self.rotation.apply(&mut rotated_query);
+        let v1_l2 = extra_v1.and_then(|extras| extras.l2_length).unwrap_or(1.0);
+        let v2_l2 = extra_v2.and_then(|extras| extras.l2_length).unwrap_or(1.0);
 
-        // TODO(turbo): apply metadata from extra value.
-        let (_extra_vec, unpacked) = self.unpack_vector(vec);
-        rotated_query
-            .iter()
-            .zip(unpacked)
-            .map(|(&q, u)| q * u)
-            .sum::<f64>() as f32
+        // Both sides were scaled by sqrt(dim)/||v|| during quantize; restore
+        // magnitudes with l2, undo the sqrt(dim)² = dim inflation.
+        raw_dot * v1_l2 * v2_l2 / self.rotation.dim() as f32
     }
 
     /// Precompute the Hadamard rotation of `query` so subsequent
-    /// [`Self::dot_precomputed`] calls skip the per-call rotation.
+    /// [`Self::score_precomputed`] calls skip the per-call rotation.
     pub fn precompute_query(&self, query: &[f32]) -> Precomputed {
         let mut rotated: Vec<f64> = query.iter().map(|&x| f64::from(x)).collect();
         self.rotation.apply(&mut rotated);
         Precomputed(rotated)
     }
 
-    /// Dot product with a query that has already been rotated via
-    /// [`Self::precompute_query`].
-    pub fn dot_precomputed(&self, query: &Precomputed, vec: &[u8]) -> f32 {
-        let (_, unpacked) = self.unpack_vector(vec);
-        query
-            .as_slice()
-            .iter()
-            .zip(unpacked)
-            .map(|(&q, u)| q * u)
-            .sum::<f64>() as f32
+    /// Similarity score with a query that has already been rotated via
+    /// [`Self::precompute_query`]. Returns an approximate `<query, v>` for Dot
+    /// and `cos(θ)` for Cosine.
+    pub fn score_precomputed(&self, query: &Precomputed, vec: &[u8]) -> f32 {
+        let (vector_extras, unpacked) = self.unpack_vector(vec);
+        let dot = dot_impl(query.as_slice().iter().copied(), unpacked);
+
+        let l2 = vector_extras
+            .and_then(|extras| extras.l2_length)
+            .unwrap_or(1.0);
+
+        // Only the stored vector carries the sqrt(dim)/||v|| scaling, so we
+        // compensate by multiplying by ||v|| and dividing by sqrt(dim).
+        dot * l2 / self.dim_sqrt
     }
+}
+
+/// Raw dot implementation between two vectors, `left` and `right`.
+#[inline]
+fn dot_impl<I, J>(left: I, right: J) -> f32
+where
+    I: Iterator<Item = f64>,
+    J: Iterator<Item = f64>,
+{
+    left.zip(right).map(|(q, u)| q * u).sum::<f64>() as f32
 }
 
 #[cfg(test)]
@@ -133,13 +145,12 @@ mod tests {
     use super::*;
     use crate::VectorParameters;
     use crate::turboquant::encoding::TqVectorExtras;
-    use crate::turboquant::rotation::HadamardRotation;
 
-    fn make_tq(dim: usize, bits: TQBits) -> TurboQuantizer {
+    fn make_tq(dim: usize, bits: TQBits, distance: DistanceType) -> TurboQuantizer {
         let metadata = Metadata {
             vector_parameters: VectorParameters {
                 dim,
-                distance_type: DistanceType::Dot,
+                distance_type: distance,
                 invert: false,
                 deprecated_count: None,
             },
@@ -181,6 +192,18 @@ mod tests {
             .sqrt()
     }
 
+    fn asymmetric_score_helper(tq: &TurboQuantizer, query: &[f32], vec: &[u8]) -> f32 {
+        let precomputed = tq.precompute_query(query);
+        tq.score_precomputed(&precomputed, vec)
+    }
+
+    /// Normalize `v` onto the unit sphere — required input for the Cosine
+    /// quantizer path.
+    fn unit_norm(v: &[f32]) -> Vec<f32> {
+        let len = l2_norm(v) as f32;
+        v.iter().map(|&x| x / len).collect()
+    }
+
     /// Helper: unpack all centroid indices from a quantized byte vector.
     fn unpack_indices(packed: &[u8], dim: usize, bits: TQBits) -> Vec<u8> {
         let mut reader = BitReader::new(packed);
@@ -196,7 +219,7 @@ mod tests {
         let mut buf = vec![0.0f64; dim];
 
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
             let n_centroids = 1u8 << bits.bit_size();
 
             for &val in &[1000.0f32, -1000.0, f32::MAX / 2.0, f32::MIN / 2.0] {
@@ -220,7 +243,7 @@ mod tests {
         for &bits in &bit_widths {
             for &dim in &dims {
                 let mut buf = vec![0.0f64; dim];
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let vec = vec![0.1; dim];
                 let result = tq.quantize(&vec, &mut buf);
                 let expected_bytes = tq.quantized_size();
@@ -245,7 +268,7 @@ mod tests {
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
             for &dim in &[128, 300, 768] {
                 let mut buf = vec![0.0f64; dim];
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let vec: Vec<f32> = (0..dim).map(|_| rng.random_range(-2.0..2.0)).collect();
 
                 let r1 = tq.quantize(&vec, &mut buf);
@@ -269,7 +292,7 @@ mod tests {
 
             for &dim in &[128, 256, 512] {
                 let mut buf = vec![0.0f64; dim];
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let vec = vec![0.0; dim];
                 let result = tq.quantize(&vec, &mut buf);
                 let indices = unpack_indices(&result, dim, bits);
@@ -299,16 +322,22 @@ mod tests {
 
             for &dim in &[128, 300, 512] {
                 let mut buf = vec![0.0f64; dim];
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let rot = HadamardRotation::new(dim);
-                let vec: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let vec_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let vec = unit_norm(&vec_raw);
 
                 let result = tq.quantize(&vec, &mut buf);
                 let indices = unpack_indices(&result, dim, bits);
 
-                // Reproduce the rotation to get the values that were quantized.
+                // Reproduce rotation AND the √dim / ||v|| rescaling that
+                // `quantize` performs before partitioning against centroids.
                 let mut rotated: Vec<f64> = vec.iter().map(|&v| f64::from(v)).collect();
                 rot.apply(&mut rotated);
+                let scale = (dim as f64).sqrt();
+                for v in rotated.iter_mut() {
+                    *v *= scale;
+                }
 
                 for (d, (&idx, &val)) in indices.iter().zip(rotated.iter()).enumerate() {
                     let assigned_centroid = f64::from(centroids[idx as usize]);
@@ -344,13 +373,16 @@ mod tests {
         let rot = HadamardRotation::new(dim);
 
         let vectors: Vec<Vec<f32>> = (0..n_vectors)
-            .map(|_| (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect())
+            .map(|_| {
+                let raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                unit_norm(&raw)
+            })
             .collect();
 
         let mut mse_per_bits = Vec::new();
 
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
             let centroids = bits.get_centroids();
             let mut total_mse = 0.0f64;
 
@@ -358,14 +390,17 @@ mod tests {
                 let packed = tq.quantize(vec, &mut buf);
                 let indices = unpack_indices(&packed, dim, bits);
 
-                // Reconstruct: map indices -> centroids, then inverse rotate.
+                // Reconstruct: map indices → centroids, inverse rotate, then
+                // undo the √dim rescaling that `quantize` applied before
+                // partitioning (unpacked values live on the √dim × scale).
+                let inv_scale = 1.0 / (dim as f64).sqrt();
                 let mut reconstructed: Vec<f64> = indices
                     .iter()
-                    .map(|&i| f64::from(centroids[i as usize]))
+                    .map(|&i| f64::from(centroids[i as usize]) * inv_scale)
                     .collect();
                 rot.apply_inverse(&mut reconstructed);
 
-                // MSE between original and reconstructed.
+                // MSE between unit-norm original and reconstructed.
                 let mse: f64 = vec
                     .iter()
                     .zip(reconstructed.iter())
@@ -402,7 +437,7 @@ mod tests {
     /// quantization: if dot(q, a) > dot(q, b), the quantized approximation
     /// should agree in the majority of cases.
     #[test]
-    fn quantize_preserves_dot_product_ordering() {
+    fn quantize_preserves_cosine_product_ordering() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
@@ -411,29 +446,26 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(55);
         let rot = HadamardRotation::new(dim);
 
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let centroids = TQBits::Bits4.get_centroids();
 
         let mut concordant = 0usize;
 
         for _ in 0..n_comparisons {
             let query: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let vec_a: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let vec_b: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let vec_a_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let vec_b_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let vec_a = unit_norm(&vec_a_raw);
+            let vec_b = unit_norm(&vec_b_raw);
 
-            // True dot products.
-            let dot_a: f64 = query
-                .iter()
-                .zip(vec_a.iter())
-                .map(|(&q, &a)| f64::from(q) * f64::from(a))
-                .sum();
-            let dot_b: f64 = query
-                .iter()
-                .zip(vec_b.iter())
-                .map(|(&q, &b)| f64::from(q) * f64::from(b))
-                .sum();
+            // True dot products (against unit-norm vectors).
+            let dot_a = true_dot(&query, &vec_a);
+            let dot_b = true_dot(&query, &vec_b);
 
-            // Approximate dot products using quantized vectors.
+            // Approximate dot products using quantized vectors. The unpacked
+            // centroids live on the √dim × rotated(v̂) scale, so dividing
+            // the reconstructed dot by √dim recovers the original-space dot.
+            let inv_scale = 1.0 / (dim as f64).sqrt();
             let approx_dot = |vec: &[f32]| -> f64 {
                 let mut buf = vec![0.0f64; vec.len()];
                 let packed = tq.quantize(vec, &mut buf);
@@ -447,7 +479,8 @@ mod tests {
                     .iter()
                     .zip(recon.iter())
                     .map(|(&q, &r)| f64::from(q) * r)
-                    .sum()
+                    .sum::<f64>()
+                    * inv_scale
             };
 
             let approx_a = approx_dot(&vec_a);
@@ -478,7 +511,7 @@ mod tests {
 
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
             let max_index = (1u8 << bits.bit_size()) - 1;
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
 
             // Use a uniform vector so rotation doesn't scramble things.
             let val = 0.5f32;
@@ -515,7 +548,7 @@ mod tests {
 
         for &dim in &odd_dims {
             for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let n_centroids = 1u8 << bits.bit_size();
                 let vec: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
 
@@ -552,7 +585,7 @@ mod tests {
             let n_centroids = 1u8 << bits.bit_size();
 
             for &dim in &[1, 64, 127, 128, 300, 768, 1025] {
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let indices: Vec<u8> = (0..dim).map(|_| rng.random_range(0..n_centroids)).collect();
 
                 let packed = tq.pack_vector(indices.iter().copied(), TqVectorExtras::default());
@@ -580,7 +613,7 @@ mod tests {
             let max_idx = (1u8 << bits.bit_size()) - 1;
 
             for &dim in &[1, 8, 128, 513] {
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
 
                 for &idx in &[0u8, max_idx] {
                     let indices = vec![idx; dim];
@@ -600,15 +633,15 @@ mod tests {
     /// `dot(0, vec) = 0` for any quantized vector — a rotated zero query is
     /// still zero, so every component of the sum is zero.
     #[test]
-    fn dot_zero_query_returns_zero() {
+    fn cosine_zero_query_returns_zero() {
         let dim = 128;
         let mut buf = vec![0.0f64; dim];
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
             let v: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin()).collect();
             let packed = tq.quantize(&v, &mut buf);
             let zero = vec![0.0f32; dim];
-            let result = tq.dot_asymmetric(&zero, &packed);
+            let result = asymmetric_score_helper(&tq, &zero, &packed);
             assert_eq!(result, 0.0, "bits={bits:?}: dot(0, v) = {result}");
         }
     }
@@ -618,7 +651,7 @@ mod tests {
     /// Rotation and per-component summation are both linear, so this holds
     /// up to floating-point precision.
     #[test]
-    fn dot_linear_in_query() {
+    fn cosine_linear_in_query() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
@@ -627,18 +660,19 @@ mod tests {
         let mut buf = vec![0.0f64; dim];
 
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
             let q1: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
             let q2: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v = unit_norm(&v_raw);
             let packed = tq.quantize(&v, &mut buf);
 
             let (k, c) = (0.7f32, -1.3f32);
             let q_combo: Vec<f32> = q1.iter().zip(&q2).map(|(a, b)| k * a + c * b).collect();
 
-            let d_combo = tq.dot_asymmetric(&q_combo, &packed);
-            let d_linear =
-                k * tq.dot_asymmetric(&q1, &packed) + c * tq.dot_asymmetric(&q2, &packed);
+            let d_combo = asymmetric_score_helper(&tq, &q_combo, &packed);
+            let d_linear = k * asymmetric_score_helper(&tq, &q1, &packed)
+                + c * asymmetric_score_helper(&tq, &q2, &packed);
 
             let tol = 1e-5 * d_combo.abs().max(d_linear.abs()).max(1.0);
             assert!(
@@ -656,7 +690,7 @@ mod tests {
     /// The Hadamard rotation is orthogonal, so `<Rq, u> = <q, R⁻¹u>` — both
     /// paths should agree up to floating-point precision regardless of bits/dim.
     #[test]
-    fn dot_matches_inverse_rotation_reconstruction() {
+    fn cosine_matches_inverse_rotation_reconstruction() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
@@ -664,24 +698,29 @@ mod tests {
 
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
             for &dim in &[128, 300, 512] {
-                let tq = make_tq(dim, bits);
+                let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let rot = HadamardRotation::new(dim);
 
                 let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-                let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let v = unit_norm(&v_raw);
                 let mut buf = vec![0.0f64; dim];
                 let packed = tq.quantize(&v, &mut buf);
 
-                // Manual path: unpack -> inverse rotate -> dot in original space.
+                // Manual path: unpack -> inverse rotate -> dot in original
+                // space. The unpacked centroids live on the scaled grid
+                // (√dim × rotated(v̂)), so we divide by √dim to match what
+                // `score_precomputed` compensates for internally.
                 let mut unpacked: Vec<f64> = tq.unpack_vector(&packed).1.collect();
                 rot.apply_inverse(&mut unpacked);
-                let manual: f32 = q
+                let manual: f32 = (q
                     .iter()
                     .zip(unpacked.iter())
                     .map(|(&qi, &ui)| f64::from(qi) * ui)
-                    .sum::<f64>() as f32;
+                    .sum::<f64>()
+                    / (dim as f64).sqrt()) as f32;
 
-                let fn_result = tq.dot_asymmetric(&q, &packed);
+                let fn_result = asymmetric_score_helper(&tq, &q, &packed);
 
                 let tol = 1e-5 * manual.abs().max(fn_result.abs()).max(1.0);
                 assert!(
@@ -693,18 +732,18 @@ mod tests {
     }
 
     /// For 4-bit quantization on reasonably large dimensions, the quantized
-    /// dot product must closely approximate the true (pre-quantization) dot
-    /// product. A badly-approximating `dot` (e.g. missing the query rotation)
-    /// yields values uncorrelated with the truth and blows this bound out.
+    /// cosine score must closely approximate the true `<q, v̂>` — matching
+    /// the inner product with the unit-norm stored vector. A broken
+    /// quantizer/scoring path yields values uncorrelated with truth.
     #[test]
-    fn dot_approximates_true_dot_product() {
+    fn cosine_approximates_true_cosine_product() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
         let dim = 512;
         let n_trials = 100;
         let mut rng = StdRng::seed_from_u64(44);
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let mut buf = vec![0.0f64; dim];
 
         let mut total_abs_err = 0.0f64;
@@ -712,19 +751,16 @@ mod tests {
 
         for _ in 0..n_trials {
             let q: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v = unit_norm(&v_raw);
 
-            let true_dot: f64 = q
-                .iter()
-                .zip(&v)
-                .map(|(&a, &b)| f64::from(a) * f64::from(b))
-                .sum();
+            let truth = true_dot(&q, &v);
 
             let packed = tq.quantize(&v, &mut buf);
-            let approx = f64::from(tq.dot_asymmetric(&q, &packed));
+            let approx = f64::from(asymmetric_score_helper(&tq, &q, &packed));
 
-            total_abs_err += (true_dot - approx).abs();
-            total_abs_true += true_dot.abs();
+            total_abs_err += (truth - approx).abs();
+            total_abs_true += truth.abs();
         }
 
         let rel_mae = total_abs_err / total_abs_true;
@@ -734,43 +770,39 @@ mod tests {
         );
     }
 
-    /// `dot_symmetric` must (a) be commutative and (b) approximate the true
-    /// dot product — even with quantization noise on *both* sides, the
-    /// orthogonality of the Hadamard rotation keeps the result close to
-    /// `<v1, v2>`.
+    /// `score_symmetric` must (a) be commutative and (b) approximate
+    /// `<â, b̂> = cos(θ)` for unit-norm inputs.
     #[test]
-    fn dot_symmetric_approximates_true_dot() {
+    fn cosine_symmetric_approximates_true_cosine() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
         let dim = 512;
         let n_trials = 100;
         let mut rng = StdRng::seed_from_u64(66);
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let mut buf = vec![0.0f64; dim];
 
         let mut total_abs_err = 0.0f64;
         let mut total_abs_true = 0.0f64;
 
         for _ in 0..n_trials {
-            let a: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let b: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let a_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let b_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let a = unit_norm(&a_raw);
+            let b = unit_norm(&b_raw);
 
-            let true_dot: f64 = a
-                .iter()
-                .zip(&b)
-                .map(|(&x, &y)| f64::from(x) * f64::from(y))
-                .sum();
+            let truth = true_dot(&a, &b);
 
             let packed_a = tq.quantize(&a, &mut buf);
             let packed_b = tq.quantize(&b, &mut buf);
 
-            let ab = tq.dot_symmetric(&packed_a, &packed_b);
-            let ba = tq.dot_symmetric(&packed_b, &packed_a);
+            let ab = tq.score_symmetric(&packed_a, &packed_b);
+            let ba = tq.score_symmetric(&packed_b, &packed_a);
             assert_eq!(ab, ba, "dot_symmetric is not commutative: {ab} vs {ba}");
 
-            total_abs_err += (f64::from(ab) - true_dot).abs();
-            total_abs_true += true_dot.abs();
+            total_abs_err += (f64::from(ab) - truth).abs();
+            total_abs_true += truth.abs();
         }
 
         let rel_mae = total_abs_err / total_abs_true;
@@ -782,39 +814,39 @@ mod tests {
         );
     }
 
-    /// `dot_symmetric(packed, packed)` approximates `||v||²` — a sharper
-    /// check than the random-pair test, since self-dot is always positive
-    /// and sensitive to sign errors in the unpack path.
+    /// `score_symmetric(Q(v̂), Q(v̂)) ≈ 1` for unit-norm `v̂` — a sharper
+    /// check than the random-pair test, since self-cosine is always 1 and
+    /// sensitive to sign errors in the unpack path.
     #[test]
-    fn dot_symmetric_self_dot_approximates_norm_squared() {
+    fn cosine_symmetric_self_cosine_approximates_one() {
         use rand::prelude::StdRng;
         use rand::{RngExt, SeedableRng};
 
         let dim = 512;
         let mut rng = StdRng::seed_from_u64(77);
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let mut buf = vec![0.0f64; dim];
 
         for _ in 0..20 {
-            let v: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
-            let norm_sq: f64 = v.iter().map(|&x| f64::from(x) * f64::from(x)).sum();
+            let v_raw: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+            let v = unit_norm(&v_raw);
 
             let packed = tq.quantize(&v, &mut buf);
-            let approx = f64::from(tq.dot_symmetric(&packed, &packed));
+            let approx = f64::from(tq.score_symmetric(&packed, &packed));
 
-            let rel_err = (norm_sq - approx).abs() / norm_sq;
+            let rel_err = (1.0 - approx).abs();
             assert!(
                 rel_err < 0.15,
-                "||v||²={norm_sq}, approx={approx}, rel_err={rel_err}"
+                "expected ≈1 for unit self-dot, got {approx} (err {rel_err})"
             );
         }
     }
 
-    // --- End-to-end tests for dot_symmetric -------------------------------
+    // --- End-to-end tests for score_symmetric -----------------------------
     //
     // Each test: build a TurboQuantizer, generate random pairs at various
     // similarity levels, compute both the original dot and the quantized
-    // dot_symmetric, compare.
+    // score_symmetric, compare.
     // ---------------------------------------------------------------------
 
     /// Run pairs at 5 mixing levels from fully independent (`t = 0.0`) to
@@ -822,42 +854,40 @@ mod tests {
     /// to `||a|| * ||b||` — that scale-invariant bound holds uniformly even
     /// when the raw dot product itself is near zero.
     #[test]
-    fn end_to_end_dot_symmetric_varied_similarity() {
+    fn end_to_end_cosine_symmetric_varied_similarity() {
         use rand::SeedableRng;
         use rand::prelude::StdRng;
 
         let dim = 512;
         let n_trials = 30;
         let mut rng = StdRng::seed_from_u64(2024);
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let mut buf = vec![0.0f64; dim];
 
         for &t in &[0.0f32, 0.25, 0.5, 0.75, 1.0] {
-            let mut max_norm_err = 0.0f64;
+            let mut max_err = 0.0f64;
 
             for _ in 0..n_trials {
-                let (a, b) = generate_mixed_pair(dim, t, &mut rng);
-                let true_d = true_dot(&a, &b);
-                let scale = l2_norm(&a) * l2_norm(&b);
+                let (a_raw, b_raw) = generate_mixed_pair(dim, t, &mut rng);
+                let a = unit_norm(&a_raw);
+                let b = unit_norm(&b_raw);
+                let truth = true_dot(&a, &b); // unit × unit → cos(θ), in [-1, 1]
 
                 let packed_a = tq.quantize(&a, &mut buf);
                 let packed_b = tq.quantize(&b, &mut buf);
-                let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+                let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
 
-                max_norm_err = max_norm_err.max((true_d - approx).abs() / scale);
+                max_err = max_err.max((truth - approx).abs());
             }
 
-            assert!(
-                max_norm_err < 0.1,
-                "t={t}: max |true-approx|/(||a||*||b||) = {max_norm_err}"
-            );
+            assert!(max_err < 0.1, "t={t}: max |cos(θ) - approx| = {max_err}");
         }
     }
 
     /// Over a shared set of varied-similarity pairs, accuracy must improve
     /// monotonically with bit width: MAE(4b) < MAE(2b) < MAE(1b).
     #[test]
-    fn end_to_end_dot_symmetric_more_bits_is_better() {
+    fn end_to_end_cosine_symmetric_more_bits_is_better() {
         use rand::SeedableRng;
         use rand::prelude::StdRng;
 
@@ -866,22 +896,24 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(2025);
         let mut buf = vec![0.0f64; dim];
 
-        // Fixed pair set (varying similarity) shared across all bit widths.
+        // Fixed unit-sphere pair set (varying similarity) shared across all
+        // bit widths.
         let pairs: Vec<(Vec<f32>, Vec<f32>)> = (0..n_pairs)
             .map(|i| {
                 let t = i as f32 / (n_pairs as f32 - 1.0);
-                generate_mixed_pair(dim, t, &mut rng)
+                let (a, b) = generate_mixed_pair(dim, t, &mut rng);
+                (unit_norm(&a), unit_norm(&b))
             })
             .collect();
 
         let mut mae_by_bits = Vec::new();
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            let tq = make_tq(dim, bits);
+            let tq = make_tq(dim, bits, DistanceType::Cosine);
             let mut total_abs_err = 0.0f64;
             for (a, b) in &pairs {
                 let packed_a = tq.quantize(a, &mut buf);
                 let packed_b = tq.quantize(b, &mut buf);
-                let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+                let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
                 total_abs_err += (true_dot(a, b) - approx).abs();
             }
             mae_by_bits.push((bits, total_abs_err / f64::from(n_pairs)));
@@ -905,23 +937,25 @@ mod tests {
     /// almost fully preserved after symmetric quantization — concordance
     /// over all pairwise comparisons should exceed 95% at 4 bits.
     #[test]
-    fn end_to_end_dot_symmetric_preserves_ordering() {
+    fn end_to_end_cosine_symmetric_preserves_ordering() {
         use rand::SeedableRng;
         use rand::prelude::StdRng;
 
         let dim = 512;
         let n_pairs = 60;
         let mut rng = StdRng::seed_from_u64(2026);
-        let tq = make_tq(dim, TQBits::Bits4);
+        let tq = make_tq(dim, TQBits::Bits4, DistanceType::Cosine);
         let mut buf = vec![0.0f64; dim];
 
         let mut pairs_scored: Vec<(f64, f64)> = Vec::with_capacity(n_pairs);
         for i in 0..n_pairs {
             let t = i as f32 / (n_pairs as f32 - 1.0);
-            let (a, b) = generate_mixed_pair(dim, t, &mut rng);
+            let (a_raw, b_raw) = generate_mixed_pair(dim, t, &mut rng);
+            let a = unit_norm(&a_raw);
+            let b = unit_norm(&b_raw);
             let packed_a = tq.quantize(&a, &mut buf);
             let packed_b = tq.quantize(&b, &mut buf);
-            let approx = f64::from(tq.dot_symmetric(&packed_a, &packed_b));
+            let approx = f64::from(tq.score_symmetric(&packed_a, &packed_b));
             pairs_scored.push((true_dot(&a, &b), approx));
         }
 

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -73,15 +73,8 @@ impl TurboQuantizer {
         let length = f64::from(extras.l2_length.unwrap_or(1.0));
         let scale = (self.rotation.dim() as f64).sqrt() / length;
 
-        // Picking the corresponding centroid indices.
-        let boundaries = self.bits.get_centroid_boundaries();
-        let encoded = buf.iter().map(|&val| {
-            let scaled = (val * scale) as f32;
-            boundaries.partition_point(|&b| scaled > b) as u8
-        });
-
         // Encode and return packed vector.
-        self.pack_vector(encoded, extras)
+        self.pack_vector(buf.iter().map(|&val| val * scale), extras)
     }
 
     /// Similarity score between two vectors that were both encoded with this
@@ -95,8 +88,8 @@ impl TurboQuantizer {
         let (extra_v2, iter2) = self.unpack_vector(v2);
         let raw_dot = dot_impl(iter1, iter2);
 
-        let v1_l2 = extra_v1.and_then(|extras| extras.l2_length).unwrap_or(1.0);
-        let v2_l2 = extra_v2.and_then(|extras| extras.l2_length).unwrap_or(1.0);
+        let v1_l2 = extra_v1.l2_length.unwrap_or(1.0);
+        let v2_l2 = extra_v2.l2_length.unwrap_or(1.0);
 
         // Both sides were scaled by sqrt(dim)/||v|| during quantize; restore
         // magnitudes with l2, undo the sqrt(dim)² = dim inflation.
@@ -118,9 +111,7 @@ impl TurboQuantizer {
         let (vector_extras, unpacked) = self.unpack_vector(vec);
         let dot = dot_impl(query.as_slice().iter().copied(), unpacked);
 
-        let l2 = vector_extras
-            .and_then(|extras| extras.l2_length)
-            .unwrap_or(1.0);
+        let l2 = vector_extras.l2_length.unwrap_or(1.0);
 
         // Only the stored vector carries the sqrt(dim)/||v|| scaling, so we
         // compensate by multiplying by ||v|| and dividing by sqrt(dim).
@@ -356,8 +347,9 @@ mod tests {
         }
     }
 
-    /// `unpack_vector` must recover the exact centroid values for every index
-    /// written by `pack_vector`, across a variety of dims and bit widths.
+    /// Feeding the centroid values yielded by `unpack_vector` back into
+    /// `pack_vector` must reproduce the same bytes — and decode to the same
+    /// values — across a variety of dims and bit widths.
     #[test]
     fn pack_unpack_vector_roundtrip() {
         use rand::prelude::StdRng;
@@ -372,16 +364,19 @@ mod tests {
             for &dim in &[1, 64, 127, 128, 300, 768, 1025] {
                 let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let indices: Vec<u8> = (0..dim).map(|_| rng.random_range(0..n_centroids)).collect();
+                let values: Vec<f64> = indices
+                    .iter()
+                    .map(|&idx| f64::from(centroids[idx as usize]))
+                    .collect();
 
-                let packed = tq.pack_vector(indices.iter().copied(), TqVectorExtras::default());
+                let packed = tq.pack_vector(values.iter().copied(), TqVectorExtras::default());
 
                 let out: Vec<f64> = tq.unpack_vector(&packed).1.collect();
 
-                for (i, (&idx, &value)) in indices.iter().zip(out.iter()).enumerate() {
-                    let expected = f64::from(centroids[idx as usize]);
+                for (i, (&expected, &value)) in values.iter().zip(out.iter()).enumerate() {
                     assert_eq!(
                         value, expected,
-                        "dim={dim}, bits={bits:?}, i={i}: index {idx} \
+                        "dim={dim}, bits={bits:?}, i={i}: \
                          decoded to {value}, expected {expected}"
                     );
                 }
@@ -725,7 +720,7 @@ mod tests {
     }
 
     /// Edge cases for the pack/unpack roundtrip: uniform all-min and all-max
-    /// index patterns exercise the bit-packing boundaries.
+    /// centroid values exercise the bit-packing boundaries.
     #[test]
     fn pack_unpack_vector_uniform_indices() {
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
@@ -736,12 +731,12 @@ mod tests {
                 let tq = make_tq(dim, bits, DistanceType::Cosine);
 
                 for &idx in &[0u8, max_idx] {
-                    let indices = vec![idx; dim];
-                    let packed = tq.pack_vector(indices.iter().copied(), TqVectorExtras::default());
+                    let expected = f64::from(centroids[idx as usize]);
+                    let values = vec![expected; dim];
+                    let packed = tq.pack_vector(values.iter().copied(), TqVectorExtras::default());
 
                     let out: Vec<f64> = tq.unpack_vector(&packed).1.collect();
 
-                    let expected = f64::from(centroids[idx as usize]);
                     for (i, &v) in out.iter().enumerate() {
                         assert_eq!(v, expected, "dim={dim}, bits={bits:?}, idx={idx}, i={i}");
                     }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -813,16 +813,24 @@ impl QuantizedVectors {
             )?,
             QuantizationConfig::Turbo(TurboQuantization {
                 turbo: turbo_config,
-            }) => Self::create_turbo(
-                vectors,
-                &vector_parameters,
-                count,
-                turbo_config,
-                storage_type,
-                path,
-                on_disk_vector_storage,
-                stopped,
-            )?,
+            }) => {
+                let mut vector_parameters = vector_parameters;
+                // TODO(turbo): Remove this manual hack after releasing TQ. For more details see the TODO inside [`Self::construct_vector_parameters`]
+                if distance == Distance::Cosine {
+                    vector_parameters.distance_type = quantization::DistanceType::Cosine;
+                }
+
+                Self::create_turbo(
+                    vectors,
+                    &vector_parameters,
+                    count,
+                    turbo_config,
+                    storage_type,
+                    path,
+                    on_disk_vector_storage,
+                    stopped,
+                )?
+            }
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -946,19 +954,27 @@ impl QuantizedVectors {
             )?,
             QuantizationConfig::Turbo(TurboQuantization {
                 turbo: turbo_config,
-            }) => Self::create_turbo_multi(
-                vectors,
-                offsets,
-                &vector_parameters,
-                vectors_count,
-                inner_vectors_count,
-                turbo_config,
-                storage_type,
-                multi_vector_config,
-                path,
-                on_disk_vector_storage,
-                stopped,
-            )?,
+            }) => {
+                let mut vector_parameters = vector_parameters;
+                // TODO(turbo): Remove this manual hack after releasing TQ. For more details see the TODO inside [`Self::construct_vector_parameters`]
+                if distance == Distance::Cosine {
+                    vector_parameters.distance_type = quantization::DistanceType::Cosine;
+                }
+
+                Self::create_turbo_multi(
+                    vectors,
+                    offsets,
+                    &vector_parameters,
+                    vectors_count,
+                    inner_vectors_count,
+                    turbo_config,
+                    storage_type,
+                    multi_vector_config,
+                    path,
+                    on_disk_vector_storage,
+                    stopped,
+                )?
+            }
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -2313,7 +2329,9 @@ impl QuantizedVectors {
                 QuantizedVectorsStorageType::Immutable => Some(deprecated_count),
             },
             distance_type: match distance {
+                // TODO(turbo): change this to 'cosine' after releasing TQ. We can't do that earlier because only TQ is allowed to use Cosine due to storage compatibility across versions.
                 Distance::Cosine => quantization::DistanceType::Dot,
+
                 Distance::Euclid => quantization::DistanceType::L2,
                 Distance::Dot => quantization::DistanceType::Dot,
                 Distance::Manhattan => quantization::DistanceType::L1,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -770,8 +770,13 @@ impl QuantizedVectors {
         });
         let on_disk_vector_storage = vector_storage.is_on_disk();
 
-        let vector_parameters =
-            Self::construct_vector_parameters(distance, dim, count, storage_type);
+        let vector_parameters = Self::construct_vector_parameters(
+            quantization_config,
+            distance,
+            dim,
+            count,
+            storage_type,
+        );
 
         let quantized_storage = match quantization_config {
             QuantizationConfig::Scalar(ScalarQuantization {
@@ -813,24 +818,16 @@ impl QuantizedVectors {
             )?,
             QuantizationConfig::Turbo(TurboQuantization {
                 turbo: turbo_config,
-            }) => {
-                let mut vector_parameters = vector_parameters;
-                // TODO(turbo): Remove this manual hack after releasing TQ. For more details see the TODO inside [`Self::construct_vector_parameters`]
-                if distance == Distance::Cosine {
-                    vector_parameters.distance_type = quantization::DistanceType::Cosine;
-                }
-
-                Self::create_turbo(
-                    vectors,
-                    &vector_parameters,
-                    count,
-                    turbo_config,
-                    storage_type,
-                    path,
-                    on_disk_vector_storage,
-                    stopped,
-                )?
-            }
+            }) => Self::create_turbo(
+                vectors,
+                &vector_parameters,
+                count,
+                turbo_config,
+                storage_type,
+                path,
+                on_disk_vector_storage,
+                stopped,
+            )?,
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -886,8 +883,13 @@ impl QuantizedVectors {
         let vectors_count = vector_storage.total_vector_count();
         let on_disk_vector_storage = vector_storage.is_on_disk();
 
-        let vector_parameters =
-            Self::construct_vector_parameters(distance, dim, inner_vectors_count, storage_type);
+        let vector_parameters = Self::construct_vector_parameters(
+            quantization_config,
+            distance,
+            dim,
+            inner_vectors_count,
+            storage_type,
+        );
 
         let offsets = (0..vectors_count as PointOffsetType)
             .map(|idx| {
@@ -954,27 +956,19 @@ impl QuantizedVectors {
             )?,
             QuantizationConfig::Turbo(TurboQuantization {
                 turbo: turbo_config,
-            }) => {
-                let mut vector_parameters = vector_parameters;
-                // TODO(turbo): Remove this manual hack after releasing TQ. For more details see the TODO inside [`Self::construct_vector_parameters`]
-                if distance == Distance::Cosine {
-                    vector_parameters.distance_type = quantization::DistanceType::Cosine;
-                }
-
-                Self::create_turbo_multi(
-                    vectors,
-                    offsets,
-                    &vector_parameters,
-                    vectors_count,
-                    inner_vectors_count,
-                    turbo_config,
-                    storage_type,
-                    multi_vector_config,
-                    path,
-                    on_disk_vector_storage,
-                    stopped,
-                )?
-            }
+            }) => Self::create_turbo_multi(
+                vectors,
+                offsets,
+                &vector_parameters,
+                vectors_count,
+                inner_vectors_count,
+                turbo_config,
+                storage_type,
+                multi_vector_config,
+                path,
+                on_disk_vector_storage,
+                stopped,
+            )?,
         };
 
         let quantized_vectors_config = QuantizedVectorsConfig {
@@ -2317,6 +2311,7 @@ impl QuantizedVectors {
     }
 
     fn construct_vector_parameters(
+        quantization_config: &QuantizationConfig,
         distance: Distance,
         dim: usize,
         deprecated_count: usize,
@@ -2329,9 +2324,15 @@ impl QuantizedVectors {
                 QuantizedVectorsStorageType::Immutable => Some(deprecated_count),
             },
             distance_type: match distance {
-                // TODO(turbo): change this to 'cosine' after releasing TQ. We can't do that earlier because only TQ is allowed to use Cosine due to storage compatibility across versions.
-                Distance::Cosine => quantization::DistanceType::Dot,
-
+                Distance::Cosine => match quantization_config {
+                    // Because of backwards compatibility,
+                    // we have to use Dot product for scalar, pq and binary quantization when distance is Cosine.
+                    // Only TurboQuant has a difference between Cosine and Dot product.
+                    QuantizationConfig::Scalar(_) => quantization::DistanceType::Dot,
+                    QuantizationConfig::Product(_) => quantization::DistanceType::Dot,
+                    QuantizationConfig::Binary(_) => quantization::DistanceType::Dot,
+                    QuantizationConfig::Turbo(_) => quantization::DistanceType::Cosine,
+                },
                 Distance::Euclid => quantization::DistanceType::L2,
                 Distance::Dot => quantization::DistanceType::Dot,
                 Distance::Manhattan => quantization::DistanceType::L1,


### PR DESCRIPTION
Implements scoring (internal + query) for cosine and dot distances.

Not included:
- 1.5 bit
- SIMD
- L1
- L2

This PR also implements all required functions of the `EncodedVectors` trait, meaning that TQ can now be used E2E from the API. 