### PR TITLE
Immutable storage geo payload index

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+use common::bitvec::BitSliceExt;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, ReadRange, UniversalRead};
@@ -93,7 +94,12 @@ impl ImmutableGeoMapIndex {
                 points_map_hashes.push(points_map_entries[i].hash.normalize());
                 points_map_offsets.push(points_map_ids.len() as u32);
                 for &id in ids {
-                    if !index.storage.deleted.get(id as usize).unwrap_or_default() {
+                    if !index
+                        .storage
+                        .deleted
+                        .get_bit(id as usize)
+                        .unwrap_or_default()
+                    {
                         points_map_ids.push(id);
                     }
                 }
@@ -114,7 +120,11 @@ impl ImmutableGeoMapIndex {
                 .iter()
                 .map(|id_values| {
                     let (id, values) = id_values?;
-                    let is_deleted = index.storage.deleted.get(id as usize).unwrap_or_default();
+                    let is_deleted = index
+                        .storage
+                        .deleted
+                        .get_bit(id as usize)
+                        .unwrap_or_default();
                     let values = match (is_deleted, values) {
                         (false, Some(values)) => values.map(Cow::into_owned).collect(),
                         (false, None) => vec![],

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -1,11 +1,13 @@
 use std::borrow::Cow;
+use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
 use common::binary_search::binary_search_by;
+use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::fs::{atomic_save_json, read_json};
+use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{MmapSlice, create_and_ensure_length};
@@ -18,7 +20,6 @@ use serde::{Deserialize, Serialize};
 
 use super::mutable_geo_index::InMemoryGeoMapIndex;
 use crate::common::Flusher;
-use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{GeoHash, GeoHashRaw};
 use crate::index::field_index::stored_point_to_values::StoredPointToValues;
@@ -77,6 +78,18 @@ impl<T> StoredGeoMapIndexStorage for T where
 ///  └─────────────────────────────────────────────────────────┘
 ///   points_map_ids
 ///
+/// Mmap-backed immutable geo index.
+///
+/// On-disk state (`counts_per_hash.bin`, `points_map.bin`, `points_map_ids.bin`,
+/// `deleted.bin`, `point_to_values.*`, etc.) is written once during
+/// [`Self::build`] and not mutated afterwards: `deleted.bin` records only the
+/// points whose payload was empty at build time.
+///
+/// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
+/// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
+/// only updates the in-memory bitvec. Callers must re-supply the authoritative
+/// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
+/// `deleted_points` argument to [`Self::open`] on reload.
 pub struct StoredGeoMapIndex<S: StoredGeoMapIndexStorage> {
     path: PathBuf,
     pub(super) storage: Storage<S>,
@@ -97,8 +110,28 @@ pub(super) struct Storage<S: StoredGeoMapIndexStorage> {
     pub(super) points_map_ids: TypedStorage<S, PointOffsetType>,
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
     pub(super) point_to_values: StoredPointToValues<GeoPoint, S>,
-    /// Deleted flags for each PointOffsetType
-    pub(super) deleted: BufferedUpdateBitSlice<MmapFile>,
+    /// In-memory deletion bitmap. Reconstructed at load time as the union of
+    /// the build-time empty-payload bits read from `deleted.bin` and the
+    /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
+    pub(super) deleted: BitVec,
+}
+
+impl<S: StoredGeoMapIndexStorage> Storage<S> {
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            counts_per_hash,
+            points_map,
+            points_map_ids,
+            point_to_values,
+            deleted,
+        } = self;
+
+        counts_per_hash.ram_usage_bytes()
+            + points_map.ram_usage_bytes()
+            + points_map_ids.ram_usage_bytes()
+            + point_to_values.ram_usage_bytes()
+            + deleted.capacity().div_ceil(u8::BITS as usize)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +145,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         dynamic_index: InMemoryGeoMapIndex,
         path: &Path,
         is_on_disk: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
@@ -219,12 +253,16 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
             },
         )?;
 
-        Self::open(path, is_on_disk)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open StoredGeoMapIndex after building it")
         })
     }
 
-    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn open(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
         let deleted_path = path.join(DELETED_PATH);
         let stats_path = path.join(STATS_PATH);
         let counts_per_hash_path = path.join(COUNTS_PER_HASH);
@@ -253,14 +291,20 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         let points_map_ids = UniversalRead::open(&points_map_ids_path, open_options)?;
         let point_to_values = StoredPointToValues::open(path, true)?;
 
-        let deleted = MmapBitSlice::open(
-            &deleted_path,
-            OpenOptions {
-                populate: Some(populate),
-                ..OpenOptions::default()
-            },
-        )?;
-        let deleted_count = deleted.count_ones()?;
+        let mut deleted = deleted_points.to_owned();
+
+        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
+
+        // `deleted` length must match `point_to_values.len()` because it only
+        // tracks the index's contents. The id-tracker's deleted mask can be
+        // shorter or longer; if shorter, the missing entries default to live
+        // (the id-tracker is the source of truth for deletions, and a shorter
+        // mask just means it doesn't yet know about those higher offsets).
+        deleted.resize(point_to_values.len(), false);
+        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+
+        let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {
             path: path.to_owned(),
@@ -269,7 +313,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                 points_map,
                 points_map_ids,
                 point_to_values,
-                deleted: BufferedUpdateBitSlice::new(deleted),
+                deleted,
             },
             deleted_count,
             points_values_count: stats.points_values_count,
@@ -285,17 +329,15 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         check_fn: impl Fn(&GeoPoint) -> bool,
     ) -> bool {
         let hw_counter = self.make_conditioned_counter(hw_counter);
-        self.storage
-            .deleted
-            .get(idx as usize)
-            .filter(|b| !b)
-            .map(|_| {
-                self.storage
-                    .point_to_values
-                    .check_values_any(idx, |v| check_fn(v), &hw_counter)
-            })
-            .map(|r| r.unwrap_or(false)) // FIXME: don't silently ignore error
-            .unwrap_or(false)
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+            self.storage
+                .point_to_values
+                .check_values_any(idx, |v| check_fn(v), &hw_counter)
+                // FIXME: don't silently ignore error
+                .unwrap_or(false)
+        } else {
+            false
+        }
     }
 
     pub fn get_values(&self, idx: u32) -> Option<impl Iterator<Item = GeoPoint> + '_> {
@@ -308,12 +350,16 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> usize {
-        self.storage
-            .deleted
-            .get(idx as usize)
-            .filter(|b| !b)
-            .and_then(|_| self.storage.point_to_values.get_values_count(idx).ok()?)
-            .unwrap_or(0)
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+            self.storage
+                .point_to_values
+                .get_values_count(idx)
+                .ok()
+                .flatten()
+                .unwrap_or(0)
+        } else {
+            0
+        }
     }
 
     pub(super) fn points_per_hash(
@@ -412,6 +458,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![
+            self.path.join(DELETED_PATH),
             self.path.join(COUNTS_PER_HASH),
             self.path.join(POINTS_MAP),
             self.path.join(POINTS_MAP_IDS),
@@ -421,15 +468,19 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         files
     }
 
+    /// No-op flusher: the on-disk state is build-time only. See the type-level
+    /// docs on [`StoredGeoMapIndex`] for the deletion durability contract.
     pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+        Box::new(|| Ok(()))
     }
 
