### PR TITLE
Allow short mmap reads

### DIFF
--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -272,15 +272,28 @@ where
     } = range;
 
     let start = byte_offset as usize;
-    let end = start + size_of::<T>() * items as usize;
+    let requested_end = start + size_of::<T>() * items as usize;
 
-    let bytes = bytes
-        .get(start..end)
-        .ok_or_else(|| UniversalIoError::OutOfBounds {
+    if start > bytes.len() {
+        return Err(UniversalIoError::OutOfBounds {
             start: start as _,
-            end: end as _,
+            end: requested_end as _,
             elements: bytes.len() / size_of::<T>(),
-        })?;
+        });
+    }
+
+    let range = if requested_end <= bytes.len() {
+        start..requested_end
+    } else {
+        // allow short reads, but align them to size of T
+        let avail_bytes = bytes.len() - start;
+        let truncated_items = avail_bytes / size_of::<T>() * size_of::<T>();
+        let end = start + truncated_items;
+
+        start..end
+    };
+
+    let bytes = &bytes[range];
 
     // `bytemuck::cast_slice` checks that `bytes` size and alignment match `T` requirements
     let items = bytemuck::cast_slice(bytes);

--- a/src/tonic/api/storage_read_api/tests.rs
+++ b/src/tonic/api/storage_read_api/tests.rs
@@ -348,7 +348,7 @@ async fn read_bytes_out_of_bounds_returns_error() {
             collection_name: TEST_COLLECTION_NAME.to_string(),
             shard_id: TEST_SHARD_ID,
             path: "oob/data.bin".to_string(),
-            byte_offset: 0,
+            byte_offset: 5,
             length: 9999,
         }))
         .await


### PR DESCRIPTION
This PR enables mmap reads to not error when the end of a range goes beyond EOF. 

When developing #8792, I enabled it to use a generic backend for reading a remote file. In linux, it uses io-uring with `O_DIRECT` flags, but in other systems it can default to use `MmapFile`. This introduces the same problem that was already solved for uring in #8466, but for mmap: 

Since `O_DIRECT` requires reads to be page-aligned, if the size of the file is not page-aligned, we will end up requesting a read that goes beyond EOF. Returning a shorter read than requested if it stumbles with EOF is pretty canonical, so I think enabling the same mechanism for mmap is appropriate. 

This is at the cost of an extra branching statement, but should be negligible.

## Alternatively...

The alternative would be to take the length of the file in consideration at the moment of requesting the read, but it would mean that io-uring should need to allocate twice: one for the page-aligned buffer, and once again for the extracted output.

I think allowing a short mmap read makes sense in the context of general I/O reads

