### PR TITLE
Introduce simple disk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "duplicate",
  "fs-err",
  "fs_extra",
  "io-uring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
  "procfs",
  "quick_cache",
  "rand 0.10.1",
+ "roaring",
  "rstest",
  "schemars 0.8.22",
  "self_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,7 @@ raft = { git = "https://github.com/tikv/raft-rs", rev = "aafb07c7bab439c6139926a
 rand = "0.10.1"
 rand_distr = "0.6.0"
 rmp-serde = "~1.3"
+roaring = "0.11.4"
 reqwest = { version = "0.13.3", default-features = false, features = [
     "json",
     "http2",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -23,7 +23,6 @@ bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
 chrono = { workspace = true }
-duplicate = "2.0.1"
 fs-err = { workspace = true }
 fs_extra = { workspace = true }
 itertools = { workspace = true }
@@ -37,7 +36,7 @@ parking_lot = { workspace = true }
 ph = { workspace = true }
 quick_cache = "0.6.22"
 rand = { workspace = true }
-roaring = "0.11.3"
+roaring = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -56,6 +55,7 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
+duplicate = "2.0.1"
 fs-err = { workspace = true, features = ["debug"] }
 rstest = { workspace = true }
 self_cell = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -23,6 +23,7 @@ bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
 chrono = { workspace = true }
+duplicate = "2.0.1"
 fs-err = { workspace = true }
 fs_extra = { workspace = true }
 itertools = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -36,6 +36,7 @@ parking_lot = { workspace = true }
 ph = { workspace = true }
 quick_cache = "0.6.22"
 rand = { workspace = true }
+roaring = "0.11.3"
 schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -1,0 +1,122 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use fs_err as fs;
+
+use crate::universal_io::{Result, UniversalIoError};
+
+/// Suffix appended to every local cache file so local mirrors can't be
+/// mistaken for the "real" (remote) copy.
+const LOCAL_FILE_SUFFIX: &str = ".partial";
+
+/// Configuration for [`DiskCache`](super::DiskCache).
+///
+/// Remote files under `remote_dir` are mirrored under `local_dir`, preserving the
+/// relative path with [`LOCAL_FILE_SUFFIX`] appended to the file name.
+#[derive(Debug)]
+pub struct DiskCacheConfig {
+    remote_dir: PathBuf,
+    local_dir: PathBuf,
+}
+
+static GLOBAL: OnceLock<DiskCacheConfig> = OnceLock::new();
+
+impl DiskCacheConfig {
+    pub fn new(remote_dir: PathBuf, local_dir: PathBuf) -> Result<Self> {
+        let remote_dir = fs::canonicalize(&remote_dir)
+            .map_err(|err| UniversalIoError::extract_not_found(err, &remote_dir))?;
+        let local_dir = fs::canonicalize(&local_dir)
+            .map_err(|err| UniversalIoError::extract_not_found(err, &local_dir))?;
+        Ok(Self {
+            remote_dir,
+            local_dir,
+        })
+    }
+
+    /// Panics on construction failure or if called more than once.
+    pub fn initialize_global(remote_dir: PathBuf, local_dir: PathBuf) {
+        let cfg = Self::new(remote_dir, local_dir).expect("failed to initialise DiskCacheConfig");
+        GLOBAL
+            .set(cfg)
+            .expect("DiskCacheConfig is already initialized");
+    }
+
+    pub fn global() -> Option<&'static DiskCacheConfig> {
+        GLOBAL.get()
+    }
+
+    pub fn local_dir(&self) -> &Path {
+        &self.local_dir
+    }
+
+    /// Canonicalises `remote_path` (does filesystem I/O); returns
+    /// [`UniversalIoError::NotFound`] if the result isn't under `remote_dir`.
+    pub fn local_path_for(&self, remote_path: &Path) -> Result<PathBuf> {
+        let canonical = fs::canonicalize(remote_path)
+            .map_err(|err| UniversalIoError::extract_not_found(err, remote_path))?;
+        let rel =
+            canonical
+                .strip_prefix(&self.remote_dir)
+                .map_err(|_| UniversalIoError::NotFound {
+                    path: remote_path.to_path_buf(),
+                })?;
+
+        let mut local = self.local_dir.join(rel);
+        local.as_mut_os_string().push(LOCAL_FILE_SUFFIX);
+        Ok(local)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fs_err as fs;
+
+    use super::DiskCacheConfig;
+
+    #[test]
+    fn strips_remote_dir_and_appends_suffix() {
+        let tmp = tempfile::Builder::new()
+            .prefix("simplediskcache-tests")
+            .tempdir()
+            .unwrap();
+        let remote_dir = tmp.path().join("remote");
+        let local_dir = tmp.path().join("local");
+        fs::create_dir_all(remote_dir.join("collections/c/segment")).unwrap();
+        fs::create_dir_all(&local_dir).unwrap();
+        let input = remote_dir.join("collections/c/segment/data.bin");
+        fs::write(&input, b"").unwrap();
+
+        let cfg = DiskCacheConfig::new(remote_dir, local_dir).unwrap();
+        let local = cfg.local_path_for(&input).unwrap();
+
+        assert_eq!(
+            local,
+            cfg.local_dir()
+                .join("collections/c/segment/data.bin.partial"),
+        );
+    }
+
+    #[test]
+    fn rejects_path_outside_remote_dir() {
+        let tmp = tempfile::Builder::new()
+            .prefix("simplediskcache-tests")
+            .tempdir()
+            .unwrap();
+        let remote_dir = tmp.path().join("remote");
+        let other_dir = tmp.path().join("other");
+        let local_dir = tmp.path().join("local");
+        fs::create_dir_all(&remote_dir).unwrap();
+        fs::create_dir_all(&other_dir).unwrap();
+        fs::create_dir_all(&local_dir).unwrap();
+        let outside = other_dir.join("data.bin");
+        fs::write(&outside, b"").unwrap();
+
+        let cfg = DiskCacheConfig::new(remote_dir, local_dir).unwrap();
+        let err = cfg.local_path_for(&outside).unwrap_err();
+
+        assert!(
+            matches!(err, crate::universal_io::UniversalIoError::NotFound { .. }),
+            "expected NotFound, got {err:?}",
+        );
+    }
+}

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -14,7 +14,8 @@ use crate::generic_consts::{AccessPattern, Sequential};
 use crate::mmap::{AdviceSetting, Madviseable};
 use crate::universal_io::pipeline::DiskCachePipeline;
 use crate::universal_io::{
-    OpenOptions, Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps
+    OpenOptions, Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead,
+    UniversalReadFileOps,
 };
 
 /// A lazily-populated local mirror of an immutable remote file.

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -21,6 +21,9 @@ use crate::universal_io::{
 ///
 /// The remote is assumed to be immutable for the lifetime of the file;
 /// this type implements [`UniversalRead`] only, but not [`UniversalWrite`].
+///
+/// WARN: There should be only a single instance of DiskCache per path.
+/// Initializing multiple instances will not reuse the same mmap and can cause UB.
 #[derive(Debug)]
 pub struct DiskCache<R> {
     pub(super) remote: R,
@@ -40,7 +43,7 @@ pub struct DiskCache<R> {
 #[derive(Debug)]
 pub(super) struct LocalState {
     pub mmap: MmapRaw,
-    /// Bitmask to know which blocks are have been fetched
+    /// Bitmask to know which blocks have been fetched so far.
     pub fetched: Mutex<RoaringBitmap>,
 }
 
@@ -88,10 +91,13 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
         path: impl AsRef<Path>,
         options: OpenOptions,
     ) -> Result<Self> {
-        debug_assert!(
-            !options.writeable,
-            "DiskCache only supports immutable files",
-        );
+        if options.writeable {
+            return Err(UniversalIoError::Uninitialized {
+                description:
+                    "DiskCache only supports immutable files, writeable option is not allowed"
+                        .to_string(),
+            });
+        }
 
         let remote_path = path.as_ref();
         let local_path = config.local_path_for(remote_path)?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -12,6 +12,7 @@ use super::BLOCK_SIZE;
 use super::config::DiskCacheConfig;
 use crate::generic_consts::{AccessPattern, Sequential};
 use crate::mmap::{AdviceSetting, Madviseable};
+use crate::universal_io::pipeline::DiskCachePipeline;
 use crate::universal_io::{
     OpenOptions, Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps
 };
@@ -22,13 +23,12 @@ use crate::universal_io::{
 /// this type implements [`UniversalRead`] only, but not [`UniversalWrite`].
 #[derive(Debug)]
 pub struct DiskCache<R> {
-    remote: R,
-    len_bytes: u64,
+    pub(super) remote: R,
     /// Open options for when it gets initialized
     open_options: OpenOptions,
     /// Path to the local mmap file
     local_path: PathBuf,
-    local: OnceLock<LocalState>,
+    pub(super) local: OnceLock<LocalState>,
     /// Prevents concurrent initialization of `local` across threads.
     ///
     /// TODO: Switch to [`OnceLock::get_or_try_init`][1] once it stabilizes
@@ -38,99 +38,46 @@ pub struct DiskCache<R> {
 }
 
 #[derive(Debug)]
-struct LocalState {
-    mmap: MmapRaw,
+pub(super) struct LocalState {
+    pub mmap: MmapRaw,
     /// Bitmask to know which blocks are have been fetched
-    fetched: Mutex<RoaringBitmap>,
+    pub fetched: Mutex<RoaringBitmap>,
 }
 
 impl LocalState {
     /// # Safety
-    /// `byte_range` must have been populated via [`DiskCache::ensure_byte_ranges`] first.
-    unsafe fn read_mmap_bytes(&self, byte_range: Range<u64>) -> &[u8] {
+    /// `byte_range` must have been populated first, caller must ensure `self.fetched` references the
+    /// blocks for the byte range.
+    pub(super) unsafe fn read_mmap_bytes(&self, byte_range: Range<u64>) -> &[u8] {
         let bytes = unsafe { std::slice::from_raw_parts(self.mmap.as_ptr(), self.mmap.len()) };
         &bytes[byte_range.start as usize..byte_range.end as usize]
     }
-}
 
-impl<R: UniversalReadFileOps> UniversalReadFileOps for DiskCache<R> {
-    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
-        R::list_files(prefix_path)
-    }
-
-    fn exists(path: &Path) -> Result<bool> {
-        R::exists(path)
-    }
-}
-
-impl<R, T> UniversalRead<T> for DiskCache<R>
-where
-    R: UniversalRead<u8>,
-    T: bytemuck::Pod,
-{
-    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
-        let config = DiskCacheConfig::global().ok_or_else(|| {
-            UniversalIoError::uninitialized(
-                "DiskCacheConfig must be initialized via `DiskCacheConfig::initialize_global` \
-                 before opening an DiskCache",
-            )
-        })?;
-        Self::open_with_config(config, path, options)
-    }
-
-    fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        let byte_range = self.compute_byte_range::<T>(range)?;
-        if byte_range.is_empty() {
-            return Ok(Cow::Borrowed(&[]));
+    /// # Safety
+    /// `DiskCache` is only used in immutable files. Since `blocks_range` can include already-fetched
+    /// data, it is possible that some sections get overwritten; however, it should be the same data,
+    /// so it is fine.
+    ///
+    /// Assumes the bytes slice covers the entirety of `blocks_range`.
+    pub(super) unsafe fn write_mmap_bytes(&self, bytes: &[u8], blocks_range: Range<u32>) {
+        let mut fetched = self.fetched.lock();
+        if fetched.contains_range(blocks_range.clone()) {
+            return;
         }
 
-        let state = self.local_state()?;
-        self.ensure_byte_ranges(state, std::iter::once(byte_range.clone()))?;
+        let byte_offset = blocks_range.start as usize * BLOCK_SIZE;
 
-        // SAFETY: `ensure_byte_ranges` above populated `byte_range`.
-        let bytes = unsafe { state.read_mmap_bytes(byte_range) };
-        Ok(Cow::Borrowed(bytemuck::cast_slice(bytes)))
-    }
+        let max_len = self.mmap.len().saturating_sub(byte_offset);
+        assert!(bytes.len() == max_len.min(blocks_range.len() * BLOCK_SIZE));
 
-    fn read_batch<'a, P: AccessPattern, Meta: 'a>(
-        &'a self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-        mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
-    ) -> Result<()> {
-        for (meta, range) in ranges {
-            let cow = self.read::<P>(range)?;
-            callback(meta, cow.as_ref())?;
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                self.mmap.as_mut_ptr().add(byte_offset),
+                bytes.len(),
+            );
         }
-        Ok(())
-    }
-
-    fn len(&self) -> Result<u64> {
-        let t_size = size_of::<T>() as u64;
-        debug_assert!(t_size > 0, "zero-sized types are not supported");
-        Ok(self.len_bytes / t_size)
-    }
-
-    fn populate(&self) -> Result<()> {
-        if self.len_bytes == 0 {
-            return Ok(());
-        }
-        if crate::low_memory::low_memory_mode().skip_populate() {
-            return Ok(());
-        }
-        let state = self.local_state()?;
-        self.ensure_byte_ranges(state, std::iter::once(0..self.len_bytes))?;
-        Ok(())
-    }
-
-    fn clear_ram_cache(&self) -> Result<()> {
-        if let Some(state) = self.local.get() {
-            state.mmap.clear_cache();
-        }
-        Ok(())
-    }
-
-    fn kind() -> UniversalKind {
-        UniversalKind::SimpleDiskCache
+        fetched.insert_range(blocks_range);
     }
 }
 
@@ -159,11 +106,9 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
         };
 
         let remote = R::open(remote_path, remote_options)?;
-        let len_bytes = UniversalRead::<u8>::len(&remote)?;
 
         Ok(Self {
             remote,
-            len_bytes,
             open_options: options,
             local_path,
             local: OnceLock::new(),
@@ -172,7 +117,7 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
     }
 
     /// Return the cached [`LocalState`], initializing it on first call.
-    fn local_state(&self) -> Result<&LocalState> {
+    pub(super) fn local_state(&self) -> Result<&LocalState> {
         if let Some(state) = self.local.get() {
             return Ok(state);
         }
@@ -210,7 +155,9 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
             .create(true)
             .truncate(true)
             .open(&self.local_path)?;
-        file.set_len(self.len_bytes)?;
+
+        let remote_len = self.remote.len()?;
+        file.set_len(remote_len)?;
         let mmap = MmapRaw::map_raw(&file)?;
 
         mmap.madvise(advice.unwrap_or(AdviceSetting::Global).resolve())?;
@@ -220,112 +167,95 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
             fetched: Mutex::new(RoaringBitmap::new()),
         })
     }
+}
 
-    /// Validate a typed [`ReadRange`] and return its byte bounds
-    /// `[start, end)`. Zero-length ranges produce `[offset, offset)`.
-    fn compute_byte_range<T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Range<u64>> {
-        let ReadRange {
-            byte_offset,
-            length,
-        } = range;
-        if length == 0 {
-            return Ok(byte_offset..byte_offset);
-        }
-        let t_size = size_of::<T>() as u64;
-        let byte_len = length
-            .checked_mul(t_size)
-            .ok_or_else(|| out_of_bounds::<T>(byte_offset, u64::MAX, self.len_bytes))?;
-        let byte_end = byte_offset
-            .checked_add(byte_len)
-            .ok_or_else(|| out_of_bounds::<T>(byte_offset, u64::MAX, self.len_bytes))?;
-        if byte_end > self.len_bytes {
-            return Err(out_of_bounds::<T>(byte_offset, byte_end, self.len_bytes));
-        }
-        Ok(byte_offset..byte_end)
+impl<R: UniversalReadFileOps> UniversalReadFileOps for DiskCache<R> {
+    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
+        R::list_files(prefix_path)
     }
 
-    // TODO: Fine-grained locking. `state.fetched` is currently held
-    // across the whole remote fetch. An atomic bitvec should enable
-    // cached reads to be handed out while other threads are handling misses.
-    //
-    /// Ensure every byte in the union of `byte_ranges` is present in
-    /// the local mmap.
-    fn ensure_byte_ranges(
-        &self,
-        state: &LocalState,
-        byte_ranges: impl IntoIterator<Item = Range<u64>>,
-    ) -> Result<()> {
-        let mut fetched = state.fetched.lock();
-
-        // Union of all block indices touched by the input.
-        let mut wanted = RoaringBitmap::new();
-        for br in byte_ranges {
-            if br.is_empty() {
-                continue;
-            }
-            let first = br.start / BLOCK_SIZE as u64;
-            let last = (br.end - 1) / BLOCK_SIZE as u64;
-            let first = u32::try_from(first).expect("file larger than 70 TiB is not supported");
-            let last = u32::try_from(last).expect("file larger than 70 TiB is not supported");
-            wanted.insert_range(first..=last);
-        }
-
-        let to_fetch = wanted - &*fetched;
-        if to_fetch.is_empty() {
-            return Ok(());
-        }
-
-        // Emit one BLOCK_SIZE-capped range per missing block. Backends
-        // that benefit from coalescing (e.g. high-latency object
-        // stores) can merge contiguous ranges inside their own
-        // `read_batch`; backends that benefit from keeping them
-        // separate (e.g. io_uring, where queue depth is the source of
-        // parallelism) can submit them individually.
-        let len_bytes = self.len_bytes;
-        let ranges = to_fetch.iter().map(|block| {
-            let byte_offset = u64::from(block) * BLOCK_SIZE as u64;
-            let length = (BLOCK_SIZE as u64).min(len_bytes - byte_offset);
-            (
-                block,
-                ReadRange {
-                    byte_offset,
-                    length,
-                },
-            )
-        });
-
-        self.remote
-            .read_batch::<Sequential, _>(ranges, |block, bytes| {
-                let byte_offset = u64::from(block) * BLOCK_SIZE as u64;
-                debug_assert_eq!(
-                    bytes.len() as u64,
-                    (BLOCK_SIZE as u64).min(len_bytes - byte_offset),
-                );
-
-                // SAFETY: `[byte_offset, byte_offset + bytes.len())` lies
-                // within the mmap. This block was not in `fetched`, so
-                // no prior writer touched it; `state.fetched` is held
-                // for the whole batch, excluding concurrent writers.
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        bytes.as_ptr(),
-                        state.mmap.as_mut_ptr().add(byte_offset as usize),
-                        bytes.len(),
-                    );
-                }
-                fetched.insert(block);
-                Ok(())
-            })?;
-
-        Ok(())
+    fn exists(path: &Path) -> Result<bool> {
+        R::exists(path)
     }
 }
 
-fn out_of_bounds<T>(start: u64, end: u64, len_bytes: u64) -> UniversalIoError {
-    let t_size = size_of::<T>().max(1) as u64;
-    UniversalIoError::OutOfBounds {
-        start,
-        end,
-        elements: (len_bytes / t_size) as usize,
+impl<R, T> UniversalRead<T> for DiskCache<R>
+where
+    R: UniversalRead<u8>,
+    T: bytemuck::Pod,
+{
+    type ReadPipeline<'a, Meta>
+        = DiskCachePipeline<'a, T, Meta, R>
+    where
+        R: 'a;
+
+    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
+        let config = DiskCacheConfig::global().ok_or_else(|| {
+            UniversalIoError::uninitialized(
+                "DiskCacheConfig must be initialized via `DiskCacheConfig::initialize_global` \
+                 before opening an DiskCache",
+            )
+        })?;
+        Self::open_with_config(config, path, options)
     }
+
+    fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+        let (_, read) = self
+            .read_iter::<P, _>(std::iter::once(((), range)))?
+            .next()
+            .expect("there's exactly one read")?;
+
+        Ok(read)
+    }
+
+    fn len(&self) -> Result<u64> {
+        let t_size = size_of::<T>();
+        debug_assert!(t_size > 0, "zero-sized types are not supported");
+
+        let bytes_len = if let Some(local) = self.local.get() {
+            local.mmap.len() as u64
+        } else {
+            self.remote.len()?
+        };
+
+        Ok(bytes_len / t_size as u64)
+    }
+
+    fn populate(&self) -> Result<()> {
+        if crate::low_memory::low_memory_mode().skip_populate() {
+            return Ok(());
+        }
+
+        let remote_len = self.remote.len()?;
+        if remote_len == 0 {
+            return Ok(());
+        }
+
+        let one_byte_per_block = (0..remote_len as usize)
+            .step_by(BLOCK_SIZE)
+            .map(|byte_offset| ((), ReadRange::one(byte_offset as u64)));
+
+        for result in UniversalRead::<u8>::read_iter::<Sequential, ()>(self, one_byte_per_block)? {
+            result?;
+        }
+
+        Ok(())
+    }
+
+    fn clear_ram_cache(&self) -> Result<()> {
+        if let Some(state) = self.local.get() {
+            state.mmap.clear_cache();
+        }
+        Ok(())
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::SimpleDiskCache
+    }
+}
+
+pub(super) fn to_block_range(range: Range<u64>) -> Range<u32> {
+    let start = (range.start / BLOCK_SIZE as u64) as u32;
+    let end = range.end.div_ceil(BLOCK_SIZE as u64) as u32;
+    start..end
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -1,0 +1,331 @@
+use std::borrow::Cow;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use fs_err as fs;
+use memmap2::MmapRaw;
+use parking_lot::Mutex;
+use roaring::RoaringBitmap;
+
+use super::BLOCK_SIZE;
+use super::config::DiskCacheConfig;
+use crate::generic_consts::{AccessPattern, Sequential};
+use crate::mmap::{AdviceSetting, Madviseable};
+use crate::universal_io::{
+    OpenOptions, Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps
+};
+
+/// A lazily-populated local mirror of an immutable remote file.
+///
+/// The remote is assumed to be immutable for the lifetime of the file;
+/// this type implements [`UniversalRead`] only, but not [`UniversalWrite`].
+#[derive(Debug)]
+pub struct DiskCache<R> {
+    remote: R,
+    len_bytes: u64,
+    /// Open options for when it gets initialized
+    open_options: OpenOptions,
+    /// Path to the local mmap file
+    local_path: PathBuf,
+    local: OnceLock<LocalState>,
+    /// Prevents concurrent initialization of `local` across threads.
+    ///
+    /// TODO: Switch to [`OnceLock::get_or_try_init`][1] once it stabilizes
+    ///
+    /// [1]: https://github.com/rust-lang/rust/issues/109737
+    init_lock: Mutex<()>,
+}
+
+#[derive(Debug)]
+struct LocalState {
+    mmap: MmapRaw,
+    /// Bitmask to know which blocks are have been fetched
+    fetched: Mutex<RoaringBitmap>,
+}
+
+impl LocalState {
+    /// # Safety
+    /// `byte_range` must have been populated via [`DiskCache::ensure_byte_ranges`] first.
+    unsafe fn read_mmap_bytes(&self, byte_range: Range<u64>) -> &[u8] {
+        let bytes = unsafe { std::slice::from_raw_parts(self.mmap.as_ptr(), self.mmap.len()) };
+        &bytes[byte_range.start as usize..byte_range.end as usize]
+    }
+}
+
+impl<R: UniversalReadFileOps> UniversalReadFileOps for DiskCache<R> {
+    fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
+        R::list_files(prefix_path)
+    }
+
+    fn exists(path: &Path) -> Result<bool> {
+        R::exists(path)
+    }
+}
+
+impl<R, T> UniversalRead<T> for DiskCache<R>
+where
+    R: UniversalRead<u8>,
+    T: bytemuck::Pod,
+{
+    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
+        let config = DiskCacheConfig::global().ok_or_else(|| {
+            UniversalIoError::uninitialized(
+                "DiskCacheConfig must be initialized via `DiskCacheConfig::initialize_global` \
+                 before opening an DiskCache",
+            )
+        })?;
+        Self::open_with_config(config, path, options)
+    }
+
+    fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+        let byte_range = self.compute_byte_range::<T>(range)?;
+        if byte_range.is_empty() {
+            return Ok(Cow::Borrowed(&[]));
+        }
+
+        let state = self.local_state()?;
+        self.ensure_byte_ranges(state, std::iter::once(byte_range.clone()))?;
+
+        // SAFETY: `ensure_byte_ranges` above populated `byte_range`.
+        let bytes = unsafe { state.read_mmap_bytes(byte_range) };
+        Ok(Cow::Borrowed(bytemuck::cast_slice(bytes)))
+    }
+
+    fn read_batch<'a, P: AccessPattern, Meta: 'a>(
+        &'a self,
+        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
+        mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
+    ) -> Result<()> {
+        for (meta, range) in ranges {
+            let cow = self.read::<P>(range)?;
+            callback(meta, cow.as_ref())?;
+        }
+        Ok(())
+    }
+
+    fn len(&self) -> Result<u64> {
+        let t_size = size_of::<T>() as u64;
+        debug_assert!(t_size > 0, "zero-sized types are not supported");
+        Ok(self.len_bytes / t_size)
+    }
+
+    fn populate(&self) -> Result<()> {
+        if self.len_bytes == 0 {
+            return Ok(());
+        }
+        if crate::low_memory::low_memory_mode().skip_populate() {
+            return Ok(());
+        }
+        let state = self.local_state()?;
+        self.ensure_byte_ranges(state, std::iter::once(0..self.len_bytes))?;
+        Ok(())
+    }
+
+    fn clear_ram_cache(&self) -> Result<()> {
+        if let Some(state) = self.local.get() {
+            state.mmap.clear_cache();
+        }
+        Ok(())
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::SimpleDiskCache
+    }
+}
+
+impl<R: UniversalRead<u8>> DiskCache<R> {
+    /// Open an [`DiskCache`] with an explicit configuration
+    pub fn open_with_config(
+        config: &DiskCacheConfig,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+    ) -> Result<Self> {
+        debug_assert!(
+            !options.writeable,
+            "DiskCache only supports immutable files",
+        );
+
+        let remote_path = path.as_ref();
+        let local_path = config.local_path_for(remote_path)?;
+
+        let remote_options = OpenOptions {
+            writeable: false,
+            prevent_caching: Some(true),
+            populate: Populate::No,
+            need_sequential: false,
+            disk_parallel: None,
+            advice: None,
+        };
+
+        let remote = R::open(remote_path, remote_options)?;
+        let len_bytes = UniversalRead::<u8>::len(&remote)?;
+
+        Ok(Self {
+            remote,
+            len_bytes,
+            open_options: options,
+            local_path,
+            local: OnceLock::new(),
+            init_lock: Mutex::new(()),
+        })
+    }
+
+    /// Return the cached [`LocalState`], initializing it on first call.
+    fn local_state(&self) -> Result<&LocalState> {
+        if let Some(state) = self.local.get() {
+            return Ok(state);
+        }
+
+        // Only first thread is able to initialize
+        let _guard = self.init_lock.lock();
+        if let Some(state) = self.local.get() {
+            return Ok(state);
+        }
+
+        let state = self.init_local_state()?;
+        if self.local.set(state).is_err() {
+            unreachable!("OnceLock::set must succeed while holding init_lock");
+        }
+        Ok(self.local.get().expect("just initialized"))
+    }
+
+    fn init_local_state(&self) -> Result<LocalState> {
+        if let Some(parent) = self.local_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let OpenOptions {
+            writeable: _,       // always needs to be writeable
+            need_sequential: _, // TODO: add sequential mmap
+            disk_parallel: _,   // unsupported
+            populate: _,        // this is handled in populate() function
+            advice,
+            prevent_caching: _, // TODO: use o_direct
+        } = self.open_options;
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&self.local_path)?;
+        file.set_len(self.len_bytes)?;
+        let mmap = MmapRaw::map_raw(&file)?;
+
+        mmap.madvise(advice.unwrap_or(AdviceSetting::Global).resolve())?;
+
+        Ok(LocalState {
+            mmap,
+            fetched: Mutex::new(RoaringBitmap::new()),
+        })
+    }
+
+    /// Validate a typed [`ReadRange`] and return its byte bounds
+    /// `[start, end)`. Zero-length ranges produce `[offset, offset)`.
+    fn compute_byte_range<T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Range<u64>> {
+        let ReadRange {
+            byte_offset,
+            length,
+        } = range;
+        if length == 0 {
+            return Ok(byte_offset..byte_offset);
+        }
+        let t_size = size_of::<T>() as u64;
+        let byte_len = length
+            .checked_mul(t_size)
+            .ok_or_else(|| out_of_bounds::<T>(byte_offset, u64::MAX, self.len_bytes))?;
+        let byte_end = byte_offset
+            .checked_add(byte_len)
+            .ok_or_else(|| out_of_bounds::<T>(byte_offset, u64::MAX, self.len_bytes))?;
+        if byte_end > self.len_bytes {
+            return Err(out_of_bounds::<T>(byte_offset, byte_end, self.len_bytes));
+        }
+        Ok(byte_offset..byte_end)
+    }
+
+    // TODO: Fine-grained locking. `state.fetched` is currently held
+    // across the whole remote fetch. An atomic bitvec should enable
+    // cached reads to be handed out while other threads are handling misses.
+    //
+    /// Ensure every byte in the union of `byte_ranges` is present in
+    /// the local mmap.
+    fn ensure_byte_ranges(
+        &self,
+        state: &LocalState,
+        byte_ranges: impl IntoIterator<Item = Range<u64>>,
+    ) -> Result<()> {
+        let mut fetched = state.fetched.lock();
+
+        // Union of all block indices touched by the input.
+        let mut wanted = RoaringBitmap::new();
+        for br in byte_ranges {
+            if br.is_empty() {
+                continue;
+            }
+            let first = br.start / BLOCK_SIZE as u64;
+            let last = (br.end - 1) / BLOCK_SIZE as u64;
+            let first = u32::try_from(first).expect("file larger than 70 TiB is not supported");
+            let last = u32::try_from(last).expect("file larger than 70 TiB is not supported");
+            wanted.insert_range(first..=last);
+        }
+
+        let to_fetch = wanted - &*fetched;
+        if to_fetch.is_empty() {
+            return Ok(());
+        }
+
+        // Emit one BLOCK_SIZE-capped range per missing block. Backends
+        // that benefit from coalescing (e.g. high-latency object
+        // stores) can merge contiguous ranges inside their own
+        // `read_batch`; backends that benefit from keeping them
+        // separate (e.g. io_uring, where queue depth is the source of
+        // parallelism) can submit them individually.
+        let len_bytes = self.len_bytes;
+        let ranges = to_fetch.iter().map(|block| {
+            let byte_offset = u64::from(block) * BLOCK_SIZE as u64;
+            let length = (BLOCK_SIZE as u64).min(len_bytes - byte_offset);
+            (
+                block,
+                ReadRange {
+                    byte_offset,
+                    length,
+                },
+            )
+        });
+
+        self.remote
+            .read_batch::<Sequential, _>(ranges, |block, bytes| {
+                let byte_offset = u64::from(block) * BLOCK_SIZE as u64;
+                debug_assert_eq!(
+                    bytes.len() as u64,
+                    (BLOCK_SIZE as u64).min(len_bytes - byte_offset),
+                );
+
+                // SAFETY: `[byte_offset, byte_offset + bytes.len())` lies
+                // within the mmap. This block was not in `fetched`, so
+                // no prior writer touched it; `state.fetched` is held
+                // for the whole batch, excluding concurrent writers.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        state.mmap.as_mut_ptr().add(byte_offset as usize),
+                        bytes.len(),
+                    );
+                }
+                fetched.insert(block);
+                Ok(())
+            })?;
+
+        Ok(())
+    }
+}
+
+fn out_of_bounds<T>(start: u64, end: u64, len_bytes: u64) -> UniversalIoError {
+    let t_size = size_of::<T>().max(1) as u64;
+    UniversalIoError::OutOfBounds {
+        start,
+        end,
+        elements: (len_bytes / t_size) as usize,
+    }
+}

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -84,7 +84,7 @@ impl LocalState {
     }
 }
 
