### PR TITLE
Fix Edge build with pinning transitive

### DIFF
--- a/lib/edge/publish/examples/Cargo.toml
+++ b/lib/edge/publish/examples/Cargo.toml
@@ -10,3 +10,5 @@ qdrant-edge = { path = "../qdrant-edge" }
 fs-err = "3"
 tempfile = "3"
 ureq = "3"
+# Pin transitive: i_key_sort 0.10.2 fails to compile (upstream bug, BinLayout::new missing).
+i_key_sort = "=0.10.1"


### PR DESCRIPTION
https://github.com/qdrant/qdrant/actions/runs/24837684774/job/72702447636

```
    Checking i_key_sort v0.10.2
error[E0599]: no function or associated item named `new` found for struct `BinLayout<K>` in the current scope
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/i_key_sort-0.10.2/src/sort/parallel/bin_layout.rs:25:25
   |
25 |         Some(BinLayout::new(min_key, max_key, max_bins_count))
   |                         ^^^ function or associated item not found in `BinLayout<_>`
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/i_key_sort-0.10.2/src/sort/bin_layout.rs:9:1
   |
 9 | pub(crate) struct BinLayout<K> {
   | ------------------------------ function or associated item `new` not found for this struct
   |
note: if you're trying to build a new `BinLayout<_>` consider using one of the following associated functions:
      parallel::bin_layout::<impl BinLayout<K>>::with_cpu_count
      BinLayout::<K>::with_keys
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/i_key_sort-0.10.2/src/sort/parallel/bin_layout.rs:11:5
   |
11 | /     pub(super) fn with_cpu_count<T, F>(cpu: usize, slice: &[T], key: F) -> Option<Self>
12 | |     where
13 | |         T: Copy + Send + Sync,
14 | |         F: KeyFn<T, K> + Send + Sync,
   | |_____________________________________^
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/i_key_sort-0.10.2/src/sort/bin_layout.rs:71:5
   |
71 |       pub fn with_keys<T, F: KeyFn<T, K>>(array: &[T], key: F) -> Option<Self> {
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `i_key_sort` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: Recipe `rs-check` failed on line 24 with exit code 101
Error: Process completed with exit code 101.

```