### PR TITLE
Fix consensus test port collision across xdist workers

### DIFF
--- a/tests/consensus_tests/test_cluster_rejoin.py
+++ b/tests/consensus_tests/test_cluster_rejoin.py
@@ -344,9 +344,9 @@ def start_preconfigured_cluster(tmp_path: pathlib.Path, peers: int = 3):
     shutil.copytree(PROJECT_ROOT / "tests/consensus_tests/test_cluster_rejoin_data", f"{peer_dirs[0]}/storage")
 
     # Modify peer URI in Raft state to prevent URI change on startup 🙄
-    p2p_port = get_port()
-    grpc_port = get_port()
-    http_port = get_port()
+    p2p_port = get_port_triple()
+    grpc_port = p2p_port + 1
+    http_port = p2p_port + 2
 
     with open(f"{peer_dirs[0]}/storage/raft_state.json", "r+") as file:
         state = json.load(file)

--- a/tests/consensus_tests/test_peer_snapshot_bootstrap.py
+++ b/tests/consensus_tests/test_peer_snapshot_bootstrap.py
@@ -23,7 +23,7 @@ def test_peer_snapshot_bootstrap(tmp_path: pathlib.Path):
     #
     # If the port changes and the peer have to report URI change,
     # *4 out of 5 times it will fail to do so*, and the test will fail.