-impl<R: UniversalRead<u8>> DiskCache<R> {
+impl<R: UniversalRead> DiskCache<R> {
     /// Open an [`DiskCache`] with an explicit configuration
     pub fn open_with_config(
         config: &DiskCacheConfig,
@@ -162,7 +162,7 @@ impl<R: UniversalRead<u8>> DiskCache<R> {
             .truncate(true)
             .open(&self.local_path)?;
 
-        let remote_len = self.remote.len()?;
+        let remote_len = self.remote.len::<u8>()?;
         file.set_len(remote_len)?;
         let mmap = MmapRaw::map_raw(&file)?;
 
@@ -185,15 +185,15 @@ impl<R: UniversalReadFileOps> UniversalReadFileOps for DiskCache<R> {
     }
 }
 
-impl<R, T> UniversalRead<T> for DiskCache<R>
+impl<R> UniversalRead for DiskCache<R>
 where
-    R: UniversalRead<u8>,
-    T: bytemuck::Pod,
+    R: UniversalRead,
 {
-    type ReadPipeline<'a, Meta>
+    type ReadPipeline<'a, T, Meta>
         = DiskCachePipeline<'a, T, Meta, R>
     where
-        R: 'a;
+        R: 'a,
+        T: bytemuck::Pod;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let config = DiskCacheConfig::global().ok_or_else(|| {
@@ -205,23 +205,27 @@ where
         Self::open_with_config(config, path, options)
     }
 
-    fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P, T>(&self, range: ReadRange) -> Result<Cow<'_, [T]>>
+    where
+        P: AccessPattern,
+        T: bytemuck::Pod,
+    {
         let (_, read) = self
-            .read_iter::<P, _>(std::iter::once(((), range)))?
+            .read_iter::<P, T, _>(std::iter::once(((), range)))?
             .next()
             .expect("there's exactly one read")?;
 
         Ok(read)
     }
 
-    fn len(&self) -> Result<u64> {
+    fn len<T>(&self) -> Result<u64> {
         let t_size = size_of::<T>();
         debug_assert!(t_size > 0, "zero-sized types are not supported");
 
         let bytes_len = if let Some(local) = self.local.get() {
             local.mmap.len() as u64
         } else {
-            self.remote.len()?
+            self.remote.len::<u8>()?
         };
 
         Ok(bytes_len / t_size as u64)
@@ -232,7 +236,7 @@ where
             return Ok(());
         }
 
-        let remote_len = self.remote.len()?;
+        let remote_len = self.remote.len::<u8>()?;
         if remote_len == 0 {
             return Ok(());
         }
@@ -241,7 +245,7 @@ where
             .step_by(BLOCK_SIZE)
             .map(|byte_offset| ((), ReadRange::one(byte_offset as u64)));
 
-        for result in UniversalRead::<u8>::read_iter::<Sequential, ()>(self, one_byte_per_block)? {
+        for result in self.read_iter::<Sequential, u8, ()>(one_byte_per_block)? {
             result?;
         }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -1,0 +1,15 @@
+mod config;
+mod file;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::DiskCacheConfig;
+pub use file::DiskCache;
+
+/// Files are logically split into fixed-size blocks; the roaring bitmap
+/// tracks population on a per-block basis.
+///
+/// Matches `disk_cache::BLOCK_SIZE` and is a small multiple of typical
+/// filesystem block sizes (usually 4 KiB).
+const BLOCK_SIZE: usize = 16 * 1024; // 16kB

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -1,6 +1,7 @@
 mod config;
 mod file;
 
+pub mod pipeline;
 #[cfg(test)]
 mod tests;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -17,20 +17,21 @@ struct RemoteMeta<'file, Meta, R> {
 
 pub struct DiskCachePipeline<'file, T, Meta, R>
 where
-    R: UniversalRead<u8> + 'file,
+    R: UniversalRead + 'file,
+    T: bytemuck::Pod,
 {
-    remote_pipeline: OnceCell<R::ReadPipeline<'file, RemoteMeta<'file, Meta, R>>>,
+    remote_pipeline: OnceCell<R::ReadPipeline<'file, u8, RemoteMeta<'file, Meta, R>>>,
     result: Option<(Meta, &'file [T])>,
 }
 
 impl<'file, T, Meta, R> DiskCachePipeline<'file, T, Meta, R>
 where
     T: bytemuck::Pod,
-    R: UniversalRead<u8> + 'file,
+    R: UniversalRead + 'file,
 {
     fn get_or_init_remote_pipeline(
         &mut self,
-    ) -> universal_io::Result<&mut R::ReadPipeline<'file, RemoteMeta<'file, Meta, R>>> {
+    ) -> universal_io::Result<&mut R::ReadPipeline<'file, u8, RemoteMeta<'file, Meta, R>>> {
         if self.remote_pipeline.get().is_none() {
             let remote = R::ReadPipeline::new()?;
             // We just observed the cell as empty and hold `&mut self`, so set cannot fail.
@@ -71,7 +72,7 @@ impl<'file, T, Meta, Remote> UniversalReadPipeline<'file, T, Meta>
     for DiskCachePipeline<'file, T, Meta, Remote>
 where
     T: bytemuck::Pod + Copy + 'static,
-    Remote: UniversalRead<u8>,
+    Remote: UniversalRead,
 {
     type File = DiskCache<Remote>;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -1,0 +1,162 @@
+use std::borrow::Cow;
+use std::cell::OnceCell;
+use std::ops::Range;
+
+use crate::generic_consts::AccessPattern;
+use crate::universal_io::read::UniversalReadPipeline;
+use crate::universal_io::simple_disk_cache::BLOCK_SIZE;
+use crate::universal_io::simple_disk_cache::file::to_block_range;
+use crate::universal_io::{self, DiskCache, ReadRange, UniversalIoError, UniversalRead};
+
+struct RemoteMeta<'file, Meta, R> {
+    file: &'file DiskCache<R>,
+    blocks_range: Range<u32>,
+    read_range: ReadRange,
+    meta: Meta,
+}
+
+pub struct DiskCachePipeline<'file, T, Meta, R>
+where
+    R: UniversalRead<u8> + 'file,
+{
+    remote_pipeline: OnceCell<R::ReadPipeline<'file, RemoteMeta<'file, Meta, R>>>,
+    result: Option<(Meta, &'file [T])>,
+}
+
+impl<'file, T, Meta, R> DiskCachePipeline<'file, T, Meta, R>
+where
+    T: bytemuck::Pod,
+    R: UniversalRead<u8> + 'file,
+{
+    fn get_or_init_remote_pipeline(
+        &mut self,
+    ) -> universal_io::Result<&mut R::ReadPipeline<'file, RemoteMeta<'file, Meta, R>>> {
+        if self.remote_pipeline.get().is_none() {
+            let remote = R::ReadPipeline::new()?;
+            // We just observed the cell as empty and hold `&mut self`, so set cannot fail.
+            let _ = self.remote_pipeline.set(remote);
+        }
+        Ok(self.remote_pipeline.get_mut().expect("just initialized"))
+    }
+
+    fn wait_for_remote(&mut self) -> universal_io::Result<Option<(Meta, &'file [T])>> {
+        let Some(remote_pipeline) = self.remote_pipeline.get_mut() else {
+            return Ok(None);
+        };
+
+        let Some((meta, bytes)) = remote_pipeline.wait()? else {
+            return Ok(None);
+        };
+
+        let RemoteMeta {
+            file,
+            blocks_range,
+            read_range,
+            meta,
+        } = meta;
+
+        let local = file.local_state()?;
+
+        let mmap_bytes = unsafe {
+            local.write_mmap_bytes(&bytes, blocks_range);
+
+            local.read_mmap_bytes(read_range.into_byte_range::<T>())
+        };
+
+        Ok(Some((meta, bytemuck::cast_slice(mmap_bytes))))
+    }
+}
+
+impl<'file, T, Meta, Remote> UniversalReadPipeline<'file, T, Meta>
+    for DiskCachePipeline<'file, T, Meta, Remote>
+where
+    T: bytemuck::Pod + Copy + 'static,
+    Remote: UniversalRead<u8>,
+{
+    type File = DiskCache<Remote>;
+
+    fn new() -> crate::universal_io::Result<Self> {
+        Ok(Self {
+            remote_pipeline: OnceCell::new(),
+            result: None,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.result.is_none()
+            && self
+                .remote_pipeline
+                .get_mut()
+                .is_none_or(|remote| remote.can_schedule())
+    }
+
+    fn schedule<P: AccessPattern>(
+        &mut self,
+        meta: Meta,
+        file: &'file DiskCache<Remote>,
+        range: crate::universal_io::ReadRange,
+    ) -> crate::universal_io::Result<()> {
+        // Short-circuit if range is empty
+        if range.length == 0 {
+            self.result = Some((meta, &[]));
+            return Ok(());
+        }
+
+        let local = file.local_state()?;
+
+        let byte_range = range.into_byte_range::<T>();
+
+        // Validate byte range
+        if byte_range.end > local.mmap.len() as u64 {
+            // TODO: Grow local file if remote file has grown, or OOB
+            return Err(UniversalIoError::OutOfBounds {
+                start: byte_range.start,
+                end: byte_range.end,
+                elements: range.length as usize,
+            });
+        }
+
+        let blocks_range = to_block_range(byte_range.clone());
+
+        // Check if blocks are already fetched
+        if local.fetched.lock().contains_range(blocks_range.clone()) {
+            // The range is already local, put into result.
+            let bytes = unsafe { local.read_mmap_bytes(byte_range) };
+            self.result = Some((meta, bytemuck::cast_slice(bytes)));
+            return Ok(());
+        }
+
+        // Schedule BLOCK_SIZE aligned read from remote. Making sure to not try to read past EOF.
+        let byte_offset = blocks_range.start as usize * BLOCK_SIZE;
+        let fetch_length = blocks_range.len() * BLOCK_SIZE;
+        let max_length = local.mmap.len().saturating_sub(byte_offset);
+        let blocks_byte_range = ReadRange {
+            byte_offset: byte_offset as u64,
+            length: fetch_length.min(max_length) as u64,
+        };
+
+        let pipelined_meta = RemoteMeta {
+            file,
+            blocks_range,
+            read_range: range,
+            meta,
+        };
+
+        let remote_pipeline = self.get_or_init_remote_pipeline()?;
+        remote_pipeline.schedule::<P>(pipelined_meta, &file.remote, blocks_byte_range)?;
+
+        Ok(())
+    }
+
+    fn wait(
+        &mut self,
+    ) -> crate::universal_io::Result<Option<(Meta, std::borrow::Cow<'file, [T]>)>> {
+        if let Some((meta, slice)) = self.result.take() {
+            return Ok(Some((meta, Cow::Borrowed(slice))));
+        }
+
+        Ok(self
+            .wait_for_remote()?
+            .map(|(meta, items)| (meta, Cow::Borrowed(items))))
+    }
+}

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -1,0 +1,214 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use fs_err as fs;
+
+use super::{BLOCK_SIZE, DiskCache, DiskCacheConfig};
+use crate::generic_consts::Sequential;
+#[cfg(target_os = "linux")]
+use crate::universal_io::IoUringFile;
+#[cfg(not(target_os = "linux"))]
+use crate::universal_io::MmapFile;
+use crate::universal_io::{OpenOptions, ReadRange, UniversalRead};
+
+fn make_test_data(n_bytes: usize) -> Vec<u8> {
+    (0..n_bytes).map(|i| (i % 251) as u8).collect()
+}
+
+type Remote = cfg_select! {
+    target_os = "linux" => { IoUringFile }
+    _ => { MmapFile }
+};
+
+struct Scenario {
+    _tmp: tempfile::TempDir,
+    remote_path: PathBuf,
+    data: Vec<u8>,
+    config: DiskCacheConfig,
+}
+
+impl Scenario {
+    fn new(n_bytes: usize) -> Self {
+        let tmp = tempfile::Builder::new()
+            .prefix("disk_cache_tests")
+            .tempdir()
+            .unwrap();
+        let remote_dir = tmp.path().join("remote");
+        let local_dir = tmp.path().join("local");
+        fs::create_dir_all(&remote_dir).unwrap();
+        fs::create_dir_all(&local_dir).unwrap();
+
+        let remote_path = remote_dir.join("data.bin");
+        let data = make_test_data(n_bytes);
+        fs::write(&remote_path, &data).unwrap();
+
+        Self {
+            _tmp: tmp,
+            remote_path,
+            data,
+            config: DiskCacheConfig::new(remote_dir, local_dir).unwrap(),
+        }
+    }
+
+    fn expected_local_path(&self) -> PathBuf {
+        self.config.local_path_for(&self.remote_path).unwrap()
+    }
+
+    fn open(&self) -> DiskCache<Remote> {
+        DiskCache::open_with_config(
+            &self.config,
+            &self.remote_path,
+            OpenOptions {
+                writeable: false,
+                ..OpenOptions::default()
+            },
+        )
+        .unwrap()
+    }
+}
+
+#[test]
+fn basic_read_returns_remote_bytes() {
+    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+    let file = scn.open();
+
+    // Read inside the first block.
+    let bytes = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: 10,
+            length: 20,
+        },
+    )
+    .unwrap();
+    assert_eq!(&*bytes, &scn.data[10..30]);
+
+    // Last block includes the 100-byte tail.
+    let last = scn.data.len() as u64;
+    let bytes = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: last - 50,
+            length: 50,
+        },
+    )
+    .unwrap();
+    assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
+}
+
+#[test]
+fn read_spanning_multiple_blocks_is_stitched() {
+    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+    let file = scn.open();
+
+    let start = (BLOCK_SIZE - 50) as u64;
+    let len = (BLOCK_SIZE + 100) as u64;
+    let bytes = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: start,
+            length: len,
+        },
+    )
+    .unwrap();
+    let start = start as usize;
+    let end = start + len as usize;
+    assert!(matches!(bytes, Cow::Borrowed(_)));
+    assert_eq!(bytes.as_ref(), &scn.data[start..end]);
+}
+
+#[test]
+fn local_file_is_created_on_first_read() {
+    let scn = Scenario::new(BLOCK_SIZE * 2);
+    let expected_local = scn.expected_local_path();
+
+    let file = scn.open();
+
+    // Before the first read, the local file doesn't exist yet.
+    assert!(
+        !expected_local.exists(),
+        "local file should not exist before first read: {}",
+        expected_local.display(),
+    );
+
+    // Trigger one read. This must bring up the local file.
+    let _ = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: 0,
+            length: 1,
+        },
+    )
+    .unwrap();
+
+    assert!(
+        expected_local.exists(),
+        "local file should exist after first read"
+    );
+    assert_eq!(
+        fs::metadata(&expected_local).unwrap().len(),
+        scn.data.len() as u64,
+        "local file should be sized to the remote",
+    );
+}
+
+#[test]
+fn empty_read_does_not_materialize_local_file() {
+    let scn = Scenario::new(BLOCK_SIZE);
+    let expected_local = scn.expected_local_path();
+    let file = scn.open();
+
+    let bytes = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: 0,
+            length: 0,
+        },
+    )
+    .unwrap();
+    assert!(bytes.is_empty());
+    assert!(
+        !expected_local.exists(),
+        "zero-length read must not trigger local-file initialisation",
+    );
+}
+
+#[test]
+fn populate_fetches_every_block() {
+    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+    let file = scn.open();
+
+    UniversalRead::<u8>::populate(&file).unwrap();
+
+    let bytes = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: 0,
+            length: scn.data.len() as u64,
+        },
+    )
+    .unwrap();
+    assert_eq!(&*bytes, &scn.data[..]);
+}
+
+#[test]
+fn read_past_end_returns_out_of_bounds() {
+    let scn = Scenario::new(1024);
+    let file = scn.open();
+
+    let err = UniversalRead::<u8>::read::<Sequential>(
+        &file,
+        ReadRange {
+            byte_offset: 1000,
+            length: 100,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::universal_io::UniversalIoError::OutOfBounds { .. }
+        ),
+        "expected OutOfBounds, got {err:?}",
+    );
+}

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -47,7 +47,7 @@ impl Scenario {
 
     fn open<R>(&self) -> DiskCache<R>
     where
-        R: UniversalRead<u8>,
+        R: UniversalRead,
     {
         DiskCache::open_with_config(
             &self.config,
@@ -78,26 +78,22 @@ mod tests_mod {
         let file = scn.open::<R>();
 
         // Read inside the first block.
-        let bytes = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: 10,
                 length: 20,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert_eq!(&*bytes, &scn.data[10..30]);
 
         // Last block includes the 100-byte tail.
         let last = scn.data.len() as u64;
-        let bytes = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: last - 50,
                 length: 50,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
     }
 
@@ -108,14 +104,12 @@ mod tests_mod {
 
         let start = (BLOCK_SIZE - 50) as u64;
         let len = (BLOCK_SIZE + 100) as u64;
-        let bytes = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: start,
                 length: len,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         let start = start as usize;
         let end = start + len as usize;
         assert!(matches!(bytes, Cow::Borrowed(_)));
@@ -137,14 +131,12 @@ mod tests_mod {
         );
 
         // Trigger one read. This must bring up the local file.
-        let _ = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let _ = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: 0,
                 length: 1,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
 
         assert!(
             expected_local.exists(),
@@ -163,14 +155,12 @@ mod tests_mod {
         let expected_local = scn.expected_local_path();
         let file = scn.open::<R>();
 
-        let bytes = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: 0,
                 length: 0,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert!(bytes.is_empty());
         assert!(
             !expected_local.exists(),
@@ -183,16 +173,14 @@ mod tests_mod {
         let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
         let file = scn.open::<R>();
 
-        UniversalRead::<u8>::populate(&file).unwrap();
+        file.populate().unwrap();
 
-        let bytes = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: 0,
                 length: scn.data.len() as u64,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert_eq!(&*bytes, &scn.data[..]);
     }
 
@@ -201,14 +189,12 @@ mod tests_mod {
         let scn = Scenario::new(1024);
         let file = scn.open::<R>();
 
-        let err = UniversalRead::<u8>::read::<Sequential>(
-            &file,
-            ReadRange {
+        let err = file
+            .read::<Sequential, u8>(ReadRange {
                 byte_offset: 1000,
                 length: 100,
-            },
-        )
-        .unwrap_err();
+            })
+            .unwrap_err();
         assert!(
             matches!(
                 err,

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -97,7 +97,7 @@ fn basic_read_returns_remote_bytes() {
 }
 
 #[test]
-fn read_spanning_multiple_blocks_is_stitched() {
+fn read_spanning_multiple_blocks_is_contiguous() {
     let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
     let file = scn.open();
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -5,20 +5,11 @@ use fs_err as fs;
 
 use super::{BLOCK_SIZE, DiskCache, DiskCacheConfig};
 use crate::generic_consts::Sequential;
-#[cfg(target_os = "linux")]
-use crate::universal_io::IoUringFile;
-#[cfg(not(target_os = "linux"))]
-use crate::universal_io::MmapFile;
 use crate::universal_io::{OpenOptions, ReadRange, UniversalRead};
 
 fn make_test_data(n_bytes: usize) -> Vec<u8> {
     (0..n_bytes).map(|i| (i % 251) as u8).collect()
 }
-
-type Remote = cfg_select! {
-    target_os = "linux" => { IoUringFile }
-    _ => { MmapFile }
-};
 
 struct Scenario {
     _tmp: tempfile::TempDir,
@@ -54,7 +45,10 @@ impl Scenario {
         self.config.local_path_for(&self.remote_path).unwrap()
     }
 
-    fn open(&self) -> DiskCache<Remote> {
+    fn open<R>(&self) -> DiskCache<R>
+    where
+        R: UniversalRead<u8>,
+    {
         DiskCache::open_with_config(
             &self.config,
             &self.remote_path,
@@ -67,148 +61,160 @@ impl Scenario {
     }
 }
 
-#[test]
-fn basic_read_returns_remote_bytes() {
-    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
-    let file = scn.open();
+#[duplicate::duplicate_item(
+    tests_mod       R               cfg_predicate;
+    [tests_mmap]    [MmapFile]      [cfg(all())];
+    [tests_uring]   [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
+#[cfg(test)]
+mod tests_mod {
+    use super::*;
+    #[cfg_predicate]
+    use crate::universal_io::R;
+    #[test]
+    fn basic_read_returns_remote_bytes() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>();
 
-    // Read inside the first block.
-    let bytes = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: 10,
-            length: 20,
-        },
-    )
-    .unwrap();
-    assert_eq!(&*bytes, &scn.data[10..30]);
+        // Read inside the first block.
+        let bytes = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: 10,
+                length: 20,
+            },
+        )
+        .unwrap();
+        assert_eq!(&*bytes, &scn.data[10..30]);
 
-    // Last block includes the 100-byte tail.
-    let last = scn.data.len() as u64;
-    let bytes = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: last - 50,
-            length: 50,
-        },
-    )
-    .unwrap();
-    assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
-}
+        // Last block includes the 100-byte tail.
+        let last = scn.data.len() as u64;
+        let bytes = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: last - 50,
+                length: 50,
+            },
+        )
+        .unwrap();
+        assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
+    }
 
-#[test]
-fn read_spanning_multiple_blocks_is_contiguous() {
-    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
-    let file = scn.open();
+    #[test]
+    fn read_spanning_multiple_blocks_is_contiguous() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>();
 
-    let start = (BLOCK_SIZE - 50) as u64;
-    let len = (BLOCK_SIZE + 100) as u64;
-    let bytes = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: start,
-            length: len,
-        },
-    )
-    .unwrap();
-    let start = start as usize;
-    let end = start + len as usize;
-    assert!(matches!(bytes, Cow::Borrowed(_)));
-    assert_eq!(bytes.as_ref(), &scn.data[start..end]);
-}
+        let start = (BLOCK_SIZE - 50) as u64;
+        let len = (BLOCK_SIZE + 100) as u64;
+        let bytes = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: start,
+                length: len,
+            },
+        )
+        .unwrap();
+        let start = start as usize;
+        let end = start + len as usize;
+        assert!(matches!(bytes, Cow::Borrowed(_)));
+        assert_eq!(bytes.as_ref(), &scn.data[start..end]);
+    }
 
-#[test]
-fn local_file_is_created_on_first_read() {
-    let scn = Scenario::new(BLOCK_SIZE * 2);
-    let expected_local = scn.expected_local_path();
+    #[test]
+    fn local_file_is_created_on_first_read() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+        let expected_local = scn.expected_local_path();
 
-    let file = scn.open();
+        let file = scn.open::<R>();
 
-    // Before the first read, the local file doesn't exist yet.
-    assert!(
-        !expected_local.exists(),
-        "local file should not exist before first read: {}",
-        expected_local.display(),
-    );
+        // Before the first read, the local file doesn't exist yet.
+        assert!(
+            !expected_local.exists(),
+            "local file should not exist before first read: {}",
+            expected_local.display(),
+        );
 
-    // Trigger one read. This must bring up the local file.
-    let _ = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: 0,
-            length: 1,
-        },
-    )
-    .unwrap();
+        // Trigger one read. This must bring up the local file.
+        let _ = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: 0,
+                length: 1,
+            },
+        )
+        .unwrap();
 
-    assert!(
-        expected_local.exists(),
-        "local file should exist after first read"
-    );
-    assert_eq!(
-        fs::metadata(&expected_local).unwrap().len(),
-        scn.data.len() as u64,
-        "local file should be sized to the remote",
-    );
-}
+        assert!(
+            expected_local.exists(),
+            "local file should exist after first read"
+        );
+        assert_eq!(
+            fs::metadata(&expected_local).unwrap().len(),
+            scn.data.len() as u64,
+            "local file should be sized to the remote",
+        );
+    }
 
