### PR TITLE
Sync peers after CreateNamedVector/DeleteNamedVector

### DIFF
--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -155,9 +155,14 @@ impl Dispatcher {
                 };
 
             let do_sync_nodes = match &op {
-                // Sync nodes after collection or shard key creation
+                // Sync nodes after collection or shard key creation, or after
+                // adding/removing a named vector — in all of these cases callers
+                // expect the updated collection config to be visible on every
+                // peer on return.
                 CollectionMetaOperations::CreateCollection(_)
-                | CollectionMetaOperations::CreateShardKey(_) => true,
+                | CollectionMetaOperations::CreateShardKey(_)
+                | CollectionMetaOperations::CreateNamedVector(_)
+                | CollectionMetaOperations::DeleteNamedVector(_) => true,
 
                 // Sync nodes when creating or renaming collection aliases
                 CollectionMetaOperations::ChangeAliases(changes) => {
@@ -178,8 +183,6 @@ impl Dispatcher {
                 | CollectionMetaOperations::DropShardKey(_)
                 | CollectionMetaOperations::CreatePayloadIndex(_)
                 | CollectionMetaOperations::DropPayloadIndex(_)
-                | CollectionMetaOperations::CreateNamedVector(_)
-                | CollectionMetaOperations::DeleteNamedVector(_)
                 | CollectionMetaOperations::Nop { .. } => false,
 
                 #[cfg(feature = "staging")]

--- a/tests/consensus_tests/test_named_vector_crud.py
+++ b/tests/consensus_tests/test_named_vector_crud.py
@@ -1,5 +1,4 @@
 import pathlib
-from time import sleep
 
 import requests
 
@@ -227,11 +226,11 @@ def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
     killed_peer.kill()
     print(f"Killed peer at port {killed_peer.http_port}")
 
-    # Perform some consensus operations to trigger WAL compaction + snapshot
-    # Delete vector v1 and create v2 with different dimensions
-    # Use wait=False because a peer is down — await_consensus_sync can't reach all peers
-    delete_vector_name(peer_api_uris[0], COLLECTION_NAME, VECTOR_NAME, wait=False)
-    sleep(1)  # Give consensus time to propagate to surviving peers
+    # Perform some consensus operations to trigger WAL compaction + snapshot.
+    # Delete vector v1 and create v2 with different dimensions.
+    # Use a short timeout because a peer is down — the server will still await
+    # consensus sync across all peers and hit the client timeout on the dead one.
+    delete_vector_name(peer_api_uris[0], COLLECTION_NAME, VECTOR_NAME, wait=False, timeout=2)
 
     # Verify v1 is gone on surviving peers
     for uri in peer_api_uris[:-1]:
@@ -244,8 +243,8 @@ def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
         COLLECTION_NAME,
         VECTOR_NAME,
         {"dense": {"size": VECTOR_DIM2, "distance": "Dot"}},
+        timeout=2,
     )
-    sleep(1)  # Give consensus time to propagate to surviving peers
 
     # Verify v2 exists on surviving peers
     for uri in peer_api_uris[:-1]:
@@ -258,8 +257,9 @@ def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
         create_vector_name(
             peer_api_uris[0], COLLECTION_NAME, "tmp_vec",
             {"dense": {"size": 2, "distance": "Cosine"}},
+            timeout=2,
         )
-        delete_vector_name(peer_api_uris[0], COLLECTION_NAME, "tmp_vec")
+        delete_vector_name(peer_api_uris[0], COLLECTION_NAME, "tmp_vec", timeout=2)
 
 
     # Upload 200 points with v1


### PR DESCRIPTION
This is an AI attempt to fix flacky integration test failure from https://github.com/qdrant/qdrant/actions/runs/24732154480/job/72349258561?pr=8756

Seems reasonable, since we are removing `sleep` and waiting in consensus makes sense as well.


---

## Summary

- `submit_collection_meta_op` returned after the leader's local apply for `CreateNamedVector` / `DeleteNamedVector`, so an immediate `GET /collections/{name}` on a different peer could still see the stale vectors config (the root of a flaky `test_create_vector_no_optimization`).
- Moved both ops into the `do_sync_nodes = true` branch in `lib/storage/src/dispatcher.rs` so the API only returns once all reachable peers have caught up on consensus, matching `CreateCollection` / `CreateShardKey`.
- Dropped the `sleep(1)` workarounds in `test_vector_crud_with_consensus_snapshot` that were papering over the same race; tightened the client timeout on calls made while a peer is killed so the server-side sync bounds quickly on the unreachable node.

## Test plan

- [ ] `cargo check -p storage` (done locally)
- [ ] Run `tests/consensus_tests/test_named_vector_crud.py::test_create_vector_no_optimization` repeatedly (flaky case)
- [ ] Run `tests/consensus_tests/test_named_vector_crud.py::test_vector_crud_with_consensus_snapshot`
- [ ] CI on the rest of the consensus test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)