### PR TITLE
Use snapshot transfers by default

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -798,7 +798,7 @@ impl Collection {
 
             // Select shard transfer method, prefer user configured method or choose one now
             // If all peers are 1.8+, we try WAL delta transfer, otherwise we use the default method
-            let default_method = self.default_shard_transfer_method().await;
+            let default_method = self.default_shard_transfer_method();
             let shard_transfer_method = self
                 .shared_storage_config
                 .default_shard_transfer_method

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -58,7 +58,7 @@ impl Collection {
 
     pub async fn start_shard_transfer<T, F>(
         &self,
-        mut shard_transfer: ShardTransfer,
+        shard_transfer: ShardTransfer,
         consensus: Box<dyn ShardTransferConsensus>,
         temp_dir: PathBuf,
         on_finish: T,
@@ -68,11 +68,17 @@ impl Collection {
         T: Future<Output = ()> + Send + 'static,
         F: Future<Output = ()> + Send + 'static,
     {
-        // Select transfer method
-        let default_method = self.default_shard_transfer_method().await;
+        // The coordinating peer must pick the transfer method before submitting
+        // to consensus, so that every peer applies the same method for a given
+        // transfer. If `method` is None here, a submission site forgot to fill
+        // it in — refuse rather than pick a local default that could diverge
+        // across peers.
         if shard_transfer.method.is_none() {
-            log::warn!("No shard transfer method selected, defaulting to {default_method:?}");
-            shard_transfer.method.replace(default_method);
+            return Err(CollectionError::service_error(format!(
+                "Shard transfer {}:{} -> {} has no method set; the coordinating peer must \
+                 pick a transfer method before submitting to consensus",
+                shard_transfer.shard_id, shard_transfer.from, shard_transfer.to,
+            )));
         }
 
         let do_transfer = {
@@ -99,7 +105,9 @@ impl Collection {
             let from_is_local = from_replica_set.is_local().await;
             let to_is_local = to_replica_set.is_local().await;
 
-            let transfer_method = shard_transfer.method.unwrap_or(default_method);
+            // Checked at the top of the function — the method is always set by the
+            // peer that submitted this transfer to consensus.
+            let transfer_method = shard_transfer.method.expect("transfer method must be set");
             let initial_state = match transfer_method {
                 ShardTransferMethod::StreamRecords => ReplicaState::Partial,
 

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -59,7 +59,7 @@ impl Collection {
     }
 
     /// Default shard transfer method for Qdrant 1.18.0+
-    pub async fn default_shard_transfer_method(&self) -> ShardTransferMethod {
+    pub fn default_shard_transfer_method(&self) -> ShardTransferMethod {
         self.shared_storage_config
             .default_shard_transfer_method
             .unwrap_or(ShardTransferMethod::Snapshot)

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -43,7 +43,8 @@ impl Collection {
             .unwrap_or(false)
     }
 
-    pub async fn default_shard_transfer_method(&self) -> ShardTransferMethod {
+    /// Legacy default shard transfer method for Qdrant <1.18.0
+    pub async fn legacy_default_shard_transfer_method(&self) -> ShardTransferMethod {
         if self.is_prevent_unoptimized().await {
             // With prevent_unoptimized, use snapshot as the default method.
             // For automatic transfers, mod.rs prefers WalDelta when all peers
@@ -55,6 +56,13 @@ impl Collection {
                 .default_shard_transfer_method
                 .unwrap_or(ShardTransferMethod::StreamRecords)
         }
+    }
+
+    /// Default shard transfer method for Qdrant 1.18.0+
+    pub async fn default_shard_transfer_method(&self) -> ShardTransferMethod {
+        self.shared_storage_config
+            .default_shard_transfer_method
+            .unwrap_or(ShardTransferMethod::Snapshot)
     }
 
     pub async fn start_shard_transfer<T, F>(
@@ -89,7 +97,7 @@ impl Collection {
                     shard_transfer.shard_id, shard_transfer.from, shard_transfer.to,
                 )));
             }
-            let default_method = self.default_shard_transfer_method().await;
+            let default_method = self.legacy_default_shard_transfer_method().await;
             log::warn!(
                 "No shard transfer method selected, defaulting to {default_method:?} \
                  (cluster contains peers older than 1.18.0)",

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use common::defaults;
 use fs_err::tokio as tokio_fs;
 use parking_lot::Mutex;
+use semver::Version;
 use tokio_util::task::AbortOnDropHandle;
 
 use super::Collection;
@@ -58,7 +59,7 @@ impl Collection {
 
     pub async fn start_shard_transfer<T, F>(
         &self,
-        shard_transfer: ShardTransfer,
+        mut shard_transfer: ShardTransfer,
         consensus: Box<dyn ShardTransferConsensus>,
         temp_dir: PathBuf,
         on_finish: T,
@@ -70,15 +71,30 @@ impl Collection {
     {
         // The coordinating peer must pick the transfer method before submitting
         // to consensus, so that every peer applies the same method for a given
-        // transfer. If `method` is None here, a submission site forgot to fill
-        // it in — refuse rather than pick a local default that could diverge
-        // across peers.
+        // transfer.
+        //
+        // Once every peer is at 1.18.0+, all submission sites guarantee the
+        // method is set, so a missing method indicates a bug — refuse it.
+        // For mixed clusters (some peers <1.18.0), an older submission site
+        // may still send `None`; fall back to this peer's local default to
+        // preserve compatibility.
         if shard_transfer.method.is_none() {
-            return Err(CollectionError::service_error(format!(
-                "Shard transfer {}:{} -> {} has no method set; the coordinating peer must \
-                 pick a transfer method before submitting to consensus",
-                shard_transfer.shard_id, shard_transfer.from, shard_transfer.to,
-            )));
+            let all_peers_enforce = self
+                .channel_service
+                .all_peers_at_version(&Version::new(1, 18, 0));
+            if all_peers_enforce {
+                return Err(CollectionError::service_error(format!(
+                    "Shard transfer {}:{} -> {} has no method set; the coordinating peer must \
+                     pick a transfer method before submitting to consensus",
+                    shard_transfer.shard_id, shard_transfer.from, shard_transfer.to,
+                )));
+            }
+            let default_method = self.default_shard_transfer_method().await;
+            log::warn!(
+                "No shard transfer method selected, defaulting to {default_method:?} \
+                 (cluster contains peers older than 1.18.0)",
+            );
+            shard_transfer.method = Some(default_method);
         }
 
         let do_transfer = {

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -314,7 +314,7 @@ pub async fn do_update_collection_cluster(
             // applies the same one — the consensus entry carries it explicitly.
             let method = match move_shard.method {
                 Some(method) => method,
-                None => collection.default_shard_transfer_method().await,
+                None => collection.default_shard_transfer_method(),
             };
 
             // submit operation to consensus
@@ -356,7 +356,7 @@ pub async fn do_update_collection_cluster(
             // applies the same one — the consensus entry carries it explicitly.
             let method = match replicate_shard.method {
                 Some(method) => method,
-                None => collection.default_shard_transfer_method().await,
+                None => collection.default_shard_transfer_method(),
             };
 
             // submit operation to consensus
@@ -417,7 +417,7 @@ pub async fn do_update_collection_cluster(
             validate_peer_exists(from_peer_id)?;
 
             // Decide on a transfer-method and check its validity in combination with filters.
-            let method = collection.default_shard_transfer_method().await;
+            let method = collection.default_shard_transfer_method();
             if !method.is_streaming() && filter.is_some() {
                 return Err(StorageError::bad_request(format!(
                     "Can't do shard transfer using method {method:?} in combination with a filter",

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -310,6 +310,13 @@ pub async fn do_update_collection_cluster(
             validate_peer_exists(move_shard.to_peer_id)?;
             validate_peer_exists(move_shard.from_peer_id)?;
 
+            // Resolve the transfer method on this peer so the whole cluster
+            // applies the same one — the consensus entry carries it explicitly.
+            let method = match move_shard.method {
+                Some(method) => method,
+                None => collection.default_shard_transfer_method().await,
+            };
+
             // submit operation to consensus
             dispatcher
                 .submit_collection_meta_op(
@@ -321,7 +328,7 @@ pub async fn do_update_collection_cluster(
                             to: move_shard.to_peer_id,
                             from: move_shard.from_peer_id,
                             sync: false,
-                            method: move_shard.method,
+                            method: Some(method),
                             filter: None,
                         }),
                     ),
@@ -345,6 +352,13 @@ pub async fn do_update_collection_cluster(
             // validate source peer exists
             validate_peer_exists(replicate_shard.from_peer_id)?;
 
+            // Resolve the transfer method on this peer so the whole cluster
+            // applies the same one — the consensus entry carries it explicitly.
+            let method = match replicate_shard.method {
+                Some(method) => method,
+                None => collection.default_shard_transfer_method().await,
+            };
+
             // submit operation to consensus
             dispatcher
                 .submit_collection_meta_op(
@@ -356,7 +370,7 @@ pub async fn do_update_collection_cluster(
                             to: replicate_shard.to_peer_id,
                             from: replicate_shard.from_peer_id,
                             sync: true,
-                            method: replicate_shard.method,
+                            method: Some(method),
                             filter: None,
                         }),
                     ),

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -25,7 +25,9 @@ use collection::shards::replica_set;
 use collection::shards::replica_set::replica_set_state;
 use collection::shards::resharding::ReshardKey;
 use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
-use collection::shards::transfer::{ShardTransfer, ShardTransferKey, ShardTransferRestart};
+use collection::shards::transfer::{
+    ShardTransfer, ShardTransferKey, ShardTransferMethod, ShardTransferRestart,
+};
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use rand::seq::IteratorRandom;
@@ -416,13 +418,12 @@ pub async fn do_update_collection_cluster(
             validate_peer_exists(to_peer_id)?;
             validate_peer_exists(from_peer_id)?;
 
-            // Decide on a transfer-method and check its validity in combination with filters.
-            let method = collection.default_shard_transfer_method();
-            if !method.is_streaming() && filter.is_some() {
-                return Err(StorageError::bad_request(format!(
-                    "Can't do shard transfer using method {method:?} in combination with a filter",
-                )));
-            }
+            // Require stream records based transfer if a filter is given
+            let method = if filter.is_none() {
+                collection.default_shard_transfer_method()
+            } else {
+                ShardTransferMethod::StreamRecords
+            };
 
             // submit operation to consensus
             dispatcher


### PR DESCRIPTION
Depends on <https://github.com/qdrant/qdrant/pull/8782>

Switches the default shard transfer method from stream records to snapshot. This is desired because snapshot based transfers generally perform much better. WAL delta transfers are still preferred for automatic recovery transfers, after which it might fall back to snapshots.

Two changes are made to make this happen:
1. select default method on entrypoint peer, not on each peer separately
2. use `snapshot` method as default

Before this PR, selecting the default transfer method was not synchronized. If you'd trigger a transfer with no method, each peer would select the default method separately. Peers selecting different versions breaks consensus as transfers don't match up. Since we change the default method, running a cluster with mixed versions could trigger this. It was also possible to set different defaults in the configuration of each peer.

Now the peer that first sees the transfer request is responsible for setting the default transfer method. For user requests it'd be the entry point of their request. For automatic recovery transfers it'd be the peer that triggered the recovery.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
