### PR TITLE
feat: add shared Rust FFI crate and mobile bindings (iOS, Android) for Qdrant Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cancel"
 version = "0.0.0"
 dependencies = [
@@ -1119,6 +1179,29 @@ name = "cap"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f125eb85b84a24c36b02ed1d22c9dd8632f53b3cde6e4d23512f94021030003"
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cast"
@@ -1336,7 +1419,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "fnv",
- "fs-err",
+ "fs-err 3.3.0",
  "fs4 1.1.0",
  "fs_extra",
  "futures",
@@ -1428,7 +1511,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
- "fs-err",
+ "fs-err 3.3.0",
  "fs_extra",
  "io-uring",
  "itertools 0.14.0",
@@ -1946,7 +2029,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "flate2",
- "fs-err",
+ "fs-err 3.3.0",
  "indicatif",
  "reqwest 0.13.3",
 ]
@@ -2154,7 +2237,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "common",
- "fs-err",
+ "fs-err 3.3.0",
  "itertools 0.14.0",
  "log",
  "ordered-float 5.3.0",
@@ -2639,6 +2722,15 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs-err"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
@@ -3002,7 +3094,18 @@ checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
 dependencies = [
  "log",
  "plain",
- "scroll",
+ "scroll 0.11.0",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.12.0",
 ]
 
 [[package]]
