### PR TITLE
Immutable storage for mmap map index

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -85,7 +85,7 @@ impl IndexSelector<'_> {
                     );
                 }
 
-                self.map_new(field, create_if_missing)?
+                self.map_new(field, create_if_missing, deleted_points)?
                     .map(FieldIndex::IntMapIndex)
             }
             (PayloadIndexType::DatetimeIndex, PayloadSchemaParams::Datetime(_)) => self
@@ -93,7 +93,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::DatetimeIndex),
 
             (PayloadIndexType::KeywordIndex, PayloadSchemaParams::Keyword(_)) => self
-                .map_new(field, create_if_missing)?
+                .map_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::KeywordIndex),
 
             (PayloadIndexType::FloatIndex, PayloadSchemaParams::Float(_)) => self
@@ -118,11 +118,11 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::BoolIndex),
 
             (PayloadIndexType::UuidIndex, PayloadSchemaParams::Uuid(_)) => self
-                .map_new(field, create_if_missing)?
+                .map_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::UuidMapIndex),
 
             (PayloadIndexType::UuidMapIndex, PayloadSchemaParams::Uuid(_)) => self
-                .map_new(field, create_if_missing)?
+                .map_new(field, create_if_missing, deleted_points)?
                 .map(FieldIndex::UuidMapIndex),
 
             (PayloadIndexType::NullIndex, _) => {
@@ -150,14 +150,14 @@ impl IndexSelector<'_> {
     ) -> OperationResult<Option<Vec<FieldIndex>>> {
         let indexes = match payload_schema.expand().as_ref() {
             PayloadSchemaParams::Keyword(_) => self
-                .map_new(field, create_if_missing)?
+                .map_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::KeywordIndex(index)]),
             PayloadSchemaParams::Integer(integer_params) => {
                 let use_lookup = integer_params.lookup.unwrap_or(true);
                 let use_range = integer_params.range.unwrap_or(true);
 
                 let lookup = if use_lookup {
-                    match self.map_new(field, create_if_missing)? {
+                    match self.map_new(field, create_if_missing, deleted_points)? {
                         Some(index) => Some(FieldIndex::IntMapIndex(index)),
                         None => return Ok(None),
                     }
@@ -196,7 +196,7 @@ impl IndexSelector<'_> {
                 .numeric_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::DatetimeIndex(index)]),
             PayloadSchemaParams::Uuid(_) => self
-                .map_new(field, create_if_missing)?
+                .map_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::UuidMapIndex(index)]),
         };
 
@@ -216,6 +216,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::KeywordMmapIndex,
                     FieldIndexBuilder::KeywordGridstoreIndex,
+                    deleted_points,
                 )]
             }
             PayloadSchemaParams::Integer(integer_params) => {
@@ -227,6 +228,7 @@ impl IndexSelector<'_> {
                         field,
                         FieldIndexBuilder::IntMapMmapIndex,
                         FieldIndexBuilder::IntMapGridstoreIndex,
+                        deleted_points,
                     ))
                 } else {
                     None
@@ -280,6 +282,7 @@ impl IndexSelector<'_> {
                     field,
                     FieldIndexBuilder::UuidMmapIndex,
                     FieldIndexBuilder::UuidGridstoreIndex,
+                    deleted_points,
                 )]
             }
         };
@@ -291,13 +294,14 @@ impl IndexSelector<'_> {
         &self,
         field: &JsonPath,
         create_if_missing: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<MapIndex<N>>>
     where
         Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
     {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                MapIndex::new_mmap(&map_dir(dir, field), *is_on_disk)?
+                MapIndex::new_mmap(&map_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 MapIndex::new_gridstore(map_dir(dir, field), create_if_missing)?
@@ -310,14 +314,15 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         make_mmap: fn(MapIndexMmapBuilder<N>) -> FieldIndexBuilder,
         make_gridstore: fn(MapIndexGridstoreBuilder<N>) -> FieldIndexBuilder,
+        deleted_points: &BitSlice,
     ) -> FieldIndexBuilder
     where
         Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
     {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                make_mmap(MapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk))
-            }
+            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
+                MapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk, deleted_points),
+            ),
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 make_gridstore(MapIndex::builder_gridstore(map_dir(dir, field)))
             }

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::ops::Range;
 use std::path::PathBuf;
 
