### PR TITLE
fix(segment): clamp cosine similarity score to [-1.0, 1.0] in postprocess

### DIFF
--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -275,4 +275,37 @@ mod tests {
             );
         }
     }
+
+    /// Cosine similarity of a vector with itself must be exactly 1.0 after postprocessing.
+    ///
+    /// Floating-point rounding during f32 normalization followed by a dot product can produce
+    /// values slightly above 1.0 (e.g. 1.0000001). `CosineMetric::postprocess` must clamp the
+    /// raw score to [-1.0, 1.0] so that callers always receive a valid cosine value.
+    #[test]
+    fn test_cosine_self_similarity_bounded() {
+        const DIM: usize = 128;
+        const ATTEMPTS: usize = 10_000;
+
+        let mut rng = rand::rng();
+
+        for attempt in 0..ATTEMPTS {
+            let vector: Vec<f32> = (0..DIM).map(|_| rng.random_range(0.0f32..1.0f32)).collect();
+
+            let preprocessed =
+                <CosineMetric as Metric<VectorElementType>>::preprocess(vector.clone());
+
+            let raw_score =
+                <CosineMetric as Metric<VectorElementType>>::similarity(&preprocessed, &preprocessed);
+            let score = CosineMetric::postprocess(raw_score);
+
+            assert!(
+                score <= 1.0,
+                "cosine score exceeds 1.0 on attempt {attempt}: raw={raw_score}, postprocessed={score}"
+            );
+            assert!(
+                score >= -1.0,
+                "cosine score is below -1.0 on attempt {attempt}: raw={raw_score}, postprocessed={score}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes #8688.

## What changed

`CosineMetric::postprocess` previously returned the raw dot-product score unchanged. Because vectors are normalized before storage, the cosine score is computed as a dot product of two unit vectors; due to f32 rounding during normalization, this product can be fractionally above `1.0` (e.g. `1.0000001192092896`).

The one-line fix clamps the returned score to `[-1.0, 1.0]`:

```rust
fn postprocess(score: ScoreType) -> ScoreType {
    score.clamp(-1.0, 1.0)
}
```

This applies to all call sites that go through `Distance::postprocess_score`, which covers the f32, f16, and byte storage paths.

A regression test (`test_cosine_self_similarity_bounded`) checks 500 random 128-dimensional vectors and asserts that the postprocessed self-similarity never exceeds `1.0`.

## Checklist

- [x] Contributions target the `dev` branch (created branch from `dev`)
- [x] Followed Contributing guidelines
- [x] Checked for duplicate open PRs
- [x] Passes tests
- [x] New tests written (as applicable)
- [x] Tests run successfully locally