@@ -3043,7 +3146,7 @@ dependencies = [
  "dataset",
  "ecow",
  "env_logger",
- "fs-err",
+ "fs-err 3.3.0",
  "itertools 0.14.0",
  "log",
  "lz4_flex",
@@ -5804,7 +5907,7 @@ dependencies = [
  "config",
  "console-subscriber",
  "constant_time_eq 0.4.2",
- "fs-err",
+ "fs-err 3.3.0",
  "futures",
  "futures-util",
  "gpu",
@@ -5864,6 +5967,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "qdrant-edge-ffi"
+version = "0.1.0"
+dependencies = [
+ "ahash",
+ "edge",
+ "ordered-float 5.3.0",
+ "parking_lot",
+ "segment",
+ "serde_json",
+ "shard",
+ "sparse",
+ "thiserror 2.0.18",
+ "uniffi",
+ "uuid",
+]
+
+[[package]]
+name = "qdrant-edge-ffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "qdrant-edge-py"
 version = "0.6.1"
 dependencies = [
@@ -5903,7 +6030,7 @@ dependencies = [
  "cc",
  "common",
  "criterion",
- "fs-err",
+ "fs-err 3.3.0",
  "num-traits",
  "num_threads",
  "ordered-float 5.3.0",
@@ -6741,7 +6868,7 @@ dependencies = [
  "ci_info",
  "getopts",
  "nias",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -6859,7 +6986,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 dependencies = [
- "scroll_derive",
+ "scroll_derive 0.11.1",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive 0.12.1",
 ]
 
 [[package]]
@@ -6867,6 +7003,17 @@ name = "scroll_derive"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6979,7 +7126,7 @@ dependencies = [
  "ecow",
  "env_logger",
  "fnv",
- "fs-err",
+ "fs-err 3.3.0",
  "fs_extra",
  "geo",
  "geohash",
@@ -7181,6 +7328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7320,7 +7476,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
- "fs-err",
+ "fs-err 3.3.0",
  "fs4 1.1.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -7485,6 +7641,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7535,7 +7697,7 @@ dependencies = [
  "common",
  "criterion",
  "dataset",
- "fs-err",
+ "fs-err 3.3.0",
  "generic-tests",
  "gridstore",
  "half 2.7.1",
@@ -7607,7 +7769,7 @@ dependencies = [
  "common",
  "dashmap",
  "env_logger",
- "fs-err",
+ "fs-err 3.3.0",
  "futures",
  "http 0.2.12",
  "issues",
@@ -7810,13 +7972,13 @@ dependencies = [
  "clap",
  "colorz",
  "glob-match",
- "goblin",
+ "goblin 0.7.1",
  "libc",
  "libloading",
  "log",
  "num-traits",
  "rand 0.8.5",
- "scroll",
+ "scroll 0.11.0",
  "tempfile",
  "thiserror 1.0.69",
  "windows 0.62.2",
@@ -7856,6 +8018,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -8102,6 +8273,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8130,6 +8316,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow 0.7.15",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -8551,6 +8743,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniffi"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err 2.11.0",
+ "glob",
+ "goblin 0.8.2",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+dependencies = [
+ "camino",
+ "fs-err 2.11.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+dependencies = [
+ "anyhow",
+ "siphasher 1.0.3",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8717,7 +9042,7 @@ dependencies = [
  "criterion",
  "docopt",
  "env_logger",
- "fs-err",
+ "fs-err 3.3.0",
  "fs4 1.1.0",
  "hdrhistogram",
  "log",
@@ -8926,6 +9251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,6 +346,8 @@ members = [
     "lib/edge",
     "lib/edge/python",
     "lib/edge/python/codegen",
+    "lib/edge/ffi",
+    "lib/edge/ffi/bindgen",
     "lib/gridstore",
     "lib/macros",
     "lib/posting_list",
@@ -360,6 +362,17 @@ members = [
 [profile.release]
 lto = "fat"
 codegen-units = 1
+
+# Profile for mobile XCFramework / AAR builds.
+# Trades a bit of runtime perf for much faster link times and smaller binaries.
+# Panics abort instead of unwinding — which is also what we want on iOS/Android
+# to avoid surprise aborts-in-Drop across the FFI boundary.
+[profile.release-mobile]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
 
 # Inherit from release, because we are not rebuilding often,
 # and we don't want the huge binary sizes from debug builds.

--- a/lib/edge/android/.gitignore
+++ b/lib/edge/android/.gitignore
@@ -1,0 +1,10 @@
+/.gradle/
+/build/
+/qdrant-edge/build/
+/qdrant-edge-ffi/build/
+/qdrant-edge-ffi/src/main/jniLibs/*/libqdrant_edge_ffi.so
+/qdrant-edge-ffi/src/main/kotlin/
+/example/build/
+local.properties
+*.iml
+.idea/

--- a/lib/edge/android/Makefile
+++ b/lib/edge/android/Makefile
@@ -1,0 +1,106 @@
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+SCRIPT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+WORKSPACE_ROOT := $(abspath $(SCRIPT_DIR)/../../..)
+AAR := $(SCRIPT_DIR)qdrant-edge/build/outputs/aar/qdrant-edge-release.aar
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+.PHONY: setup
+setup: setup-homebrew setup-rust setup-targets setup-ndk ## Install all prerequisites
+
+.PHONY: setup-homebrew
+setup-homebrew: ## Install Homebrew dependencies (protobuf)
+	@command -v brew >/dev/null 2>&1 || { echo "Homebrew not found. Install from https://brew.sh"; exit 1; }
+	brew install protobuf
+
+.PHONY: setup-rust
+setup-rust: ## Install Rust toolchain + cargo-ndk
+	@if ! command -v rustup >/dev/null 2>&1; then \
+		echo "Installing rustup..."; \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
+		echo 'source "$$HOME/.cargo/env"' >> ~/.zshrc; \
+	fi
+	cargo install cargo-ndk
+	@echo "Rust toolchain OK: $$(rustc --version 2>/dev/null || echo 'restart shell to activate')"
+
+.PHONY: setup-targets
+setup-targets: ## Install required Rust cross-compilation targets for Android
+	rustup target add \
+		aarch64-linux-android \
+		x86_64-linux-android
+	@echo "Note: 32-bit targets (armv7/x86) are excluded due to upstream crate limitations"
+
+.PHONY: setup-ndk
+setup-ndk: ## Check Android NDK availability
+	@if [ -n "$${ANDROID_NDK_HOME:-}" ]; then \
+		echo "NDK found: $$ANDROID_NDK_HOME"; \
+	elif [ -n "$${ANDROID_HOME:-}" ]; then \
+		NDK_DIR=$$(ls -d "$$ANDROID_HOME/ndk/"* 2>/dev/null | sort -V | tail -1 || true); \
+		if [ -n "$$NDK_DIR" ]; then \
+			echo "NDK found: $$NDK_DIR"; \
+		else \
+			echo "No NDK found. Install via: sdkmanager --install 'ndk;27.0.12077973'"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "ERROR: ANDROID_NDK_HOME or ANDROID_HOME must be set."; \
+		echo "  Install Android SDK + NDK, then export ANDROID_HOME=/path/to/sdk"; \
+		exit 1; \
+	fi
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+.PHONY: build
+build: ## Build native libs + Kotlin bindings (release-mobile profile)
+	@bash $(SCRIPT_DIR)build-aar.sh
+
+.PHONY: build-debug
+build-debug: ## Build native libs + Kotlin bindings (debug)
+	@bash $(SCRIPT_DIR)build-aar.sh --debug
+
+.PHONY: aar
+aar: build ## Build the AAR (release-mobile, requires Gradle / Android SDK)
+	cd $(SCRIPT_DIR) && ./gradlew :qdrant-edge:assembleRelease
+	@echo ""
+	@echo "AAR built: $(AAR)"
+
+.PHONY: aar-debug
+aar-debug: build-debug ## Build the AAR (debug)
+	cd $(SCRIPT_DIR) && ./gradlew :qdrant-edge:assembleDebug
+
+# ── Info ─────────────────────────────────────────────────────────────────────
+
+.PHONY: size
+size: ## Show per-ABI .so size breakdown
+	@echo "=== Per-ABI native library sizes ==="
+	@for abi in arm64-v8a x86_64; do \
+		so="$(SCRIPT_DIR)qdrant-edge-ffi/src/main/jniLibs/$$abi/libqdrant_edge_ffi.so"; \
+		if [ -f "$$so" ]; then \
+			printf "  %-16s %s\n" "$$abi:" "$$(du -sh "$$so" | cut -f1)"; \
+		fi; \
+	done
+	@if [ -f "$(AAR)" ]; then \
+		echo ""; \
+		echo "=== AAR size ==="; \
+		du -sh "$(AAR)"; \
+	fi
+
+# ── Clean ────────────────────────────────────────────────────────────────────
+
+.PHONY: clean
+clean: ## Remove build outputs
+	rm -rf $(SCRIPT_DIR)qdrant-edge-ffi/src/main/jniLibs/*/libqdrant_edge_ffi.so
+	rm -rf $(SCRIPT_DIR)qdrant-edge-ffi/src/main/kotlin
+	rm -rf $(SCRIPT_DIR)qdrant-edge-ffi/build
+	rm -rf $(SCRIPT_DIR)qdrant-edge/build
+	rm -rf $(SCRIPT_DIR)example/build
+	rm -rf $(SCRIPT_DIR).gradle $(SCRIPT_DIR)build
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/lib/edge/android/README.md
+++ b/lib/edge/android/README.md
@@ -1,0 +1,107 @@
+# Qdrant Edge — Android (Kotlin)
+
+Kotlin/Android bindings for [Qdrant Edge](https://qdrant.tech/documentation/edge/edge-quickstart/),
+built from the shared `qdrant-edge-ffi` Rust crate via [UniFFI](https://github.com/mozilla/uniffi-rs).
+
+## Supported ABIs
+
+| ABI          | Target triple             | Devices                |
+|--------------|---------------------------|------------------------|
+| `arm64-v8a`  | `aarch64-linux-android`   | Modern phones/tablets  |
+| `x86_64`     | `x86_64-linux-android`    | Emulators (Intel/AMD)  |
+
+> 32-bit targets (`armeabi-v7a`, `x86`) are excluded: upstream Qdrant
+> dependencies overflow on 32-bit const evaluation.
+
+## Quick start
+
+```bash
+make setup      # Install Rust, cargo-ndk, protobuf; verify NDK
+make build      # Cross-compile native libs + generate Kotlin bindings
+make aar        # (Optional) Assemble the AAR via Gradle
+make size       # Show .so and AAR sizes
+```
+
+## Prerequisites
+
+- **Rust** (via `rustup`) + `cargo-ndk`
+- **Android NDK** — set `ANDROID_NDK_HOME` or install under `$ANDROID_HOME/ndk/`
+- **Protocol Buffers** — `brew install protobuf`
+- **Android SDK** — only needed for `make aar`
+
+## Integration
+
+Consumers import from the public facade package only:
+
+```kotlin
+import tech.qdrant.edge.*
+
+val shard = EdgeShard.load(path = dataDir, config = config)
+```
+
+### As a Gradle composite build
+
+```kotlin
+// settings.gradle.kts
+includeBuild("path/to/qdrant/lib/edge/android") {
+    dependencySubstitution {
+        substitute(module("tech.qdrant:qdrant-edge")).using(project(":qdrant-edge"))
+    }
+}
+```
+
+### As an AAR
+
+1. `make aar` → `qdrant-edge/build/outputs/aar/qdrant-edge-release.aar`
+2. Drop the AAR into your app's `libs/` directory.
+3. In `build.gradle.kts`:
+
+   ```kotlin
+   dependencies {
+       implementation(files("libs/qdrant-edge-release.aar"))
+       implementation("net.java.dev.jna:jna:5.14.0@aar")
+   }
+   ```
+
+## Module layout
+
+```
+android/
+├── build-aar.sh               Cross-compile Rust + generate Kotlin bindings
+├── Makefile                   setup / build / aar / size / clean
+├── settings.gradle.kts
+├── build.gradle.kts
+├── qdrant-edge/               Public facade (import this)
+│   ├── build.gradle.kts
+│   └── src/main/kotlin/tech/qdrant/edge/PublicApi.kt
+├── qdrant-edge-ffi/           Internal module (UniFFI bindings + .so files)
+│   ├── build.gradle.kts
+│   ├── proguard-rules.pro
+│   └── src/main/
+│       ├── jniLibs/           Populated by build-aar.sh
+│       └── kotlin/            Populated by build-aar.sh
+└── example/                   Example Android app
+```
+
+`:qdrant-edge` holds the public API (`EdgeShard`, `Point`, `Query`, …) as
+typealiases onto `tech.qdrant.edge.ffi.*`. `:qdrant-edge-ffi` is an
+implementation detail and may change on every UniFFI upgrade.
+
+## Documentation
+
+Every public type and method carries doc comments authored in Rust that
+UniFFI propagates to Kotlin KDoc. Hover in Android Studio / IntelliJ for
+summaries, error notes, and examples.
+
+## Makefile targets
+
+| Target        | Description                                        |
+|---------------|----------------------------------------------------|
+| `setup`       | Install all prerequisites                          |
+| `build`       | Cross-compile + generate Kotlin bindings (release) |
+| `build-debug` | Same, debug mode                                   |
+| `aar`         | Build + package AAR via Gradle                     |
+| `aar-debug`   | AAR in debug mode                                  |
+| `size`        | Show per-ABI .so sizes + AAR size                  |
+| `clean`       | Remove build artifacts                             |
+| `help`        | Show available targets                             |

--- a/lib/edge/android/build-aar.sh
+++ b/lib/edge/android/build-aar.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Build Qdrant Edge as an AAR with Kotlin bindings for Android.
+#
+# Prerequisites:
+#   - Rust toolchain (rustup)
+#   - Android NDK (via $ANDROID_NDK_HOME or Android SDK's ndk-bundle)
+#   - cargo-ndk (`cargo install cargo-ndk`)
+#
+# Usage:
+#   ./build-aar.sh [--debug]
+#
+#   --debug   Build in debug mode (faster compile, larger binary)
+#
+# Release builds use the `release-mobile` Cargo profile (thin LTO, symbol
+# stripping, panic=abort) defined in the workspace Cargo.toml.
+#
+# Output:
+#   qdrant-edge-ffi/src/main/jniLibs/<abi>/   Native .so per Android ABI
+#   qdrant-edge-ffi/src/main/kotlin/          UniFFI-generated Kotlin sources
+
+set -euo pipefail
+
+# Force the default target directory; a stray env var from the parent shell
+# would otherwise send outputs somewhere this script doesn't expect.
+unset CARGO_TARGET_DIR CARGO_BUILD_TARGET_DIR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FFI_MODULE_DIR="$SCRIPT_DIR/qdrant-edge-ffi"
+JNILIBS_DIR="$FFI_MODULE_DIR/src/main/jniLibs"
+KOTLIN_SRC_DIR="$FFI_MODULE_DIR/src/main/kotlin"
+
+CRATE_NAME="qdrant_edge_ffi"
+LIB_NAME="lib${CRATE_NAME}.so"
+PACKAGE_NAME="qdrant-edge-ffi"
+
+PROFILE="release-mobile"
+CARGO_FLAGS="--profile release-mobile"
+
+for arg in "$@"; do
+    case "$arg" in
+        --debug) PROFILE="debug"; CARGO_FLAGS="" ;;
+        -h|--help)
+            awk '/^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+            exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# Android target triple / ABI pairs (parallel arrays — bash 3.2 compatible).
+# 32-bit targets (armv7/x86) are excluded because upstream Qdrant dependencies
+# overflow on 32-bit const evaluation (e.g. the `bitm` crate).
+TARGETS=(
+    "aarch64-linux-android"
+    "x86_64-linux-android"
+)
+ABIS=(
+    "arm64-v8a"
+    "x86_64"
+)
+
+# ── Preflight ───────────────────────────────────────────────────────────────
+
+if ! command -v cargo-ndk >/dev/null 2>&1; then
+    echo "ERROR: cargo-ndk not found. Install with: cargo install cargo-ndk" >&2
+    exit 1
+fi
+
+if [ -z "${ANDROID_NDK_HOME:-}" ]; then
+    if [ -z "${ANDROID_HOME:-}" ]; then
+        echo "ERROR: ANDROID_NDK_HOME or ANDROID_HOME must be set." >&2
+        echo "  export ANDROID_NDK_HOME=/path/to/ndk" >&2
+        exit 1
+    fi
+    NDK_DIR=$(ls -d "$ANDROID_HOME/ndk/"* 2>/dev/null | sort -V | tail -1 || true)
+    if [ -z "$NDK_DIR" ]; then
+        echo "ERROR: No NDK found under \$ANDROID_HOME/ndk/. Install one via the SDK Manager." >&2
+        exit 1
+    fi
+    export ANDROID_NDK_HOME="$NDK_DIR"
+    echo "==> Using NDK at: $ANDROID_NDK_HOME"
+fi
+
+# ── Install targets ─────────────────────────────────────────────────────────
+
+echo "==> Installing required Rust targets..."
+for target in "${TARGETS[@]}"; do
+    rustup target add "$target" 2>/dev/null || true
+done
+
+# ── Build shared libraries ──────────────────────────────────────────────────
+
+echo "==> Building shared libraries..."
+for i in "${!TARGETS[@]}"; do
+    target="${TARGETS[$i]}"
+    abi="${ABIS[$i]}"
+    echo "    Building for $target ($abi)..."
+    cargo ndk \
+        --target "$target" \
+        --platform 24 \
+        -- build $CARGO_FLAGS \
+        --lib \
+        --package "$PACKAGE_NAME" \
+        --manifest-path "$WORKSPACE_ROOT/Cargo.toml"
+done
+
+# ── Copy .so files to jniLibs ───────────────────────────────────────────────
+
+echo "==> Copying .so files to jniLibs..."
+for i in "${!TARGETS[@]}"; do
+    target="${TARGETS[$i]}"
+    abi="${ABIS[$i]}"
+    src="$WORKSPACE_ROOT/target/$target/$PROFILE/$LIB_NAME"
+    dest="$JNILIBS_DIR/$abi/$LIB_NAME"
+    mkdir -p "$JNILIBS_DIR/$abi"
+    cp "$src" "$dest"
+    echo "    $abi: $(du -sh "$dest" | cut -f1)"
+done
+
+# ── Generate Kotlin bindings ────────────────────────────────────────────────
+
+echo "==> Generating Kotlin bindings..."
+# Generate straight into the FFI module's Kotlin source tree — uniffi-bindgen
+# creates the `tech/qdrant/edge/ffi/` package subtree as set in uniffi.toml.
+mkdir -p "$KOTLIN_SRC_DIR"
+FIRST_TARGET="${TARGETS[0]}"
+cargo run \
+    --package "qdrant-edge-ffi-bindgen" \
+    --bin uniffi-bindgen \
+    --manifest-path "$WORKSPACE_ROOT/Cargo.toml" \
+    -- generate \
+    --library "$WORKSPACE_ROOT/target/$FIRST_TARGET/$PROFILE/$LIB_NAME" \
+    --language kotlin \
+    --config "$WORKSPACE_ROOT/lib/edge/ffi/uniffi.toml" \
+    --out-dir "$KOTLIN_SRC_DIR"
+
+# ── Done ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Done! Output:"
+echo "  Native libs:    $JNILIBS_DIR"
+echo "  Kotlin sources: $KOTLIN_SRC_DIR"
+echo ""
+echo "Next: run 'make aar' (or './gradlew :qdrant-edge:assembleRelease') to"
+echo "      package the AAR."

--- a/lib/edge/android/build.gradle.kts
+++ b/lib/edge/android/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.library") version "8.7.3" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+}

--- a/lib/edge/android/example/build.gradle.kts
+++ b/lib/edge/android/example/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "tech.qdrant.edge.example"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "tech.qdrant.edge.example"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation(project(":qdrant-edge"))
+}

--- a/lib/edge/android/example/src/main/AndroidManifest.xml
+++ b/lib/edge/android/example/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="QdrantEdgeExample"
+        android:supportsRtl="true">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/lib/edge/android/example/src/main/kotlin/tech/qdrant/edge/example/MainActivity.kt
+++ b/lib/edge/android/example/src/main/kotlin/tech/qdrant/edge/example/MainActivity.kt
@@ -1,0 +1,280 @@
+package tech.qdrant.edge.example
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import java.io.File
+import java.util.UUID
+
+import tech.qdrant.edge.*
+
+private const val TAG = "QdrantEdge"
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Thread {
+            try {
+                runDemo()
+            } catch (e: Exception) {
+                Log.e(TAG, "Demo failed", e)
+            }
+        }.start()
+    }
+
+    private fun runDemo() {
+        val dataDir = File(cacheDir, "qdrant-edge-android-example")
+        if (dataDir.exists()) dataDir.deleteRecursively()
+        dataDir.mkdirs()
+
+        // ── Load shard ──────────────────────────────────────────────────
+        Log.i(TAG, "---- Load shard ----")
+
+        val config = EdgeConfig(
+            vectorData = mapOf(
+                "" to VectorDataConfig(
+                    size = 4uL,
+                    distance = Distance.DOT,
+                    quantizationConfig = null,
+                    multivectorConfig = null,
+                    datatype = null,
+                )
+            ),
+            sparseVectorData = emptyMap(),
+        )
+
+        val shard = EdgeShard.load(path = dataDir.absolutePath, config = config)
+        Log.i(TAG, "Shard loaded at: ${dataDir.absolutePath}")
+
+        // ── Upsert ──────────────────────────────────────────────────────
+        Log.i(TAG, "---- Upsert ----")
+
+        val randomUuid = UUID.randomUUID().toString()
+
+        val upsertOp = UpdateOperation.upsertPoints(
+            points = listOf(
+                Point(
+                    id = PointId.NumId(1uL),
+                    vector = Vector.Single(listOf(6.0f, 9.0f, 4.0f, 2.0f)),
+                    payload = """{"null":null,"str":"string","uint":42,"int":-69,"float":4.2,"bool":true}""",
+                ),
+                Point(
+                    id = PointId.Uuid("e9408f2b-b917-4af1-ab75-d97ac6b2c047"),
+                    vector = Vector.Single(listOf(6.0f, 9.0f, 3.0f, -2.0f)),
+                    payload = """{"hello":"world","price":199.99}""",
+                ),
+                Point(
+                    id = PointId.Uuid(randomUuid),
+                    vector = Vector.Single(listOf(1.0f, 6.0f, 4.0f, 2.0f)),
+                    payload = """{"hello":"world","price":999.99}""",
+                ),
+            ),
+        )
+
+        shard.update(operation = upsertOp)
+        Log.i(TAG, "Upserted 3 points (ids: 1, e9408f2b-..., ${randomUuid.take(8)}...)")
+
+        // ── Query ───────────────────────────────────────────────────────
+        Log.i(TAG, "---- Query ----")
+
+        val queryResults = shard.query(
+            request = QueryRequest(
+                limit = 10uL,
+                offset = null,
+                query = ScoringQuery.Vector(Query.Nearest(
+                    vector = listOf(6.0f, 9.0f, 4.0f, 2.0f),
+                    using = null,
+                )),
+                prefetches = emptyList(),
+                withVector = WithVector.Bool(true),
+                withPayload = WithPayload.Bool(true),
+                filter = null,
+                scoreThreshold = null,
+                params = null,
+            ),
+        )
+
+        Log.i(TAG, "Query returned ${queryResults.size} results:")
+        queryResults.forEach { printScoredPoint(it) }
+
+        // ── Search ──────────────────────────────────────────────────────
+        Log.i(TAG, "---- Search ----")
+
+        val searchResults = shard.search(
+            request = SearchRequest(
+                query = Query.Nearest(
+                    vector = listOf(1.0f, 1.0f, 1.0f, 1.0f),
+                    using = null,
+                ),
+                limit = 10uL,
+                offset = null,
+                filter = null,
+                params = null,
+                withVector = WithVector.Bool(true),
+                withPayload = WithPayload.Bool(true),
+                scoreThreshold = null,
+            ),
+        )
+
+        Log.i(TAG, "Search returned ${searchResults.size} results:")
+        searchResults.forEach { printScoredPoint(it) }
+
+        // ── Search + Filter ─────────────────────────────────────────────
+        Log.i(TAG, "---- Search + Filter ----")
+
+        val searchFilter = Filter(
+            must = listOf(
+                Condition.Field(
+                    FieldCondition(
+                        key = "hello",
+                        `match` = Match.Text("world"),
+                        range = null,
+                        geoBoundingBox = null,
+                        geoRadius = null,
+                        valuesCount = null,
+                    )
+                ),
+                Condition.Field(
+                    FieldCondition(
+                        key = "price",
+                        `match` = null,
+                        range = RangeFloat(gte = 500.0, gt = null, lte = null, lt = null),
+                        geoBoundingBox = null,
+                        geoRadius = null,
+                        valuesCount = null,
+                    )
+                ),
+            ),
+            should = null,
+            mustNot = null,
+        )
+
+        val filteredResults = shard.search(
+            request = SearchRequest(
+                query = Query.Nearest(
+                    vector = listOf(1.0f, 1.0f, 1.0f, 1.0f),
+                    using = null,
+                ),
+                limit = 10uL,
+                offset = null,
+                filter = searchFilter,
+                params = null,
+                withVector = WithVector.Bool(true),
+                withPayload = WithPayload.Bool(true),
+                scoreThreshold = null,
+            ),
+        )
+
+        Log.i(TAG, "Filtered search returned ${filteredResults.size} results:")
+        filteredResults.forEach { printScoredPoint(it) }
+
+        // ── Retrieve ────────────────────────────────────────────────────
+        Log.i(TAG, "---- Retrieve ----")
+
+        val retrieved = shard.retrieve(
+            pointIds = listOf(PointId.NumId(1uL)),
+            withPayload = WithPayload.Bool(true),
+            withVector = WithVector.Bool(true),
+        )
+
+        Log.i(TAG, "Retrieved ${retrieved.size} records:")
+        retrieved.forEach { printRecord(it) }
+
+        // ── Scroll ──────────────────────────────────────────────────────
+        Log.i(TAG, "---- Scroll ----")
+
+        var scrollResponse = shard.scroll(
+            request = ScrollRequest(
+                offset = null,
+                limit = 2uL,
+                filter = null,
+                withPayload = null,
+                withVector = null,
+                orderBy = null,
+            ),
+        )
+
+        Log.i(TAG, "Scroll page 1 (${scrollResponse.records.size} records):")
+        scrollResponse.records.forEach { printRecord(it) }
+
+        while (scrollResponse.nextOffset != null) {
+            val nextOffset = scrollResponse.nextOffset!!
+            Log.i(TAG, "--- Next scroll (offset = ${pointIdStr(nextOffset)}) ---")
+            scrollResponse = shard.scroll(
+                request = ScrollRequest(
+                    offset = nextOffset,
+                    limit = 2uL,
+                    filter = null,
+                    withPayload = null,
+                    withVector = null,
+                    orderBy = null,
+                ),
+            )
+            scrollResponse.records.forEach { printRecord(it) }
+        }
+
+        // ── Count ───────────────────────────────────────────────────────
+        Log.i(TAG, "---- Count ----")
+
+        val count = shard.count(request = CountRequest(filter = null, exact = true))
+        Log.i(TAG, "Total points count: $count")
+
+        // ── Facet ───────────────────────────────────────────────────────
+        Log.i(TAG, "---- Facet (requires payload index) ----")
+
+        try {
+            val facetResponse = shard.facet(
+                request = FacetRequest(
+                    key = "hello",
+                    limit = 10uL,
+                    exact = false,
+                    filter = null,
+                ),
+            )
+            Log.i(TAG, "Facet results (${facetResponse.hits.size} hits):")
+            facetResponse.hits.forEach { hit ->
+                Log.i(TAG, "  ${hit.value}: ${hit.count}")
+            }
+        } catch (e: Exception) {
+            Log.i(TAG, "Facet error (expected without payload index): $e")
+        }
+
+        // ── Info ────────────────────────────────────────────────────────
+        Log.i(TAG, "---- Info ----")
+
+        val info = shard.info()
+        Log.i(TAG, "Segments: ${info.segmentsCount}, Points: ${info.pointsCount}, Indexed vectors: ${info.indexedVectorsCount}")
+
+        // ── Close and reopen ────────────────────────────────────────────
+        Log.i(TAG, "---- Close and reopen shard ----")
+
+        shard.close()
+        Log.i(TAG, "Shard closed.")
+
+        val reopenedShard = EdgeShard.load(path = dataDir.absolutePath, config = null)
+        val reopenedInfo = reopenedShard.info()
+        Log.i(TAG, "Reopened shard - Segments: ${reopenedInfo.segmentsCount}, Points: ${reopenedInfo.pointsCount}, Indexed vectors: ${reopenedInfo.indexedVectorsCount}")
+
+        reopenedShard.close()
+        Log.i(TAG, "Done!")
+    }
+
+    private fun pointIdStr(id: PointId): String = when (id) {
+        is PointId.NumId -> id.`value`.toString()
+        is PointId.Uuid -> id.`value`
+    }
+
+    private fun printScoredPoint(p: ScoredPoint) {
+        val idStr = pointIdStr(p.id)
+        Log.i(TAG, "  id: $idStr, version: ${p.version}, score: ${p.score}")
+        p.payload?.let { Log.i(TAG, "    payload: $it") }
+        p.vector?.let { Log.i(TAG, "    vector: $it") }
+    }
+
+    private fun printRecord(r: Record) {
+        val idStr = pointIdStr(r.id)
+        Log.i(TAG, "  id: $idStr")
+        r.payload?.let { Log.i(TAG, "    payload: $it") }
+        r.vector?.let { Log.i(TAG, "    vector: $it") }
+    }
+}

--- a/lib/edge/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/edge/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/lib/edge/android/qdrant-edge-ffi/build.gradle.kts
+++ b/lib/edge/android/qdrant-edge-ffi/build.gradle.kts
@@ -1,0 +1,38 @@
+// Internal module: UniFFI-generated Kotlin bindings + native .so libraries.
+// Consumers depend on :qdrant-edge, not this module directly.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "tech.qdrant.edge.ffi"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        consumerProguardFiles("proguard-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    // `api` so consuming modules can reach into `tech.qdrant.edge.ffi.*` if
+    // they need the raw UniFFI types (advanced use only).
+    api("net.java.dev.jna:jna:5.14.0@aar")
+}

--- a/lib/edge/android/qdrant-edge-ffi/proguard-rules.pro
+++ b/lib/edge/android/qdrant-edge-ffi/proguard-rules.pro
@@ -1,0 +1,9 @@
+# Consumer ProGuard rules for :qdrant-edge-ffi.
+#
+# R8 under `isMinifyEnabled = true` would otherwise strip classes that JNA
+# and the UniFFI-generated bindings reach through reflection.
+
+-dontwarn java.awt.*
+-keep class com.sun.jna.** { *; }
+-keep class * implements com.sun.jna.** { *; }
+-keep class tech.qdrant.edge.ffi.** { *; }

--- a/lib/edge/android/qdrant-edge-ffi/src/main/AndroidManifest.xml
+++ b/lib/edge/android/qdrant-edge-ffi/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/lib/edge/android/qdrant-edge/build.gradle.kts
+++ b/lib/edge/android/qdrant-edge/build.gradle.kts
@@ -1,0 +1,35 @@
+// Public facade module. Re-exports `tech.qdrant.edge.ffi.*` (UniFFI-generated)
+// as `tech.qdrant.edge.*` via typealiases, hiding FFI plumbing from consumers.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "tech.qdrant.edge"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    api(project(":qdrant-edge-ffi"))
+}

--- a/lib/edge/android/qdrant-edge/src/main/AndroidManifest.xml
+++ b/lib/edge/android/qdrant-edge/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/lib/edge/android/qdrant-edge/src/main/kotlin/tech/qdrant/edge/PublicApi.kt
+++ b/lib/edge/android/qdrant-edge/src/main/kotlin/tech/qdrant/edge/PublicApi.kt
@@ -1,0 +1,85 @@
+@file:Suppress("unused")
+
+package tech.qdrant.edge
+
+// Public API for Qdrant Edge on Android.
+//
+// Every symbol below is a compile-time typealias onto the UniFFI-generated
+// bindings in `:qdrant-edge-ffi`. Consumers import `tech.qdrant.edge.*` and
+// never see FFI plumbing (`FfiConverter*`, `RustBuffer`, …).
+//
+// When a new public type is added to the Rust FFI crate, add a typealias
+// here. Types that should stay internal simply don't get an alias.
+
+// ---- Shards & operations --------------------------------------------------
+
+public typealias EdgeShard = tech.qdrant.edge.ffi.EdgeShard
+public typealias UpdateOperation = tech.qdrant.edge.ffi.UpdateOperation
+
+// ---- Configs & records ----------------------------------------------------
+
+public typealias BinaryQuantizationParams = tech.qdrant.edge.ffi.BinaryQuantizationParams
+public typealias CountRequest = tech.qdrant.edge.ffi.CountRequest
+public typealias EdgeConfig = tech.qdrant.edge.ffi.EdgeConfig
+public typealias FacetHit = tech.qdrant.edge.ffi.FacetHit
+public typealias FacetRequest = tech.qdrant.edge.ffi.FacetRequest
+public typealias FacetResponse = tech.qdrant.edge.ffi.FacetResponse
+public typealias FieldCondition = tech.qdrant.edge.ffi.FieldCondition
+public typealias Filter = tech.qdrant.edge.ffi.Filter
+public typealias GeoBoundingBox = tech.qdrant.edge.ffi.GeoBoundingBox
+public typealias GeoPoint = tech.qdrant.edge.ffi.GeoPoint
+public typealias GeoRadius = tech.qdrant.edge.ffi.GeoRadius
+public typealias MultiVectorConfig = tech.qdrant.edge.ffi.MultiVectorConfig
+public typealias OrderBy = tech.qdrant.edge.ffi.OrderBy
+public typealias Point = tech.qdrant.edge.ffi.Point
+public typealias PointVectors = tech.qdrant.edge.ffi.PointVectors
+public typealias Prefetch = tech.qdrant.edge.ffi.Prefetch
+public typealias ProductQuantizationParams = tech.qdrant.edge.ffi.ProductQuantizationParams
+public typealias QueryRequest = tech.qdrant.edge.ffi.QueryRequest
+public typealias RangeFloat = tech.qdrant.edge.ffi.RangeFloat
+public typealias Record = tech.qdrant.edge.ffi.Record
+public typealias ScalarQuantizationParams = tech.qdrant.edge.ffi.ScalarQuantizationParams
+public typealias ScoredPoint = tech.qdrant.edge.ffi.ScoredPoint
+public typealias ScrollRequest = tech.qdrant.edge.ffi.ScrollRequest
+public typealias ScrollResponse = tech.qdrant.edge.ffi.ScrollResponse
+public typealias SearchParams = tech.qdrant.edge.ffi.SearchParams
+public typealias SearchRequest = tech.qdrant.edge.ffi.SearchRequest
+public typealias ShardInfo = tech.qdrant.edge.ffi.ShardInfo
+public typealias SparseVector = tech.qdrant.edge.ffi.SparseVector
+public typealias SparseVectorDataConfig = tech.qdrant.edge.ffi.SparseVectorDataConfig
+public typealias ValuesCount = tech.qdrant.edge.ffi.ValuesCount
+public typealias VectorDataConfig = tech.qdrant.edge.ffi.VectorDataConfig
+
+// ---- Enums ----------------------------------------------------------------
+
+public typealias BinaryQuantizationEncoding = tech.qdrant.edge.ffi.BinaryQuantizationEncoding
+public typealias BinaryQuantizationQueryEncoding = tech.qdrant.edge.ffi.BinaryQuantizationQueryEncoding
+public typealias CompressionRatio = tech.qdrant.edge.ffi.CompressionRatio
+public typealias Direction = tech.qdrant.edge.ffi.Direction
+public typealias Distance = tech.qdrant.edge.ffi.Distance
+public typealias Modifier = tech.qdrant.edge.ffi.Modifier
+public typealias MultiVectorComparator = tech.qdrant.edge.ffi.MultiVectorComparator
+public typealias Sample = tech.qdrant.edge.ffi.Sample
+public typealias ScalarType = tech.qdrant.edge.ffi.ScalarType
+public typealias SparseIndexType = tech.qdrant.edge.ffi.SparseIndexType
+public typealias UpdateMode = tech.qdrant.edge.ffi.UpdateMode
+public typealias VectorStorageDatatype = tech.qdrant.edge.ffi.VectorStorageDatatype
+
+// ---- Sealed unions --------------------------------------------------------
+
+public typealias Condition = tech.qdrant.edge.ffi.Condition
+public typealias Fusion = tech.qdrant.edge.ffi.Fusion
+public typealias Match = tech.qdrant.edge.ffi.Match
+public typealias NamedVector = tech.qdrant.edge.ffi.NamedVector
+public typealias PointId = tech.qdrant.edge.ffi.PointId
+public typealias QuantizationConfig = tech.qdrant.edge.ffi.QuantizationConfig
+public typealias Query = tech.qdrant.edge.ffi.Query
+public typealias ScoringQuery = tech.qdrant.edge.ffi.ScoringQuery
+public typealias ValueVariants = tech.qdrant.edge.ffi.ValueVariants
+public typealias Vector = tech.qdrant.edge.ffi.Vector
+public typealias WithPayload = tech.qdrant.edge.ffi.WithPayload
+public typealias WithVector = tech.qdrant.edge.ffi.WithVector
+
+// ---- Errors ---------------------------------------------------------------
+
+public typealias EdgeException = tech.qdrant.edge.ffi.EdgeException

--- a/lib/edge/android/settings.gradle.kts
+++ b/lib/edge/android/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "qdrant-edge-android"
+
+include(":qdrant-edge-ffi")
+include(":qdrant-edge")
+include(":example")

--- a/lib/edge/ffi/Cargo.toml
+++ b/lib/edge/ffi/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "qdrant-edge-ffi"
+version = "0.1.0"
+authors = ["Qdrant Team <info@qdrant.tech>"]
+license = "Apache-2.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[lib]
+name = "qdrant_edge_ffi"
+crate-type = ["staticlib", "cdylib", "lib"]
+
+[dependencies]
+edge = { path = ".." }
+segment = { path = "../../segment", default-features = false }
+shard = { path = "../../shard" }
+sparse = { path = "../../sparse" }
+
+uniffi = "0.31"
+thiserror = "2"
+uuid = "1"
+ahash = { workspace = true }
+parking_lot = { workspace = true }
+serde_json = { workspace = true }
+ordered-float = { workspace = true }
+
+[build-dependencies]
+uniffi = { version = "0.31", features = ["build"] }

--- a/lib/edge/ffi/bindgen/Cargo.toml
+++ b/lib/edge/ffi/bindgen/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "qdrant-edge-ffi-bindgen"
+version = "0.1.0"
+authors = ["Qdrant Team <info@qdrant.tech>"]
+license = "Apache-2.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+uniffi = { version = "0.31", features = ["cli"] }
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "main.rs"

--- a/lib/edge/ffi/bindgen/main.rs
+++ b/lib/edge/ffi/bindgen/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/lib/edge/ffi/src/config.rs
+++ b/lib/edge/ffi/src/config.rs
@@ -1,0 +1,677 @@
+use std::collections::HashMap;
+
+use segment::data_types::modifier::Modifier as SegmentModifier;
+use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType as SegmentSparseIndexType};
+use segment::types::{
+    BinaryQuantization, BinaryQuantizationConfig, BinaryQuantizationEncoding as SegmentBinaryQuantizationEncoding,
+    BinaryQuantizationQueryEncoding as SegmentBinaryQuantizationQueryEncoding,
+    CompressionRatio as SegmentCompressionRatio, Distance as SegmentDistance,
+    Indexes, MultiVectorComparator as SegmentMultiVectorComparator,
+    MultiVectorConfig as SegmentMultiVectorConfig, PayloadStorageType,
+    ProductQuantization, ProductQuantizationConfig,
+    QuantizationConfig as SegmentQuantizationConfig,
+    ScalarQuantization, ScalarQuantizationConfig, ScalarType as SegmentScalarType,
+    SegmentConfig, SparseVectorDataConfig as SegmentSparseVectorDataConfig,
+    SparseVectorStorageType, VectorDataConfig as SegmentVectorDataConfig,
+    VectorStorageDatatype as SegmentVectorStorageDatatype, VectorStorageType,
+};
+
+// ── Distance ────────────────────────────────────────────────────────────────
+
+/// The similarity metric used to compare two vectors.
+///
+/// The choice of distance must match the metric used to train the embeddings
+/// that will be stored in the shard; for example, OpenAI `text-embedding-3`
+/// embeddings expect `Cosine`.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum Distance {
+    /// Cosine similarity. Vectors are compared by the angle between them;
+    /// magnitude is ignored. Suitable for most text-embedding models.
+    Cosine,
+    /// Euclidean (L2) distance. Smaller values indicate more similar
+    /// vectors.
+    Euclid,
+    /// Dot product. Larger values indicate more similar vectors; assumes
+    /// vectors are pre-normalized if magnitude should not dominate.
+    Dot,
+    /// Manhattan (L1) distance — the sum of absolute coordinate differences.
+    Manhattan,
+}
+
+impl From<Distance> for SegmentDistance {
+    fn from(d: Distance) -> Self {
+        match d {
+            Distance::Cosine => SegmentDistance::Cosine,
+            Distance::Euclid => SegmentDistance::Euclid,
+            Distance::Dot => SegmentDistance::Dot,
+            Distance::Manhattan => SegmentDistance::Manhattan,
+        }
+    }
+}
+
+impl From<SegmentDistance> for Distance {
+    fn from(d: SegmentDistance) -> Self {
+        match d {
+            SegmentDistance::Cosine => Distance::Cosine,
+            SegmentDistance::Euclid => Distance::Euclid,
+            SegmentDistance::Dot => Distance::Dot,
+            SegmentDistance::Manhattan => Distance::Manhattan,
+        }
+    }
+}
+
+// ── VectorStorageDatatype ───────────────────────────────────────────────────
+
+/// The in-storage numeric datatype for vector components.
+///
+/// Lowering the datatype reduces memory and disk footprint at the cost of
+/// some recall. `Float32` is the safe default; `Float16` halves memory with
+/// negligible accuracy impact for most models; `Uint8` requires that
+/// embeddings already be quantized into the `[0, 255]` range.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum VectorStorageDatatype {
+    /// Full-precision 32-bit IEEE 754 floats.
+    Float32,
+    /// Half-precision 16-bit floats (IEEE 754 binary16).
+    Float16,
+    /// Unsigned 8-bit integers. Requires pre-quantized embeddings.
+    Uint8,
+}
+
+impl From<VectorStorageDatatype> for SegmentVectorStorageDatatype {
+    fn from(d: VectorStorageDatatype) -> Self {
+        match d {
+            VectorStorageDatatype::Float32 => SegmentVectorStorageDatatype::Float32,
+            VectorStorageDatatype::Float16 => SegmentVectorStorageDatatype::Float16,
+            VectorStorageDatatype::Uint8 => SegmentVectorStorageDatatype::Uint8,
+        }
+    }
+}
+
+impl From<SegmentVectorStorageDatatype> for VectorStorageDatatype {
+    fn from(d: SegmentVectorStorageDatatype) -> Self {
+        match d {
+            SegmentVectorStorageDatatype::Float32 => VectorStorageDatatype::Float32,
+            SegmentVectorStorageDatatype::Float16 => VectorStorageDatatype::Float16,
+            SegmentVectorStorageDatatype::Uint8 => VectorStorageDatatype::Uint8,
+        }
+    }
+}
+
+// ── MultiVectorComparator ───────────────────────────────────────────────────
+
+/// The aggregation strategy used to collapse multi-vector scores into a
+/// single point score.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum MultiVectorComparator {
+    /// ColBERT-style max-similarity: for each query vector, take its best
+    /// match across the point's vectors, then sum those maxima.
+    MaxSim,
+}
+
+impl From<MultiVectorComparator> for SegmentMultiVectorComparator {
+    fn from(c: MultiVectorComparator) -> Self {
+        match c {
+            MultiVectorComparator::MaxSim => SegmentMultiVectorComparator::MaxSim,
+        }
+    }
+}
+
+impl From<SegmentMultiVectorComparator> for MultiVectorComparator {
+    fn from(c: SegmentMultiVectorComparator) -> Self {
+        match c {
+            SegmentMultiVectorComparator::MaxSim => MultiVectorComparator::MaxSim,
+        }
+    }
+}
+
+// ── MultiVectorConfig ───────────────────────────────────────────────────────
+
+/// Configuration for a multi-vector field, where each point stores an
+/// arbitrary number of vectors aggregated at query time.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct MultiVectorConfig {
+    /// Strategy used to aggregate per-vector similarities into the final
+    /// point score.
+    pub comparator: MultiVectorComparator,
+}
+
+impl From<MultiVectorConfig> for SegmentMultiVectorConfig {
+    fn from(c: MultiVectorConfig) -> Self {
+        SegmentMultiVectorConfig {
+            comparator: SegmentMultiVectorComparator::from(c.comparator),
+        }
+    }
+}
+
+impl From<SegmentMultiVectorConfig> for MultiVectorConfig {
+    fn from(c: SegmentMultiVectorConfig) -> Self {
+        MultiVectorConfig {
+            comparator: MultiVectorComparator::from(c.comparator),
+        }
+    }
+}
+
+// ── ScalarType ──────────────────────────────────────────────────────────────
+
+/// The target scalar type used by scalar quantization.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum ScalarType {
+    /// Signed 8-bit integer scalars.
+    Int8,
+}
+
+impl From<ScalarType> for SegmentScalarType {
+    fn from(s: ScalarType) -> Self {
+        match s {
+            ScalarType::Int8 => SegmentScalarType::Int8,
+        }
+    }
+}
+
+impl From<SegmentScalarType> for ScalarType {
+    fn from(s: SegmentScalarType) -> Self {
+        match s {
+            SegmentScalarType::Int8 => ScalarType::Int8,
+        }
+    }
+}
+
+// ── CompressionRatio ────────────────────────────────────────────────────────
+
+/// Target compression ratio for product quantization.
+///
+/// Higher ratios reduce index size and speed up search at the cost of
+/// recall. `X4` is conservative; `X64` is aggressive and typically requires
+/// a reranking pass over the raw vectors to maintain quality.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum CompressionRatio {
+    /// 4× compression.
+    X4,
+    /// 8× compression.
+    X8,
+    /// 16× compression.
+    X16,
+    /// 32× compression.
+    X32,
+    /// 64× compression.
+    X64,
+}
+
+impl From<CompressionRatio> for SegmentCompressionRatio {
+    fn from(c: CompressionRatio) -> Self {
+        match c {
+            CompressionRatio::X4 => SegmentCompressionRatio::X4,
+            CompressionRatio::X8 => SegmentCompressionRatio::X8,
+            CompressionRatio::X16 => SegmentCompressionRatio::X16,
+            CompressionRatio::X32 => SegmentCompressionRatio::X32,
+            CompressionRatio::X64 => SegmentCompressionRatio::X64,
+        }
+    }
+}
+
+impl From<SegmentCompressionRatio> for CompressionRatio {
+    fn from(c: SegmentCompressionRatio) -> Self {
+        match c {
+            SegmentCompressionRatio::X4 => CompressionRatio::X4,
+            SegmentCompressionRatio::X8 => CompressionRatio::X8,
+            SegmentCompressionRatio::X16 => CompressionRatio::X16,
+            SegmentCompressionRatio::X32 => CompressionRatio::X32,
+            SegmentCompressionRatio::X64 => CompressionRatio::X64,
+        }
+    }
+}
+
+// ── BinaryQuantizationEncoding ──────────────────────────────────────────────
+
+/// The number of bits each vector component is encoded to during binary
+/// quantization.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum BinaryQuantizationEncoding {
+    /// 1-bit-per-component encoding (maximum compression).
+    OneBit,
+    /// 2-bit-per-component encoding.
+    TwoBits,
+    /// Hybrid 1.5-bits-per-component encoding.
+    OneAndHalfBits,
+}
+
+impl From<BinaryQuantizationEncoding> for SegmentBinaryQuantizationEncoding {
+    fn from(e: BinaryQuantizationEncoding) -> Self {
+        match e {
+            BinaryQuantizationEncoding::OneBit => SegmentBinaryQuantizationEncoding::OneBit,
+            BinaryQuantizationEncoding::TwoBits => SegmentBinaryQuantizationEncoding::TwoBits,
+            BinaryQuantizationEncoding::OneAndHalfBits => {
+                SegmentBinaryQuantizationEncoding::OneAndHalfBits
+            }
+        }
+    }
+}
+
+impl From<SegmentBinaryQuantizationEncoding> for BinaryQuantizationEncoding {
+    fn from(e: SegmentBinaryQuantizationEncoding) -> Self {
+        match e {
+            SegmentBinaryQuantizationEncoding::OneBit => BinaryQuantizationEncoding::OneBit,
+            SegmentBinaryQuantizationEncoding::TwoBits => BinaryQuantizationEncoding::TwoBits,
+            SegmentBinaryQuantizationEncoding::OneAndHalfBits => {
+                BinaryQuantizationEncoding::OneAndHalfBits
+            }
+        }
+    }
+}
+
+// ── BinaryQuantizationQueryEncoding ─────────────────────────────────────────
+
+/// The encoding used for the query vector when searching a binary-quantized
+/// field.
+///
+/// A finer query encoding trades a small amount of query-time memory for
+/// better recall against a binary-quantized index.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum BinaryQuantizationQueryEncoding {
+    /// Use the server default (currently equivalent to `Binary`).
+    Default,
+    /// Encode the query with the same binary scheme as the index.
+    Binary,
+    /// Encode the query as 4-bit scalars (higher recall, higher memory).
+    Scalar4Bits,
+    /// Encode the query as 8-bit scalars (highest recall, highest memory).
+    Scalar8Bits,
+}
+
+impl From<BinaryQuantizationQueryEncoding> for SegmentBinaryQuantizationQueryEncoding {
+    fn from(e: BinaryQuantizationQueryEncoding) -> Self {
+        match e {
+            BinaryQuantizationQueryEncoding::Default => SegmentBinaryQuantizationQueryEncoding::Default,
+            BinaryQuantizationQueryEncoding::Binary => SegmentBinaryQuantizationQueryEncoding::Binary,
+            BinaryQuantizationQueryEncoding::Scalar4Bits => SegmentBinaryQuantizationQueryEncoding::Scalar4Bits,
+            BinaryQuantizationQueryEncoding::Scalar8Bits => SegmentBinaryQuantizationQueryEncoding::Scalar8Bits,
+        }
+    }
+}
+
+impl From<SegmentBinaryQuantizationQueryEncoding> for BinaryQuantizationQueryEncoding {
+    fn from(e: SegmentBinaryQuantizationQueryEncoding) -> Self {
+        match e {
+            SegmentBinaryQuantizationQueryEncoding::Default => BinaryQuantizationQueryEncoding::Default,
+            SegmentBinaryQuantizationQueryEncoding::Binary => BinaryQuantizationQueryEncoding::Binary,
+            SegmentBinaryQuantizationQueryEncoding::Scalar4Bits => BinaryQuantizationQueryEncoding::Scalar4Bits,
+            SegmentBinaryQuantizationQueryEncoding::Scalar8Bits => BinaryQuantizationQueryEncoding::Scalar8Bits,
+        }
+    }
+}
+
+// ── Quantization configs ────────────────────────────────────────────────────
+
+/// Parameters for scalar quantization.
+///
+/// Scalar quantization reduces each component to a smaller integer type,
+/// compressing the index ~4× while preserving most of the search quality.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ScalarQuantizationParams {
+    /// Target scalar datatype (currently only `Int8` is supported).
+    pub r#type: ScalarType,
+    /// Optional quantile used to clip extreme values during calibration.
+    /// `0.99` is a typical choice.
+    pub quantile: Option<f32>,
+    /// If `true`, keep the quantized data in RAM; otherwise allow it to be
+    /// memory-mapped.
+    pub always_ram: Option<bool>,
+}
+
+/// Parameters for product quantization.
+///
+/// Product quantization splits the vector into sub-vectors and encodes each
+/// with its own codebook, achieving higher compression than scalar
+/// quantization at the cost of more complex training.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ProductQuantizationParams {
+    /// Target compression ratio.
+    pub compression: CompressionRatio,
+    /// If `true`, keep the quantized data in RAM; otherwise allow it to be
+    /// memory-mapped.
+    pub always_ram: Option<bool>,
+}
+
+/// Parameters for binary quantization.
+///
+/// Binary quantization encodes each vector component with a small number of
+/// bits, providing maximum compression for ANN search with optional
+/// rescoring.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct BinaryQuantizationParams {
+    /// If `true`, keep the quantized data in RAM; otherwise allow it to be
+    /// memory-mapped.
+    pub always_ram: Option<bool>,
+    /// Bits-per-component encoding for the stored index.
+    pub encoding: Option<BinaryQuantizationEncoding>,
+    /// Encoding used for the query vector at search time. Defaults to match
+    /// the index encoding when not set.
+    pub query_encoding: Option<BinaryQuantizationQueryEncoding>,
+}
+
+/// Selects a vector quantization strategy for a vector field.
+///
+/// Quantization trades a small amount of recall for lower memory and
+/// faster queries. See the Qdrant docs for guidance on picking between
+/// variants.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum QuantizationConfig {
+    /// Scalar (int8) quantization — 4× compression, minor recall loss.
+    Scalar { config: ScalarQuantizationParams },
+    /// Product quantization — configurable compression, good for
+    /// high-dimensional vectors.
+    Product { config: ProductQuantizationParams },
+    /// Binary quantization — maximum compression, best for very large
+    /// collections and often paired with reranking.
+    Binary { config: BinaryQuantizationParams },
+}
+
+impl From<QuantizationConfig> for SegmentQuantizationConfig {
+    fn from(c: QuantizationConfig) -> Self {
+        match c {
+            QuantizationConfig::Scalar { config } => {
+                SegmentQuantizationConfig::Scalar(ScalarQuantization {
+                    scalar: ScalarQuantizationConfig {
+                        r#type: SegmentScalarType::from(config.r#type),
+                        quantile: config.quantile,
+                        always_ram: config.always_ram,
+                    },
+                })
+            }
+            QuantizationConfig::Product { config } => {
+                SegmentQuantizationConfig::Product(ProductQuantization {
+                    product: ProductQuantizationConfig {
+                        compression: SegmentCompressionRatio::from(config.compression),
+                        always_ram: config.always_ram,
+                    },
+                })
+            }
+            QuantizationConfig::Binary { config } => {
+                SegmentQuantizationConfig::Binary(BinaryQuantization {
+                    binary: BinaryQuantizationConfig {
+                        always_ram: config.always_ram,
+                        encoding: config.encoding.map(SegmentBinaryQuantizationEncoding::from),
+                        query_encoding: config
+                            .query_encoding
+                            .map(SegmentBinaryQuantizationQueryEncoding::from),
+                    },
+                })
+            }
+        }
+    }
+}
+
+impl TryFrom<SegmentQuantizationConfig> for QuantizationConfig {
+    type Error = ();
+
+    fn try_from(c: SegmentQuantizationConfig) -> std::result::Result<Self, Self::Error> {
+        match c {
+            SegmentQuantizationConfig::Scalar(ScalarQuantization { scalar }) => {
+                Ok(QuantizationConfig::Scalar {
+                    config: ScalarQuantizationParams {
+                        r#type: ScalarType::from(scalar.r#type),
+                        quantile: scalar.quantile,
+                        always_ram: scalar.always_ram,
+                    },
+                })
+            }
+            SegmentQuantizationConfig::Product(ProductQuantization { product }) => {
+                Ok(QuantizationConfig::Product {
+                    config: ProductQuantizationParams {
+                        compression: CompressionRatio::from(product.compression),
+                        always_ram: product.always_ram,
+                    },
+                })
+            }
+            SegmentQuantizationConfig::Binary(BinaryQuantization { binary }) => {
+                Ok(QuantizationConfig::Binary {
+                    config: BinaryQuantizationParams {
+                        always_ram: binary.always_ram,
+                        encoding: binary.encoding.map(BinaryQuantizationEncoding::from),
+                        query_encoding: binary
+                            .query_encoding
+                            .map(BinaryQuantizationQueryEncoding::from),
+                    },
+                })
+            }
+            // Turbo quantization has no FFI equivalent yet; hide it from the
+            // simplified surface instead of panicking when a collection that
+            // uses it is loaded.
+            SegmentQuantizationConfig::Turbo(_) => Err(()),
+        }
+    }
+}
+
+// ── VectorDataConfig ────────────────────────────────────────────────────────
+
+/// Configuration for a single dense vector field.
+///
+/// A named dense vector field is defined by its dimensionality (`size`), its
+/// similarity metric (`distance`), and optional quantization and
+/// multi-vector settings.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct VectorDataConfig {
+    /// Number of components per vector. Must match the embedding model
+    /// output dimensionality.
+    pub size: u64,
+    /// Similarity metric used for scoring.
+    pub distance: Distance,
+    /// Optional quantization strategy. `None` keeps raw vectors.
+    pub quantization_config: Option<QuantizationConfig>,
+    /// Optional multi-vector aggregation config. Set this when each point
+    /// stores multiple vectors (e.g. ColBERT-style retrieval).
+    pub multivector_config: Option<MultiVectorConfig>,
+    /// Optional storage datatype; defaults to `Float32` when unset.
+    pub datatype: Option<VectorStorageDatatype>,
+}
+
+impl From<VectorDataConfig> for SegmentVectorDataConfig {
+    fn from(c: VectorDataConfig) -> Self {
+        SegmentVectorDataConfig {
+            size: c.size as usize,
+            distance: SegmentDistance::from(c.distance),
+            storage_type: VectorStorageType::InRamChunkedMmap,
+            index: Indexes::Plain {},
+            quantization_config: c.quantization_config.map(SegmentQuantizationConfig::from),
+            multivector_config: c.multivector_config.map(SegmentMultiVectorConfig::from),
+            datatype: c.datatype.map(SegmentVectorStorageDatatype::from),
+        }
+    }
+}
+
+impl From<SegmentVectorDataConfig> for VectorDataConfig {
+    fn from(c: SegmentVectorDataConfig) -> Self {
+        VectorDataConfig {
+            size: c.size as u64,
+            distance: Distance::from(c.distance),
+            quantization_config: c.quantization_config.and_then(|q| q.try_into().ok()),
+            multivector_config: c.multivector_config.map(MultiVectorConfig::from),
+            datatype: c.datatype.map(VectorStorageDatatype::from),
+        }
+    }
+}
+
+// ── SparseIndexType ─────────────────────────────────────────────────────────
+
+/// Storage mode for a sparse vector index.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum SparseIndexType {
+    /// In-RAM, mutable index. Supports updates; uses more memory.
+    MutableRam,
+    /// In-RAM, immutable index. Rebuilt on update; faster queries.
+    ImmutableRam,
+    /// Memory-mapped on-disk index. Lowest memory footprint.
+    Mmap,
+}
+
+impl From<SparseIndexType> for SegmentSparseIndexType {
+    fn from(t: SparseIndexType) -> Self {
+        match t {
+            SparseIndexType::MutableRam => SegmentSparseIndexType::MutableRam,
+            SparseIndexType::ImmutableRam => SegmentSparseIndexType::ImmutableRam,
+            SparseIndexType::Mmap => SegmentSparseIndexType::Mmap,
+        }
+    }
+}
+
+impl From<SegmentSparseIndexType> for SparseIndexType {
+    fn from(t: SegmentSparseIndexType) -> Self {
+        match t {
+            SegmentSparseIndexType::MutableRam => SparseIndexType::MutableRam,
+            SegmentSparseIndexType::ImmutableRam => SparseIndexType::ImmutableRam,
+            SegmentSparseIndexType::Mmap => SparseIndexType::Mmap,
+        }
+    }
+}
+
+// ── Modifier ────────────────────────────────────────────────────────────────
+
+/// Optional scoring adjustment applied on top of the raw vector similarity.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum Modifier {
+    /// No modification; use the raw similarity score.
+    None,
+    /// Apply inverse-document-frequency weighting to sparse vector scores.
+    /// Recommended for bag-of-words style sparse embeddings like BM42.
+    Idf,
+}
+
+impl From<Modifier> for SegmentModifier {
+    fn from(m: Modifier) -> Self {
+        match m {
+            Modifier::None => SegmentModifier::None,
+            Modifier::Idf => SegmentModifier::Idf,
+        }
+    }
+}
+
+impl From<SegmentModifier> for Modifier {
+    fn from(m: SegmentModifier) -> Self {
+        match m {
+            SegmentModifier::None => Modifier::None,
+            SegmentModifier::Idf => Modifier::Idf,
+        }
+    }
+}
+
+// ── SparseVectorDataConfig ──────────────────────────────────────────────────
+
+/// Configuration for a single sparse vector field (e.g. SPLADE, BM42).
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct SparseVectorDataConfig {
+    /// If set, switches to an exact full-scan search when the number of
+    /// candidates falls below this threshold. Useful for small shards
+    /// where ANN adds overhead without recall benefit.
+    pub full_scan_threshold: Option<u64>,
+    /// Optional storage datatype for sparse values; defaults to `Float32`.
+    pub datatype: Option<VectorStorageDatatype>,
+    /// Optional score modifier (e.g. IDF weighting).
+    pub modifier: Option<Modifier>,
+}
+
+impl From<SparseVectorDataConfig> for SegmentSparseVectorDataConfig {
+    fn from(c: SparseVectorDataConfig) -> Self {
+        SegmentSparseVectorDataConfig {
+            index: SparseIndexConfig {
+                index_type: SegmentSparseIndexType::MutableRam,
+                full_scan_threshold: c.full_scan_threshold.map(|v| v as usize),
+                datatype: c.datatype.map(SegmentVectorStorageDatatype::from),
+            },
+            storage_type: SparseVectorStorageType::Mmap,
+            modifier: c.modifier.map(SegmentModifier::from),
+        }
+    }
+}
+
+impl From<SegmentSparseVectorDataConfig> for SparseVectorDataConfig {
+    fn from(c: SegmentSparseVectorDataConfig) -> Self {
+        SparseVectorDataConfig {
+            full_scan_threshold: c.index.full_scan_threshold.map(|v| v as u64),
+            datatype: c.index.datatype.map(VectorStorageDatatype::from),
+            modifier: c.modifier.map(Modifier::from),
+        }
+    }
+}
+
+// ── EdgeConfig (wraps SegmentConfig) ────────────────────────────────────────
+
+/// Top-level configuration passed to [`EdgeShard::load`] when creating a new
+/// shard, and returned by [`EdgeShard::config`] for existing shards.
+///
+/// An `EdgeConfig` defines one or more dense and/or sparse vector fields by
+/// name. Each field is independently searchable; points may omit fields
+/// they do not need.
+///
+/// ## Example
+///
+/// ```swift
+/// let config = EdgeConfig(
+///     vectorData: ["text": VectorDataConfig(size: 384, distance: .cosine,
+///                                           quantizationConfig: nil,
+///                                           multivectorConfig: nil,
+///                                           datatype: nil)],
+///     sparseVectorData: [:]
+/// )
+/// ```
+///
+/// ```kotlin
+/// val config = EdgeConfig(
+///     vectorData = mapOf(
+///         "text" to VectorDataConfig(
+///             size = 384u,
+///             distance = Distance.COSINE,
+///             quantizationConfig = null,
+///             multivectorConfig = null,
+///             datatype = null,
+///         )
+///     ),
+///     sparseVectorData = emptyMap(),
+/// )
+/// ```
+///
+/// [`EdgeShard::load`]: crate::EdgeShard::load
+/// [`EdgeShard::config`]: crate::EdgeShard::config
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct EdgeConfig {
+    /// Named dense vector fields. Each key is a vector name referenced by
+    /// `Point`, `Query.nearest(..., using: ...)`, etc.
+    pub vector_data: HashMap<String, VectorDataConfig>,
+    /// Named sparse vector fields.
+    pub sparse_vector_data: HashMap<String, SparseVectorDataConfig>,
+}
+
+impl From<EdgeConfig> for SegmentConfig {
+    fn from(c: EdgeConfig) -> Self {
+        SegmentConfig {
+            vector_data: c
+                .vector_data
+                .into_iter()
+                .map(|(k, v)| (k, SegmentVectorDataConfig::from(v)))
+                .collect(),
+            sparse_vector_data: c
+                .sparse_vector_data
+                .into_iter()
+                .map(|(k, v)| (k, SegmentSparseVectorDataConfig::from(v)))
+                .collect(),
+            payload_storage_type: PayloadStorageType::Mmap,
+        }
+    }
+}
+
+impl From<SegmentConfig> for EdgeConfig {
+    fn from(c: SegmentConfig) -> Self {
+        EdgeConfig {
+            vector_data: c
+                .vector_data
+                .into_iter()
+                .map(|(k, v)| (k, VectorDataConfig::from(v)))
+                .collect(),
+            sparse_vector_data: c
+                .sparse_vector_data
+                .into_iter()
+                .map(|(k, v)| (k, SparseVectorDataConfig::from(v)))
+                .collect(),
+        }
+    }
+}

