### PR TITLE
Tq plus

### DIFF
--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -22,7 +22,7 @@ fn make_tq(dim: usize, bits: TQBits) -> TurboQuantizer {
         mode: TQMode::Normal,
         error_correction: None,
     };
-    TurboQuantizer::new_from_metadata(&metadata)
+    TurboQuantizer::new_from_metadata(&metadata).expect("metadata is hand-constructed")
 }
 
 fn random_vector(dim: usize, rng: &mut StdRng) -> Vec<f32> {

--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -20,6 +20,7 @@ fn make_tq(dim: usize, bits: TQBits) -> TurboQuantizer {
         },
         bits,
         mode: TQMode::Normal,
+        error_correction: None,
     };
     TurboQuantizer::new_from_metadata(&metadata)
 }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -447,7 +447,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         };
 
         let vector_stats = if storage_encoding_needs_states || query_encoding_needs_stats {
-            Some(VectorStats::build(orig_data.clone(), vector_parameters))
+            Some(VectorStats::build(orig_data.clone(), vector_parameters.dim))
         } else {
             None
         };

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -30,14 +30,21 @@ impl<'a> TqVectorExtras<'a> {
     }
 
     /// Returns the size (in bytes) required for the extras.
-    pub(super) fn size_for(_bits: TQBits, distance: DistanceType, _mode: TQMode) -> usize {
-        match distance {
+    pub(super) fn size_for(_bits: TQBits, distance: DistanceType, mode: TQMode) -> usize {
+        let scaling_factor_size = match distance {
             // 4 Bytes for merged l2 with re-normalization applied.
             DistanceType::Dot => size_of::<f32>(),
             // 4 Bytes for re-normalization.
             DistanceType::Cosine => size_of::<f32>(),
             DistanceType::L1 | DistanceType::L2 => size_of::<f32>(),
-        }
+        };
+        let ec_correction_size = match mode {
+            // TQ+ stores `xm = ⟨X, M⟩` per vector for the symmetric-scoring
+            // slow path.
+            TQMode::Plus => size_of::<f32>(),
+            TQMode::Normal => 0,
+        };
+        scaling_factor_size + ec_correction_size
     }
 
     /// Per-vector scaling factor that scoring multiplies into the centroid dot.
@@ -47,6 +54,21 @@ impl<'a> TqVectorExtras<'a> {
         let bytes: [u8; 4] = self.src[..size_of::<f32>()]
             .try_into()
             .expect("expected at least 4 bytes for scaling_factor");
+        f32::from_le_bytes(bytes)
+    }
+
+    /// TQ+ per-vector `⟨X, M⟩` correction. Only present when the quantizer
+    /// was configured with [`TQMode::Plus`]; the caller is responsible for
+    /// only calling this getter in that mode (validated via `debug_assert`).
+    pub fn ec_correction(&self) -> f32 {
+        debug_assert!(
+            self.src.len() >= 2 * size_of::<f32>(),
+            "ec_correction is only stored for TQMode::Plus"
+        );
+        let off = size_of::<f32>();
+        let bytes: [u8; 4] = self.src[off..off + size_of::<f32>()]
+            .try_into()
+            .expect("expected 4 bytes for ec_correction");
         f32::from_le_bytes(bytes)
     }
 }
@@ -161,10 +183,13 @@ impl TurboQuantizer {
     }
 
     /// Encodes the given raw extras values and appends them to `buf`.
+    /// `ec_correction` (`xm = ⟨X, M⟩`) is required when the quantizer is in
+    /// [`TQMode::Plus`] and ignored otherwise.
     pub(super) fn pack_extras_into(
         &self,
         l2_length: Option<f32>,
         centroid_norm: Option<f32>,
+        ec_correction: Option<f32>,
         buf: &mut Vec<u8>,
     ) {
         let scaling_factor = match self.distance {
@@ -175,6 +200,10 @@ impl TurboQuantizer {
         };
 
         buf.extend(&scaling_factor.to_le_bytes());
+
+        if matches!(self.mode, TQMode::Plus) {
+            buf.extend(&ec_correction.unwrap_or(0.0).to_le_bytes());
+        }
     }
 }
 
@@ -222,11 +251,15 @@ mod tests {
                 for &distance in SUPPORTED_DISTANCES {
                     let predicted_extra_size = TqVectorExtras::size_for(bits, distance, mode);
 
-                    let tq = TurboQuantizer::new(dim, bits, mode, distance);
+                    let tq = TurboQuantizer::new(dim, bits, mode, distance, None);
                     let (l2_length, centroid_norm, expected_scaling) = example_extras(distance);
+                    let expected_ec = match mode {
+                        TQMode::Plus => Some(-0.5),
+                        TQMode::Normal => None,
+                    };
 
                     let mut buf = Vec::new();
-                    tq.pack_extras_into(l2_length, centroid_norm, &mut buf);
+                    tq.pack_extras_into(l2_length, centroid_norm, expected_ec, &mut buf);
                     assert_eq!(
                         buf.len(),
                         predicted_extra_size,
@@ -243,6 +276,13 @@ mod tests {
                         expected_scaling,
                         "scaling_factor roundtrip (bits={bits:?}, mode={mode:?}, distance={distance:?})",
                     );
+                    if let Some(expected) = expected_ec {
+                        assert_eq!(
+                            extras.ec_correction(),
+                            expected,
+                            "ec_correction roundtrip (bits={bits:?}, mode={mode:?}, distance={distance:?})",
+                        );
+                    }
                 }
             }
         }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -165,7 +165,12 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                     bits,
                     mode,
                     error_correction: None,
-                });
+                })
+                .map_err(|e| {
+                    EncodingError::EncodingError(format!(
+                        "Failed to construct pre-quantizer for TQ+ stats pass: {e}",
+                    ))
+                })?;
                 let padded_dim = pre_quantizer.padded_dim;
                 let mut buf = vec![0.0f64; padded_dim];
                 let mut stats_builder = crate::vector_stats::VectorStatsBuilder::new(padded_dim);
@@ -181,8 +186,13 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                 let mut shift = vec![0.0f32; padded_dim];
                 let mut scale = vec![1.0f32; padded_dim];
                 for (i, s) in stats.elements_stats.iter().enumerate() {
+                    // Always recenter — even constant-but-biased coordinates
+                    // benefit from `shift = -mean` (so the codebook sees them
+                    // at 0). Only the variance reciprocal needs the EPSILON
+                    // guard against division blow-up on truly zero-variance
+                    // coords.
+                    shift[i] = -s.mean;
                     if s.stddev > f32::EPSILON {
-                        shift[i] = -s.mean;
                         scale[i] = s.stddev.recip();
                     }
                 }
@@ -200,7 +210,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
             }),
         };
 