-#[test]
-fn empty_read_does_not_materialize_local_file() {
-    let scn = Scenario::new(BLOCK_SIZE);
-    let expected_local = scn.expected_local_path();
-    let file = scn.open();
+    #[test]
+    fn empty_read_does_not_materialize_local_file() {
+        let scn = Scenario::new(BLOCK_SIZE);
+        let expected_local = scn.expected_local_path();
+        let file = scn.open::<R>();
 
-    let bytes = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: 0,
-            length: 0,
-        },
-    )
-    .unwrap();
-    assert!(bytes.is_empty());
-    assert!(
-        !expected_local.exists(),
-        "zero-length read must not trigger local-file initialisation",
-    );
-}
+        let bytes = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: 0,
+                length: 0,
+            },
+        )
+        .unwrap();
+        assert!(bytes.is_empty());
+        assert!(
+            !expected_local.exists(),
+            "zero-length read must not trigger local-file initialisation",
+        );
+    }
 
-#[test]
-fn populate_fetches_every_block() {
-    let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
-    let file = scn.open();
+    #[test]
+    fn populate_fetches_every_block() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>();
 
-    UniversalRead::<u8>::populate(&file).unwrap();
+        UniversalRead::<u8>::populate(&file).unwrap();
 
-    let bytes = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: 0,
-            length: scn.data.len() as u64,
-        },
-    )
-    .unwrap();
-    assert_eq!(&*bytes, &scn.data[..]);
-}
+        let bytes = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: 0,
+                length: scn.data.len() as u64,
+            },
+        )
+        .unwrap();
+        assert_eq!(&*bytes, &scn.data[..]);
+    }
 