--- a/lib/edge/ffi/src/error.rs
+++ b/lib/edge/ffi/src/error.rs
@@ -1,0 +1,43 @@
+use segment::common::operation_error::OperationError;
+
+/// The error type returned from fallible `EdgeShard` operations and
+/// `UpdateOperation` constructors.
+///
+/// All error variants carry a human-readable `message` describing the cause.
+/// On the Swift side this surfaces as a throwing error; on the Kotlin side as
+/// a checked exception.
+///
+/// ## Example
+///
+/// ```swift
+/// do {
+///     let shard = try EdgeShard.load(path: dataDir, config: nil)
+/// } catch let error as EdgeError {
+///     print("Failed to load shard: \(error)")
+/// }
+/// ```
+///
+/// ```kotlin
+/// try {
+///     val shard = EdgeShard.load(path = dataDir, config = null)
+/// } catch (e: EdgeException.OperationException) {
+///     println("Failed to load shard: ${e.message}")
+/// }
+/// ```
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum EdgeError {
+    /// A recoverable operation failure (I/O error, invalid input, missing
+    /// configuration, corrupted segment, etc.).
+    #[error("{message}")]
+    OperationError { message: String },
+}
+
+impl From<OperationError> for EdgeError {
+    fn from(err: OperationError) -> Self {
+        EdgeError::OperationError {
+            message: err.to_string(),
+        }
+    }
+}
+
+pub type Result<T, E = EdgeError> = std::result::Result<T, E>;

