### PR TITLE
Speed up e2e tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,8 +9,30 @@ on:
 env:
   CARGO_TERM_COLOR: always
   UV_VERSION: 0.9.17
+  MINIO_IMAGE: satantime/minio-server@sha256:21f80e40e980b34464ec6bb470d264e735037ab4246358b79f18198071726531
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'src/**'
+              - 'lib/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Dockerfile'
+              - 'tools/**'
+              - 'config/**'
+              - 'tests/e2e_tests/**'
+              - '.github/workflows/integration-tests.yml'
+
   integration-tests:
 
     runs-on: ubuntu-latest
@@ -156,22 +178,37 @@ jobs:
 
   test-shard-snapshot-api-s3-minio:
     runs-on: ubuntu-latest
-    # Setup minio server
-    services:
-      minio:
-        image: satantime/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
     steps:
+      - name: Pull minio image
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_on: error
+          command: docker pull ${{ env.MINIO_IMAGE }}
+      - name: Start minio
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ACCESS_KEY=minioadmin \
+            -e MINIO_SECRET_KEY=minioadmin \
+            ${{ env.MINIO_IMAGE }}
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+              echo "minio is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "minio did not become ready" >&2
+          docker logs minio
+          exit 1
       - name: Setup test bucket
         env:
           AWS_ACCESS_KEY_ID: "minioadmin"
           AWS_SECRET_ACCESS_KEY: "minioadmin"
           AWS_EC2_METADATA_DISABLED: "true"
-        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
+        run: aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -210,65 +247,112 @@ jobs:
 
           ./tests/shard-snapshot-api.sh test-all
 
-  e2e-tests:
+  build-e2e-image:
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          lfs: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build Qdrant Docker image
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: |
+            docker buildx build \
+              --tag qdrant/qdrant:e2e-tests \
+              --cache-from "type=gha,scope=${{ github.ref }}-e2e" \
+              --cache-from "type=gha,scope=${{ github.base_ref }}-e2e" \
+              --cache-to "type=gha,mode=max,scope=${{ github.ref }}-e2e" \
+              --load \
+              --build-arg PROFILE=ci \
+              --build-arg FEATURES=data-consistency-check,staging \
+              .
+      - name: Save and compress image
+        run: docker save qdrant/qdrant:e2e-tests | zstd -1 -o /tmp/e2e-image.tar.zst
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-image
+          path: /tmp/e2e-image.tar.zst
+          retention-days: 1
+          compression-level: 0
 
-    # Setup minio server
-    services:
-      minio:
-        image: satantime/minio-server
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ACCESS_KEY: "minioadmin"
-          MINIO_SECRET_KEY: "minioadmin"
+  e2e-tests:
+    needs: build-e2e-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
-      - name: Setup test bucket
-        env:
-          AWS_ACCESS_KEY_ID: "minioadmin"
-          AWS_SECRET_ACCESS_KEY: "minioadmin"
-          AWS_EC2_METADATA_DISABLED: "true"
-        run: echo $(aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket)
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true  # Fetch LFS files automatically
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install uv and Python dependencies
         run: |
           curl -LsSf https://astral.sh/uv/$UV_VERSION/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           uv --project tests lock --check
           uv --project tests sync
-      - name: Build Qdrant Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - name: Download Qdrant image
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          context: .
-          tags: qdrant/qdrant:e2e-tests
-          cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
-          load: true
-          build-args: |
-            PROFILE=ci
-            FEATURES=data-consistency-check,staging
-      - name: Verify Docker image
-        run: docker images | grep qdrant
-      - name: Run e2e tests
-        run: uv --project tests run pytest -n 4 --dist=loadgroup tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
+          name: e2e-image
+          path: /tmp
+      - name: Load Qdrant image
+        run: zstd -dc /tmp/e2e-image.tar.zst | docker load
+      - name: Pull minio image
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_on: error
+          command: docker pull ${{ env.MINIO_IMAGE }}
+      - name: Start minio
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ACCESS_KEY=minioadmin \
+            -e MINIO_SECRET_KEY=minioadmin \
+            ${{ env.MINIO_IMAGE }}
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+              echo "minio is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "minio did not become ready" >&2
+          docker logs minio
+          exit 1
+      - name: Setup test bucket
+        env:
+          AWS_ACCESS_KEY_ID: "minioadmin"
+          AWS_SECRET_ACCESS_KEY: "minioadmin"
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test-bucket
+      - name: Run e2e tests (shard ${{ matrix.shard }}/3)
+        run: |
+          uv --project tests run pytest \
+            -n 2 \
+            --splits 3 --group ${{ matrix.shard }} \
+            tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
         shell: bash