-    first_peer_port = get_port()
+    first_peer_port = get_port_triple()
 
     # Start bootstrap
     (bootstrap_api_uri, bootstrap_uri) = start_first_peer(

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -91,6 +91,37 @@ def get_port() -> int:
                 continue
             return allocated_port
 
+
+def get_port_triple() -> int:
+    # Allocate a contiguous triple (port, port+1, port+2) for a peer's
+    # p2p/grpc/http ports. Required so that restarts with `port=p.p2p_port`
+    # — which derive grpc=port+1, http=port+2 — find those slots free even
+    # under pytest-xdist, where other workers' `busy_ports` are not visible.
+    # Verifies bindability across processes by probing all three with bind().
+    while True:
+        s0 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s0.bind(('', 0))
+            base = s0.getsockname()[1]
+            if any((base + d) in busy_ports for d in range(-2, 5)):
+                s0.close()
+                continue
+            s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                s1.bind(('', base + 1))
+                s2.bind(('', base + 2))
+                return base
+            except OSError:
+                continue
+            finally:
+                s1.close()
+                s2.close()
+        except OSError:
+            continue
+        finally:
+            s0.close()
+
 def is_coverage_mode() -> bool:
     return os.getenv("COVERAGE") == "1"
 
@@ -149,11 +180,12 @@ def init_pytest_log_folder() -> str:
 def start_peer(peer_dir: Path, log_file: str, bootstrap_uri: str, port=None, extra_env=None, reinit=False, uris_in_env=False) -> str:
     if extra_env is None:
         extra_env = {}
-    p2p_port = get_port() if port is None else port + 0
+    base_port = get_port_triple() if port is None else port
+    p2p_port = base_port + 0
     _occupy_port(p2p_port)
-    grpc_port = get_port() if port is None else port + 1
+    grpc_port = base_port + 1
     _occupy_port(grpc_port)
-    http_port = get_port() if port is None else port + 2
+    http_port = base_port + 2
     _occupy_port(http_port)
 
     test_log_folder = init_pytest_log_folder()
@@ -190,11 +222,12 @@ def start_first_peer(peer_dir: Path, log_file: str, port=None, extra_env=None, r
     if extra_env is None:
         extra_env = {}
 
-    p2p_port = get_port() if port is None else port + 0
+    base_port = get_port_triple() if port is None else port
+    p2p_port = base_port + 0
     _occupy_port(p2p_port)
-    grpc_port = get_port() if port is None else port + 1
+    grpc_port = base_port + 1
     _occupy_port(grpc_port)
-    http_port = get_port() if port is None else port + 2
+    http_port = base_port + 2
     _occupy_port(http_port)
 
     test_log_folder = init_pytest_log_folder()

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -68,11 +68,38 @@ def kill_all_processes():
             print(f"Cleanup error for {p.pid}: {e}")
 
 
+# Each pytest-xdist worker owns a disjoint slice of the port space, so concurrent
+# workers never compete for the same port range. Ports stay below the Linux
+# default ephemeral range (32768) so OS-assigned random sockets don't collide
+# either. Slice size of 300 = 100 peer triples, which comfortably covers any
+# single test even with dynamically added peers.
+_PORT_SLICE_BASE = 20000
+_PORT_SLICE_SIZE = 300
+
+
+def _xdist_worker_index() -> int:
+    name = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    if name.startswith("gw") and name[2:].isdigit():
+        return int(name[2:])
+    return 0
+
+
+_WORKER_SLICE_START = _PORT_SLICE_BASE + _xdist_worker_index() * _PORT_SLICE_SIZE
+_WORKER_SLICE_END = _WORKER_SLICE_START + _PORT_SLICE_SIZE
+_next_port_in_slice = _WORKER_SLICE_START
+
+
+def _reset_port_slice():
+    global _next_port_in_slice
+    _next_port_in_slice = _WORKER_SLICE_START
+
+
 @pytest.fixture(autouse=True)
 def every_test():
     if processes:
         print(f"WARN: {len(processes)} leaked peer processes from previous test, cleaning")
         kill_all_processes()
+    _reset_port_slice()
     yield
     kill_all_processes()
 
@@ -92,20 +119,44 @@ def get_port() -> int:
             return allocated_port
 
 
+def _try_bind_triple(base: int) -> bool:
+    sockets = []
+    try:
+        for offset in range(3):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                s.bind(('', base + offset))
+                sockets.append(s)
+            except OSError:
+                return False
+        return True
+    finally:
+        for s in sockets:
+            s.close()
+
+
 def get_port_triple() -> int:
-    # Allocate a contiguous triple (port, port+1, port+2) for a peer's
-    # p2p/grpc/http ports. Required so that restarts with `port=p.p2p_port`
-    # — which derive grpc=port+1, http=port+2 — find those slots free even
-    # under pytest-xdist, where other workers' `busy_ports` are not visible.
-    # Verifies bindability across processes by probing all three with bind().
+    # Allocate a contiguous triple (p2p, grpc, http) for a peer. Each xdist
+    # worker draws from its own slice, so the original cross-worker collision
+    # on `port+1` / `port+2` (which restart paths derive from p2p_port) cannot
+    # happen. Within the slice we still probe-bind() each candidate so
+    # unrelated processes occupying a slot are skipped, not deterministically
+    # crashed-into. Falls back to OS-assigned ports if the slice is exhausted.
+    global _next_port_in_slice
+    while _next_port_in_slice + 3 <= _WORKER_SLICE_END:
+        base = _next_port_in_slice
+        _next_port_in_slice += 3
+        if _try_bind_triple(base):
+            return base
+    return _get_port_triple_from_os()
+
+
+def _get_port_triple_from_os() -> int:
     while True:
         s0 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             s0.bind(('', 0))
             base = s0.getsockname()[1]
-            if any((base + d) in busy_ports for d in range(-2, 5)):
-                s0.close()
-                continue
             s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:


### PR DESCRIPTION
## Summary

- Flake repro: `test_collection_recovery_user_requests_above_limit` failed on CI with `404 - Collection 'test_collection' doesn't exist!` when probing the just-restarted peer. The peer's log showed `ERROR qdrant: Error while starting REST server: Address already in use (os error 98)` — the 404 came from another xdist worker's peer that happened to be listening on the same port.
- Root cause: `start_peer`/`start_first_peer` allocated p2p/grpc/http via three independent `get_port()` calls. Only `p2p_port` was OS-reserved by the test. On restart with `port=p.p2p_port`, the framework derives `grpc=port+1` and `http=port+2`, but those neighbors were never validated. Under `pytest -n auto --dist=loadfile`, the per-worker `busy_ports` dict can't see other workers' allocations, so the ±2 buffer in `get_port()` doesn't protect against cross-worker collisions.
- Fix: add `get_port_triple()` which picks a base port and probes `bind()` on `base+1` and `base+2` to verify the contiguous slot is free across processes. Route `start_peer`, `start_first_peer`, and the two test sites that pass an explicit `port=` (`test_peer_snapshot_bootstrap`, `test_cluster_rejoin`) through it.

## Test plan

- [ ] Re-run `test_collection_recovery_user_requests_above_limit` repeatedly under `pytest -n auto --dist=loadfile` and confirm no flake.
- [ ] Spot-check `test_peer_snapshot_bootstrap` and `test_cluster_rejoin` still pass (they use `port=` for restart, which is the path the fix targets).
- [ ] Sanity-check full `tests/consensus_tests` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)