### PR TITLE
[UIO] Dynamic mmap flags

### DIFF
--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -189,17 +189,20 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
     /// written via a single `write_batch` call.
     ///
     /// Assumes the indices for the `updates` iterator increase monotonically
-    pub fn set_ascending_bits_batch(
+    pub fn set_ascending_bits_batch<TKey>(
         &mut self,
-        updates: impl IntoIterator<Item = (u64, bool)>,
-    ) -> Result<()> {
+        updates: impl IntoIterator<Item = (TKey, bool)>,
+    ) -> Result<()>
+    where
+        TKey: num_traits::cast::AsPrimitive<u64>,
+    {
         // Group updates into runs of consecutive elements. A new run starts
         // whenever the element index jumps by more than 1.
         let mut prev_element: Option<u64> = None;
         let mut run_start = 0u64;
 
         let runs = updates.into_iter().chunk_by(move |(bit_idx, _)| {
-            let element_idx = Self::element_idx(*bit_idx);
+            let element_idx = Self::element_idx(bit_idx.as_());
             if prev_element.is_none_or(|prev| element_idx > prev + 1) {
                 run_start = element_idx;
             }
@@ -212,7 +215,7 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
         for (element_start, run_updates) in &runs {
             let run_updates: Vec<_> = run_updates.collect();
 
-            let last_element = Self::element_idx(run_updates.last().unwrap().0);
+            let last_element = Self::element_idx(run_updates.last().unwrap().0.as_());
             let num_elements = last_element - element_start + 1;
             if element_start + num_elements > self.element_len {
                 return Err(UniversalIoError::OutOfBounds {
@@ -233,7 +236,7 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
 
             for (bit_idx, value) in run_updates {
                 let bit_offset =
-                    bit_idx as usize - (element_start as usize * BITS_PER_ELEMENT as usize);
+                    bit_idx.as_() as usize - (element_start as usize * BITS_PER_ELEMENT as usize);
                 bitslice.set(bit_offset, value);
             }
 
@@ -545,7 +548,7 @@ mod tests {
 
         // Empty batch is a no-op
         storage
-            .set_ascending_bits_batch(std::iter::empty())
+            .set_ascending_bits_batch(std::iter::empty::<(usize, bool)>())
             .unwrap();
         assert_bits(&storage, |i| matches!(i / 64, 0 | 3 | 7 | 111));
     }

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -284,6 +284,39 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
         self.storage.write(0, &buf)
     }
 
+    /// Read-modify-write a single bit. Returns the previous value.
+    ///
+    /// Only writes to the backend if the element actually changed.
+    pub fn replace_bit(&mut self, bit_index: u64, value: bool) -> Result<bool> {
+        let element_index = Self::element_idx(bit_index);
+        let bit_within_element = Self::bit_within_element(bit_index);
+
+        if element_index >= self.element_len {
+            return Err(UniversalIoError::OutOfBounds {
+                start: bit_index,
+                end: bit_index + 1,
+                elements: self.bit_len() as usize,
+            });
+        }
+
+        let mut element = self
+            .storage
+            .read::<Random>(ReadRange::one(element_index * size_of::<BitStore>() as u64))?[0];
+
+        let element = &mut element;
+
+        let bitslice = BitSlice::from_element_mut(element);
+
+        let old_bit = bitslice.replace(bit_within_element as usize, value);
+
+        if old_bit != value {
+            self.storage
+                .write(element_index * size_of::<BitStore>() as u64, &[*element])?;
+        }
+
+        Ok(old_bit)
+    }
+
     /// Get a flusher for the underlying storage.
     pub fn flusher(&self) -> Flusher {
         self.storage.flusher()
@@ -297,41 +330,6 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::*;
-
-    impl<S: UniversalWrite<BitStore>> StoredBitSlice<S> {
-        /// Read-modify-write a single bit. Returns the previous value.
-        ///
-        /// Only writes to the backend if the element actually changed.
-        pub fn replace_bit(&mut self, bit_index: u64, value: bool) -> Result<bool> {
-            let element_index = Self::element_idx(bit_index);
-            let bit_within_element = Self::bit_within_element(bit_index);
-
-            if element_index >= self.element_len {
-                return Err(UniversalIoError::OutOfBounds {
-                    start: bit_index,
-                    end: bit_index + 1,
-                    elements: self.bit_len() as usize,
-                });
-            }
-
-            let mut element = self
-                .storage
-                .read::<Random>(ReadRange::one(element_index * size_of::<BitStore>() as u64))?[0];
-
-            let element = &mut element;
-
-            let bitslice = BitSlice::from_element_mut(element);
-
-            let old_bit = bitslice.replace(bit_within_element as usize, value);
-
-            if old_bit != value {
-                self.storage
-                    .write(element_index * size_of::<BitStore>() as u64, &[*element])?;
-            }
-
-            Ok(old_bit)
-        }
-    }
 
     fn create_temp_file(data: &[u8]) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -189,20 +189,17 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
     /// written via a single `write_batch` call.
     ///
     /// Assumes the indices for the `updates` iterator increase monotonically
-    pub fn set_ascending_bits_batch<TKey>(
+    pub fn set_ascending_bits_batch(
         &mut self,
-        updates: impl IntoIterator<Item = (TKey, bool)>,
-    ) -> Result<()>
-    where
-        TKey: num_traits::cast::AsPrimitive<u64>,
-    {
+        updates: impl IntoIterator<Item = (u64, bool)>,
+    ) -> Result<()> {
         // Group updates into runs of consecutive elements. A new run starts
         // whenever the element index jumps by more than 1.
         let mut prev_element: Option<u64> = None;
         let mut run_start = 0u64;
 
         let runs = updates.into_iter().chunk_by(move |(bit_idx, _)| {
-            let element_idx = Self::element_idx(bit_idx.as_());
+            let element_idx = Self::element_idx(*bit_idx);
             if prev_element.is_none_or(|prev| element_idx > prev + 1) {
                 run_start = element_idx;
             }
@@ -215,7 +212,7 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
         for (element_start, run_updates) in &runs {
             let run_updates: Vec<_> = run_updates.collect();
 
-            let last_element = Self::element_idx(run_updates.last().unwrap().0.as_());
+            let last_element = Self::element_idx(run_updates.last().unwrap().0);
             let num_elements = last_element - element_start + 1;
             if element_start + num_elements > self.element_len {
                 return Err(UniversalIoError::OutOfBounds {
@@ -236,7 +233,7 @@ impl<S: UniversalWrite<u64>> StoredBitSlice<S> {
 
             for (bit_idx, value) in run_updates {
                 let bit_offset =
-                    bit_idx.as_() as usize - (element_start as usize * BITS_PER_ELEMENT as usize);
+                    bit_idx as usize - (element_start as usize * BITS_PER_ELEMENT as usize);
                 bitslice.set(bit_offset, value);
             }
 
@@ -548,7 +545,7 @@ mod tests {
 
         // Empty batch is a no-op
         storage
-            .set_ascending_bits_batch(std::iter::empty::<(usize, bool)>())
+            .set_ascending_bits_batch(std::iter::empty::<(u64, bool)>())
             .unwrap();
         assert_bits(&storage, |i| matches!(i / 64, 0 | 3 | 7 | 111));
     }

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -22,11 +22,16 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
     // Build dynamic mmap flags with random deletions
     let mut dynamic_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
     dynamic_flags.set_len(FLAG_COUNT).unwrap();
-    random_flags
-        .iter()
-        .enumerate()
-        .filter(|(_, flag)| **flag)
-        .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true).unwrap()));
+    dynamic_flags
+        .set_ascending_bits(
+            random_flags
+                .iter()
+                .enumerate()
+                .filter(|(_, flag)| **flag)
+                .map(|(i, _)| (i, true)),
+        )
+        .unwrap();
+
     dynamic_flags.flusher()().unwrap();
     let real_count = random_flags.iter().filter(|&&flag| flag).count();
 

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -28,7 +28,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
                 .iter()
                 .enumerate()
                 .filter(|(_, flag)| **flag)
-                .map(|(i, _)| (i, true)),
+                .map(|(i, _)| (i as u64, true)),
         )
         .unwrap();
 

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -26,7 +26,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
         .iter()
         .enumerate()
         .filter(|(_, flag)| **flag)
-        .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true)));
+        .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true).unwrap()));
     dynamic_flags.flusher()().unwrap();
     let real_count = random_flags.iter().filter(|&&flag| flag).count();
 
@@ -36,7 +36,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
         b.iter(|| {
             let mut count = 0;
             for i in 0..FLAG_COUNT {
-                if dynamic_flags.get(i) {
+                if dynamic_flags.get(i).unwrap() {
                     count += 1;
                 }
                 check_process_stopped(&stopped).unwrap();
@@ -50,7 +50,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
         b.iter(|| {
             let mut count = 0;
             for i in 0..FLAG_COUNT {
-                if dynamic_flags.get(i) {
+                if dynamic_flags.get(i).unwrap() {
                     count += 1;
                 }
             }
@@ -61,7 +61,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
 
     group.bench_function("count-ones", |b| {
         b.iter(|| {
-            let count = dynamic_flags.count_flags();
+            let count = dynamic_flags.count_flags().unwrap();
             assert_eq!(count, real_count);
             black_box(count)
         });

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -28,19 +28,19 @@ pub struct BitvecFlags {
 }
 
 impl BitvecFlags {
-    pub fn new(mmap_flags: DynamicMmapFlags) -> Self {
+    pub fn new(mmap_flags: DynamicMmapFlags) -> OperationResult<Self> {
         // load flags into memory
-        let bitvec = BitVec::from_bitslice(mmap_flags.get_bitslice());
+        let bitvec = BitVec::from_bitslice(&*mmap_flags.get_bitslice()?);
 
         if let Err(err) = mmap_flags.clear_cache() {
             log::warn!("Failed to clear bitslice cache: {err}");
         }
 
-        Self {
+        Ok(Self {
             len: mmap_flags.len(),
             storage: BufferedDynamicFlags::new(mmap_flags),
             bitvec,
-        }
+        })
     }
 
     pub fn len(&self) -> usize {
@@ -134,7 +134,7 @@ mod tests {
         // Create and update flags
         {
             let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
-            let mut bitvec_flags = BitvecFlags::new(mmap_flags);
+            let mut bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
             for i in 16..20 {
@@ -163,7 +163,7 @@ mod tests {
         // Verify bitmap consistency after reload
         {
             let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
-            let bitvec_flags = BitvecFlags::new(mmap_flags);
+            let bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload
             let iter_trues: Vec<_> = bitvec_flags.iter_trues().collect();

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -97,7 +97,7 @@ impl BufferedDynamicFlags {
             flags_guard.set_ascending_bits(
                 updates
                     .iter()
-                    .map(|(index, value)| (*index, *value))
+                    .map(|(index, value)| (u64::from(*index), *value))
                     .sorted_by_key(|(index, _value)| *index),
             )?;
 

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -94,7 +94,7 @@ impl BufferedDynamicFlags {
             }
 
             for (&index, &value) in &updates {
-                flags_guard.set(index as usize, value);
+                flags_guard.set(index as usize, value)?;
             }
 
             flags_guard.flusher()()?;
@@ -142,8 +142,8 @@ mod tests {
         {
             let mut mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
             mmap_flags.set_len(3).unwrap();
-            mmap_flags.set(0, true);
-            mmap_flags.set(2, true);
+            mmap_flags.set(0, true).unwrap();
+            mmap_flags.set(2, true).unwrap();
             mmap_flags.flusher()().unwrap();
         }
 
@@ -155,7 +155,7 @@ mod tests {
             let flags = buffered_flags.storage.lock();
 
             // Initial state should match
-            assert_eq!(flags.count_flags(), 2);
+            assert_eq!(flags.count_flags().unwrap(), 2);
             assert_eq!(flags.len(), 3);
 
             drop(flags);
@@ -183,11 +183,11 @@ mod tests {
             let flags = buffered_flags.storage.lock();
 
             let expected_trues = vec![0, 1, 2, 5, 7];
-            let actual_trues: Vec<_> = flags.iter_trues().collect();
+            let actual_trues: Vec<_> = flags.iter_trues().unwrap().collect();
             assert_eq!(actual_trues, expected_trues);
 
-            assert_eq!(flags.count_flags(), 5);
-            assert_eq!(flags.len() - flags.count_flags(), 4);
+            assert_eq!(flags.count_flags().unwrap(), 5);
+            assert_eq!(flags.len() - flags.count_flags().unwrap(), 4);
         }
     }
 
@@ -209,7 +209,7 @@ mod tests {
             mmap_flags.set_len(num_flags).unwrap();
 
             for (i, &value) in initial_flags.iter().enumerate() {
-                mmap_flags.set(i, value);
+                mmap_flags.set(i, value).unwrap();
             }
 
             mmap_flags.flusher()().unwrap();
@@ -234,7 +234,7 @@ mod tests {
             // Verify initial state loaded correctly
             let initial_true_count = initial_flags.iter().filter(|&&b| b).count();
             assert_eq!(
-                buffered_flags.storage.lock().count_flags(),
+                buffered_flags.storage.lock().count_flags().unwrap(),
                 initial_true_count
             );
 
@@ -261,13 +261,13 @@ mod tests {
 
             let expected_true_count = expected_state.iter().filter(|&&b| b).count();
             let flags = buffered_flags.storage.lock();
-            assert_eq!(flags.count_flags(), expected_true_count);
+            assert_eq!(flags.count_flags().unwrap(), expected_true_count);
             assert_eq!(flags.len(), num_flags);
 
             // Verify specific values for a sample
             for i in (0..num_flags).step_by(100) {
                 let expected = expected_state[i];
-                let actual = flags.get(i);
+                let actual = flags.get(i).unwrap();
                 assert_eq!(actual, expected, "Mismatch at index {i}");
             }
         }
@@ -317,7 +317,7 @@ mod tests {
                 let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
                 for (i, &expected) in expected_state.iter().enumerate() {
-                    let actual = buffered_flags.storage.lock().get(i);
+                    let actual = buffered_flags.storage.lock().get(i).unwrap();
                     assert_eq!(
                         actual, expected,
                         "Cycle {cycle_num}, index {i}: expected {expected}, got {actual}"
@@ -326,7 +326,7 @@ mod tests {
 
                 let expected_true_count = expected_state.iter().filter(|&&b| b).count();
                 assert_eq!(
-                    buffered_flags.storage.lock().count_flags(),
+                    buffered_flags.storage.lock().count_flags().unwrap(),
                     expected_true_count
                 );
             }
@@ -359,11 +359,11 @@ mod tests {
             let flags = buffered_flags.storage.lock();
 
             assert_eq!(flags.len(), 1);
-            assert_eq!(flags.count_flags(), 1);
-            assert_eq!(flags.len() - flags.count_flags(), 0);
-            assert!(flags.get(0));
+            assert_eq!(flags.count_flags().unwrap(), 1);
+            assert_eq!(flags.len() - flags.count_flags().unwrap(), 0);
+            assert!(flags.get(0).unwrap());
 
-            let trues: Vec<_> = flags.iter_trues().collect();
+            let trues: Vec<_> = flags.iter_trues().unwrap().collect();
             assert_eq!(trues, vec![0]);
         }
     }
@@ -398,20 +398,20 @@ mod tests {
             let flags = buffered_flags.storage.lock();
 
             assert_eq!(flags.len(), 100001);
-            assert_eq!(flags.count_flags(), 4);
+            assert_eq!(flags.count_flags().unwrap(), 4);
 
             // Verify specific indices
-            assert!(flags.get(0));
-            assert!(flags.get(1000));
-            assert!(flags.get(50000));
-            assert!(flags.get(100000));
+            assert!(flags.get(0).unwrap());
+            assert!(flags.get(1000).unwrap());
+            assert!(flags.get(50000).unwrap());
+            assert!(flags.get(100000).unwrap());
 
             // Verify some gaps are false
-            assert!(!flags.get(500));
-            assert!(!flags.get(25000));
-            assert!(!flags.get(75000));
+            assert!(!flags.get(500).unwrap());
+            assert!(!flags.get(25000).unwrap());
+            assert!(!flags.get(75000).unwrap());
 
-            let trues: Vec<_> = flags.iter_trues().collect();
+            let trues: Vec<_> = flags.iter_trues().unwrap().collect();
             assert_eq!(trues, vec![0, 1000, 50000, 100000]);
         }
     }
@@ -428,7 +428,7 @@ mod tests {
             let mut mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
             mmap_flags.set_len(10).unwrap();
             for i in 0..10 {
-                mmap_flags.set(i, i % 2 == 0); // Even indices true
+                mmap_flags.set(i, i % 2 == 0).unwrap(); // Even indices true
             }
             mmap_flags.flusher()().unwrap();
         }
@@ -439,7 +439,7 @@ mod tests {
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Initial state: [true, false, true, false, true, false, true, false, true, false]
-            assert_eq!(buffered_flags.storage.lock().count_flags(), 5);
+            assert_eq!(buffered_flags.storage.lock().count_flags().unwrap(), 5);
 
             // First overwrite: flip all values
             for i in 0..10 {
@@ -467,14 +467,14 @@ mod tests {
 
             let flags = buffered_flags.storage.lock();
 
-            assert_eq!(flags.count_flags(), 0);
-            assert_eq!(flags.len() - flags.count_flags(), 10);
+            assert_eq!(flags.count_flags().unwrap(), 0);
+            assert_eq!(flags.len() - flags.count_flags().unwrap(), 10);
 
             for i in 0..10 {
-                assert!(!flags.get(i), "Index {i} should be false");
+                assert!(!flags.get(i).unwrap(), "Index {i} should be false");
             }
 
-            let trues: Vec<_> = flags.iter_trues().collect();
+            let trues: Vec<_> = flags.iter_trues().unwrap().collect();
             assert!(trues.is_empty());
         }
     }

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
+use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 
 use super::dynamic_mmap_flags::DynamicMmapFlags;
@@ -93,9 +94,12 @@ impl BufferedDynamicFlags {
                 flags_guard.set_len(required_len)?;
             }
 
-            for (&index, &value) in &updates {
-                flags_guard.set(index as usize, value)?;
-            }
+            flags_guard.set_ascending_bits(
+                updates
+                    .iter()
+                    .map(|(index, value)| (*index, *value))
+                    .sorted_by_key(|(index, _value)| *index),
+            )?;
 
             flags_guard.flusher()()?;
 

--- a/lib/segment/src/common/flags/dynamic_mmap_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_mmap_flags.rs
@@ -176,15 +176,11 @@ impl DynamicMmapFlags {
         Ok(())
     }
 
-    pub fn get<TKey>(&self, key: TKey) -> OperationResult<bool>
-    where
-        TKey: num_traits::cast::AsPrimitive<usize>,
-    {
-        let key: usize = key.as_();
-        if key >= self.status.len {
+    pub fn get(&self, index: usize) -> OperationResult<bool> {
+        if index >= self.status.len {
             return Ok(false);
         }
-        Ok(self.flags.get_bit(key as u64)?.unwrap_or(false))
+        Ok(self.flags.get_bit(index as u64)?.unwrap_or(false))
     }
 
     /// Count number of set flags
@@ -202,29 +198,19 @@ impl DynamicMmapFlags {
     /// Ignore the call if the index is out of bounds.
     ///
     /// Returns previous value of the flag.
-    #[cfg_attr(
-        not(test),
-        deprecated = "use `set_ascending_bits` for persisting in batch"
-    )]
-    pub fn set<TKey>(&mut self, key: TKey, value: bool) -> OperationResult<bool>
-    where
-        TKey: num_traits::cast::AsPrimitive<usize>,
-    {
-        let key: usize = key.as_();
-        debug_assert!(key < self.status.len);
-        if key >= self.status.len {
+    #[cfg(any(test, feature = "testing"))]
+    pub fn set(&mut self, index: usize, value: bool) -> OperationResult<bool> {
+        debug_assert!(index < self.status.len);
+        if index >= self.status.len {
             return Ok(false);
         }
-        Ok(self.flags.replace_bit(key as u64, value)?)
+        Ok(self.flags.replace_bit(index as u64, value)?)
     }
 
-    pub fn set_ascending_bits<TKey>(
+    pub fn set_ascending_bits(
         &mut self,
-        updates: impl IntoIterator<Item = (TKey, bool)>,
-    ) -> OperationResult<()>
-    where
-        TKey: num_traits::cast::AsPrimitive<u64>,
-    {
+        updates: impl IntoIterator<Item = (u64, bool)>,
+    ) -> OperationResult<()> {
         Ok(self.flags.set_ascending_bits_batch(updates)?)
     }
 

--- a/lib/segment/src/common/flags/dynamic_mmap_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_mmap_flags.rs
@@ -1,15 +1,15 @@
+use std::borrow::Cow;
 use std::cmp::max;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::counter::referenced_counter::HwMetricRefCounter;
-use common::mmap::{
-    AdviceSetting, Madviseable as _, MmapBitSlice, MmapType, advice, create_and_ensure_length,
-    open_write_mmap,
-};
+use common::mmap::{AdviceSetting, MmapType, create_and_ensure_length, open_write_mmap};
+use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
+use common::universal_io::{MmapFile, OpenOptions};
 use fs_err as fs;
+use itertools::Either;
 use memmap2::MmapMut;
 
 use crate::common::Flusher;
@@ -50,7 +50,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
 
 pub struct DynamicMmapFlags {
     /// Current mmap'ed BitSlice for flags
-    flags: MmapBitSlice,
+    flags: StoredBitSlice<MmapFile>,
     status: MmapType<DynamicMmapStatus>,
     directory: PathBuf,
 }
@@ -65,17 +65,11 @@ impl fmt::Debug for DynamicMmapFlags {
     }
 }
 
-/// Based on the number of flags determines the size of the mmap file.
-fn mmap_capacity_bytes(num_flags: usize) -> usize {
+/// Based on the number of flags determines the size in bytes for the storage file.
+fn file_size_for(num_flags: usize) -> usize {
     let number_of_bytes = num_flags.div_ceil(u8::BITS as usize);
 
     max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
-}
-
-/// Based on the current length determines how many flags can fit into the mmap file without resizing it.
-fn mmap_max_current_size(len: usize) -> usize {
-    let mmap_capacity_bytes = mmap_capacity_bytes(len);
-    mmap_capacity_bytes * u8::BITS as usize
 }
 
 impl DynamicMmapFlags {
@@ -103,7 +97,7 @@ impl DynamicMmapFlags {
         }
 
         // Open first mmap
-        let flags = Self::open_mmap(status.len, directory, populate)?;
+        let flags = Self::open_storage(status.len, directory, populate)?;
         Ok(Self {
             flags,
             status,
@@ -111,36 +105,30 @@ impl DynamicMmapFlags {
         })
     }
 
-    fn open_mmap(
+    fn open_storage(
         num_flags: usize,
         directory: &Path,
         populate: bool,
     ) -> OperationResult<MmapBitSlice> {
-        let capacity_bytes = mmap_capacity_bytes(num_flags);
+        let capacity_bytes = file_size_for(num_flags);
+        let path = directory.join(FLAGS_FILE);
 
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
-            .open(directory.join(FLAGS_FILE))?;
+            .open(&path)?;
         file.set_len(capacity_bytes as u64)?;
-
-        let flags_mmap = unsafe { MmapMut::map_mut(&file)? };
         drop(file);
 
-        flags_mmap.madvise(advice::get_global())?;
-
-        if populate {
-            flags_mmap.populate();
-        } else {
-            #[cfg(unix)]
-            if let Err(err) = flags_mmap.advise(memmap2::Advice::WillNeed) {
-                log::error!("Failed to advise MADV_WILLNEED for deleted flags: {err}");
-            }
-        }
-
-        let flags = MmapBitSlice::try_from(flags_mmap, 0)?;
+        let options = OpenOptions {
+            writeable: true,
+            populate: Some(populate),
+            advice: Some(AdviceSetting::Global),
+            ..Default::default()
+        };
+        let flags = MmapBitSlice::open(&path, options)?;
         Ok(flags)
     }
 
@@ -164,7 +152,7 @@ impl DynamicMmapFlags {
         }
 
         // Capacity can be up to 2x the current length
-        let current_capacity = mmap_max_current_size(self.status.len);
+        let current_capacity = usize::try_from(self.flags.bit_len()).expect("bit_len fits usize");
 
         if new_len > current_capacity {
             // Flush the current mmaps before resizing
@@ -172,7 +160,7 @@ impl DynamicMmapFlags {
 
             // Don't read the whole file on resize
             let populate = false;
-            let flags = Self::open_mmap(new_len, &self.directory, populate)?;
+            let flags = Self::open_storage(new_len, &self.directory, populate)?;
 
             // Swap operation. It is important this section is not interrupted by errors.
             self.flags = flags;
@@ -182,70 +170,42 @@ impl DynamicMmapFlags {
         Ok(())
     }
 
-    pub fn get<TKey>(&self, key: TKey) -> bool
+    pub fn get<TKey>(&self, key: TKey) -> OperationResult<bool>
     where
         TKey: num_traits::cast::AsPrimitive<usize>,
     {
         let key: usize = key.as_();
         if key >= self.status.len {
-            return false;
+            return Ok(false);
         }
-        self.flags[key]
+        Ok(self.flags.get_bit(key as u64)?.unwrap_or(false))
     }
 
     /// Count number of set flags
-    pub fn count_flags(&self) -> usize {
+    pub fn count_flags(&self) -> OperationResult<usize> {
         // Take a bitslice of our set length, count ones in it
         // This uses bit-indexing, returning a new bitslice, extra bits within capacity are not counted
-        self.flags[..self.status.len].count_ones()
+        let bits = self.flags.read_all()?;
+        Ok(bits
+            .get(..self.status.len)
+            .map(|s| s.count_ones())
+            .unwrap_or(0))
     }
 
     /// Set the `true` value of the flag at the given index.
     /// Ignore the call if the index is out of bounds.
     ///
     /// Returns previous value of the flag.
-    pub fn set<TKey>(&mut self, key: TKey, value: bool) -> bool
+    pub fn set<TKey>(&mut self, key: TKey, value: bool) -> OperationResult<bool>
     where
         TKey: num_traits::cast::AsPrimitive<usize>,
     {
         let key: usize = key.as_();
         debug_assert!(key < self.status.len);
         if key >= self.status.len {
-            return false;
+            return Ok(false);
         }
-        self.flags.replace(key, value)
-    }
-
-    /// This method will set the flag at the given index to the given value.
-    /// If current length is not enough, it will resize the flags with amortized cost (x2)
-    /// All new flags will be set to false.
-    ///
-    /// Returns previous value of the flag.
-    pub fn set_with_resize<TKey>(
-        &mut self,
-        key: TKey,
-        value: bool,
-        hw_counter_ref: HwMetricRefCounter,
-    ) -> OperationResult<bool>
-    where
-        TKey: num_traits::cast::AsPrimitive<usize>,
-    {
-        // Measure write of single bool.
-        hw_counter_ref.incr_delta(size_of::<bool>());
-
-        let key: usize = key.as_();
-        if key >= self.status.len {
-            if value {
-                let new_len = key + 1;
-                hw_counter_ref.incr_delta(new_len - self.status.len);
-                self.set_len(new_len)?;
-            } else {
-                // Default value is false, so we don't need to resize
-                return Ok(false);
-            }
-        }
-
-        Ok(self.flags.replace(key, value))
+        Ok(self.flags.replace_bit(key as u64, value)?)
     }
 
     pub fn flusher(&self) -> Flusher {
@@ -260,10 +220,17 @@ impl DynamicMmapFlags {
         })
     }
 
-    pub fn get_bitslice(&self) -> &BitSlice {
+    pub fn get_bitslice(&self) -> OperationResult<Cow<'_, BitSlice>> {
         // Take subslice with actual length, bitslice may be larger due to extra allocated capacity
         // See `mmap_capacity_bytes`
-        &self.flags[..self.len()]
+        let len = self.len();
+        Ok(match self.flags.read_all()? {
+            Cow::Borrowed(bitslice) => Cow::Borrowed(&bitslice[..len]),
+            Cow::Owned(mut bitvec) => {
+                bitvec.truncate(len);
+                Cow::Owned(bitvec)
+            }
+        })
     }
 
     // no immutable files, everything is mutable
@@ -275,8 +242,21 @@ impl DynamicMmapFlags {
     }
 
     /// Iterate over all "true" flags
-    pub fn iter_trues(&self) -> impl Iterator<Item = PointOffsetType> + '_ {
-        self.flags.iter_ones().map(|x| x as PointOffsetType)
+    pub fn iter_trues(&self) -> OperationResult<impl Iterator<Item = PointOffsetType> + '_> {
+        Ok(match self.flags.read_all()? {
+            Cow::Borrowed(bitslice) => {
+                Either::Left(bitslice.iter_ones().map(|x| x as PointOffsetType))
+            }
+            Cow::Owned(bitvec) => {
+                // Owned path: backend doesn't support zero-copy; materialize into Vec
+                // so we don't return a reference to a local
+                let indices: Vec<PointOffsetType> = bitvec
+                    .iter_ones()
+                    .map(|x| x as PointOffsetType)
+                    .collect();
+                Either::Right(indices.into_iter())
+            }
+        })
     }
 
     /// Populate all pages in the mmap.
@@ -293,7 +273,7 @@ impl DynamicMmapFlags {
             status: _,
             directory: _,
         } = self;
-        flags.clear_cache()?;
+        flags.clear_ram_cache()?;
         Ok(())
     }
 }
@@ -323,14 +303,14 @@ mod tests {
                 .iter()
                 .enumerate()
                 .filter(|(_, flag)| **flag)
-                .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true)));
+                .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true).unwrap()));
 
             dynamic_flags.set_len(num_flags * 2).unwrap();
             random_flags
                 .iter()
                 .enumerate()
                 .filter(|(_, flag)| !*flag)
-                .for_each(|(i, _)| assert!(!dynamic_flags.set(num_flags + i, true)));
+                .for_each(|(i, _)| assert!(!dynamic_flags.set(num_flags + i, true).unwrap()));
 
             dynamic_flags.flusher()().unwrap();
         }
@@ -339,8 +319,8 @@ mod tests {
             let dynamic_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
             assert_eq!(dynamic_flags.status.len, num_flags * 2);
             for (i, flag) in random_flags.iter().enumerate() {
-                assert_eq!(dynamic_flags.get(i), *flag);
-                assert_eq!(dynamic_flags.get(num_flags + i), !*flag);
+                assert_eq!(dynamic_flags.get(i).unwrap(), *flag);
+                assert_eq!(dynamic_flags.get(num_flags + i).unwrap(), !*flag);
             }
         }
     }
@@ -359,16 +339,16 @@ mod tests {
             .iter()
             .enumerate()
             .filter(|(_, flag)| **flag)
-            .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true)));
+            .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true).unwrap()));
         dynamic_flags.flusher()().unwrap();
 
         // Test count flags method
-        let count = dynamic_flags.count_flags();
+        let count = dynamic_flags.count_flags().unwrap();
 
         // Compare against manually counting every flag
         let mut manual_count = 0;
         for i in 0..num_flags {
-            if dynamic_flags.get(i) {
+            if dynamic_flags.get(i).unwrap() {
                 manual_count += 1;
             }
         }
@@ -378,11 +358,11 @@ mod tests {
 
     #[test]
     fn test_capacity() {
-        assert_eq!(mmap_capacity_bytes(0), 128);
-        assert_eq!(mmap_capacity_bytes(1), 128);
-        assert_eq!(mmap_capacity_bytes(1023), 128);
-        assert_eq!(mmap_capacity_bytes(1024), 128);
-        assert_eq!(mmap_capacity_bytes(1025), 256);
-        assert_eq!(mmap_capacity_bytes(10000), 2048);
+        assert_eq!(file_size_for(0), 128);
+        assert_eq!(file_size_for(1), 128);
+        assert_eq!(file_size_for(1023), 128);
+        assert_eq!(file_size_for(1024), 128);
+        assert_eq!(file_size_for(1025), 256);
+        assert_eq!(file_size_for(10000), 2048);
     }
 }

--- a/lib/segment/src/common/flags/dynamic_mmap_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_mmap_flags.rs
@@ -48,8 +48,14 @@ fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
     Ok(open_write_mmap(&status_file, AdviceSetting::Global, false)?)
 }
 
+/// Mutable persisted bitslice. This uses no buffering for updates.
+///
+/// For buffered variants, check [`RoaringFlags`][1] or [`BitvecFlags`][2]
+///
+/// [1]: super::roaring_flags::RoaringFlags
+/// [2]: super::bitvec_flags::BitvecFlags
 pub struct DynamicMmapFlags {
-    /// Current mmap'ed BitSlice for flags
+    /// On-disk BitSlice for flags
     flags: StoredBitSlice<MmapFile>,
     status: MmapType<DynamicMmapStatus>,
     directory: PathBuf,
@@ -96,7 +102,7 @@ impl DynamicMmapFlags {
             status.flusher()()?;
         }
 
-        // Open first mmap
+        // Open storage
         let flags = Self::open_storage(status.len, directory, populate)?;
         Ok(Self {
             flags,
@@ -196,6 +202,10 @@ impl DynamicMmapFlags {
     /// Ignore the call if the index is out of bounds.
     ///
     /// Returns previous value of the flag.
+    #[cfg_attr(
+        not(test),
+        deprecated = "use `set_ascending_bits` for persisting in batch"
+    )]
     pub fn set<TKey>(&mut self, key: TKey, value: bool) -> OperationResult<bool>
     where
         TKey: num_traits::cast::AsPrimitive<usize>,
@@ -206,6 +216,16 @@ impl DynamicMmapFlags {
             return Ok(false);
         }
         Ok(self.flags.replace_bit(key as u64, value)?)
+    }
+
+    pub fn set_ascending_bits<TKey>(
+        &mut self,
+        updates: impl IntoIterator<Item = (TKey, bool)>,
+    ) -> OperationResult<()>
+    where
+        TKey: num_traits::cast::AsPrimitive<u64>,
+    {
+        Ok(self.flags.set_ascending_bits_batch(updates)?)
     }
 
     pub fn flusher(&self) -> Flusher {
@@ -222,7 +242,7 @@ impl DynamicMmapFlags {
 
     pub fn get_bitslice(&self) -> OperationResult<Cow<'_, BitSlice>> {
         // Take subslice with actual length, bitslice may be larger due to extra allocated capacity
-        // See `mmap_capacity_bytes`
+        // See `file_size_for`
         let len = self.len();
         Ok(match self.flags.read_all()? {
             Cow::Borrowed(bitslice) => Cow::Borrowed(&bitslice[..len]),
@@ -250,10 +270,8 @@ impl DynamicMmapFlags {
             Cow::Owned(bitvec) => {
                 // Owned path: backend doesn't support zero-copy; materialize into Vec
                 // so we don't return a reference to a local
-                let indices: Vec<PointOffsetType> = bitvec
-                    .iter_ones()
-                    .map(|x| x as PointOffsetType)
-                    .collect();
+                let indices: Vec<PointOffsetType> =
+                    bitvec.iter_ones().map(|x| x as PointOffsetType).collect();
                 Either::Right(indices.into_iter())
             }
         })

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -28,20 +28,20 @@ pub struct RoaringFlags {
 }
 
 impl RoaringFlags {
-    pub fn new(mmap_flags: DynamicMmapFlags) -> Self {
+    pub fn new(mmap_flags: DynamicMmapFlags) -> OperationResult<Self> {
         // load flags into memory
-        let bitmap = RoaringBitmap::from_sorted_iter(mmap_flags.iter_trues())
+        let bitmap = RoaringBitmap::from_sorted_iter(mmap_flags.iter_trues()?)
             .expect("iter_trues iterates in sorted order");
 
         if let Err(err) = mmap_flags.clear_cache() {
             log::warn!("Failed to clear bitslice cache: {err}");
         }
 
-        Self {
+        Ok(Self {
             len: mmap_flags.len(),
             storage: BufferedDynamicFlags::new(mmap_flags),
             bitmap,
-        }
+        })
     }
 
     pub fn len(&self) -> usize {
@@ -135,7 +135,7 @@ mod tests {
         // Create and update flags
         {
             let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
-            let mut roaring_flags = RoaringFlags::new(mmap_flags);
+            let mut roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
             for i in 16..20 {
@@ -155,7 +155,7 @@ mod tests {
         // Verify bitmap consistency after reload
         {
             let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
-            let roaring_flags = RoaringFlags::new(mmap_flags);
+            let roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload
             let iter_trues: Vec<_> = roaring_flags.iter_trues().collect();

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -71,12 +71,12 @@ impl MutableBoolIndex {
         // Trues bitslice
         let trues_path = path.join(TRUES_DIRNAME);
         let trues_slice = DynamicMmapFlags::open(&trues_path, false)?;
-        let trues_flags = RoaringFlags::new(trues_slice);
+        let trues_flags = RoaringFlags::new(trues_slice)?;
 
         // Falses bitslice
         let falses_path = path.join(FALSES_DIRNAME);
         let falses_slice = DynamicMmapFlags::open(&falses_path, false)?;
-        let falses_flags = RoaringFlags::new(falses_slice);
+        let falses_flags = RoaringFlags::new(falses_slice)?;
 
         let trues_count = trues_flags.count_trues();
         let falses_count = falses_flags.count_trues();

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -80,11 +80,11 @@ impl MutableNullIndex {
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
         let has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
-        let has_values_flags = RoaringFlags::new(has_values_mmap);
+        let has_values_flags = RoaringFlags::new(has_values_mmap)?;
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
         let is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
-        let is_null_flags = RoaringFlags::new(is_null_mmap);
+        let is_null_flags = RoaringFlags::new(is_null_mmap)?;
 
         let storage = Storage {
             has_values_flags,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -252,7 +252,7 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 
     let vectors = ChunkedVectors::open(&vectors_path, dim, madvise, Some(populate))?;
 
-    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
+    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
     let deleted_count = deleted.count_trues();
 
     Ok(AppendableMmapDenseVectorStorage {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -512,7 +512,7 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     let vectors = ChunkedVectors::open(&vectors_path, dim, madvise, Some(populate))?;
     let offsets = ChunkedVectors::open(&offsets_path, 1, madvise, Some(populate))?;
 
-    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
+    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
     let deleted_count = deleted.count_trues();
 
     Ok(AppendableMmapMultiDenseVectorStorage {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -65,7 +65,7 @@ impl MmapSparseVectorStorage {
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
-        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
+        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
 
         let deleted_count = deleted.count_trues();
         let next_point_offset = deleted
@@ -106,7 +106,7 @@ impl MmapSparseVectorStorage {
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
-        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?);
+        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
 
         Ok(Self {
             storage,


### PR DESCRIPTION
Refactors the `DynamicMmapFlags` to use `StoredBitSlice` instead of plain mmap. 

This PR only covers the `flags` field, we'll refactor `status` (`MmapType`) later. 

Additionally, it leverages `set_ascending_bits_batch` during flushing.