### PR TITLE
ci: improve docker build caches for long e2e tests and consistency tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -134,9 +134,9 @@ jobs:
           context: tools/schema2openapi
           tags: schema2openapi
           cache-from: |
-            type=gha,scope=${{ github.ref }}-schema2openapi
-            type=gha,scope=${{ github.base_ref }}-schema2openapi
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-schema2openapi
+            type=gha,scope=${{ github.base_ref || github.ref_name }}-schema2openapi
+            type=gha,scope=dev-schema2openapi
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-schema2openapi', github.ref_name) || '' }}
           load: true
           build-args: |
             PROFILE=ci

--- a/.github/workflows/long-e2e-tests.yml
+++ b/.github/workflows/long-e2e-tests.yml
@@ -34,9 +34,9 @@ jobs:
           context: .
           tags: qdrant/qdrant:e2e-tests
           cache-from: |
-            type=gha,scope=${{ github.ref }}-e2e
-            type=gha,scope=${{ github.base_ref }}-e2e
-          cache-to: type=gha,mode=max,scope=${{ github.ref }}-e2e
+            type=gha,scope=${{ github.base_ref || github.ref_name }}-e2e
+            type=gha,scope=dev-e2e
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-e2e', github.ref_name) || '' }}
           load: true
           build-args: |
             PROFILE=ci


### PR DESCRIPTION
A follow-up on https://github.com/qdrant/qdrant/pull/8786. Improve GHA cache usage for other jobs that build docker images.