### PR TITLE
Fix panic in validate_iter when two siblings fail validation

### DIFF
--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use serde::Serialize;
-use validator::{Validate, ValidationError, ValidationErrors};
+use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
 
 // Multivector should be small enough to fit the chunk of vector storage
 
@@ -11,15 +11,32 @@ pub const MAX_MULTIVECTOR_FLATTENED_LEN: usize = 32 * 1024;
 #[cfg(not(debug_assertions))]
 pub const MAX_MULTIVECTOR_FLATTENED_LEN: usize = 1024 * 1024;
 
-#[allow(clippy::manual_try_fold)] // `try_fold` can't be used because it shortcuts on Err
+/// Validate every item in an iterator and collect per-item errors under a
+/// placeholder `?` key. We can't use `ValidationErrors::merge` repeatedly with
+/// the same key — its internal `add_nested` panics on the second insert
+/// ("Attempt to replace non-empty ValidationErrors entry"). For N≥2 we use a
+/// `List` indexed by position; for N=1 we keep the historical `Struct` shape so
+/// existing renderings (`?.<field>`) are preserved.
 pub fn validate_iter<T: Validate>(iter: impl Iterator<Item = T>) -> Result<(), ValidationErrors> {
-    let errors = iter
-        .filter_map(|v| v.validate().err())
-        .fold(Err(ValidationErrors::new()), |bag, err| {
-            ValidationErrors::merge(bag, "?", Err(err))
-        })
-        .unwrap_err();
-    errors.errors().is_empty().then_some(()).ok_or(errors)
+    let mut child_errors: Vec<ValidationErrors> = iter.filter_map(|v| v.validate().err()).collect();
+    if child_errors.is_empty() {
+        return Ok(());
+    }
+
+    let kind = if child_errors.len() == 1 {
+        ValidationErrorsKind::Struct(Box::new(child_errors.pop().unwrap()))
+    } else {
+        ValidationErrorsKind::List(
+            child_errors
+                .into_iter()
+                .enumerate()
+                .map(|(i, e)| (i, Box::new(e)))
+                .collect(),
+        )
+    };
+    let mut bag = ValidationErrors::new();
+    bag.errors_mut().insert(Cow::Borrowed("?"), kind);
+    Err(bag)
 }
 
 /// Validate the value is in `[min, max]`
@@ -392,6 +409,41 @@ mod tests {
             validate_geo_polygon(&good_polygon).is_ok(),
             "good polygon should not error on validation",
         );
+    }
+
+    #[test]
+    fn test_validate_iter() {
+        #[derive(validator::Validate)]
+        struct Item {
+            #[validate(range(min = 1))]
+            idx: u32,
+        }
+
+        // Empty iter — Ok
+        assert!(validate_iter(std::iter::empty::<&Item>()).is_ok());
+
+        // All valid — Ok
+        let valid = [Item { idx: 1 }, Item { idx: 2 }];
+        assert!(validate_iter(valid.iter()).is_ok());
+
+        // Single failure — Struct under `?` (preserves historical `?.<field>`
+        // rendering for existing call sites).
+        let one_bad = [Item { idx: 0 }];
+        let err = validate_iter(one_bad.iter()).expect_err("should fail");
+        match err.errors().get("?") {
+            Some(ValidationErrorsKind::Struct(_)) => {}
+            other => panic!("expected Struct under `?`, got {other:?}"),
+        }
+
+        // Two+ failures — must NOT panic (regression: prior impl called
+        // `ValidationErrors::merge(_, "?", _)` repeatedly, and validator's
+        // internal `add_nested` panics on the second insert).
+        let many_bad = [Item { idx: 0 }, Item { idx: 0 }, Item { idx: 0 }];
+        let err = validate_iter(many_bad.iter()).expect_err("should fail");
+        match err.errors().get("?") {
+            Some(ValidationErrorsKind::List(list)) => assert_eq!(list.len(), 3),
+            other => panic!("expected List under `?`, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/openapi/test_validation.py
+++ b/tests/openapi/test_validation.py
@@ -70,3 +70,56 @@ def test_validation_query_param(collection_name):
     assert not response.ok
     assert 'Validation error' in response.json()["status"]["error"]
     assert 'timeout: value 0 invalid' in response.json()["status"]["error"]
+
+
+# Regression: two sibling validation errors used to panic
+# `common::validation::validate_iter` (validator's internal `add_nested` panics
+# on a second insert under the same key), surfacing as a dropped connection
+# instead of a 4xx. Length-mismatched sparse vectors with non-empty indices
+# fail validation without short-circuiting `VectorStruct::is_empty`.
+
+_INVALID_SPARSE = {"indices": [0, 1], "values": [0.0]}
+
+
+def test_validation_iter_named_vectors(collection_name):
+    # Hits VectorStruct::Named -> validate_iter (lib/api/src/rest/schema.rs).
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {"a": _INVALID_SPARSE, "b": _INVALID_SPARSE},
+                }
+            ],
+        },
+    )
+    assert not response.ok
+    assert 'Validation error' in response.json()["status"]["error"]
+
+
+def test_validation_iter_batch_named_vectors(collection_name):
+    # Hits BatchVectorStruct::Named -> validate_iter (lib/api/src/rest/validate.rs).
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/batch',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "operations": [
+                {
+                    "upsert": {
+                        "batch": {
+                            "ids": [1, 2],
+                            "vectors": {"a": [_INVALID_SPARSE, _INVALID_SPARSE]},
+                        }
+                    }
+                }
+            ]
+        },
+    )
+    assert not response.ok
+    assert 'Validation error' in response.json()["status"]["error"]