--- a/lib/edge/ffi/src/filter.rs
+++ b/lib/edge/ffi/src/filter.rs
@@ -1,0 +1,362 @@
+use ahash::AHashSet;
+use segment::types::{
+    AnyVariants, Condition as SegmentCondition, FieldCondition as SegmentFieldCondition,
+    Filter as SegmentFilter, GeoPoint as SegmentGeoPoint,
+    GeoBoundingBox as SegmentGeoBoundingBox, GeoRadius as SegmentGeoRadius,
+    HasIdCondition, HasVectorCondition, IsEmptyCondition, IsNullCondition,
+    Match as SegmentMatch, MatchAny, MatchExcept, MatchText, MatchValue,
+    PayloadField, PointIdType, Range, RangeInterface,
+    ValuesCount as SegmentValuesCount, ValueVariants as SegmentValueVariants,
+};
+use segment::utils::maybe_arc::MaybeArc;
+
+use crate::types::PointId;
+
+// ── GeoPoint ────────────────────────────────────────────────────────────────
+
+/// A latitude/longitude pair in decimal degrees.
+///
+/// Latitude must be in `[-90, 90]` and longitude in `[-180, 180]`.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GeoPoint {
+    /// Longitude in decimal degrees.
+    pub lon: f64,
+    /// Latitude in decimal degrees.
+    pub lat: f64,
+}
+
+impl From<GeoPoint> for SegmentGeoPoint {
+    fn from(p: GeoPoint) -> Self {
+        SegmentGeoPoint::new(p.lon, p.lat).expect("valid geo point")
+    }
+}
+
+impl From<SegmentGeoPoint> for GeoPoint {
+    fn from(p: SegmentGeoPoint) -> Self {
+        GeoPoint {
+            lon: p.lon.into_inner(),
+            lat: p.lat.into_inner(),
+        }
+    }
+}
+
+// ── GeoBoundingBox ──────────────────────────────────────────────────────────
+
+/// An axis-aligned geographic bounding box, used by geo filters.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GeoBoundingBox {
+    /// Top-left corner (north-west).
+    pub top_left: GeoPoint,
+    /// Bottom-right corner (south-east).
+    pub bottom_right: GeoPoint,
+}
+
+impl From<GeoBoundingBox> for SegmentGeoBoundingBox {
+    fn from(b: GeoBoundingBox) -> Self {
+        SegmentGeoBoundingBox {
+            top_left: SegmentGeoPoint::from(b.top_left),
+            bottom_right: SegmentGeoPoint::from(b.bottom_right),
+        }
+    }
+}
+
+// ── GeoRadius ───────────────────────────────────────────────────────────────
+
+/// A circular geographic region defined by a center and a radius.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GeoRadius {
+    /// Center of the circle.
+    pub center: GeoPoint,
+    /// Radius in meters.
+    pub radius: f64,
+}
+
+impl From<GeoRadius> for SegmentGeoRadius {
+    fn from(r: GeoRadius) -> Self {
+        SegmentGeoRadius {
+            center: SegmentGeoPoint::from(r.center),
+            radius: ordered_float::OrderedFloat(r.radius),
+        }
+    }
+}
+
+// ── RangeFloat ──────────────────────────────────────────────────────────────
+
+/// A numeric range filter with optional inclusive/exclusive bounds.
+///
+/// Any combination of bounds can be set; unset bounds are treated as
+/// unbounded. `gte` (≥) and `gt` (>) should not both be set simultaneously;
+/// likewise for `lte` and `lt`.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct RangeFloat {
+    /// Inclusive lower bound (≥).
+    pub gte: Option<f64>,
+    /// Exclusive lower bound (>).
+    pub gt: Option<f64>,
+    /// Inclusive upper bound (≤).
+    pub lte: Option<f64>,
+    /// Exclusive upper bound (<).
+    pub lt: Option<f64>,
+}
+
+// ── MatchValue ──────────────────────────────────────────────────────────────
+
+/// A scalar payload value used by [`Match::Value`].
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum ValueVariants {
+    /// A string value.
+    String { value: String },
+    /// A signed 64-bit integer.
+    Integer { value: i64 },
+    /// A boolean value.
+    Bool { value: bool },
+}
+
+impl From<ValueVariants> for SegmentValueVariants {
+    fn from(v: ValueVariants) -> Self {
+        match v {
+            ValueVariants::String { value } => SegmentValueVariants::String(value),
+            ValueVariants::Integer { value } => SegmentValueVariants::Integer(value),
+            ValueVariants::Bool { value } => SegmentValueVariants::Bool(value),
+        }
+    }
+}
+
+// ── Match ───────────────────────────────────────────────────────────────────
+
+/// How a [`FieldCondition`] compares a payload field.
+///
+/// For each variant, exactly one of its alternative payloads should be set
+/// (e.g. for `Any`, pass either `strings` or `integers`, not both).
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum Match {
+    /// Exact scalar match.
+    Value { value: ValueVariants },
+    /// Full-text match on a string field (requires a full-text index on the
+    /// payload key).
+    Text { text: String },
+    /// The field value must equal any of the given strings or integers.
+    Any { strings: Option<Vec<String>>, integers: Option<Vec<i64>> },
+    /// The field value must equal none of the given strings or integers.
+    Except { strings: Option<Vec<String>>, integers: Option<Vec<i64>> },
+}
+
+impl From<Match> for SegmentMatch {
+    fn from(m: Match) -> Self {
+        match m {
+            Match::Value { value } => SegmentMatch::Value(MatchValue {
+                value: SegmentValueVariants::from(value),
+            }),
+            Match::Text { text } => SegmentMatch::Text(MatchText { text }),
+            Match::Any { strings, integers } => {
+                let any = if let Some(strings) = strings {
+                    AnyVariants::Strings(strings.into_iter().collect())
+                } else if let Some(integers) = integers {
+                    AnyVariants::Integers(integers.into_iter().collect())
+                } else {
+                    AnyVariants::Strings(Default::default())
+                };
+                SegmentMatch::Any(MatchAny { any })
+            }
+            Match::Except { strings, integers } => {
+                let except = if let Some(strings) = strings {
+                    AnyVariants::Strings(strings.into_iter().collect())
+                } else if let Some(integers) = integers {
+                    AnyVariants::Integers(integers.into_iter().collect())
+                } else {
+                    AnyVariants::Strings(Default::default())
+                };
+                SegmentMatch::Except(MatchExcept { except })
+            }
+        }
+    }
+}
+
+// ── ValuesCount ─────────────────────────────────────────────────────────────
+
+/// Matches points where the field value count falls in the given range.
+///
+/// Useful for filtering by the cardinality of an array-valued payload
+/// field — e.g. "points with at least 3 tags".
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ValuesCount {
+    /// Inclusive lower bound (≥).
+    pub gte: Option<u64>,
+    /// Exclusive lower bound (>).
+    pub gt: Option<u64>,
+    /// Inclusive upper bound (≤).
+    pub lte: Option<u64>,
+    /// Exclusive upper bound (<).
+    pub lt: Option<u64>,
+}
+
+impl From<ValuesCount> for SegmentValuesCount {
+    fn from(v: ValuesCount) -> Self {
+        SegmentValuesCount {
+            lt: v.lt.map(|x| x as usize),
+            gt: v.gt.map(|x| x as usize),
+            gte: v.gte.map(|x| x as usize),
+            lte: v.lte.map(|x| x as usize),
+        }
+    }
+}
+
+// ── FieldCondition ──────────────────────────────────────────────────────────
+
+/// A filter condition applied to a single payload field.
+///
+/// Exactly one of `match`, `range`, `geo_bounding_box`, `geo_radius`, or
+/// `values_count` should be set; setting more than one is an error. The
+/// payload `key` uses JSON-path syntax for nested fields (e.g.
+/// `"meta.location"`).
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FieldCondition {
+    /// Payload key to test (JSON-path syntax supported).
+    pub key: String,
+    /// Scalar / text / list match.
+    pub r#match: Option<Match>,
+    /// Numeric range comparison.
+    pub range: Option<RangeFloat>,
+    /// Geographic bounding-box containment.
+    pub geo_bounding_box: Option<GeoBoundingBox>,
+    /// Geographic radius containment.
+    pub geo_radius: Option<GeoRadius>,
+    /// Cardinality filter over array-valued payloads.
+    pub values_count: Option<ValuesCount>,
+}
+
+impl From<FieldCondition> for SegmentFieldCondition {
+    fn from(c: FieldCondition) -> Self {
+        SegmentFieldCondition {
+            key: c.key.parse().expect("valid json path"),
+            r#match: c.r#match.map(SegmentMatch::from),
+            range: c.range.map(|r| {
+                RangeInterface::Float(Range {
+                    gte: r.gte.map(ordered_float::OrderedFloat),
+                    gt: r.gt.map(ordered_float::OrderedFloat),
+                    lte: r.lte.map(ordered_float::OrderedFloat),
+                    lt: r.lt.map(ordered_float::OrderedFloat),
+                })
+            }),
+            geo_bounding_box: c.geo_bounding_box.map(SegmentGeoBoundingBox::from),
+            geo_radius: c.geo_radius.map(SegmentGeoRadius::from),
+            geo_polygon: None,
+            values_count: c.values_count.map(SegmentValuesCount::from),
+            is_empty: None,
+            is_null: None,
+        }
+    }
+}
+
+// ── Condition ───────────────────────────────────────────────────────────────
+
+/// A single filter clause, composed into larger filters by [`Filter`].
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum Condition {
+    /// Match against a specific payload field.
+    Field { condition: FieldCondition },
+    /// The given payload key must be absent or empty.
+    IsEmpty { key: String },
+    /// The given payload key must hold the JSON `null` value.
+    IsNull { key: String },
+    /// Point ID must match any of the listed IDs.
+    HasId { ids: Vec<PointId> },
+    /// The point must have a vector in the named field.
+    HasVector { vector_name: String },
+    /// Nested filter — useful for grouping `should` clauses inside a
+    /// `must` / `must_not`.
+    Filter { filter: Filter },
+}
+
+impl From<Condition> for SegmentCondition {
+    fn from(c: Condition) -> Self {
+        match c {
+            Condition::Field { condition } => SegmentCondition::Field(SegmentFieldCondition::from(condition)),
+            Condition::IsEmpty { key } => SegmentCondition::IsEmpty(IsEmptyCondition {
+                is_empty: PayloadField {
+                    key: key.parse().expect("valid json path"),
+                },
+            }),
+            Condition::IsNull { key } => SegmentCondition::IsNull(IsNullCondition {
+                is_null: PayloadField {
+                    key: key.parse().expect("valid json path"),
+                },
+            }),
+            Condition::HasId { ids } => {
+                let id_set: AHashSet<PointIdType> =
+                    ids.into_iter().map(PointIdType::from).collect();
+                SegmentCondition::HasId(HasIdCondition {
+                    has_id: MaybeArc::NoArc(id_set),
+                })
+            }
+            Condition::HasVector { vector_name } => {
+                SegmentCondition::HasVector(HasVectorCondition {
+                    has_vector: vector_name,
+                })
+            }
+            Condition::Filter { filter } => SegmentCondition::Filter(SegmentFilter::from(filter)),
+        }
+    }
+}
+
+// ── Filter ──────────────────────────────────────────────────────────────────
+
+/// A boolean combination of [`Condition`]s.
+///
+/// Semantics:
+/// - `must`: all clauses must match (logical AND).
+/// - `should`: at least one clause must match (logical OR).
+/// - `must_not`: no clause may match (logical NOT AND).
+///
+/// All three fields are optional; an empty filter matches every point.
+///
+/// ## Example
+///
+/// ```swift
+/// let filter = Filter(
+///     must: [.field(condition:
+///         FieldCondition(key: "category",
+///                        match: .value(value: .string(value: "news")),
+///                        range: nil, geoBoundingBox: nil,
+///                        geoRadius: nil, valuesCount: nil))],
+///     should: nil,
+///     mustNot: nil
+/// )
+/// ```
+///
+/// ```kotlin
+/// val filter = Filter(
+///     must = listOf(Condition.Field(FieldCondition(
+///         key = "category",
+///         `match` = Match.Value(ValueVariants.String("news")),
+///         range = null, geoBoundingBox = null,
+///         geoRadius = null, valuesCount = null,
+///     ))),
+///     should = null,
+///     mustNot = null,
+/// )
+/// ```
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct Filter {
+    /// Clauses that must all match.
+    pub must: Option<Vec<Condition>>,
+    /// Clauses of which at least one must match.
+    pub should: Option<Vec<Condition>>,
+    /// Clauses that must all fail to match.
+    pub must_not: Option<Vec<Condition>>,
+}
+
+impl From<Filter> for SegmentFilter {
+    fn from(f: Filter) -> Self {
+        SegmentFilter {
+            must: f.must.map(|v| v.into_iter().map(SegmentCondition::from).collect()),
+            should: f
+                .should
+                .map(|v| v.into_iter().map(SegmentCondition::from).collect()),
+            must_not: f
+                .must_not
+                .map(|v| v.into_iter().map(SegmentCondition::from).collect()),
+            min_should: None,
+        }
+    }
+}

