### PR TITLE
Refactor quantized scorers for (future) io_uring support

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -20,6 +20,16 @@ use fs_err::File;
 pub trait EncodedStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]>;
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], mut callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        for (idx, &offset) in offsets.iter().enumerate() {
+            let vector = self.get_vector_data(offset);
+            callback(idx, &vector);
+        }
+    }
+
     fn is_on_disk(&self) -> bool;
 
     fn upsert_vector(

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -48,6 +48,13 @@ pub trait EncodedVectors: Sized {
     where
         F: FnMut(usize, &[u8]);
 
+    fn score(
+        &self,
+        query: &Self::EncodedQuery,
+        encoded_vector: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> f32;
+
     fn score_point(
         &self,
         query: &Self::EncodedQuery,

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -44,6 +44,10 @@ pub trait EncodedVectors: Sized {
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]);
+
     fn score_point(
         &self,
         query: &Self::EncodedQuery,

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -847,6 +847,15 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
         self.encoded_vectors.for_each_in_batch(offsets, callback);
     }
 
+    fn score(
+        &self,
+        query: &Self::EncodedQuery,
+        encoded_vector: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> f32 {
+        self.score_bytes(True, query, encoded_vector, hw_counter)
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryBQ<TBitsStoreType>,

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -840,6 +840,13 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
         )
     }
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryBQ<TBitsStoreType>,

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -533,6 +533,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
         EncodedQueryPQ { lut }
     }
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryPQ,

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -540,6 +540,15 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
         self.encoded_vectors.for_each_in_batch(offsets, callback);
     }
 
+    fn score(
+        &self,
+        query: &Self::EncodedQuery,
+        encoded_vector: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> f32 {
+        self.score_bytes(True, query, encoded_vector, hw_counter)
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryPQ,

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -602,6 +602,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
         }
     }
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryU8,

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -609,6 +609,15 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
         self.encoded_vectors.for_each_in_batch(offsets, callback);
     }
 
+    fn score(
+        &self,
+        query: &Self::EncodedQuery,
+        encoded_vector: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> f32 {
+        self.score_bytes(True, query, encoded_vector, hw_counter)
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryU8,

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -421,6 +421,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         self.quantizer.precompute_query(query)
     }
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryTQ,

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -428,6 +428,15 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         self.encoded_vectors.for_each_in_batch(offsets, callback);
     }
 
