### PR TITLE
Fix missing validation on adding named vector

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -17724,7 +17724,8 @@
             "description": "Dimensionality of the vectors",
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "maximum": 65536,
+            "minimum": 1
           },
           "distance": {
             "$ref": "#/components/schemas/Distance"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -231,6 +231,8 @@ fn configure_validation(builder: Builder) -> Builder {
             ("DeleteFieldIndexCollection.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("DeleteFieldIndexCollection.field_name", "length(min = 1)"),
             ("CreateVectorNameRequest.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
+            ("CreateVectorNameRequest.vector_config", ""),
+            ("DenseVectorCreationConfig.size", "range(min = 1, max = 65536)"),
             ("DeleteVectorNameRequest.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("SearchPoints.collection_name", "length(min = 1, max = 255), custom(function = \"common::validation::validate_collection_name_legacy\")"),
             ("SearchPoints.filter", ""),
@@ -360,7 +362,9 @@ fn configure_validation(builder: Builder) -> Builder {
             ("SearchMatrixPoints.sample", "range(min = 2)"),
             ("SearchMatrixPoints.limit", "range(min = 1)"),
             ("SearchMatrixPoints.timeout", "range(min = 1)")
-        ], &[])
+        ], &[
+            "SparseVectorCreationConfig",
+        ])
         .type_attribute(".", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5570,12 +5570,14 @@ pub struct DeleteFieldIndexCollection {
 /// Dense vector creation parameters.
 /// Only includes immutable properties that define the vector space.
 /// Storage type, index, and quantization are configured separately.
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DenseVectorCreationConfig {
     /// Size/dimensionality of the vectors
     #[prost(uint64, tag = "1")]
+    #[validate(range(min = 1, max = 65536))]
     pub size: u64,
     /// Distance function used for comparing vectors
     #[prost(enumeration = "Distance", tag = "2")]
@@ -5589,6 +5591,7 @@ pub struct DenseVectorCreationConfig {
 }
 /// Sparse vector creation parameters.
 /// Only includes immutable properties that define the vector space.
+#[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5623,6 +5626,7 @@ pub struct CreateVectorNameRequest {
     pub timeout: ::core::option::Option<u64>,
     /// Configuration for the new vector - either dense or sparse
     #[prost(oneof = "create_vector_name_request::VectorConfig", tags = "4, 5")]
+    #[validate(nested)]
     pub vector_config: ::core::option::Option<create_vector_name_request::VectorConfig>,
 }
 /// Nested message and enum types in `CreateVectorNameRequest`.

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -74,6 +74,16 @@ impl Validate for grpc::vectors_config_diff::Config {
     }
 }
 
+impl Validate for grpc::create_vector_name_request::VectorConfig {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        use grpc::create_vector_name_request::VectorConfig;
+        match self {
+            VectorConfig::DenseConfig(dense) => dense.validate(),
+            VectorConfig::SparseConfig(sparse) => sparse.validate(),
+        }
+    }
+}
+
 impl Validate for grpc::quantization_config::Quantization {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use grpc::quantization_config::Quantization;
@@ -530,8 +540,9 @@ mod tests {
     use validator::Validate;
 
     use crate::grpc::qdrant::{
-        CreateCollection, CreateFieldIndexCollection, GeoLineString, GeoPoint, GeoPolygon,
-        SearchPoints, UpdateCollection,
+        CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest,
+        DenseVectorCreationConfig, GeoLineString, GeoPoint, GeoPolygon, SearchPoints,
+        UpdateCollection, create_vector_name_request,
     };
 
     #[test]
@@ -737,5 +748,47 @@ mod tests {
             good_polygon.validate().is_ok(),
             "good polygon should not error on validation"
         );
+    }
+
+    #[test]
+    fn test_create_vector_name_request() {
+        let request_with_zero_size = CreateVectorNameRequest {
+            collection_name: "test".into(),
+            vector_name: "vec".into(),
+            vector_config: Some(create_vector_name_request::VectorConfig::DenseConfig(
+                DenseVectorCreationConfig {
+                    size: 0,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        assert!(request_with_zero_size.validate().is_err());
+
+        let request_with_oversize = CreateVectorNameRequest {
+            collection_name: "test".into(),
+            vector_name: "vec".into(),
+            vector_config: Some(create_vector_name_request::VectorConfig::DenseConfig(
+                DenseVectorCreationConfig {
+                    size: 65537,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        assert!(request_with_oversize.validate().is_err());
+
+        let good_request = CreateVectorNameRequest {
+            collection_name: "test".into(),
+            vector_name: "vec".into(),
+            vector_config: Some(create_vector_name_request::VectorConfig::DenseConfig(
+                DenseVectorCreationConfig {
+                    size: 768,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        assert!(good_request.validate().is_ok());
     }
 }

--- a/lib/segment/src/data_types/vector_name_config.rs
+++ b/lib/segment/src/data_types/vector_name_config.rs
@@ -33,18 +33,20 @@ pub enum VectorNameConfig {
 }
 
 /// Wrapper for dense vector creation config.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct DenseVectorNameConfig {
     /// Dense vector parameters
+    #[validate(nested)]
     pub dense: DenseVectorConfig,
 }
 
 /// Wrapper for sparse vector creation config.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct SparseVectorNameConfig {
     /// Sparse vector parameters
+    #[validate(nested)]
     pub sparse: SparseVectorConfig,
 }
 
@@ -52,10 +54,11 @@ pub struct SparseVectorNameConfig {
 ///
 /// Only includes properties that define the vector space and cannot be changed
 /// after creation. Storage type, index type, and quantization are inferred.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct DenseVectorConfig {
     /// Dimensionality of the vectors
+    #[validate(range(min = 1, max = 65536))]
     pub size: usize,
     /// Distance function used for measuring distance between vectors
     pub distance: Distance,
@@ -71,7 +74,7 @@ pub struct DenseVectorConfig {
 ///
 /// Only includes properties that define the vector space and cannot be changed
 /// after creation.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct SparseVectorConfig {
     /// Value modifier for sparse vectors (e.g., IDF)
@@ -84,7 +87,10 @@ pub struct SparseVectorConfig {
 
 impl Validate for VectorNameConfig {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        Ok(())
+        match self {
+            VectorNameConfig::Dense(config) => config.validate(),
+            VectorNameConfig::Sparse(config) => config.validate(),
+        }
     }
 }
 

--- a/tests/openapi/test_named_vector_crud.py
+++ b/tests/openapi/test_named_vector_crud.py
@@ -95,6 +95,28 @@ def test_delete_recreate_vector_scroll(collection_name):
         assert len(point['vector']['vec_b']) == VECTOR_SIZE2
 
 
+def test_create_vector_rejects_zero_size(collection_name):
+    """size: 0 must be rejected at the API boundary, not reach the storage layer."""
+    response = requests.put(
+        f"{QDRANT_HOST}/collections/{collection_name}/vectors/vec_zero",
+        params={'wait': 'true'},
+        json={"dense": {"size": 0, "distance": "Cosine"}},
+    )
+    assert response.status_code == 422, response.text
+    assert "size" in response.text
+
+
+def test_create_vector_rejects_oversize(collection_name):
+    """size above 65536 must be rejected at the API boundary."""
+    response = requests.put(
+        f"{QDRANT_HOST}/collections/{collection_name}/vectors/vec_huge",
+        params={'wait': 'true'},
+        json={"dense": {"size": 65537, "distance": "Cosine"}},
+    )
+    assert response.status_code == 422, response.text
+    assert "size" in response.text
+
+
 def test_delete_recreate_indexed_vector_scroll():
     """
     Delete and recreate a named vector on indexed segments (HNSW built),


### PR DESCRIPTION
Adding a new named vector with `size=0` results in an HTTP 500 error.

```json
{"status":{"error":"Service internal error: The vector's dimension cannot be 0"}
```

This PR adds the missing validation for the REST and gRPC API.