--- a/lib/edge/ffi/src/lib.rs
+++ b/lib/edge/ffi/src/lib.rs
@@ -1,0 +1,361 @@
+pub mod config;
+pub mod error;
+pub mod filter;
+pub mod query;
+pub mod types;
+pub mod update;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use segment::data_types::facets::FacetValue;
+use segment::types::{PointIdType, SegmentConfig, WithPayloadInterface, WithVector as SegmentWithVector};
+
+use crate::config::EdgeConfig;
+use crate::error::{EdgeError, Result};
+use crate::query::*;
+use crate::types::*;
+use crate::update::UpdateOperation;
+
+uniffi::setup_scaffolding!();
+
+/// An embeddable, file-backed vector search engine.
+///
+/// `EdgeShard` is the main entry point for Qdrant Edge. It owns a
+/// write-ahead log (WAL) and one or more segments on disk at a given path,
+/// and exposes the full range of Qdrant search and update operations:
+/// `upsert`, `search`, `query`, `scroll`, `count`, `facet`, `retrieve`, and
+/// payload/vector mutations.
+///
+/// An instance is obtained via [`EdgeShard::load`]. Call [`EdgeShard::close`]
+/// when you no longer need the shard to release the underlying resources;
+/// the shard is also closed automatically when the reference count drops to
+/// zero.
+///
+/// ## Example
+///
+/// ```swift
+/// let shard = try EdgeShard.load(path: dataDir, config: myConfig)
+/// try shard.update(operation: .upsertPoints(points: [/* ... */]))
+/// let hits = try shard.search(
+///     request: SearchRequest(
+///         query: .nearest(vector: [0.1, 0.2, 0.3, 0.4], using: nil),
+///         limit: 10,
+///         // ... other defaults
+///     )
+/// )
+/// ```
+///
+/// ```kotlin
+/// val shard = EdgeShard.load(path = dataDir, config = myConfig)
+/// shard.update(operation = UpdateOperation.upsertPoints(listOf(/* ... */)))
+/// val hits = shard.search(
+///     request = SearchRequest(
+///         query = Query.Nearest(listOf(0.1f, 0.2f, 0.3f, 0.4f), null),
+///         limit = 10u,
+///         // ... other defaults
+///     )
+/// )
+/// ```
+#[derive(uniffi::Object)]
+pub struct EdgeShard {
+    inner: Mutex<Option<edge::EdgeShard>>,
+}
+
+#[uniffi::export]
+impl EdgeShard {
+    /// Opens an existing shard at `path`, or creates a new one.
+    ///
+    /// If `path` already contains segments, they are loaded and `config` must
+    /// be either `nil`/`null` or fully compatible with the stored segment
+    /// configuration. If `path` is empty (or does not yet exist), `config` is
+    /// required and a new appendable segment is created from it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the path is not writable,
+    /// the WAL cannot be opened, stored segments are incompatible with the
+    /// provided `config`, or the directory contains no segments and no
+    /// `config` was supplied.
+    #[uniffi::constructor]
+    pub fn load(path: String, config: Option<EdgeConfig>) -> Result<Arc<Self>> {
+        // The FFI `EdgeConfig` is the simplified surface (vectors + sparse);
+        // we hydrate it into the richer `edge::EdgeConfig` via SegmentConfig.
+        let edge_config = config
+            .map(SegmentConfig::from)
+            .map(|sc| edge::EdgeConfig::from_segment_config(&sc));
+        let shard = edge::EdgeShard::load(&PathBuf::from(path), edge_config)?;
+        Ok(Arc::new(Self {
+            inner: Mutex::new(Some(shard)),
+        }))
+    }
+
+    /// Flushes the write-ahead log and all segments to disk synchronously.
+    ///
+    /// Normal operations already persist their WAL records, but this call
+    /// forces the OS-level `fsync` so data is durable even across device
+    /// power loss. Call this at application-suspend points on mobile.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard has already been
+    /// closed via [`EdgeShard::close`].
+    pub fn flush(&self) -> Result<()> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        shard.flush();
+        Ok(())
+    }
+
+    /// Closes the shard, flushing any pending data and releasing the WAL and
+    /// segment file handles.
+    ///
+    /// After this call returns, any further operation on the shard will fail
+    /// with [`EdgeError::OperationError`]. Calling `close` on an
+    /// already-closed shard is a no-op.
+    pub fn close(&self) {
+        self.inner.lock().take();
+    }
+
+    /// Applies a batch of point upserts, deletes, or payload/vector edits
+    /// atomically.
+    ///
+    /// Construct the `operation` using one of the `UpdateOperation`
+    /// constructors (e.g. [`UpdateOperation::upsert_points`],
+    /// [`UpdateOperation::delete_points`], [`UpdateOperation::set_payload`]).
+    /// Changes are written to the WAL before being applied to segments, so
+    /// they are durable across crashes once this call returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed, the
+    /// operation is malformed, or the underlying WAL write fails.
+    pub fn update(&self, operation: Arc<UpdateOperation>) -> Result<()> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        shard.update(operation.inner.clone())?;
+        Ok(())
+    }
+
+    /// Executes a high-level query, supporting fusion, prefetching,
+    /// re-ranking, and score thresholds.
+    ///
+    /// This is the most general search entry point. For simple nearest-neighbor
+    /// search use [`EdgeShard::search`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed, the
+    /// request is invalid, or a required payload index is missing.
+    pub fn query(&self, request: QueryRequest) -> Result<Vec<ScoredPoint>> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let points = shard.query(request.into())?;
+        Ok(points.into_iter().map(ScoredPoint::from).collect())
+    }
+
+    /// Executes a single nearest-neighbor search against a dense vector
+    /// field.
+    ///
+    /// Returns the top `request.limit` points scored against `request.query`,
+    /// optionally filtered by `request.filter`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed, the
+    /// vector dimensionality does not match the configured vector field, or
+    /// the filter references a payload key without an index.
+    pub fn search(&self, request: SearchRequest) -> Result<Vec<ScoredPoint>> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let points = shard.search(request.into())?;
+        Ok(points.into_iter().map(ScoredPoint::from).collect())
+    }
+
+    /// Iterates over points in the shard in batches.
+    ///
+    /// Useful for exporting all points, paginating through a filter match,
+    /// or implementing custom offline processing. Pass the returned
+    /// `next_offset` back as `request.offset` to fetch the next page; when
+    /// `next_offset` is `nil`/`null`, iteration is complete.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed or
+    /// the request is malformed.
+    pub fn scroll(
+        &self,
+        request: ScrollRequest,
+    ) -> Result<ScrollResponse> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let (records, next_offset) = shard.scroll(request.into())?;
+        Ok(ScrollResponse {
+            records: records.into_iter().map(Record::from).collect(),
+            next_offset: next_offset.map(PointId::from),
+        })
+    }
+
+    /// Counts the points matching the request filter.
+    ///
+    /// When `request.exact` is `true`, every matching point is visited; when
+    /// `false`, an approximate count may be returned faster.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed or
+    /// the filter references a payload key without an index.
+    pub fn count(&self, request: CountRequest) -> Result<u64> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let count = shard.count(request.into())?;
+        Ok(count as u64)
+    }
+
+    /// Aggregates distinct payload values for a given key, with counts.
+    ///
+    /// Faceting requires the payload `key` to have a payload index; call
+    /// [`UpdateOperation::set_payload`] and index the field beforehand.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed or
+    /// the payload key is not indexed.
+    pub fn facet(&self, request: FacetRequest) -> Result<FacetResponse> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let response = shard.facet(request.into())?;
+        let hits = response
+            .hits
+            .into_iter()
+            .map(|h| FacetHit {
+                value: match &h.value {
+                    FacetValue::Keyword(s) => s.clone(),
+                    FacetValue::Int(i) => i.to_string(),
+                    FacetValue::Uuid(u) => uuid::Uuid::from_u128(*u).to_string(),
+                    FacetValue::Bool(b) => b.to_string(),
+                },
+                count: h.count as u64,
+            })
+            .collect();
+        Ok(FacetResponse { hits })
+    }
+
+    /// Fetches the points with the given IDs.
+    ///
+    /// IDs that do not exist in the shard are simply omitted from the
+    /// returned list; no error is raised. Pass `with_payload` and/or
+    /// `with_vector` to control what is included in each returned
+    /// [`Record`](crate::types::Record).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed.
+    pub fn retrieve(
+        &self,
+        point_ids: Vec<PointId>,
+        with_payload: Option<WithPayload>,
+        with_vector: Option<WithVector>,
+    ) -> Result<Vec<Record>> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let records = shard.retrieve(
+            &ids,
+            with_payload.map(WithPayloadInterface::from),
+            with_vector.map(SegmentWithVector::from),
+        )?;
+        Ok(records.into_iter().map(Record::from).collect())
+    }
+
+    /// Returns summary information about the shard: number of segments,
+    /// total points, and indexed vector count.
+    ///
+    /// Useful for debugging, UI "collection stats" screens, and sanity
+    /// checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed.
+    pub fn info(&self) -> Result<ShardInfo> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        let info = shard.info();
+        Ok(ShardInfo {
+            segments_count: info.segments_count as u64,
+            points_count: info.points_count as u64,
+            indexed_vectors_count: info.indexed_vectors_count as u64,
+        })
+    }
+
+    /// Returns the segment configuration the shard was loaded or created
+    /// with.
+    ///
+    /// The returned [`EdgeConfig`] is a snapshot at the time of the call; it
+    /// is safe to inspect and discard.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`] if the shard is closed.
+    pub fn config(&self) -> Result<EdgeConfig> {
+        let guard = self.inner.lock();
+        let shard = guard.as_ref().ok_or(EdgeError::OperationError {
+            message: "EdgeShard is closed".into(),
+        })?;
+        Ok(EdgeConfig::from(shard.config().plain_segment_config()))
+    }
+}
+
+/// Unpacks a Qdrant snapshot archive into `target_path`.
+///
+/// The resulting directory can be passed to [`EdgeShard::load`] to open the
+/// snapshot as a local shard. Useful for shipping pre-computed search
+/// indexes inside an app bundle.
+///
+/// # Errors
+///
+/// Returns an [`EdgeError::OperationError`] if `snapshot_path` does not
+/// exist, the archive is corrupt, or `target_path` is not writable.
+#[uniffi::export]
+pub fn unpack_snapshot(snapshot_path: String, target_path: String) -> Result<()> {
+    edge::EdgeShard::unpack_snapshot(
+        &PathBuf::from(snapshot_path),
+        &PathBuf::from(target_path),
+    )?;
+    Ok(())
+}
+
+// ── ScrollResponse ──────────────────────────────────────────────────────────
+
+/// A single page of results returned by [`EdgeShard::scroll`].
+///
+/// When `next_offset` is `Some`/non-`null`, more records are available;
+/// pass it back as `ScrollRequest.offset` on the next call to continue
+/// iteration. When `next_offset` is `None`/`null`, the scroll is exhausted.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ScrollResponse {
+    /// The records in this page, in scroll order.
+    pub records: Vec<Record>,
+    /// Opaque cursor to pass as the `offset` on the next scroll call, or
+    /// `None`/`null` if the scroll is complete.
+    pub next_offset: Option<PointId>,
+}

--- a/lib/edge/ffi/src/query.rs
+++ b/lib/edge/ffi/src/query.rs
@@ -1,0 +1,454 @@
+use ordered_float::OrderedFloat;
+use segment::data_types::order_by::{
+    Direction as SegmentDirection, OrderBy as SegmentOrderBy, OrderByInterface,
+};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal};
+use segment::types::{
+    Filter as SegmentFilter, PointIdType,
+    SearchParams as SegmentSearchParams, WithPayloadInterface,
+    WithVector as SegmentWithVector,
+};
+use shard::count::CountRequestInternal;
+use shard::facet::FacetRequestInternal;
+use shard::query::*;
+use shard::query::query_enum::QueryEnum;
+use shard::scroll::ScrollRequestInternal;
+use shard::search::CoreSearchRequest;
+
+use crate::filter::Filter;
+use crate::types::{PointId, WithPayload, WithVector};
+
+// ── SearchParams ────────────────────────────────────────────────────────────
+
+/// Tuning parameters that affect how a single ANN search is executed.
+///
+/// These are tuning knobs; the defaults are reasonable for most workloads.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct SearchParams {
+    /// HNSW `ef` parameter — the size of the candidate set kept during
+    /// graph traversal. Higher values increase recall and latency. `None`
+    /// uses the collection default.
+    pub hnsw_ef: Option<u64>,
+    /// If `true`, skip the ANN index and perform an exact brute-force
+    /// search. Useful for small shards or recall ground-truthing.
+    pub exact: bool,
+    /// If `true`, skip points whose filter matches reference unindexed
+    /// payload fields. Rarely needed on mobile.
+    pub indexed_only: bool,
+}
+
+impl From<SearchParams> for SegmentSearchParams {
+    fn from(p: SearchParams) -> Self {
+        SegmentSearchParams {
+            hnsw_ef: p.hnsw_ef.map(|v| v as usize),
+            exact: p.exact,
+            quantization: None,
+            indexed_only: p.indexed_only,
+            acorn: None,
+        }
+    }
+}
+
+// ── Query (nearest vector query) ────────────────────────────────────────────
+
+/// A primitive query expressed as a single dense vector.
+///
+/// Used directly by [`SearchRequest`] and as the leaf of more complex
+/// [`ScoringQuery`] expressions.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum Query {
+    /// Nearest-neighbor search against a dense vector field.
+    Nearest {
+        /// The query vector. Dimensionality must match the target field.
+        vector: Vec<f32>,
+        /// Name of the dense vector field to search. Pass `None`/`null` to
+        /// target the default (unnamed) field.
+        using: Option<String>,
+    },
+}
+
+impl From<Query> for QueryEnum {
+    fn from(q: Query) -> Self {
+        match q {
+            Query::Nearest { vector, using } => {
+                let using = using.unwrap_or_else(|| DEFAULT_VECTOR_NAME.to_string());
+                QueryEnum::Nearest(segment::data_types::vectors::NamedQuery {
+                    query: VectorInternal::Dense(vector),
+                    using: Some(using),
+                })
+            }
+        }
+    }
+}
+
+// ── ScoringQuery ────────────────────────────────────────────────────────────
+
+/// The scoring strategy applied by [`QueryRequest`].
+///
+/// `Vector` is the most common case — score by vector similarity. `Fusion`
+/// and `OrderBy` operate on pre-scored prefetch results.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum ScoringQuery {
+    /// Score results by vector similarity (the typical search case).
+    Vector { query: Query },
+    /// Fuse scores from multiple prefetch branches. Requires a non-empty
+    /// `QueryRequest.prefetches`.
+    Fusion { fusion: Fusion },
+    /// Rank results by a payload field instead of vector similarity.
+    OrderBy { order_by: OrderBy },
+    /// Sample results at random.
+    Sample { sample: Sample },
+}
+
+impl From<ScoringQuery> for shard::query::ScoringQuery {
+    fn from(q: ScoringQuery) -> Self {
+        match q {
+            ScoringQuery::Vector { query } => {
+                shard::query::ScoringQuery::Vector(QueryEnum::from(query))
+            }
+            ScoringQuery::Fusion { fusion } => {
+                shard::query::ScoringQuery::Fusion(FusionInternal::from(fusion))
+            }
+            ScoringQuery::OrderBy { order_by } => {
+                shard::query::ScoringQuery::OrderBy(SegmentOrderBy::from(order_by))
+            }
+            ScoringQuery::Sample { sample } => {
+                shard::query::ScoringQuery::Sample(SampleInternal::from(sample))
+            }
+        }
+    }
+}
+
+// ── Fusion ──────────────────────────────────────────────────────────────────
+
+/// Fusion strategies for combining multiple prefetch branches into one
+/// ranked result set.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum Fusion {
+    /// Reciprocal Rank Fusion. `k` is the smoothing constant (60 is a
+    /// common default in the literature).
+    Rrf { k: u64 },
+    /// Distribution-based Score Fusion.
+    Dbsf,
+}
+
+impl From<Fusion> for FusionInternal {
+    fn from(f: Fusion) -> Self {
+        match f {
+            Fusion::Rrf { k } => FusionInternal::Rrf {
+                k: k as usize,
+                weights: None,
+            },
+            Fusion::Dbsf => FusionInternal::Dbsf,
+        }
+    }
+}
+
+// ── OrderBy ─────────────────────────────────────────────────────────────────
+
+/// Orders results by a payload field rather than vector similarity.
+///
+/// Requires the payload `key` to have a numeric index.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OrderBy {
+    /// Payload key to sort by. JSON-path syntax is supported.
+    pub key: String,
+    /// Sort direction. Defaults to ascending when unset.
+    pub direction: Option<Direction>,
+}
+
+impl From<OrderBy> for SegmentOrderBy {
+    fn from(o: OrderBy) -> Self {
+        SegmentOrderBy {
+            key: o.key.parse().expect("valid json path"),
+            direction: o.direction.map(SegmentDirection::from),
+            start_from: None,
+        }
+    }
+}
+
+// ── Direction ───────────────────────────────────────────────────────────────
+
+/// Sort direction used by [`OrderBy`].
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum Direction {
+    /// Ascending (smallest first).
+    Asc,
+    /// Descending (largest first).
+    Desc,
+}
+
+impl From<Direction> for SegmentDirection {
+    fn from(d: Direction) -> Self {
+        match d {
+            Direction::Asc => SegmentDirection::Asc,
+            Direction::Desc => SegmentDirection::Desc,
+        }
+    }
+}
+
+// ── Sample ──────────────────────────────────────────────────────────────────
+
+/// Sampling strategies for [`ScoringQuery::Sample`].
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum Sample {
+    /// Uniform random sampling.
+    Random,
+}
+
+impl From<Sample> for SampleInternal {
+    fn from(s: Sample) -> Self {
+        match s {
+            Sample::Random => SampleInternal::Random,
+        }
+    }
+}
+
+// ── Prefetch ────────────────────────────────────────────────────────────────
+
+/// A single branch of a multi-stage query pipeline.
+///
+/// Prefetches produce candidate sets that are then combined (e.g. fused,
+/// reranked) by the outer [`QueryRequest`]. Prefetches can themselves
+/// contain nested prefetches for more complex pipelines.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct Prefetch {
+    /// Maximum number of candidates this branch contributes.
+    pub limit: u64,
+    /// Scoring strategy for this branch. `None`/`null` means "pass-through"
+    /// if there are nested `prefetches`.
+    pub query: Option<ScoringQuery>,
+    /// Nested prefetch branches (for recursive fusion / reranking).
+    pub prefetches: Vec<Prefetch>,
+    /// Optional filter applied to this branch only.
+    pub filter: Option<Filter>,
+    /// Minimum score threshold; candidates scoring below are dropped.
+    pub score_threshold: Option<f32>,
+    /// Branch-specific search parameters.
+    pub params: Option<SearchParams>,
+}
+
+impl From<Prefetch> for ShardPrefetch {
+    fn from(p: Prefetch) -> Self {
+        ShardPrefetch {
+            prefetches: p.prefetches.into_iter().map(ShardPrefetch::from).collect(),
+            limit: p.limit as usize,
+            query: p.query.map(shard::query::ScoringQuery::from),
+            params: p.params.map(SegmentSearchParams::from),
+            filter: p.filter.map(SegmentFilter::from),
+            score_threshold: p.score_threshold.map(OrderedFloat),
+        }
+    }
+}
+
+// ── QueryRequest ────────────────────────────────────────────────────────────
+
+/// The general-purpose query request supporting prefetching, fusion, and
+/// re-ranking.
+///
+/// For a plain nearest-neighbor search use [`SearchRequest`] instead — it
+/// has a smaller surface area.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct QueryRequest {
+    /// Maximum number of results to return.
+    pub limit: u64,
+    /// Number of results to skip (for pagination).
+    pub offset: Option<u64>,
+    /// Scoring strategy. If `None`/`null`, the request must have
+    /// `prefetches` and relies on fusion implicit in the prefetch stage.
+    pub query: Option<ScoringQuery>,
+    /// Optional prefetch branches used for multi-stage retrieval / fusion.
+    pub prefetches: Vec<Prefetch>,
+    /// Include vectors in the response.
+    pub with_vector: Option<WithVector>,
+    /// Include payload in the response.
+    pub with_payload: Option<WithPayload>,
+    /// Optional filter applied to all candidates.
+    pub filter: Option<Filter>,
+    /// Minimum score threshold; candidates scoring below are dropped.
+    pub score_threshold: Option<f32>,
+    /// Search tuning parameters.
+    pub params: Option<SearchParams>,
+}
+
+impl From<QueryRequest> for ShardQueryRequest {
+    fn from(r: QueryRequest) -> Self {
+        ShardQueryRequest {
+            prefetches: r.prefetches.into_iter().map(ShardPrefetch::from).collect(),
+            limit: r.limit as usize,
+            offset: r.offset.unwrap_or(0) as usize,
+            with_vector: r.with_vector.map(SegmentWithVector::from).unwrap_or_default(),
+            with_payload: r
+                .with_payload
+                .map(WithPayloadInterface::from)
+                .unwrap_or_default(),
+            query: r.query.map(shard::query::ScoringQuery::from),
+            filter: r.filter.map(SegmentFilter::from),
+            score_threshold: r.score_threshold.map(OrderedFloat),
+            params: r.params.map(SegmentSearchParams::from),
+        }
+    }
+}
+
+// ── SearchRequest ───────────────────────────────────────────────────────────
+
+/// A plain nearest-neighbor search request.
+///
+/// Use this for the common case of "find the K most similar points to this
+/// vector, optionally filtered". For more advanced pipelines (fusion,
+/// multi-stage retrieval) use [`QueryRequest`].
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct SearchRequest {
+    /// Vector query describing what to search for.
+    pub query: Query,
+    /// Maximum number of results to return.
+    pub limit: u64,
+    /// Number of results to skip (for pagination).
+    pub offset: Option<u64>,
+    /// Optional filter applied to all candidates.
+    pub filter: Option<Filter>,
+    /// Search tuning parameters.
+    pub params: Option<SearchParams>,
+    /// Include vectors in the response.
+    pub with_vector: Option<WithVector>,
+    /// Include payload in the response.
+    pub with_payload: Option<WithPayload>,
+    /// Minimum score threshold; candidates scoring below are dropped.
+    pub score_threshold: Option<f32>,
+}
+
+impl From<SearchRequest> for CoreSearchRequest {
+    fn from(r: SearchRequest) -> Self {
+        CoreSearchRequest {
+            query: QueryEnum::from(r.query),
+            limit: r.limit as usize,
+            offset: r.offset.unwrap_or(0) as usize,
+            filter: r.filter.map(SegmentFilter::from),
+            params: r.params.map(SegmentSearchParams::from),
+            with_vector: r.with_vector.map(SegmentWithVector::from),
+            with_payload: r.with_payload.map(WithPayloadInterface::from),
+            score_threshold: r.score_threshold,
+        }
+    }
+}
+
+// ── ScrollRequest ───────────────────────────────────────────────────────────
+
+/// A batched iteration request.
+///
+/// Pass the returned `next_offset` from
+/// [`ScrollResponse`](crate::ScrollResponse) as `offset` on the next call to
+/// page through all matching points.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ScrollRequest {
+    /// Opaque cursor from a previous scroll, or `None`/`null` to start
+    /// from the beginning.
+    pub offset: Option<PointId>,
+    /// Maximum points per page. Defaults to a server-side value when unset.
+    pub limit: Option<u64>,
+    /// Optional filter applied to the iteration.
+    pub filter: Option<Filter>,
+    /// Include payload in each record.
+    pub with_payload: Option<WithPayload>,
+    /// Include vectors in each record.
+    pub with_vector: Option<WithVector>,
+    /// Iterate in payload-key order instead of ID order. Requires a
+    /// payload index on the key.
+    pub order_by: Option<OrderBy>,
+}
+
+impl From<ScrollRequest> for ScrollRequestInternal {
+    fn from(r: ScrollRequest) -> Self {
+        ScrollRequestInternal {
+            offset: r.offset.map(PointIdType::from),
+            limit: r.limit.map(|v| v as usize),
+            filter: r.filter.map(SegmentFilter::from),
+            with_payload: r.with_payload.map(WithPayloadInterface::from),
+            with_vector: r.with_vector.map(SegmentWithVector::from).unwrap_or_default(),
+            order_by: r.order_by.map(|o| OrderByInterface::Struct(SegmentOrderBy::from(o))),
+        }
+    }
+}
+
+// ── CountRequest ────────────────────────────────────────────────────────────
+
+/// A point-counting request.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct CountRequest {
+    /// Optional filter. `None`/`null` counts all points in the shard.
+    pub filter: Option<Filter>,
+    /// If `true`, return an exact count (scans every matching point);
+    /// otherwise, the shard is free to return a fast estimate.
+    pub exact: bool,
+}
+
+impl From<CountRequest> for CountRequestInternal {
+    fn from(r: CountRequest) -> Self {
+        CountRequestInternal {
+            filter: r.filter.map(SegmentFilter::from),
+            exact: r.exact,
+        }
+    }
+}
+
+// ── FacetRequest ────────────────────────────────────────────────────────────
+
+/// A facet (grouped count) request.
+///
+/// Facets aggregate distinct payload values with counts, useful for
+/// building UI filter sidebars.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FacetRequest {
+    /// Payload key to facet on. Must have a payload index.
+    pub key: String,
+    /// Maximum number of distinct values to return.
+    pub limit: u64,
+    /// If `true`, count every matching point; otherwise a fast estimate
+    /// may be returned.
+    pub exact: bool,
+    /// Optional filter restricting which points participate in the facet.
+    pub filter: Option<Filter>,
+}
+
+impl From<FacetRequest> for FacetRequestInternal {
+    fn from(r: FacetRequest) -> Self {
+        FacetRequestInternal {
+            key: r.key.parse().expect("valid json path"),
+            limit: r.limit as usize,
+            filter: r.filter.map(SegmentFilter::from),
+            exact: r.exact,
+        }
+    }
+}
+
+// ── FacetResponse ───────────────────────────────────────────────────────────
+
+/// A single (value, count) row in a facet response.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FacetHit {
+    /// Facet value, stringified. Integer/UUID/bool values are rendered as
+    /// their canonical string form.
+    pub value: String,
+    /// Number of points with this facet value.
+    pub count: u64,
+}
+
+/// The result of a facet aggregation.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FacetResponse {
+    /// Hits in descending count order, up to `FacetRequest.limit` entries.
+    pub hits: Vec<FacetHit>,
+}
+
+// ── ShardInfo ───────────────────────────────────────────────────────────────
+
+/// Summary information about a shard's on-disk state.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ShardInfo {
+    /// Number of segments in the shard.
+    pub segments_count: u64,
+    /// Total number of points across all segments.
+    pub points_count: u64,
+    /// Number of vectors that have been indexed (i.e. reachable via ANN).
+    pub indexed_vectors_count: u64,
+}

