### PR TITLE
[AI] Do not hold shards_holder.read on search

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -187,9 +187,9 @@ impl Collection {
         // update collection config
         self.collection_config.read().await.save(&self.path)?;
         // apply config change to all shards
-        let mut shard_holder = self.shards_holder.write().await;
+        let shard_holder = self.shards_holder.write().await;
         let updates = shard_holder
-            .all_shards_mut()
+            .all_shards()
             .map(|replica_set| replica_set.on_strict_mode_config_update());
         future::try_join_all(updates).await?;
         Ok(())

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use futures::{TryFutureExt, future};
+use futures::future;
 use itertools::{Either, Itertools};
 use segment::types::{
-    ExtendedPointId, Filter, Order, ScoredPoint, WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, Order, ScoredPoint, ShardKey, WithPayloadInterface, WithVector,
 };
 use shard::retrieve::record_internal::RecordInternal;
 use shard::search::CoreSearchRequestBatch;
@@ -155,34 +155,45 @@ impl Collection {
 
         let instant = Instant::now();
 
-        // query all shards concurrently
-        let all_searches_res = {
+        // Snapshot the targeted shards under the read guard, then drop it
+        // before awaiting the per-shard searches. Holding the guard across
+        // the searches would block writers (e.g. shard creation) for the
+        // entire search duration; cloning `Arc<ShardReplicaSet>` lets each
+        // search keep the shard alive on its own.
+        let targets: Vec<(Arc<_>, Option<ShardKey>)> = {
             let shard_holder = self.shards_holder.read().await;
-            let target_shards = shard_holder.select_shards(shard_selection)?;
-            let all_searches = target_shards.into_iter().map(|(shard, shard_key)| {
-                let shard_key = shard_key.cloned();
-                shard
+            shard_holder
+                .select_shards(shard_selection)?
+                .into_iter()
+                .map(|(shard, shard_key)| (Arc::clone(shard), shard_key.cloned()))
+                .collect()
+        };
+
+        // query all shards concurrently
+        let all_searches = targets.into_iter().map(|(shard, shard_key)| {
+            let request = request.clone();
+            let hw_measurement_acc = hw_measurement_acc.clone();
+            async move {
+                let mut records = shard
                     .core_search(
-                        request.clone(),
+                        request,
                         read_consistency,
                         shard_selection.is_shard_id(),
                         timeout,
-                        hw_measurement_acc.clone(),
+                        hw_measurement_acc,
                     )
-                    .and_then(move |mut records| async move {
-                        if shard_key.is_none() {
-                            return Ok(records);
+                    .await?;
+                if shard_key.is_some() {
+                    for batch in &mut records {
+                        for point in batch {
+                            point.shard_key.clone_from(&shard_key);
                         }
-                        for batch in &mut records {
-                            for point in batch {
-                                point.shard_key.clone_from(&shard_key);
-                            }
-                        }
-                        Ok(records)
-                    })
-            });
-            future::try_join_all(all_searches).await?
-        };
+                    }
+                }
+                CollectionResult::Ok(records)
+            }
+        });
+        let all_searches_res = future::try_join_all(all_searches).await?;
 
         let result = self
             .merge_from_shards(

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -219,7 +219,7 @@ impl Collection {
 
         for (shard_id, shard_info) in shards {
             let shard_key = shards_key_mapping.shard_key(shard_id);
-            match shards_holder.get_shard_mut(shard_id) {
+            match shards_holder.get_shard(shard_id) {
                 Some(replica_set) => {
                     replica_set
                         .apply_state(shard_info.replicas, shard_key)
@@ -228,7 +228,7 @@ impl Collection {
                 None => {
                     let mut shard_replicas: Vec<_> = shard_info.replicas.keys().copied().collect();
                     shard_replicas.sort_unstable();
-                    let mut replica_set = self
+                    let replica_set = self
                         .create_replica_set(shard_id, shard_key.clone(), &shard_replicas, None)
                         .await?;
                     replica_set

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -116,6 +116,7 @@ pub struct LocalShard {
     pub(super) search_runtime: AdaptiveSearchHandle,
     disk_usage_watcher: DiskUsageWatcher,
     read_rate_limiter: Option<ParkingMutex<RateLimiter>>,
+    write_rate_limiter: Option<ParkingMutex<RateLimiter>>,
 
     is_gracefully_stopped: bool,
 
@@ -301,6 +302,12 @@ impl LocalShard {
                 .map(RateLimiter::new_per_minute)
                 .map(ParkingMutex::new)
         });
+        let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
+            strict_mode
+                .write_rate_limit
+                .map(RateLimiter::new_per_minute)
+                .map(ParkingMutex::new)
+        });
 
         drop(config); // release `shared_config` from borrow checker
 
@@ -322,6 +329,7 @@ impl LocalShard {
             total_optimized_points,
             disk_usage_watcher,
             read_rate_limiter,
+            write_rate_limiter,
             is_gracefully_stopped: false,
             update_operation_lock: scroll_read_lock,
             applied_seq_handler,
@@ -902,23 +910,24 @@ impl LocalShard {
     }
 
     /// Apply shard's strict mode configuration update
-    /// - Update read rate limiter
+    /// - Update read and write rate limiters
     pub async fn on_strict_mode_config_update(&mut self) {
         let config = self.collection_config.read().await;
 
-        if let Some(strict_mode_config) = &config.strict_mode_config
-            && strict_mode_config.enabled == Some(true)
-        {
-            // update read rate limiter
-            if let Some(read_rate_limit_per_min) = strict_mode_config.read_rate_limit {
-                let new_read_rate_limiter = RateLimiter::new_per_minute(read_rate_limit_per_min);
-                self.read_rate_limiter
-                    .replace(parking_lot::Mutex::new(new_read_rate_limiter));
-                return;
-            }
-        }
-        // remove read rate limiter for all other situations
-        self.read_rate_limiter.take();
+        let strict_mode = config
+            .strict_mode_config
+            .as_ref()
+            .filter(|cfg| cfg.enabled == Some(true));
+
+        let read_rate_limit_per_min = strict_mode.and_then(|cfg| cfg.read_rate_limit);
+        let write_rate_limit_per_min = strict_mode.and_then(|cfg| cfg.write_rate_limit);
+
+        self.read_rate_limiter = read_rate_limit_per_min
+            .map(RateLimiter::new_per_minute)
+            .map(ParkingMutex::new);
+        self.write_rate_limiter = write_rate_limit_per_min
+            .map(RateLimiter::new_per_minute)
+            .map(ParkingMutex::new);
     }
 
     pub async fn estimate_cardinality<'a>(
@@ -1310,6 +1319,33 @@ impl LocalShard {
                     log::debug!("Read rate limit error on {context} with {err:?}");
                     CollectionError::rate_limit_error(err, cost, false)
                 })?;
+        }
+        Ok(())
+    }
+
+    /// Check if the write rate limiter allows the operation to proceed.
+    ///
+    /// Mirrors `check_read_rate_limiter` but for writes; the cost is computed
+    /// lazily via `cost_fn` (which may be async, e.g. cardinality estimates).
+    /// Returns an error if the rate limit is exceeded.
+    pub(crate) async fn check_write_rate_limiter<F>(
+        &self,
+        hw_measurement_acc: &HwMeasurementAcc,
+        cost_fn: F,
+    ) -> CollectionResult<()>
+    where
+        F: AsyncFnOnce() -> usize,
+    {
+        // Do not rate limit internal operation tagged with disposable measurement
+        if hw_measurement_acc.is_disposable() {
+            return Ok(());
+        }
+        if let Some(rate_limiter) = &self.write_rate_limiter {
+            let cost = cost_fn().await;
+            rate_limiter
+                .lock()
+                .try_consume(cost as f64)
+                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
         }
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use common::rate_limiting::RateLimiter;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use replica_set_state::{ReplicaSetState, ReplicaState};
@@ -106,7 +105,10 @@ pub struct ShardReplicaSet {
     locally_disabled_peers: parking_lot::RwLock<locally_disabled_peers::Registry>,
     pub(crate) shard_path: PathBuf,
     pub(crate) shard_id: ShardId,
-    shard_key: Option<ShardKey>,
+    /// Optional shard key. Wrapped in `parking_lot::RwLock` so it can be
+    /// reassigned via `&self` (e.g. when applying snapshot state on a shard
+    /// that was already mounted).
+    shard_key: parking_lot::RwLock<Option<ShardKey>>,
     notify_peer_failure_cb: ChangePeerFromState,
     abort_shard_transfer_cb: AbortShardTransfer,
     channel_service: ChannelService,
@@ -122,7 +124,6 @@ pub struct ShardReplicaSet {
     write_ordering_lock: Mutex<()>,
     /// Local clock set, used to tag new operations on this shard.
     clock_set: Mutex<ClockSet>,
-    write_rate_limiter: Option<parking_lot::Mutex<RateLimiter>>,
     pub partial_snapshot_meta: PartialSnapshotMeta,
 }
 
@@ -201,19 +202,9 @@ impl ShardReplicaSet {
         let replica_set_shard_config = ShardConfig::new_replica_set();
         replica_set_shard_config.save(&shard_path)?;
 
-        // Initialize the write rate limiter
-        let config = collection_config.read().await;
-        let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
-            strict_mode
-                .write_rate_limit
-                .map(RateLimiter::new_per_minute)
-                .map(parking_lot::Mutex::new)
-        });
-        drop(config);
-
         Ok(Self {
             shard_id,
-            shard_key,
+            shard_key: parking_lot::RwLock::new(shard_key),
             local: RwLock::new(local),
             remotes: RwLock::new(remote_shards),
             replica_state: replica_state.into(),
@@ -232,7 +223,6 @@ impl ShardReplicaSet {
             optimizer_resource_budget,
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
-            write_rate_limiter,
             partial_snapshot_meta: PartialSnapshotMeta::default(),
         })
     }
@@ -342,19 +332,9 @@ impl ShardReplicaSet {
             None
         };
 
-        // Initialize the write rate limiter
-        let config = collection_config.read().await;
-        let write_rate_limiter = config.strict_mode_config.as_ref().and_then(|strict_mode| {
-            strict_mode
-                .write_rate_limit
-                .map(RateLimiter::new_per_minute)
-                .map(parking_lot::Mutex::new)
-        });
-        drop(config);
-
         let replica_set = Self {
             shard_id,
-            shard_key,
+            shard_key: parking_lot::RwLock::new(shard_key),
             local: RwLock::new(local),
             remotes: RwLock::new(remote_shards),
             replica_state: replica_state.into(),
@@ -374,7 +354,6 @@ impl ShardReplicaSet {
             optimizer_resource_budget,
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
-            write_rate_limiter,
             partial_snapshot_meta: PartialSnapshotMeta::default(),
         };
 
@@ -389,14 +368,14 @@ impl ShardReplicaSet {
         replica_set
     }
 
-    pub async fn stop_gracefully(self) {
+    pub async fn stop_gracefully(&self) {
         if let Some(local) = self.local.write().await.take() {
             local.stop_gracefully().await;
         }
     }
 
-    pub fn shard_key(&self) -> Option<&ShardKey> {
-        self.shard_key.as_ref()
+    pub fn shard_key(&self) -> Option<ShardKey> {
+        self.shard_key.read().clone()
     }
 
     pub fn this_peer_id(&self) -> PeerId {
@@ -838,7 +817,7 @@ impl ShardReplicaSet {
     }
 
     pub async fn apply_state(
-        &mut self,
+        &self,
         replicas: HashMap<PeerId, ReplicaState>,
         shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
@@ -931,7 +910,7 @@ impl ShardReplicaSet {
         }
 
         // Apply shard key
-        self.shard_key = shard_key;
+        *self.shard_key.write() = shard_key;
 
         Ok(())
     }
@@ -949,53 +928,12 @@ impl ShardReplicaSet {
     }
 
     /// Apply shard's strict mode configuration update
-    /// - Update read and write rate limiters
-    pub(crate) async fn on_strict_mode_config_update(&mut self) -> CollectionResult<()> {
-        let mut read_local = self.local.write().await;
-        if let Some(shard) = read_local.as_mut() {
-            shard.on_strict_mode_config_update().await
-        }
-        drop(read_local);
-        let config = self.collection_config.read().await;
-        if let Some(strict_mode_config) = &config.strict_mode_config
-            && strict_mode_config.enabled == Some(true)
-        {
-            // update write rate limiter
-            if let Some(write_rate_limit_per_min) = strict_mode_config.write_rate_limit {
-                let new_write_rate_limiter = RateLimiter::new_per_minute(write_rate_limit_per_min);
-                self.write_rate_limiter
-                    .replace(parking_lot::Mutex::new(new_write_rate_limiter));
-                return Ok(());
-            }
-        }
-        // remove write rate limiter for all other situations
-        self.write_rate_limiter.take();
-        Ok(())
-    }
-
-    /// Check if the write rate limiter allows the operation to proceed
-    /// - hw_measurement_acc: the current hardware measurement accumulator
-    /// - cost_fn: the cost of the operation called lazily
     ///
-    /// Returns an error if the rate limit is exceeded.
-    async fn check_write_rate_limiter<F>(
-        &self,
-        hw_measurement_acc: &HwMeasurementAcc,
-        cost_fn: F,
-    ) -> CollectionResult<()>
-    where
-        F: AsyncFnOnce() -> usize,
-    {
-        // Do not rate limit internal operation tagged with disposable measurement
-        if hw_measurement_acc.is_disposable() {
-            return Ok(());
-        }
-        if let Some(rate_limiter) = &self.write_rate_limiter {
-            let cost = cost_fn().await;
-            rate_limiter
-                .lock()
-                .try_consume(cost as f64)
-                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
+    /// The actual rate limiters live on `LocalShard`, so this just delegates
+    /// while we hold the local-shard write lock.
+    pub(crate) async fn on_strict_mode_config_update(&self) -> CollectionResult<()> {
+        if let Some(shard) = self.local.write().await.as_mut() {
+            shard.on_strict_mode_config_update().await;
         }
         Ok(())
     }

--- a/lib/collection/src/shards/replica_set/telemetry.rs
+++ b/lib/collection/src/shards/replica_set/telemetry.rs
@@ -24,7 +24,7 @@ impl ShardReplicaSet {
 
         Ok(ReplicaSetTelemetry {
             id: self.shard_id,
-            key: self.shard_key.clone(),
+            key: self.shard_key(),
             local: local_telemetry,
             remote: self
                 .remotes

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -588,28 +588,35 @@ impl ShardReplicaSet {
 
     /// Check write rate limiter for the operation
     ///
-    /// Lazily compute the cost of the operation and check against the write rate limiter
+    /// Lazily compute the cost of the operation and check against the write
+    /// rate limiter. The limiter lives on `LocalShard`; proxy wrappers forward
+    /// writes to that same local shard, so we resolve the wrapped local shard
+    /// uniformly via [`Shard::local_shard`]. `Dummy` shards have no limiter.
     async fn check_operation_write_rate_limiter(
         &self,
         hw_measurement: &HwMeasurementAcc,
         local: &Shard,
         operation: &OperationWithClockTag,
     ) -> CollectionResult<()> {
-        self.check_write_rate_limiter(hw_measurement, || async {
-            let mut ratelimiter_cost = 1;
+        let Some(local_shard) = local.local_shard() else {
+            return Ok(());
+        };
+        local_shard
+            .check_write_rate_limiter(hw_measurement, async || {
+                let mut ratelimiter_cost = 1;
 
-            // Estimate the cost based on affected points if filter is available.
-            match local
-                .estimate_request_cardinality(&operation.operation, hw_measurement)
-                .await
-            {
-                Ok(est) => ratelimiter_cost = 1.max(est.exp),
-                Err(err) => log::error!("Estimating cardinality: {err:?}"),
-            }
+                // Estimate the cost based on affected points if filter is available.
+                match local
+                    .estimate_request_cardinality(&operation.operation, hw_measurement)
+                    .await
+                {
+                    Ok(est) => ratelimiter_cost = 1.max(est.exp),
+                    Err(err) => log::error!("Estimating cardinality: {err:?}"),
+                }
 
-            ratelimiter_cost
-        })
-        .await?;
+                ratelimiter_cost
+            })
+            .await?;
         Ok(())
     }
 

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -77,6 +77,21 @@ impl Shard {
         }
     }
 
+    /// Return the underlying [`LocalShard`] if this shard wraps one.
+    ///
+    /// Proxy variants forward writes to a wrapped local shard, so callers
+    /// that need the local-shard's state (e.g. rate limiters) can reach it
+    /// uniformly through this accessor. `Dummy` returns `None`.
+    pub fn local_shard(&self) -> Option<&LocalShard> {
+        match self {
+            Shard::Local(local_shard) => Some(local_shard),
+            Shard::Proxy(proxy_shard) => Some(&proxy_shard.wrapped_shard),
+            Shard::ForwardProxy(proxy_shard) => Some(&proxy_shard.wrapped_shard),
+            Shard::QueueProxy(proxy_shard) => proxy_shard.wrapped_shard(),
+            Shard::Dummy(_) => None,
+        }
+    }
+
     pub async fn get_telemetry_data(
         &self,
         detail: TelemetryDetail,

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -65,7 +65,13 @@ pub const SHARD_KEY_MAPPING_FILE: &str = "shard_key_mapping.json";
 pub struct ShardHolder {
     /// `BTreeMap` for deterministic iteration order by `ShardId` — iteration is externally
     /// observable (fan-out, telemetry, consensus state apply).
-    shards: BTreeMap<ShardId, ShardReplicaSet>,
+    ///
+    /// Values are `Arc` so consumers can clone a handle, drop the outer
+    /// `ShardHolder` lock, and still operate on the shard. This matters
+    /// especially for searches: holding the `ShardHolder` read lock across
+    /// every `core_search` await would block writers (e.g. shard creation)
+    /// for the duration of the search.
+    shards: BTreeMap<ShardId, Arc<ShardReplicaSet>>,
     pub(crate) shard_transfers: SaveOnDisk<HashSet<ShardTransfer>>,
     pub(crate) shard_transfer_changes: broadcast::Sender<ShardTransferChange>,
     pub(crate) resharding_state: SaveOnDisk<Option<ReshardState>>,
@@ -130,7 +136,7 @@ impl ShardHolder {
     pub async fn stop_gracefully(&mut self) {
         let futures = std::mem::take(&mut self.shards)
             .into_values()
-            .map(|shard| shard.stop_gracefully());
+            .map(|shard| async move { shard.stop_gracefully().await });
         futures::future::join_all(futures).await;
     }
 
@@ -227,7 +233,7 @@ impl ShardHolder {
         shard: ShardReplicaSet,
         shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
-        let evicted = self.shards.insert(shard_id, shard);
+        let evicted = self.shards.insert(shard_id, Arc::new(shard));
         if let Some(evicted) = evicted {
             debug_assert!(false, "Overwriting existing shard id {shard_id}");
             evicted.stop_gracefully().await;
@@ -333,7 +339,7 @@ impl ShardHolder {
         extra_shards: AHashMap<ShardId, ShardReplicaSet>,
     ) -> CollectionResult<()> {
         for (extra_shard_id, extra_shard) in extra_shards {
-            let evicted = self.shards.insert(extra_shard_id, extra_shard);
+            let evicted = self.shards.insert(extra_shard_id, Arc::new(extra_shard));
             if let Some(evicted) = evicted {
                 evicted.stop_gracefully().await;
             }
@@ -358,31 +364,23 @@ impl ShardHolder {
         self.shards.contains_key(&shard_id)
     }
 
-    pub fn get_shard(&self, shard_id: ShardId) -> Option<&ShardReplicaSet> {
+    pub fn get_shard(&self, shard_id: ShardId) -> Option<&Arc<ShardReplicaSet>> {
         self.shards.get(&shard_id)
     }
 
-    pub fn get_shard_mut(&mut self, shard_id: ShardId) -> Option<&mut ShardReplicaSet> {
-        self.shards.get_mut(&shard_id)
-    }
-
-    pub fn get_shards(&self) -> impl Iterator<Item = (ShardId, &ShardReplicaSet)> {
+    pub fn get_shards(&self) -> impl Iterator<Item = (ShardId, &Arc<ShardReplicaSet>)> {
         self.shards.iter().map(|(id, shard)| (*id, shard))
     }
 
-    pub fn all_shards(&self) -> impl Iterator<Item = &ShardReplicaSet> {
+    pub fn all_shards(&self) -> impl Iterator<Item = &Arc<ShardReplicaSet>> {
         self.shards.values()
-    }
-
-    pub fn all_shards_mut(&mut self) -> impl Iterator<Item = &mut ShardReplicaSet> {
-        self.shards.values_mut()
     }
 
     pub fn split_by_shard<O: SplitByShard + Clone>(
         &self,
         operation: O,
         shard_keys_selection: &Option<ShardKey>,
-    ) -> CollectionResult<Vec<(&ShardReplicaSet, O)>> {
+    ) -> CollectionResult<Vec<(&Arc<ShardReplicaSet>, O)>> {
         let Some(hashring) = self.rings.get(&shard_keys_selection.clone()) else {
             return if let Some(shard_key) = shard_keys_selection {
                 Err(CollectionError::bad_input(format!(
@@ -568,7 +566,7 @@ impl ShardHolder {
     pub fn select_shards<'a>(
         &'a self,
         shard_selector: &'a ShardSelectorInternal,
-    ) -> CollectionResult<Vec<(&'a ShardReplicaSet, Option<&'a ShardKey>)>> {
+    ) -> CollectionResult<Vec<(&'a Arc<ShardReplicaSet>, Option<&'a ShardKey>)>> {
         let mut res = Vec::new();
 
         match shard_selector {
@@ -1162,7 +1160,7 @@ impl ShardHolder {
     ///
     /// This method is cancel safe.
     pub async fn stream_shard_snapshot(
-        shard: OwnedRwLockReadGuard<ShardHolder, ShardReplicaSet>,
+        shard: OwnedRwLockReadGuard<ShardHolder, Arc<ShardReplicaSet>>,
         collection_name: &str,
         shard_id: ShardId,
         manifest: Option<SnapshotManifest>,

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -314,7 +314,7 @@ impl Dispatcher {
                 .await;
 
             for replica_set in shard_holder.all_shards() {
-                if replica_set.shard_key() != Some(&shard_key) {
+                if replica_set.shard_key().as_ref() != Some(&shard_key) {
                     continue;
                 }
 


### PR DESCRIPTION
Currently, when running search, we are holding 

```
let shard_holder = self.shards_holder.read().await;
```

but this creates problems if user creates shards in parallel (with custom shard key, maybe).
Because of this, consensus loop might stuck, and I believe that is what happened in this CI test: 

https://github.com/qdrant/qdrant/actions/runs/25058352913/job/73404994822?pr=8826


This PR applies the similar approach, as we already have on segment level - we collect list of segments and release segment holder.

For this refactoring to happen nicely, I had to move write_rate_limiter on the local shard level, but it doesn't seem to affect anything, as rate limit check was already only applied if local shard was available.

