### PR TITLE
ci: improve docker build caches for e2e and consensus jobs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -106,9 +106,9 @@ jobs:
           context: .
           tags: qdrant_consensus
           cache-from: |
-            type=gha,scope=${{ github.ref }}
-            type=gha,scope=${{ github.base_ref }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}
+            type=gha,scope=${{ github.base_ref || github.ref_name }}-consensus
+            type=gha,scope=dev-consensus
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-consensus', github.ref_name) || '' }}
           load: true
           build-args: |
             PROFILE=ci
@@ -251,9 +251,9 @@ jobs:
           context: .
           tags: qdrant/qdrant:e2e-tests
           cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+            type=gha,scope=${{ github.base_ref || github.ref_name }}-e2e
+            type=gha,scope=dev-e2e
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-e2e', github.ref_name) || '' }}
           load: true
           build-args: |
             PROFILE=ci

--- a/tests/consensus_tests/test_restart.sh
+++ b/tests/consensus_tests/test_restart.sh
@@ -11,7 +11,7 @@ function clear_after_tests()
 }
 
 # Prevent double building in docker-compose
-docker buildx build --build-arg=PROFILE=ci --load ../../ --tag=qdrant_consensus
+docker buildx build --build-arg=PROFILE=ci --build-arg=FEATURES=staging --load ../../ --tag=qdrant_consensus
 docker compose down --volumes
 docker compose up -d --force-recreate
 trap clear_after_tests EXIT


### PR DESCRIPTION
* fix GHA cache eviction: cache-to now only writes on push to master/dev, not PRs
* fix `test_restart.sh` to follow the same build-args as in CI, to ensure that dockerbuild re-uses caches

**Note on how e2e image leverages the caches now**: 

cache-from reads the dev-e2e GHA scope, populated only by pushes to dev. A PR build imports that, hits every unchanged layer (i.e the expensive cargo-chef cook dep layer) and only recompiles the final `cargo build --bin qdrant` step because the source changed. No cache-to on PRs, so no LRU eviction of the dev-e2e blobs.