### PR TITLE
ci: centralize just setup in a composite action

### DIFF
--- a/.github/actions/setup-just/action.yaml
+++ b/.github/actions/setup-just/action.yaml
@@ -1,0 +1,9 @@
+name: Install Just
+description: "Install a pinned version of the just command runner"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      with:
+        just-version: "1.50.0"

--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -167,6 +167,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: "1.50.0"
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -166,9 +166,8 @@ jobs:
       - name: Checkout Qdrant
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-        with:
-          just-version: "1.50.0"
+      - name: Install Just
+        uses: ./.github/actions/setup-just
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/edge-rust-release.yml
+++ b/.github/workflows/edge-rust-release.yml
@@ -41,6 +41,8 @@ jobs:
         # TODO: switch to extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0 once this PR is merged:
         # https://github.com/extractions/setup-crate/pull/8
         uses: xzfc/setup-just@fb4bb125d47d4680296d3f3766c6ec83f70b3523
+        with:
+          just-version: "1.50.0"
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/edge-rust-release.yml
+++ b/.github/workflows/edge-rust-release.yml
@@ -38,11 +38,7 @@ jobs:
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - name: Install Just
-        # TODO: switch to extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0 once this PR is merged:
-        # https://github.com/extractions/setup-crate/pull/8
-        uses: xzfc/setup-just@fb4bb125d47d4680296d3f3766c6ec83f70b3523
-        with:
-          just-version: "1.50.0"
+        uses: ./.github/actions/setup-just
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: "1.50.0"
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -58,9 +58,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-        with:
-          just-version: "1.50.0"
+        uses: ./.github/actions/setup-just
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0


### PR DESCRIPTION
## Summary
- Pin \`just\` to version \`1.50.0\` (previously each call site resolved \"latest\" via the GitHub API on every run, so CI silently inherited whatever \`just\` release was newest).
- Add \`.github/actions/setup-just\` composite action wrapping \`extractions/setup-just@v4.0.0\` with the version pin in one place.
- Replace all 3 inline \`setup-just\` call sites (\`edge-test\`, \`edge-py-release\`, \`edge-rust-release\`) with \`uses: ./.github/actions/setup-just\`.
- Drop the \`xzfc/setup-just\` workaround fork in \`edge-rust-release\`: the missing \`just-version\` input support that motivated the fork was resolved in \`extractions/setup-just@v4.0.0\`, so the TODO can go away.
- Mirrors the same pattern as the recently merged protoc composite action (#8805).

## Test plan
- [ ] CI passes on this PR.
- [ ] Confirm in a job log that \`just --version\` reports \`1.50.0\` on all three workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)