### PR TITLE
TurboQuant E2E segment-level HNSW tests

### DIFF
--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -16,57 +16,56 @@ mod tests {
     const BITS: &[TQBits] = &[TQBits::Bits4, TQBits::Bits2, TQBits::Bits1_5, TQBits::Bits1];
     const MODE: TQMode = TQMode::Normal;
 
-    /// Tolerance for Dot-product scoring. For centered U[-1, 1] inputs the dot
-    /// product magnitude scales as sqrt(dim) (std of the true score plus the
-    /// Lloyd-Max quantization error both scale the same way), so the tolerance
-    /// follows suit. Coefficients are empirically calibrated (~1.8x observed
-    /// max across VECTORS_COUNT trials on both symmetric and asymmetric paths).
-    fn error_dot(dim: usize, bits: TQBits) -> f32 {
-        let per_sqrt_dim = match bits {
-            TQBits::Bits4 => 0.3,
-            TQBits::Bits2 => 1.0,
-            TQBits::Bits1_5 => 1.5,
-            TQBits::Bits1 => 1.7,
-        };
-        per_sqrt_dim * (dim as f32).sqrt()
-    }
-
-    /// Tolerance for Cosine scoring. Unit-norm inputs mean cos(θ) ∈ [-1, 1] and
-    /// the quantization error on the score shrinks as 1/sqrt(dim). Coefficients
-    /// are empirically calibrated (~1.8x observed max).
-    fn error_cosine(dim: usize, bits: TQBits) -> f32 {
-        let per_inv_sqrt_dim = match bits {
-            TQBits::Bits4 => 1.0,
-            TQBits::Bits2 => 3.0,
+    /// Absolute tolerance for an approximate score: an empirical per-bit
+    /// coefficient (≈ 1.8x observed max across VECTORS_COUNT trials) times
+    /// the signal-std of the input data. The mean-error / signal-std ratio
+    /// is shared by the Dot, Cosine, and L2 paths, so the same coefficient
+    /// table is used; only the caller's `signal_std` differs by metric and
+    /// data distribution.
+    fn error(bits: TQBits, signal_std: f32) -> f32 {
+        let coef = match bits {
+            TQBits::Bits1 => 5.1,
             TQBits::Bits1_5 => 4.0,
-            TQBits::Bits1 => 5.0,
+            TQBits::Bits2 => 3.0,
+            TQBits::Bits4 => 0.9,
         };
-        let error = per_inv_sqrt_dim / (dim as f32).sqrt();
-        assert!(error < 1.0);
-        error
+        coef * signal_std
     }
 
-    /// Tolerance for L2 scoring. The L2 score is
-    /// `‖q‖² + ‖v‖² − 2·<q, v>`; the norms are stored exactly as extras, so
-    /// all quantization noise lives in the dot term and is multiplied by 2.
-    /// That makes the absolute L2 error track twice the Dot tolerance.
-    fn error_l2(dim: usize, bits: TQBits) -> f32 {
-        2.0 * error_dot(dim, bits)
+    /// Signal-std of dot products of two independent U[-1, 1]^d vectors.
+    fn dot_signal_std(dim: usize) -> f32 {
+        (dim as f32 / 9.0).sqrt()
     }
 
-    /// Tolerance for L1 scoring. The L1 path dequantizes both sides (full
-    /// inverse rotation + Lloyd-Max noise per coord) before summing |a−b|.
-    /// Per-coord errors enter the sum signed (sign(a_i−b_i)·δ_i), so the
-    /// cancellation makes the total error scale as sqrt(dim) rather than
-    /// linearly. Coefficients are empirically calibrated (~1.8x observed max
-    /// across both symmetric and asymmetric paths); the symmetric path
-    /// dominates at low bits because both vectors carry dequantization noise.
+    /// Signal-std of cosine of two independent unit-norm random vectors in d-dim.
+    fn cosine_signal_std(dim: usize) -> f32 {
+        1.0 / (dim as f32).sqrt()
+    }
+
+    /// Signal-std of the L2-squared score for two independent U[-1, 1]^d
+    /// vectors. The score is `‖q‖² + ‖v‖² − 2·<q, v>`; the norms are stored
+    /// exactly as extras and contribute no quantization noise, so the
+    /// signal variance is dominated by the `−2·<q, v>` term — i.e. twice
+    /// the dot-product std.
+    fn l2_signal_std(dim: usize) -> f32 {
+        2.0 * dot_signal_std(dim)
+    }
+
+    /// Tolerance for L1 scoring. Has its own per-bit coefficient table
+    /// because the L1 path's noise/signal ratio doesn't track the dot/cosine
+    /// pattern: it dequantizes both sides (full inverse rotation + Lloyd-Max
+    /// noise per coord) before summing |a − b|. Per-coord errors enter the
+    /// sum signed (sign(a_i − b_i)·δ_i), so cancellation makes the total
+    /// scale as sqrt(dim). Coefficients are empirically calibrated
+    /// (~1.8x observed max across both symmetric and asymmetric paths);
+    /// the symmetric path dominates at low bits because both vectors carry
+    /// dequantization noise.
     fn error_l1(dim: usize, bits: TQBits) -> f32 {
         let per_sqrt_dim = match bits {
-            TQBits::Bits4 => 0.7,
-            TQBits::Bits2 => 3.0,
-            TQBits::Bits1_5 => 4.5,
             TQBits::Bits1 => 7.5,
+            TQBits::Bits1_5 => 4.5,
+            TQBits::Bits2 => 3.0,
+            TQBits::Bits4 => 0.7,
         };
         per_sqrt_dim * (dim as f32).sqrt()
     }
@@ -77,10 +76,10 @@ mod tests {
     /// for the tolerance formulas above to be useful.
     fn should_test(dim: usize, bits: TQBits) -> bool {
         let min_dim = match bits {
-            TQBits::Bits4 => 8,
-            TQBits::Bits2 => 32,
-            TQBits::Bits1_5 => 48,
             TQBits::Bits1 => 64,
+            TQBits::Bits1_5 => 48,
+            TQBits::Bits2 => 32,
+            TQBits::Bits4 => 8,
         };
         dim >= min_dim
     }
@@ -105,7 +104,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_dot(dim, bits);
+                let error = error(bits, dot_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -158,7 +157,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_cosine(dim, bits);
+                let error = error(bits, cosine_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -213,7 +212,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_dot(dim, bits);
+                let error = error(bits, dot_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -264,7 +263,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_cosine(dim, bits);
+                let error = error(bits, cosine_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -319,7 +318,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_dot(dim, bits);
+                let error = error(bits, dot_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 // Place the zero vector at index 0; fill the rest with random
                 // data so the encoded batch resembles a realistic input.
@@ -373,7 +372,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_dot(dim, bits);
+                let error = error(bits, dot_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -430,7 +429,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_cosine(dim, bits);
+                let error = error(bits, cosine_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 // Index 0 is the zero vector (not routed through `normalize`,
                 // which would divide by zero); the rest are unit-norm random.
@@ -487,7 +486,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_cosine(dim, bits);
+                let error = error(bits, cosine_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -583,12 +582,9 @@ mod tests {
         }
     }
 
-    // The L1 and L2 tests below are disabled because TQ does not yet implement
-    // those metrics (encoding panics with `unimplemented!()`). They are kept
-    // here so they can be enabled once support lands — uncomment the matching
-    // `use crate::metrics::{l1_similarity, l2_similarity};` above as well.
-    // The `error_dot` tolerance is a placeholder; L1/L2 error scales differently
-    // and will need its own calibrated formula.
+    // L2 (squared) and L1 score tests. Tolerance for L2 reuses the unified
+    // `error()` with `l2_signal_std`; L1 has its own coefficient table
+    // because its noise/signal scaling per bit doesn't match dot/cosine.
 
     #[test]
     fn test_tq_l2() {
@@ -597,7 +593,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_l2(dim, bits);
+                let error = error(bits, l2_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {
@@ -650,7 +646,7 @@ mod tests {
                 if !should_test(dim, bits) {
                     continue;
                 }
-                let error = error_l2(dim, bits);
+                let error = error(bits, l2_signal_std(dim));
                 let mut rng = rand::rngs::StdRng::seed_from_u64(42);
                 let mut vector_data: Vec<Vec<f32>> = vec![];
                 for _ in 0..VECTORS_COUNT {

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -9,11 +9,12 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
 use common::progress_tracker::ProgressTracker;
 use common::types::{ScoreType, ScoredPointOffset};
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use rand_distr::StandardNormal;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, QueryVector, only_default_vector};
 use segment::entry::{NonAppendableSegmentEntry, SegmentEntry};
-use segment::fixtures::payload_fixtures::{STR_KEY, random_vector};
+use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::index::hnsw_index::hnsw::{HNSWIndex, HnswIndexOpenArgs};
 use segment::index::{VectorIndex, VectorIndexEnum};
 use segment::json_path::JsonPath;
@@ -26,7 +27,8 @@ use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
     CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig,
     Indexes, ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
-    ScalarQuantizationConfig, SearchParams,
+    ScalarQuantizationConfig, SearchParams, TurboQuantBitSize, TurboQuantQuantizationConfig,
+    TurboQuantization,
 };
 use segment::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
@@ -41,6 +43,32 @@ pub fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -
         .collect::<BTreeSet<_>>()
         .intersection(&b[0].iter().map(|x| x.idx).collect())
         .count()
+}
+
+/// Sample test vectors with a distribution suited to the distance metric.
+///
+/// * Cosine: uniform on the unit sphere (standard normal per coordinate
+///   then normalized). The result is symmetric around zero, matching what
+///   typical embedding pipelines (BERT, CLIP, ...) produce.
+/// * Dot, Euclid, Manhattan: standard normal per coordinate, *not*
+///   normalized. This gives vectors with non-trivial magnitudes, so a dot
+///   test actually exercises dot product and not an implicit cosine
+///   similarity (which would be the case for unit-norm input).
+///
+/// Avoids `segment::fixtures::random_vector` (which gives values in
+/// `[0, 1)` — a positive-orthant distribution that is unrepresentative
+/// for cosine-similarity benchmarking).
+fn random_test_vector(rng: &mut StdRng, dim: usize, distance: Distance) -> Vec<f32> {
+    let raw: Vec<f32> = (0..dim)
+        .map(|_| rng.sample::<f64, _>(StandardNormal) as f32)
+        .collect();
+    match distance {
+        Distance::Cosine => {
+            let l2 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+            raw.into_iter().map(|x| x / l2).collect()
+        }
+        Distance::Dot | Distance::Euclid | Distance::Manhattan => raw,
+    }
 }
 
 fn hnsw_quantized_search_test(
@@ -72,7 +100,7 @@ fn hnsw_quantized_search_test(
     let mut segment = build_simple_segment(dir.path(), dim, distance).unwrap();
     for n in 0..num_vectors {
         let idx = n.into();
-        let vector = random_vector(&mut rng, dim);
+        let vector = random_test_vector(&mut rng, dim, distance);
         segment
             .upsert_point(op_num, idx, only_default_vector(&vector), &hw_counter)
             .unwrap();
@@ -150,7 +178,7 @@ fn hnsw_quantized_search_test(
     .unwrap();
 
     let query_vectors = (0..attempts)
-        .map(|_| random_vector(&mut rng, dim).into())
+        .map(|_| random_test_vector(&mut rng, dim, distance).into())
         .collect::<Vec<_>>();
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
         JsonPath::new(STR_KEY),
@@ -408,6 +436,190 @@ fn hnsw_product_quantization_manhattan_test() {
         }
         .into(),
         false,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_test() {
+    // Bits4 has enough headroom to use the standard helper (40% recall floor),
+    // matching the scalar/PQ tests' shape (filtered + unfiltered check_matches,
+    // check_oversampling, check_rescoring on zero-overwritten vectors).
+    hnsw_quantized_search_test(
+        Distance::Cosine,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_dot_test() {
+    // See `hnsw_turbo_quantization_cosine_test` for rationale.
+    hnsw_quantized_search_test(
+        Distance::Dot,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_larger_test() {
+    // See `hnsw_turbo_quantization_cosine_test` for rationale.
+    hnsw_quantized_search_test(
+        Distance::Cosine,
+        2003,
+        256,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_bits2_test() {
+    // Bits2 also clears the standard helper's 40% recall floor on
+    // unit-sphere data, so it can share the scalar/PQ test shape.
+    hnsw_quantized_search_test(
+        Distance::Cosine,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits2),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_dot_bits2_test() {
+    // See `hnsw_turbo_quantization_cosine_bits2_test` for rationale.
+    hnsw_quantized_search_test(
+        Distance::Dot,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits2),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_larger_bits2_test() {
+    // See `hnsw_turbo_quantization_cosine_bits2_test` for rationale.
+    hnsw_quantized_search_test(
+        Distance::Cosine,
+        2003,
+        131,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits2),
+            },
+        }),
+        true,
+    );
+}
+
+// L2 (Euclid) and L1 (Manhattan) coverage at Bits4 and Bits2.
+// Bits1 and Bits1_5 are intentionally omitted across all distances:
+// they don't reliably clear the standard helper's 40% recall floor
+// and would be flaky-to-failing under this shape.
+
+#[test]
+fn hnsw_turbo_quantization_euclid_test() {
+    hnsw_quantized_search_test(
+        Distance::Euclid,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_manhattan_test() {
+    hnsw_quantized_search_test(
+        Distance::Manhattan,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_euclid_bits2_test() {
+    hnsw_quantized_search_test(
+        Distance::Euclid,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits2),
+            },
+        }),
+        true,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_manhattan_bits2_test() {
+    hnsw_quantized_search_test(
+        Distance::Manhattan,
+        1003,
+        64,
+        QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                plus: None,
+                bits: Some(TurboQuantBitSize::Bits2),
+            },
+        }),
+        true,
     );
 }
 

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -25,10 +25,10 @@ use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    CompressionRatio, Condition, Distance, FieldCondition, Filter, HnswConfig, HnswGlobalConfig,
-    Indexes, ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams,
-    ScalarQuantizationConfig, SearchParams, TurboQuantBitSize, TurboQuantQuantizationConfig,
-    TurboQuantization,
+    BinaryQuantizationConfig, BinaryQuantizationEncoding, CompressionRatio, Condition, Distance,
+    FieldCondition, Filter, HnswConfig, HnswGlobalConfig, Indexes, ProductQuantizationConfig,
+    QuantizationConfig, QuantizationSearchParams, ScalarQuantizationConfig, SearchParams,
+    TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization,
 };
 use segment::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
@@ -620,6 +620,345 @@ fn hnsw_turbo_quantization_manhattan_bits2_test() {
             },
         }),
         true,
+    );
+}
+
+/// Bits1/Bits1_5 are below the standard helper's recall floor; instead
+/// anchor on binary quantization at the same effective bit-width and
+/// assert the quantization-error gap (rescored top-K score sum vs. exact
+/// top-K) is at most BQ's and not dramatically smaller.
+fn hnsw_quantized_low_bit_compare_test(
+    distance: Distance,
+    num_vectors: u64,
+    dim: usize,
+    tq_bits: TurboQuantBitSize,
+    bq_encoding: BinaryQuantizationEncoding,
+) {
+    let stopped = AtomicBool::new(false);
+
+    let m = 16;
+    let ef = 64;
+    let ef_construct = 64;
+    let top = 20;
+    let attempts = 25;
+    let payloads_count: u64 = 50;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let vectors: Vec<Vec<f32>> = (0..num_vectors)
+        .map(|_| random_test_vector(&mut rng, dim, distance))
+        .collect();
+    let queries: Vec<QueryVector> = (0..attempts)
+        .map(|_| random_test_vector(&mut rng, dim, distance).into())
+        .collect();
+
+    let tq_config = QuantizationConfig::Turbo(TurboQuantization {
+        turbo: TurboQuantQuantizationConfig {
+            always_ram: Some(true),
+            plus: None,
+            bits: Some(tq_bits),
+        },
+    });
+    let bq_config: QuantizationConfig = BinaryQuantizationConfig {
+        always_ram: Some(true),
+        encoding: Some(bq_encoding),
+        query_encoding: None,
+    }
+    .into();
+
+    let (tq_segment, tq_index, _tq_dirs) = build_quantized_hnsw_for_compare(
+        &vectors,
+        distance,
+        &tq_config,
+        m,
+        ef_construct,
+        payloads_count,
+        &mut rng,
+        &stopped,
+    );
+    let (_bq_segment, bq_index, _bq_dirs) = build_quantized_hnsw_for_compare(
+        &vectors,
+        distance,
+        &bq_config,
+        m,
+        ef_construct,
+        payloads_count,
+        &mut rng,
+        &stopped,
+    );
+
+    let rescored_params = SearchParams {
+        hnsw_ef: Some(ef),
+        quantization: Some(QuantizationSearchParams {
+            rescore: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut tq_total_loss: f64 = 0.0;
+    let mut bq_total_loss: f64 = 0.0;
+    for query in &queries {
+        let exact_result = tq_segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_index
+            .borrow()
+            .search(&[query], None, top, None, &Default::default())
+            .unwrap();
+        let exact_sum: f64 = exact_result[0].iter().map(|p| f64::from(p.score)).sum();
+
+        let tq_result = tq_index
+            .search(
+                &[query],
+                None,
+                top,
+                Some(&rescored_params),
+                &Default::default(),
+            )
+            .unwrap();
+        let tq_sum: f64 = tq_result[0].iter().map(|p| f64::from(p.score)).sum();
+
+        let bq_result = bq_index
+            .search(
+                &[query],
+                None,
+                top,
+                Some(&rescored_params),
+                &Default::default(),
+            )
+            .unwrap();
+        let bq_sum: f64 = bq_result[0].iter().map(|p| f64::from(p.score)).sum();
+
+        tq_total_loss += exact_sum - tq_sum;
+        bq_total_loss += exact_sum - bq_sum;
+    }
+
+    let tq_avg_loss = tq_total_loss / f64::from(attempts);
+    let bq_avg_loss = bq_total_loss / f64::from(attempts);
+    println!(
+        "low-bit compare: distance={distance:?}, dim={dim}, num={num_vectors}, \
+         tq_bits={tq_bits:?}, bq_encoding={bq_encoding:?}, \
+         tq_avg_loss={tq_avg_loss:.6}, bq_avg_loss={bq_avg_loss:.6}",
+    );
+
+    let eps = f64::from(ScoreType::EPSILON);
+    assert!(
+        tq_avg_loss >= -eps,
+        "tq_avg_loss should be non-negative, got {tq_avg_loss}",
+    );
+    assert!(
+        bq_avg_loss >= -eps,
+        "bq_avg_loss should be non-negative, got {bq_avg_loss}",
+    );
+
+    // Slack absorbs single-query noise around the TQ <= BQ inequality.
+    let upper_tolerance = bq_avg_loss.abs() * 0.10 + 1e-3;
+    assert!(
+        tq_avg_loss <= bq_avg_loss + upper_tolerance,
+        "Expected TurboQuant error <= Binary error \
+         (distance={distance:?}, tq_bits={tq_bits:?}, bq_encoding={bq_encoding:?}): \
+         tq_avg_loss={tq_avg_loss}, bq_avg_loss={bq_avg_loss}",
+    );
+
+    // Loose floor: catches a broken TQ (e.g. accidentally near-lossless)
+    // without rejecting TQ's genuine accuracy edge over BQ on this data.
+    let lower_tolerance = bq_avg_loss.abs() * 0.05 + 1e-3;
+    assert!(
+        tq_avg_loss + lower_tolerance >= bq_avg_loss * 0.10,
+        "Expected TurboQuant error to be in the same ballpark as Binary error \
+         (distance={distance:?}, tq_bits={tq_bits:?}, bq_encoding={bq_encoding:?}): \
+         tq_avg_loss={tq_avg_loss}, bq_avg_loss={bq_avg_loss}",
+    );
+}
+
+/// Caller must keep the returned tempdirs alive for as long as the segment
+/// and HNSW index are used.
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+fn build_quantized_hnsw_for_compare(
+    vectors: &[Vec<f32>],
+    distance: Distance,
+    quantization_config: &QuantizationConfig,
+    m: usize,
+    ef_construct: usize,
+    payloads_count: u64,
+    rng: &mut StdRng,
+    stopped: &AtomicBool,
+) -> (
+    Segment,
+    HNSWIndex,
+    (tempfile::TempDir, tempfile::TempDir, tempfile::TempDir),
+) {
+    let dim = vectors[0].len();
+    let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+    let quantized_dir = Builder::new().prefix("quantized_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut segment = build_simple_segment(segment_dir.path(), dim, distance).unwrap();
+    let mut op_num: u64 = 0;
+    for (n, vector) in vectors.iter().enumerate() {
+        let idx = (n as u64).into();
+        segment
+            .upsert_point(op_num, idx, only_default_vector(vector), &hw_counter)
+            .unwrap();
+        op_num += 1;
+    }
+
+    segment
+        .create_field_index(
+            op_num,
+            &JsonPath::new(STR_KEY),
+            Some(&Keyword.into()),
+            &hw_counter,
+        )
+        .unwrap();
+    op_num += 1;
+    for n in 0..payloads_count {
+        let idx = n.into();
+        let payload = payload_json! {STR_KEY: STR_KEY};
+        segment
+            .set_full_payload(op_num, idx, &payload, &hw_counter)
+            .unwrap();
+        op_num += 1;
+    }
+
+    segment.vector_data.values_mut().for_each(|vector_storage| {
+        let quantized_vectors = QuantizedVectors::create(
+            &vector_storage.vector_storage.borrow(),
+            quantization_config,
+            QuantizedVectorsStorageType::Immutable,
+            quantized_dir.path(),
+            4,
+            stopped,
+        )
+        .unwrap();
+        vector_storage.quantized_vectors = Arc::new(AtomicRefCell::new(Some(quantized_vectors)));
+    });
+
+    let hnsw_config = HnswConfig {
+        m,
+        ef_construct,
+        full_scan_threshold: 2 * payloads_count as usize,
+        max_indexing_threads: 2,
+        on_disk: Some(false),
+        payload_m: None,
+        inline_storage: None,
+    };
+
+    let permit = Arc::new(ResourcePermit::dummy(2));
+    let hnsw_index = HNSWIndex::build(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .quantized_vectors
+                .clone(),
+            payload_index: segment.payload_index.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            old_indices: &[],
+            gpu_device: None,
+            rng,
+            stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
+            feature_flags: FeatureFlags::default(),
+            progress: ProgressTracker::new_for_test(),
+        },
+    )
+    .unwrap();
+
+    (segment, hnsw_index, (segment_dir, hnsw_dir, quantized_dir))
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_bits1_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Cosine,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1,
+        BinaryQuantizationEncoding::OneBit,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_dot_bits1_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Dot,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1,
+        BinaryQuantizationEncoding::OneBit,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_euclid_bits1_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Euclid,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1,
+        BinaryQuantizationEncoding::OneBit,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_manhattan_bits1_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Manhattan,
+        503,
+        64,
+        TurboQuantBitSize::Bits1,
+        BinaryQuantizationEncoding::OneBit,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_cosine_bits1_5_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Cosine,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1_5,
+        BinaryQuantizationEncoding::OneAndHalfBits,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_dot_bits1_5_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Dot,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1_5,
+        BinaryQuantizationEncoding::OneAndHalfBits,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_euclid_bits1_5_test() {
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Euclid,
+        1003,
+        128,
+        TurboQuantBitSize::Bits1_5,
+        BinaryQuantizationEncoding::OneAndHalfBits,
+    );
+}
+
+#[test]
+fn hnsw_turbo_quantization_manhattan_bits1_5_test() {
+    // See `hnsw_turbo_quantization_manhattan_bits1_test` for rationale.
+    hnsw_quantized_low_bit_compare_test(
+        Distance::Manhattan,
+        503,
+        64,
+        TurboQuantBitSize::Bits1_5,
+        BinaryQuantizationEncoding::OneAndHalfBits,
     );
 }
 


### PR DESCRIPTION
Depends on https://github.com/qdrant/qdrant/pull/8794

This PR implements hnsw test coverage for TurboQuant. Bits 1 and 1.5 are omitted (for now) as they don't fit into our current test-helper because of their low accuracy.

This PR also improves on the existing tests in `test_tq.rs` which now use a single source for allowed error calculation.