-use common::bitvec::BitVec;
+use common::bitvec::{BitSliceExt, BitVec};
 use common::mmap_hashmap::Key;
 use common::types::PointOffsetType;
 use gridstore::Blob;
@@ -54,7 +54,11 @@ where
                 (
                     value,
                     ids.iter().copied().filter(|idx| {
-                        let is_deleted = index.storage.deleted.get(*idx as usize).unwrap_or(false);
+                        let is_deleted = index
+                            .storage
+                            .deleted
+                            .get_bit(*idx as usize)
+                            .unwrap_or(false);
                         !is_deleted
                     }),
                 )

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -1,13 +1,15 @@
 use std::borrow::{Borrow, Cow};
 use std::iter;
 use std::mem::size_of;
+use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use ahash::HashMap;
+use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
-use common::fs::{atomic_save_json, read_json};
+use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::mmap::create_and_ensure_length;
 use common::mmap_hashmap::{Key, MmapHashMap, READ_ENTRY_OVERHEAD};
 use common::stored_bitslice::MmapBitSlice;
@@ -19,7 +21,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{IdIter, MapIndexKey};
 use crate::common::Flusher;
-use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::stored_point_to_values::{StoredPointToValues, ValuesIter};
 
@@ -27,6 +28,18 @@ const DELETED_PATH: &str = "deleted.bin";
 const HASHMAP_PATH: &str = "values_to_points.bin";
 const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
+/// Mmap-backed immutable map index.
+///
+/// On-disk state (`values_to_points.bin`, `deleted.bin`, `point_to_values.*`,
+/// `mmap_field_index_config.json`) is written once during [`Self::build`] and
+/// not mutated afterwards: `deleted.bin` records only the points whose payload
+/// was empty at build time.
+///
+/// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
+/// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
+/// only updates the in-memory bitvec. Callers must re-supply the authoritative
+/// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
+/// `deleted_points` argument to [`Self::open`] on reload.
 pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
     path: PathBuf,
     pub(super) storage: Storage<N>,