--- a/lib/edge/ffi/src/types.rs
+++ b/lib/edge/ffi/src/types.rs
@@ -1,0 +1,369 @@
+use std::collections::HashMap;
+
+use segment::data_types::vectors::VectorStructInternal;
+use segment::types::{
+    Payload, PointIdType, ScoredPoint as SegmentScoredPoint,
+    WithPayloadInterface, WithVector as SegmentWithVector,
+};
+use shard::operations::point_ops::{
+    PointStructPersisted, VectorPersisted, VectorStructPersisted,
+};
+use shard::retrieve::record_internal::RecordInternal;
+use sparse::common::sparse_vector::SparseVector as InternalSparseVector;
+
+// ── PointId ─────────────────────────────────────────────────────────────────
+
+/// The identifier of a point stored in a shard.
+///
+/// Every point has exactly one ID, which is either a 64-bit unsigned
+/// integer or a UUID string. IDs must be unique within a shard.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum PointId {
+    /// Numeric identifier.
+    NumId { value: u64 },
+    /// UUID identifier formatted as a canonical `8-4-4-4-12` hyphenated
+    /// string. Must parse as a valid RFC 4122 UUID.
+    Uuid { value: String },
+}
+
+impl From<PointId> for PointIdType {
+    fn from(id: PointId) -> Self {
+        match id {
+            PointId::NumId { value } => PointIdType::NumId(value),
+            PointId::Uuid { value } => {
+                PointIdType::Uuid(uuid::Uuid::parse_str(&value).expect("valid UUID"))
+            }
+        }
+    }
+}
+
+impl From<PointIdType> for PointId {
+    fn from(id: PointIdType) -> Self {
+        match id {
+            PointIdType::NumId(value) => PointId::NumId { value },
+            PointIdType::Uuid(value) => PointId::Uuid {
+                value: value.to_string(),
+            },
+        }
+    }
+}
+
+// ── SparseVector ────────────────────────────────────────────────────────────
+
+/// A sparse vector represented as parallel arrays of indices and values.
+///
+/// Produced by sparse embedding models such as SPLADE or BM42. `indices` and
+/// `values` must have the same length; each `indices[i]` is a feature/token
+/// ID whose weight is `values[i]`. Indices are typically sorted in ascending
+/// order, though Qdrant does not require it.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct SparseVector {
+    /// Non-zero feature indices.
+    pub indices: Vec<u32>,
+    /// Weights aligned 1-to-1 with `indices`.
+    pub values: Vec<f32>,
+}
+
+impl From<SparseVector> for InternalSparseVector {
+    fn from(v: SparseVector) -> Self {
+        InternalSparseVector {
+            indices: v.indices,
+            values: v.values,
+        }
+    }
+}
+
+impl From<InternalSparseVector> for SparseVector {
+    fn from(v: InternalSparseVector) -> Self {
+        SparseVector {
+            indices: v.indices,
+            values: v.values,
+        }
+    }
+}
+
+// ── NamedVector ─────────────────────────────────────────────────────────────
+
+/// A single vector value associated with a specific vector field.
+///
+/// The variant chosen must match the field's configuration in
+/// [`EdgeConfig`](crate::config::EdgeConfig) — for example, a `Dense`
+/// variant cannot be stored in a field declared as sparse.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum NamedVector {
+    /// A single dense vector. Component count must match the field's
+    /// `size`.
+    Dense { values: Vec<f32> },
+    /// A sparse vector (SPLADE-, BM42-style).
+    Sparse { vector: SparseVector },
+    /// A multi-vector: a variable number of dense vectors (e.g. ColBERT
+    /// per-token embeddings).
+    MultiDense { vectors: Vec<Vec<f32>> },
+}
+
+impl From<NamedVector> for VectorPersisted {
+    fn from(v: NamedVector) -> Self {
+        match v {
+            NamedVector::Dense { values } => VectorPersisted::Dense(values),
+            NamedVector::Sparse { vector } => {
+                VectorPersisted::Sparse(InternalSparseVector::from(vector))
+            }
+            NamedVector::MultiDense { vectors } => VectorPersisted::MultiDense(vectors),
+        }
+    }
+}
+
+impl From<VectorPersisted> for NamedVector {
+    fn from(v: VectorPersisted) -> Self {
+        match v {
+            VectorPersisted::Dense(values) => NamedVector::Dense { values },
+            VectorPersisted::Sparse(vector) => NamedVector::Sparse {
+                vector: SparseVector::from(vector),
+            },
+            VectorPersisted::MultiDense(vectors) => NamedVector::MultiDense { vectors },
+        }
+    }
+}
+
+// ── Vector (top-level input for point construction) ─────────────────────────
+
+/// The vector payload attached to a [`Point`] at upsert time.
+///
+/// Use `Single` for shards with exactly one dense vector field, `Named` for
+/// shards with multiple vector fields, and `MultiDense` for a single
+/// multi-vector field.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum Vector {
+    /// A single dense vector, to be stored in the shard's (sole) dense
+    /// vector field.
+    Single { values: Vec<f32> },
+    /// A variable-sized multi-vector, stored in the shard's (sole)
+    /// multi-vector field.
+    MultiDense { vectors: Vec<Vec<f32>> },
+    /// A map of vector field names to per-field values. Use this variant
+    /// when the shard has more than one vector field or mixes dense and
+    /// sparse vectors.
+    Named { map: HashMap<String, NamedVector> },
+}
+
+impl From<Vector> for VectorStructPersisted {
+    fn from(v: Vector) -> Self {
+        match v {
+            Vector::Single { values } => VectorStructPersisted::Single(values),
+            Vector::MultiDense { vectors } => VectorStructPersisted::MultiDense(vectors),
+            Vector::Named { map } => VectorStructPersisted::Named(
+                map.into_iter()
+                    .map(|(k, v)| (k, VectorPersisted::from(v)))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+impl From<VectorStructPersisted> for Vector {
+    fn from(v: VectorStructPersisted) -> Self {
+        match v {
+            VectorStructPersisted::Single(values) => Vector::Single { values },
+            VectorStructPersisted::MultiDense(vectors) => Vector::MultiDense { vectors },
+            VectorStructPersisted::Named(map) => Vector::Named {
+                map: map
+                    .into_iter()
+                    .map(|(k, v)| (k, NamedVector::from(v)))
+                    .collect(),
+            },
+        }
+    }
+}
+
+// ── Payload (JSON string) ───────────────────────────────────────────────────
+
+/// Payload is represented as a JSON string across the FFI boundary.
+pub fn payload_to_json(payload: &Payload) -> String {
+    serde_json::to_string(&payload.0).unwrap_or_default()
+}
+
+pub fn json_to_payload(json: &str) -> std::result::Result<Payload, String> {
+    let map: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(json).map_err(|e| e.to_string())?;
+    Ok(Payload(map))
+}
+
+fn vector_struct_internal_to_json(v: &VectorStructInternal) -> String {
+    match v {
+        VectorStructInternal::Single(dense) => serde_json::to_string(dense).unwrap_or_default(),
+        VectorStructInternal::MultiDense(multi) => {
+            serde_json::to_string(multi).unwrap_or_default()
+        }
+        VectorStructInternal::Named(map) => serde_json::to_string(map).unwrap_or_default(),
+    }
+}
+
+// ── WithPayload / WithVector ────────────────────────────────────────────────
+
+/// Controls which payload fields are included in retrieval responses.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum WithPayload {
+    /// Include all payload fields (`enable = true`) or none
+    /// (`enable = false`).
+    Bool { enable: bool },
+    /// Include only the listed payload fields. Use JSON-path syntax to
+    /// select nested keys (e.g. `"meta.author"`).
+    Fields { fields: Vec<String> },
+}
+
+impl From<WithPayload> for WithPayloadInterface {
+    fn from(w: WithPayload) -> Self {
+        match w {
+            WithPayload::Bool { enable } => WithPayloadInterface::Bool(enable),
+            WithPayload::Fields { fields } => {
+                WithPayloadInterface::Fields(fields.into_iter().filter_map(|f| f.parse().ok()).collect())
+            }
+        }
+    }
+}
+
+/// Controls which vector fields are included in retrieval responses.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum WithVector {
+    /// Include all vectors (`enable = true`) or none (`enable = false`).
+    Bool { enable: bool },
+    /// Include only the listed vector fields (by name).
+    Names { names: Vec<String> },
+}
+
+impl From<WithVector> for SegmentWithVector {
+    fn from(w: WithVector) -> Self {
+        match w {
+            WithVector::Bool { enable } => SegmentWithVector::Bool(enable),
+            WithVector::Names { names } => SegmentWithVector::Selector(names),
+        }
+    }
+}
+
+// ── Point ───────────────────────────────────────────────────────────────────
+
+/// A point to be upserted into a shard.
+///
+/// ## Example
+///
+/// ```swift
+/// let point = Point(
+///     id: .numId(value: 42),
+///     vector: .single(values: [0.1, 0.2, 0.3, 0.4]),
+///     payload: #"{"title":"Hello"}"#
+/// )
+/// ```
+///
+/// ```kotlin
+/// val point = Point(
+///     id = PointId.NumId(42u),
+///     vector = Vector.Single(listOf(0.1f, 0.2f, 0.3f, 0.4f)),
+///     payload = """{"title":"Hello"}""",
+/// )
+/// ```
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct Point {
+    /// Unique identifier within the shard.
+    pub id: PointId,
+    /// Vector value(s). Must match the shard's configured vector fields.
+    pub vector: Vector,
+    /// Optional payload, encoded as a JSON object string.
+    /// `None`/`null` stores an empty payload.
+    pub payload: Option<String>,
+}
+
+impl Point {
+    pub fn into_internal(self) -> std::result::Result<PointStructPersisted, String> {
+        let payload = match self.payload {
+            Some(json) => Some(json_to_payload(&json)?),
+            None => None,
+        };
+        Ok(PointStructPersisted {
+            id: PointIdType::from(self.id),
+            vector: VectorStructPersisted::from(self.vector),
+            payload,
+        })
+    }
+}
+
+// ── ScoredPoint ─────────────────────────────────────────────────────────────
+
+/// A single search hit returned from [`EdgeShard::search`] or
+/// [`EdgeShard::query`].
+///
+/// [`EdgeShard::search`]: crate::EdgeShard::search
+/// [`EdgeShard::query`]: crate::EdgeShard::query
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ScoredPoint {
+    /// The point's identifier.
+    pub id: PointId,
+    /// The shard-local version of the point at the time it was returned.
+    pub version: u64,
+    /// Similarity score against the query. Higher is better for `Cosine`
+    /// and `Dot`; lower is better for `Euclid` and `Manhattan`.
+    pub score: f32,
+    /// Payload as a JSON object string, or `None`/`null` if the request
+    /// did not ask for payload.
+    pub payload: Option<String>,
+    /// Vectors as a JSON string, or `None`/`null` if the request did not
+    /// ask for vectors.
+    pub vector: Option<String>,
+}
+
+impl From<SegmentScoredPoint> for ScoredPoint {
+    fn from(p: SegmentScoredPoint) -> Self {
+        ScoredPoint {
+            id: PointId::from(p.id),
+            version: p.version,
+            score: p.score,
+            payload: p.payload.map(|p| payload_to_json(&p)),
+            vector: p
+                .vector
+                .as_ref()
+                .map(|v| vector_struct_internal_to_json(v)),
+        }
+    }
+}
+
+// ── Record ──────────────────────────────────────────────────────────────────
+
+/// A point returned from [`EdgeShard::retrieve`] or
+/// [`EdgeShard::scroll`], without a similarity score.
+///
+/// [`EdgeShard::retrieve`]: crate::EdgeShard::retrieve
+/// [`EdgeShard::scroll`]: crate::EdgeShard::scroll
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct Record {
+    /// The point's identifier.
+    pub id: PointId,
+    /// Payload as a JSON object string, or `None`/`null` if not requested.
+    pub payload: Option<String>,
+    /// Vectors as a JSON string, or `None`/`null` if not requested.
+    pub vector: Option<String>,
+}
+
+impl From<RecordInternal> for Record {
+    fn from(r: RecordInternal) -> Self {
+        Record {
+            id: PointId::from(r.id),
+            payload: r.payload.map(|p| payload_to_json(&p)),
+            vector: r
+                .vector
+                .as_ref()
+                .map(|v| vector_struct_internal_to_json(v)),
+        }
+    }
+}
+
+// ── PointVectors (for update_vectors) ───────────────────────────────────────
+
+/// Replacement vectors for an existing point, used with
+/// [`UpdateOperation::update_vectors`](crate::update::UpdateOperation::update_vectors).
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct PointVectors {
+    /// The point to update. Must already exist in the shard.
+    pub id: PointId,
+    /// New vector value(s). Only the named fields present here are
+    /// replaced; other vector fields on the point are left untouched.
+    pub vector: Vector,
+}

--- a/lib/edge/ffi/src/update.rs
+++ b/lib/edge/ffi/src/update.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use segment::types::{Filter as SegmentFilter, PointIdType};
+use shard::operations::point_ops::{
+    PointIdsList, PointInsertOperationsInternal, VectorStructPersisted,
+};
+use shard::operations::{CollectionUpdateOperations, payload_ops, point_ops, vector_ops};
+
+use crate::filter::Filter;
+use crate::types::{Point, PointId, PointVectors, json_to_payload};
+
+// ── UpdateMode ──────────────────────────────────────────────────────────────
+
+/// Controls how an upsert handles existing vs. missing point IDs.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum UpdateMode {
+    /// Insert new points and overwrite existing points (default).
+    Upsert,
+    /// Fail if any provided ID already exists.
+    InsertOnly,
+    /// Fail if any provided ID does not already exist.
+    UpdateOnly,
+}
+
+impl From<UpdateMode> for shard::operations::point_ops::UpdateMode {
+    fn from(m: UpdateMode) -> Self {
+        match m {
+            UpdateMode::Upsert => shard::operations::point_ops::UpdateMode::Upsert,
+            UpdateMode::InsertOnly => shard::operations::point_ops::UpdateMode::InsertOnly,
+            UpdateMode::UpdateOnly => shard::operations::point_ops::UpdateMode::UpdateOnly,
+        }
+    }
+}
+
+// ── UpdateOperation ─────────────────────────────────────────────────────────
+
+/// An opaque, immutable description of a single update to apply to a shard.
+///
+/// Build one via the static constructors (`upsertPoints`, `deletePoints`,
+/// `setPayload`, …) and pass it to [`EdgeShard::update`](crate::EdgeShard::update).
+/// All changes contained in a single `UpdateOperation` are applied
+/// atomically.
+///
+/// ## Example
+///
+/// ```swift
+/// let op = try UpdateOperation.upsertPoints(points: [point1, point2])
+/// try shard.update(operation: op)
+/// ```
+///
+/// ```kotlin
+/// val op = UpdateOperation.upsertPoints(listOf(point1, point2))
+/// shard.update(op)
+/// ```
+#[derive(uniffi::Object)]
+pub struct UpdateOperation {
+    pub(crate) inner: CollectionUpdateOperations,
+}
+
+#[uniffi::export]
+impl UpdateOperation {
+    /// Builds an upsert operation: insert new points and overwrite any
+    /// existing points with matching IDs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`](crate::error::EdgeError)
+    /// if any point's `payload` field is not valid JSON or any UUID ID is
+    /// malformed.
+    #[uniffi::constructor]
+    pub fn upsert_points(
+        points: Vec<Point>,
+    ) -> std::result::Result<Arc<Self>, crate::error::EdgeError> {
+        let internal_points: std::result::Result<Vec<_>, _> =
+            points.into_iter().map(|p| p.into_internal()).collect();
+        let internal_points =
+            internal_points.map_err(|e| crate::error::EdgeError::OperationError { message: e })?;
+        let points = PointInsertOperationsInternal::PointsList(internal_points);
+        let operation = point_ops::PointOperations::UpsertPoints(points);
+        Ok(Arc::new(Self {
+            inner: CollectionUpdateOperations::PointOperation(operation),
+        }))
+    }
+
+    /// Builds an operation that deletes the points with the given IDs.
+    ///
+    /// IDs that do not exist in the shard are silently ignored.
+    #[uniffi::constructor]
+    pub fn delete_points(point_ids: Vec<PointId>) -> Arc<Self> {
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let operation = point_ops::PointOperations::DeletePoints { ids };
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::PointOperation(operation),
+        })
+    }
+
+    /// Builds an operation that deletes every point matching `filter`.
+    ///
+    /// Use a narrowly-scoped filter to avoid accidentally wiping the shard.
+    #[uniffi::constructor]
+    pub fn delete_points_by_filter(filter: Filter) -> Arc<Self> {
+        let operation = point_ops::PointOperations::DeletePointsByFilter(SegmentFilter::from(filter));
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::PointOperation(operation),
+        })
+    }
+
+    /// Builds an operation that replaces the vector fields of existing
+    /// points.
+    ///
+    /// Payload is left untouched. Only the vector fields present in each
+    /// [`PointVectors`] are replaced; other fields of the point are
+    /// preserved.
+    #[uniffi::constructor]
+    pub fn update_vectors(point_vectors: Vec<PointVectors>) -> Arc<Self> {
+        let points = point_vectors
+            .into_iter()
+            .map(|pv| shard::operations::vector_ops::PointVectorsPersisted {
+                id: PointIdType::from(pv.id),
+                vector: VectorStructPersisted::from(pv.vector),
+            })
+            .collect();
+        let operation =
+            vector_ops::VectorOperations::UpdateVectors(vector_ops::UpdateVectorsOp {
+                points,
+                update_filter: None,
+            });
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::VectorOperation(operation),
+        })
+    }
+
+    /// Builds an operation that removes named vectors from the given points.
+    ///
+    /// The points themselves remain; only the listed vector fields are
+    /// cleared.
+    #[uniffi::constructor]
+    pub fn delete_vectors(point_ids: Vec<PointId>, vector_names: Vec<String>) -> Arc<Self> {
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let operation =
+            vector_ops::VectorOperations::DeleteVectors(PointIdsList::from(ids), vector_names);
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::VectorOperation(operation),
+        })
+    }
+
+    /// Builds an operation that merges `payload_json` into the payloads of
+    /// the given points.
+    ///
+    /// Existing keys are overwritten; keys not present in `payload_json`
+    /// are preserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EdgeError::OperationError`](crate::error::EdgeError) if
+    /// `payload_json` is not a valid JSON object string.
+    #[uniffi::constructor]
+    pub fn set_payload(
+        point_ids: Vec<PointId>,
+        payload_json: String,
+    ) -> std::result::Result<Arc<Self>, crate::error::EdgeError> {
+        let payload = json_to_payload(&payload_json)
+            .map_err(|e| crate::error::EdgeError::OperationError { message: e })?;
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let operation = payload_ops::PayloadOps::SetPayload(payload_ops::SetPayloadOp {
+            payload,
+            points: Some(ids),
+            filter: None,
+            key: None,
+        });
+        Ok(Arc::new(Self {
+            inner: CollectionUpdateOperations::PayloadOperation(operation),
+        }))
+    }
+
+    /// Builds an operation that removes specific keys from the payload of
+    /// the given points.
+    ///
+    /// Keys use JSON-path syntax for nested values. Missing keys are
+    /// silently ignored.
+    #[uniffi::constructor]
+    pub fn delete_payload(point_ids: Vec<PointId>, keys: Vec<String>) -> Arc<Self> {
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let keys = keys
+            .into_iter()
+            .map(|k| k.parse().expect("valid json path"))
+            .collect();
+        let operation = payload_ops::PayloadOps::DeletePayload(payload_ops::DeletePayloadOp {
+            keys,
+            points: Some(ids),
+            filter: None,
+        });
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::PayloadOperation(operation),
+        })
+    }
+
+    /// Builds an operation that completely removes the payload of the
+    /// given points (all keys).
+    ///
+    /// The points themselves remain; only the payload is cleared.
+    #[uniffi::constructor]
+    pub fn clear_payload(point_ids: Vec<PointId>) -> Arc<Self> {
+        let ids: Vec<PointIdType> = point_ids.into_iter().map(PointIdType::from).collect();
+        let operation = payload_ops::PayloadOps::ClearPayload { points: ids };
+        Arc::new(Self {
+            inner: CollectionUpdateOperations::PayloadOperation(operation),
+        })
+    }
+}