-#[test]
-fn read_past_end_returns_out_of_bounds() {
-    let scn = Scenario::new(1024);
-    let file = scn.open();
+    #[test]
+    fn read_past_end_returns_out_of_bounds() {
+        let scn = Scenario::new(1024);
+        let file = scn.open::<R>();
 
-    let err = UniversalRead::<u8>::read::<Sequential>(
-        &file,
-        ReadRange {
-            byte_offset: 1000,
-            length: 100,
-        },
-    )
-    .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            crate::universal_io::UniversalIoError::OutOfBounds { .. }
-        ),
-        "expected OutOfBounds, got {err:?}",
-    );
+        let err = UniversalRead::<u8>::read::<Sequential>(
+            &file,
+            ReadRange {
+                byte_offset: 1000,
+                length: 100,
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::universal_io::UniversalIoError::OutOfBounds { .. }
+            ),
+            "expected OutOfBounds, got {err:?}",
+        );
+    }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -112,7 +112,7 @@ tracing = { workspace = true, optional = true }
 macro_rules_attribute = "0.2.2"
 nom = "8.0.0"
 half = { workspace = true }
-roaring = { version = "0.11.4" }
+roaring = { workspace = true }
 duplicate = "2.0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
As a simpler alternative to `CachedSlice`, which can work when the local disk is smaller than the remote disk, this PR introduces `simple_disk_cache::DiskCache`, which assumes a large-enough local disk. 

This is basically a local copy of the given file, with a bitmask on top. The local file gets initialized lazily with the length of the upstream file, and the contents --chunked in 16KB blocks-- get pulled lazily as they get requested.

This PR already implements the `ReadPipeline` trait, and every read is funneled through this.

There are a few limitations, that can be addressed later:
- The local file is hardcoded to be mmap, but we may want to use universal io there too. Not easy since we need to be able to write to it under `&` ref, so `MmapRaw` makes it easier without a lock.
- The bitmask lives entirely in memory, we cannot reuse anything on restart.