@@ -38,7 +51,23 @@ pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
 pub(super) struct Storage<N: MapIndexKey + Key + ?Sized> {
     pub(super) value_to_points: MmapHashMap<N, PointOffsetType>,
     point_to_values: StoredPointToValues<N, MmapFile>,
-    pub(super) deleted: BufferedUpdateBitSlice<MmapFile>,
+    /// In-memory deletion bitmap. Reconstructed at load time as the union of
+    /// the build-time empty-payload bits read from `deleted.bin` and the
+    /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
+    pub(super) deleted: BitVec,
+}
+
+impl<N: MapIndexKey + Key + ?Sized> Storage<N> {
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            value_to_points: _,
+            point_to_values,
+            deleted,
+        } = self;
+
+        // `value_to_points` is a mmap-backed hashmap with no in-memory state.
+        point_to_values.ram_usage_bytes() + deleted.capacity().div_ceil(u8::BITS as usize)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,7 +77,11 @@ struct MmapMapIndexConfig {
 
 impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     /// Open and load mmap map index from the given path
-    pub fn open(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn open(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
         let hashmap_path = path.join(HASHMAP_PATH);
         let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
@@ -65,21 +98,27 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         let hashmap = MmapHashMap::open(&hashmap_path, do_populate)?;
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
-        let deleted = MmapBitSlice::open(
-            &deleted_path,
-            OpenOptions {
-                populate: Some(do_populate),
-                ..OpenOptions::default()
-            },
-        )?;
-        let deleted_count = deleted.count_ones()?;
+        let mut deleted = deleted_points.to_owned();
+
+        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
+
+        // `deleted` length must match `point_to_values.len()` because it only
+        // tracks the index's contents. The id-tracker's deleted mask can be
+        // shorter or longer; if shorter, the missing entries default to live
+        // (the id-tracker is the source of truth for deletions, and a shorter
+        // mask just means it doesn't yet know about those higher offsets).
+        deleted.resize(point_to_values.len(), false);
+        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+
+        let deleted_count = deleted.count_ones();
 
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
                 value_to_points: hashmap,
                 point_to_values,
-                deleted: BufferedUpdateBitSlice::new(deleted),
+                deleted,
             },
             deleted_count,
             total_key_value_pairs: config.total_key_value_pairs,
@@ -92,6 +131,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         point_to_values: Vec<Vec<<N as MapIndexKey>::Owned>>,
         values_to_points: HashMap<<N as MapIndexKey>::Owned, Vec<PointOffsetType>>,
         is_on_disk: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
@@ -143,13 +183,15 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             deleted.flusher()()?;
         }
 
-        Self::open(path, is_on_disk)?.ok_or_else(|| {
+        Self::open(path, is_on_disk, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open MmapMapIndex after building it")
         })
     }
 
+    /// No-op flusher: the on-disk state is build-time only. See the type-level
+    /// docs on [`MmapMapIndex`] for the deletion durability contract.
     pub fn flusher(&self) -> Flusher {
-        self.storage.deleted.flusher()
+        Box::new(|| Ok(()))
     }
 
     pub fn wipe(self) -> OperationResult<()> {
@@ -175,16 +217,22 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.path.join(HASHMAP_PATH), self.path.join(CONFIG_PATH)];
+        let mut files = vec![
+            self.path.join(HASHMAP_PATH),
+            self.path.join(DELETED_PATH),
+            self.path.join(CONFIG_PATH),
+        ];
         files.extend(self.storage.point_to_values.immutable_files());
         files
     }
 
+    /// Marks `idx` as deleted in the in-memory deletion bitvec.
+    ///
+    /// Not persisted: on reopen, deletions must be re-supplied via the
+    /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
         let idx = idx as usize;
-        if let Some(deleted) = self.storage.deleted.get(idx)
-            && !deleted
-        {
+        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
             self.storage.deleted.set(idx, true);
             self.deleted_count += 1;
         }
@@ -203,7 +251,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             .payload_index_io_read_counter()
             .incr_delta(size_of::<bool>());
 
