### PR TITLE
Properly handle `O_DIRECT` in io-uring

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -162,12 +162,10 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, IoUringFile, Meta>
         if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
             return Err(UniversalIoError::QueueIsFull);
         }
-        let state = &mut self.runtime.state;
-        let entry = if file.direct_io {
-            state.read_o_direct(meta, file.fd(), range)
-        } else {
-            state.read(meta, file.fd(), range)
-        };
+        let entry = self
+            .runtime
+            .state
+            .read(meta, file.fd(), range, file.direct_io);
         unsafe {
             squeue.push(&entry).expect("submission queue is not full");
         }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -85,6 +85,15 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
     }
 
     fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+        if self.direct_io {
+            // direct_io needs special handling
+            return self
+                .read_iter::<P, _>([((), range)])?
+                .next()
+                .expect("there's exactly one read")
+                .map(|(_, data)| data);
+        }
+
         let mut items = vec![T::zeroed(); range.length as usize];
         let bytes = bytemuck::cast_slice_mut(&mut items);
         self.file.read_exact_at(bytes, range.byte_offset)?;

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -153,10 +153,12 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, IoUringFile, Meta>
         if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
             return Err(UniversalIoError::QueueIsFull);
         }
-        let entry = self
-            .runtime
-            .state
-            .read(meta, file.fd(), range, file.direct_io);
+        let state = &mut self.runtime.state;
+        let entry = if file.direct_io {
+            state.read_o_direct(meta, file.fd(), range)
+        } else {
+            state.read(meta, file.fd(), range)
+        };
         unsafe {
             squeue.push(&entry).expect("submission queue is not full");
         }

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -194,16 +194,16 @@ where
 
         // Make sure read buffer is kernel-page aligned
         let page_byte_offset = byte_offset & !(KERNEL_PAGE_SIZE - 1); // page-aligned byte offset
-        let read_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
+        let inner_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
 
         let buffer_len =
-            (read_byte_offset + length * size_of::<T>() as u64).next_multiple_of(KERNEL_PAGE_SIZE);
+            (inner_byte_offset + length * size_of::<T>() as u64).next_multiple_of(KERNEL_PAGE_SIZE);
         let buffer: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); buffer_len as _];
         let (slot, req) = self.init(
             meta,
             IoUringRequest::ODirectRead {
                 buffer,
-                byte_offset: page_byte_offset as usize,
+                inner_byte_offset: inner_byte_offset as usize,
                 items_len: length as usize,
             },
         );