--- a/lib/edge/ffi/uniffi.toml
+++ b/lib/edge/ffi/uniffi.toml
@@ -1,0 +1,4 @@
+[bindings.kotlin]
+# UniFFI-generated Kotlin lands in the internal `:qdrant-edge-ffi` module.
+# The public `:qdrant-edge` module re-exports it as `tech.qdrant.edge.*`.
+package_name = "tech.qdrant.edge.ffi"

--- a/lib/edge/swift/.gitignore
+++ b/lib/edge/swift/.gitignore
@@ -1,0 +1,4 @@
+/out/
+/target/
+.build/
+.swiftpm/

--- a/lib/edge/swift/Makefile
+++ b/lib/edge/swift/Makefile
@@ -1,0 +1,83 @@
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+SCRIPT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+WORKSPACE_ROOT := $(abspath $(SCRIPT_DIR)/../../..)
+XCFRAMEWORK := $(SCRIPT_DIR)out/QdrantEdge.xcframework
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+.PHONY: setup
+setup: setup-homebrew setup-rust setup-targets ## Install all prerequisites
+
+.PHONY: setup-homebrew
+setup-homebrew: ## Install Homebrew dependencies (protobuf)
+	@command -v brew >/dev/null 2>&1 || { echo "Homebrew not found. Install from https://brew.sh"; exit 1; }
+	brew install protobuf
+
+.PHONY: setup-rust
+setup-rust: ## Install Rust toolchain (stable + nightly for tier-3 targets)
+	@if ! command -v rustup >/dev/null 2>&1; then \
+		echo "Installing rustup..."; \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
+		echo 'source "$$HOME/.cargo/env"' >> ~/.zshrc; \
+	fi
+	rustup toolchain install nightly --profile minimal
+	rustup component add rust-src --toolchain nightly
+	@echo "Rust toolchain OK: $$(rustc --version 2>/dev/null || echo 'restart shell to activate')"
+
+.PHONY: setup-targets
+setup-targets: ## Install required Rust cross-compilation targets
+	rustup target add \
+		aarch64-apple-ios \
+		aarch64-apple-ios-sim \
+		x86_64-apple-ios \
+		aarch64-apple-darwin \
+		x86_64-apple-darwin
+	@echo "tvOS/visionOS targets are tier-3 and will be built with nightly -Z build-std"
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+.PHONY: build
+build: ## Build the XCFramework (iOS + macOS)
+	@bash $(SCRIPT_DIR)build-xcframework.sh
+
+.PHONY: build-all
+build-all: ## Build the XCFramework (all platforms incl. tvOS/visionOS)
+	@bash $(SCRIPT_DIR)build-xcframework.sh --all-platforms
+
+.PHONY: build-debug
+build-debug: ## Build the XCFramework (debug, iOS + macOS)
+	@bash $(SCRIPT_DIR)build-xcframework.sh --debug
+
+# ── Info ─────────────────────────────────────────────────────────────────────
+
+.PHONY: size
+size: ## Show XCFramework size breakdown
+	@if [ ! -d "$(XCFRAMEWORK)" ]; then \
+		echo "XCFramework not found. Run 'make build' first."; exit 1; \
+	fi
+	@echo "=== XCFramework total ==="
+	@du -sh "$(XCFRAMEWORK)"
+	@echo ""
+	@echo "=== Per-platform static library sizes ==="
+	@find "$(XCFRAMEWORK)" -name '*.a' -exec sh -c 'echo "$$(du -sh "$$1" | cut -f1)\t$$(basename $$(dirname $$(dirname "$$1")))"' _ {} \;
+	@echo ""
+	@echo "=== Architecture details ==="
+	@find "$(XCFRAMEWORK)" -name '*.a' | while read lib; do \
+		echo "--- $$(basename $$(dirname $$(dirname "$$lib"))) ---"; \
+		lipo -info "$$lib"; \
+	done
+
+# ── Clean ────────────────────────────────────────────────────────────────────
+
+.PHONY: clean
+clean: ## Remove build outputs
+	rm -rf $(SCRIPT_DIR)out
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/lib/edge/swift/Package.swift
+++ b/lib/edge/swift/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "QdrantEdge",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v13),
+        .tvOS(.v15),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "QdrantEdge",
+            targets: ["QdrantEdge", "qdrant_edge_ffiFFI"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "QdrantEdge",
+            dependencies: ["qdrant_edge_ffiFFI"],
+            path: "out/swift-bindings",
+            sources: ["QdrantEdge.swift"]
+        ),
+        .binaryTarget(
+            name: "qdrant_edge_ffiFFI",
+            path: "out/QdrantEdge.xcframework"
+        ),
+    ]
+)

--- a/lib/edge/swift/README.md
+++ b/lib/edge/swift/README.md
@@ -1,0 +1,79 @@
+# Qdrant Edge — Swift
+
+Swift bindings for [Qdrant Edge](https://qdrant.tech/documentation/edge/edge-quickstart/),
+the embeddable vector search engine. Ships as an **XCFramework** with
+pre-compiled static libraries for iOS, macOS, and (optionally) tvOS/visionOS.
+
+## Supported slices
+
+| Slice                            | Architectures    | Purpose                              |
+|----------------------------------|------------------|--------------------------------------|
+| `ios-arm64`                      | arm64            | Physical iOS devices                 |
+| `ios-arm64_x86_64-simulator`     | arm64 + x86_64   | iOS Simulator (Apple Silicon/Intel)  |
+| `macos-arm64_x86_64`             | arm64 + x86_64   | Native macOS apps                    |
+| `tvos-arm64`                     | arm64            | Physical Apple TV                    |
+| `tvos-arm64_x86_64-simulator`    | arm64 + x86_64   | tvOS Simulator                       |
+| `visionos-arm64`                 | arm64            | Apple Vision Pro                     |
+| `visionos-arm64-simulator`       | arm64            | visionOS Simulator                   |
+
+`make build` covers iOS + macOS. `make build-all` adds tvOS and visionOS;
+those are Rust tier-3 targets and require the nightly toolchain.
+
+## Quick start
+
+```bash
+make setup      # Install Rust, protobuf, cross-compilation targets
+make build      # Build the XCFramework (release)
+make size       # Show XCFramework size breakdown
+```
+
+## Integration
+
+Add the package to your Swift project:
+
+```swift
+.package(path: "path/to/lib/edge/swift")
+```
+
+Import and use:
+
+```swift
+import QdrantEdge
+
+let shard = try EdgeShard.load(path: dataDir, config: config)
+```
+
+See `example/` for a complete demo app.
+
+## Project layout
+
+```
+swift/
+├── build-xcframework.sh       Cross-compile Rust + generate Swift bindings
+├── demote-ffi-internals.sh    Post-process QdrantEdge.swift (see below)
+├── Makefile                   setup / build / build-all / size / clean
+├── Package.swift              SPM manifest
+├── example/                   Swift example app
+└── out/                       Build output (gitignored)
+    ├── QdrantEdge.xcframework
+    └── swift-bindings/        QdrantEdge.swift + QdrantEdgeFFI.h
+```
+
+The Rust crate and `uniffi-bindgen` CLI live under `lib/edge/ffi/`.
+
+## Public API
+
+UniFFI emits `QdrantEdge.swift` with a mix of user-facing domain types
+(`EdgeShard`, `Point`, `Query`, `Filter`, …) and FFI plumbing
+(`FfiConverter*`, `RustBuffer`, `Uniffi*`, `*_lift`/`*_lower`, …). After
+generation, `demote-ffi-internals.sh` rewrites the plumbing declarations
+from `public` to `internal`, so `import QdrantEdge` in consumer code only
+surfaces the real domain API.
+
+The rewrite is safe because `QdrantEdge.swift` compiles into a single
+Swift module; the plumbing is only referenced from within that file, and
+`internal` keeps those references valid while hiding them from consumers.
+
+Every public type and method carries doc comments authored in Rust that
+UniFFI propagates to Swift Quick Help. ⌥-click in Xcode for summaries,
+error notes, and examples.

--- a/lib/edge/swift/build-xcframework.sh
+++ b/lib/edge/swift/build-xcframework.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Build Qdrant Edge as an XCFramework with Swift bindings.
+#
+# Prerequisites:
+#   - Xcode (with command-line tools)
+#   - Rust toolchain (rustup)
+#   - For tvOS/visionOS: nightly toolchain + rust-src (see `make setup`)
+#
+# Usage:
+#   ./build-xcframework.sh [--debug] [--all-platforms]
+#
+#   --debug          Build in debug mode (faster compile, larger binary)
+#   --all-platforms  Include tvOS and visionOS (tier-3, requires nightly)
+#
+# Output:
+#   out/QdrantEdge.xcframework   - The XCFramework
+#   out/swift-bindings/          - Generated Swift source and headers
+
+set -euo pipefail
+
+# Force the default target directory; a stray env var from the parent shell
+# would otherwise send outputs somewhere this script doesn't expect.
+unset CARGO_TARGET_DIR CARGO_BUILD_TARGET_DIR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+OUT_DIR="$SCRIPT_DIR/out"
+BINDINGS_DIR="$OUT_DIR/swift-bindings"
+XCFRAMEWORK_DIR="$OUT_DIR/QdrantEdge.xcframework"
+
+CRATE_NAME="qdrant_edge_ffi"
+LIB_NAME="lib${CRATE_NAME}.a"
+PACKAGE_NAME="qdrant-edge-ffi"
+
+# Release builds use the `release-mobile` Cargo profile (thin LTO,
+# `strip = "symbols"`, `panic = "abort"`) defined in the workspace Cargo.toml.
+PROFILE="release-mobile"
+CARGO_FLAGS="--profile release-mobile"
+ALL_PLATFORMS=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --debug) PROFILE="debug"; CARGO_FLAGS="" ;;
+        --all-platforms) ALL_PLATFORMS=true ;;
+        -h|--help)
+            awk '/^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+            exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# ── Targets ──────────────────────────────────────────────────────────────────
+
+# Tier 1/2 — build with stable toolchain
+STABLE_TARGETS=(
+    "aarch64-apple-ios"           # iOS devices
+    "aarch64-apple-ios-sim"       # iOS Simulator (Apple Silicon)
+    "x86_64-apple-ios"            # iOS Simulator (Intel)
+    "aarch64-apple-darwin"        # macOS (Apple Silicon)
+    "x86_64-apple-darwin"         # macOS (Intel)
+)
+
+# Tier 3 — require nightly + -Z build-std
+TIER3_TARGETS=()
+if $ALL_PLATFORMS; then
+    TIER3_TARGETS=(
+        "aarch64-apple-tvos"          # tvOS devices
+        "aarch64-apple-tvos-sim"      # tvOS Simulator (Apple Silicon)
+        "x86_64-apple-tvos"           # tvOS Simulator (Intel)
+        "aarch64-apple-visionos"      # visionOS devices
+        "aarch64-apple-visionos-sim"  # visionOS Simulator
+    )
+fi
+
+ALL_TARGETS=("${STABLE_TARGETS[@]}" ${TIER3_TARGETS[@]+"${TIER3_TARGETS[@]}"})
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+echo "==> Installing required Rust targets..."
+for target in "${STABLE_TARGETS[@]}"; do
+    rustup target add "$target" 2>/dev/null || true
+done
+
+echo "==> Building static libraries..."
+for target in "${STABLE_TARGETS[@]}"; do
+    echo "    Building for $target (stable)..."
+    cargo build $CARGO_FLAGS \
+        --lib \
+        --package "$PACKAGE_NAME" \
+        --target "$target" \
+        --manifest-path "$WORKSPACE_ROOT/Cargo.toml"
+done
+for target in ${TIER3_TARGETS[@]+"${TIER3_TARGETS[@]}"}; do
+    echo "    Building for $target (nightly + build-std)..."
+    cargo +nightly build $CARGO_FLAGS \
+        --lib \
+        --package "$PACKAGE_NAME" \
+        --target "$target" \
+        --manifest-path "$WORKSPACE_ROOT/Cargo.toml" \
+        -Z build-std
+done
+
+# The `release-mobile` profile already strips symbols; `--debug` keeps them
+# for backtraces. Any other profile would need an explicit `strip -S` pass
+# here, which we don't support at the moment.
+
+# ── Universal (fat) libraries ────────────────────────────────────────────────
+
+echo "==> Creating universal (fat) libraries..."
+mkdir -p "$OUT_DIR/ios-simulator-universal"
+mkdir -p "$OUT_DIR/macos-universal"
+
+lipo -create \
+    "$WORKSPACE_ROOT/target/aarch64-apple-ios-sim/$PROFILE/$LIB_NAME" \
+    "$WORKSPACE_ROOT/target/x86_64-apple-ios/$PROFILE/$LIB_NAME" \
+    -output "$OUT_DIR/ios-simulator-universal/$LIB_NAME"
+
+lipo -create \
+    "$WORKSPACE_ROOT/target/aarch64-apple-darwin/$PROFILE/$LIB_NAME" \
+    "$WORKSPACE_ROOT/target/x86_64-apple-darwin/$PROFILE/$LIB_NAME" \
+    -output "$OUT_DIR/macos-universal/$LIB_NAME"
+
+if $ALL_PLATFORMS; then
+    mkdir -p "$OUT_DIR/tvos-simulator-universal"
+    lipo -create \
+        "$WORKSPACE_ROOT/target/aarch64-apple-tvos-sim/$PROFILE/$LIB_NAME" \
+        "$WORKSPACE_ROOT/target/x86_64-apple-tvos/$PROFILE/$LIB_NAME" \
+        -output "$OUT_DIR/tvos-simulator-universal/$LIB_NAME"
+fi
+
+# ── Swift bindings ───────────────────────────────────────────────────────────
+
+echo "==> Generating Swift bindings..."
+mkdir -p "$BINDINGS_DIR"
+
+cargo run \
+    --package "qdrant-edge-ffi-bindgen" \
+    --bin uniffi-bindgen \
+    --manifest-path "$WORKSPACE_ROOT/Cargo.toml" \
+    -- generate \
+    --library "$WORKSPACE_ROOT/target/aarch64-apple-ios/$PROFILE/$LIB_NAME" \
+    --language swift \
+    --out-dir "$BINDINGS_DIR"
+
+echo "==> Renaming generated bindings to PascalCase..."
+mv "$BINDINGS_DIR/${CRATE_NAME}.swift" "$BINDINGS_DIR/QdrantEdge.swift"
+mv "$BINDINGS_DIR/${CRATE_NAME}FFI.h" "$BINDINGS_DIR/QdrantEdgeFFI.h"
+mv "$BINDINGS_DIR/${CRATE_NAME}FFI.modulemap" "$BINDINGS_DIR/QdrantEdgeFFI.modulemap" 2>/dev/null || true
+
+echo "==> Demoting FFI plumbing to internal..."
+"$SCRIPT_DIR/demote-ffi-internals.sh" "$BINDINGS_DIR/QdrantEdge.swift"
+
+# ── Headers & modulemap ─────────────────────────────────────────────────────
+
+echo "==> Preparing headers..."
+
+HEADER_DIRS=("$OUT_DIR/headers-ios" "$OUT_DIR/headers-sim" "$OUT_DIR/headers-mac")
+if $ALL_PLATFORMS; then
+    HEADER_DIRS+=(
+        "$OUT_DIR/headers-tvos" "$OUT_DIR/headers-tvos-sim"
+        "$OUT_DIR/headers-visionos" "$OUT_DIR/headers-visionos-sim"
+    )
+fi
+
+for hdir in "${HEADER_DIRS[@]}"; do
+    rm -rf "$hdir"
+    mkdir -p "$hdir"
+    cp "$BINDINGS_DIR/QdrantEdgeFFI.h" "$hdir/"
+    cat > "$hdir/module.modulemap" << 'MODULEMAP'
+module qdrant_edge_ffiFFI {
+    header "QdrantEdgeFFI.h"
+    link "qdrant_edge_ffi"
+    export *
+}
+MODULEMAP
+done
+
+# ── XCFramework ──────────────────────────────────────────────────────────────
+
+echo "==> Building XCFramework..."
+rm -rf "$XCFRAMEWORK_DIR"
+
+XCFRAMEWORK_ARGS=(
+    -library "$WORKSPACE_ROOT/target/aarch64-apple-ios/$PROFILE/$LIB_NAME"
+        -headers "$OUT_DIR/headers-ios"
+    -library "$OUT_DIR/ios-simulator-universal/$LIB_NAME"
+        -headers "$OUT_DIR/headers-sim"
+    -library "$OUT_DIR/macos-universal/$LIB_NAME"
+        -headers "$OUT_DIR/headers-mac"
+)
+
+if $ALL_PLATFORMS; then
+    XCFRAMEWORK_ARGS+=(
+        -library "$WORKSPACE_ROOT/target/aarch64-apple-tvos/$PROFILE/$LIB_NAME"
+            -headers "$OUT_DIR/headers-tvos"
+        -library "$OUT_DIR/tvos-simulator-universal/$LIB_NAME"
+            -headers "$OUT_DIR/headers-tvos-sim"
+        -library "$WORKSPACE_ROOT/target/aarch64-apple-visionos/$PROFILE/$LIB_NAME"
+            -headers "$OUT_DIR/headers-visionos"
+        -library "$WORKSPACE_ROOT/target/aarch64-apple-visionos-sim/$PROFILE/$LIB_NAME"
+            -headers "$OUT_DIR/headers-visionos-sim"
+    )
+fi
+
+xcodebuild -create-xcframework "${XCFRAMEWORK_ARGS[@]}" -output "$XCFRAMEWORK_DIR"
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+
+echo "==> Cleaning up temporary files..."
+rm -rf "${HEADER_DIRS[@]}"
+rm -rf "$OUT_DIR/ios-simulator-universal" "$OUT_DIR/macos-universal"
+if $ALL_PLATFORMS; then
+    rm -rf "$OUT_DIR/tvos-simulator-universal"
+fi
+
+echo ""
+echo "Done! Output:"
+echo "  XCFramework:    $XCFRAMEWORK_DIR"
+echo "  Swift bindings: $BINDINGS_DIR"
+if ! $ALL_PLATFORMS; then
+    echo ""
+    echo "Note: tvOS/visionOS not included. Use --all-platforms to add them."
+fi

