### PR TITLE
Callback-based for_each_payload_block

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
@@ -147,12 +147,13 @@ impl PayloadFieldIndex for ImmutableBoolIndex {
     }
 
     #[inline]
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        self.0.payload_blocks(threshold, key)
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.0.for_each_payload_block(threshold, key, f)
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -213,14 +213,15 @@ impl PayloadFieldIndex for BoolIndex {
         }
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: crate::types::PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<super::PayloadBlockCondition>> + '_> {
+        f: &mut dyn FnMut(super::PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         match self {
-            BoolIndex::Mmap(index) => index.payload_blocks(threshold, key),
-            BoolIndex::Immutable(index) => index.payload_blocks(threshold, key),
+            BoolIndex::Mmap(index) => index.for_each_payload_block(threshold, key, f),
+            BoolIndex::Immutable(index) => index.for_each_payload_block(threshold, key, f),
         }
     }
 }
@@ -597,10 +598,13 @@ mod tests {
                 index.add_point(i as u32, &[&value], &hw_counter).unwrap();
             });
 
-        let blocks = index
-            .payload_blocks(0, JsonPath::new(FIELD_NAME))
-            .map(Result::unwrap)
-            .collect_vec();
+        let mut blocks = Vec::new();
+        index
+            .for_each_payload_block(0, JsonPath::new(FIELD_NAME), &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
+            .unwrap();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].cardinality, 6);
         assert_eq!(blocks[1].cardinality, 6);

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -489,36 +489,25 @@ impl PayloadFieldIndex for MutableBoolIndex {
         })
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        let make_block = |count, value, key: PayloadKeyType| {
-            if count > threshold {
-                Some(Ok(PayloadBlockCondition {
-                    condition: FieldCondition::new_match(
-                        key,
-                        Match::Value(MatchValue {
-                            value: ValueVariants::Bool(value),
-                        }),
-                    ),
-                    cardinality: count,
-                }))
-            } else {
-                None
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        let mut handle_block = |cardinality, value: bool, key: PayloadKeyType| {
+            if cardinality > threshold {
+                f(PayloadBlockCondition {
+                    condition: FieldCondition::new_match(key.clone(), Match::from(value)),
+                    cardinality,
+                })?;
             }
+            Ok(())
         };
 
         // just two possible blocks: true and false
-        let iter = [
-            make_block(self.trues_count, true, key.clone()),
-            make_block(self.falses_count, false, key),
-        ]
-        .into_iter()
-        .flatten();
-
-        Box::new(iter)
+        handle_block(self.trues_count, true, key.clone())?;
+        handle_block(self.falses_count, false, key)
     }
 }
 

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -65,11 +65,12 @@ pub trait PayloadFieldIndex {
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_>;
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()>;
 }
 
 pub trait ValueIndexer {
@@ -259,13 +260,14 @@ impl FieldIndex {
             .estimate_cardinality(condition, hw_counter)
     }
 
-    pub fn payload_blocks(
+    pub fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         self.get_payload_field_index()
-            .payload_blocks(threshold, key)
+            .for_each_payload_block(threshold, key, f)
     }
 
     pub fn add_point(

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -367,26 +367,24 @@ pub trait InvertedIndex {
         &self,
     ) -> impl Iterator<Item = OperationResult<(&str, usize)>> + '_;
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> impl Iterator<Item = OperationResult<PayloadBlockCondition>> + '_ {
-        let map_filter_condition = move |item: OperationResult<(&str, usize)>| match item {
-            Ok((token, postings_len)) if postings_len >= threshold => {
-                Some(Ok(PayloadBlockCondition {
-                    condition: FieldCondition::new_match(key.clone(), Match::new_text(token)),
-                    cardinality: postings_len,
-                }))
-            }
-            Ok(_) => None,
-            Err(err) => Some(Err(err)),
-        };
-
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         // It might be very hard to predict possible combinations of conditions,
         // so we only build it for individual tokens
-        self.vocab_with_postings_len_iter()
-            .filter_map(map_filter_condition)
+        self.vocab_with_postings_len_iter().try_for_each(|item| {
+            let (token, postings_len) = item?;
+            if postings_len >= threshold {
+                f(PayloadBlockCondition {
+                    condition: FieldCondition::new_match(key.clone(), Match::new_text(token)),
+                    cardinality: postings_len,
+                })?;
+            }
+            Ok(())
+        })
     }
 
     fn check_match(

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -408,16 +408,21 @@ fn test_congruence(
 
         if !deleted {
             for threshold in 1..=10 {
-                assert_eq!(
-                    index_a
-                        .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                        .map(Result::unwrap)
-                        .count(),
-                    index_b
-                        .payload_blocks(threshold, JsonPath::new(FIELD_NAME))
-                        .map(Result::unwrap)
-                        .count(),
-                );
+                let mut count_a = 0;
+                index_a
+                    .for_each_payload_block(threshold, JsonPath::new(FIELD_NAME), &mut |_| {
+                        count_a += 1;
+                        Ok(())
+                    })
+                    .unwrap();
+                let mut count_b = 0;
+                index_b
+                    .for_each_payload_block(threshold, JsonPath::new(FIELD_NAME), &mut |_| {
+                        count_b += 1;
+                        Ok(())
+                    })
+                    .unwrap();
+                assert_eq!(count_a, count_b);
             }
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -139,15 +139,22 @@ impl FullTextIndex {
         }
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         match self {
-            Self::Mutable(index) => Box::new(index.inverted_index.payload_blocks(threshold, key)),
-            Self::Immutable(index) => Box::new(index.inverted_index.payload_blocks(threshold, key)),
-            Self::Mmap(index) => Box::new(index.inverted_index.payload_blocks(threshold, key)),
+            Self::Mutable(index) => index
+                .inverted_index
+                .for_each_payload_block(threshold, key, f),
+            Self::Immutable(index) => index
+                .inverted_index
+                .for_each_payload_block(threshold, key, f),
+            Self::Mmap(index) => index
+                .inverted_index
+                .for_each_payload_block(threshold, key, f),
         }
     }
 
@@ -529,12 +536,13 @@ impl PayloadFieldIndex for FullTextIndex {
         )?))
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        self.payload_blocks(threshold, key)
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.for_each_payload_block(threshold, key, f)
     }
 }
 

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -629,24 +629,22 @@ impl PayloadFieldIndex for GeoMapIndex {
         Ok(None)
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        let large_hashes = match self.large_hashes(threshold) {
-            Ok(large_hashes) => large_hashes,
-            Err(e) => return Box::new(std::iter::once(Err(e))),
-        };
-        Box::new(large_hashes.map(move |(geo_hash, size)| {
-            Ok(PayloadBlockCondition {
-                condition: FieldCondition::new_geo_bounding_box(
-                    key.clone(),
-                    geo_hash_to_box(geo_hash),
-                ),
-                cardinality: size,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.large_hashes(threshold)?
+            .try_for_each(|(geo_hash, size)| {
+                f(PayloadBlockCondition {
+                    condition: FieldCondition::new_geo_bounding_box(
+                        key.clone(),
+                        geo_hash_to_box(geo_hash),
+                    ),
+                    cardinality: size,
+                })
             })
-        }))
     }
 }
 
@@ -1045,10 +1043,13 @@ mod tests {
             assert!(size < 1000);
         }
 
-        let blocks = field_index
-            .payload_blocks(100, JsonPath::new("test"))
-            .map(Result::unwrap)
-            .collect_vec();
+        let mut blocks = Vec::new();
+        field_index
+            .for_each_payload_block(100, JsonPath::new("test"), &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
+            .unwrap();
         blocks.iter().for_each(|block| {
             let hw_acc = HwMeasurementAcc::new();
             let hw_counter = hw_acc.get_counter_cell();

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -394,10 +394,6 @@ where
             .map(|(idx, _)| *idx)
     }
 
-    pub fn iter_values(&self) -> Box<dyn Iterator<Item = &N> + '_> {
-        Box::new(self.value_to_points.keys().map(|v| v.borrow()))
-    }
-
     pub fn for_each_value(
         &self,
         mut f: impl FnMut(&N) -> OperationResult<()>,

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -341,10 +341,6 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         }
     }
 
-    pub fn iter_values(&self) -> impl Iterator<Item = &N> + '_ {
-        self.storage.value_to_points.keys()
-    }
-
     pub fn for_each_value(
         &self,
         mut f: impl FnMut(&N) -> OperationResult<()>,

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -237,14 +237,6 @@ where
         }
     }
 