-        timeout-minutes: 20
+        timeout-minutes: 15
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: e2e-test-logs
+          name: e2e-test-logs-shard-${{ matrix.shard }}
           path: |
             tests/e2e_tests/test_*.log
             tests/e2e_tests/**/logs/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -350,7 +350,7 @@ jobs:
           uv --project tests run pytest \
             -n 2 \
             --splits 3 --group ${{ matrix.shard }} \
-            --store-durations \
+            --store-durations --durations-path tests/e2e_tests/.test_durations \
             tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
         shell: bash
         timeout-minutes: 15
@@ -359,7 +359,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-shard-${{ matrix.shard }}
-          path: .test_durations
+          path: tests/e2e_tests/.test_durations
           retention-days: 1
           include-hidden-files: true
       - name: Upload test logs on failure

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -352,27 +352,12 @@ jobs:
             tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
         shell: bash
         timeout-minutes: 15
-      - name: Locate test durations file
-        if: always()
-        run: |
-          echo "=== cwd ==="
-          pwd
-          echo "=== find under workspace ==="
-          find "$GITHUB_WORKSPACE" -name '.test_durations' \
-               -not -path '*/.venv/*' -not -path '*/node_modules/*' \
-               2>/dev/null || true
-          echo "=== find under /tmp ==="
-          find /tmp -name '.test_durations' 2>/dev/null || true
       - name: Upload test durations
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-shard-${{ matrix.shard }}
-          path: |
-            **/.test_durations
-            !**/.venv/**
-            !**/__pycache__/**
-          if-no-files-found: warn
+          path: .test_durations
           retention-days: 1
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,6 +31,8 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - 'tests/e2e_tests/**'
+              - 'tests/pyproject.toml'
+              - 'tests/uv.lock'
               - '.github/workflows/integration-tests.yml'
 
   integration-tests:
@@ -354,7 +356,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-shard-${{ matrix.shard }}
-          path: .test_durations
+          path: tests/.test_durations
           retention-days: 1
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -350,18 +350,10 @@ jobs:
           uv --project tests run pytest \
             -n 2 \
             --splits 3 --group ${{ matrix.shard }} \
-            --store-durations --durations-path tests/e2e_tests/.test_durations \
-            tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
+            --durations-path tests/e2e_tests/.test_durations \
+            tests/e2e_tests -v --tb=short --durations=5 -rs -m "not longrunning"
         shell: bash
         timeout-minutes: 15
-      - name: Upload test durations
-        if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-durations-shard-${{ matrix.shard }}
-          path: tests/e2e_tests/.test_durations
-          retention-days: 1
-          include-hidden-files: true
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -345,9 +345,17 @@ jobs:
           uv --project tests run pytest \
             -n 2 \
             --splits 3 --group ${{ matrix.shard }} \
+            --store-durations \
             tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
         shell: bash
         timeout-minutes: 15
+      - name: Upload test durations
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-durations-shard-${{ matrix.shard }}
+          path: .test_durations
+          retention-days: 1
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,9 +130,9 @@ jobs:
           context: .
           tags: qdrant_consensus
           cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref || github.ref_name }}-consensus
+            type=gha,scope=dev-consensus
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-consensus', github.ref_name) || '' }}
           load: true
           build-args: |
             PROFILE=ci

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -261,6 +261,8 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build Qdrant Docker image
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        env:
+          CACHE_TO_ARG: ${{ github.event_name == 'push' && format('--cache-to type=gha,mode=max,scope={0}-e2e', github.ref_name) || '' }}
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -269,9 +271,9 @@ jobs:
             docker buildx build \
               --progress=plain \
               --tag qdrant/qdrant:e2e-tests \
-              --cache-from "type=gha,scope=${{ github.ref }}-e2e" \
-              --cache-from "type=gha,scope=${{ github.base_ref }}-e2e" \
-              --cache-to "type=gha,mode=max,scope=${{ github.ref }}-e2e" \
+              --cache-from "type=gha,scope=${{ github.base_ref || github.ref_name }}-e2e" \
+              --cache-from "type=gha,scope=dev-e2e" \
+              $CACHE_TO_ARG \
               --load \
               --build-arg PROFILE=ci \
               --build-arg FEATURES=data-consistency-check,staging \
@@ -359,6 +361,7 @@ jobs:
           name: test-durations-shard-${{ matrix.shard }}
           path: .test_durations
           retention-days: 1
+          include-hidden-files: true
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -267,6 +267,7 @@ jobs:
           retry_on: error
           command: |
             docker buildx build \
+              --progress=plain \
               --tag qdrant/qdrant:e2e-tests \
               --cache-from "type=gha,scope=${{ github.ref }}-e2e" \
               --cache-from "type=gha,scope=${{ github.base_ref }}-e2e" \
@@ -351,12 +352,27 @@ jobs:
             tests/e2e_tests -v --tb=short --durations=5 -m "not longrunning"
         shell: bash
         timeout-minutes: 15
+      - name: Locate test durations file
+        if: always()
+        run: |
+          echo "=== cwd ==="
+          pwd
+          echo "=== find under workspace ==="
+          find "$GITHUB_WORKSPACE" -name '.test_durations' \
+               -not -path '*/.venv/*' -not -path '*/node_modules/*' \
+               2>/dev/null || true
+          echo "=== find under /tmp ==="
+          find /tmp -name '.test_durations' 2>/dev/null || true
       - name: Upload test durations
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-shard-${{ matrix.shard }}
-          path: tests/.test_durations
+          path: |
+            **/.test_durations
+            !**/.venv/**
+            !**/__pycache__/**
+          if-no-files-found: warn
           retention-days: 1
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -11,7 +11,7 @@ function clear_after_tests()
 }
 
 # Prevent double building in docker-compose
-docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=qdrant_consensus
+docker buildx build --build-arg=PROFILE=ci --build-arg=FEATURES=staging --load ../../ --tag=qdrant_consensus
 docker compose down --volumes
 docker compose up -d --force-recreate
 trap clear_after_tests EXIT

--- a/tests/e2e_tests/.test_durations
+++ b/tests/e2e_tests/.test_durations
@@ -1,0 +1,19 @@
+{
+  "e2e_tests/test_bugs.py::TestSnapshotsInterferenceWithConsensus::test_snapshot_does_not_block_other_operations[qdrant_compose0]": 337.4045226940001,
+  "e2e_tests/test_continuous_snapshots.py::TestContinuousSnapshots::test_continuous_snapshots": 8.97672835200001,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.16.0]@compatibility": 51.52099562599997,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.16.1]@compatibility": 52.686344951,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.16.2]@compatibility": 85.940226876,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.16.3]@compatibility": 95.45315375900009,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.17.0]@compatibility": 78.61033717200002,
+  "e2e_tests/test_data_compatibility.py::TestStorageCompatibility::test_compatibility[v1.17.1]@compatibility": 52.95291753299995,
+  "e2e_tests/test_immutable_index.py::TestImmutableIndex::test_immutable_full_text_index": 2.6313369920000014,
+  "e2e_tests/test_low_disk.py::TestLowDisk::test_low_disk_handling[indexing]": 72.443975763,
+  "e2e_tests/test_low_disk.py::TestLowDisk::test_low_disk_handling[search]": 22.052386685999977,
+  "e2e_tests/test_snapshots_recovery.py::TestSnapshotsRecovery::test_snapshots_recovery[local]": 1.3079720680000264,
+  "e2e_tests/test_snapshots_recovery.py::TestSnapshotsRecovery::test_snapshots_recovery[s3]": 1.7975209310000082,
+  "e2e_tests/test_strict_mode_memory.py::TestStrictModeMemory::test_memory_threshold_blocks_then_recovers_after_delete": 14.102287067999995,
+  "e2e_tests/test_tls.py::TestTLS::test_tls_connectivity[grpc]": 20.464151897000022,
+  "e2e_tests/test_tls.py::TestTLS::test_tls_connectivity[http]": 17.81874769999999,
+  "e2e_tests/test_tls.py::TestTLS::test_tls_shard_transfer": 6.447323200999989
+}

--- a/tests/e2e_tests/README.md
+++ b/tests/e2e_tests/README.md
@@ -66,3 +66,13 @@ E2E tests are split across shards in CI using [pytest-split](https://github.com/
 
 4. Revert the workflow changes from step 1.
 5. Commit the updated `tests/e2e_tests/.test_durations` together with the workflow revert.
+
+# Local buildx cache
+
+When no pre-built `qdrant/qdrant:e2e-tests` exists locally, the `qdrant_image` fixture builds one 
+via a dedicated `qdrant-e2e-builder` (docker-container driver) with a persistent cache at `~/.cache/qdrant-e2e-buildx`.
+
+- First run is cold; subsequent runs reuse the `cargo chef cook` layer while `Cargo.lock` is unchanged.
+- Cache is shared across checkouts and worktrees.
+- Reset: `rm -rf ~/.cache/qdrant-e2e-buildx`. Remove builder: `docker buildx rm qdrant-e2e-builder`.
+- CI never builds here — it loads the image from the `build-e2e-image` artifact.

--- a/tests/e2e_tests/README.md
+++ b/tests/e2e_tests/README.md
@@ -20,3 +20,49 @@ Follow those steps to recreate the reference storage data and snapshot.
 1. run `PROJECT_ROOT/tests/e2e_tests/test_data/compatibility/gen_storage_compat_data.sh`
 2. make sure to pick the right version when asked for which system generated the files
 3. push the new archives to the GCP bucket (ask for the credentials if you don't have them)
+
+# Refresh test durations
+
+E2E tests are split across shards in CI using [pytest-split](https://github.com/jerry-git/pytest-split), which reads `tests/e2e_tests/.test_durations` to balance per-test wall time across shards. The file drifts over time as tests are added, removed, or change in duration; refresh it when shard imbalance becomes noticeable.
+
+1. On a branch, temporarily edit `.github/workflows/integration-tests.yml` — in the `e2e-tests` job, add `--store-durations` to the pytest command and add the upload step right after it:
+
+   ```yaml
+   - name: Run e2e tests (shard ${{ matrix.shard }}/3)
+     run: |
+       uv --project tests run pytest \
+         -n 2 \
+         --splits 3 --group ${{ matrix.shard }} \
+         --store-durations --durations-path tests/e2e_tests/.test_durations \
+         tests/e2e_tests -v --tb=short --durations=5 -rs -m "not longrunning"
+     shell: bash
+     timeout-minutes: 15
+   - name: Upload test durations
+     if: success()
+     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+     with:
+       name: test-durations-shard-${{ matrix.shard }}
+       path: tests/e2e_tests/.test_durations
+       retention-days: 1
+       include-hidden-files: true
+   ```
+
+2. Push and let CI run all three shards to completion.
+3. Download and merge the per-shard artifacts into one file:
+
+   ```bash
+   gh run download <run-id> -p 'test-durations-shard-*'
+   python3 -c '
+   import json, glob
+   merged = {}
+   for p in sorted(glob.glob("test-durations-shard-*/.test_durations")):
+       with open(p) as f:
+           merged.update(json.load(f))
+   json.dump(dict(sorted(merged.items())), open("tests/e2e_tests/.test_durations","w"), indent=2)
+   print(f"{len(merged)} tests")
+   '
+   rm -rf test-durations-shard-*
+   ```
+
+4. Revert the workflow changes from step 1.
+5. Commit the updated `tests/e2e_tests/.test_durations` together with the workflow revert.

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -94,11 +94,23 @@ def qdrant_image(docker_client: docker.DockerClient, request) -> str:
         else:
             print(f"Building Docker image {image_tag}...")
 
-        # Build image using docker buildx
+        cache_dir = Path.home() / ".cache" / "qdrant-e2e-buildx"
+        builder_name = "qdrant-e2e-builder"
+        if subprocess.run(
+            ["docker", "buildx", "inspect", builder_name],
+            capture_output=True,
+        ).returncode != 0:
+            subprocess.run(
+                ["docker", "buildx", "create", "--name", builder_name, "--driver", "docker-container"],
+                check=True,
+            )
         build_cmd = [
             "docker", "buildx", "build",
+            f"--builder={builder_name}",
             "--build-arg=PROFILE=ci",
             "--build-arg=FEATURES=data-consistency-check,staging",
+            f"--cache-from=type=local,src={cache_dir}",
+            f"--cache-to=type=local,dest={cache_dir},mode=max",
             "--load",
             str(project_root),
             f"--tag={image_tag}"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "retry>=0.9.2,<0.10",
     "docker>=7.1.0,<8",
     "pytest-xdist>=3.8.0,<4",
+    "pytest-split>=0.10,<1",
     "pytest-subtests>=0.14.1,<0.15",
     "qdrant-client>=1.16.1,<2",
     "tqdm>=4.67.1,<5",

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1578,6 +1578,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
 name = "pytest-subtests"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1745,6 +1757,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-cases" },
+    { name = "pytest-split" },
     { name = "pytest-subtests" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
@@ -1765,6 +1778,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.10,<3" },
     { name = "pytest", specifier = ">=8.4,<9" },
     { name = "pytest-cases", specifier = ">=3.9.1,<4" },
+    { name = "pytest-split", specifier = ">=0.10,<1" },
     { name = "pytest-subtests", specifier = ">=0.14.1,<0.15" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4" },


### PR DESCRIPTION
  - extract e2e image build into a job, the e2e-tests jobs then download the artifact instead of rebuilding
  - sharded e2e tests via pytest-split (3 shards × -n 2) with a seeded tests/e2e_tests/.test_durations.                                                                                                                                       
  - gate e2e jobs on dorny/paths-filter; PRs skip e2e when unrelated
  - fix GHA cache eviction: cache-to now only writes on push to master/dev, not PRs
  - pin MinIO image, add retries on the image pull and docker build
  - document how to refresh .test_durations
  - do not rebuild image in `test-consensus-compose`
  - use local cache for local e2e tests runs

Note on how e2e image leverages the caches now: `cache-from` reads the `dev-e2e` GHA scope, populated only by pushes to dev. Each push to dev overwrites it with a fresh manifest + blobs, so the scope never churns. A PR build imports that stable manifest, hits every unchanged layer (i.e the expensive cargo-chef cook dep layer) and only recompiles the final `cargo build --bin qdrant` step because the source changed. No cache-to on PRs, so no LRU eviction of the dev-e2e blobs.