@@ -268,7 +268,7 @@ where
             }
             IoUringRequest::ODirectRead {
                 buffer,
-                byte_offset,
+                inner_byte_offset,
                 items_len,
             } => {
                 // We need to return an aligned Vec
@@ -286,14 +286,14 @@ where
                 let initialized_bytes = unsafe { buffer[..byte_length].assume_init_ref() };
 
                 // Make sure there are at least the requested num of items
-                let avail_items = byte_length.saturating_sub(byte_offset) / size_of::<T>();
+                let avail_items = byte_length.saturating_sub(inner_byte_offset) / size_of::<T>();
                 assert!(
                     items_len <= avail_items,
                     "expected at least {items_len} items, got {avail_items}"
                 );
 
                 // Cast requested range into &[T]
-                let items_range = byte_offset..byte_offset + items_len * size_of::<T>();
+                let items_range = inner_byte_offset..inner_byte_offset + items_len * size_of::<T>();
                 let items_bytes = &initialized_bytes[items_range];
                 let items_slice = bytemuck::cast_slice(items_bytes);
 
@@ -333,7 +333,7 @@ pub enum IoUringRequest<'data, T> {
 
     ODirectRead {
         buffer: Vec<MaybeUninit<u8>>,
-        byte_offset: usize,
+        inner_byte_offset: usize,
         items_len: usize,
     },
 
@@ -354,7 +354,7 @@ impl<'data, T> IoUringRequest<'data, T> {
         match self {
             IoUringRequest::ODirectRead {
                 buffer,
-                byte_offset: _,
+                inner_byte_offset: _,
                 items_len: _,
             } => buffer,
             _ => panic!(),

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -19,13 +19,11 @@ impl PageAlignedBytes {
         Self([MaybeUninit::uninit(); KERNEL_PAGE_SIZE as usize])
     }
 
-    fn as_maybe_bytes(vec: Vec<Self>) -> Vec<MaybeUninit<u8>> {
-        let (ptr, length, capacity) = vec.into_raw_parts();
+    fn as_maybe_bytes(slice: &[Self]) -> &[MaybeUninit<u8>] {
         unsafe {
-            Vec::from_raw_parts(
-                ptr as *mut MaybeUninit<u8>,
-                length * KERNEL_PAGE_SIZE as usize,
-                capacity * KERNEL_PAGE_SIZE as usize,
+            std::slice::from_raw_parts(
+                slice.as_ptr() as *const MaybeUninit<u8>,
+                slice.len() * KERNEL_PAGE_SIZE as usize,
             )
         }
     }
@@ -238,7 +236,7 @@ where
         let bytes_ptr = buffer.as_mut_ptr().cast();
 
         opcode::Read::new(fd, bytes_ptr, bytes_len)
-            .offset(byte_offset)
+            .offset(page_byte_offset)
             .build()
             .user_data(slot as u64)
     }
@@ -296,7 +294,7 @@ where
                 inner_byte_offset,
                 items_len,
             } => {
-                let buffer_bytes = PageAlignedBytes::as_maybe_bytes(buffer);
+                let buffer_bytes = PageAlignedBytes::as_maybe_bytes(&buffer);
 
                 // We need to return a `T`-aligned Vec
 

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -164,50 +164,55 @@ where
 
     /// Allocates `Vec<MaybeUninit<T>>`, reinterprets it as `Vec<MaybeUninit<u8>>`, and stores the byte buffer
     /// so the kernel writes into correctly aligned memory for `T`.
-    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange, direct_io: bool) -> squeue::Entry {
+    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,
         } = range;
 
-        let (slot, bytes_ptr, byte_length, byte_offset) = if direct_io {
-            // Make sure read buffer is kernel-page aligned
-            let page_byte_offset = byte_offset & !(KERNEL_PAGE_SIZE - 1); // page-aligned byte offset
-            let read_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
+        // Size the buffer exactly to the number of items to read
+        let items: Vec<MaybeUninit<T>> = vec![MaybeUninit::uninit(); length as _];
+        let (slot, req) = self.init(meta, IoUringRequest::Read { items });
+        let items = req.expect_read();
 
-            let buffer_len = (read_byte_offset + length * size_of::<T>() as u64)
-                .next_multiple_of(KERNEL_PAGE_SIZE);
-            let buffer: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); buffer_len as _];
-            let (slot, req) = self.init(
-                meta,
-                IoUringRequest::ODirectRead {
-                    buffer,
-                    byte_offset: page_byte_offset as usize,
-                    items_len: length as usize,
-                },
-            );
-            let buffer = req.expect_o_direct_read();
-
-            let byte_length = buffer.len();
-            let byte_length =
-                u32::try_from(byte_length).expect("read buffer length fit within u32");
-            let bytes_ptr = buffer.as_mut_ptr().cast();
-
-            (slot, bytes_ptr, byte_length, page_byte_offset)
-        } else {
-            // Size the buffer exactly to the number of items to read
-            let items: Vec<MaybeUninit<T>> = vec![MaybeUninit::uninit(); length as _];
-            let (slot, req) = self.init(meta, IoUringRequest::Read { items });
-            let items = req.expect_read();
-
-            let bytes_ptr = items.as_mut_ptr().cast();
-            let byte_length = length * size_of::<T>() as u64;
-            let byte_length =
-                u32::try_from(byte_length).expect("read buffer length fit within u32");
-            (slot, bytes_ptr, byte_length, byte_offset)
-        };
+        let bytes_ptr = items.as_mut_ptr().cast();
+        let byte_length = length * size_of::<T>() as u64;
+        let byte_length = u32::try_from(byte_length).expect("read buffer length fit within u32");
 
         opcode::Read::new(fd, bytes_ptr, byte_length)
+            .offset(byte_offset)
+            .build()
+            .user_data(slot as u64)
+    }
+
+    /// Allocates a `Vec<MaybeUninit<u8>>` aligned to 4kB.
+    pub fn read_o_direct(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
+        let ReadRange {
+            byte_offset,
+            length,
+        } = range;
+
+        // Make sure read buffer is kernel-page aligned
+        let page_byte_offset = byte_offset & !(KERNEL_PAGE_SIZE - 1); // page-aligned byte offset
+        let read_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
+
+        let buffer_len =
+            (read_byte_offset + length * size_of::<T>() as u64).next_multiple_of(KERNEL_PAGE_SIZE);
+        let buffer: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); buffer_len as _];
+        let (slot, req) = self.init(
+            meta,
+            IoUringRequest::ODirectRead {
+                buffer,
+                byte_offset: page_byte_offset as usize,
+                items_len: length as usize,
+            },
+        );
+        let buffer = req.expect_o_direct_read();
+
+        let buffer_len = u32::try_from(buffer_len).expect("read buffer length fit within u32");
+        let bytes_ptr = buffer.as_mut_ptr().cast();
+
+        opcode::Read::new(fd, bytes_ptr, buffer_len)
             .offset(byte_offset)
             .build()
             .user_data(slot as u64)

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -22,7 +22,7 @@ impl PageAlignedBytes {
     fn as_maybe_bytes(slice: &[Self]) -> &[MaybeUninit<u8>] {
         unsafe {
             std::slice::from_raw_parts(
-                slice.as_ptr() as *const MaybeUninit<u8>,
+                slice.as_ptr().cast::<MaybeUninit<u8>>(),
                 slice.len() * KERNEL_PAGE_SIZE as usize,
             )
         }
@@ -368,7 +368,6 @@ pub enum IoUringRequest<'data, T> {
 
 impl<'data, T> IoUringRequest<'data, T> {
     pub fn expect_read(&mut self) -> &mut Vec<MaybeUninit<T>> {
-        #[expect(clippy::match_wildcard_for_single_variants)]
         match self {
             IoUringRequest::Read { items } => items,
             _ => panic!(),
@@ -376,7 +375,6 @@ impl<'data, T> IoUringRequest<'data, T> {
     }
 
     pub fn expect_o_direct_read(&mut self) -> &mut Vec<PageAlignedBytes> {
-        #[expect(clippy::match_wildcard_for_single_variants)]
         match self {
             IoUringRequest::ODirectRead {
                 buffer,
@@ -388,7 +386,6 @@ impl<'data, T> IoUringRequest<'data, T> {
     }
 
     pub fn expect_write(&self) -> &'data [T] {
-        #[expect(clippy::match_wildcard_for_single_variants)]
         match self {
             IoUringRequest::Write(items) => items,
             _ => panic!(),

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -307,8 +307,9 @@ where
 
                 // We need to return a `T`-aligned Vec
 
-                // TODO(perf): if T's alignment matches a page size, we can cast the buffer and return
-                // without a second allocation.
+                // TODO(perf): Currently, we are allocating 2 Vecs: a page-aligned vec, and then the `T`-aligned one.
+                //             In theory we can use `opcode::ReadFixed` to use preregistered buffers so that we only
+                //             allocate one extra buffer per read. Not done for now since it complicates implementation.
 
                 //
                 // buffer_bytes

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -10,6 +10,27 @@ use crate::maybe_uninit;
 
 const KERNEL_PAGE_SIZE: u64 = 4096; // 4 kB
 
+#[derive(Debug, Clone)]
+#[repr(C, align(4096))]
+pub struct PageAlignedBytes([MaybeUninit<u8>; KERNEL_PAGE_SIZE as usize]);
+
+impl PageAlignedBytes {
+    const fn uninit() -> Self {
+        Self([MaybeUninit::uninit(); KERNEL_PAGE_SIZE as usize])
+    }
+
+    fn as_maybe_bytes(vec: Vec<Self>) -> Vec<MaybeUninit<u8>> {
+        let (ptr, length, capacity) = vec.into_raw_parts();
+        unsafe {
+            Vec::from_raw_parts(
+                ptr as *mut MaybeUninit<u8>,
+                length * KERNEL_PAGE_SIZE as usize,
+                capacity * KERNEL_PAGE_SIZE as usize,
+            )
+        }
+    }
+}
+
 pub struct IoUringRuntime<'data, T: bytemuck::Pod, Meta = u64> {
     pub io_uring: IoUringGuard,
     pub state: IoUringState<'data, T, Meta>,
@@ -196,9 +217,13 @@ where
         let page_byte_offset = byte_offset & !(KERNEL_PAGE_SIZE - 1); // page-aligned byte offset
         let inner_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
 
-        let buffer_len =
+        let bytes_len =
             (inner_byte_offset + length * size_of::<T>() as u64).next_multiple_of(KERNEL_PAGE_SIZE);
-        let buffer: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); buffer_len as _];
+
+        let num_pages = bytes_len / KERNEL_PAGE_SIZE;
+
+        let buffer: Vec<PageAlignedBytes> = vec![PageAlignedBytes::uninit(); num_pages as _];
+
         let (slot, req) = self.init(
             meta,
             IoUringRequest::ODirectRead {
@@ -209,10 +234,10 @@ where
         );
         let buffer = req.expect_o_direct_read();
 
-        let buffer_len = u32::try_from(buffer_len).expect("read buffer length fit within u32");
+        let bytes_len = u32::try_from(bytes_len).expect("read buffer length fit within u32");
         let bytes_ptr = buffer.as_mut_ptr().cast();
 
-        opcode::Read::new(fd, bytes_ptr, buffer_len)
+        opcode::Read::new(fd, bytes_ptr, bytes_len)
             .offset(byte_offset)
             .build()
             .user_data(slot as u64)
@@ -271,19 +296,22 @@ where
                 inner_byte_offset,
                 items_len,
             } => {
-                // We need to return an aligned Vec
+                let buffer_bytes = PageAlignedBytes::as_maybe_bytes(buffer);
 
-                // TODO: if aligment matches, we can cast the buffer and return
+                // We need to return a `T`-aligned Vec
+
+                // TODO(perf): if aligment matches a page size, we can cast the buffer and return
+                // without a second allocation.
 
                 //
-                // buffer
+                // buffer_bytes
                 // │     ┌────┬────items┬────┬────┐      byte_length    │
                 // ├─────┤ 1  │ 2  │ 3  │ 4  │ 5  ├───────────>|────────┤
                 // │     └────┴────┴────┴────┴────┘                     │
                 //       ^
-                //   byte_start
+                //   inner_byte_offset
 
-                let initialized_bytes = unsafe { buffer[..byte_length].assume_init_ref() };
+                let initialized_bytes = unsafe { buffer_bytes[..byte_length].assume_init_ref() };
 
                 // Make sure there are at least the requested num of items
                 let avail_items = byte_length.saturating_sub(inner_byte_offset) / size_of::<T>();
@@ -332,7 +360,7 @@ pub enum IoUringRequest<'data, T> {
     },
 
     ODirectRead {
-        buffer: Vec<MaybeUninit<u8>>,
+        buffer: Vec<PageAlignedBytes>,
         inner_byte_offset: usize,
         items_len: usize,
     },
@@ -349,7 +377,7 @@ impl<'data, T> IoUringRequest<'data, T> {
         }
     }
 
-    pub fn expect_o_direct_read(&mut self) -> &mut Vec<MaybeUninit<u8>> {
+    pub fn expect_o_direct_read(&mut self) -> &mut Vec<PageAlignedBytes> {
         #[expect(clippy::match_wildcard_for_single_variants)]
         match self {
             IoUringRequest::ODirectRead {

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -8,13 +8,18 @@ use slab::Slab;
 use super::*;
 use crate::maybe_uninit;
 
-pub struct IoUringRuntime<'data, T, Meta = u64> {
+const KERNEL_PAGE_SIZE: u64 = 4096; // 4 kB
+
+pub struct IoUringRuntime<'data, T: bytemuck::Pod, Meta = u64> {
     pub io_uring: IoUringGuard,
     pub state: IoUringState<'data, T, Meta>,
     pub in_progress: usize,
 }
 
-impl<'data, T, Meta> IoUringRuntime<'data, T, Meta> {
+impl<'data, T, Meta> IoUringRuntime<'data, T, Meta>
+where
+    T: bytemuck::Pod,
+{
     pub fn new() -> Result<Self> {
         let mut io_uring = pool::get_io_uring()?;
         let capacity = io_uring.submission().capacity();
@@ -120,7 +125,10 @@ impl<'data, T, Meta> IoUringRuntime<'data, T, Meta> {
     }
 }
 
-impl<'data, T, Meta> Drop for IoUringRuntime<'data, T, Meta> {
+impl<'data, T, Meta> Drop for IoUringRuntime<'data, T, Meta>
+where
+    T: bytemuck::Pod,
+{
     fn drop(&mut self) {
         while self.in_progress > 0 || !self.io_uring.submission().is_empty() {
             // TODO: Cancel operations with `io_uring::Submitter::register_sync_cancel`?
@@ -144,7 +152,10 @@ pub struct IoUringState<'data, T, Meta> {
     requests: Slab<(Meta, IoUringRequest<'data, T>)>,
 }
 
-impl<'data, T, Meta> IoUringState<'data, T, Meta> {
+impl<'data, T, Meta> IoUringState<'data, T, Meta>
+where
+    T: bytemuck::Pod,
+{
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             requests: Slab::with_capacity(capacity),
@@ -153,24 +164,49 @@ impl<'data, T, Meta> IoUringState<'data, T, Meta> {
 
     /// Allocates `Vec<MaybeUninit<T>>`, reinterprets it as `Vec<MaybeUninit<u8>>`, and stores the byte buffer
     /// so the kernel writes into correctly aligned memory for `T`.
-    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange, direct_io: bool) -> squeue::Entry
-    where
-        T: bytemuck::Pod,
-    {
+    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange, direct_io: bool) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,
         } = range;
 
-        let mut items: Vec<MaybeUninit<T>> = Vec::with_capacity(length as _);
-        items.resize_with(length as _, || MaybeUninit::uninit());
+        let (slot, bytes_ptr, byte_length, byte_offset) = if direct_io {
+            // Make sure read buffer is kernel-page aligned
+            let page_byte_offset = byte_offset & !(KERNEL_PAGE_SIZE - 1); // page-aligned byte offset
+            let read_byte_offset = byte_offset - page_byte_offset; // offset within buffer where the request starts
 
-        let (slot, req) = self.init(meta, IoUringRequest::Read { items, direct_io });
-        let items = req.expect_read();
+            let buffer_len = (read_byte_offset + length * size_of::<T>() as u64)
+                .next_multiple_of(KERNEL_PAGE_SIZE);
+            let buffer: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); buffer_len as _];
+            let (slot, req) = self.init(
+                meta,
+                IoUringRequest::ODirectRead {
+                    buffer,
+                    byte_offset: page_byte_offset as usize,
+                    items_len: length as usize,
+                },
+            );
+            let buffer = req.expect_o_direct_read();
 
-        let bytes_ptr = items.as_mut_ptr().cast();
-        let byte_length = length * size_of::<T>() as u64;
-        let byte_length = u32::try_from(byte_length).expect("read buffer length fit within u32");
+            let byte_length = buffer.len();
+            let byte_length =
+                u32::try_from(byte_length).expect("read buffer length fit within u32");
+            let bytes_ptr = buffer.as_mut_ptr().cast();
+
+            (slot, bytes_ptr, byte_length, page_byte_offset)
+        } else {
+            // Size the buffer exactly to the number of items to read
+            let items: Vec<MaybeUninit<T>> = vec![MaybeUninit::uninit(); length as _];
+            let (slot, req) = self.init(meta, IoUringRequest::Read { items });
+            let items = req.expect_read();
+
+            let bytes_ptr = items.as_mut_ptr().cast();
+            let byte_length = length * size_of::<T>() as u64;
+            let byte_length =
+                u32::try_from(byte_length).expect("read buffer length fit within u32");
+            (slot, bytes_ptr, byte_length, byte_offset)
+        };
+
         opcode::Read::new(fd, bytes_ptr, byte_length)
             .offset(byte_offset)
             .build()
@@ -183,10 +219,7 @@ impl<'data, T, Meta> IoUringState<'data, T, Meta> {
         fd: Fd,
         byte_offset: u64,
         items: &'data [T],
-    ) -> squeue::Entry
-    where
-        T: bytemuck::Pod,
-    {
+    ) -> squeue::Entry {
         let (slot, req) = self.init(meta, IoUringRequest::Write(items));
         let items = req.expect_write();
 
@@ -222,20 +255,48 @@ impl<'data, T, Meta> IoUringState<'data, T, Meta> {
         let byte_length = byte_length as usize;
 
         let resp = match req {
-            IoUringRequest::Read {
-                mut items,
-                direct_io,
-            } => {
-                if direct_io {
-                    let item_length = byte_length / size_of::<T>();
-                    debug_assert!(item_length <= items.len());
-
-                    items.truncate(item_length);
-                } else {
-                    assert_eq!(size_of_val(items.as_slice()), byte_length);
-                }
+            IoUringRequest::Read { items } => {
+                assert_eq!(size_of_val(items.as_slice()), byte_length);
 
                 let items: Vec<T> = unsafe { maybe_uninit::assume_init_vec(items) };
+                IoUringResponse::Read(items)
+            }
+            IoUringRequest::ODirectRead {
+                buffer,
+                byte_offset,
+                items_len,
+            } => {
+                // We need to return an aligned Vec
+
+                // TODO: if aligment matches, we can cast the buffer and return
+
+                //
+                // buffer
+                // │     ┌────┬────items┬────┬────┐      byte_length    │
+                // ├─────┤ 1  │ 2  │ 3  │ 4  │ 5  ├───────────>|────────┤
+                // │     └────┴────┴────┴────┴────┘                     │
+                //       ^
+                //   byte_start
+
+                let initialized_bytes = unsafe { buffer[..byte_length].assume_init_ref() };
+
+                // Make sure there are at least the requested num of items
+                let avail_items = byte_length.saturating_sub(byte_offset) / size_of::<T>();
+                assert!(
+                    items_len <= avail_items,
+                    "expected at least {items_len} items, got {avail_items}"
+                );
+
+                // Cast requested range into &[T]
+                let items_range = byte_offset..byte_offset + items_len * size_of::<T>();
+                let items_bytes = &initialized_bytes[items_range];
+                let items_slice = bytemuck::cast_slice(items_bytes);
+
+                // Copy into new Vec
+                let mut items: Vec<T> = Vec::with_capacity(items_len as _);
+                items.spare_capacity_mut().write_clone_of_slice(items_slice);
+                unsafe { items.set_len(items_len as _) }
+
                 IoUringResponse::Read(items)
             }
 
@@ -263,7 +324,12 @@ impl<'data, T, Meta> Drop for IoUringState<'data, T, Meta> {
 pub enum IoUringRequest<'data, T> {
     Read {
         items: Vec<MaybeUninit<T>>,
-        direct_io: bool,
+    },
+
+    ODirectRead {
+        buffer: Vec<MaybeUninit<u8>>,
+        byte_offset: usize,
+        items_len: usize,
     },
 
     Write(&'data [T]),
@@ -273,7 +339,19 @@ impl<'data, T> IoUringRequest<'data, T> {
     pub fn expect_read(&mut self) -> &mut Vec<MaybeUninit<T>> {
         #[expect(clippy::match_wildcard_for_single_variants)]
         match self {
-            IoUringRequest::Read { items, .. } => items,
+            IoUringRequest::Read { items } => items,
+            _ => panic!(),
+        }
+    }
+
+    pub fn expect_o_direct_read(&mut self) -> &mut Vec<MaybeUninit<u8>> {
+        #[expect(clippy::match_wildcard_for_single_variants)]
+        match self {
+            IoUringRequest::ODirectRead {
+                buffer,
+                byte_offset: _,
+                items_len: _,
+            } => buffer,
             _ => panic!(),
         }
     }

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -300,7 +300,7 @@ where
 
                 // We need to return a `T`-aligned Vec
 
-                // TODO(perf): if aligment matches a page size, we can cast the buffer and return
+                // TODO(perf): if T's alignment matches a page size, we can cast the buffer and return
                 // without a second allocation.
 
                 //

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -181,9 +181,18 @@ where
         }
     }
 
+    /// Prepare the buffer for storing the read with correct alignment, and returns the queue entry.
+    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange, o_direct: bool) -> squeue::Entry {
+        if o_direct {
+            self.read_o_direct(meta, fd, range)
+        } else {
+            self.read_exact(meta, fd, range)
+        }
+    }
+
     /// Allocates `Vec<MaybeUninit<T>>`, reinterprets it as `Vec<MaybeUninit<u8>>`, and stores the byte buffer
     /// so the kernel writes into correctly aligned memory for `T`.
-    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
+    fn read_exact(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,
@@ -205,7 +214,7 @@ where
     }
 
     /// Allocates a `Vec<MaybeUninit<u8>>` aligned to 4kB.
-    pub fn read_o_direct(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
+    fn read_o_direct(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -324,9 +324,7 @@ where
                 let items_slice = bytemuck::cast_slice(items_bytes);
 
                 // Copy into new Vec
-                let mut items: Vec<T> = Vec::with_capacity(items_len as _);
-                items.spare_capacity_mut().write_clone_of_slice(items_slice);
-                unsafe { items.set_len(items_len as _) }
+                let items: Vec<T> = items_slice.to_vec();
 
                 IoUringResponse::Read(items)
             }

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -2,14 +2,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use nix::libc;
+use rstest::rstest;
 
 use super::super::*;
 use super::*;
 use crate::generic_consts::Sequential;
 use crate::universal_io::read::UniversalRead;
 
-#[test]
-fn test_io_uring_file_for_u64() -> Result<()> {
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
     // 1. Write some u64 binary data to a file using regular std::fs APIs
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test_u64.bin");
@@ -18,8 +21,13 @@ fn test_io_uring_file_for_u64() -> Result<()> {
     let bytes = bytemuck::cast_slice(&data);
     fs_err::write(&path, bytes).unwrap();
 
+    let opts = OpenOptions {
+        prevent_caching: Some(o_direct),
+        ..Default::default()
+    };
+
     // 2. Read data back using `IoUringFile` and verify it matches what was written
-    let file = TypedStorage::<IoUringFile, u64>::open(&path, OpenOptions::default())?;
+    let file = TypedStorage::<IoUringFile, u64>::open(&path, opts)?;
 
     // Read all elements
     let read_back = file.read::<Sequential>(ReadRange {
@@ -42,15 +50,22 @@ fn test_io_uring_file_for_u64() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_io_uring_read_batch() -> Result<()> {
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test_batch.bin");
 
     let data: Vec<u64> = (0..256).collect();
     fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
-    let file = TypedStorage::<IoUringFile, u64>::open(&path, OpenOptions::default())?;
+    let opts = OpenOptions {
+        prevent_caching: Some(o_direct),
+        ..Default::default()
+    };
+
+    let file = TypedStorage::<IoUringFile, u64>::open(&path, opts)?;
     let elem = size_of::<u64>() as u64;
 
     // Non-contiguous ranges across the file.
@@ -122,8 +137,10 @@ fn test_io_uring_read_batch() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_io_uring_concurrent_read_iter() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -143,8 +160,7 @@ fn test_io_uring_concurrent_read_iter() -> Result<()> {
     fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
 
     let opts = OpenOptions {
-        // TODO: should use O_DIRECT (Some(true)), but it hangs - needs separate investigation
-        prevent_caching: Some(false),
+        prevent_caching: Some(o_direct),
         ..Default::default()
     };
     let file_a = TypedStorage::<IoUringFile, u64>::open(&path_a, opts)?;
@@ -191,8 +207,10 @@ fn test_io_uring_concurrent_read_iter() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_io_uring_read_multi_iter_basic() -> Result<()> {
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -206,7 +224,10 @@ fn test_io_uring_read_multi_iter_basic() -> Result<()> {
     let data_1: Vec<u64> = (1000..1128).collect();
     fs_err::write(&path_1, bytemuck::cast_slice(&data_1)).unwrap();
 
-    let opts = OpenOptions::default();
+    let opts = OpenOptions {
+        prevent_caching: Some(o_direct),
+        ..Default::default()
+    };
     let file_0 = <IoUringFile as UniversalRead<u64>>::open(&path_0, opts)?;
     let file_1 = <IoUringFile as UniversalRead<u64>>::open(&path_1, opts)?;
     let files = [file_0, file_1];
@@ -241,8 +262,10 @@ fn test_io_uring_read_multi_iter_basic() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -253,13 +276,18 @@ fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
     let mut all_data: Vec<Vec<u64>> = Vec::new();
     let mut files: Vec<IoUringFile> = Vec::new();
 
+    let opts = OpenOptions {
+        prevent_caching: Some(o_direct),
+        ..Default::default()
+    };
+
     for i in 0..NUM_FILES {
         let base = (i as u64) * 10_000;
         let data: Vec<u64> = (base..base + ELEMENTS_PER_FILE).collect();
         let path = dir.path().join(format!("f{i}.bin"));
         fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
-        let file = <IoUringFile as UniversalRead<u64>>::open(&path, OpenOptions::default())?;
+        let file = <IoUringFile as UniversalRead<u64>>::open(&path, opts)?;
         files.push(file);
         all_data.push(data);
     }


### PR DESCRIPTION
Instead of allowing short reads when using `O_DIRECT` (see #8466, #8808), this PR properly handles the flag by generating an aligned buffer, and extracting the requested output from it after it has been filled.

To do this, I added a new `IoUringRequest::ODirectRead` variant, which holds the extended buffer, and the information to extract the requested items from it.