### PR TITLE
Fix linux import lints

### DIFF
--- a/lib/common/common/src/process_cpu_usage.rs
+++ b/lib/common/common/src/process_cpu_usage.rs
@@ -9,8 +9,11 @@
 //! Currently only Linux is supported (via `/proc/self/stat`); other
 //! platforms return `None`.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
 
+#[cfg(target_os = "linux")]
 use parking_lot::Mutex;
 
 /// Sampling window: how often we query the OS for process CPU time.


### PR DESCRIPTION
#8790 Introduced some ungated imports, which were triggering "unused import" lints.