-        let is_deleted = self.storage.deleted.get(idx as usize).is_some_and(|b| b);
+        let is_deleted = self
+            .storage
+            .deleted
+            .get_bit(idx as usize)
+            .is_some_and(|b| b);
 
         Ok(!is_deleted
             && self
@@ -222,17 +274,15 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         // We can account cost of reading `bool`, but it will likely be more expensive, than
         // actually reading bool itself.
 
-        self.storage
-            .deleted
-            .get(idx as usize)
-            .filter(|b| !b)
-            .and_then(|_| {
-                self.storage
-                    .point_to_values
-                    .values_iter(idx, hw_counter)
-                    .ok()?
-                    .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = Cow<'_, N>>>)
-            })
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+            self.storage
+                .point_to_values
+                .values_iter(idx, hw_counter)
+                .ok()?
+                .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = Cow<'_, N>>>)
+        } else {
+            None
+        }
     }
 
     pub fn for_points_values(
@@ -244,7 +294,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         let hw_counter = self.make_conditioned_counter(hw_counter);
 
         points.try_for_each(|idx| {
-            if self.storage.deleted.get(idx as usize) != Some(false) {
+            if self.storage.deleted.get_bit(idx as usize) != Some(false) {
                 return Ok(());
             }
             if let Some(iter) = self.storage.point_to_values.values_iter(idx, hw_counter)? {
@@ -255,11 +305,11 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        self.storage
-            .deleted
-            .get(idx as usize)
-            .filter(|b| !b)
-            .and_then(|_| self.storage.point_to_values.get_values_count(idx).ok()?)
+        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+            self.storage.point_to_values.get_values_count(idx).ok()?
+        } else {
+            None
+        }
     }
 
     pub fn get_indexed_points(&self) -> usize {
@@ -319,7 +369,13 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                 Box::new(
                     slice
                         .iter()
-                        .filter(|idx| !self.storage.deleted.get(**idx as usize).unwrap_or(false))
+                        .filter(|idx| {
+                            !self
+                                .storage
+                                .deleted
+                                .get_bit(**idx as usize)
+                                .unwrap_or(false)
+                        })
                         .copied(),
                 )
             }
@@ -357,7 +413,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             let count = v
                 .iter()
                 .filter(|&&idx| {
-                    !self.storage.deleted.get(idx as usize).unwrap_or(true)
+                    !self.storage.deleted.get_bit(idx as usize).unwrap_or(true)
 
                     // TODO(deferred): Maybe we can improve this filter and use take_while instead. For this we
                     // need to make sure that `v` is always sorted which we _can_ enforce when finalizing the index.
@@ -387,7 +443,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
                 let mut iter = v
                     .iter()
                     .copied()
-                    .filter(|idx| !self.storage.deleted.get(*idx as usize).unwrap_or(true))
+                    .filter(|idx| !self.storage.deleted.get_bit(*idx as usize).unwrap_or(true))
                     .measure_hw_with_acc(
                         hw_counter.new_accumulator(),
                         size_of::<PointOffsetType>(),
@@ -420,7 +476,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let Self {
-            path: _,
+            path,
             storage,
             deleted_count: _,
             total_key_value_pairs: _,
@@ -429,11 +485,15 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         let Storage {
             value_to_points,
             point_to_values,
-            deleted,
+            deleted: _,
         } = storage;
         value_to_points.clear_cache()?;
-        deleted.clear_cache()?;
+        clear_disk_cache(&path.join(DELETED_PATH))?;
         point_to_values.clear_cache()?;
         Ok(())
+    }
+
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        self.storage.ram_usage_bytes()
     }
 }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use ahash::HashMap;
+use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap_hashmap::Key;
 use common::types::PointOffsetType;
@@ -120,7 +121,11 @@ where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(path: &Path, is_on_disk: bool) -> OperationResult<Option<Self>> {
+    pub fn new_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> OperationResult<Option<Self>> {
         // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
         // pure-mmap `Storage` variant at load time. Files are shared between
         // variants; the persisted `is_on_disk` flag in `mmap_index` is
@@ -128,7 +133,8 @@ where
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = MmapMapIndex::open(path, effective_is_on_disk)? else {
+        let Some(mmap_index) = MmapMapIndex::open(path, effective_is_on_disk, deleted_points)?
+        else {
             // Files don't exist, cannot load
             return Ok(None);
         };
@@ -148,12 +154,17 @@ where
         Ok(index.map(MapIndex::Mutable))
     }
 
-    pub fn builder_mmap(path: &Path, is_on_disk: bool) -> MapIndexMmapBuilder<N> {
+    pub fn builder_mmap(
+        path: &Path,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> MapIndexMmapBuilder<N> {
         MapIndexMmapBuilder {
             path: path.to_owned(),
             point_to_values: Default::default(),
             values_to_points: Default::default(),
             is_on_disk,
+            deleted_points: deleted_points.to_owned(),
         }
     }
 
@@ -488,7 +499,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.ram_usage_bytes(),
             MapIndex::Immutable(index) => index.ram_usage_bytes(),
-            MapIndex::Mmap(_) => 0,
+            MapIndex::Mmap(index) => index.ram_usage_bytes(),
         }
     }
 
@@ -580,6 +591,7 @@ pub struct MapIndexMmapBuilder<N: MapIndexKey + ?Sized> {
     point_to_values: Vec<Vec<<N as MapIndexKey>::Owned>>,
     values_to_points: HashMap<<N as MapIndexKey>::Owned, Vec<PointOffsetType>>,
     is_on_disk: bool,
+    deleted_points: BitVec,
 }
 
 impl<N: MapIndexKey + ?Sized> FieldIndexBuilderTrait for MapIndexMmapBuilder<N>
@@ -639,6 +651,7 @@ where
             self.point_to_values,
             self.values_to_points,
             self.is_on_disk,
+            &self.deleted_points,
         )?)))
     }
 }