### PR DESCRIPTION
  ## Summary

Two reports from a schemathesis run flagged endpoints that closed the connection without sending a response on certain payloads:

  - `POST /collections/{collection_name}/points/batch`
  - `PUT /collections/{collection_name}/points/vectors`

 Root cause: `common::validation::validate_iter` accumulated per-item validation errors by repeatedly calling `ValidationErrors::merge(_, "?", _)`. 

The validator crate's internal `add_nested` panics on the second insert under the same key, so any iterator with two or more failing items took down the request handler. 

Actix-web caught the panic at the worker level and dropped the connection, surfacing as `RemoteDisconnected: Remote end closed connection without response` on the client.

  ## Original panic

  ```
  2026-04-21T14:04:07.798897Z ERROR qdrant::startup: Panic backtrace:
     0: qdrant::startup::setup_panic_hook::{{closure}}
     1: std::panicking::panic_with_hook
     2: std::panicking::panic_handler::{closure#0}
     3: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::panic_handler::{closure#0}, !>
     4: __rustc::rust_begin_unwind
     5: core::panicking::panic_fmt
     6: validator::types::ValidationErrors::merge
     7: hashbrown::raw::RawIterRange<T>::fold_impl
     8: common::validation::validate_iter
     9: api::rest::validate::<impl validator::traits::Validate for api::rest::schema::Batch>::validate
    10: <api::rest::schema::PointsBatch as validator::traits::ValidateArgs>::validate_with_args
    11: <api::rest::schema::PointInsertOperations as validator::traits::Validate>::validate
    12: <qdrant::common::update::UpdateOperation as validator::traits::Validate>::validate
    13: <alloc::vec::Vec<T> as validator::traits::Validate>::validate
    14: <qdrant::common::update::UpdateOperations as validator::traits::Validate>::validate
    15: <T as futures_util::fns::FnOnce1<A>>::call_once
    16: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
    ... (actix-web / tokio frames)

  2026-04-21T14:04:07.798966Z ERROR qdrant::startup: Panic occurred in
  file /home/agourlay/.cargo/registry/src/index.crates.io-…/validator-0.20.0/src/types.rs
  at line 187: Attempt to replace non-empty ValidationErrors entry
  ```

  Reproducer (from the schemathesis report):

  ```sh
  curl -X POST -H 'Content-Type: application/json' \
    -d '{"operations":[{"upsert":{"batch":{"ids":[],"vectors":{"":[[[]],{"indices":[],"values":[0.0]}]}}}}]}' \
    http://127.0.0.1:6333/collections/0/points/batch
  # → curl: (52) Empty reply from server
  ```

  ## Blast radius

  `validate_iter` is called from six sites; all panic on ≥2 sibling validation errors:

  - `lib/api/src/rest/schema.rs` — `VectorStruct::Named`
  - `lib/api/src/rest/validate.rs` — `BatchVectorStruct::Named`
  - `lib/shard/src/operations/point_ops.rs` — `VectorStructPersisted::Named`
  - `lib/collection/src/operations/types.rs` — `VectorsConfig::Multi`, `VectorsConfigDiff`, `SparseVectorsConfig`

  So `PUT /collections/{n}` with two invalid named vector configs is also reachable.

  ## Fix

  `lib/common/common/src/validation.rs` — replace the merge-loop with explicit `ValidationErrorsKind` construction.

 For one failing item we keep `Struct` (preserves the historical `?.<field>` rendering used by existing tests and surfaced in user-facing error messages); for two or more we use `List` indexed by position so siblings coexist:

  ```rust
  pub fn validate_iter<T: Validate>(iter: impl Iterator<Item = T>) -> Result<(), ValidationErrors> {
      let mut child_errors: Vec<ValidationErrors> =
          iter.filter_map(|v| v.validate().err()).collect();
      if child_errors.is_empty() {
          return Ok(());
      }
      let kind = if child_errors.len() == 1 {
          ValidationErrorsKind::Struct(Box::new(child_errors.pop().unwrap()))
      } else {
          ValidationErrorsKind::List(
              child_errors.into_iter().enumerate().map(|(i, e)| (i, Box::new(e))).collect(),
          )
      };
      let mut bag = ValidationErrors::new();
      bag.errors_mut().insert(Cow::Borrowed("?"), kind);
      Err(bag)
  }
  ```

  Public API and user-visible error rendering for existing call sites are unchanged.

  ## Tests

  - `lib/common/common/src/validation.rs` — new `test_validate_iter` unit test covers empty / all-valid / one-bad (Struct under `?`) / three-bad (List with 3 entries under `?`). The three-bad case is the
  explicit panic regression.
  - `tests/openapi/test_validation.py` — two new integration tests reproducing the original schemathesis cases via `PUT /points/vectors` and `POST /points/batch` with two invalid named sparse vectors. They
  previously raised `ConnectionError`; now return a 4xx with a `Validation error in JSON body` payload.

  ## Test plan

  - [ ] `cargo test -p common --lib validation::` — all 6 tests pass
  - [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
  - [ ] Integration: with a running qdrant, `pytest tests/openapi/test_validation.py` — all 5 tests pass
  - [ ] Spot-check the two reproducer curls return 422 instead of dropping the connection