+    /// Marks `idx` as deleted in the in-memory deletion bitvec.
+    ///
+    /// Not persisted: on reopen, deletions must be re-supplied via the
+    /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
         let idx = idx as usize;
-        if let Some(deleted) = self.storage.deleted.get(idx)
-            && !deleted
-        {
+        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
             self.storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
@@ -540,7 +591,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                     values
                         .iter()
                         .copied()
-                        .filter(|&id| !self.storage.deleted.get(id as usize).unwrap_or(true)),
+                        .filter(|&id| !self.storage.deleted.get_bit(id as usize).unwrap_or(true)),
                 );
                 Ok(())
             },
@@ -588,7 +639,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let Self {
-            path: _,
+            path,
             storage,
             deleted_count: _,
             points_values_count: _,
@@ -600,13 +651,17 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
             points_map,
             points_map_ids,
             point_to_values,
-            deleted,
+            deleted: _,
         } = storage;
-        deleted.clear_cache()?;
+        clear_disk_cache(&path.join(DELETED_PATH))?;
         counts_per_hash.clear_ram_cache()?;
         points_map.clear_ram_cache()?;
         points_map_ids.clear_ram_cache()?;
         point_to_values.clear_cache()?;
         Ok(())
+    }
+
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        self.storage.ram_usage_bytes()
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -1,6 +1,7 @@
 use std::cmp::{max, min};
 use std::path::{Path, PathBuf};
 
