### PR TITLE
ci: centralize protoc setup in a composite action

### DIFF
--- a/.github/actions/setup-protoc/action.yaml
+++ b/.github/actions/setup-protoc/action.yaml
@@ -1,10 +1,47 @@
 name: Install Protoc
-description: "Install a pinned version of protoc"
+description: "Install a pinned protoc by downloading the release zip directly (no GitHub API calls)"
+
+inputs:
+  version:
+    description: "Protoc version, without the leading 'v'"
+    required: false
+    default: "34.1"
 
 runs:
   using: "composite"
   steps:
-    - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-      with:
-        version: "34.1"
-        repo-token: ${{ github.token }}
+    - name: Download and install protoc ${{ inputs.version }}
+      shell: bash
+      env:
+        PROTOC_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          Linux-X64)    suffix="linux-x86_64" ;;
+          Linux-ARM64)  suffix="linux-aarch_64" ;;
+          macOS-X64)    suffix="osx-x86_64" ;;
+          macOS-ARM64)  suffix="osx-aarch_64" ;;
+          Windows-X64)  suffix="win64" ;;
+          Windows-X86)  suffix="win32" ;;
+          *)
+            echo "::error::Unsupported runner: $RUNNER_OS-$RUNNER_ARCH"
+            exit 1
+            ;;
+        esac
+
+        install_dir="$RUNNER_TEMP/protoc-$PROTOC_VERSION"
+        zip="$RUNNER_TEMP/protoc.zip"
+        url="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${suffix}.zip"
+
+        echo "Downloading $url"
+        curl -fsSL --retry 3 --retry-delay 2 -o "$zip" "$url"
+
+        mkdir -p "$install_dir"
+        unzip -q -o "$zip" -d "$install_dir"
+        rm -f "$zip"
+
+        chmod +x "$install_dir/bin/"* 2>/dev/null || true
+
+        echo "$install_dir/bin" >> "$GITHUB_PATH"
+        "$install_dir/bin/protoc" --version

--- a/.github/actions/setup-protoc/action.yaml
+++ b/.github/actions/setup-protoc/action.yaml
@@ -1,0 +1,10 @@
+name: Install Protoc
+description: "Install a pinned version of protoc"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+      with:
+        version: "34.1"
+        repo-token: ${{ github.token }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,9 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: Install nextest
         uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
       - name: Install llvm-cov
@@ -53,9 +51,7 @@ jobs:
           fetch-depth: 0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: Install nextest
         uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
       - name: Install llvm-cov

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,9 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: integration-tests
@@ -50,9 +48,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: integration-tests
@@ -146,9 +142,7 @@ jobs:
             PROFILE=ci
             FEATURES=staging
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: gRPC file consistency check
         run: ./tests/grpc_consistency_check.sh
       - name: OpenAPI file consistency check
@@ -179,9 +173,7 @@ jobs:
           shared-key: integration-tests
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: Install dependencies
         run: sudo apt-get install clang jq
       - name: Build

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -31,9 +31,7 @@ jobs:
           cargo -Vv
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - name: Install cross-compilation tools
@@ -99,9 +97,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
 
       - name: Build
         run: cargo build --release --locked
@@ -126,9 +122,7 @@ jobs:
           sudo apt-get install -y gcc-multilib clang cmake protobuf-compiler libfuse2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -21,9 +21,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - name: Install Protoc
-      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/setup-protoc
     - name: Install nextest
       uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
     - name: Install Vulkan packages

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -25,9 +25,7 @@ jobs:
         components: rustfmt, clippy
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Protoc
-      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/setup-protoc
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - name: Install Protoc
-      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/setup-protoc
     - name: Install mold
       uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
     - name: Enable mold on Linux


### PR DESCRIPTION
I am trying to fix this protoc install problem. It is usually degraded the most, not just today. 

Action is using github api access to check version every time, even if version is provided explicitly. 
I propose the straight-forward way - replace with script which downloads exact version.

## Test plan
- [ ] CI runs all affected workflows green on this PR.
- [ ] Spot-check a job log to confirm protoc 34.1 is what gets installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)