### PR TITLE
Fix flaky test_max_segment_size

### DIFF
--- a/tests/consensus_tests/test_segment_max_size.py
+++ b/tests/consensus_tests/test_segment_max_size.py
@@ -42,10 +42,14 @@ def test_max_segment_size(tmp_path: pathlib.Path):
 
     upsert_random_points(peer_api_uris[0], 20, batch_size=5)
 
-    collection_cluster_info_after = get_collection_info(peer_api_uris[0], COLLECTION_NAME)
+    # The optimization worker creates a new appendable segment asynchronously
+    # once existing ones exceed max_segment_size_kb, and the payload index
+    # backfill is async too. Poll for both.
+    def optimizer_caught_up():
+        info = get_collection_info(peer_api_uris[0], COLLECTION_NAME)
+        return (
+            info["segments_count"] > collection_cluster_info_before["segments_count"]
+            and info["payload_schema"]["city"]["points"] == 20
+        )
 
-    # Number of segments must have grown due to limited segment size
-    assert collection_cluster_info_before["segments_count"] < collection_cluster_info_after["segments_count"]
-
-    # We must have indexed all points
-    assert collection_cluster_info_after["payload_schema"]["city"]["points"] == 20
+    wait_for(optimizer_caught_up)


### PR DESCRIPTION
## Summary

- `test_max_segment_size` asserted `segments_count` growth and `payload_schema.city.points == 20` immediately after upserting points, but both happen asynchronously: the optimization worker creates a new appendable segment via `ensure_appendable_segment_with_capacity` once existing ones exceed `max_segment_size_kb`, and payload index backfill is async too. CI hit `assert 2 < 2` when the check ran before the worker reacted.
- Replaced the bare asserts with a `wait_for` poll covering both conditions.

## Test plan

- [ ] `pytest tests/consensus_tests/test_segment_max_size.py` passes locally
- [ ] CI run for the consensus test suite is green