-        let quantizer = TurboQuantizer::new_from_metadata(&metadata);
+        let quantizer = TurboQuantizer::new_from_metadata(&metadata).map_err(|e| {
+            EncodingError::EncodingError(format!(
+                "Failed to construct quantizer from metadata: {e}",
+            ))
+        })?;
         let mut buf = vec![0.0f64; quantizer.padded_dim];
 
         for vector in data {
@@ -255,7 +269,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         let contents = fs::read_to_string(meta_path)?;
         let metadata: Metadata = serde_json::from_str(&contents)?;
 
-        let quantizer = TurboQuantizer::new_from_metadata(&metadata);
+        let quantizer = TurboQuantizer::new_from_metadata(&metadata)?;
 
         let result = Self {
             encoded_vectors,

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -89,8 +89,16 @@ pub struct EncodedQueryTQ {
 /// (rotation-applied query, quantized to the SIMD-friendly integer form);
 /// on architectures without a matching SIMD instruction set the scalar
 /// reference kernel inside each type takes over automatically.
+///
+/// `Bits1Wide` is the same kernel as `Bits1` but with 12-bit query
+/// quantization instead of the default 8-bit. Used in TQ+ for 1-bit storage:
+/// the per-coord `D'` pre-scaling pushes some query coords into the bottom
+/// of the 8-bit integer range, where rounding noise is large relative to
+/// the signal — widening to 12 bits drops the scoring error by ~10× and
+/// recovers most of the recall the 8-bit form loses.
 pub enum EncodedQueryTQData {
     Bits1(Query1bitSimd),
+    Bits1Wide(Query1bitSimd<12>),
     Bits2(Query2bitSimd),
     Bits4(Query4bitSimd),
 }
@@ -155,8 +163,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                 });
                 let padded_dim = pre_quantizer.padded_dim;
                 let mut buf = vec![0.0f64; padded_dim];
-                let mut stats_builder =
-                    crate::vector_stats::VectorStatsBuilder::new(padded_dim);
+                let mut stats_builder = crate::vector_stats::VectorStatsBuilder::new(padded_dim);
                 for vector in data.clone() {
                     if stopped.load(Ordering::Relaxed) {
                         return Err(EncodingError::Stopped);
@@ -172,12 +179,10 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
             vector_parameters: *vector_parameters,
             bits,
             mode,
-            error_correction: error_correction
-                .as_ref()
-                .map(|ec| ErrorCorrectionMetadata {
-                    shift: ec.shift.clone(),
-                    scale: ec.scale.clone(),
-                }),
+            error_correction: error_correction.as_ref().map(|ec| ErrorCorrectionMetadata {
+                shift: ec.shift.clone(),
+                scale: ec.scale.clone(),
+            }),
         };
 
         let quantizer = TurboQuantizer::new_from_metadata(&metadata);

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -153,20 +153,10 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         // pulls the rotated, length-rescaled coordinates onto the Lloyd-Max
         // N(0, 1) codebook before quantization.
         //
-        // Shift uses per-coordinate **median**, not mean. For 1-bit storage
-        // the codebook boundary sits at 0, so post-shift values are
-        // quantized purely by sign — median is the sign-balance point of the
-        // distribution, mean isn't (skewed coords pull mean off the median).
-        // On highly anisotropic embeddings (dbpedia-openai is the reference
-        // case) this swaps a 60/40 biased sign distribution for 50/50 and
-        // recovers the recall the mean-based shift loses. Higher bit-widths
-        // are less sensitive but still benefit. Matches llama-turbo-quant.
-        //
-        // Median requires the per-coord samples in memory, so we cap the
-        // stats pass at `MAX_STATS_VECTORS` and use only the first chunk.
-        // Median estimates converge fast (~ √N), so 10K is plenty even for
-        // million-vector indexes.
-        const MAX_STATS_VECTORS: usize = 10_000;
+        // Shift uses per-coordinate mean. Median is more robust on skewed
+        // distributions and is a recall improvement worth landing — but
+        // separately. This first PR is the mean-based form so the diff stays
+        // focused on the rest of the integration.
         let error_correction = match mode {
             TQMode::Normal => None,
             TQMode::Plus => {
@@ -178,38 +168,22 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                 });
                 let padded_dim = pre_quantizer.padded_dim;
                 let mut buf = vec![0.0f64; padded_dim];
-                let mut coord_values: Vec<Vec<f32>> = (0..padded_dim).map(|_| Vec::new()).collect();
-                for vector in data.clone().take(MAX_STATS_VECTORS) {
+                let mut stats_builder = crate::vector_stats::VectorStatsBuilder::new(padded_dim);
+                for vector in data.clone() {
                     if stopped.load(Ordering::Relaxed) {
                         return Err(EncodingError::Stopped);
                     }
                     pre_quantizer.preprocess_into(vector.as_ref(), &mut buf);
-                    for (slot, &v) in coord_values.iter_mut().zip(buf.iter()) {
-                        slot.push(v as f32);
-                    }
+                    stats_builder.add(buf.as_slice());
                 }
+                let stats = stats_builder.build();
 
                 let mut shift = vec![0.0f32; padded_dim];
                 let mut scale = vec![1.0f32; padded_dim];
-                for (i, values) in coord_values.iter_mut().enumerate() {
-                    if values.is_empty() {
-                        continue;
-                    }
-                    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-                    let n = values.len();
-                    let median = if n % 2 == 0 {
-                        (values[n / 2 - 1] + values[n / 2]) / 2.0
-                    } else {
-                        values[n / 2]
-                    };
-                    // Stddev around the mean (matches llama, biased estimator).
-                    let mean = values.iter().sum::<f32>() / n as f32;
-                    let variance =
-                        values.iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>() / n as f32;
-                    let sigma = variance.sqrt();
-                    if sigma > f32::EPSILON {
-                        shift[i] = -median;
-                        scale[i] = sigma.recip();
+                for (i, s) in stats.elements_stats.iter().enumerate() {
+                    if s.stddev > f32::EPSILON {
+                        shift[i] = -s.mean;
+                        scale[i] = s.stddev.recip();
                     }
                 }
                 Some(ErrorCorrection::new(shift, scale))

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -90,15 +90,15 @@ pub struct EncodedQueryTQ {
 /// on architectures without a matching SIMD instruction set the scalar
 /// reference kernel inside each type takes over automatically.
 ///
-/// `Bits1Wide` is the same kernel as `Bits1` but with 12-bit query
-/// quantization instead of the default 8-bit. Used in TQ+ for 1-bit storage:
-/// the per-coord `D'` pre-scaling pushes some query coords into the bottom
-/// of the 8-bit integer range, where rounding noise is large relative to
-/// the signal — widening to 12 bits drops the scoring error by ~10× and
-/// recovers most of the recall the 8-bit form loses.
+/// `Bits1Wide` is the same kernel as `Bits1` but with 16-bit query
+/// quantization instead of the default 8-bit (the kernel's max). Used in
+/// TQ+ for 1-bit storage: the per-coord `D'` pre-scaling pushes some query
+/// coords into the bottom of the 8-bit integer range, where rounding noise
+/// is large relative to the signal — widening to 16 bits drops the scoring
+/// error far enough to recover the recall the 8-bit form loses.
 pub enum EncodedQueryTQData {
     Bits1(Query1bitSimd),
-    Bits1Wide(Query1bitSimd<12>),
+    Bits1Wide(Query1bitSimd<16>),
     Bits2(Query2bitSimd),
     Bits4(Query4bitSimd),
 }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -73,6 +73,13 @@ pub struct EncodedQueryTQ {
     // Store the original query in pre-rotated form for L1 distance, where we need to dequantize vectors and apply inverse rotation to them.
     query: Option<Vec<f32>>,
 
+    /// Rotated query (pre-EC) — populated only for TQ+ Dot/Cosine/L2.  The
+    /// asymmetric SIMD path can't represent the per-coordinate `D'_i`
+    /// weighting TQ+ requires, so scoring decodes centroids on the fly and
+    /// folds in `D'_i` from a scalar loop. SIMD support for this is a
+    /// follow-up.
+    pub(super) rotated_query: Option<Vec<f32>>,
+
     /// TQ+ asymmetric-scoring scalar correction `qm = ⟨Q, M⟩ = -⟨rotated_q, shift⟩`.
     /// `0.0` when EC is not configured. Added to the SIMD raw_dot so the
     /// existing score formulas can stay unchanged.

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -65,7 +65,11 @@ pub struct EncodedVectorsTQ<TStorage: EncodedStorage> {
 
 /// Encoded query type for Turbo Quant.
 pub struct EncodedQueryTQ {
-    data: EncodedQueryTQData,
+    /// SIMD-encoded query for the Normal-mode asymmetric path. `None` when
+    /// EC is configured: the SIMD encoder can't carry the per-coordinate
+    /// `D'_i` weighting TQ+ requires, so we skip the encoding entirely and
+    /// score via the scalar `score_precomputed_ec` path using `rotated_query`.
+    data: Option<EncodedQueryTQData>,
 
     // Store the original query's l2 norm for Dot and L2 distances, where we can compute it once and reuse for all distance computations.
     l2_norm: Option<f32>,

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -65,11 +65,12 @@ pub struct EncodedVectorsTQ<TStorage: EncodedStorage> {
 
 /// Encoded query type for Turbo Quant.
 pub struct EncodedQueryTQ {
-    /// SIMD-encoded query for the Normal-mode asymmetric path. `None` when
-    /// EC is configured: the SIMD encoder can't carry the per-coordinate
-    /// `D'_i` weighting TQ+ requires, so we skip the encoding entirely and
-    /// score via the scalar `score_precomputed_ec` path using `rotated_query`.
-    data: Option<EncodedQueryTQData>,
+    /// SIMD-encoded query for the asymmetric scoring path. For TQ+, the
+    /// rotated query is pre-multiplied by `D' = 1/scale` per coord so the
+    /// SIMD raw_dot computes `⟨Q · D', X+⟩` directly — the asymmetric score
+    /// formulas then just add `ec_correction` and apply renorm's
+    /// `scaling_factor`, identical to the Normal-mode path.
+    data: EncodedQueryTQData,
 
     // Store the original query's l2 norm for Dot and L2 distances, where we can compute it once and reuse for all distance computations.
     l2_norm: Option<f32>,
@@ -77,16 +78,9 @@ pub struct EncodedQueryTQ {
     // Store the original query in pre-rotated form for L1 distance, where we need to dequantize vectors and apply inverse rotation to them.
     query: Option<Vec<f32>>,
 
-    /// Rotated query (pre-EC) — populated only for TQ+ Dot/Cosine/L2.  The
-    /// asymmetric SIMD path can't represent the per-coordinate `D'_i`
-    /// weighting TQ+ requires, so scoring decodes centroids on the fly and
-    /// folds in `D'_i` from a scalar loop. SIMD support for this is a
-    /// follow-up.
-    pub(super) rotated_query: Option<Vec<f32>>,
-
     /// TQ+ asymmetric-scoring scalar correction `qm = ⟨Q, M⟩ = -⟨rotated_q, shift⟩`.
     /// `0.0` when EC is not configured. Added to the SIMD raw_dot so the
-    /// existing score formulas can stay unchanged.
+    /// existing score formulas stay unchanged.
     ec_correction: f32,
 }
 

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -152,6 +152,21 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         // TQ+: first pass over `data` to fit per-coordinate shift/scale that
         // pulls the rotated, length-rescaled coordinates onto the Lloyd-Max
         // N(0, 1) codebook before quantization.
+        //
+        // Shift uses per-coordinate **median**, not mean. For 1-bit storage
+        // the codebook boundary sits at 0, so post-shift values are
+        // quantized purely by sign — median is the sign-balance point of the
+        // distribution, mean isn't (skewed coords pull mean off the median).
+        // On highly anisotropic embeddings (dbpedia-openai is the reference
+        // case) this swaps a 60/40 biased sign distribution for 50/50 and
+        // recovers the recall the mean-based shift loses. Higher bit-widths
+        // are less sensitive but still benefit. Matches llama-turbo-quant.
+        //
+        // Median requires the per-coord samples in memory, so we cap the
+        // stats pass at `MAX_STATS_VECTORS` and use only the first chunk.
+        // Median estimates converge fast (~ √N), so 10K is plenty even for
+        // million-vector indexes.
+        const MAX_STATS_VECTORS: usize = 10_000;
         let error_correction = match mode {
             TQMode::Normal => None,
             TQMode::Plus => {
@@ -163,15 +178,44 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                 });
                 let padded_dim = pre_quantizer.padded_dim;
                 let mut buf = vec![0.0f64; padded_dim];
-                let mut stats_builder = crate::vector_stats::VectorStatsBuilder::new(padded_dim);
-                for vector in data.clone() {
+                let mut coord_values: Vec<Vec<f32>> =
+                    (0..padded_dim).map(|_| Vec::new()).collect();
+                for vector in data.clone().take(MAX_STATS_VECTORS) {
                     if stopped.load(Ordering::Relaxed) {
                         return Err(EncodingError::Stopped);
                     }
                     pre_quantizer.preprocess_into(vector.as_ref(), &mut buf);
-                    stats_builder.add(buf.as_slice());
+                    for (slot, &v) in coord_values.iter_mut().zip(buf.iter()) {
+                        slot.push(v as f32);
+                    }
                 }
-                Some(ErrorCorrection::from_stats(&stats_builder.build()))
+
+                let mut shift = vec![0.0f32; padded_dim];
+                let mut scale = vec![1.0f32; padded_dim];
+                for (i, values) in coord_values.iter_mut().enumerate() {
+                    if values.is_empty() {
+                        continue;
+                    }
+                    values.sort_by(|a, b| {
+                        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                    let n = values.len();
+                    let median = if n % 2 == 0 {
+                        (values[n / 2 - 1] + values[n / 2]) / 2.0
+                    } else {
+                        values[n / 2]
+                    };
+                    // Stddev around the mean (matches llama, biased estimator).
+                    let mean = values.iter().sum::<f32>() / n as f32;
+                    let variance =
+                        values.iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>() / n as f32;
+                    let sigma = variance.sqrt();
+                    if sigma > f32::EPSILON {
+                        shift[i] = -median;
+                        scale[i] = sigma.recip();
+                    }
+                }
+                Some(ErrorCorrection::new(shift, scale))
             }
         };
 

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -90,15 +90,15 @@ pub struct EncodedQueryTQ {
 /// on architectures without a matching SIMD instruction set the scalar
 /// reference kernel inside each type takes over automatically.
 ///
-/// `Bits1Wide` is the same kernel as `Bits1` but with 12-bit query
-/// quantization instead of the default 8-bit. Used in TQ+ for 1-bit storage:
-/// the per-coord `D'` pre-scaling pushes some query coords into the bottom
-/// of the 8-bit integer range, where rounding noise is large relative to
-/// the signal — widening to 12 bits drops the scoring error by ~10× per
-/// the parity test in `query1bit`, which is enough headroom in practice.
+/// `Bits1Wide` is the same kernel as `Bits1` but with 16-bit query
+/// quantization instead of the default 8-bit (the kernel's max). Used in
+/// TQ+ for 1-bit storage: the per-coord `D'` pre-scaling pushes some query
+/// coords into the bottom of the 8-bit integer range, where rounding noise
+/// is large relative to the signal — 16 bits gives the most headroom the
+/// existing kernel supports.
 pub enum EncodedQueryTQData {
     Bits1(Query1bitSimd),
-    Bits1Wide(Query1bitSimd<12>),
+    Bits1Wide(Query1bitSimd<16>),
     Bits2(Query2bitSimd),
     Bits4(Query4bitSimd),
 }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -90,15 +90,15 @@ pub struct EncodedQueryTQ {
 /// on architectures without a matching SIMD instruction set the scalar
 /// reference kernel inside each type takes over automatically.
 ///
-/// `Bits1Wide` is the same kernel as `Bits1` but with 16-bit query
-/// quantization instead of the default 8-bit (the kernel's max). Used in
-/// TQ+ for 1-bit storage: the per-coord `D'` pre-scaling pushes some query
-/// coords into the bottom of the 8-bit integer range, where rounding noise
-/// is large relative to the signal — widening to 16 bits drops the scoring
-/// error far enough to recover the recall the 8-bit form loses.
+/// `Bits1Wide` is the same kernel as `Bits1` but with 12-bit query
+/// quantization instead of the default 8-bit. Used in TQ+ for 1-bit storage:
+/// the per-coord `D'` pre-scaling pushes some query coords into the bottom
+/// of the 8-bit integer range, where rounding noise is large relative to
+/// the signal — widening to 12 bits drops the scoring error by ~10× per
+/// the parity test in `query1bit`, which is enough headroom in practice.
 pub enum EncodedQueryTQData {
     Bits1(Query1bitSimd),
-    Bits1Wide(Query1bitSimd<16>),
+    Bits1Wide(Query1bitSimd<12>),
     Bits2(Query2bitSimd),
     Bits4(Query4bitSimd),
 }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::EncodingError;
 use crate::encoded_storage::{EncodedStorage, EncodedStorageBuilder};
 use crate::encoded_vectors::{EncodedVectors, VectorParameters, validate_vector_parameters};
-use crate::turboquant::quantization::TurboQuantizer;
+use crate::turboquant::quantization::{ErrorCorrection, TurboQuantizer};
 use crate::turboquant::simd::{Query1bitSimd, Query2bitSimd, Query4bitSimd};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -72,7 +72,11 @@ pub struct EncodedQueryTQ {
 
     // Store the original query in pre-rotated form for L1 distance, where we need to dequantize vectors and apply inverse rotation to them.
     query: Option<Vec<f32>>,
-    // TODO(turbo): add precomputed extras here when needed
+
+    /// TQ+ asymmetric-scoring scalar correction `qm = ⟨Q, M⟩ = -⟨rotated_q, shift⟩`.
+    /// `0.0` when EC is not configured. Added to the SIMD raw_dot so the
+    /// existing score formulas can stay unchanged.
+    ec_correction: f32,
 }
 
 /// SIMD-ready encoded query, one variant per supported bit-width.  Each
@@ -91,6 +95,16 @@ pub struct Metadata {
     pub vector_parameters: VectorParameters,
     pub bits: TQBits,
     pub mode: TQMode,
+    pub error_correction: Option<ErrorCorrectionMetadata>,
+}
+
+/// On-disk form of TQ+'s [`ErrorCorrection`]. Stores only `shift` and `scale`
+/// — derived caches like `D'_i²` and `⟨M, M⟩` are recomputed at load time so
+/// `shift` / `scale` remain the single source of truth.
+#[derive(Serialize, Deserialize)]
+pub struct ErrorCorrectionMetadata {
+    pub shift: Vec<f32>,
+    pub scale: Vec<f32>,
 }
 
 impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
@@ -122,10 +136,43 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
     ) -> Result<Self, EncodingError> {
         debug_assert!(validate_vector_parameters(data.clone(), vector_parameters).is_ok());
 
+        // TQ+: first pass over `data` to fit per-coordinate shift/scale that
+        // pulls the rotated, length-rescaled coordinates onto the Lloyd-Max
+        // N(0, 1) codebook before quantization.
+        let error_correction = match mode {
+            TQMode::Normal => None,
+            TQMode::Plus => {
+                let pre_quantizer = TurboQuantizer::new_from_metadata(&Metadata {
+                    vector_parameters: *vector_parameters,
+                    bits,
+                    mode,
+                    error_correction: None,
+                });
+                let padded_dim = pre_quantizer.padded_dim;
+                let mut buf = vec![0.0f64; padded_dim];
+                let mut stats_builder =
+                    crate::vector_stats::VectorStatsBuilder::new(padded_dim);
+                for vector in data.clone() {
+                    if stopped.load(Ordering::Relaxed) {
+                        return Err(EncodingError::Stopped);
+                    }
+                    pre_quantizer.preprocess_into(vector.as_ref(), &mut buf);
+                    stats_builder.add(buf.as_slice());
+                }
+                Some(ErrorCorrection::from_stats(&stats_builder.build()))
+            }
+        };
+
         let metadata = Metadata {
             vector_parameters: *vector_parameters,
             bits,
             mode,
+            error_correction: error_correction
+                .as_ref()
+                .map(|ec| ErrorCorrectionMetadata {
+                    shift: ec.shift.clone(),
+                    scale: ec.scale.clone(),
+                }),
         };
 
         let quantizer = TurboQuantizer::new_from_metadata(&metadata);

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -178,8 +178,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                 });
                 let padded_dim = pre_quantizer.padded_dim;
                 let mut buf = vec![0.0f64; padded_dim];
-                let mut coord_values: Vec<Vec<f32>> =
-                    (0..padded_dim).map(|_| Vec::new()).collect();
+                let mut coord_values: Vec<Vec<f32>> = (0..padded_dim).map(|_| Vec::new()).collect();
                 for vector in data.clone().take(MAX_STATS_VECTORS) {
                     if stopped.load(Ordering::Relaxed) {
                         return Err(EncodingError::Stopped);
@@ -196,9 +195,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                     if values.is_empty() {
                         continue;
                     }
-                    values.sort_by(|a, b| {
-                        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-                    });
+                    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
                     let n = values.len();
                     let median = if n % 2 == 0 {
                         (values[n / 2 - 1] + values[n / 2]) / 2.0

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -235,15 +235,27 @@ impl TurboQuantizer {
     }
 
     /// L2 norm of the centroid vector chosen by quantizing `buf * scale`.
+    /// For TQ+, the stored centroids approximate `X+`, but renorm scoring
+    /// needs `cn` to track `‖rescaled_quantized‖` so the per-vector correction
+    /// stays close to deterministic `sqrt(d)`. We undo EC on each centroid
+    /// (`c · D' + M`) before measuring, matching llama-turbo-quant's approach.
     fn compute_centroid_norm(&self, buf: &[f64], scale: f64) -> f32 {
         let centroids = self.bits.get_centroids();
         let boundaries = self.bits.get_centroid_boundaries();
         let mut sq_sum = 0.0_f64;
-        for &val in buf {
+        for (i, &val) in buf.iter().enumerate() {
             let scaled = val * scale;
             let idx = boundaries.partition_point(|&b| (scaled as f32) > b);
             let c = f64::from(centroids[idx]);
-            sq_sum += c * c;
+            // For TQ+, revert EC so `c_reverted` lives in rescaled-space.
+            // `‖rescaled‖ = sqrt(d)` deterministically across vectors, so
+            // `cn` only drifts from `sqrt(d)` due to quantization noise —
+            // exactly what renorm's `l2 / cn` is designed to correct.
+            let c_reverted = match &self.error_correction {
+                Some(ec) => c / f64::from(ec.scale[i]) - f64::from(ec.shift[i]),
+                None => c,
+            };
+            sq_sum += c_reverted * c_reverted;
         }
         let norm = sq_sum.sqrt() as f32;
         debug_assert!(
@@ -258,15 +270,29 @@ impl TurboQuantizer {
         let scaling_factor = f64::from(extras.scaling_factor());
 
         // Stored field is `l2/cn_quant` (`l2 == 1.0` for Cosine).
-        // To recover the original l2 length, we need to `* cn_quant`.
+        // To recover the original l2 length, we need to `* cn_quant` measured
+        // in the same space `cn` was stored in. For TQ+ that's the EC-reverted
+        // (rescaled) space, matching `compute_centroid_norm`'s convention.
         let recovered_l2 = match self.distance {
             DistanceType::Dot | DistanceType::Cosine => {
-                let cn_quant = self
-                    .unpack_vector(quantized)
-                    .0
-                    .map(|x| x * x)
-                    .sum::<f64>()
-                    .sqrt();
+                let cn_quant = match &self.error_correction {
+                    Some(ec) => self
+                        .unpack_vector(quantized)
+                        .0
+                        .enumerate()
+                        .map(|(i, x)| {
+                            let r = x / f64::from(ec.scale[i]) - f64::from(ec.shift[i]);
+                            r * r
+                        })
+                        .sum::<f64>()
+                        .sqrt(),
+                    None => self
+                        .unpack_vector(quantized)
+                        .0
+                        .map(|x| x * x)
+                        .sum::<f64>()
+                        .sqrt(),
+                };
                 scaling_factor * cn_quant
             }
             DistanceType::L1 | DistanceType::L2 => scaling_factor,
@@ -339,6 +365,35 @@ impl TurboQuantizer {
         }
     }
 
+    /// TQ+ asymmetric-scoring slow path. Decodes the stored centroids and
+    /// computes `Σ R_q_i · c_i · D'_i = Σ R_q_i · (rescaled_i − M_i)`. Caller
+    /// adds `qm = ⟨R_q, M⟩` to recover `⟨R_q, rescaled⟩`.
+    fn score_precomputed_ec(
+        &self,
+        data_bytes: &[u8],
+        query: &EncodedQueryTQ,
+        ec: &ErrorCorrection,
+    ) -> f32 {
+        let centroids = self.bits.get_centroids();
+        let bit_size = self.bits.bit_size();
+        let mut reader = common::bitpacking::BitReader::new(data_bytes);
+        reader.set_bits(bit_size);
+
+        let rotated_q = query
+            .rotated_query
+            .as_ref()
+            .expect("TQ+ asymmetric scoring requires rotated_query in EncodedQueryTQ");
+
+        let mut sum: f32 = 0.0;
+        for (i, &q) in rotated_q.iter().enumerate() {
+            let idx: u8 = reader.read();
+            let c = centroids[idx as usize];
+            // c · D'_i = c / scale_i (since scale = 1/D').
+            sum += q * c / ec.scale[i];
+        }
+        sum
+    }
+
     /// TQ+ symmetric-scoring slow path. Decodes both packed vectors into
     /// centroids, takes a per-coord-weighted dot with `D'_i²`, and folds in
     /// the precomputed `xm_a + xm_b − ⟨M, M⟩` so the caller can apply the
@@ -394,18 +449,20 @@ impl TurboQuantizer {
         };
 
         // TQ+ asymmetric: ⟨Q, X⟩ = ⟨Q .* D', X+⟩ + ⟨Q, M⟩, where D' = 1/scale
-        // and M = -shift. Pre-scale the query by D' so the SIMD raw_dot
-        // computes the first term, and stash the scalar `qm` for the second.
+        // and M = -shift. We deliberately do NOT pre-scale `rotated` by `D'`
+        // here. The SIMD encoder normalizes by `max(|input|)`, so a query whose
+        // coords have wildly varying magnitudes (which `R_q · D'` does when
+        // stats produce a non-flat `D'` — exactly the data TQ+ is meant for)
+        // gets quantized with poor precision on the small-D' coords. Instead,
+        // we keep `rotated` unscaled and let `score_precomputed` do a scalar
+        // decode-and-dot that folds in `D'_i` per coord.  SIMD support for
+        // this path is a follow-up.
         let ec_correction: f32 = if let Some(ec) = &self.error_correction {
-            let qm: f64 = rotated
+            rotated
                 .iter()
                 .zip(ec.shift.iter())
                 .map(|(&q, &s)| q * f64::from(-s))
-                .sum();
-            for (q, &s) in rotated.iter_mut().zip(ec.scale.iter()) {
-                *q /= f64::from(s);
-            }
-            qm as f32
+                .sum::<f64>() as f32
         } else {
             0.0
         };
@@ -420,6 +477,13 @@ impl TurboQuantizer {
         // has no downstream benefit here).
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
+        let rotated_query = self.error_correction.as_ref().and_then(|_| match self.distance {
+            DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
+                Some(rotated_f32.clone())
+            }
+            DistanceType::L1 => None,
+        });
+
         let data = match self.bits {
             TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
@@ -430,6 +494,7 @@ impl TurboQuantizer {
             data,
             l2_norm,
             query,
+            rotated_query,
             ec_correction,
         }
     }
@@ -439,14 +504,25 @@ impl TurboQuantizer {
     /// and `cos(θ)` for Cosine.
     pub fn score_precomputed(&self, query: &EncodedQueryTQ, vec: &[u8]) -> f32 {
         let (data_bytes, vector_extras) = self.split_vector(vec);
-        let raw_dot = match &query.data {
-            EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
-            EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
-            EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
+        // TQ+: SIMD's uniform-weight dot can't carry the per-coord `D'_i`
+        // weighting required to recover ⟨Q, rescaled_v⟩ from `c ≈ X+`.
+        // Decode centroids in a scalar loop and fold in `D'_i` from `ec.scale`.
+        // The +qm correction is added below. L1 short-circuits to the
+        // dequantize-and-L1 path below, so we skip the dot computation for it.
+        let needs_dot =
+            !matches!(self.distance, DistanceType::L1) || self.error_correction.is_none();
+        let dot = if !needs_dot {
+            0.0
+        } else {
+            match &self.error_correction {
+                Some(ec) => self.score_precomputed_ec(data_bytes, query, ec) + query.ec_correction,
+                None => match &query.data {
+                    EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
+                    EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
+                    EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
+                },
+            }
         };
-        // TQ+: SIMD raw_dot ≈ ⟨Q .* D', X+⟩; add `qm = ⟨Q, M⟩` to recover
-        // ⟨Q, rescaled_v⟩, which is the quantity the existing arms expect.
-        let dot = raw_dot + query.ec_correction;
 
         match self.distance {
             DistanceType::Cosine | DistanceType::Dot => {

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -64,7 +64,7 @@ impl ErrorCorrection {
         Self::new(shift, scale)
     }
 
-    fn new(shift: Vec<f32>, scale: Vec<f32>) -> Self {
+    pub(super) fn new(shift: Vec<f32>, scale: Vec<f32>) -> Self {
         let mm_const = shift.iter().map(|&s| s * s).sum();
         let d_prime_sq = scale
             .iter()

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -345,10 +345,19 @@ impl TurboQuantizer {
         }
     }
 
-    /// TQ+ symmetric-scoring slow path. Decodes both packed vectors into
-    /// centroids, takes a per-coord-weighted dot with `D'_i²`, and folds in
-    /// the precomputed `xm_a + xm_b − ⟨M, M⟩` so the caller can apply the
-    /// usual `* v1_scale * v2_scale` formulas as if EC weren't there.
+    /// TQ+ symmetric-scoring slow path.
+    ///
+    /// For 1-bit storage we use llama's unweighted form `Σ c_a · c_b` (raw
+    /// centroid dot, no `D'²`, no `xm` fold-in). The "math-correct" weighted
+    /// form `Σ c_a c_b D'_i² + xm_a + xm_b − ⟨M, M⟩` recovers
+    /// `⟨rescaled_a, rescaled_b⟩` exactly, but for 1-bit + anisotropic data
+    /// (dbpedia-openai) the per-coord `D'²` amplifies the large quantization
+    /// error of the ±c codebook on high-`D'` coords, corrupting the HNSW
+    /// graph that `score_internal` is used to build.
+    ///
+    /// For Bits2/Bits4 the codebook is fine-grained enough that quantization
+    /// noise per coord is small relative to signal, so the math-correct
+    /// weighted form remains the better choice.
     fn score_symmetric_ec(
         &self,
         data_v1: &[u8],
@@ -364,18 +373,30 @@ impl TurboQuantizer {
         let mut reader2 = common::bitpacking::BitReader::new(data_v2);
         reader2.set_bits(bit_size);
 
-        let mut weighted: f32 = 0.0;
-        for i in 0..self.padded_dim {
-            let idx1: u8 = reader1.read();
-            let idx2: u8 = reader2.read();
-            let c1 = centroids[idx1 as usize];
-            let c2 = centroids[idx2 as usize];
-            weighted += c1 * c2 * ec.d_prime_sq[i];
+        match self.bits {
+            TQBits::Bits1 | TQBits::Bits1_5 => {
+                let mut sum: f32 = 0.0;
+                for _ in 0..self.padded_dim {
+                    let idx1: u8 = reader1.read();
+                    let idx2: u8 = reader2.read();
+                    sum += centroids[idx1 as usize] * centroids[idx2 as usize];
+                }
+                sum
+            }
+            TQBits::Bits2 | TQBits::Bits4 => {
+                let mut weighted: f32 = 0.0;
+                for i in 0..self.padded_dim {
+                    let idx1: u8 = reader1.read();
+                    let idx2: u8 = reader2.read();
+                    let c1 = centroids[idx1 as usize];
+                    let c2 = centroids[idx2 as usize];
+                    weighted += c1 * c2 * ec.d_prime_sq[i];
+                }
+                let xm_a = extra_v1.ec_correction();
+                let xm_b = extra_v2.ec_correction();
+                weighted + xm_a + xm_b - ec.mm_const
+            }
         }
-
-        let xm_a = extra_v1.ec_correction();
-        let xm_b = extra_v2.ec_correction();
-        weighted + xm_a + xm_b - ec.mm_const
     }
 
     /// Precompute the Hadamard rotation of `query` and hand it to the

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -449,15 +449,15 @@ impl TurboQuantizer {
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
         // For TQ+ + Bits1 storage, widen query quantization from the default
-        // 8 bits to 12. The per-coord `D'` pre-scaling can push some coords
-        // toward the small end of the integer range; 8 bits loses too much
-        // there. 12 bits drops the SIMD scoring error by ~10× per the
-        // `test_query_dotprod_matches_reference` parity test in `query1bit`.
+        // 8 bits to the kernel's max of 16. The per-coord `D'` pre-scaling
+        // can push some coords toward the small end of the integer range;
+        // 8 bits loses too much there. 16 bits gives enough headroom to
+        // recover recall on real datasets where D' has wide variance.
         let use_wide_query =
             self.error_correction.is_some() && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
         let data = match self.bits {
             TQBits::Bits1 | TQBits::Bits1_5 if use_wide_query => {
-                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<12>::new(&rotated_f32))
+                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<16>::new(&rotated_f32))
             }
             TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -5,7 +5,10 @@ use crate::turboquant::simd::{
     Query1bitSimd, Query2bitSimd, Query4bitSimd, score_1bit_internal, score_2bit_internal,
     score_4bit_internal,
 };
-use crate::turboquant::{EncodedQueryTQ, EncodedQueryTQData, Metadata, TQBits, TQMode};
+use crate::turboquant::{
+    EncodedQueryTQ, EncodedQueryTQData, ErrorCorrectionMetadata, Metadata, TQBits, TQMode,
+};
+use crate::vector_stats::VectorStats;
 
 /// Quantize vectors using TurboQuant.
 pub struct TurboQuantizer {
@@ -14,14 +17,83 @@ pub struct TurboQuantizer {
     pub(super) mode: TQMode,
     pub(super) distance: DistanceType,
     pub(super) padded_dim: usize,
+    pub(super) error_correction: Option<ErrorCorrection>,
 
     // Pre-calculated `sqrt(dim)` used in L2 scoring.
     dim_sqrt: f32,
 }
 
+/// TQ+ per-coordinate shift+scale: pulls each rotated, length-rescaled
+/// coordinate onto the Lloyd-Max codebook's N(0, 1) grid before quantization.
+///
+/// `apply` maps `x → (x + shift) · scale = (x − M) / D'` where `M = -shift`
+/// and `D' = 1 / scale`. `revert` is the exact inverse.
+pub struct ErrorCorrection {
+    pub shift: Vec<f32>,
+    pub scale: Vec<f32>,
+    /// `D'_i² = 1 / scale_i²` per coordinate. Used in the symmetric TQ+
+    /// scoring path's per-coord-weighted dot. Recomputed from `scale` rather
+    /// than persisted — `scale` is the single source of truth.
+    pub(super) d_prime_sq: Vec<f32>,
+    /// `⟨M, M⟩ = Σ shift²` global constant. Used in symmetric TQ+ scoring to
+    /// cancel the double-counted `⟨M, M⟩` from `xm_a + xm_b`.
+    pub(super) mm_const: f32,
+}
+
+impl ErrorCorrection {
+    pub fn new_from_metadata(metadata: &ErrorCorrectionMetadata) -> Self {
+        Self::new(metadata.shift.clone(), metadata.scale.clone())
+    }
+
+    /// Build from already-computed per-coordinate stats. `shift = -mean` and
+    /// `scale = 1 / stddev` so that `apply` maps each coordinate to ~N(0, 1),
+    /// matching the precomputed Lloyd-Max codebook.
+    pub fn from_stats(stats: &VectorStats) -> Self {
+        let shift: Vec<f32> = stats.elements_stats.iter().map(|s| -s.mean).collect();
+        let scale: Vec<f32> = stats
+            .elements_stats
+            .iter()
+            .map(|s| {
+                if s.stddev > f32::EPSILON {
+                    s.stddev.recip()
+                } else {
+                    1.0
+                }
+            })
+            .collect();
+        Self::new(shift, scale)
+    }
+
+    fn new(shift: Vec<f32>, scale: Vec<f32>) -> Self {
+        let mm_const = shift.iter().map(|&s| s * s).sum();
+        let d_prime_sq = scale
+            .iter()
+            .map(|&s| {
+                if s.abs() > f32::EPSILON {
+                    (s * s).recip()
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        ErrorCorrection {
+            shift,
+            scale,
+            d_prime_sq,
+            mm_const,
+        }
+    }
+}
+
 impl TurboQuantizer {
     /// Initialize a new TurboQuantizer.
-    pub fn new(dim: usize, bits: TQBits, mode: TQMode, distance: DistanceType) -> Self {
+    pub fn new(
+        dim: usize,
+        bits: TQBits,
+        mode: TQMode,
+        distance: DistanceType,
+        error_correction: Option<ErrorCorrection>,
+    ) -> Self {
         let padded_dim = Self::padded_dim(dim, bits);
         let rotation = HadamardRotation::new(padded_dim);
         let dim_sqrt = (padded_dim as f32).sqrt();
@@ -31,6 +103,7 @@ impl TurboQuantizer {
             mode,
             distance,
             padded_dim,
+            error_correction,
             dim_sqrt,
         }
     }
@@ -42,11 +115,23 @@ impl TurboQuantizer {
             metadata.bits,
             metadata.mode,
             metadata.vector_parameters.distance_type,
+            metadata
+                .error_correction
+                .as_ref()
+                .map(ErrorCorrection::new_from_metadata),
         )
     }
 
-    /// Quantize a given vector with TurboQuant.
-    pub fn quantize(&self, vec: &[f32], buf: &mut [f64]) -> Vec<u8> {
+    /// Pad, rotate, and length-rescale `vec` into `buf`. After this call `buf`
+    /// holds rotated coordinates whose per-vector L2 norm is `sqrt(padded_dim)`,
+    /// matching the Lloyd-Max N(0, 1) centroid grid. Returns the original L2
+    /// length (pre-rescale) for distance metrics that store it; `None` for
+    /// Cosine.
+    ///
+    /// Used both by [`Self::quantize`] and by the TQ+ first pass in
+    /// [`crate::turboquant::EncodedVectorsTQ::encode`] when computing per-
+    /// coordinate stats over rescaled rotated samples.
+    pub(crate) fn preprocess_into(&self, vec: &[f32], buf: &mut [f64]) -> Option<f32> {
         debug_assert!(vec.len() <= self.padded_dim);
         debug_assert_eq!(buf.len(), self.padded_dim);
 
@@ -62,14 +147,58 @@ impl TurboQuantizer {
         // Rotate the vector.
         self.rotation.apply(buf);
 
-        // Compute the L2 length once: it both feeds the rescale below and
-        // gets serialized into the extras bytes appended by pack_vector.
         let l2_length = self.compute_l2_length(buf);
 
         // Rescale so per-coordinate variance is ~1 — matching the Lloyd-Max
-        // N(0, 1) centroid grid.
+        // N(0, 1) centroid grid. Guard against zero-length inputs: the rescale
+        // would be 0 · ∞ = NaN, which corrupts both the packing (via NaN
+        // partition_point) and the TQ+ stats first pass (Welford on NaN poisons
+        // every coordinate).
         let length = f64::from(l2_length.unwrap_or(1.0));
-        let scale = (self.padded_dim as f64).sqrt() / length;
+        if length > 0.0 {
+            let length_scale = (self.padded_dim as f64).sqrt() / length;
+            for v in buf.iter_mut() {
+                *v *= length_scale;
+            }
+        }
+
+        l2_length
+    }
+
+    /// Quantize a given vector with TurboQuant.
+    pub fn quantize(&self, vec: &[f32], buf: &mut [f64]) -> Vec<u8> {
+        let l2_length = self.preprocess_into(vec, buf);
+        // After `preprocess_into` the rescale is already in `buf`; from here on
+        // we treat `buf` as the rescaled vector and don't re-multiply by
+        // `scale`. Centroid-norm and packing operate on `buf` directly.
+        let scale = 1.0_f64;
+
+        // TQ+: stash `xm = ⟨X, M⟩ = -Σ X_i · shift_i` (computed on the
+        // rescaled pre-EC vector) for the symmetric-scoring slow path, then
+        // apply the per-coordinate shift+scale that pulls each coord onto the
+        // codebook's N(0, 1) grid.
+        //
+        // Zero-input guard: if the rescaled vector is identically zero (e.g.
+        // Cosine zero vector — the length-rescale guard preserves zero), the
+        // true scoring contract is `score == 0`. Applying EC would inject
+        // `shift · scale` into every coord and the resulting quantization
+        // noise overwhelms the small centroid_norm, blowing past the test
+        // tolerance. Skip EC for zero inputs and store `xm = 0`.
+        let xm = self.error_correction.as_ref().map(|ec| {
+            let rescaled_l2_sq: f64 = buf.iter().map(|&x| x * x).sum();
+            if rescaled_l2_sq < 1e-12 {
+                return 0.0_f32;
+            }
+            let xm: f64 = buf
+                .iter()
+                .zip(ec.shift.iter())
+                .map(|(&x, &s)| x * f64::from(-s))
+                .sum();
+            for (i, v) in buf.iter_mut().enumerate() {
+                *v = (*v + f64::from(ec.shift[i])) * f64::from(ec.scale[i]);
+            }
+            xm as f32
+        });
 
         // Compute the post-quantization centroid norm for Dot and Cosine so
         // re-normalized scoring can divide by ||c|| instead of sqrt(d).
@@ -98,7 +227,7 @@ impl TurboQuantizer {
             self.distance,
             self.mode,
         ));
-        self.pack_extras_into(l2_length, centroid_norm, &mut extras_bytes);
+        self.pack_extras_into(l2_length, centroid_norm, xm, &mut extras_bytes);
         let extras = TqVectorExtras::from_bytes(&extras_bytes);
 
         // Encode and return packed vector.
@@ -144,7 +273,19 @@ impl TurboQuantizer {
         };
 
         let scale = recovered_l2 / (self.padded_dim as f64).sqrt();
-        unpacked.into_iter().map(|x| x * scale).collect()
+        match &self.error_correction {
+            // TQ+: stored centroids approximate `X+`; revert EC to recover the
+            // rescaled coordinate before applying the length scale.
+            Some(ec) => unpacked
+                .into_iter()
+                .enumerate()
+                .map(|(i, x)| {
+                    let rescaled = x / f64::from(ec.scale[i]) - f64::from(ec.shift[i]);
+                    rescaled * scale
+                })
+                .collect(),
+            None => unpacked.into_iter().map(|x| x * scale).collect(),
+        }
     }
 
     /// Similarity score between two vectors that were both encoded with this
@@ -157,15 +298,18 @@ impl TurboQuantizer {
         let (data_v1, extra_v1) = self.split_vector(v1);
         let (data_v2, extra_v2) = self.split_vector(v2);
 
-        // `score_{N}bit_internal` computes `Σ centroid(a_k) · centroid(b_k)`
-        // directly on packed bytes — same quantity the old
-        // `dot_impl(unpack_vector, unpack_vector)` f64 path produced, now via
-        // the bit-width's SIMD kernel (with a scalar fallback built in).
-        let raw_dot = match self.bits {
-            TQBits::Bits1 => score_1bit_internal(data_v1, data_v2),
-            TQBits::Bits1_5 => score_1bit_internal(data_v1, data_v2),
-            TQBits::Bits2 => score_2bit_internal(data_v1, data_v2),
-            TQBits::Bits4 => score_4bit_internal(data_v1, data_v2),
+        // For TQ+, the SIMD kernels' uniform-weight dot can't produce the
+        // per-coord-weighted `Σ X+_a_i · X+_b_i · D'_i²` we need. Fall back to
+        // a scalar loop and add the precomputed `xm_a + xm_b − ⟨M, M⟩`.
+        // SIMD support for this path is a follow-up.
+        let raw_dot = match &self.error_correction {
+            Some(ec) => self.score_symmetric_ec(data_v1, data_v2, &extra_v1, &extra_v2, ec),
+            None => match self.bits {
+                TQBits::Bits1 => score_1bit_internal(data_v1, data_v2),
+                TQBits::Bits1_5 => score_1bit_internal(data_v1, data_v2),
+                TQBits::Bits2 => score_2bit_internal(data_v1, data_v2),
+                TQBits::Bits4 => score_4bit_internal(data_v1, data_v2),
+            },
         };
 
         let v1_scale = extra_v1.scaling_factor();
@@ -195,6 +339,39 @@ impl TurboQuantizer {
         }
     }
 
+    /// TQ+ symmetric-scoring slow path. Decodes both packed vectors into
+    /// centroids, takes a per-coord-weighted dot with `D'_i²`, and folds in
+    /// the precomputed `xm_a + xm_b − ⟨M, M⟩` so the caller can apply the
+    /// usual `* v1_scale * v2_scale` formulas as if EC weren't there.
+    fn score_symmetric_ec(
+        &self,
+        data_v1: &[u8],
+        data_v2: &[u8],
+        _extra_v1: &TqVectorExtras<'_>,
+        _extra_v2: &TqVectorExtras<'_>,
+        ec: &ErrorCorrection,
+    ) -> f32 {
+        let centroids = self.bits.get_centroids();
+        let bit_size = self.bits.bit_size();
+        let mut reader1 = common::bitpacking::BitReader::new(data_v1);
+        reader1.set_bits(bit_size);
+        let mut reader2 = common::bitpacking::BitReader::new(data_v2);
+        reader2.set_bits(bit_size);
+
+        let mut weighted: f32 = 0.0;
+        for i in 0..self.padded_dim {
+            let idx1: u8 = reader1.read();
+            let idx2: u8 = reader2.read();
+            let c1 = centroids[idx1 as usize];
+            let c2 = centroids[idx2 as usize];
+            weighted += c1 * c2 * ec.d_prime_sq[i];
+        }
+
+        let xm_a = _extra_v1.ec_correction();
+        let xm_b = _extra_v2.ec_correction();
+        weighted + xm_a + xm_b - ec.mm_const
+    }
+
     /// Precompute the Hadamard rotation of `query` and hand it to the
     /// bit-width's SIMD encoder.  Subsequent [`Self::score_precomputed`]
     /// calls reuse this precomputation — rotation runs once, not per score.
@@ -214,6 +391,23 @@ impl TurboQuantizer {
                 Some(rotated.iter().map(|&i| i * i).sum::<f64>().sqrt() as f32)
             }
             DistanceType::Cosine => None,
+        };
+
+        // TQ+ asymmetric: ⟨Q, X⟩ = ⟨Q .* D', X+⟩ + ⟨Q, M⟩, where D' = 1/scale
+        // and M = -shift. Pre-scale the query by D' so the SIMD raw_dot
+        // computes the first term, and stash the scalar `qm` for the second.
+        let ec_correction: f32 = if let Some(ec) = &self.error_correction {
+            let qm: f64 = rotated
+                .iter()
+                .zip(ec.shift.iter())
+                .map(|(&q, &s)| q * f64::from(-s))
+                .sum();
+            for (q, &s) in rotated.iter_mut().zip(ec.scale.iter()) {
+                *q /= f64::from(s);
+            }
+            qm as f32
+        } else {
+            0.0
         };
 
         let query = match self.distance {
@@ -236,6 +430,7 @@ impl TurboQuantizer {
             data,
             l2_norm,
             query,
+            ec_correction,
         }
     }
 
@@ -244,11 +439,14 @@ impl TurboQuantizer {
     /// and `cos(θ)` for Cosine.
     pub fn score_precomputed(&self, query: &EncodedQueryTQ, vec: &[u8]) -> f32 {
         let (data_bytes, vector_extras) = self.split_vector(vec);
-        let dot = match &query.data {
+        let raw_dot = match &query.data {
             EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
             EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
             EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
         };
+        // TQ+: SIMD raw_dot ≈ ⟨Q .* D', X+⟩; add `qm = ⟨Q, M⟩` to recover
+        // ⟨Q, rescaled_v⟩, which is the quantity the existing arms expect.
+        let dot = raw_dot + query.ec_correction;
 
         match self.distance {
             DistanceType::Cosine | DistanceType::Dot => {
@@ -287,7 +485,7 @@ mod tests {
     use super::*;
 
     fn make_tq(dim: usize, bits: TQBits, distance: DistanceType) -> TurboQuantizer {
-        TurboQuantizer::new(dim, bits, TQMode::Normal, distance)
+        TurboQuantizer::new(dim, bits, TQMode::Normal, distance, None)
     }
 
     /// Build a vector pair that has a given magnitude of similarity, tuned by `similarity`.

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -373,8 +373,8 @@ impl TurboQuantizer {
         &self,
         data_v1: &[u8],
         data_v2: &[u8],
-        _extra_v1: &TqVectorExtras<'_>,
-        _extra_v2: &TqVectorExtras<'_>,
+        extra_v1: &TqVectorExtras<'_>,
+        extra_v2: &TqVectorExtras<'_>,
         ec: &ErrorCorrection,
     ) -> f32 {
         let centroids = self.bits.get_centroids();
@@ -393,8 +393,8 @@ impl TurboQuantizer {
             weighted += c1 * c2 * ec.d_prime_sq[i];
         }
 
-        let xm_a = _extra_v1.ec_correction();
-        let xm_b = _extra_v2.ec_correction();
+        let xm_a = extra_v1.ec_correction();
+        let xm_b = extra_v2.ec_correction();
         weighted + xm_a + xm_b - ec.mm_const
     }
 

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -40,11 +40,33 @@ pub struct ErrorCorrection {
 }
 
 impl ErrorCorrection {
-    pub fn new_from_metadata(metadata: &ErrorCorrectionMetadata) -> Self {
-        Self::new(metadata.shift.clone(), metadata.scale.clone())
+    /// Reconstruct from persisted metadata, validating that `shift` and
+    /// `scale` have the expected length. Returns an error if the metadata
+    /// has been truncated or otherwise corrupted.
+    pub fn new_from_metadata(
+        metadata: &ErrorCorrectionMetadata,
+        padded_dim: usize,
+    ) -> std::io::Result<Self> {
+        if metadata.shift.len() != padded_dim || metadata.scale.len() != padded_dim {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "ErrorCorrection metadata length mismatch: shift={}, scale={}, expected={}",
+                    metadata.shift.len(),
+                    metadata.scale.len(),
+                    padded_dim,
+                ),
+            ));
+        }
+        Ok(Self::new(metadata.shift.clone(), metadata.scale.clone()))
     }
 
     pub(super) fn new(shift: Vec<f32>, scale: Vec<f32>) -> Self {
+        debug_assert_eq!(
+            shift.len(),
+            scale.len(),
+            "ErrorCorrection shift/scale length mismatch",
+        );
         let mm_const = shift.iter().map(|&s| s * s).sum();
         let d_prime_sq = scale
             .iter()
@@ -88,18 +110,23 @@ impl TurboQuantizer {
         }
     }
 
-    /// Initialize a new TurboQuantizer from metadata.
-    pub fn new_from_metadata(metadata: &Metadata) -> Self {
-        Self::new(
+    /// Initialize a new TurboQuantizer from metadata. Returns `Err` if the
+    /// persisted `ErrorCorrection` shift/scale lengths don't match the
+    /// expected `padded_dim`.
+    pub fn new_from_metadata(metadata: &Metadata) -> std::io::Result<Self> {
+        let padded_dim = Self::padded_dim(metadata.vector_parameters.dim, metadata.bits);
+        let error_correction = metadata
+            .error_correction
+            .as_ref()
+            .map(|m| ErrorCorrection::new_from_metadata(m, padded_dim))
+            .transpose()?;
+        Ok(Self::new(
             metadata.vector_parameters.dim,
             metadata.bits,
             metadata.mode,
             metadata.vector_parameters.distance_type,
-            metadata
-                .error_correction
-                .as_ref()
-                .map(ErrorCorrection::new_from_metadata),
-        )
+            error_correction,
+        ))
     }
 
     /// Pad, rotate, and length-rescale `vec` into `buf`. After this call `buf`
@@ -246,8 +273,13 @@ impl TurboQuantizer {
     }
 
     pub fn dequantize(&self, quantized: &[u8]) -> Vec<f64> {
-        let (unpacked, extras) = self.unpack_vector(quantized);
+        let (unpacked_iter, extras) = self.unpack_vector(quantized);
         let scaling_factor = f64::from(extras.scaling_factor());
+        // Materialize the unpacked centroids once. `unpack_vector` returns a
+        // streaming `BitReader` iterator and used to be invoked twice (here
+        // and in the `cn_quant` recompute below) — bit-unpacking the same
+        // bytes twice for every dequantize call.
+        let unpacked: Vec<f64> = unpacked_iter.collect();
 
         // Stored field is `l2/cn_quant` (`l2 == 1.0` for Cosine).
         // To recover the original l2 length, we need to `* cn_quant` measured
@@ -256,22 +288,16 @@ impl TurboQuantizer {
         let recovered_l2 = match self.distance {
             DistanceType::Dot | DistanceType::Cosine => {
                 let cn_quant = match &self.error_correction {
-                    Some(ec) => self
-                        .unpack_vector(quantized)
-                        .0
+                    Some(ec) => unpacked
+                        .iter()
                         .enumerate()
-                        .map(|(i, x)| {
+                        .map(|(i, &x)| {
                             let r = x / f64::from(ec.scale[i]) - f64::from(ec.shift[i]);
                             r * r
                         })
                         .sum::<f64>()
                         .sqrt(),
-                    None => self
-                        .unpack_vector(quantized)
-                        .0
-                        .map(|x| x * x)
-                        .sum::<f64>()
-                        .sqrt(),
+                    None => unpacked.iter().map(|&x| x * x).sum::<f64>().sqrt(),
                 };
                 scaling_factor * cn_quant
             }
@@ -347,17 +373,18 @@ impl TurboQuantizer {
 
     /// TQ+ symmetric-scoring slow path.
     ///
-    /// For 1-bit storage we use llama's unweighted form `Σ c_a · c_b` (raw
-    /// centroid dot, no `D'²`, no `xm` fold-in). The "math-correct" weighted
-    /// form `Σ c_a c_b D'_i² + xm_a + xm_b − ⟨M, M⟩` recovers
-    /// `⟨rescaled_a, rescaled_b⟩` exactly, but for 1-bit + anisotropic data
-    /// (dbpedia-openai) the per-coord `D'²` amplifies the large quantization
-    /// error of the ±c codebook on high-`D'` coords, corrupting the HNSW
-    /// graph that `score_internal` is used to build.
+    /// **Bits1 / Bits1_5**: plain `Σ c_a · c_b` — no `D'²` weighting, no
+    /// `xm`/`mm` fold-in. Matches llama-turbo-quant's 1-bit symmetric path.
+    /// This computes `⟨X⁺_a, X⁺_b⟩` (centered+normalized space), not the
+    /// rescaled-space dot. Mathematically a different quantity, but for
+    /// HNSW ranking it's stable: no `D'⁴` variance amplification on
+    /// anisotropic coords. Adding `xm + xm − ⟨M, M⟩` *without* `D'²`
+    /// scrambles scales (centroid dot is in `X⁺`-space units, `xm`/`mm`
+    /// are in `X`-space units) and destroys ranking entirely.
     ///
-    /// For Bits2/Bits4 the codebook is fine-grained enough that quantization
-    /// noise per coord is small relative to signal, so the math-correct
-    /// weighted form remains the better choice.
+    /// **Bits2 / Bits4**: full math-correct form `Σ c_a c_b D'_i² + xm_a
+    /// + xm_b − ⟨M, M⟩`. Codebooks are fine-grained enough that the
+    /// quantization noise stays small even after `D'⁴` amplification.
     fn score_symmetric_ec(
         &self,
         data_v1: &[u8],

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -449,15 +449,14 @@ impl TurboQuantizer {
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
         // For TQ+ + Bits1 storage, widen query quantization from the default
-        // 8 bits to 12. The per-coord `D'` pre-scaling can push some coords
-        // toward the small end of the integer range; 8 bits loses too much
-        // there. 12 bits drops the SIMD scoring error by ~10× per the
-        // `test_query_dotprod_matches_reference` parity test in `query1bit`.
+        // 8 bits to the kernel's max of 16. The per-coord `D'` pre-scaling
+        // can push some coords toward the small end of the integer range;
+        // 8 bits loses too much there.
         let use_wide_query =
             self.error_correction.is_some() && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
         let data = match self.bits {
             TQBits::Bits1 | TQBits::Bits1_5 if use_wide_query => {
-                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<12>::new(&rotated_f32))
+                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<16>::new(&rotated_f32))
             }
             TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -449,15 +449,15 @@ impl TurboQuantizer {
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
         // For TQ+ + Bits1 storage, widen query quantization from the default
-        // 8 bits to the kernel's max of 16. The per-coord `D'` pre-scaling
-        // can push some coords toward the small end of the integer range;
-        // 8 bits loses too much there. 16 bits gives enough headroom to
-        // recover recall on real datasets where D' has wide variance.
+        // 8 bits to 12. The per-coord `D'` pre-scaling can push some coords
+        // toward the small end of the integer range; 8 bits loses too much
+        // there. 12 bits drops the SIMD scoring error by ~10× per the
+        // `test_query_dotprod_matches_reference` parity test in `query1bit`.
         let use_wide_query =
             self.error_correction.is_some() && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
         let data = match self.bits {
             TQBits::Bits1 | TQBits::Bits1_5 if use_wide_query => {
-                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<16>::new(&rotated_f32))
+                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<12>::new(&rotated_f32))
             }
             TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -477,18 +477,23 @@ impl TurboQuantizer {
         // has no downstream benefit here).
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
-        let rotated_query = self.error_correction.as_ref().and_then(|_| match self.distance {
-            DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
-                Some(rotated_f32.clone())
+        let (data, rotated_query) = match (&self.error_correction, self.distance) {
+            // TQ+ Dot/Cosine/L2: skip SIMD encoding (can't represent per-coord
+            // `D'_i` weighting); store rotated query for the scalar path.
+            (Some(_), DistanceType::Dot | DistanceType::Cosine | DistanceType::L2) => {
+                (None, Some(rotated_f32))
             }
-            DistanceType::L1 => None,
-        });
-
-        let data = match self.bits {
-            TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
-            TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
-            TQBits::Bits2 => EncodedQueryTQData::Bits2(Query2bitSimd::new(&rotated_f32)),
-            TQBits::Bits4 => EncodedQueryTQData::Bits4(Query4bitSimd::new(&rotated_f32)),
+            // Normal mode (any distance) and TQ+ L1 (uses dequantize fallback):
+            // build the SIMD encoding.
+            _ => {
+                let data = match self.bits {
+                    TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
+                    TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
+                    TQBits::Bits2 => EncodedQueryTQData::Bits2(Query2bitSimd::new(&rotated_f32)),
+                    TQBits::Bits4 => EncodedQueryTQData::Bits4(Query4bitSimd::new(&rotated_f32)),
+                };
+                (Some(data), None)
+            }
         };
         EncodedQueryTQ {
             data,
@@ -509,18 +514,20 @@ impl TurboQuantizer {
         // Decode centroids in a scalar loop and fold in `D'_i` from `ec.scale`.
         // The +qm correction is added below. L1 short-circuits to the
         // dequantize-and-L1 path below, so we skip the dot computation for it.
-        let needs_dot =
-            !matches!(self.distance, DistanceType::L1) || self.error_correction.is_none();
+        let needs_dot = !matches!(self.distance, DistanceType::L1);
         let dot = if !needs_dot {
             0.0
+        } else if let Some(ec) = &self.error_correction {
+            self.score_precomputed_ec(data_bytes, query, ec) + query.ec_correction
         } else {
-            match &self.error_correction {
-                Some(ec) => self.score_precomputed_ec(data_bytes, query, ec) + query.ec_correction,
-                None => match &query.data {
-                    EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
-                    EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
-                    EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
-                },
+            match query
+                .data
+                .as_ref()
+                .expect("Normal-mode asymmetric scoring requires SIMD data")
+            {
+                EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
+                EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
+                EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
             }
         };
 

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -365,35 +365,6 @@ impl TurboQuantizer {
         }
     }
 
-    /// TQ+ asymmetric-scoring slow path. Decodes the stored centroids and
-    /// computes `Σ R_q_i · c_i · D'_i = Σ R_q_i · (rescaled_i − M_i)`. Caller
-    /// adds `qm = ⟨R_q, M⟩` to recover `⟨R_q, rescaled⟩`.
-    fn score_precomputed_ec(
-        &self,
-        data_bytes: &[u8],
-        query: &EncodedQueryTQ,
-        ec: &ErrorCorrection,
-    ) -> f32 {
-        let centroids = self.bits.get_centroids();
-        let bit_size = self.bits.bit_size();
-        let mut reader = common::bitpacking::BitReader::new(data_bytes);
-        reader.set_bits(bit_size);
-
-        let rotated_q = query
-            .rotated_query
-            .as_ref()
-            .expect("TQ+ asymmetric scoring requires rotated_query in EncodedQueryTQ");
-
-        let mut sum: f32 = 0.0;
-        for (i, &q) in rotated_q.iter().enumerate() {
-            let idx: u8 = reader.read();
-            let c = centroids[idx as usize];
-            // c · D'_i = c / scale_i (since scale = 1/D').
-            sum += q * c / ec.scale[i];
-        }
-        sum
-    }
-
     /// TQ+ symmetric-scoring slow path. Decodes both packed vectors into
     /// centroids, takes a per-coord-weighted dot with `D'_i²`, and folds in
     /// the precomputed `xm_a + xm_b − ⟨M, M⟩` so the caller can apply the
@@ -449,20 +420,20 @@ impl TurboQuantizer {
         };
 
         // TQ+ asymmetric: ⟨Q, X⟩ = ⟨Q .* D', X+⟩ + ⟨Q, M⟩, where D' = 1/scale
-        // and M = -shift. We deliberately do NOT pre-scale `rotated` by `D'`
-        // here. The SIMD encoder normalizes by `max(|input|)`, so a query whose
-        // coords have wildly varying magnitudes (which `R_q · D'` does when
-        // stats produce a non-flat `D'` — exactly the data TQ+ is meant for)
-        // gets quantized with poor precision on the small-D' coords. Instead,
-        // we keep `rotated` unscaled and let `score_precomputed` do a scalar
-        // decode-and-dot that folds in `D'_i` per coord.  SIMD support for
-        // this path is a follow-up.
+        // and M = -shift. Pre-scale `rotated` by `D'` so the existing SIMD
+        // raw_dot computes ⟨Q+, X+⟩, and stash `qm = ⟨Q, M⟩` for the scalar
+        // correction. The whole point of TQ+ is that scoring code-paths stay
+        // identical — only the query precomputation changes.
         let ec_correction: f32 = if let Some(ec) = &self.error_correction {
-            rotated
+            let qm: f64 = rotated
                 .iter()
                 .zip(ec.shift.iter())
                 .map(|(&q, &s)| q * f64::from(-s))
-                .sum::<f64>() as f32
+                .sum();
+            for (q, &s) in rotated.iter_mut().zip(ec.scale.iter()) {
+                *q /= f64::from(s);
+            }
+            qm as f32
         } else {
             0.0
         };
@@ -477,29 +448,16 @@ impl TurboQuantizer {
         // has no downstream benefit here).
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
-        let (data, rotated_query) = match (&self.error_correction, self.distance) {
-            // TQ+ Dot/Cosine/L2: skip SIMD encoding (can't represent per-coord
-            // `D'_i` weighting); store rotated query for the scalar path.
-            (Some(_), DistanceType::Dot | DistanceType::Cosine | DistanceType::L2) => {
-                (None, Some(rotated_f32))
-            }
-            // Normal mode (any distance) and TQ+ L1 (uses dequantize fallback):
-            // build the SIMD encoding.
-            _ => {
-                let data = match self.bits {
-                    TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
-                    TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
-                    TQBits::Bits2 => EncodedQueryTQData::Bits2(Query2bitSimd::new(&rotated_f32)),
-                    TQBits::Bits4 => EncodedQueryTQData::Bits4(Query4bitSimd::new(&rotated_f32)),
-                };
-                (Some(data), None)
-            }
+        let data = match self.bits {
+            TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
+            TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
+            TQBits::Bits2 => EncodedQueryTQData::Bits2(Query2bitSimd::new(&rotated_f32)),
+            TQBits::Bits4 => EncodedQueryTQData::Bits4(Query4bitSimd::new(&rotated_f32)),
         };
         EncodedQueryTQ {
             data,
             l2_norm,
             query,
-            rotated_query,
             ec_correction,
         }
     }
@@ -509,27 +467,14 @@ impl TurboQuantizer {
     /// and `cos(θ)` for Cosine.
     pub fn score_precomputed(&self, query: &EncodedQueryTQ, vec: &[u8]) -> f32 {
         let (data_bytes, vector_extras) = self.split_vector(vec);
-        // TQ+: SIMD's uniform-weight dot can't carry the per-coord `D'_i`
-        // weighting required to recover ⟨Q, rescaled_v⟩ from `c ≈ X+`.
-        // Decode centroids in a scalar loop and fold in `D'_i` from `ec.scale`.
-        // The +qm correction is added below. L1 short-circuits to the
-        // dequantize-and-L1 path below, so we skip the dot computation for it.
-        let needs_dot = !matches!(self.distance, DistanceType::L1);
-        let dot = if !needs_dot {
-            0.0
-        } else if let Some(ec) = &self.error_correction {
-            self.score_precomputed_ec(data_bytes, query, ec) + query.ec_correction
-        } else {
-            match query
-                .data
-                .as_ref()
-                .expect("Normal-mode asymmetric scoring requires SIMD data")
-            {
-                EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
-                EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
-                EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
-            }
+        let raw_dot = match &query.data {
+            EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
+            EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
+            EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
         };
+        // TQ+: SIMD raw_dot ≈ ⟨Q · D', X+⟩; add `qm = ⟨Q, M⟩` to recover
+        // ⟨Q, rescaled_v⟩, which is the quantity the existing arms expect.
+        let dot = raw_dot + query.ec_correction;
 
         match self.distance {
             DistanceType::Cosine | DistanceType::Dot => {

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -453,8 +453,8 @@ impl TurboQuantizer {
         // toward the small end of the integer range; 8 bits loses too much
         // there. 12 bits drops the SIMD scoring error by ~10× per the
         // `test_query_dotprod_matches_reference` parity test in `query1bit`.
-        let use_wide_query = self.error_correction.is_some()
-            && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
+        let use_wide_query =
+            self.error_correction.is_some() && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
         let data = match self.bits {
             TQBits::Bits1 | TQBits::Bits1_5 if use_wide_query => {
                 EncodedQueryTQData::Bits1Wide(Query1bitSimd::<12>::new(&rotated_f32))

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -448,7 +448,17 @@ impl TurboQuantizer {
         // has no downstream benefit here).
         let rotated_f32: Vec<f32> = rotated.iter().map(|&x| x as f32).collect();
 
+        // For TQ+ + Bits1 storage, widen query quantization from the default
+        // 8 bits to 12. The per-coord `D'` pre-scaling can push some coords
+        // toward the small end of the integer range; 8 bits loses too much
+        // there. 12 bits drops the SIMD scoring error by ~10× per the
+        // `test_query_dotprod_matches_reference` parity test in `query1bit`.
+        let use_wide_query = self.error_correction.is_some()
+            && matches!(self.bits, TQBits::Bits1 | TQBits::Bits1_5);
         let data = match self.bits {
+            TQBits::Bits1 | TQBits::Bits1_5 if use_wide_query => {
+                EncodedQueryTQData::Bits1Wide(Query1bitSimd::<12>::new(&rotated_f32))
+            }
             TQBits::Bits1 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits1_5 => EncodedQueryTQData::Bits1(Query1bitSimd::new(&rotated_f32)),
             TQBits::Bits2 => EncodedQueryTQData::Bits2(Query2bitSimd::new(&rotated_f32)),
@@ -469,6 +479,7 @@ impl TurboQuantizer {
         let (data_bytes, vector_extras) = self.split_vector(vec);
         let raw_dot = match &query.data {
             EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
+            EncodedQueryTQData::Bits1Wide(q) => q.dotprod(data_bytes),
             EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
             EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
         };

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -8,7 +8,6 @@ use crate::turboquant::simd::{
 use crate::turboquant::{
     EncodedQueryTQ, EncodedQueryTQData, ErrorCorrectionMetadata, Metadata, TQBits, TQMode,
 };
-use crate::vector_stats::VectorStats;
 
 /// Quantize vectors using TurboQuant.
 pub struct TurboQuantizer {
@@ -43,25 +42,6 @@ pub struct ErrorCorrection {
 impl ErrorCorrection {
     pub fn new_from_metadata(metadata: &ErrorCorrectionMetadata) -> Self {
         Self::new(metadata.shift.clone(), metadata.scale.clone())
-    }
-
-    /// Build from already-computed per-coordinate stats. `shift = -mean` and
-    /// `scale = 1 / stddev` so that `apply` maps each coordinate to ~N(0, 1),
-    /// matching the precomputed Lloyd-Max codebook.
-    pub fn from_stats(stats: &VectorStats) -> Self {
-        let shift: Vec<f32> = stats.elements_stats.iter().map(|s| -s.mean).collect();
-        let scale: Vec<f32> = stats
-            .elements_stats
-            .iter()
-            .map(|s| {
-                if s.stddev > f32::EPSILON {
-                    s.stddev.recip()
-                } else {
-                    1.0
-                }
-            })
-            .collect();
-        Self::new(shift, scale)
     }
 
     pub(super) fn new(shift: Vec<f32>, scale: Vec<f32>) -> Self {

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -173,7 +173,6 @@ mod test {
     /// reducing distortion in vectors where energy is concentrated.
     #[test]
     fn hadamard_reduces_distortion() {
-        use crate::VectorParameters;
         use crate::vector_stats::VectorStats;
 
         for dim in [100, 101, 300, 384, 512, 1024, 1025, 1586] {
@@ -209,17 +208,8 @@ mod test {
                 .map(|v| v.into_iter().map(|i| i as f32).collect::<Vec<_>>())
                 .collect();
 
-            let mut params = VectorParameters {
-                dim,
-                distance_type: crate::DistanceType::Dot,
-                invert: false,
-                deprecated_count: None,
-            };
-
-            let stats_before = VectorStats::build(vectors.iter(), &params);
-
-            params.dim = rot.dim;
-            let stats_after = VectorStats::build(rotated.iter(), &params);
+            let stats_before = VectorStats::build(vectors.iter(), dim);
+            let stats_after = VectorStats::build(rotated.iter(), rot.dim);
 
             // Measure how uniform the per-dimension stddevs are by looking at
             // the ratio between max and min stddev across dimensions.

--- a/lib/quantization/src/vector_stats.rs
+++ b/lib/quantization/src/vector_stats.rs
@@ -49,7 +49,11 @@ impl VectorStatsBuilder {
     where
         f64: From<T>,
     {
-        debug_assert_eq!(
+        // `assert_eq!` rather than `debug_assert_eq!` — a length mismatch
+        // here would silently zip-truncate in release builds, partially
+        // updating the Welford aggregates and corrupting them without ever
+        // surfacing the error.
+        assert_eq!(
             vector.len(),
             self.stats.elements_stats.len(),
             "Vector length does not match the expected dimension"

--- a/lib/quantization/src/vector_stats.rs
+++ b/lib/quantization/src/vector_stats.rs
@@ -45,7 +45,10 @@ impl VectorStatsBuilder {
         }
     }
 
-    pub fn add<T: Copy + Into<f64>>(&mut self, vector: &[T]) {
+    pub fn add<T: Copy>(&mut self, vector: &[T])
+    where
+        f64: From<T>,
+    {
         debug_assert_eq!(
             vector.len(),
             self.stats.elements_stats.len(),
@@ -60,7 +63,7 @@ impl VectorStatsBuilder {
             .zip(self.means.iter_mut())
             .zip(self.m2.iter_mut())
         {
-            let value_f64: f64 = value.into();
+            let value_f64 = f64::from(value);
             let value_f32 = value_f64 as f32;
             if value_f32 < element_stats.min {
                 element_stats.min = value_f32;
@@ -98,7 +101,8 @@ impl VectorStatsBuilder {
 impl VectorStats {
     pub fn build<T>(data: impl Iterator<Item = impl AsRef<[T]>>, dim: usize) -> Self
     where
-        T: Copy + Into<f64>,
+        T: Copy,
+        f64: From<T>,
     {
         let mut builder = VectorStatsBuilder::new(dim);
         for vector in data {

--- a/lib/quantization/src/vector_stats.rs
+++ b/lib/quantization/src/vector_stats.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::VectorParameters;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VectorStats {
     pub elements_stats: Vec<VectorElementStats>,
@@ -26,68 +24,86 @@ impl Default for VectorElementStats {
     }
 }
 
-impl VectorStats {
-    pub fn build<'a>(
-        data: impl Iterator<Item = impl AsRef<[f32]> + 'a>,
-        vector_params: &VectorParameters,
-    ) -> Self {
-        // The Welford's Algorithm.
-        let mut stats = VectorStats {
-            elements_stats: vec![VectorElementStats::default(); vector_params.dim],
-        };
+/// Streaming Welford accumulator. Use [`VectorStatsBuilder::add`] for each
+/// sample, then [`VectorStatsBuilder::build`] to finalize.
+pub struct VectorStatsBuilder {
+    stats: VectorStats,
+    means: Vec<f64>,
+    m2: Vec<f64>,
+    count: u64,
+}
 
-        // For internal calculations use higher precision.
-        let mut m2 = vec![0.0f64; vector_params.dim];
-        let mut means = vec![0.0f64; vector_params.dim];
-
-        let mut count = 0;
-        for vector in data {
-            let vector = vector.as_ref();
-            count += 1;
-
-            debug_assert_eq!(
-                vector.len(),
-                vector_params.dim,
-                "Vector length does not match the expected dimension"
-            );
-
-            for (((&value, element_stats), mean), m2) in vector
-                .iter()
-                .zip(stats.elements_stats.iter_mut())
-                .zip(means.iter_mut())
-                .zip(m2.iter_mut())
-            {
-                element_stats.min = if value < element_stats.min {
-                    value
-                } else {
-                    element_stats.min
-                };
-                element_stats.max = if value > element_stats.max {
-                    value
-                } else {
-                    element_stats.max
-                };
-
-                let delta = f64::from(value) - *mean;
-                *mean += delta / f64::from(count);
-                *m2 += delta * (f64::from(value) - *mean);
-            }
+impl VectorStatsBuilder {
+    pub fn new(dim: usize) -> Self {
+        VectorStatsBuilder {
+            stats: VectorStats {
+                elements_stats: vec![VectorElementStats::default(); dim],
+            },
+            means: vec![0.0f64; dim],
+            m2: vec![0.0f64; dim],
+            count: 0,
         }
+    }
 
-        for ((element_stats, means), m2) in stats
+    pub fn add<T: Copy + Into<f64>>(&mut self, vector: &[T]) {
+        debug_assert_eq!(
+            vector.len(),
+            self.stats.elements_stats.len(),
+            "Vector length does not match the expected dimension"
+        );
+        self.count += 1;
+        let count_f64 = self.count as f64;
+
+        for (((&value, element_stats), mean), m2) in vector
+            .iter()
+            .zip(self.stats.elements_stats.iter_mut())
+            .zip(self.means.iter_mut())
+            .zip(self.m2.iter_mut())
+        {
+            let value_f64: f64 = value.into();
+            let value_f32 = value_f64 as f32;
+            if value_f32 < element_stats.min {
+                element_stats.min = value_f32;
+            }
+            if value_f32 > element_stats.max {
+                element_stats.max = value_f32;
+            }
+
+            let delta = value_f64 - *mean;
+            *mean += delta / count_f64;
+            *m2 += delta * (value_f64 - *mean);
+        }
+    }
+
+    pub fn build(mut self) -> VectorStats {
+        let count = self.count;
+        for ((element_stats, means), m2) in self
+            .stats
             .elements_stats
             .iter_mut()
-            .zip(means.iter())
-            .zip(m2.iter())
+            .zip(self.means.iter())
+            .zip(self.m2.iter())
         {
             element_stats.stddev = if count > 1 {
-                (*m2 / f64::from(count - 1)).sqrt() as f32
+                (*m2 / (count - 1) as f64).sqrt() as f32
             } else {
                 0.0
             };
             element_stats.mean = *means as f32;
         }
+        self.stats
+    }
+}
 
-        stats
+impl VectorStats {
+    pub fn build<T>(data: impl Iterator<Item = impl AsRef<[T]>>, dim: usize) -> Self
+    where
+        T: Copy + Into<f64>,
+    {
+        let mut builder = VectorStatsBuilder::new(dim);
+        for vector in data {
+            builder.add(vector.as_ref());
+        }
+        builder.build()
     }
 }

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -15,7 +15,6 @@ mod tests {
     const DIMS: &[usize] = &[16, 64, 65, 128, 384, 512];
     const BITS: &[TQBits] = &[TQBits::Bits4, TQBits::Bits2, TQBits::Bits1_5, TQBits::Bits1];
 
-
     /// Absolute tolerance for an approximate score: an empirical per-bit
     /// coefficient (≈ 1.8x observed max across VECTORS_COUNT trials) times
     /// the signal-std of the input data. The mean-error / signal-std ratio
@@ -827,6 +826,7 @@ mod tests {
     /// `‖X+‖` has chi-squared spread across vectors — see
     /// [`TurboQuantizer::compute_centroid_norm`] for the EC-revert that fixes it.
     #[rstest::rstest]
+    #[case::bits1(TQBits::Bits1)]
     #[case::bits2(TQBits::Bits2)]
     #[case::bits4(TQBits::Bits4)]
     fn recall_skewed_data(#[case] bits: TQBits) {
@@ -839,9 +839,7 @@ mod tests {
         // Pre-rotation per-coord scale: a few coords have huge variance, most
         // have small. Realistic embeddings have similar structure (a few
         // "spike" directions).
-        let coord_scales: Vec<f32> = (0..dim)
-            .map(|i| if i < 8 { 100.0 } else { 1.0 })
-            .collect();
+        let coord_scales: Vec<f32> = (0..dim).map(|i| if i < 8 { 100.0 } else { 1.0 }).collect();
         let make_vec = |rng: &mut StdRng| -> Vec<f32> {
             coord_scales
                 .iter()
@@ -850,9 +848,8 @@ mod tests {
         };
         let vectors: Vec<Vec<f32>> = (0..n).map(|_| make_vec(&mut rng)).collect();
         let queries: Vec<Vec<f32>> = (0..n_queries).map(|_| make_vec(&mut rng)).collect();
-        let true_dot = |a: &[f32], b: &[f32]| -> f32 {
-            a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
-        };
+        let true_dot =
+            |a: &[f32], b: &[f32]| -> f32 { a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum() };
 
         let recall_for = |mode: TQMode| -> f32 {
             let vp = VectorParameters {

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -819,4 +819,93 @@ mod tests {
             }
         }
     }
+
+    /// Recall regression probe — non-uniform per-coordinate variance data
+    /// (the case where TQ+ should HELP, not hurt). Asserts Plus-mode recall@k
+    /// stays close to Normal-mode on data with a few high-variance "spike"
+    /// directions. Catches the failure mode where renorm's `cn` drifts because
+    /// `‖X+‖` has chi-squared spread across vectors — see
+    /// [`TurboQuantizer::compute_centroid_norm`] for the EC-revert that fixes it.
+    #[rstest::rstest]
+    #[case::bits2(TQBits::Bits2)]
+    #[case::bits4(TQBits::Bits4)]
+    fn recall_skewed_data(#[case] bits: TQBits) {
+        use rand::prelude::StdRng;
+        let dim = 256;
+        let n = 1000;
+        let n_queries = 50;
+        let topk = 10;
+        let mut rng = StdRng::seed_from_u64(42);
+        // Pre-rotation per-coord scale: a few coords have huge variance, most
+        // have small. Realistic embeddings have similar structure (a few
+        // "spike" directions).
+        let coord_scales: Vec<f32> = (0..dim)
+            .map(|i| if i < 8 { 100.0 } else { 1.0 })
+            .collect();
+        let make_vec = |rng: &mut StdRng| -> Vec<f32> {
+            coord_scales
+                .iter()
+                .map(|&s| s * (rng.random_range(-1.0..1.0)))
+                .collect()
+        };
+        let vectors: Vec<Vec<f32>> = (0..n).map(|_| make_vec(&mut rng)).collect();
+        let queries: Vec<Vec<f32>> = (0..n_queries).map(|_| make_vec(&mut rng)).collect();
+        let true_dot = |a: &[f32], b: &[f32]| -> f32 {
+            a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+        };
+
+        let recall_for = |mode: TQMode| -> f32 {
+            let vp = VectorParameters {
+                dim,
+                distance_type: DistanceType::Dot,
+                invert: false,
+                deprecated_count: None,
+            };
+            let qsize =
+                EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(&vp, bits, mode);
+            let encoded = EncodedVectorsTQ::encode(
+                vectors.iter(),
+                TestEncodedStorageBuilder::new(None, qsize),
+                &vp,
+                n,
+                bits,
+                mode,
+                None,
+                &AtomicBool::new(false),
+            )
+            .unwrap();
+            let counter = HardwareCounterCell::new();
+            let mut total = 0.0;
+            for q in &queries {
+                let mut truth: Vec<(usize, f32)> = vectors
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| (i, true_dot(q, v)))
+                    .collect();
+                truth.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+                let truth_top: Vec<usize> = truth.iter().take(topk).map(|x| x.0).collect();
+
+                let qq = encoded.encode_query(q);
+                let mut q_scores: Vec<(usize, f32)> = (0..n)
+                    .map(|i| (i, encoded.score_point(&qq, i as u32, &counter)))
+                    .collect();
+                q_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+                let q_top: Vec<usize> = q_scores.iter().take(topk).map(|x| x.0).collect();
+
+                let hits = truth_top.iter().filter(|i| q_top.contains(i)).count();
+                total += hits as f32 / topk as f32;
+            }
+            total / n_queries as f32
+        };
+
+        let normal = recall_for(TQMode::Normal);
+        let plus = recall_for(TQMode::Plus);
+        // Plus must not be meaningfully worse than Normal. We allow a small
+        // 2% slack since the codebook is the same and EC's value comes from
+        // distribution fit, which on this seed is marginal.
+        assert!(
+            plus >= normal - 0.02,
+            "bits={bits:?}: Plus recall regressed (Normal={normal:.3}, Plus={plus:.3})"
+        );
+    }
 }

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -14,7 +14,7 @@ mod tests {
 
     const DIMS: &[usize] = &[16, 64, 65, 128, 384, 512];
     const BITS: &[TQBits] = &[TQBits::Bits4, TQBits::Bits2, TQBits::Bits1_5, TQBits::Bits1];
-    const MODE: TQMode = TQMode::Normal;
+
 
     /// Absolute tolerance for an approximate score: an empirical per-bit
     /// coefficient (≈ 1.8x observed max across VECTORS_COUNT trials) times
@@ -97,8 +97,10 @@ mod tests {
         dot_similarity(a, b) / (l2_norm(a) * l2_norm(b))
     }
 
-    #[test]
-    fn test_tq_dot() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_dot(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -122,7 +124,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -130,7 +132,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -150,8 +152,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_cosine() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_cosine(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -177,7 +181,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -185,7 +189,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -205,8 +209,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_dot_internal() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_dot_internal(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -229,7 +235,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -237,7 +243,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -256,8 +262,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_cosine_internal() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_cosine_internal(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -281,7 +289,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -289,7 +297,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -308,8 +316,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_zero_vector_dot() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_zero_vector_dot(#[case] mode: TQMode) {
         // A zero vector stored in the dataset, scored with Dot against a
         // non-zero query, should produce a score close to the true dot
         // product, which is exactly 0.
@@ -338,7 +348,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -346,7 +356,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -363,8 +373,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_zero_query_dot() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_zero_query_dot(#[case] mode: TQMode) {
         // A zero query, scored with Dot against any encoded vector, should
         // produce a score close to the true dot product, which is exactly 0.
         for &bits in BITS {
@@ -390,7 +402,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -398,7 +410,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -417,8 +429,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_zero_vector_cosine() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_zero_vector_cosine(#[case] mode: TQMode) {
         // A zero vector stored in the dataset, scored with Cosine against a
         // unit-norm query, should produce a score close to 0. Cosine of a
         // zero vector is mathematically undefined; the implementation's
@@ -451,7 +465,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -459,7 +473,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -476,8 +490,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_zero_query_cosine() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_zero_query_cosine(#[case] mode: TQMode) {
         // A zero query, scored with Cosine against any unit-norm vector,
         // should produce a score close to 0. Same convention as above:
         // zero is preserved through query preprocessing.
@@ -505,7 +521,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -513,7 +529,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -532,8 +548,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_dim_one_dot() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_dim_one_dot(#[case] mode: TQMode) {
         // dim=1 is degenerate (no room for Hadamard Gaussianization, quant
         // noise dominates). Just verify the path doesn't panic and yields
         // finite, sanely bounded scores; accuracy bounds elsewhere don't apply.
@@ -556,7 +574,7 @@ mod tests {
                 EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                     &vector_parameters,
                     bits,
-                    MODE,
+                    mode,
                 );
             let encoded = EncodedVectorsTQ::encode(
                 vector_data.iter(),
@@ -564,7 +582,7 @@ mod tests {
                 &vector_parameters,
                 VECTORS_COUNT,
                 bits,
-                MODE,
+                mode,
                 None,
                 &AtomicBool::new(false),
             )
@@ -586,8 +604,10 @@ mod tests {
     // `error()` with `l2_signal_std`; L1 has its own coefficient table
     // because its noise/signal scaling per bit doesn't match dot/cosine.
 
-    #[test]
-    fn test_tq_l2() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_l2(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -611,7 +631,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -619,7 +639,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -639,8 +659,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_l2_internal() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_l2_internal(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -663,7 +685,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -671,7 +693,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -690,8 +712,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_l1() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_l1(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -715,7 +739,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -723,7 +747,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )
@@ -743,8 +767,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_tq_l1_internal() {
+    #[rstest::rstest]
+    #[case::normal(TQMode::Normal)]
+    #[case::plus(TQMode::Plus)]
+    fn test_tq_l1_internal(#[case] mode: TQMode) {
         for &bits in BITS {
             for &dim in DIMS {
                 if !should_test(dim, bits) {
@@ -767,7 +793,7 @@ mod tests {
                     EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
                         &vector_parameters,
                         bits,
-                        MODE,
+                        mode,
                     );
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
@@ -775,7 +801,7 @@ mod tests {
                     &vector_parameters,
                     VECTORS_COUNT,
                     bits,
-                    MODE,
+                    mode,
                     None,
                     &AtomicBool::new(false),
                 )


### PR DESCRIPTION
Shift and scale data to better codebook fitting in TQ.

Sanity check measurement on dbpedia (no oversampling):

TQ+ 4bit: 0.926
TQ 4bit: 0.913
SQ: 0.881

TQ+ 2bit: 0.836
TQ 2bit: 0.786
BQ 2bit: 0.733

TQ+ 1bit: 0.742
TQ 1bit: 0.632
BQ asym: 0.706