### PR TITLE
Refactor `Sparse*QueryScorer` for (future) io_uring support

### DIFF
--- a/lib/gridstore/src/error.rs
+++ b/lib/gridstore/src/error.rs
@@ -1,7 +1,7 @@
 use common::mmap;
 use common::universal_io::UniversalIoError;
 
-use crate::tracker::PageId;
+use crate::tracker::{PageId, PointOffset};
 
 #[derive(thiserror::Error, Debug)]
 pub enum GridstoreError {
@@ -21,6 +21,8 @@ pub enum GridstoreError {
     ValidationError { message: String },
     #[error("Page {page_id} not found")]
     PageNotFound { page_id: PageId },
+    #[error("value {point_offset} not found")]
+    ValueNotFound { point_offset: PointOffset },
 }
 
 impl GridstoreError {

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -375,17 +375,18 @@ impl<V: Blob> Gridstore<V> {
         self.with_view(|view| view.get_value::<P>(point_offset, hw_counter))
     }
 
-    pub fn for_each_in_batch<P, F>(
+    pub fn for_each_in_batch<P, F, E>(
         &self,
         offsets: &[PointOffset],
         callback: F,
         hw_counter: &HardwareCounterCell,
-    ) -> Result<()>
+    ) -> std::result::Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, V),
+        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
+        E: From<GridstoreError>,
     {
-        self.with_view(|view| view.for_each_in_batch::<P, F>(offsets, callback, hw_counter))
+        self.with_view(|view| view.for_each_in_batch::<P, F, E>(offsets, callback, hw_counter))
     }
 
     #[cfg(test)]

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -374,6 +374,19 @@ impl<V: Blob> Gridstore<V> {
         self.with_view(|view| view.get_value::<P>(point_offset, hw_counter))
     }
 
+    pub fn for_each_in_batch<P, F>(
+        &self,
+        offsets: &[PointOffset],
+        callback: F,
+        hw_counter: &HardwareCounterCell,
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+        F: FnMut(usize, V),
+    {
+        self.with_view(|view| view.for_each_in_batch::<P, F>(offsets, callback, hw_counter))
+    }
+
     #[cfg(test)]
     pub fn get_pointer(&self, point_offset: PointOffset) -> Option<ValuePointer> {
         self.tracker.read().get(point_offset).ok().flatten()

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -310,11 +310,12 @@ impl<V: Blob> Gridstore<V> {
             return Ok(None);
         };
 
-        let raw = self.with_view(|view| view.read_from_pages::<Random>(pointer))?;
-        let decompressed = self.with_view(|view| view.decompress(raw));
-        let value = V::from_bytes(&decompressed);
-
-        Ok(Some(value))
+        self.with_view(|view| {
+            let raw = view.read_from_pages::<Random>(pointer)?;
+            let decompressed = view.decompress(raw);
+            let value = V::from_bytes(&decompressed);
+            Ok(Some(value))
+        })
     }
 
     /// Clear the storage, going back to the initial state.

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -263,8 +263,12 @@ fn test_write_across_pages() {
         .unwrap();
 
     let read_value = storage
-        .with_view(|view| view.read_from_pages::<Random>(pointer))
+        .with_view(|view| {
+            view.read_from_pages::<Random>(pointer)
+                .map(|val| val.into_owned())
+        })
         .unwrap();
+
     assert_eq!(value, read_value);
 }
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1262,3 +1262,126 @@ fn test_skip_deferred_flush_after_clear() {
     assert!(storage.get_pointer(0).is_none(), "point must not exist");
     assert_eq!(storage.max_point_offset(), 0, "must have zero points");
 }
+
+/// `Pages::read_batch_from_pages` must yield the same bytes as calling
+/// `read_from_pages` for each pointer individually. Covers the small/multi-page mix
+/// and synthetic zero-length pointers.
+#[test]
+fn test_read_batch_from_pages_congruent_with_read_from_pages() {
+    // Use small pages so larger payloads span multiple pages.
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None);
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    // Mix of payload sizes so we exercise both single-page and multi-page reads.
+    let num_payloads = 50u32;
+    for point_offset in 0..num_payloads {
+        let size_factor = (point_offset % 8) as usize + 1;
+        let payload = random_payload(rng, size_factor);
+        storage
+            .put_value(point_offset, &payload, hw_counter_ref)
+            .unwrap();
+    }
+
+    let mut pointers: Vec<ValuePointer> = (0..num_payloads)
+        .map(|i| storage.get_pointer(i).unwrap())
+        .collect();
+
+    // Synthetic zero-length pointer to exercise that branch.
+    pointers.push(ValuePointer::new(0, 0, 0));
+
+    pointers.shuffle(rng);
+
+    let pages = storage.pages.read();
+
+    let single_results: Vec<Vec<u8>> = pointers
+        .iter()
+        .map(|ptr| {
+            pages
+                .read_from_pages::<Random>(*ptr, &storage.config)
+                .unwrap()
+                .into_owned()
+        })
+        .collect();
+
+    let mut batch_results: Vec<Option<Vec<u8>>> = vec![None; pointers.len()];
+
+    let pointers_opt: Vec<_> = pointers.into_iter().map(Some).collect();
+    pages
+        .read_batch_from_pages::<Random, _, GridstoreError>(
+            pointers_opt,
+            &storage.config,
+            |idx, raw_opt| {
+                batch_results[idx] = raw_opt.map(|raw| raw.into_owned());
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    for (i, single) in single_results.iter().enumerate() {
+        assert_eq!(
+            batch_results[i].as_ref(),
+            Some(single),
+            "batch read mismatch at idx {i}, len {}",
+            single.len(),
+        );
+    }
+}
+
+/// `GridstoreView::for_each_in_batch` must yield the same values as calling
+/// `get_value` per offset, including missing/out-of-range offsets that should be
+/// silently skipped (matching `get_value`'s `Ok(None)`).
+#[test]
+fn test_for_each_in_batch_congruent_with_get_value() {
+    let (_dir, mut storage) = empty_storage();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    let num_payloads = 100u32;
+    for point_offset in 0..num_payloads {
+        let size_factor = (point_offset % 5) as usize + 1;
+        let payload = random_payload(rng, size_factor);
+        storage
+            .put_value(point_offset, &payload, hw_counter_ref)
+            .unwrap();
+    }
+
+    // Delete a few values to create gaps.
+    for &id in &[3u32, 17, 42, 88] {
+        storage.delete_value(id).unwrap();
+    }
+
+    // Build offsets including deleted points and out-of-range ones.
+    let mut offsets: Vec<u32> = (0..num_payloads).collect();
+    offsets.push(num_payloads + 5);
+    offsets.push(num_payloads + 100);
+    offsets.shuffle(rng);
+
+    let single_results: Vec<Option<Payload>> = offsets
+        .iter()
+        .map(|&o| storage.get_value::<Random>(o, &hw_counter).unwrap())
+        .collect();
+
+    let mut batch_results: Vec<Option<Payload>> = vec![None; offsets.len()];
+    storage
+        .for_each_in_batch::<Random, _, GridstoreError>(
+            &offsets,
+            |idx, value| {
+                batch_results[idx] = value;
+                Ok(())
+            },
+            &hw_counter,
+        )
+        .unwrap();
+
+    for (i, (single, batch)) in single_results.iter().zip(&batch_results).enumerate() {
+        assert_eq!(single, batch, "mismatch at idx {i} (offset {})", offsets[i]);
+    }
+}

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -124,10 +124,7 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         let mut result = Ok(());
         let mut point_offsets = point_offsets.iter();
         let pointers = iter::from_fn(|| {
-            let Some(&point_offset) = point_offsets.next() else {
-                return None;
-            };
-
+            let &point_offset = point_offsets.next()?;
             match self.get_pointer(point_offset) {
                 Ok(Some(ptr)) => Some(ptr),
                 Ok(None) => {

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::iter;
 use std::ops::ControlFlow;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -110,7 +111,7 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
 
     pub fn for_each_in_batch<P, F>(
         &self,
-        offsets: &[PointOffset],
+        point_offsets: &[PointOffset],
         mut callback: F,
         hw_counter: &HardwareCounterCell,
     ) -> Result<()>
@@ -118,12 +119,29 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         P: AccessPattern,
         F: FnMut(usize, V),
     {
-        let pointers = offsets.iter().map(|&offset| {
-            self.get_pointer(offset)
-                .expect("value pointer read")
-                .expect("value exists")
+        // Read value pointers for given point offsets, until there's read error or value pointer
+        // does not exist, extract any error from the iterator into `result` variable
+        let mut result = Ok(());
+        let mut point_offsets = point_offsets.iter();
+        let pointers = iter::from_fn(|| {
+            let Some(&point_offset) = point_offsets.next() else {
+                return None;
+            };
+
+            match self.get_pointer(point_offset) {
+                Ok(Some(ptr)) => Some(ptr),
+                Ok(None) => {
+                    result = Err(GridstoreError::ValueNotFound { point_offset });
+                    None
+                }
+                Err(err) => {
+                    result = Err(err);
+                    None
+                }
+            }
         });
 
+        // `read_batch_from_pages` iterator would stop, as soon as there's a value pointer error
         let values = self
             .pages
             .read_batch_from_pages::<P, _>(pointers, self.config)?;
@@ -139,7 +157,8 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
             callback(idx, value);
         }
 
-        Ok(())
+        // And we can propagate value pointer error to the caller
+        result
     }
 
     /// Iterate over all the values in the storage.

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::ControlFlow;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -65,7 +66,10 @@ impl<'a, V, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     }
 
     /// Read raw value from the pages, considering that values can span more than one page.
-    pub fn read_from_pages<P: AccessPattern>(&self, pointer: ValuePointer) -> Result<Vec<u8>> {
+    pub fn read_from_pages<P: AccessPattern>(
+        &self,
+        pointer: ValuePointer,
+    ) -> Result<Cow<'_, [u8]>> {
         self.pages.read_from_pages::<P>(pointer, self.config)
     }
 }
@@ -78,10 +82,10 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         }
     }
 
-    pub(super) fn decompress(&self, value: Vec<u8>) -> Vec<u8> {
+    pub(super) fn decompress<'val>(&self, value: Cow<'val, [u8]>) -> Cow<'val, [u8]> {
         match self.config.compression {
             Compression::None => value,
-            Compression::LZ4 => decompress_lz4(&value),
+            Compression::LZ4 => decompress_lz4(&value).into(),
         }
     }
 
@@ -129,7 +133,7 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
 
             hw_counter.payload_io_read_counter().incr_delta(raw.len());
 
-            let decompressed = self.decompress(raw.into_owned());
+            let decompressed = self.decompress(raw);
             let value = V::from_bytes(&decompressed);
 
             callback(idx, value);

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::iter;
 use std::ops::ControlFlow;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -109,53 +108,33 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         Ok(Some(value))
     }
 
-    pub fn for_each_in_batch<P, F>(
+    pub fn for_each_in_batch<P, F, E>(
         &self,
         point_offsets: &[PointOffset],
         mut callback: F,
         hw_counter: &HardwareCounterCell,
-    ) -> Result<()>
+    ) -> std::result::Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, V),
+        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
+        E: From<GridstoreError>,
     {
-        // Read value pointers for given point offsets, until there's read error or value pointer
-        // does not exist, extract any error from the iterator into `result` variable
-        let mut result = Ok(());
-        let mut point_offsets = point_offsets.iter();
-        let pointers = iter::from_fn(|| {
-            let &point_offset = point_offsets.next()?;
-            match self.get_pointer(point_offset) {
-                Ok(Some(ptr)) => Some(ptr),
-                Ok(None) => {
-                    result = Err(GridstoreError::ValueNotFound { point_offset });
-                    None
-                }
-                Err(err) => {
-                    result = Err(err);
-                    None
-                }
-            }
-        });
+        // Resolve all pointers in a single batched tracker read so async backends
+        // (e.g. io_uring) can fetch them in parallel.
+        let pointers = self.tracker.get_batch(point_offsets)?;
 
-        // `read_batch_from_pages` iterator would stop, as soon as there's a value pointer error
-        let values = self
-            .pages
-            .read_batch_from_pages::<P, _>(pointers, self.config)?;
-
-        for result in values {
-            let (idx, raw) = result?;
-
-            hw_counter.payload_io_read_counter().incr_delta(raw.len());
-
-            let decompressed = self.decompress(raw);
-            let value = V::from_bytes(&decompressed);
-
-            callback(idx, value);
-        }
-
-        // And we can propagate value pointer error to the caller
-        result
+        // Stream decoded values straight to the caller — no intermediate buffer.
+        // The callback `idx` maps 1-to-1 to `point_offsets`; missing offsets are
+        // delivered as `None`.
+        self.pages
+            .read_batch_from_pages::<P, _, E>(pointers, self.config, |idx, raw_opt| {
+                let value = raw_opt.map(|raw| {
+                    hw_counter.payload_io_read_counter().incr_delta(raw.len());
+                    let decompressed = self.decompress(raw);
+                    V::from_bytes(&decompressed)
+                });
+                callback(idx, value)
+            })
     }
 
     /// Iterate over all the values in the storage.

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -114,10 +114,23 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         P: AccessPattern,
         F: FnMut(usize, V),
     {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let value = self
-                .get_value::<P>(offset, hw_counter)?
-                .expect("value exists");
+        let pointers = offsets.iter().map(|&offset| {
+            self.get_pointer(offset)
+                .expect("value pointer read")
+                .expect("value exists")
+        });
+
+        let values = self
+            .pages
+            .read_batch_from_pages::<P, _>(pointers, self.config)?;
+
+        for result in values {
+            let (idx, raw) = result?;
+
+            hw_counter.payload_io_read_counter().incr_delta(raw.len());
+
+            let decompressed = self.decompress(raw.into_owned());
+            let value = V::from_bytes(&decompressed);
 
             callback(idx, value);
         }

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -104,6 +104,27 @@ impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
         Ok(Some(value))
     }
 
+    pub fn for_each_in_batch<P, F>(
+        &self,
+        offsets: &[PointOffset],
+        mut callback: F,
+        hw_counter: &HardwareCounterCell,
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+        F: FnMut(usize, V),
+    {
+        for (idx, &offset) in offsets.iter().enumerate() {
+            let value = self
+                .get_value::<P>(offset, hw_counter)?
+                .expect("value exists");
+
+            callback(idx, value);
+        }
+
+        Ok(())
+    }
+
     /// Iterate over all the values in the storage.
     ///
     /// Stops when any of these conditions is true:

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,17 +1,18 @@
 use std::borrow::Cow;
-use std::iter;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
-use ahash::{HashMapExt as _, HashSet};
+use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::universal_io::{
     FileIndex, Flusher, OpenOptions, ReadRange, UniversalRead, UniversalWrite,
 };
+use itertools::Either;
 
 use crate::Result;
 use crate::config::StorageConfig;
+use crate::error::GridstoreError;
 use crate::tracker::{PageId, ValuePointer};
 
 pub fn page_path(base_path: &Path, page_id: PageId) -> PathBuf {
@@ -136,10 +137,24 @@ impl<S: UniversalRead<u8>> Pages<S> {
         let value_start = u64::from(block_offset) * block_size_bytes;
         assert!(value_start < page_len);
 
+        // A zero-length pointer would otherwise yield no entries; emit a single
+        // empty range so callers (read_from_pages, read_batch_from_pages,
+        // write_to_pages) get a uniform per-pointer iteration.
+        if total_length == 0 {
+            return Either::Left(std::iter::once((
+                0,
+                page_id,
+                ReadRange {
+                    byte_offset: value_start,
+                    length: 0,
+                },
+            )));
+        }
+
         let mut buf_offset = 0;
         let mut start = value_start;
 
-        std::iter::from_fn(move || {
+        Either::Right(std::iter::from_fn(move || {
             if buf_offset >= total_length {
                 return None;
             }
@@ -157,7 +172,7 @@ impl<S: UniversalRead<u8>> Pages<S> {
             page_id += 1;
             start = 0;
             Some(result)
-        })
+        }))
     }
 
     pub fn value_len_pages(pointer: ValuePointer, config: &StorageConfig) -> usize {
@@ -211,14 +226,24 @@ impl<S: UniversalRead<u8>> Pages<S> {
         Ok(Cow::Owned(unsafe { assume_init_vec(buffer) }))
     }
 
-    pub fn read_batch_from_pages<P, I>(
+    /// Batch-read values pointed to by `pointers`, invoking `callback` for each
+    /// input slot.
+    ///
+    /// The callback is invoked once per slot in `pointers`, receiving the slot
+    /// index and `Some(bytes)` for set pointers (in arbitrary order — io_uring
+    /// completions may interleave) or `None` for empty slots (after all data
+    /// arrives). The callback's error type `E` flows back through the function
+    /// so callers don't have to bridge it themselves.
+    pub fn read_batch_from_pages<P, F, E>(
         &self,
-        pointers: I,
+        pointers: Vec<Option<ValuePointer>>,
         config: &StorageConfig,
-    ) -> Result<impl Iterator<Item = Result<(usize, Cow<'_, [u8]>)>>>
+        mut callback: F,
+    ) -> std::result::Result<(), E>
     where
         P: AccessPattern,
-        I: IntoIterator<Item = ValuePointer>,
+        F: FnMut(usize, Option<Cow<'_, [u8]>>) -> std::result::Result<(), E>,
+        E: From<GridstoreError>,
     {
         struct ReadMeta {
             value_idx: usize,
@@ -227,70 +252,84 @@ impl<S: UniversalRead<u8>> Pages<S> {
             len_pages: usize,
         }
 
+        let mut empty_values = Vec::new(); // expect (almost) no values
+
         let reads = pointers
-            .into_iter()
+            .iter()
+            .copied()
             .enumerate()
-            .flat_map(move |(value_idx, pointer)| {
-                let len_bytes = pointer.length as usize;
-                let len_pages = Self::value_len_pages(pointer, config);
+            .flat_map(|(value_idx, pointer_opt)| {
+                if pointer_opt.is_none() {
+                    empty_values.push(value_idx);
+                }
+                pointer_opt.into_iter().flat_map(move |pointer| {
+                    let len_bytes = pointer.length as usize;
+                    let len_pages = Self::value_len_pages(pointer, config);
 
-                Self::get_page_value_ranges(pointer, config).map(
-                    move |(buffer_offset, page_idx, range)| {
-                        let meta = ReadMeta {
-                            value_idx,
-                            buffer_offset,
-                            len_bytes,
-                            len_pages,
-                        };
+                    Self::get_page_value_ranges(pointer, config).map(
+                        move |(buffer_offset, page_idx, range)| {
+                            let meta = ReadMeta {
+                                value_idx,
+                                buffer_offset,
+                                len_bytes,
+                                len_pages,
+                            };
 
-                        let page = &self.pages[page_idx as usize];
-                        (meta, page, range)
-                    },
-                )
+                            let page = &self.pages[page_idx as usize];
+                            (meta, page, range)
+                        },
+                    )
+                })
             });
 
-        let mut chunks = S::read_multi_iter::<P, _>(reads)?;
-        let mut values = ahash::HashMap::new();
+        let chunks = S::read_multi_iter::<P, _>(reads).map_err(GridstoreError::from)?;
 
-        let iter = iter::from_fn(move || {
-            for result in chunks.by_ref() {
-                let (meta, bytes) = match result {
-                    Ok(chunk) => chunk,
-                    Err(err) => return Some(Err(err.into())),
-                };
+        // Multi-page values need buffering since chunks for the same value may
+        // arrive interleaved with chunks for other values. Single-page reads
+        // (the common case, including zero-length) bypass this map entirely.
+        let mut pending: AHashMap<usize, (Vec<MaybeUninit<u8>>, usize)> = AHashMap::new();
 
-                let ReadMeta {
-                    value_idx,
-                    buffer_offset,
-                    len_bytes,
-                    len_pages,
-                } = meta;
+        for result in chunks {
+            let (meta, bytes) = result.map_err(GridstoreError::from)?;
 
-                if len_pages == 1 {
-                    return Some(Ok((value_idx, bytes)));
-                }
+            let ReadMeta {
+                value_idx,
+                buffer_offset,
+                len_bytes,
+                len_pages,
+            } = meta;
 
-                let (value_buffer, pages_read) = values
-                    .entry(value_idx)
-                    .or_insert_with(|| (vec![MaybeUninit::uninit(); len_bytes], 0));
-
-                value_buffer[buffer_offset..buffer_offset + bytes.len()]
-                    .write_copy_of_slice(&bytes);
-
-                *pages_read += 1;
-
-                if *pages_read >= len_pages {
-                    let (value_buffer, _) = values.remove(&value_idx).expect("value exists");
-                    let value_buffer = unsafe { assume_init_vec(value_buffer) };
-
-                    return Some(Ok((value_idx, Cow::Owned(value_buffer))));
-                }
+            if len_pages <= 1 {
+                callback(value_idx, Some(bytes))?;
+                continue;
             }
 
-            None
-        });
+            let (value_buffer, pages_read) = pending
+                .entry(value_idx)
+                .or_insert_with(|| (vec![MaybeUninit::uninit(); len_bytes], 0));
 
-        Ok(iter)
+            value_buffer[buffer_offset..buffer_offset + bytes.len()].write_copy_of_slice(&bytes);
+
+            *pages_read += 1;
+
+            if *pages_read >= len_pages {
+                let (value_buffer, _) = pending.remove(&value_idx).expect("value exists");
+                let value_buffer = unsafe { assume_init_vec(value_buffer) };
+
+                callback(value_idx, Some(Cow::Owned(value_buffer)))?;
+            }
+        }
+
+        debug_assert!(
+            pending.is_empty(),
+            "all valid pointers should have been delivered",
+        );
+
+        for idx in empty_values {
+            callback(idx, None)?;
+        }
+
+        Ok(())
     }
 
     /// Populate all pages in the mmap.

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -185,19 +185,31 @@ impl<S: UniversalRead<u8>> Pages<S> {
         &self,
         pointer: ValuePointer,
         config: &StorageConfig,
-    ) -> Result<Vec<u8>> {
-        // Avoid initializing buffer with zeros, as it will be overwritten by file access;
-        let mut raw_value = vec![MaybeUninit::<u8>::uninit(); pointer.length as usize];
-
+    ) -> Result<Cow<'_, [u8]>> {
         let reads = Self::get_page_value_ranges(pointer, config)
             .map(|(buf_offset, page, range)| (buf_offset, &self.pages[page as usize], range));
 
-        S::read_multi::<P, _>(reads, |offset, slice| {
-            raw_value[offset..offset + slice.len()].write_copy_of_slice(slice);
-            Ok(())
-        })?;
+        let pages = Self::value_len_pages(pointer, config);
 
-        Ok(unsafe { assume_init_vec(raw_value) })
+        let mut buffer = if pages == 1 {
+            // Avoid allocating buffer, if value fits within single page
+            Vec::new()
+        } else {
+            // Avoid initializing buffer with zeros, as it will be overwritten by file read
+            vec![MaybeUninit::uninit(); pointer.length as _]
+        };
+
+        for result in S::read_multi_iter::<P, _>(reads)? {
+            let (offset, bytes) = result?;
+
+            if pages == 1 {
+                return Ok(bytes);
+            }
+
+            buffer[offset..offset + bytes.len()].write_copy_of_slice(&bytes);
+        }
+
+        Ok(Cow::Owned(unsafe { assume_init_vec(buffer) }))
     }
 
     pub fn read_batch_from_pages<P, I>(

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::iter;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
@@ -158,6 +161,26 @@ impl<S: UniversalRead<u8>> Pages<S> {
         })
     }
 
+    pub fn value_len_pages(pointer: ValuePointer, config: &StorageConfig) -> usize {
+        let ValuePointer {
+            page_id: _,
+            block_offset,
+            length: value_length,
+        } = pointer;
+
+        let page_size_bytes = config.page_size_bytes as u64;
+        let block_size_bytes = config.block_size_bytes as u64;
+
+        let block_offset = u64::from(block_offset);
+        let value_length = u64::from(value_length);
+
+        let byte_offset = block_offset * block_size_bytes;
+        assert!(byte_offset < page_size_bytes);
+
+        let pages = (byte_offset + value_length).div_ceil(page_size_bytes);
+        pages as usize
+    }
+
     pub fn read_from_pages<P: AccessPattern>(
         &self,
         pointer: ValuePointer,
@@ -175,6 +198,68 @@ impl<S: UniversalRead<u8>> Pages<S> {
         })?;
 
         Ok(unsafe { assume_init_vec(raw_value) })
+    }
+
+    pub fn read_batch_from_pages<P, I>(
+        &self,
+        pointers: I,
+        config: &StorageConfig,
+    ) -> Result<impl Iterator<Item = Result<(usize, Cow<'_, [u8]>)>>>
+    where
+        P: AccessPattern,
+        I: IntoIterator<Item = ValuePointer>,
+    {
+        let reads = pointers
+            .into_iter()
+            .enumerate()
+            .flat_map(move |(value_idx, pointer)| {
+                let len_bytes = pointer.length as usize;
+                let len_pages = Self::value_len_pages(pointer, config);
+
+                Self::get_page_value_ranges(pointer, config).map(
+                    move |(buffer_offset, page_idx, range)| {
+                        let meta = (value_idx, buffer_offset, len_bytes, len_pages);
+                        let page = &self.pages[page_idx as usize];
+                        (meta, page, range)
+                    },
+                )
+            });
+
+        let mut chunks = S::read_multi_iter::<P, _>(reads)?;
+        let mut values = HashMap::new();
+
+        let iter = iter::from_fn(move || {
+            for result in chunks.by_ref() {
+                let ((value_idx, buffer_offset, len_bytes, len_pages), bytes) = match result {
+                    Ok(chunk) => chunk,
+                    Err(err) => return Some(Err(err.into())),
+                };
+
+                if len_pages == 1 {
+                    return Some(Ok((value_idx, bytes)));
+                }
+
+                let (value_buffer, pages_read) = values
+                    .entry(value_idx)
+                    .or_insert_with(|| (vec![MaybeUninit::uninit(); len_bytes], 0));
+
+                value_buffer[buffer_offset..buffer_offset + bytes.len()]
+                    .write_copy_of_slice(&bytes);
+
+                *pages_read += 1;
+
+                if *pages_read >= len_pages {
+                    let (value_buffer, _) = values.remove(&value_idx).expect("value exists");
+                    let value_buffer = unsafe { assume_init_vec(value_buffer) };
+
+                    return Some(Ok((value_idx, Cow::Owned(value_buffer))));
+                }
+            }
+
+            None
+        });
+
+        Ok(iter)
     }
 
     /// Populate all pages in the mmap.

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::iter;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
-use ahash::HashSet;
+use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::universal_io::{
@@ -250,7 +249,7 @@ impl<S: UniversalRead<u8>> Pages<S> {
             });
 
         let mut chunks = S::read_multi_iter::<P, _>(reads)?;
-        let mut values = HashMap::new();
+        let mut values = AHashMap::new();
 
         let iter = iter::from_fn(move || {
             for result in chunks.by_ref() {

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -3,7 +3,7 @@ use std::iter;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
-use ahash::{AHashMap, HashSet};
+use ahash::{HashMapExt as _, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::universal_io::{
@@ -242,6 +242,7 @@ impl<S: UniversalRead<u8>> Pages<S> {
                             len_bytes,
                             len_pages,
                         };
+
                         let page = &self.pages[page_idx as usize];
                         (meta, page, range)
                     },
@@ -249,22 +250,21 @@ impl<S: UniversalRead<u8>> Pages<S> {
             });
 
         let mut chunks = S::read_multi_iter::<P, _>(reads)?;
-        let mut values = AHashMap::new();
+        let mut values = ahash::HashMap::new();
 
         let iter = iter::from_fn(move || {
             for result in chunks.by_ref() {
-                let (
-                    ReadMeta {
-                        value_idx,
-                        buffer_offset,
-                        len_bytes,
-                        len_pages,
-                    },
-                    bytes,
-                ) = match result {
+                let (meta, bytes) = match result {
                     Ok(chunk) => chunk,
                     Err(err) => return Some(Err(err.into())),
                 };
+
+                let ReadMeta {
+                    value_idx,
+                    buffer_offset,
+                    len_bytes,
+                    len_pages,
+                } = meta;
 
                 if len_pages == 1 {
                     return Some(Ok((value_idx, bytes)));

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -221,6 +221,13 @@ impl<S: UniversalRead<u8>> Pages<S> {
         P: AccessPattern,
         I: IntoIterator<Item = ValuePointer>,
     {
+        struct ReadMeta {
+            value_idx: usize,
+            buffer_offset: usize,
+            len_bytes: usize,
+            len_pages: usize,
+        }
+
         let reads = pointers
             .into_iter()
             .enumerate()
@@ -230,7 +237,12 @@ impl<S: UniversalRead<u8>> Pages<S> {
 
                 Self::get_page_value_ranges(pointer, config).map(
                     move |(buffer_offset, page_idx, range)| {
-                        let meta = (value_idx, buffer_offset, len_bytes, len_pages);
+                        let meta = ReadMeta {
+                            value_idx,
+                            buffer_offset,
+                            len_bytes,
+                            len_pages,
+                        };
                         let page = &self.pages[page_idx as usize];
                         (meta, page, range)
                     },
@@ -242,7 +254,15 @@ impl<S: UniversalRead<u8>> Pages<S> {
 
         let iter = iter::from_fn(move || {
             for result in chunks.by_ref() {
-                let ((value_idx, buffer_offset, len_bytes, len_pages), bytes) = match result {
+                let (
+                    ReadMeta {
+                        value_idx,
+                        buffer_offset,
+                        len_bytes,
+                        len_pages,
+                    },
+                    bytes,
+                ) = match result {
                     Ok(chunk) => chunk,
                     Err(err) => return Some(Err(err.into())),
                 };

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -373,6 +373,61 @@ impl<S: UniversalRead<u8>> Tracker<S> {
         }
     }
 
+    /// Get the page pointers for a batch of point offsets.
+    ///
+    /// Issues a single batched read against the underlying storage so async
+    /// backends (e.g. io_uring) can fetch all entries in parallel. Pending
+    /// updates and out-of-range offsets are handled before/after the batch
+    /// read, mirroring [`get`](Self::get).
+    pub fn get_batch(&self, point_offsets: &[PointOffset]) -> Result<Vec<Option<ValuePointer>>> {
+        let item_size = std::mem::size_of::<Optional<ValuePointer>>();
+        let header_size = std::mem::size_of::<TrackerHeader>();
+        let storage_len = self.storage.len()?;
+
+        let mut result: Vec<Option<ValuePointer>> = vec![None; point_offsets.len()];
+        let mut storage_reads: Vec<(usize, ReadRange)> = Vec::with_capacity(point_offsets.len());
+
+        for (i, &point_offset) in point_offsets.iter().enumerate() {
+            // Pending updates take precedence over storage.
+            if let Some(pending) = self.pending_updates.get(&point_offset) {
+                if pending.is_empty() {
+                    debug_assert!(false, "pending updates must not be empty");
+                } else {
+                    result[i] = pending.current;
+                    continue;
+                }
+            }
+
+            let start_offset = header_size + point_offset as usize * item_size;
+            let end_offset = start_offset + item_size;
+            if end_offset as u64 > storage_len {
+                // Out of range, leave as None.
+                continue;
+            }
+
+            storage_reads.push((
+                i,
+                ReadRange {
+                    byte_offset: start_offset as u64,
+                    length: item_size as u64,
+                },
+            ));
+        }
+
+        let reads = storage_reads
+            .iter()
+            .map(|(i, range)| (*i, &self.storage, *range));
+
+        for read_result in S::read_multi_iter::<Random, _>(reads)? {
+            let (i, bytes) = read_result?;
+            #[expect(deprecated, reason = "legacy code")]
+            let opt: &Optional<ValuePointer> = unsafe { transmute_from_u8(bytes.as_ref()) };
+            result[i] = opt.is_some().copied();
+        }
+
+        Ok(result)
+    }
+
     /// Iterate over the pointers in the tracker
     /// Starts from the given point offset
     pub fn iter_pointers(

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -273,6 +273,7 @@ impl From<GridstoreError> for OperationError {
                 Self::service_error(format!("Gridstore IO error: {err}"))
             }
             GridstoreError::PageNotFound { .. } => Self::service_error(err.to_string()),
+            GridstoreError::ValueNotFound { .. } => Self::service_error(err.to_string()),
         }
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -101,16 +101,6 @@ impl<
     }
 
     #[inline]
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
-    #[inline]
     fn score(&self, against: &[TElement]) -> ScoreType {
         let cpu_counter = self.hardware_counter.cpu_counter();
 

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -87,16 +87,6 @@ impl<
     }
 
     #[inline]
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
-    #[inline]
     fn score(&self, v2: &[TElement]) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
         TMetric::similarity(&self.query, v2)

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -7,7 +7,6 @@ use crate::data_types::vectors::TypedMultiDenseVectorRef;
 use crate::spaces::metric::Metric;
 use crate::types::{MultiVectorComparator, MultiVectorConfig};
 use crate::vector_storage::VectorOffset;
-use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 
 pub mod custom_query_scorer;
 pub mod metric_query_scorer;
@@ -21,26 +20,12 @@ pub trait QueryScorer {
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType;
 
-    #[inline]
-    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        assert_eq!(ids.len(), scores.len());
-
-        let batched_ids = ids.chunks(VECTOR_READ_BATCH_SIZE);
-        let batched_scores = scores.chunks_mut(VECTOR_READ_BATCH_SIZE);
-
-        for (ids, scores) in batched_ids.zip(batched_scores) {
-            self.score_stored_batch_impl(ids, scores);
-        }
-    }
-
     /// Score a batch of points
     ///
-    /// Enable underlying storage to optimize pre-fetching of data
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(ids.len() <= VECTOR_READ_BATCH_SIZE);
+    /// Enables underlying storage to optimize pre-fetching of data
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
-        // no specific implementation for batch scoring
         for (idx, id) in ids.iter().enumerate() {
             scores[idx] = self.score_stored(*id);
         }

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -135,15 +135,6 @@ impl<
             });
     }
 
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
     #[inline]
     fn score(&self, against: &TypedMultiDenseVector<TElement>) -> ScoreType {
         self.score_ref(TypedMultiDenseVectorRef::from(against))

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -120,15 +120,6 @@ impl<
             });
     }
 
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         let v1 = self.vector_storage.get_multi::<Random>(point_a);
         let v2 = self.vector_storage.get_multi::<Random>(point_b);

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -69,11 +69,7 @@ impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScor
             .vector_io_read()
             .incr_delta(stored.indices.len() + stored.values.len());
 
-        self.query.score_by(|example| {
-            let cpu_units = example.indices.len() + stored.indices.len();
-            self.hardware_counter.cpu_counter().incr_delta(cpu_units);
-            stored.score(example).unwrap_or(0.0)
-        })
+        self.score(&stored)
     }
 
     fn score(&self, v: &SparseVector) -> ScoreType {
@@ -82,6 +78,30 @@ impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScor
             self.hardware_counter.cpu_counter().incr_delta(cpu_units);
             example.score(v).unwrap_or(0.0)
         })
+    }
+
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(ids.len(), scores.len());
+
+        self.vector_storage
+            .for_each_in_sparse_batch(ids, |idx, vector| {
+                // not exactly correct for Gridstore where the indices are compressed into u8
+                self.hardware_counter
+                    .vector_io_read()
+                    .incr_delta(vector.indices.len() + vector.values.len());
+
+                scores[idx] = self.score(&vector);
+            })
+            .expect("sparse vectors read");
+    }
+
+    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert!(
+            false,
+            "score_stored_batch_impl should not be used, use score_stored_batch instead"
+        );
+
+        self.score_stored_batch(ids, scores); // fallback
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -95,15 +95,6 @@ impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScor
             .expect("sparse vectors read");
     }
 
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {
         unimplemented!("Custom scorer can compare against multiple vectors, not just one")
     }

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -66,17 +66,25 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
         self.score_ref(v2)
     }
 
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+    #[inline]
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
-        for idx in 0..ids.len() {
-            scores[idx] = self.score_ref(
-                &self
-                    .vector_storage
-                    .get_sparse::<Random>(ids[idx])
-                    .expect("Sparse vector not found"),
-            );
-        }
+        self.vector_storage
+            .for_each_in_sparse_batch(ids, |idx, vector| {
+                scores[idx] = self.score_ref(&vector);
+            })
+            .expect("sparse vectors read");
+    }
+
+    #[inline]
+    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert!(
+            false,
+            "score_stored_batch_impl should not be used, use score_stored_batch instead"
+        );
+
+        self.score_stored_batch(ids, scores); // fallback
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -77,16 +77,6 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
             .expect("sparse vectors read");
     }
 
-    #[inline]
-    fn score_stored_batch_impl(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert!(
-            false,
-            "score_stored_batch_impl should not be used, use score_stored_batch instead"
-        );
-
-        self.score_stored_batch(ids, scores); // fallback
-    }
-
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         let v1 = self
             .vector_storage

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -59,6 +59,17 @@ impl SparseVectorStorage for EmptySparseVectorStorage {
     ) -> OperationResult<Option<SparseVector>> {
         Ok(None)
     }
+
+    fn for_each_in_sparse_batch<F>(
+        &self,
+        _keys: &[PointOffsetType],
+        _callback: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(usize, SparseVector),
+    {
+        Ok(())
+    }
 }
 
 impl VectorStorage for EmptySparseVectorStorage {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -203,16 +203,16 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
     where
         F: FnMut(usize, SparseVector),
     {
-        self.storage.for_each_in_batch::<Random, _>(
+        self.storage.for_each_in_batch::<Random, _, OperationError>(
             keys,
             |idx, vector| {
-                let vector = SparseVector::try_from(vector).expect("valid sparse vector");
-                callback(idx, vector);
+                if let Some(vector) = vector {
+                    callback(idx, SparseVector::try_from(vector)?);
+                }
+                Ok(())
             },
             &HardwareCounterCell::disposable(),
-        )?;
-
-        Ok(())
+        )
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::AccessPattern;
+use common::generic_consts::{AccessPattern, Random};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use fs_err as fs;
@@ -193,6 +193,26 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
             .get_value::<P>(key, &HardwareCounterCell::disposable())? // Vector storage read IO not measured
             .map(SparseVector::try_from)
             .transpose()
+    }
+
+    fn for_each_in_sparse_batch<F>(
+        &self,
+        keys: &[PointOffsetType],
+        mut callback: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(usize, SparseVector),
+    {
+        self.storage.for_each_in_batch::<Random, _>(
+            keys,
+            |idx, vector| {
+                let vector = SparseVector::try_from(vector).expect("valid sparse vector");
+                callback(idx, vector);
+            },
+            &HardwareCounterCell::disposable(),
+        )?;
+
+        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -113,6 +113,22 @@ impl SparseVectorStorage for VolatileSparseVectorStorage {
         let opt_vector = self.vectors.get(key as usize).cloned().flatten();
         Ok(opt_vector)
     }
+
+    fn for_each_in_sparse_batch<F>(
+        &self,
+        keys: &[PointOffsetType],
+        mut callback: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(usize, SparseVector),
+    {
+        for (idx, &key) in keys.iter().enumerate() {
+            let vector = self.get_sparse::<Random>(key)?;
+            callback(idx, vector);
+        }
+
+        Ok(())
+    }
 }
 
 impl VectorStorage for VolatileSparseVectorStorage {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -206,6 +206,22 @@ pub trait SparseVectorStorage: VectorStorage {
         &self,
         key: PointOffsetType,
     ) -> OperationResult<Option<SparseVector>>;
+
+    fn for_each_in_sparse_batch<F>(
+        &self,
+        keys: &[PointOffsetType],
+        mut callback: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(usize, SparseVector),
+    {
+        for (idx, &key) in keys.iter().enumerate() {
+            let vector = self.get_sparse::<Random>(key)?;
+            callback(idx, vector);
+        }
+
+        Ok(())
+    }
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -210,18 +210,10 @@ pub trait SparseVectorStorage: VectorStorage {
     fn for_each_in_sparse_batch<F>(
         &self,
         keys: &[PointOffsetType],
-        mut callback: F,
+        callback: F,
     ) -> OperationResult<()>
     where
-        F: FnMut(usize, SparseVector),
-    {
-        for (idx, &key) in keys.iter().enumerate() {
-            let vector = self.get_sparse::<Random>(key)?;
-            callback(idx, vector);
-        }
-
-        Ok(())
-    }
+        F: FnMut(usize, SparseVector);
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {


### PR DESCRIPTION
Similar to #8685 and #8702. Refactor `Sparse*QueryScorer` (and `Gridstore`), so that it utilizes `UniversalRead::read_multi_iter` instead of single `read`s.

**TODO:**
- [x] error handling
- [ ] benchmarks

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