--- a/lib/edge/swift/demote-ffi-internals.sh
+++ b/lib/edge/swift/demote-ffi-internals.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Rewrite UniFFI's generated QdrantEdge.swift so its FFI plumbing types
+# (FfiConverter*, Uniffi*, RustBuffer, ForeignBytes, InitializationResult,
+# and the *_lift / *_lower free functions) are declared `internal` instead
+# of `public`. The real domain types (EdgeShard, Point, Query, …) keep
+# their `public` visibility.
+#
+# Safe because QdrantEdge.swift compiles into a single Swift module and
+# the plumbing is only referenced from within that file.
+#
+# Usage: demote-ffi-internals.sh <path-to-QdrantEdge.swift>
+# Idempotent: a marker on line 3 prevents double-processing.
+
+set -euo pipefail
+
+SWIFT_FILE="${1:-}"
+if [ -z "$SWIFT_FILE" ] || [ ! -f "$SWIFT_FILE" ]; then
+    echo "Usage: $0 <path-to-QdrantEdge.swift>" >&2
+    exit 1
+fi
+
+MARKER="// Post-processed by demote-ffi-internals.sh: FFI plumbing demoted to internal."
+
+if head -n 5 "$SWIFT_FILE" | grep -qF "$MARKER"; then
+    echo "==> $(basename "$SWIFT_FILE") already processed; skipping."
+    exit 0
+fi
+
+PUBLIC_BEFORE=$(grep -cE "^public " "$SWIFT_FILE" || true)
+
+# `public static func` at column 0 is left untouched: UniFFI emits genuine
+# class members (EdgeShard.load, UpdateOperation.upsertPoints) without
+# indentation.
+perl -i -pe '
+    s/^public (struct|enum|protocol|func|class|final|typealias|var|let) (FfiConverter|Uniffi|uniffi|RustBuffer|ForeignBytes|InitializationResult)/internal $1 $2/;
+    s/^public (func) ([A-Za-z_][A-Za-z0-9_]*_(lift|lower))\b/internal $1 $2/;
+' "$SWIFT_FILE"
+
+PUBLIC_AFTER=$(grep -cE "^public " "$SWIFT_FILE" || true)
+DEMOTED=$((PUBLIC_BEFORE - PUBLIC_AFTER))
+
+perl -i -pe '
+    if ($. == 3 && !$done) {
+        print "'"$MARKER"'\n";
+        $done = 1;
+    }
+' "$SWIFT_FILE"
+
+echo "==> Demoted $DEMOTED public declarations to internal ($PUBLIC_BEFORE → $PUBLIC_AFTER)."
+
+if command -v swift-format >/dev/null 2>&1; then
+    echo "==> Running swift-format..."
+    swift-format --in-place "$SWIFT_FILE"
+else
+    echo "==> swift-format not found; skipping format pass."
+fi

--- a/lib/edge/swift/example/Package.swift
+++ b/lib/edge/swift/example/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "QdrantEdgeExample",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v13),
+        .tvOS(.v15),
+        .visionOS(.v1),
+    ],
+    dependencies: [
+        .package(name: "QdrantEdge", path: ".."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "QdrantEdgeExample",
+            dependencies: ["QdrantEdge"],
+            path: "Sources"
+        ),
+    ]
+)

--- a/lib/edge/swift/example/Sources/main.swift
+++ b/lib/edge/swift/example/Sources/main.swift
@@ -1,0 +1,303 @@
+import Foundation
+import QdrantEdge
+
+// MARK: - Helpers
+
+func toJson(_ dict: [String: Any]) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return String(data: data, encoding: .utf8)!
+}
+
+func printScoredPoint(_ p: ScoredPoint) {
+    let idStr: String
+    switch p.id {
+    case let .numId(value): idStr = "\(value)"
+    case let .uuid(value): idStr = value
+    }
+    print("  id: \(idStr), version: \(p.version), score: \(p.score)")
+    if let payload = p.payload { print("    payload: \(payload)") }
+    if let vector = p.vector { print("    vector: \(vector)") }
+}
+
+func printRecord(_ r: Record) {
+    let idStr: String
+    switch r.id {
+    case let .numId(value): idStr = "\(value)"
+    case let .uuid(value): idStr = value
+    }
+    print("  id: \(idStr)")
+    if let payload = r.payload { print("    payload: \(payload)") }
+    if let vector = r.vector { print("    vector: \(vector)") }
+}
+
+func pointIdDescription(_ id: PointId) -> String {
+    switch id {
+    case let .numId(value): return "\(value)"
+    case let .uuid(value): return value
+    }
+}
+
+// MARK: - Setup
+
+let dataDir = FileManager.default.temporaryDirectory
+    .appendingPathComponent("qdrant-edge-swift-example")
+    .path
+
+// Clean up any previous run
+if FileManager.default.fileExists(atPath: dataDir) {
+    try FileManager.default.removeItem(atPath: dataDir)
+}
+
+try FileManager.default.createDirectory(atPath: dataDir, withIntermediateDirectories: true)
+
+// MARK: - Load shard
+
+print("---- Load shard ----")
+
+let config = EdgeConfig(
+    vectorData: [
+        "": VectorDataConfig(
+            size: 4,
+            distance: .dot,
+            quantizationConfig: nil,
+            multivectorConfig: nil,
+            datatype: nil
+        ),
+    ],
+    sparseVectorData: [:]
+)
+
+let shard = try EdgeShard.load(path: dataDir, config: config)
+print("Shard loaded at: \(dataDir)")
+
+// MARK: - Upsert
+
+print("\n---- Upsert ----")
+
+let randomUuid = UUID().uuidString
+
+let upsertOp = try UpdateOperation.upsertPoints(points: [
+    Point(
+        id: .numId(value: 1),
+        vector: .single(values: [6.0, 9.0, 4.0, 2.0]),
+        payload: toJson([
+            "null": NSNull(),
+            "str": "string",
+            "uint": 42,
+            "int": -69,
+            "float": 4.20,
+            "bool": true,
+            "obj": [
+                "null": NSNull(),
+                "str": "string",
+                "uint": 42,
+                "int": -69,
+                "float": 4.20,
+                "bool": true,
+                "obj": [String: Any](),
+                "arr": [Any](),
+            ] as [String: Any],
+            "arr": [NSNull(), "string", 42, -69, 4.20, true, [String: Any](), [Any]()] as [Any],
+        ] as [String: Any])
+    ),
+    Point(
+        id: .uuid(value: "e9408f2b-b917-4af1-ab75-d97ac6b2c047"),
+        vector: .single(values: [6.0, 9.0, 3.0, -2.0]),
+        payload: toJson([
+            "hello": "world",
+            "price": 199.99,
+        ])
+    ),
+    Point(
+        id: .uuid(value: randomUuid),
+        vector: .single(values: [1.0, 6.0, 4.0, 2.0]),
+        payload: toJson([
+            "hello": "world",
+            "price": 999.99,
+        ])
+    ),
+])
+
+try shard.update(operation: upsertOp)
+print("Upserted 3 points (ids: 1, e9408f2b-..., \(randomUuid.prefix(8))...)")
+
+// MARK: - Query
+
+print("\n---- Query ----")
+
+let queryResults = try shard.query(request: QueryRequest(
+    limit: 10,
+    offset: nil,
+    query: .vector(query: .nearest(vector: [6.0, 9.0, 4.0, 2.0], using: nil)),
+    prefetches: [],
+    withVector: .bool(enable: true),
+    withPayload: .bool(enable: true),
+    filter: nil,
+    scoreThreshold: nil,
+    params: nil
+))
+
+print("Query returned \(queryResults.count) results:")
+for point in queryResults {
+    printScoredPoint(point)
+}
+
+// MARK: - Search
+
+print("\n---- Search ----")
+
+let searchResults = try shard.search(request: SearchRequest(
+    query: .nearest(vector: [1.0, 1.0, 1.0, 1.0], using: nil),
+    limit: 10,
+    offset: nil,
+    filter: nil,
+    params: nil,
+    withVector: .bool(enable: true),
+    withPayload: .bool(enable: true),
+    scoreThreshold: nil
+))
+
+print("Search returned \(searchResults.count) results:")
+for point in searchResults {
+    printScoredPoint(point)
+}
+
+// MARK: - Search + Filter
+
+print("\n---- Search + Filter ----")
+
+let searchFilter = Filter(
+    must: [
+        .field(condition: FieldCondition(
+            key: "hello",
+            match: .text(text: "world"),
+            range: nil,
+            geoBoundingBox: nil,
+            geoRadius: nil,
+            valuesCount: nil
+        )),
+        .field(condition: FieldCondition(
+            key: "price",
+            match: nil,
+            range: RangeFloat(gte: 500.0, gt: nil, lte: nil, lt: nil),
+            geoBoundingBox: nil,
+            geoRadius: nil,
+            valuesCount: nil
+        )),
+    ],
+    should: nil,
+    mustNot: nil
+)
+
+let filteredResults = try shard.search(request: SearchRequest(
+    query: .nearest(vector: [1.0, 1.0, 1.0, 1.0], using: nil),
+    limit: 10,
+    offset: nil,
+    filter: searchFilter,
+    params: nil,
+    withVector: .bool(enable: true),
+    withPayload: .bool(enable: true),
+    scoreThreshold: nil
+))
+
+print("Filtered search returned \(filteredResults.count) results:")
+for point in filteredResults {
+    printScoredPoint(point)
+}
+
+// MARK: - Retrieve
+
+print("\n---- Retrieve ----")
+
+let retrieved = try shard.retrieve(
+    pointIds: [.numId(value: 1)],
+    withPayload: .bool(enable: true),
+    withVector: .bool(enable: true)
+)
+
+print("Retrieved \(retrieved.count) records:")
+for record in retrieved {
+    printRecord(record)
+}
+
+// MARK: - Scroll
+
+print("\n---- Scroll ----")
+
+var scrollResponse = try shard.scroll(request: ScrollRequest(
+    offset: nil,
+    limit: 2,
+    filter: nil,
+    withPayload: nil,
+    withVector: nil,
+    orderBy: nil
+))
+
+print("Scroll page 1 (\(scrollResponse.records.count) records):")
+for record in scrollResponse.records {
+    printRecord(record)
+}
+
+while let nextOffset = scrollResponse.nextOffset {
+    print("--- Next scroll (offset = \(pointIdDescription(nextOffset))) ---")
+    scrollResponse = try shard.scroll(request: ScrollRequest(
+        offset: nextOffset,
+        limit: 2,
+        filter: nil,
+        withPayload: nil,
+        withVector: nil,
+        orderBy: nil
+    ))
+    for record in scrollResponse.records {
+        printRecord(record)
+    }
+}
+
+// MARK: - Count
+
+print("\n---- Count ----")
+
+let count = try shard.count(request: CountRequest(filter: nil, exact: true))
+print("Total points count: \(count)")
+
+// MARK: - Facet
+
+print("\n---- Facet (requires payload index) ----")
+
+// Facet requires a payload index on the field being faceted.
+// Without a payload index this will fail, which is expected.
+do {
+    let facetResponse = try shard.facet(request: FacetRequest(
+        key: "hello",
+        limit: 10,
+        exact: false,
+        filter: nil
+    ))
+    print("Facet results (\(facetResponse.hits.count) hits):")
+    for hit in facetResponse.hits {
+        print("  \(hit.value): \(hit.count)")
+    }
+} catch {
+    print("Facet error (expected without payload index): \(error)")
+}
+
+// MARK: - Info
+
+print("\n---- Info ----")
+
+let info = try shard.info()
+print("Segments: \(info.segmentsCount), Points: \(info.pointsCount), Indexed vectors: \(info.indexedVectorsCount)")
+
+// MARK: - Close and reopen
+
+print("\n---- Close and reopen shard ----")
+
+shard.close()
+print("Shard closed.")
+
+let reopenedShard = try EdgeShard.load(path: dataDir, config: nil)
+let reopenedInfo = try reopenedShard.info()
+print("Reopened shard - Segments: \(reopenedInfo.segmentsCount), Points: \(reopenedInfo.pointsCount), Indexed vectors: \(reopenedInfo.indexedVectorsCount)")
+
+reopenedShard.close()
+print("\nDone!")


### PR DESCRIPTION
## Summary

This PR introduces the foundation for running **Qdrant Edge on Apple platforms
and Android**: a shared `qdrant-edge-ffi` crate that exposes a curated subset
of `lib/edge` through [UniFFI](https://mozilla.github.io/uniffi-rs/), plus
ready-to-consume Swift and Kotlin SDKs generated from it.

It is split into three commits to make review easy — each is self-contained
and compiles independently against `dev`:

1. **`qdrant-edge-ffi` crate** — the single source of truth for the FFI
   surface (`lib/edge/ffi/`). UniFFI proc-macro annotations on the public
   types, `thiserror`-based error enum, Rustdoc on every exported item so
   the generated Swift Quick Help / Kotlin KDoc is not empty. Adds a
   `release-mobile` Cargo profile (`lto = "thin"`, `codegen-units = 1`,
   `strip = "symbols"`, `panic = "abort"`) used by both mobile build
   scripts.
2. **Swift SDK** (`lib/edge/swift/`) — `build-xcframework.sh` cross-compiles
   for iOS device + iOS Simulator (universal) + macOS (universal), with
   optional tvOS/visionOS via `--all-platforms`. Bindings are shipped as a
   Swift Package (`Package.swift` + local `.xcframework` today; `url:` +
   `checksum:` for publication). A `demote-ffi-internals.sh` post-pass
   rewrites UniFFI's `public` helper declarations (`FfiConverter*`,
   `RustBuffer`, etc.) to `internal` so only the curated API appears in
   Xcode autocomplete. Includes an `example/` SwiftPM target exercising the
   full surface.
3. **Android SDK** (`lib/edge/android/`) — `build-aar.sh` cross-compiles
   for `arm64-v8a`, `armeabi-v7a`, and `x86_64` via `cargo-ndk`, then
   packages the `.so`s plus generated Kotlin into an AAR. A two-module
   Gradle layout hides UniFFI's internal plumbing: `:qdrant-edge-ffi`
   (internal, `tech.qdrant.edge.ffi.*`) and `:qdrant-edge` (public,
   `tech.qdrant.edge.*` via typealiases). Includes an `example/` app
   exercising the full surface.

The FFI surface is intentionally narrow for v1 — it wraps the synchronous
`EdgeShard` API (`upsert`, `search`, `query`, `scroll`, `count`, `facet`,
`retrieve`, payload/vector mutations, snapshots). There are no `async fn`s
exposed yet; the Swift/Kotlin wrappers are plain sync calls.

## Motivation

Teams building mobile apps that embed Qdrant for on-device search
currently have to hand-roll the FFI boundary. Shipping a supported,
documented set of bindings from this repo:

- eliminates drift between Swift and Kotlin SDKs (one UniFFI definition),
- gives mobile users the same API shape and documentation as the Rust
  crate, via Quick Help / KDoc generated from Rustdoc,
- produces reproducible, strip-optimised binaries via a dedicated
  `release-mobile` profile.

## What's not in this PR

- Publication flow (zipped XCFramework GitHub Release + SwiftPM mirror
  repo; Maven Central via Sonatype Central Portal). Packaging doc with the
  target pipeline has been shared with the team separately.
- CI jobs for the mobile build scripts.
- Async FFI surface (none of the wrapped `EdgeShard` operations are async
  today).

## All Submissions

- [x] Contributions target the `dev` branch.
- [x] Checked there are no other open PRs for this change.
- [x] Followed the contributing guidelines.

## New Feature Submissions

- [x] Does your submission pass tests? (`cargo check -p qdrant-edge-ffi`
      is green; the example SwiftPM target builds and the demote script
      has been run end-to-end locally.)
- [ ] `cargo +nightly fmt --all` — will run before merge.
- [ ] `cargo clippy --workspace --all-features` — pre-existing workspace
      clippy warnings only; none introduced by this PR.

## Changes to Core Features

- [x] No changes to existing core features. The new crate lives under
      `lib/edge/ffi/` and the workspace `Cargo.toml` only gains the new
      members and the `release-mobile` profile.
- [ ] Added tests — the FFI crate currently ships only the example apps
      (Swift + Android) as integration tests. Unit tests for the
      type-conversion layer can be added in a follow-up if preferred.