-    pub fn iter_values(&self) -> Box<dyn Iterator<Item = &N> + '_> {
-        match self {
-            MapIndex::Mutable(index) => index.iter_values(),
-            MapIndex::Immutable(index) => index.iter_values(),
-            MapIndex::Mmap(index) => Box::new(index.iter_values()),
-        }
-    }
-
     pub fn for_each_value(&self, f: impl FnMut(&N) -> OperationResult<()>) -> OperationResult<()> {
         match self {
             MapIndex::Mutable(index) => index.for_each_value(f),
@@ -474,17 +466,21 @@ where
         &'a self,
         excluded: &'a IndexSet<K, A>,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a>
+    ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>>
     where
         A: BuildHasher,
         K: Borrow<N> + Hash + Eq,
     {
-        Box::new(
-            self.iter_values()
-                .filter(|key| !excluded.contains((*key).borrow()))
-                .flat_map(move |key| self.get_iterator(key.borrow(), hw_counter))
-                .unique(),
-        )
+        let mut points = IndexSet::new();
+        self.for_each_value(|key| {
+            if !excluded.contains(key.borrow()) {
+                self.get_iterator(key.borrow(), hw_counter).for_each(|p| {
+                    points.insert(p);
+                });
+            }
+            Ok(())
+        })?;
+        Ok(Box::new(points.into_iter()))
     }
 
     /// Approximate RAM usage in bytes for in-memory structures.
@@ -762,7 +758,7 @@ impl PayloadFieldIndex for MapIndex<str> {
                 }
             },
             Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(keywords) => Some(self.except_set(keywords, hw_counter)),
+                AnyVariants::Strings(keywords) => Some(self.except_set(keywords, hw_counter)?),
                 AnyVariants::Integers(other) => {
                     if other.is_empty() {
                         Some(Box::new(iter::empty()))
@@ -839,27 +835,24 @@ impl PayloadFieldIndex for MapIndex<str> {
         })
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        Box::new(
-            self.iter_values()
-                .map(|value| {
-                    (
-                        value,
-                        self.get_count_for_value(value, &HardwareCounterCell::disposable()) // Payload_blocks only used in HNSW building, which is unmeasured.
-                            .unwrap_or(0),
-                    )
-                })
-                .filter(move |(_value, count)| *count > threshold)
-                .map(move |(value, count)| PayloadBlockCondition {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.for_each_value(|value| {
+            let count = self
+                .get_count_for_value(value, &HardwareCounterCell::disposable()) // Payload_blocks only used in HNSW building, which is unmeasured.
+                .unwrap_or(0);
+            if count > threshold {
+                f(PayloadBlockCondition {
                     condition: FieldCondition::new_match(key.clone(), value.to_string().into()),
                     cardinality: count,
-                })
-                .map(Ok),
-        )
+                })?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -935,12 +928,16 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
                         else {
                             return Ok(None);
                         };
-                        Some(Box::new(
-                            self.iter_values()
-                                .filter(move |key| !excluded_uuids.contains(*key))
-                                .flat_map(move |key| self.get_iterator(key, hw_counter))
-                                .unique(),
-                        ))
+                        let mut points = IndexSet::new();
+                        self.for_each_value(|key| {
+                            if !excluded_uuids.contains(key) {
+                                self.get_iterator(key, hw_counter).for_each(|p| {
+                                    points.insert(p);
+                                });
+                            }
+                            Ok(())
+                        })?;
+                        Some(Box::new(points.into_iter()))
                     }
                     AnyVariants::Integers(other) => {
                         if other.is_empty() {
@@ -1039,30 +1036,27 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
         })
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        Box::new(
-            self.iter_values()
-                .map(move |value| {
-                    (
-                        value,
-                        self.get_count_for_value(value, &HardwareCounterCell::disposable()) // payload_blocks only used in HNSW building, which is unmeasured.
-                            .unwrap_or(0),
-                    )
-                })
-                .filter(move |(_value, count)| *count >= threshold)
-                .map(move |(value, count)| PayloadBlockCondition {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.for_each_value(|value| {
+            let count = self
+                .get_count_for_value(value, &HardwareCounterCell::disposable()) // payload_blocks only used in HNSW building, which is unmeasured.
+                .unwrap_or(0);
+            if count >= threshold {
+                f(PayloadBlockCondition {
                     condition: FieldCondition::new_match(
                         key.clone(),
                         Uuid::from_u128(*value).to_string().into(),
                     ),
                     cardinality: count,
-                })
-                .map(Ok),
-        )
+                })?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -1124,7 +1118,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
                             None
                         }
                     }
-                    AnyVariants::Integers(integers) => Some(self.except_set(integers, hw_counter)),
+                    AnyVariants::Integers(integers) => Some(self.except_set(integers, hw_counter)?),
                 },
                 _ => None,
             };
@@ -1194,27 +1188,24 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
         })
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        Box::new(
-            self.iter_values()
-                .map(move |value| {
-                    (
-                        value,
-                        self.get_count_for_value(value, &HardwareCounterCell::disposable()) // Only used in HNSW building so no measurement needed here.
-                            .unwrap_or(0),
-                    )
-                })
-                .filter(move |(_value, count)| *count >= threshold)
-                .map(move |(value, count)| PayloadBlockCondition {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.for_each_value(|value| {
+            let count = self
+                .get_count_for_value(value, &HardwareCounterCell::disposable()) // Only used in HNSW building so no measurement needed here.
+                .unwrap_or(0);
+            if count >= threshold {
+                f(PayloadBlockCondition {
                     condition: FieldCondition::new_match(key.clone(), (*value).into()),
                     cardinality: count,
-                })
-                .map(Ok),
-        )
+                })?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -1475,9 +1466,12 @@ mod tests {
 
         let index = builder.finalize().unwrap();
 
-        for block in index.payload_blocks(50, PayloadKeyType::new("test_uuid")) {
-            black_box(block.unwrap());
-        }
+        index
+            .for_each_payload_block(50, PayloadKeyType::new("test_uuid"), &mut |block| {
+                black_box(block);
+                Ok(())
+            })
+            .unwrap();
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index.rs
@@ -317,10 +317,6 @@ where
             .unwrap_or_else(|| Box::new(iter::empty::<PointOffsetType>()))
     }
 
-    pub fn iter_values(&self) -> Box<dyn Iterator<Item = &N> + '_> {
-        Box::new(self.map.keys().map(|v| v.borrow()))
-    }
-
     pub fn for_each_value(
         &self,
         mut f: impl FnMut(&N) -> OperationResult<()>,

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -380,13 +380,14 @@ impl PayloadFieldIndex for MutableNullIndex {
         })
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         _threshold: usize,
         _key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        _f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         // No payload blocks
-        Box::new(std::iter::empty())
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -892,11 +892,12 @@ where
             .transpose()
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         threshold: usize,
         key: PayloadKeyType,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         let inner = || -> OperationResult<Vec<PayloadBlockCondition>> {
             let mut lower_bound = Unbounded;
             let mut pre_lower_bound: Option<Bound<T>> = None;
@@ -964,10 +965,7 @@ where
             Ok(payload_conditions)
         };
 
-        match inner() {
-            Ok(conditions) => Box::new(conditions.into_iter().map(Ok)),
-            Err(err) => Box::new(std::iter::once(Err(err))),
-        }
+        inner()?.into_iter().try_for_each(f)
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -238,39 +238,34 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
 #[case(IndexType::RamMmap)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
     let (_temp_dir, index) = random_index(1000, 2, index_type);
+    let collect_blocks = |index: &NumericIndexInner<_>, threshold| {
+        let mut blocks = Vec::new();
+        index
+            .for_each_payload_block(threshold, JsonPath::new("test"), &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
+            .unwrap();
+        blocks
+    };
+
     let threshold = 100;
-    let blocks = index
-        .inner()
-        .payload_blocks(threshold, JsonPath::new("test"))
-        .map(Result::unwrap)
-        .collect_vec();
+    let blocks = collect_blocks(index.inner(), threshold);
     assert!(!blocks.is_empty());
     eprintln!("threshold {threshold}, blocks.len() = {:#?}", blocks.len());
 
     let threshold = 500;
-    let blocks = index
-        .inner()
-        .payload_blocks(threshold, JsonPath::new("test"))
-        .map(Result::unwrap)
-        .collect_vec();
+    let blocks = collect_blocks(index.inner(), threshold);
     assert!(!blocks.is_empty());
     eprintln!("threshold {threshold}, blocks.len() = {:#?}", blocks.len());
 
     let threshold = 1000;
-    let blocks = index
-        .inner()
-        .payload_blocks(threshold, JsonPath::new("test"))
-        .map(Result::unwrap)
-        .collect_vec();
+    let blocks = collect_blocks(index.inner(), threshold);
     assert!(!blocks.is_empty());
     eprintln!("threshold {threshold}, blocks.len() = {:#?}", blocks.len());
 
     let threshold = 10000;
-    let blocks = index
-        .inner()
-        .payload_blocks(threshold, JsonPath::new("test"))
-        .map(Result::unwrap)
-        .collect_vec();
+    let blocks = collect_blocks(index.inner(), threshold);
     assert!(!blocks.is_empty());
     eprintln!("threshold {threshold}, blocks.len() = {:#?}", blocks.len());
 }
@@ -305,11 +300,14 @@ fn test_payload_blocks_small(#[case] index_type: IndexType) {
     });
     let index = index_builder.finalize().unwrap();
 
-    let blocks = index
+    let mut blocks = Vec::new();
+    index
         .inner()
-        .payload_blocks(threshold, JsonPath::new("test"))
-        .map(Result::unwrap)
-        .collect_vec();
+        .for_each_payload_block(threshold, JsonPath::new("test"), &mut |block| {
+            blocks.push(block);
+            Ok(())
+        })
+        .unwrap();
     assert!(!blocks.is_empty());
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -35,6 +35,7 @@ use crate::common::operation_time_statistics::{
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorInternal, VectorRef};
 use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::index::field_index::PayloadBlockCondition;
 use crate::index::hnsw_index::HnswM;
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
@@ -592,12 +593,11 @@ impl HNSWIndex {
 
                 let counter = field_progress.track_progress(None);
 
-                for payload_block in payload_index_ref.payload_blocks(&field, full_scan_threshold) {
-                    let payload_block = payload_block?;
+                let mut process_block = |payload_block: PayloadBlockCondition| {
                     check_process_stopped(stopped)?;
 
                     if payload_block.cardinality > max_block_size {
-                        continue;
+                        return Ok(());
                     }
 
                     let points_to_index = Self::condition_points(
@@ -617,7 +617,7 @@ impl HNSWIndex {
                     const DELETED_POINTS_FACTOR: usize = 4; // allow block to have up to 75% of deleted points and still be indexed
 
                     if points_to_index.len() <= full_scan_threshold / DELETED_POINTS_FACTOR {
-                        continue;
+                        return Ok(());
                     }
 
                     if !is_tenant
@@ -635,7 +635,7 @@ impl HNSWIndex {
                             trace!(
                                 "skip building additional HNSW links for {field}, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
                             );
-                            continue;
+                            return Ok(());
                         }
                         trace!("graph connectivity: {graph_connectivity} for {field}");
                     }
@@ -665,7 +665,14 @@ impl HNSWIndex {
                         &counter,
                     )?;
                     graph_layers_builder.merge_from_other(additional_graph);
-                }
+                    Ok(())
+                };
+
+                payload_index_ref.for_each_payload_block(
+                    &field,
+                    full_scan_threshold,
+                    &mut process_block,
+                )?;
             }
 
             let indexed_payload_vectors = indexed_vectors_set.count_ones();

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -103,11 +103,12 @@ pub trait PayloadIndex {
 
     /// Iterate conditions for payload blocks with minimum size of `threshold`
     /// Required for building HNSW index
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         field: PayloadKeyTypeRef,
         threshold: usize,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_>;
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()>;
 
     /// Overwrite payload for point_id. If payload already exists, replace it.
     fn overwrite_payload(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -193,13 +193,14 @@ impl PayloadIndex for PlainPayloadIndex {
         }))
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         _field: PayloadKeyTypeRef,
         _threshold: usize,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
+        _f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         // No blocks for un-indexed payload
-        Box::new(std::iter::empty())
+        Ok(())
     }
 
     fn overwrite_payload(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -822,20 +822,19 @@ impl PayloadIndex for StructPayloadIndex {
         Ok(Box::new(self.struct_filtered_context(filter, hw_counter)?))
     }
 
-    fn payload_blocks(
+    fn for_each_payload_block(
         &self,
         field: PayloadKeyTypeRef,
         threshold: usize,
-    ) -> Box<dyn Iterator<Item = OperationResult<PayloadBlockCondition>> + '_> {
-        match self.field_indexes.get(field) {
-            None => Box::new(std::iter::empty()),
-            Some(indexes) => {
-                let field_clone = field.to_owned();
-                Box::new(indexes.iter().flat_map(move |field_index| {
-                    field_index.payload_blocks(threshold, field_clone.clone())
-                }))
-            }
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        if let Some(indexes) = self.field_indexes.get(field) {
+            let field_clone = field.to_owned();
+            indexes.iter().try_for_each(|field_index| {
+                field_index.for_each_payload_block(threshold, field_clone.clone(), f)
+            })?;
         }
+        Ok(())
     }
 
     fn overwrite_payload(

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -7,7 +7,6 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
 use common::progress_tracker::ProgressTracker;
 use common::types::PointOffsetType;
-use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use rand::RngExt;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
@@ -93,10 +92,13 @@ fn exact_search_test() {
         )
         .unwrap();
     let borrowed_payload_index = payload_index_ptr.borrow();
-    let blocks = borrowed_payload_index
-        .payload_blocks(&JsonPath::new(int_key), indexing_threshold)
-        .map(Result::unwrap)
-        .collect_vec();
+    let mut blocks = Vec::new();
+    borrowed_payload_index
+        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+            blocks.push(block);
+            Ok(())
+        })
+        .unwrap();
     for block in &blocks {
         assert!(
             block.condition.range.is_some(),

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -7,7 +7,6 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
 use common::progress_tracker::ProgressTracker;
 use common::types::{PointOffsetType, TelemetryDetail};
-use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use rand::prelude::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
@@ -116,10 +115,13 @@ fn _test_filterable_hnsw(
         )
         .unwrap();
     let borrowed_payload_index = payload_index_ptr.borrow();
-    let blocks = borrowed_payload_index
-        .payload_blocks(&JsonPath::new(int_key), indexing_threshold)
-        .map(Result::unwrap)
-        .collect_vec();
+    let mut blocks = Vec::new();
+    borrowed_payload_index
+        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+            blocks.push(block);
+            Ok(())
+        })
+        .unwrap();
     for block in &blocks {
         assert!(
             block.condition.range.is_some(),
@@ -303,10 +305,13 @@ fn test_hnsw_search_top_zero(#[case] num_vectors: u64, #[case] full_scan_thresho
         )
         .unwrap();
     let borrowed_payload_index = payload_index_ptr.borrow();
-    let blocks = borrowed_payload_index
-        .payload_blocks(&JsonPath::new(int_key), indexing_threshold)
-        .map(Result::unwrap)
-        .collect_vec();
+    let mut blocks = Vec::new();
+    borrowed_payload_index
+        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+            blocks.push(block);
+            Ok(())
+        })
+        .unwrap();
     for block in &blocks {
         assert!(
             block.condition.range.is_some(),


### PR DESCRIPTION
Continuation of #8764.

In this PR, `payload_blocks(…) -> Iterator<…>` is replaced with `for_each_payload_block(…, f: &mut dyn FnMut)`.

Why: same goal as in #8764. Now `iter_values` is removed in favor of `for_each_value`. So, porting `MmapHashMap::keys` should be easier.