+use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::MmapFile;
@@ -41,7 +42,11 @@ pub enum GeoMapIndex {
 }
 
 impl GeoMapIndex {
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
         // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
         // pure-mmap `Storage` variant at load time. Files are shared between
         // variants; the persisted `is_on_disk` flag in `mmap_index` is
@@ -49,7 +54,8 @@ impl GeoMapIndex {
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = StoredGeoMapIndex::open(path, effective_is_on_disk)? else {
+        let Some(mmap_index) = StoredGeoMapIndex::open(path, effective_is_on_disk, deleted_points)?
+        else {
             // Files don't exist, cannot load
             return Ok(None);
         };
@@ -67,11 +73,16 @@ impl GeoMapIndex {
         Ok(MutableGeoMapIndex::open_gridstore(dir, create_if_missing)?.map(GeoMapIndex::Mutable))
     }
 
-    pub fn builder_mmap(path: &Path, is_on_disk: bool) -> GeoMapIndexMmapBuilder {
+    pub fn builder_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> GeoMapIndexMmapBuilder {
         GeoMapIndexMmapBuilder {
             path: path.to_owned(),
             in_memory_index: InMemoryGeoMapIndex::new(),
             is_on_disk,
+            deleted_points: deleted_points.to_owned(),
         }
     }
 
@@ -303,7 +314,7 @@ impl GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.ram_usage_bytes(),
             GeoMapIndex::Immutable(index) => index.ram_usage_bytes(),
-            GeoMapIndex::Storage(_) => 0,
+            GeoMapIndex::Storage(index) => index.ram_usage_bytes(),
         }
     }
 
@@ -360,6 +371,7 @@ pub struct GeoMapIndexMmapBuilder {
     path: PathBuf,
     in_memory_index: InMemoryGeoMapIndex,
     is_on_disk: bool,
+    deleted_points: BitVec,
 }
 
 impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
@@ -388,6 +400,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
             self.in_memory_index,
             &self.path,
             self.is_on_disk,
+            &self.deleted_points,
         )?)))
     }
 }
