### PR TITLE
 Don't block update queue while waiting for deferred points

### DIFF
--- a/lib/collection/src/tests/deferred_points_tests.rs
+++ b/lib/collection/src/tests/deferred_points_tests.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -14,7 +15,7 @@ use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
-use crate::operations::types::PointRequestInternal;
+use crate::operations::types::{PointRequestInternal, UpdateStatus};
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
@@ -132,6 +133,100 @@ async fn test_deferred_points_wait_true() {
     }
 
     shard.stop_gracefully().await;
+}
+
+/// Regression test: a `wait=true` upsert that enters the deferred-points wait
+/// must not block the update worker from processing subsequent operations.
+///
+/// Optimization is disabled (`max_optimization_threads=0`) so that A's deferred
+/// wait is effectively indefinite — exposing any blocking of the worker loop.
+///
+/// - A: `WaitUntil::Visible` — enters the deferred-points wait (detached task
+///   with the fix; inline in the worker loop without it).
+/// - B: `WaitUntil::Segment` — only needs the worker to apply it to segments,
+///   so it must complete quickly as long as the worker is free to pull B.
+///
+/// Without the fix, B is never picked up while A is waiting, and its 5 s
+/// timeout trips.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wait_deferred_does_not_block_update_worker() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let collection_dir = Builder::new()
+        .prefix("test_deferred_does_not_block")
+        .tempdir()
+        .unwrap();
+    let payload_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema = Arc::new(
+        SaveOnDisk::load_or_init_default(payload_schema_dir.path().join("payload-schema.json"))
+            .unwrap(),
+    );
+
+    let mut config = create_deferred_points_config();
+    // Disable the optimizer so A's deferred wait cannot resolve on its own.
+    config.optimizer_config.max_optimization_threads = Some(0);
+
+    let shard = Arc::new(build_shard(&config, collection_dir.path(), payload_index_schema).await);
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Build up deferred state so that when A is processed, `has_deferred_points`
+    // is already true and the worker enters the deferred-wait branch.
+    for i in 1..=NUM_POINTS {
+        shard
+            .update(
+                make_upsert_op(i).into(),
+                WaitUntil::Wal,
+                None,
+                hw_acc.clone(),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Spawn A on a separate task so its future (and thus its feedback receiver)
+    // stays alive while B races. If dropped, the worker would detect the closed
+    // receiver and exit the deferred wait early — masking the regression.
+    let shard_a = Arc::clone(&shard);
+    let hw_acc_a = hw_acc.clone();
+    let a_handle = tokio::spawn(async move {
+        shard_a
+            .update(
+                make_upsert_op(NUM_POINTS + 1).into(),
+                WaitUntil::Visible,
+                None,
+                hw_acc_a,
+            )
+            .await
+    });
+
+    // Give the worker a beat to pick up A and enter its deferred wait.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let b_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        shard.update(
+            make_upsert_op(NUM_POINTS + 2).into(),
+            WaitUntil::Segment,
+            None,
+            hw_acc.clone(),
+        ),
+    )
+    .await
+    .expect("B should complete within 5s — update worker appears blocked on A's deferred wait")
+    .expect("B update call should not error");
+    assert_eq!(b_result.status, UpdateStatus::Completed);
+
+    // B only demonstrates non-blocking if A was genuinely still waiting on
+    // deferred points. With the optimizer disabled, A must not have resolved.
+    assert!(
+        !a_handle.is_finished(),
+        "A should still be waiting on deferred points — otherwise B's completion \
+         does not prove the worker was free"
+    );
+
+    // A is not expected to resolve (optimizer is disabled). Abort it so the
+    // runtime can clean up.
+    a_handle.abort();
 }
 
 /// Test that with `prevent_unoptimized=true` and `wait=false`, points that reach

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -50,7 +50,7 @@ impl UpdateWorkers {
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
-        mut optimization_finished_receiver: watch::Receiver<()>,
+        optimization_finished_receiver: watch::Receiver<()>,
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
     ) -> Receiver<UpdateSignal> {
@@ -158,29 +158,49 @@ impl UpdateWorkers {
                         log::error!("Can't update last applied_seq {err}")
                     }
 
-                    let status = if wait_for_deferred && prevent_unoptimized {
-                        let wait_result = Self::wait_for_deferred_points_ready(
-                            &segments,
-                            &optimize_sender,
-                            &mut optimization_finished_receiver,
-                            &cancel,
-                            sender.as_ref(),
-                        )
-                        .await;
-                        // Waiting for deferred points should never error out as it would mark the shard as dead
-                        if let Err(wait_result) = wait_result {
-                            log::warn!("Failed to await for deferred points: {wait_result}");
-                            UpdateStatus::WaitTimeout // ToDo: Consider special status
-                        } else {
-                            UpdateStatus::Completed
+                    if wait_for_deferred && prevent_unoptimized {
+                        if let Some(feedback) = sender {
+                            // Detach the deferred-points wait so only the originating
+                            // client waits — the update queue keeps draining.
+                            let segments = segments.clone();
+                            let optimize_sender = optimize_sender.clone();
+                            let mut optimization_finished_receiver =
+                                optimization_finished_receiver.clone();
+                            let cancel = cancel.clone();
+                            tokio::spawn(async move {
+                                let status = match Self::wait_for_deferred_points_ready(
+                                    &segments,
+                                    &optimize_sender,
+                                    &mut optimization_finished_receiver,
+                                    &cancel,
+                                    Some(&feedback),
+                                )
+                                .await
+                                {
+                                    Ok(()) => UpdateStatus::Completed,
+                                    Err(err) => {
+                                        log::warn!("Failed to await for deferred points: {err}");
+                                        UpdateStatus::WaitTimeout
+                                    }
+                                };
+                                send_feedback(
+                                    Some(feedback),
+                                    Ok(InternalUpdateResult { op_num, status }),
+                                    op_num,
+                                );
+                            });
                         }
+                        // No sender: nobody is waiting, skip the deferred wait entirely.
                     } else {
-                        UpdateStatus::Completed
-                    };
-
-                    let internal_update_result = InternalUpdateResult { op_num, status };
-
-                    send_feedback(sender, Ok(internal_update_result), op_num);
+                        send_feedback(
+                            sender,
+                            Ok(InternalUpdateResult {
+                                op_num,
+                                status: UpdateStatus::Completed,
+                            }),
+                            op_num,
+                        );
+                    }
                 }
                 UpdateSignal::Nop => optimize_sender
                     .send(OptimizerSignal::Nop)
@@ -227,7 +247,7 @@ impl UpdateWorkers {
     ) -> CollectionResult<()> {
         loop {
             // If the caller dropped their receiver (e.g. client timeout),
-            // stop waiting to avoid blocking the update worker pipeline.
+            // stop waiting since there is no one left to report to.
             if feedback_sender.is_some_and(|s| s.is_closed()) {
                 log::debug!("wait_for_deferred_points_ready: caller no longer waiting");
                 return Err(CollectionError::cancelled(


### PR DESCRIPTION
  ## Summary

  When a client writes with `wait=true` (i.e. `WaitUntil::Visible`) on a collection with `prevent_unoptimized=true`, the update worker would wait inline for the deferred points from that operation to become optimized before picking up the next signal. 

This stalled every other writer on the same shard — including those that did not ask to wait for visibility — for as long as the optimizer took to clear the deferred set.

This change detaches the wait into a spawned task that owns the client's `oneshot` feedback sender. 

The update worker returns to its main loop immediately and keeps draining the queue; the originating client still blocks on its receiver (with whatever client-side timeout it passed) until its deferred points are ready.

  ## Contract change

  - **Before**: `wait=true` on a deferred-points collection blocked both the caller *and* the entire shard update queue.
  - **After**: `wait=true` on a deferred-points collection blocks only the caller. Other writers proceed normally.

  `UpdateStatus::Completed` / `UpdateStatus::WaitTimeout` semantics returned to the caller are unchanged. Cancellation (worker restart via consensus) and client-timeout (receiver dropped) exits are preserved.

  ## Trade-off — caller wait can grow under sustained writes

The exit condition for the detached wait is *no segment has any deferred points*. With the queue no longer paused, concurrent writers can keep adding new deferred points while the original waiter is still parked. 

On a continuously-written shard the optimizer may never observe a "deferred points = 0" snapshot, so the originating `wait=true` client can end up waiting until its client-side timeout fires (and gets `UpdateStatus::WaitTimeout`).