@@ -1368,7 +1381,28 @@ mod tests {
 
     use super::*;
 
-    #[derive(Clone, Copy)]
+    /// Generous default size for the deleted-points bitslice used in tests.
+    ///
+    /// Must be larger than the stored mmap deletion bitslice for any test in
+    /// this file (which is sized to the highest point id, rounded up to a
+    /// `usize` boundary). 4096 bits comfortably covers all current tests.
+    const TEST_DELETED_BITS: usize = 4096;
+
+    /// All-zero deletion bitslice for tests that don't care about deletions.
+    fn empty_deleted() -> BitVec {
+        BitVec::repeat(false, TEST_DELETED_BITS)
+    }
+
+    /// Deletion bitslice with specific points marked as deleted.
+    fn deleted_with(points: &[PointOffsetType]) -> BitVec {
+        let mut v = empty_deleted();
+        for &p in points {
+            v.set(p as usize, true);
+        }
+        v
+    }
+
+    #[derive(Clone, Copy, PartialEq, Debug)]
     enum IndexType {
         MutableGridstore,
         Mmap,
@@ -1402,7 +1436,7 @@ mod tests {
                 builder.finalize().unwrap();
             }
             IndexType::Mmap | IndexType::RamMmap => {
-                let mut builder = MapIndex::<N>::builder_mmap(path, false);
+                let mut builder = MapIndex::<N>::builder_mmap(path, false, &empty_deleted());
                 builder.init().unwrap();
                 for (idx, values) in data.iter().enumerate() {
                     let values: Vec<Value> = values.iter().map(&into_value).collect();
@@ -1428,8 +1462,12 @@ mod tests {
             IndexType::MutableGridstore => MapIndex::<N>::new_gridstore(path.to_path_buf(), true)
                 .unwrap()
                 .unwrap(),
-            IndexType::Mmap => MapIndex::<N>::new_mmap(path, true).unwrap().unwrap(),
-            IndexType::RamMmap => MapIndex::<N>::new_mmap(path, false).unwrap().unwrap(),
+            IndexType::Mmap => MapIndex::<N>::new_mmap(path, true, &empty_deleted())
+                .unwrap()
+                .unwrap(),
+            IndexType::RamMmap => MapIndex::<N>::new_mmap(path, false, &empty_deleted())
+                .unwrap()
+                .unwrap(),
         };
         let hw_counter = HardwareCounterCell::new();
         for (idx, values) in data.iter().enumerate() {
@@ -1449,7 +1487,8 @@ mod tests {
     #[test]
     fn test_uuid_payload_index() {
         let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
-        let mut builder = MapIndex::<UuidIntType>::builder_mmap(temp_dir.path(), false);
+        let mut builder =
+            MapIndex::<UuidIntType>::builder_mmap(temp_dir.path(), false, &empty_deleted());
 
         builder.init().unwrap();
 
@@ -1477,7 +1516,8 @@ mod tests {
     #[test]
     fn test_index_non_ascending_insertion() {
         let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
-        let mut builder = MapIndex::<IntPayloadType>::builder_mmap(temp_dir.path(), false);
+        let mut builder =
+            MapIndex::<IntPayloadType>::builder_mmap(temp_dir.path(), false, &empty_deleted());
         builder.init().unwrap();
 
         let data = [vec![1, 2, 3, 4, 5, 6], vec![25], vec![10, 11]];
@@ -1639,5 +1679,166 @@ mod tests {
             0,
             "Expected RAM mmap get_values NOT to track IO reads, but counter was non-zero"
         );
+    }
+
+    /// Reload contract: runtime deletions are not persisted by the mmap map
+    /// index. Callers must re-supply the deletion bitslice on reload.
+    ///
+    /// Test data is chosen so that every value retains at least one live
+    /// point after deletions — otherwise `ImmutableMapIndex::open_mmap` hits a
+    /// pre-existing debug-only assertion when a value's slice becomes empty.
+    #[rstest]
+    #[case(IndexType::MutableGridstore)]
+    #[case(IndexType::Mmap)]
+    #[case(IndexType::RamMmap)]
+    fn test_map_index_reload(#[case] index_type: IndexType) {
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+        // Each value (1, 2, 3) appears at three points — deleting any single
+        // point leaves at least two live points per value.
+        let data: Vec<Vec<IntPayloadType>> = vec![
+            vec![1, 2], // id 0
+            vec![1],    // id 1
+            vec![2],    // id 2
+            vec![1, 3], // id 3
+            vec![2, 3], // id 4
+            vec![3],    // id 5
+        ];
+
+        // Build, remove some points, drop.
+        {
+            save_map_index::<IntPayloadType>(&data, temp_dir.path(), index_type, |v| (*v).into());
+            let mut index = load_map_index::<IntPayloadType>(&data, temp_dir.path(), index_type);
+            index.remove_point(1).unwrap();
+            index.remove_point(2).unwrap();
+            index.remove_point(5).unwrap();
+            index.flusher()().unwrap();
+            assert_eq!(index.get_indexed_points(), 3);
+            drop(index);
+        }
+
+        // Reload, re-supplying the deletion set for the mmap variants. For
+        // gridstore the argument is ignored.
+        let deleted = deleted_with(&[1, 2, 5]);
+        let new_index = match index_type {
+            IndexType::MutableGridstore => {
+                MapIndex::<IntPayloadType>::new_gridstore(temp_dir.path().to_path_buf(), true)
+                    .unwrap()
+                    .unwrap()
+            }
+            IndexType::Mmap => {
+                MapIndex::<IntPayloadType>::new_mmap(temp_dir.path(), true, &deleted)
+                    .unwrap()
+                    .unwrap()
+            }
+            IndexType::RamMmap => {
+                MapIndex::<IntPayloadType>::new_mmap(temp_dir.path(), false, &deleted)
+                    .unwrap()
+                    .unwrap()
+            }
+        };
+
+        assert_eq!(new_index.get_indexed_points(), 3);
+
+        let hw_counter = HardwareCounterCell::new();
+        for id in [1u32, 2, 5] {
+            assert_eq!(
+                new_index.values_count(id),
+                0,
+                "deleted point {id} should have no values after reload",
+            );
+        }
+        for id in [0u32, 3, 4] {
+            assert!(
+                new_index.values_count(id) > 0,
+                "live point {id} should have values after reload",
+            );
+        }
+
+        // Lookup-by-value path: consistent across variants.
+        // Value 1: originally at ids {0, 1, 3} → after deletions {0, 3}.
+        let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&1, &hw_counter).collect();
+        hits.sort();
+        assert_eq!(hits, vec![0, 3]);
+
+        // Value 2: originally at ids {0, 2, 4} → after deletions {0, 4}.
+        let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&2, &hw_counter).collect();
+        hits.sort();
+        assert_eq!(hits, vec![0, 4]);
+
+        // Value 3: originally at ids {3, 4, 5} → after deletions {3, 4}.
+        let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&3, &hw_counter).collect();
+        hits.sort();
+        assert_eq!(hits, vec![3, 4]);
+    }
+
+    /// Regression test: when reloading an mmap map index with a `deleted_points`
+    /// bitslice shorter than `point_to_values.len()`, missing entries must
+    /// default to live, not deleted. Empty-payload bits from the on-disk
+    /// `deleted.bin` and any deletions encoded inside the short bitslice must
+    /// still be honored.
+    #[rstest]
+    #[case(IndexType::Mmap)]
+    #[case(IndexType::RamMmap)]
+    fn test_map_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
+        let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+
+        // Point at id 2 has an empty payload, so build-time `deleted.bin`
+        // will mark it. Every value retains at least one live point after
+        // deleting id 1 — see note on `test_map_index_reload`.
+        let data: Vec<Vec<IntPayloadType>> = vec![
+            vec![1],    // id 0
+            vec![1, 2], // id 1
+            vec![],     // id 2 — empty payload
+            vec![2, 3], // id 3
+            vec![3],    // id 4
+        ];
+
+        save_map_index::<IntPayloadType>(&data, temp_dir.path(), index_type, |v| (*v).into());
+
+        // Reload with a bitslice shorter than `point_to_values.len()` (which
+        // is 5) marking only point 1 as deleted. Models an id-tracker whose
+        // internal range hasn't yet caught up to the index's highest id.
+        let mut short_deleted = BitVec::repeat(false, 2);
+        short_deleted.set(1, true);
+
+        let new_index = match index_type {
+            IndexType::Mmap => {
+                MapIndex::<IntPayloadType>::new_mmap(temp_dir.path(), true, &short_deleted)
+                    .unwrap()
+                    .unwrap()
+            }
+            IndexType::RamMmap => {
+                MapIndex::<IntPayloadType>::new_mmap(temp_dir.path(), false, &short_deleted)
+                    .unwrap()
+                    .unwrap()
+            }
+            IndexType::MutableGridstore => unreachable!(),
+        };
+
+        let hw_counter = HardwareCounterCell::new();
+
+        // id 1 deleted (from short bitslice), id 2 deleted (from build-time
+        // empty payload), ids 0, 3, 4 live (3 and 4 are beyond the short
+        // bitslice and must default to live).
+        assert!(new_index.values_count(0) > 0, "id 0 should be live");
+        assert_eq!(new_index.values_count(1), 0, "id 1 deleted via bitslice");
+        assert_eq!(
+            new_index.values_count(2),
+            0,
+            "id 2 deleted via build-time empty"
+        );
+        assert!(
+            new_index.values_count(3) > 0,
+            "id 3 should be live (beyond bitslice)"
+        );
+        assert!(
+            new_index.values_count(4) > 0,
+            "id 4 should be live (beyond bitslice)"
+        );
+
+        // Value `2`: originally at ids 1, 3 — after id 1 is deleted, only id 3.
+        let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&2, &hw_counter).collect();
+        hits.sort();
+        assert_eq!(hits, vec![3]);
     }
 }


### PR DESCRIPTION
Make the mmap map index immutable on disk, mirroring the change applied to the mmap numeric index in #8594 and the mmap text index in #8840.

- MmapMapIndex no longer persists runtime deletions: BufferedUpdateBitSlice is replaced with an in-memory BitVec.

- deleted.bin is now build-time only — it records the points whose payload was empty at build time. It joins values_to_points.bin, point_to_values.*, and mmap_field_index_config.json in immutable_files().
- On reload, callers must re-supply the authoritative deletion mask via the new deleted_points: &BitSlice argument to MmapMapIndex::open / MapIndex::new_mmap / builder_mmap. The id-tracker is the source of
  truth at runtime.
- The reload merges the build-time empty-payload bits with the caller-provided mask via bitor_assign, after resizing to point_to_values.len() (defaulting missing trailing entries to live).
- flusher() is now a no-op; remove_point() only updates the in-memory bitvec.
- ram_usage_bytes() now reports the in-memory deletion bitvec plus point_to_values for the mmap variant.
- Added type-level docs on MmapMapIndex and method-level docs on flusher / remove_point describing the deletion durability contract.