@@ -669,6 +682,27 @@ mod tests {
     use crate::types::test_utils::build_polygon;
     use crate::types::{GeoBoundingBox, GeoLineString, GeoPolygon, GeoRadius};
 
+    /// Generous default size for the deleted-points bitslice used in tests.
+    ///
+    /// Must be larger than the stored mmap deletion bitslice for any test in
+    /// this file (which is sized to the highest point id, rounded up to a
+    /// `usize` boundary). 4096 bits comfortably covers all current tests.
+    const TEST_DELETED_BITS: usize = 4096;
+
+    /// All-zero deletion bitslice for tests that don't care about deletions.
+    fn empty_deleted() -> BitVec {
+        BitVec::repeat(false, TEST_DELETED_BITS)
+    }
+
+    /// Deletion bitslice with specific points marked as deleted.
+    fn deleted_with(points: &[PointOffsetType]) -> BitVec {
+        let mut v = empty_deleted();
+        for &p in points {
+            v.set(p as usize, true);
+        }
+        v
+    }
+
     type Database = ();
 
     #[derive(Clone, Copy, PartialEq, Debug)]
@@ -750,10 +784,16 @@ mod tests {
             IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
                 GeoMapIndex::builder_gridstore(temp_dir.path().to_path_buf()),
             ),
-            IndexType::Mmap => IndexBuilder::Mmap(GeoMapIndex::builder_mmap(temp_dir.path(), true)),
-            IndexType::RamMmap => {
-                IndexBuilder::RamMmap(GeoMapIndex::builder_mmap(temp_dir.path(), false))
-            }
+            IndexType::Mmap => IndexBuilder::Mmap(GeoMapIndex::builder_mmap(
+                temp_dir.path(),
+                true,
+                &empty_deleted(),
+            )),
+            IndexType::RamMmap => IndexBuilder::RamMmap(GeoMapIndex::builder_mmap(
+                temp_dir.path(),
+                false,
+                &empty_deleted(),
+            )),
         };
         match &mut builder {
             IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
@@ -1239,12 +1279,12 @@ mod tests {
                     .unwrap()
                     .unwrap()
             }
-            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false)
+            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &empty_deleted())
                 .unwrap()
                 .unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(
                 ImmutableGeoMapIndex::open_mmap(
-                    StoredGeoMapIndex::open(temp_dir.path(), false)
+                    StoredGeoMapIndex::open(temp_dir.path(), false, &empty_deleted())
                         .unwrap()
                         .unwrap(),
                 )
@@ -1322,12 +1362,12 @@ mod tests {
                     .unwrap()
                     .unwrap()
             }
-            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false)
+            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &deleted_with(&[1]))
                 .unwrap()
                 .unwrap(),
             IndexType::RamMmap => GeoMapIndex::Immutable(
                 ImmutableGeoMapIndex::open_mmap(
-                    StoredGeoMapIndex::open(temp_dir.path(), false)
+                    StoredGeoMapIndex::open(temp_dir.path(), false, &deleted_with(&[1]))
                         .unwrap()
                         .unwrap(),
                 )
@@ -1842,5 +1882,185 @@ mod tests {
             &cases,
             "after point deletions",
         );
+    }
+
+    /// Reload contract: runtime deletions are not persisted by the mmap geo
+    /// index. Callers must re-supply the deletion bitslice on reload.
+    #[rstest]
+    #[case(IndexType::MutableGridstore)]
+    #[case(IndexType::Mmap)]
+    #[case(IndexType::RamMmap)]
+    fn test_geo_index_reload(#[case] index_type: IndexType) {
+        let temp_dir = {
+            let (mut builder, temp_dir, _) = create_builder(index_type);
+
+            let hw_counter = HardwareCounterCell::new();
+
+            // ids 1..=4 in/near Berlin, ids 5..=6 in Tokyo, id 7 in NYC.
+            let berlin = json!({ "lon": BERLIN.lon, "lat": BERLIN.lat });
+            let potsdam = json!({ "lon": POTSDAM.lon, "lat": POTSDAM.lat });
+            let tokyo = json!({ "lon": TOKYO.lon, "lat": TOKYO.lat });
+            let nyc = json!({ "lon": NYC.lon, "lat": NYC.lat });
+
+            builder.add_point(1, &[&berlin], &hw_counter).unwrap();
+            builder.add_point(2, &[&berlin], &hw_counter).unwrap();
+            builder.add_point(3, &[&potsdam], &hw_counter).unwrap();
+            builder.add_point(4, &[&potsdam], &hw_counter).unwrap();
+            builder.add_point(5, &[&tokyo], &hw_counter).unwrap();
+            builder.add_point(6, &[&tokyo], &hw_counter).unwrap();
+            builder.add_point(7, &[&nyc], &hw_counter).unwrap();
+
+            let mut index = builder.finalize().unwrap();
+
+            // Remove some points and flush. For Mmap/RamMmap the flush is a
+            // no-op for the deletion bitvec — the test below verifies the
+            // reload contract.
+            index.remove_point(2).unwrap();
+            index.remove_point(3).unwrap();
+            index.remove_point(6).unwrap();
+            index.flusher()().unwrap();
+            assert_eq!(index.points_count(), 4);
+            drop(index);
+            temp_dir
+        };
+
+        // Reload from disk, re-supplying the runtime deletions for the mmap
+        // variants. For the gridstore variant the argument is ignored.
+        let deleted = deleted_with(&[2, 3, 6]);
+        let new_index = match index_type {
+            IndexType::MutableGridstore => {
+                GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true)
+                    .unwrap()
+                    .unwrap()
+            }
+            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &deleted)
+                .unwrap()
+                .unwrap(),
+            IndexType::RamMmap => GeoMapIndex::Immutable(
+                ImmutableGeoMapIndex::open_mmap(
+                    StoredGeoMapIndex::open(temp_dir.path(), false, &deleted)
+                        .unwrap()
+                        .unwrap(),
+                )
+                .unwrap(),
+            ),
+        };
+
+        assert_eq!(new_index.points_count(), 4);
+
+        // Berlin radius covers Berlin + Potsdam — ids 1, 2, 3, 4 originally,
+        // expect 1, 4 after deletions.
+        let berlin_radius = GeoRadius {
+            center: BERLIN,
+            radius: OrderedFloat(50_000.0),
+        };
+        let field_condition = condition_for_geo_radius("test", berlin_radius);
+        let hw_acc = HwMeasurementAcc::new();
+        let hw_counter = hw_acc.get_counter_cell();
+        let mut hits: Vec<PointOffsetType> = new_index
+            .filter(&field_condition, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect();
+        hits.sort();
+        assert_eq!(hits, vec![1, 4]);
+
+        // Tokyo radius — id 5 only after deletion of 6.
+        let tokyo_radius = GeoRadius {
+            center: TOKYO,
+            radius: OrderedFloat(50_000.0),
+        };
+        let field_condition = condition_for_geo_radius("test", tokyo_radius);
+        let hw_acc = HwMeasurementAcc::new();
+        let hw_counter = hw_acc.get_counter_cell();
+        let mut hits: Vec<PointOffsetType> = new_index
+            .filter(&field_condition, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect();
+        hits.sort();
+        assert_eq!(hits, vec![5]);
+
+        // NYC radius — id 7 untouched.
+        let nyc_radius = GeoRadius {
+            center: NYC,
+            radius: OrderedFloat(50_000.0),
+        };
+        let field_condition = condition_for_geo_radius("test", nyc_radius);
+        let hw_acc = HwMeasurementAcc::new();
+        let hw_counter = hw_acc.get_counter_cell();
+        let mut hits: Vec<PointOffsetType> = new_index
+            .filter(&field_condition, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect();
+        hits.sort();
+        assert_eq!(hits, vec![7]);
+    }
+
+    /// Regression test: when reloading an mmap geo index with a `deleted_points`
+    /// bitslice shorter than `point_to_values.len()`, missing entries must
+    /// default to live, not deleted. Empty-payload bits from the on-disk
+    /// `deleted.bin` and any deletions encoded inside the short bitslice must
+    /// still be honored.
+    #[rstest]
+    #[case(IndexType::Mmap)]
+    #[case(IndexType::RamMmap)]
+    fn test_geo_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
+        let temp_dir = {
+            let (mut builder, temp_dir, _) = create_builder(index_type);
+
+            let hw_counter = HardwareCounterCell::new();
+
+            let berlin = json!({ "lon": BERLIN.lon, "lat": BERLIN.lat });
+
+            // ids 1..=4 with Berlin payload; id 3 has an empty payload, so
+            // build-time `deleted.bin` will mark it.
+            builder.add_point(1, &[&berlin], &hw_counter).unwrap();
+            builder.add_point(2, &[&berlin], &hw_counter).unwrap();
+            builder.add_point(3, &[], &hw_counter).unwrap();
+            builder.add_point(4, &[&berlin], &hw_counter).unwrap();
+
+            builder.finalize().unwrap();
+            temp_dir
+        };
+
+        // Reload with a bitslice shorter than `point_to_values.len()` that
+        // marks point 1 as deleted. Models an id-tracker whose internal range
+        // hasn't yet caught up to the index's highest internal id.
+        let mut short_deleted = BitVec::repeat(false, 2);
+        short_deleted.set(1, true);
+        let new_index = match index_type {
+            IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &short_deleted)
+                .unwrap()
+                .unwrap(),
+            IndexType::RamMmap => GeoMapIndex::Immutable(
+                ImmutableGeoMapIndex::open_mmap(
+                    StoredGeoMapIndex::open(temp_dir.path(), false, &short_deleted)
+                        .unwrap()
+                        .unwrap(),
+                )
+                .unwrap(),
+            ),
+            IndexType::MutableGridstore => unreachable!(),
+        };
+
+        // Expect: id 1 deleted (from short bitslice), id 3 deleted (from
+        // build-time empty payload), ids 2 and 4 live (with id 4 being beyond
+        // the short bitslice).
+        let berlin_radius = GeoRadius {
+            center: BERLIN,
+            radius: OrderedFloat(50_000.0),
+        };
+        let field_condition = condition_for_geo_radius("test", berlin_radius);
+        let hw_acc = HwMeasurementAcc::new();
+        let hw_counter = hw_acc.get_counter_cell();
+        let mut hits: Vec<PointOffsetType> = new_index
+            .filter(&field_condition, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect();
+        hits.sort();
+        assert_eq!(hits, vec![2, 4]);
     }
 }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -101,7 +101,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::FloatIndex),
 
             (PayloadIndexType::GeoIndex, PayloadSchemaParams::Geo(_)) => self
