### PR TITLE
Verify snapshot integrity with checksum in shard snapshot transfer (Fixes #3372)

### DIFF
--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -923,6 +923,7 @@ impl RemoteShard {
         shard_id: ShardId,
         url: &Url,
         snapshot_priority: SnapshotPriority,
+        checksum: Option<String>,
         api_key: Option<&str>,
     ) -> CollectionResult<RecoverSnapshotResponse> {
         let res = self
@@ -938,7 +939,7 @@ impl RemoteShard {
                             snapshot_priority: api::grpc::qdrant::ShardSnapshotPriority::from(
                                 snapshot_priority,
                             ) as i32,
-                            checksum: None,
+                            checksum,
                             api_key: api_key.map(Into::into),
                         })
                         .await

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -199,6 +199,7 @@ pub(super) async fn transfer_snapshot(
 
     let mut snapshot_temp_paths = Vec::new();
     let mut shard_download_url = local_rest_address;
+    let mut snapshot_checksum = None;
 
     let encoded_collection_name = urlencoding::encode(collection_id);
     if use_streaming_endpoint {
@@ -214,6 +215,8 @@ pub(super) async fn transfer_snapshot(
             .create_shard_snapshot(snapshots_path, collection_id, shard_id, temp_dir)
             .await?
             .await?;
+
+        snapshot_checksum = snapshot_description.checksum;
 
         // TODO: If future is cancelled until `get_shard_snapshot_path` resolves, shard snapshot may not be cleaned up...
         let snapshot_temp_path = shard_holder_read
@@ -253,6 +256,7 @@ pub(super) async fn transfer_snapshot(
             shard_id,
             &shard_download_url,
             SnapshotPriority::ShardTransfer,
+            snapshot_checksum,
             // Provide API key here so the remote can access our snapshot
             local_api_key,
         )


### PR DESCRIPTION
## Verify snapshot integrity with checksum in shard snapshot transfer

Fixes #3372

### Problem

During shard snapshot transfer, the `.snapshot` file received by the remote node was restored without any integrity check. A corrupted or truncated transfer would silently produce a broken shard with no indication of failure.

The checksum infrastructure was already fully in place — `SnapshotDescription` includes a SHA256 checksum computed at snapshot creation time, and the receiver-side `recover_shard_snapshot` function already has checksum verification logic (used by user-facing snapshot recovery). The checksum simply wasn't being passed through the transfer call chain.

### Solution

Thread the snapshot checksum from the sender through to the receiver:

1. **`lib/collection/src/shards/remote_shard.rs`** — Added a `checksum: Option<String>` parameter to `recover_shard_snapshot_from_url` and forwarded it into the `RecoverShardSnapshotRequest` gRPC message (the `checksum` field already exists in the proto definition).

2. **`lib/collection/src/shards/transfer/snapshot.rs`** — On the sender side, captured `snapshot_description.checksum` (populated during snapshot creation) and passed it to `recover_shard_snapshot_from_url`.

The receiver already handles a non-`None` checksum in `recover_shard_snapshot`: it computes the SHA256 of the downloaded file and compares it, returning a `bad_input` error on mismatch. No changes were needed on the receiver side.

### Scope

- **Non-streaming path** (nodes < v1.12): Fully covered. The snapshot file is created locally, its checksum is in `SnapshotDescription`, and is now forwarded to the receiver for verification.
- **Streaming path** (nodes ≥ v1.12): Unchanged — no snapshot file is created on the sender side, so no pre-computed checksum is available. `snapshot_checksum` stays `None` and behavior is identical to before.

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?