### PR TITLE
Fix bool index reload as immutable on appendable segments

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -21,7 +21,7 @@ use crate::index::field_index::geo_index::GeoMapIndex;
 use crate::index::field_index::null_index::MutableNullIndex;
 use crate::index::field_index::numeric_index::NumericIndex;
 use crate::index::field_index::numeric_point::Numericable;
-use crate::index::payload_config::{FullPayloadIndexType, PayloadIndexType};
+use crate::index::payload_config::{FullPayloadIndexType, IndexMutability, PayloadIndexType};
 use crate::json_path::JsonPath;
 use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
 
@@ -108,7 +108,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::FullTextIndex),
 
             (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self
-                .bool_new(field, create_if_missing, id_tracker)?
+                .bool_new(field, create_if_missing, id_tracker, index_type.mutability)?
                 .map(FieldIndex::BoolIndex),
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => self
@@ -181,9 +181,14 @@ impl IndexSelector<'_> {
             PayloadSchemaParams::Text(text_index_params) => self
                 .text_new(field, text_index_params.clone(), create_if_missing)?
                 .map(|index| vec![FieldIndex::FullTextIndex(index)]),
-            PayloadSchemaParams::Bool(_) => self
-                .bool_new(field, create_if_missing, id_tracker)?
-                .map(|index| vec![FieldIndex::BoolIndex(index)]),
+            PayloadSchemaParams::Bool(_) => {
+                let mutability = match self {
+                    IndexSelector::Mmap(_) => IndexMutability::Immutable,
+                    IndexSelector::Gridstore(_) => IndexMutability::Mutable,
+                };
+                self.bool_new(field, create_if_missing, id_tracker, mutability)?
+                    .map(|index| vec![FieldIndex::BoolIndex(index)])
+            }
             PayloadSchemaParams::Datetime(_) => self
                 .numeric_new(field, create_if_missing)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
@@ -462,12 +467,22 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         create_if_missing: bool,
         id_tracker: &IdTrackerEnum,
+        mutability: IndexMutability,
     ) -> OperationResult<Option<BoolIndex>> {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => {
                 let dir = bool_dir(dir, field);
-                ImmutableBoolIndex::open(&dir, id_tracker.deleted_point_bitslice())?
-                    .map(BoolIndex::Immutable)
+                // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
+                // format; stored mutability picks which in-memory wrapper to build.
+                match mutability {
+                    IndexMutability::Immutable => {
+                        ImmutableBoolIndex::open(&dir, id_tracker.deleted_point_bitslice())?
+                            .map(BoolIndex::Immutable)
+                    }
+                    IndexMutability::Mutable => {
+                        MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
+                    }
+                }
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1251,6 +1251,66 @@ fn test_update_payload_index_type() {
     assert_eq!(field_index[1].count_indexed_points(), point_num);
 }
 
+/// An appendable segment with a bool payload index must still accept updates
+/// after being reopened from disk.
+#[test]
+fn test_bool_index_appendable_reopen_accepts_updates() {
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let field = JsonPath::new("flag");
+    let hw_counter = HardwareCounterCell::new();
+
+    {
+        let mut payload_storage = InMemoryPayloadStorage::default();
+        payload_storage
+            .set(0, &payload_json! {"flag": true}, &hw_counter)
+            .unwrap();
+
+        let payload_storage = Arc::new(AtomicRefCell::new(payload_storage.into()));
+        let id_tracker = Arc::new(AtomicRefCell::new(create_id_tracker_fixture(2)));
+
+        let mut index = StructPayloadIndex::open(
+            payload_storage,
+            id_tracker,
+            HashMap::new(),
+            dir.path(),
+            true,
+            true,
+        )
+        .unwrap();
+
+        index
+            .set_indexed(&field, FieldType(PayloadSchemaType::Bool), &hw_counter)
+            .unwrap();
+
+        for field_index in index.field_indexes.get(&field).unwrap() {
+            field_index.flusher()().unwrap();
+        }
+    }
+
+    let payload_storage = Arc::new(AtomicRefCell::new(InMemoryPayloadStorage::default().into()));
+    let id_tracker = Arc::new(AtomicRefCell::new(create_id_tracker_fixture(2)));
+    let mut index = StructPayloadIndex::open(
+        payload_storage,
+        id_tracker,
+        HashMap::new(),
+        dir.path(),
+        true,
+        false,
+    )
+    .unwrap();
+
+    index
+        .set_payload(1, &payload_json! {"flag": false}, &None, &hw_counter)
+        .expect("update on reopened bool index must succeed");
+
+    let field_indexes = index.field_indexes.get(&field).unwrap();
+    let bool_index = field_indexes
+        .iter()
+        .find(|fi| matches!(fi, FieldIndex::BoolIndex(_)))
+        .expect("bool index present after reopen");
+    assert_eq!(bool_index.count_indexed_points(), 2);
+}
+
 fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Result<()> {
     let keywords: IndexSet<String, FnvBuildHasher> = ["value1", "value2"]
         .iter()


### PR DESCRIPTION

  Fixes a regression introduced by #8625 that prevents Qdrant from starting when a collection has a bool payload index.

  ## Symptom

  `ERROR collection::collection_manager::collection_updater: Update operation failed:
  Service internal error: Can't add values to immutable bool index`

  Triggered on WAL replay during startup, on any appendable segment with a bool payload index; regardless of whether the index was created before or after #8625.

  ## Root cause

  `BoolIndex::get_storage_type()` returns `StorageType::Mmap` for both `MutableBoolIndex` and `ImmutableBoolIndex` (they share the same on-disk format). 

The persisted index type for a bool index on an appendable segment is therefore `{ mutability: Mutable, storage_type: Mmap }`.

  On reload, `StructPayloadIndex::selector_with_type` dispatches purely on `storage_type`. 

After #8625, `IndexSelector::Mmap` + `bool_new` unconditionally opens an `ImmutableBoolIndex` — ignoring the stored `mutability`. 

Any subsequent `add_many` call (e.g. WAL replay) hits the `"Can't add values to immutable bool index"` error arm.

  ## Fix

  `bool_new` now takes an `IndexMutability` parameter and branches on it in the `Mmap` arm:

  - `Mutable` → `MutableBoolIndex::open` → `BoolIndex::Mmap`
  - `Immutable` → `ImmutableBoolIndex::open` → `BoolIndex::Immutable`

  Callers pass:
  - `new_index_with_type` (reload): `index_type.mutability` from config
  - `new_index` (fresh migration): derived from selector — `Mmap` → `Immutable`,
    `Gridstore` → `Mutable`

  Since the on-disk format is shared, existing segments load unchanged; only the in-memory wrapper differs.

  ## Test

  Added `test_bool_index_appendable_reopen_accepts_updates` in `lib/segment/tests/integration/payload_index_test.rs`. 

It builds an appendable `StructPayloadIndex` with a bool-indexed field, drops it, reopens it, and performs an update. Fails against pre-fix code with the exact error from the report; passes with the fix.