-                .geo_new(field, create_if_missing)?
+                .geo_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::GeoIndex),
 
             (PayloadIndexType::FullTextIndex, PayloadSchemaParams::Text(params)) => self
@@ -179,7 +179,7 @@ impl IndexSelector<'_> {
                 .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::FloatIndex(index)]),
             PayloadSchemaParams::Geo(_) => self
-                .geo_new(field, create_if_missing)?
+                .geo_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::GeoIndex(index)]),
             PayloadSchemaParams::Text(text_index_params) => self
                 .text_new(field, text_index_params.clone(), create_if_missing)?
@@ -258,6 +258,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::GeoMmapIndex,
                     FieldIndexBuilder::GeoGridstoreIndex,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Text(text_index_params) => {
@@ -367,10 +368,11 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<GeoMapIndex>> {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                GeoMapIndex::new_mmap(&map_dir(dir, field), *is_on_disk)?
+                GeoMapIndex::new_mmap(&map_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 GeoMapIndex::new_gridstore(map_dir(dir, field), create_if_missing)?
@@ -383,11 +385,12 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(GeoMapIndexMmapBuilder) -> FieldIndexBuilder,
         make_gridstore: fn(GeoMapIndexGridstoreBuilder) -> FieldIndexBuilder,
+        deleted_points: &BitSlice,
     ) -> FieldIndexBuilder {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                make_mmap(GeoMapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk))
-            }
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
+                GeoMapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk, deleted_points),
+            ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(GeoMapIndex::builder_gridstore(map_dir(dir, field)))
             }

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -362,7 +362,7 @@ mod tests {
 
         // Create a field index for a geo point.
         let dir = tempfile::tempdir().unwrap();
-        let mut builder = GeoMapIndex::builder_mmap(dir.path(), false);
+        let mut builder = GeoMapIndex::builder_mmap(dir.path(), false, &deleted_points);
 
         builder.add_point(0, &[], &hw_counter).unwrap();
         builder


### PR DESCRIPTION
Mirror of #8594 (numeric), #8625 (bool), #8653 (null) for the geo index.

The mmap geo index (StoredGeoMapIndex) no longer mutates `deleted.bin` after build — runtime deletions live in an in-memory BitVec reconstructed at load time as the union of the build-time empty-payload bits and the segment's id-tracker deleted bitslice.

  # Changes

- StoredGeoMapIndex::open / ::build take a new &BitSlice argument carrying the segment-level deleted mask
- flusher() becomes a no-op; remove_point() mutates only the in-memory bitvec
- deleted.bin added to immutable_files()
- ram_usage_bytes() now accounts for the in-memory bitvec + the three TypedStorage members + point_to_values
- GeoMapIndex::new_mmap / ::builder_mmap, IndexSelector::geo_new / ::geo_builder thread deleted_points through; struct_payload_index.rs already supplies it from the prior PRs

# Tests

- test_geo_index_reload — N points, remove a few, drop, reload with deleted_with(&[ids]), verify queries reflect deletions across all three index types
- test_geo_index_reload_short_deleted_bitslice — reload with a bitslice shorter than point_to_values.len(), verify out-of-range bits default to live while build-time empties and in-range bits are honored
- Existing same_geo_index_between_points_test updated to re-supply the runtime deletion on reload