+    fn score(
+        &self,
+        query: &Self::EncodedQuery,
+        encoded_vector: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> f32 {
+        self.score_bytes(True, query, encoded_vector, hw_counter)
+    }
+
     fn score_point(
         &self,
         query: &EncodedQueryTQ,

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -48,6 +48,13 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
             .unwrap_or_default()
     }
 
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        self.data.for_each_in_batch(offsets, callback);
+    }
+
     fn upsert_vector(
         &mut self,
         id: PointOffsetType,

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -90,6 +90,22 @@ where
 {
     type TVector = [TElement];
 
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(ids.len(), scores.len());
+
+        let storage = self.quantized_storage;
+
+        self.hardware_counter
+            .vector_io_read()
+            .incr_delta(ids.len() * storage.quantized_vector_size());
+
+        storage.for_each_in_batch(ids, |idx, vector| {
+            scores[idx] = self.query.score_by(|query| {
+                storage.score(query, vector, &self.hardware_counter) // inhibit `rustfmt`
+            });
+        });
+    }
+
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         // account for read outside of `score_by` because the closure is called once per example
         self.hardware_counter

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::marker::PhantomData;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
@@ -14,32 +13,29 @@ use crate::vector_storage::quantized::quantized_multivector_storage::{
 };
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedMultiQueryScorer<'a, TElement, TMetric, TEncodedVectors>
+pub struct QuantizedMultiQueryScorer<'a, TEncodedVectors>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors,
 {
     query: TEncodedVectors::EncodedQuery,
     quantized_multivector_storage: &'a TEncodedVectors,
-    metric: PhantomData<TMetric>,
-    element: PhantomData<TElement>,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TElement, TMetric, TEncodedVectors>
-    QuantizedMultiQueryScorer<'a, TElement, TMetric, TEncodedVectors>
+impl<'a, TEncodedVectors> QuantizedMultiQueryScorer<'a, TEncodedVectors>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors,
 {
-    pub fn new_multi(
+    pub fn new_multi<TElement, TMetric>(
         raw_query: &MultiDenseVectorInternal,
         quantized_multivector_storage: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
         mut hardware_counter: HardwareCounterCell,
-    ) -> Self {
+    ) -> Self
+    where
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement>,
+    {
         let mut query = Vec::new();
         for inner_vector in raw_query.multi_vectors() {
             let inner_preprocessed = TMetric::preprocess(inner_vector.to_vec());
@@ -60,21 +56,16 @@ where
         Self {
             query,
             quantized_multivector_storage,
-            metric: PhantomData,
-            element: PhantomData,
             hardware_counter,
         }
     }
 }
 
-impl<TElement, TMetric, TEncodedVectors> QueryScorer
-    for QuantizedMultiQueryScorer<'_, TElement, TMetric, TEncodedVectors>
+impl<TEncodedVectors> QueryScorer for QuantizedMultiQueryScorer<'_, TEncodedVectors>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets,
 {
-    type TVector = [TElement];
+    type TVector = ();
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let multi_vector_offset = self.quantized_multivector_storage.get_offset(idx);
@@ -88,7 +79,7 @@ where
             .score_point(&self.query, idx, &self.hardware_counter)
     }
 
-    fn score(&self, _v2: &[TElement]) -> ScoreType {
+    fn score(&self, _v2: &()) -> ScoreType {
         unimplemented!("This method is not expected to be called for quantized scorer");
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -4,6 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 
+use super::quantized_query_scorer::InternalScorerUnsupported;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::MultiDenseVectorInternal;
 use crate::spaces::metric::Metric;
@@ -58,6 +59,25 @@ where
             quantized_multivector_storage,
             hardware_counter,
         }
+    }
+
+    pub fn new_internal(
+        point_id: PointOffsetType,
+        quantized_multivector_storage: &'a TEncodedVectors,
+        mut hardware_counter: HardwareCounterCell,
+    ) -> Result<Self, InternalScorerUnsupported> {
+        let Some(query) = quantized_multivector_storage.encode_internal_vector(point_id) else {
+            return Err(InternalScorerUnsupported(hardware_counter));
+        };
+
+        hardware_counter
+            .set_vector_io_read_multiplier(usize::from(quantized_multivector_storage.is_on_disk()));
+
+        Ok(Self {
+            query,
+            quantized_multivector_storage,
+            hardware_counter,
+        })
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -434,6 +434,13 @@ where
             .collect()
     }
 
+    fn for_each_in_batch<F>(&self, _: &[PointOffsetType], _: F)
+    where
+        F: FnMut(usize, &[u8]),
+    {
+        unimplemented!("quantized multi-vector storage does not support `for_each_in_batch`")
+    }
+
     fn score_point(
         &self,
         query: &Vec<QuantizedStorage::EncodedQuery>,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -441,6 +441,10 @@ where
         unimplemented!("quantized multi-vector storage does not support `for_each_in_batch`")
     }
 
+    fn score(&self, _: &Self::EncodedQuery, _: &[u8], _: &HardwareCounterCell) -> f32 {
+        unimplemented!("quantized multi-vector storage does not support `score`");
+    }
+
     fn score_point(
         &self,
         query: &Vec<QuantizedStorage::EncodedQuery>,

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -80,6 +80,20 @@ where
 {
     type TVector = [VectorElementType];
 
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(ids.len(), scores.len());
+
+        self.hardware_counter
+            .vector_io_read()
+            .incr_delta(ids.len() * self.quantized_data.quantized_vector_size());
+
+        self.quantized_data.for_each_in_batch(ids, |idx, vector| {
+            scores[idx] = self
+                .quantized_data
+                .score(&self.query, vector, &self.hardware_counter);
+        });
+    }
+
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.hardware_counter
             .vector_io_read()

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -267,7 +267,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
 
         match query {
             QueryVector::Nearest(vector) => {
-                let query_scorer = QuantizedMultiQueryScorer::<TElement, TMetric, _>::new_multi(
+                let query_scorer = QuantizedMultiQueryScorer::new_multi::<TElement, TMetric>(
                     &MultiDenseVectorInternal::try_from(vector)?,
                     quantized_multivector_storage,
                     quantization_config,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -36,8 +36,9 @@ use crate::vector_storage::quantized::quantized_chunked_mmap_storage::{
 use crate::vector_storage::quantized::quantized_mmap_storage::{
     QuantizedMmapStorage, QuantizedMmapStorageBuilder,
 };
+use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
-    MultivectorOffsetsStorageChunkedMmap, MultivectorOffsetsStorageRam,
+    MultivectorOffsets, MultivectorOffsetsStorageChunkedMmap, MultivectorOffsetsStorageRam,
 };
 use crate::vector_storage::quantized::quantized_query_scorer::{
     InternalScorerUnsupported, QuantizedQueryScorer,
@@ -380,6 +381,20 @@ impl QuantizedVectors {
             Ok(Box::new(RawScorerImpl { query_scorer }))
         }
 
+        fn build_multi<'a, TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets>(
+            point_id: PointOffsetType,
+            quantized_data: &'a TEncodedVectors,
+            hardware_counter: HardwareCounterCell,
+        ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported> {
+            let query_scorer = QuantizedMultiQueryScorer::new_internal(
+                point_id,
+                quantized_data,
+                hardware_counter,
+            )?;
+
+            Ok(Box::new(RawScorerImpl { query_scorer }))
+        }
+
         match &self.storage_impl {
             QuantizedVectorStorage::ScalarRam(storage) => {
                 build(point_id, storage, hardware_counter)
@@ -410,40 +425,40 @@ impl QuantizedVectors {
                 build(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::ScalarRamMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::ScalarMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::ScalarChunkedMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::PQRamMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::PQMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::PQChunkedMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::BinaryRamMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::BinaryMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::BinaryChunkedMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::TQRamMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::TQMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
             QuantizedVectorStorage::TQChunkedMmapMulti(storage) => {
-                build(point_id, storage, hardware_counter)
+                build_multi(point_id, storage, hardware_counter)
             }
         }
     }


### PR DESCRIPTION
Refactors `QuantizedQueryScorer` and `QuantizedCustomQueryScorer`, so that they are ready for future `UniversalRead` integration.

What this PR does:

- adds a few methods to "quantized" traits (all with trivial implementations)
  - `EncodedVectors::for_each_in_batch` 
  - `EncodedStorage::for_each_in_batch` 
  - `EncodedStorage::score`
- implements `score_stored_batch` as a trivial composition of `for_each_in_batch` and `score`

This PR only implements these for **non multi-vector** quantized storages, because multi-vector is too special, we'll make it work later... 😅

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
