### PR TITLE
Immutable storage for mmap text index

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use ahash::AHashMap;
+use common::bitvec::BitSliceExt;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Either;
@@ -508,10 +509,21 @@ impl TryFrom<&MmapInvertedIndex> for ImmutableInvertedIndex {
             "postings and vocab must be the same size",
         );
 
+        // The in-RAM index uses `count == 0` as its deletion marker. The mmap
+        // variant tracks deletions in a separate in-memory bitmask and leaves
+        // `point_to_tokens_count` untouched on disk, so we apply the bitmask
+        // here when materializing the count vector.
+        let mut point_to_tokens_count = index.storage.point_to_tokens_count.to_vec();
+        for (idx, count) in point_to_tokens_count.iter_mut().enumerate() {
+            if index.storage.deleted_points.get_bit(idx).unwrap_or(false) {
+                *count = 0;
+            }
+        }
+
         Ok(ImmutableInvertedIndex {
             postings,
             vocab,
-            point_to_tokens_count: index.storage.point_to_tokens_count.to_vec(),
+            point_to_tokens_count,
             points_count: index.points_count(),
         })
     }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
+use std::ops::BitOrAssign;
 use std::path::PathBuf;
 
-use common::bitvec::BitVec;
+use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::fs::clear_disk_cache;
 use common::mmap::{self, Advice, AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::mmap_hashmap::{MmapHashMap, READ_ENTRY_OVERHEAD};
 use common::stored_bitslice::MmapBitSlice;
@@ -21,7 +23,6 @@ use super::postings_iterator::{
 };
 use super::{InvertedIndex, ParsedQuery, TokenId, TokenSet};
 use crate::common::Flusher;
-use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::full_text_index::inverted_index::Document;
 use crate::index::field_index::full_text_index::inverted_index::postings_iterator::{
@@ -39,6 +40,18 @@ const VOCAB_FILE: &str = "vocab.dat";
 const POINT_TO_TOKENS_COUNT_FILE: &str = "point_to_tokens_count.dat";
 const DELETED_POINTS_FILE: &str = "deleted_points.dat";
 
+/// Mmap-backed immutable full-text inverted index.
+///
+/// On-disk state (`postings.dat`, `vocab.dat`, `point_to_tokens_count.dat`,
+/// `deleted_points.dat`) is written once during [`Self::create`] and not
+/// mutated afterwards: `deleted_points.dat` records only the points whose
+/// document was empty at build time.
+///
+/// Runtime deletions live in the in-memory `Storage::deleted_points` bitvec.
+/// They are **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove`]
+/// only updates the in-memory bitvec. Callers must re-supply the authoritative
+/// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
+/// `deleted_points` argument to [`Self::open`] on reload.
 pub struct MmapInvertedIndex {
     pub(in crate::index::field_index::full_text_index) path: PathBuf,
     pub(in crate::index::field_index::full_text_index) storage: Storage,
@@ -51,8 +64,20 @@ pub(in crate::index::field_index::full_text_index) struct Storage {
     pub(in crate::index::field_index::full_text_index) postings: MmapPostingsEnum,
     pub(in crate::index::field_index::full_text_index) vocab: MmapHashMap<str, TokenId>,
     pub(in crate::index::field_index::full_text_index) point_to_tokens_count: MmapSlice<usize>,
-    pub(in crate::index::field_index::full_text_index) deleted_points:
-        BufferedUpdateBitSlice<MmapFile>,
+    pub(in crate::index::field_index::full_text_index) deleted_points: BitVec,
+}
+
+impl Storage {
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            postings: _,
+            vocab: _,
+            point_to_tokens_count: _,
+            deleted_points,
+        } = self;
+
+        deleted_points.capacity().div_ceil(u8::BITS as usize)
+    }
 }
 
 impl MmapInvertedIndex {
@@ -119,6 +144,7 @@ impl MmapInvertedIndex {
         path: PathBuf,
         populate: bool,
         has_positions: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let postings_path = path.join(POSTINGS_FILE);
         let vocab_path = path.join(VOCAB_FILE);
@@ -160,15 +186,21 @@ impl MmapInvertedIndex {
             )?)?
         };
 
-        let deleted = MmapBitSlice::open(
-            &deleted_points_path,
-            OpenOptions {
-                populate: Some(populate),
-                ..OpenOptions::default()
-            },
-        )?;
-        let num_deleted_points = deleted.count_ones()?;
-        let deleted_points = BufferedUpdateBitSlice::new(deleted);
+        let deleted_payload_mmap =
+            MmapBitSlice::open(&deleted_points_path, OpenOptions::default())?;
+        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
+
+        // `deleted` length must match `point_to_tokens_count.len()` because it
+        // only tracks the index's contents. The id-tracker's deleted mask can
+        // be shorter or longer; if shorter, the missing entries default to
+        // live (the id-tracker is the source of truth for deletions, and a
+        // shorter mask just means it doesn't yet know about those higher
+        // offsets).
+        let mut deleted = deleted_points.to_owned();
+        deleted.resize(point_to_tokens_count.len(), false);
+        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+
+        let num_deleted_points = deleted.count_ones();
         let points_count = point_to_tokens_count.len() - num_deleted_points;
 
         Ok(Some(Self {
@@ -177,7 +209,7 @@ impl MmapInvertedIndex {
                 postings,
                 vocab,
                 point_to_tokens_count,
-                deleted_points,
+                deleted_points: deleted,
             },
             active_points_count: points_count,
             is_on_disk: !populate,
@@ -197,7 +229,7 @@ impl MmapInvertedIndex {
         let is_deleted = self
             .storage
             .deleted_points
-            .get(point_id as usize)
+            .get_bit(point_id as usize)
             .unwrap_or(true);
         !is_deleted
     }
@@ -401,11 +433,23 @@ impl MmapInvertedIndex {
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        vec![self.path.join(POSTINGS_FILE), self.path.join(VOCAB_FILE)]
+        vec![
+            self.path.join(POSTINGS_FILE),
+            self.path.join(VOCAB_FILE),
+            self.path.join(POINT_TO_TOKENS_COUNT_FILE),
+            self.path.join(DELETED_POINTS_FILE),
+        ]
     }
 
+    /// No-op flusher: the on-disk state is build-time only. See the type-level
+    /// docs on [`MmapInvertedIndex`] for the deletion durability contract.
+    #[allow(clippy::unused_self)]
     pub fn flusher(&self) -> Flusher {
-        self.storage.deleted_points.flusher()
+        Box::new(|| Ok(()))
+    }
+
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        self.storage.ram_usage_bytes()
     }
 
     pub fn is_on_disk(&self) -> bool {
@@ -424,7 +468,7 @@ impl MmapInvertedIndex {
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         let Self {
-            path: _,
+            path,
             storage,
             active_points_count: _,
             is_on_disk: _,
@@ -433,12 +477,12 @@ impl MmapInvertedIndex {
             postings,
             vocab,
             point_to_tokens_count,
-            deleted_points,
+            deleted_points: _,
         } = storage;
         postings.clear_cache()?;
         vocab.clear_cache()?;
         point_to_tokens_count.clear_cache()?;
-        deleted_points.clear_cache()?;
+        clear_disk_cache(&path.join(DELETED_POINTS_FILE))?;
         Ok(())
     }
 }
@@ -471,7 +515,7 @@ impl InvertedIndex for MmapInvertedIndex {
     }
 
     fn remove(&mut self, idx: PointOffsetType) -> bool {
-        let Some(is_deleted) = self.storage.deleted_points.get(idx as usize) else {
+        let Some(is_deleted) = self.storage.deleted_points.get_bit(idx as usize) else {
             return false; // Never existed
         };
 
@@ -480,14 +524,7 @@ impl InvertedIndex for MmapInvertedIndex {
         }
 
         self.storage.deleted_points.set(idx as usize, true);
-        if let Some(count) = self.storage.point_to_tokens_count.get_mut(idx as usize) {
-            *count = 0;
-
-            // `deleted_points`'s length can be larger than `point_to_tokens_count`'s length.
-            // Only if the index is within bounds of `point_to_tokens_count`, we decrement the active points count.
-            self.active_points_count -= 1;
-        }
-
+        self.active_points_count -= 1;
         true
     }
 
@@ -542,7 +579,7 @@ impl InvertedIndex for MmapInvertedIndex {
         if self
             .storage
             .deleted_points
-            .get(point_id as usize)
+            .get_bit(point_id as usize)
             .unwrap_or(true)
         {
             return true;
@@ -559,7 +596,7 @@ impl InvertedIndex for MmapInvertedIndex {
         if self
             .storage
             .deleted_points
-            .get(point_id as usize)
+            .get_bit(point_id as usize)
             .unwrap_or(true)
         {
             return 0;

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -405,6 +405,7 @@ pub trait InvertedIndex {
 #[cfg(test)]
 mod tests {
 
+    use common::bitvec::{BitSliceExt, BitVec};
     use common::counter::hardware_counter::HardwareCounterCell;
     use rand::RngExt;
     use rand::seq::SliceRandom;
@@ -543,9 +544,15 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
-        let mmap = MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching)
-            .unwrap()
-            .unwrap();
+        let empty_deleted = BitVec::new();
+        let mmap = MmapInvertedIndex::open(
+            mmap_dir.path().into(),
+            false,
+            phrase_matching,
+            &empty_deleted,
+        )
+        .unwrap()
+        .unwrap();
 
         let imm_mmap = ImmutableInvertedIndex::try_from(&mmap).unwrap();
 
@@ -579,7 +586,7 @@ mod tests {
         for (point_id, count) in immutable.point_to_tokens_count.iter().enumerate() {
             // Check same deleted points
             assert_eq!(
-                mmap.storage.deleted_points.get(point_id).unwrap(),
+                mmap.storage.deleted_points.get_bit(point_id).unwrap(),
                 *count == 0,
                 "point_id: {point_id}",
             );
@@ -609,10 +616,15 @@ mod tests {
 
         let immutable = ImmutableInvertedIndex::from(mut_index.clone());
         MmapInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
-        let mut mmap_index =
-            MmapInvertedIndex::open(mmap_dir.path().into(), false, phrase_matching)
-                .unwrap()
-                .unwrap();
+        let empty_deleted = BitVec::new();
+        let mut mmap_index = MmapInvertedIndex::open(
+            mmap_dir.path().into(),
+            false,
+            phrase_matching,
+            &empty_deleted,
+        )
+        .unwrap()
+        .unwrap();
 
         let mut imm_mmap_index = ImmutableInvertedIndex::try_from(&mmap_index).unwrap();
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use fs_err as fs;
@@ -27,17 +28,23 @@ impl MmapFullTextIndex {
         path: PathBuf,
         config: TextIndexParams,
         is_on_disk: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let populate = !is_on_disk;
 
         let has_positions = config.phrase_matching == Some(true);
         let tokenizer = Tokenizer::new_from_text_index_params(&config);
 
-        let inverted_index = MmapInvertedIndex::open(path, populate, has_positions)?;
+        let inverted_index =
+            MmapInvertedIndex::open(path, populate, has_positions, deleted_points)?;
         Ok(inverted_index.map(|inverted_index| Self {
             inverted_index,
             tokenizer,
         }))
+    }
+
+    pub(crate) fn ram_usage_bytes(&self) -> usize {
+        self.inverted_index.ram_usage_bytes()
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
@@ -96,10 +103,16 @@ pub struct FullTextMmapIndexBuilder {
     config: TextIndexParams,
     is_on_disk: bool,
     tokenizer: Tokenizer,
+    deleted_points: BitVec,
 }
 
 impl FullTextMmapIndexBuilder {
-    pub fn new(path: PathBuf, config: TextIndexParams, is_on_disk: bool) -> Self {
+    pub fn new(
+        path: PathBuf,
+        config: TextIndexParams,
+        is_on_disk: bool,
+        deleted_points: &BitSlice,
+    ) -> Self {
         let with_positions = config.phrase_matching.unwrap_or_default();
         let tokenizer = Tokenizer::new_from_text_index_params(&config);
         Self {
@@ -108,6 +121,7 @@ impl FullTextMmapIndexBuilder {
             config,
             is_on_disk,
             tokenizer,
+            deleted_points: deleted_points.to_owned(),
         }
     }
 }
@@ -184,6 +198,7 @@ impl FieldIndexBuilderTrait for FullTextMmapIndexBuilder {
             config,
             is_on_disk,
             tokenizer,
+            deleted_points,
         } = self;
 
         let immutable = ImmutableInvertedIndex::from(mutable_index);
@@ -195,11 +210,13 @@ impl FieldIndexBuilderTrait for FullTextMmapIndexBuilder {
         let populate = !is_on_disk;
         let has_positions = config.phrase_matching.unwrap_or_default();
         let inverted_index =
-            MmapInvertedIndex::open(path, populate, has_positions)?.ok_or_else(|| {
-                OperationError::service_error(
-                    "Failed to open MmapInvertedIndex that was just created",
-                )
-            })?;
+            MmapInvertedIndex::open(path, populate, has_positions, &deleted_points)?.ok_or_else(
+                || {
+                    OperationError::service_error(
+                        "Failed to open MmapInvertedIndex that was just created",
+                    )
+                },
+            )?;
 
         let mmap_index = MmapFullTextIndex {
             inverted_index,

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -1,5 +1,6 @@
 mod test_congruence;
 
+use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use tempfile::Builder;
@@ -224,8 +225,13 @@ fn test_phrase_matching() {
             .make_empty()
             .unwrap();
 
-    let mut mmap_builder =
-        FullTextIndex::builder_mmap(temp_dir.path().to_path_buf(), config.clone(), true);
+    let empty_deleted = BitVec::new();
+    let mut mmap_builder = FullTextIndex::builder_mmap(
+        temp_dir.path().to_path_buf(),
+        config.clone(),
+        true,
+        &empty_deleted,
+    );
     mmap_builder.init().unwrap();
 
     // Add some test documents with phrases

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use rand::rngs::StdRng;
@@ -87,6 +88,7 @@ fn create_builder(
         ..TextIndexParams::default()
     };
 
+    let empty_deleted = BitVec::new();
     let mut builder = match index_type {
         IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
             FullTextIndex::builder_gridstore(temp_dir.path().to_path_buf(), config),
@@ -95,11 +97,13 @@ fn create_builder(
             temp_dir.path().to_path_buf(),
             config,
             true,
+            &empty_deleted,
         )),
         IndexType::ImmRamMmap => IndexBuilder::ImmRamMmap(FullTextIndex::builder_mmap(
             temp_dir.path().to_path_buf(),
             config,
             false,
+            &empty_deleted,
         )),
     };
     match &mut builder {
@@ -116,11 +120,23 @@ fn reopen_index(
     temp_dir: &TempDir,
     #[allow(unused_variables)] db: &Database,
     phrase_matching: bool,
+    num_points: usize,
 ) -> FullTextIndex {
     let config = TextIndexParams {
         phrase_matching: Some(phrase_matching),
         ..TextIndexParams::default()
     };
+
+    // Capture the deletion state so we can re-supply it on reopen of the
+    // mmap-backed variants. The mmap index no longer persists runtime
+    // deletions: callers (id-tracker in production, this test in unit tests)
+    // are responsible for the cumulative deletion mask.
+    let mut deleted = BitVec::repeat(false, num_points);
+    for point_id in 0..num_points as PointOffsetType {
+        if index.values_is_empty(point_id) {
+            deleted.set(point_id as usize, true);
+        }
+    }
 
     // Drop the original index to ensure files are flushed
     drop(index);
@@ -134,14 +150,14 @@ fn reopen_index(
         }
         IndexType::ImmMmap => {
             // Reopen with is_on_disk = true (mmap directly)
-            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, true)
+            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, true, &deleted)
                 .unwrap()
                 .expect("Failed to reopen ImmMmap index")
         }
         IndexType::ImmRamMmap => {
             // Reopen with is_on_disk = false (load into RAM)
             // This is the path that will call ImmutableFullTextIndex::open_mmap
-            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, false)
+            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, false, &deleted)
                 .unwrap()
                 .expect("Failed to reopen ImmRamMmap index")
         }
@@ -192,7 +208,14 @@ fn build_random_index(
 
     // Reopen the index if requested
     let index = if reopen {
-        reopen_index(index, index_type, &temp_dir, &db, phrase_matching)
+        reopen_index(
+            index,
+            index_type,
+            &temp_dir,
+            &db,
+            phrase_matching,
+            num_points,
+        )
     } else {
         index
     };

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 
 use ahash::AHashSet;
+use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,7 @@ impl FullTextIndex {
         path: PathBuf,
         config: TextIndexParams,
         is_on_disk: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
         // pure-mmap variant at load time. Files are shared between variants;
@@ -43,7 +45,9 @@ impl FullTextIndex {
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = MmapFullTextIndex::open(path, config, effective_is_on_disk)? else {
+        let Some(mmap_index) =
+            MmapFullTextIndex::open(path, config, effective_is_on_disk, deleted_points)?
+        else {
             return Ok(None);
         };
 
@@ -86,8 +90,9 @@ impl FullTextIndex {
         path: PathBuf,
         config: TextIndexParams,
         is_on_disk: bool,
+        deleted_points: &BitSlice,
     ) -> FullTextMmapIndexBuilder {
-        FullTextMmapIndexBuilder::new(path, config, is_on_disk)
+        FullTextMmapIndexBuilder::new(path, config, is_on_disk, deleted_points)
     }
 
     pub fn builder_gridstore(
@@ -368,7 +373,7 @@ impl FullTextIndex {
         match self {
             FullTextIndex::Mutable(index) => index.ram_usage_bytes(),
             FullTextIndex::Immutable(index) => index.ram_usage_bytes(),
-            FullTextIndex::Mmap(_) => 0,
+            FullTextIndex::Mmap(index) => index.ram_usage_bytes(),
         }
     }
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -105,7 +105,7 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::GeoIndex),
 
             (PayloadIndexType::FullTextIndex, PayloadSchemaParams::Text(params)) => self
-                .text_new(field, params.clone(), create_if_missing)?
+                .text_new(field, params.clone(), create_if_missing, deleted_points)?
                 .map(FieldIndex::FullTextIndex),
 
             (PayloadIndexType::BoolIndex, PayloadSchemaParams::Bool(_)) => self
@@ -182,7 +182,12 @@ impl IndexSelector<'_> {
                 .geo_new(field, create_if_missing, deleted_points)?
                 .map(|index| vec![FieldIndex::GeoIndex(index)]),
             PayloadSchemaParams::Text(text_index_params) => self
-                .text_new(field, text_index_params.clone(), create_if_missing)?
+                .text_new(
+                    field,
+                    text_index_params.clone(),
+                    create_if_missing,
+                    deleted_points,
+                )?
                 .map(|index| vec![FieldIndex::FullTextIndex(index)]),
             PayloadSchemaParams::Bool(_) => self
                 .bool_new(
@@ -262,7 +267,7 @@ impl IndexSelector<'_> {
                 )]
             }
             PayloadSchemaParams::Text(text_index_params) => {
-                vec![self.text_builder(field, text_index_params.clone())]
+                vec![self.text_builder(field, text_index_params.clone(), deleted_points)]
             }
             PayloadSchemaParams::Bool(_) => {
                 vec![self.bool_builder(field)?]
@@ -468,10 +473,11 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         config: TextIndexParams,
         create_if_missing: bool,
+        deleted_points: &BitSlice,
     ) -> OperationResult<Option<FullTextIndex>> {
         Ok(match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
-                FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk)?
+                FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk, deleted_points)?
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
                 FullTextIndex::new_gridstore(text_dir(dir, field), config, create_if_missing)?
@@ -479,13 +485,19 @@ impl IndexSelector<'_> {
         })
     }
 
-    fn text_builder(&self, field: &JsonPath, config: TextIndexParams) -> FieldIndexBuilder {
+    fn text_builder(
+        &self,
+        field: &JsonPath,
+        config: TextIndexParams,
+        deleted_points: &BitSlice,
+    ) -> FieldIndexBuilder {
         match self {
             IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(
                     text_dir(dir, field),
                     config,
                     *is_on_disk,
+                    deleted_points,
                 ))
             }
             IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {


### PR DESCRIPTION
Make the mmap full-text index immutable on disk, mirroring the change applied to the mmap numeric index in #8594.

- MmapInvertedIndex no longer persists runtime deletions: BufferedUpdateBitSlice is replaced with an in-memory BitVec.

- deleted_points.dat is now build-time only — it records the points whose document was empty at build time. point_to_tokens_count.dat and deleted_points.dat join postings.dat/vocab.dat in immutable_files().
 - On reload, callers must re-supply the authoritative deletion mask via the new deleted_points: &BitSlice argument to MmapInvertedIndex::open / MmapFullTextIndex::open / FullTextIndex::new_mmap / builder_mmap.
   The id-tracker is the source of truth at runtime.
- The reload merges the build-time empty-payload bits with the caller-provided mask via bitor_assign, after resizing to point_to_tokens_count.len() (defaulting missing trailing entries to live).
- flusher() is now a no-op; remove() only updates the in-memory bitvec.
- ImmutableInvertedIndex::try_from(&MmapInvertedIndex) now applies the deletion bitmask when materializing the count vector (the in-RAM variant uses count == 0 as its deletion marker).
- ram_usage_bytes() now reports the in-memory deletion bitvec size for the mmap variant.