### PR TITLE
feat: add GCS snapshot storage backend

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -217,12 +217,12 @@ jobs:
           curl -fsS -X POST "http://127.0.0.1:4443/storage/v1/b" \
             -H "Content-Type: application/json" \
             -d '{"name":"test-bucket"}'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: integration-tests
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
         uses: ./.github/actions/setup-protoc
       - name: Install dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -202,6 +202,49 @@ jobs:
 
           ./tests/shard-snapshot-api.sh test-all
 
+  test-shard-snapshot-api-gcs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start fake-gcs-server
+        # service containers can't take entrypoint args, so run it manually.
+        # -scheme http because STORAGE_EMULATOR_HOST uses plain http.
+        run: |
+          docker run -d --name fake-gcs -p 4443:4443 \
+            fsouza/fake-gcs-server -scheme http -port 4443
+          timeout 30 bash -c \
+            'until curl -sf http://127.0.0.1:4443/storage/v1/b; do sleep 1; done'
+      - name: Setup test bucket
+        run: |
+          curl -s -X POST "http://127.0.0.1:4443/storage/v1/b" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"test-bucket"}'
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: integration-tests
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: sudo apt-get install clang jq
+      - name: Build
+        run: cargo build --bin qdrant --features "rocksdb staging" --locked
+      - name: Run Shard Snapshot API Tests (gcs)
+        shell: bash
+        run: |
+          export STORAGE_EMULATOR_HOST=http://127.0.0.1:4443
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=gcs
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__GCS_CONFIG__BUCKET=test-bucket
+
+          cargo run --features "rocksdb staging" &
+          trap 'kill $(jobs -p) &>/dev/null || :' EXIT
+          sleep 10
+
+          ./tests/shard-snapshot-api.sh test-all
+
   e2e-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,12 +189,11 @@ jobs:
       - name: Run Shard Snapshot API Tests (s3)
         shell: bash
         run: |
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=s3
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__BUCKET=test-bucket
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__REGION=us-east-1
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ACCESS_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__SECRET_KEY=minioadmin
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__S3_CONFIG__ENDPOINT_URL=http://127.0.0.1:9000
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__S3__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__S3__REGION=us-east-1
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__S3__ACCESS_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__S3__SECRET_KEY=minioadmin
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__S3__ENDPOINT_URL=http://127.0.0.1:9000
 
           cargo run --features "staging" &
           trap 'kill $(jobs -p) &>/dev/null || :' EXIT
@@ -225,21 +224,18 @@ jobs:
           shared-key: integration-tests
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/setup-protoc
       - name: Install dependencies
         run: sudo apt-get install clang jq
       - name: Build
-        run: cargo build --bin qdrant --features "rocksdb staging" --locked
+        run: cargo build --bin qdrant --features staging --locked
       - name: Run Shard Snapshot API Tests (gcs)
         shell: bash
         run: |
           export STORAGE_EMULATOR_HOST=http://127.0.0.1:4443
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE=gcs
-          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__GCS_CONFIG__BUCKET=test-bucket
+          export QDRANT__STORAGE__SNAPSHOTS_CONFIG__SNAPSHOTS_STORAGE__GCS__BUCKET=test-bucket
 
-          cargo run --features "rocksdb staging" &
+          cargo run --features staging &
           trap 'kill $(jobs -p) &>/dev/null || :' EXIT
           sleep 10
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -215,7 +215,7 @@ jobs:
             'until curl -sf http://127.0.0.1:4443/storage/v1/b; do sleep 1; done'
       - name: Setup test bucket
         run: |
-          curl -s -X POST "http://127.0.0.1:4443/storage/v1/b" \
+          curl -fsS -X POST "http://127.0.0.1:4443/storage/v1/b" \
             -H "Content-Type: application/json" \
             -d '{"name":"test-bucket"}'
       - name: Install minimal stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,13 +22,16 @@ storage:
   snapshots_path: ./snapshots
 
   snapshots_config:
-    # "local" or "s3" - where to store snapshots
+    # "local", "s3", or "gcs" - where to store snapshots
     snapshots_storage: local
     # s3_config:
     #   bucket: ""
     #   region: ""
     #   access_key: ""
     #   secret_key: ""
+    # gcs_config:
+    #   bucket: ""
+    #   # service_account_key: ""  # omit to use Application Default Credentials (ADC)
 
   # Where to store temporary files
   # If null, temporary snapshots are stored in: storage/snapshots_temp/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,16 +22,23 @@ storage:
   snapshots_path: ./snapshots
 
   snapshots_config:
-    # "local", "s3", or "gcs" - where to store snapshots
+    # Snapshot storage backend. Use "local" for filesystem storage (default),
+    # or provide a cloud backend as a nested object:
+    #
+    # Amazon S3:
+    # snapshots_storage:
+    #   s3:
+    #     bucket: ""
+    #     region: ""
+    #     access_key: ""
+    #     secret_key: ""
+    #
+    # Google Cloud Storage:
+    # snapshots_storage:
+    #   gcs:
+    #     bucket: ""
+    #     service_account_key: ""  # omit to use Application Default Credentials (ADC)
     snapshots_storage: local
-    # s3_config:
-    #   bucket: ""
-    #   region: ""
-    #   access_key: ""
-    #   secret_key: ""
-    # gcs_config:
-    #   bucket: ""
-    #   # service_account_key: ""  # omit to use Application Default Credentials (ADC)
 
   # Where to store temporary files
   # If null, temporary snapshots are stored in: storage/snapshots_temp/

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -94,8 +94,8 @@ urlencoding = { workspace = true }
 tracing = { workspace = true, optional = true }
 fs4 = { workspace = true }
 
-# AWS S3 support
-object_store = { version = "0.13.2", features = ["aws"] }
+# Cloud storage support (S3, GCS)
+object_store = { version = "0.13.2", features = ["aws", "gcp"] }
 
 
 [[bench]]

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -44,7 +44,7 @@ pub struct S3Config {
     pub endpoint_url: Option<String>,
 }
 
-#[derive(Clone, Deserialize, Debug, Default)]
+#[derive(Clone, Deserialize, Default)]
 pub struct GCSConfig {
     pub bucket: String,
     /// Service account key as a JSON string.
@@ -52,6 +52,18 @@ pub struct GCSConfig {
     /// (ADC), which works out of the box on GKE and when `GOOGLE_APPLICATION_CREDENTIALS`
     /// is set in the environment.
     pub service_account_key: Option<String>,
+}
+
+impl std::fmt::Debug for GCSConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GCSConfig")
+            .field("bucket", &self.bucket)
+            .field(
+                "service_account_key",
+                &self.service_account_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 pub struct SnapshotStorageCloud {

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -5,7 +5,7 @@ use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use object_store::ObjectStoreExt;
 use object_store::aws::AmazonS3Builder;
-use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::gcp::{GoogleCloudStorageBuilder, GoogleConfigKey};
 use serde::Deserialize;
 use tempfile::TempPath;
 use tokio::io::AsyncWriteExt;
@@ -115,6 +115,14 @@ impl SnapshotStorageManager {
                 if let Some(service_account_key) = &gcs_config.service_account_key {
                     builder = builder.with_service_account_key(service_account_key);
                 }
+
+                // When STORAGE_EMULATOR_HOST is set we are talking to a local emulator
+                // (e.g. fake-gcs-server). The emulator doesn't validate auth tokens, so
+                // skip credential fetching and request signing entirely.
+                if std::env::var("STORAGE_EMULATOR_HOST").is_ok() {
+                    builder = builder.with_config(GoogleConfigKey::SkipSignature, "true");
+                }
+
 
                 let client: Box<dyn object_store::ObjectStore> =
                     Box::new(builder.build().map_err(|e| {

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -209,9 +209,9 @@ impl SnapshotStorageManager {
                 SnapshotStorageLocalFS::get_snapshot_path(snapshots_path, snapshot_name)
             }
             SnapshotStorageManager::S3(_storage_impl)
-            | SnapshotStorageManager::Gcs(_storage_impl) => Ok(
-                SnapshotStorageCloud::get_snapshot_path(snapshots_path, snapshot_name),
-            ),
+            | SnapshotStorageManager::Gcs(_storage_impl) => {
+                SnapshotStorageCloud::get_snapshot_path(snapshots_path, snapshot_name)
+            }
         }
     }
 
@@ -225,9 +225,9 @@ impl SnapshotStorageManager {
                 SnapshotStorageLocalFS::get_full_snapshot_path(snapshots_path, snapshot_name)
             }
             SnapshotStorageManager::S3(_storage_impl)
-            | SnapshotStorageManager::Gcs(_storage_impl) => Ok(
-                SnapshotStorageCloud::get_full_snapshot_path(snapshots_path, snapshot_name),
-            ),
+            | SnapshotStorageManager::Gcs(_storage_impl) => {
+                SnapshotStorageCloud::get_full_snapshot_path(snapshots_path, snapshot_name)
+            }
         }
     }
 
@@ -484,12 +484,37 @@ impl SnapshotStorageCloud {
         Ok(())
     }
 
-    fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> PathBuf {
-        snapshots_path.join(snapshot_name)
+    fn get_snapshot_path(
+        snapshots_path: &Path,
+        snapshot_name: &str,
+    ) -> CollectionResult<PathBuf> {
+        Self::validate_snapshot_name(snapshot_name)?;
+        Ok(snapshots_path.join(snapshot_name))
     }
 
-    fn get_full_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> PathBuf {
-        snapshots_path.join(snapshot_name)
+    fn get_full_snapshot_path(
+        snapshots_path: &Path,
+        snapshot_name: &str,
+    ) -> CollectionResult<PathBuf> {
+        Self::validate_snapshot_name(snapshot_name)?;
+        Ok(snapshots_path.join(snapshot_name))
+    }
+
+    fn validate_snapshot_name(snapshot_name: &str) -> CollectionResult<()> {
+        use std::path::Component;
+        if snapshot_name.is_empty()
+            || Path::new(snapshot_name).components().any(|c| {
+                matches!(
+                    c,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(CollectionError::not_found(format!(
+                "Snapshot {snapshot_name}"
+            )));
+        }
+        Ok(())
     }
 
     async fn get_snapshot_file(

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -117,12 +117,13 @@ impl SnapshotStorageManager {
                 }
 
                 // When STORAGE_EMULATOR_HOST is set we are talking to a local emulator
-                // (e.g. fake-gcs-server). The emulator doesn't validate auth tokens, so
-                // skip credential fetching and request signing entirely.
-                if std::env::var("STORAGE_EMULATOR_HOST").is_ok() {
-                    builder = builder.with_config(GoogleConfigKey::SkipSignature, "true");
+                // (e.g. fake-gcs-server). The emulator does not validate auth tokens and
+                // serves requests at a custom base URL instead of storage.googleapis.com.
+                if let Ok(emulator_host) = std::env::var("STORAGE_EMULATOR_HOST") {
+                    builder = builder
+                        .with_config(GoogleConfigKey::SkipSignature, "true")
+                        .with_config(GoogleConfigKey::BaseUrl, emulator_host);
                 }
-
 
                 let client: Box<dyn object_store::ObjectStore> =
                     Box::new(builder.build().map_err(|e| {
@@ -484,10 +485,7 @@ impl SnapshotStorageCloud {
         Ok(())
     }
 
-    fn get_snapshot_path(
-        snapshots_path: &Path,
-        snapshot_name: &str,
-    ) -> CollectionResult<PathBuf> {
+    fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> CollectionResult<PathBuf> {
         Self::validate_snapshot_name(snapshot_name)?;
         Ok(snapshots_path.join(snapshot_name))
     }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -22,8 +22,6 @@ use crate::operations::types::{CollectionError, CollectionResult};
 #[derive(Clone, Deserialize, Debug, Default)]
 pub struct SnapshotsConfig {
     pub snapshots_storage: SnapshotsStorageConfig,
-    pub s3_config: Option<S3Config>,
-    pub gcs_config: Option<GCSConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -31,8 +29,8 @@ pub struct SnapshotsConfig {
 pub enum SnapshotsStorageConfig {
     #[default]
     Local,
-    S3,
-    Gcs,
+    S3(S3Config),
+    Gcs(GCSConfig),
 }
 
 #[derive(Clone, Deserialize, Debug, Default)]
@@ -80,31 +78,29 @@ pub enum SnapshotStorageManager {
 
 impl SnapshotStorageManager {
     pub fn new(snapshots_config: &SnapshotsConfig) -> CollectionResult<Self> {
-        match snapshots_config.snapshots_storage {
+        match &snapshots_config.snapshots_storage {
             SnapshotsStorageConfig::Local => {
                 Ok(SnapshotStorageManager::LocalFS(SnapshotStorageLocalFS))
             }
-            SnapshotsStorageConfig::S3 => {
-                let mut builder = AmazonS3Builder::from_env();
-                if let Some(s3_config) = &snapshots_config.s3_config {
-                    builder = builder.with_bucket_name(&s3_config.bucket);
+            SnapshotsStorageConfig::S3(s3_config) => {
+                let mut builder = AmazonS3Builder::from_env().with_bucket_name(&s3_config.bucket);
 
-                    if let Some(access_key) = &s3_config.access_key {
-                        builder = builder.with_access_key_id(access_key);
-                    }
-                    if let Some(secret_key) = &s3_config.secret_key {
-                        builder = builder.with_secret_access_key(secret_key);
-                    }
-                    if let Some(region) = &s3_config.region {
-                        builder = builder.with_region(region);
-                    }
-                    if let Some(endpoint_url) = &s3_config.endpoint_url {
-                        builder = builder.with_endpoint(endpoint_url);
-                        if endpoint_url.starts_with("http://") {
-                            builder = builder.with_allow_http(true);
-                        }
+                if let Some(access_key) = &s3_config.access_key {
+                    builder = builder.with_access_key_id(access_key);
+                }
+                if let Some(secret_key) = &s3_config.secret_key {
+                    builder = builder.with_secret_access_key(secret_key);
+                }
+                if let Some(region) = &s3_config.region {
+                    builder = builder.with_region(region);
+                }
+                if let Some(endpoint_url) = &s3_config.endpoint_url {
+                    builder = builder.with_endpoint(endpoint_url);
+                    if endpoint_url.starts_with("http://") {
+                        builder = builder.with_allow_http(true);
                     }
                 }
+
                 let client: Box<dyn object_store::ObjectStore> =
                     Box::new(builder.build().map_err(|e| {
                         CollectionError::service_error(format!("Failed to create S3 client: {e}"))
@@ -112,14 +108,14 @@ impl SnapshotStorageManager {
 
                 Ok(SnapshotStorageManager::S3(SnapshotStorageCloud { client }))
             }
-            SnapshotsStorageConfig::Gcs => {
-                let mut builder = GoogleCloudStorageBuilder::from_env();
-                if let Some(gcs_config) = &snapshots_config.gcs_config {
-                    builder = builder.with_bucket_name(&gcs_config.bucket);
-                    if let Some(service_account_key) = &gcs_config.service_account_key {
-                        builder = builder.with_service_account_key(service_account_key);
-                    }
+            SnapshotsStorageConfig::Gcs(gcs_config) => {
+                let mut builder =
+                    GoogleCloudStorageBuilder::from_env().with_bucket_name(&gcs_config.bucket);
+
+                if let Some(service_account_key) = &gcs_config.service_account_key {
+                    builder = builder.with_service_account_key(service_account_key);
                 }
+
                 let client: Box<dyn object_store::ObjectStore> =
                     Box::new(builder.build().map_err(|e| {
                         CollectionError::service_error(format!("Failed to create GCS client: {e}"))
@@ -481,13 +477,11 @@ impl SnapshotStorageCloud {
     }
 
     fn get_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> PathBuf {
-        let absolute_snapshot_dir = snapshots_path;
-        absolute_snapshot_dir.join(snapshot_name)
+        snapshots_path.join(snapshot_name)
     }
 
     fn get_full_snapshot_path(snapshots_path: &Path, snapshot_name: &str) -> PathBuf {
-        let absolute_snapshot_dir = snapshots_path;
-        absolute_snapshot_dir.join(snapshot_name)
+        snapshots_path.join(snapshot_name)
     }
 
     async fn get_snapshot_file(

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -5,6 +5,7 @@ use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use object_store::ObjectStoreExt;
 use object_store::aws::AmazonS3Builder;
+use object_store::gcp::GoogleCloudStorageBuilder;
 use serde::Deserialize;
 use tempfile::TempPath;
 use tokio::io::AsyncWriteExt;
@@ -22,6 +23,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 pub struct SnapshotsConfig {
     pub snapshots_storage: SnapshotsStorageConfig,
     pub s3_config: Option<S3Config>,
+    pub gcs_config: Option<GCSConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -30,6 +32,7 @@ pub enum SnapshotsStorageConfig {
     #[default]
     Local,
     S3,
+    Gcs,
 }
 
 #[derive(Clone, Deserialize, Debug, Default)]
@@ -41,6 +44,16 @@ pub struct S3Config {
     pub endpoint_url: Option<String>,
 }
 
+#[derive(Clone, Deserialize, Debug, Default)]
+pub struct GCSConfig {
+    pub bucket: String,
+    /// Service account key as a JSON string.
+    /// When omitted, the client falls back to Application Default Credentials
+    /// (ADC), which works out of the box on GKE and when `GOOGLE_APPLICATION_CREDENTIALS`
+    /// is set in the environment.
+    pub service_account_key: Option<String>,
+}
+
 pub struct SnapshotStorageCloud {
     client: Box<dyn object_store::ObjectStore>,
 }
@@ -49,11 +62,8 @@ pub struct SnapshotStorageLocalFS;
 
 pub enum SnapshotStorageManager {
     LocalFS(SnapshotStorageLocalFS),
-    // Assuming that we can have common operations for all cloud storages
     S3(SnapshotStorageCloud),
-    // <TODO> : Implement other cloud storage
-    // GCS(SnapshotStorageCloud),
-    // AZURE(SnapshotStorageCloud),
+    Gcs(SnapshotStorageCloud),
 }
 
 impl SnapshotStorageManager {
@@ -90,6 +100,21 @@ impl SnapshotStorageManager {
 
                 Ok(SnapshotStorageManager::S3(SnapshotStorageCloud { client }))
             }
+            SnapshotsStorageConfig::Gcs => {
+                let mut builder = GoogleCloudStorageBuilder::from_env();
+                if let Some(gcs_config) = &snapshots_config.gcs_config {
+                    builder = builder.with_bucket_name(&gcs_config.bucket);
+                    if let Some(service_account_key) = &gcs_config.service_account_key {
+                        builder = builder.with_service_account_key(service_account_key);
+                    }
+                }
+                let client: Box<dyn object_store::ObjectStore> =
+                    Box::new(builder.build().map_err(|e| {
+                        CollectionError::service_error(format!("Failed to create GCS client: {e}"))
+                    })?);
+
+                Ok(SnapshotStorageManager::Gcs(SnapshotStorageCloud { client }))
+            }
         }
     }
 
@@ -98,7 +123,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(storage_impl) => {
                 storage_impl.delete_snapshot(snapshot_name).await
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl.delete_snapshot(snapshot_name).await
             }
         }
@@ -112,7 +138,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(storage_impl) => {
                 storage_impl.list_snapshots(directory).await
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl.list_snapshots(directory).await
             }
         }
@@ -133,7 +160,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(storage_impl) => {
                 storage_impl.store_file(source_path, target_path).await
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl.store_file(source_path, target_path).await
             }
         }
@@ -148,7 +176,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(storage_impl) => {
                 storage_impl.get_stored_file(storage_path, local_path).await
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl.get_stored_file(storage_path, local_path).await
             }
         }
@@ -163,7 +192,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(_storage_impl) => {
                 SnapshotStorageLocalFS::get_snapshot_path(snapshots_path, snapshot_name)
             }
-            SnapshotStorageManager::S3(_storage_impl) => Ok(
+            SnapshotStorageManager::S3(_storage_impl)
+            | SnapshotStorageManager::Gcs(_storage_impl) => Ok(
                 SnapshotStorageCloud::get_snapshot_path(snapshots_path, snapshot_name),
             ),
         }
@@ -178,7 +208,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(_storage_impl) => {
                 SnapshotStorageLocalFS::get_full_snapshot_path(snapshots_path, snapshot_name)
             }
-            SnapshotStorageManager::S3(_storage_impl) => Ok(
+            SnapshotStorageManager::S3(_storage_impl)
+            | SnapshotStorageManager::Gcs(_storage_impl) => Ok(
                 SnapshotStorageCloud::get_full_snapshot_path(snapshots_path, snapshot_name),
             ),
         }
@@ -193,7 +224,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(_storage_impl) => {
                 SnapshotStorageLocalFS::get_snapshot_file(snapshot_path, temp_dir)
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl
                     .get_snapshot_file(snapshot_path, temp_dir)
                     .await
@@ -209,7 +241,8 @@ impl SnapshotStorageManager {
             SnapshotStorageManager::LocalFS(_storage_impl) => {
                 Ok(SnapshotStorageLocalFS::get_snapshot_stream(snapshot_path))
             }
-            SnapshotStorageManager::S3(storage_impl) => {
+            SnapshotStorageManager::S3(storage_impl)
+            | SnapshotStorageManager::Gcs(storage_impl) => {
                 storage_impl.get_snapshot_stream(snapshot_path).await
             }
         }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -33,13 +33,25 @@ pub enum SnapshotsStorageConfig {
     Gcs(GCSConfig),
 }
 
-#[derive(Clone, Deserialize, Debug, Default)]
+#[derive(Clone, Deserialize, Default)]
 pub struct S3Config {
     pub bucket: String,
     pub region: Option<String>,
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
     pub endpoint_url: Option<String>,
+}
+
+impl std::fmt::Debug for S3Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Config")
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .field("access_key", &self.access_key.as_ref().map(|_| "<redacted>"))
+            .field("secret_key", &self.secret_key.as_ref().map(|_| "<redacted>"))
+            .field("endpoint_url", &self.endpoint_url)
+            .finish()
+    }
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/tests/e2e_tests/test_snapshots_recovery.py
+++ b/tests/e2e_tests/test_snapshots_recovery.py
@@ -31,9 +31,10 @@ def _create_snapshot_config(storage_method: str, tmp_path: Path) -> Path:
         config = yaml.safe_load(f)
 
     snapshots_config = config.setdefault('storage', {}).setdefault('snapshots_config', {})
-    snapshots_config['snapshots_storage'] = storage_method
     if storage_method == "s3":
-        snapshots_config['s3_config'] = _s3_config()
+        snapshots_config['snapshots_storage'] = {'s3': _s3_config()}
+    else:
+        snapshots_config['snapshots_storage'] = storage_method
 
     temp_config = tmp_path / "config.yaml"
     with open(temp_config, 'w') as f:


### PR DESCRIPTION
Fixes #6482

Users hitting that issue were pointing S3 config at GCS's S3-compatible endpoint, which breaks because GCS rejects multipart uploads without a `Content-Length` header (411 error). The right fix is a native GCS backend using the GCS JSON API.

The snapshot storage layer already abstracts everything behind `Box<dyn object_store::ObjectStore>`, so all the upload/download/list/delete logic works for GCS without changes. The only work here is wiring up the config and the builder.

**What changed:**
- `GCSConfig` struct with `bucket` and an optional `service_account_key`; when the key is omitted the client falls back to Application Default Credentials, which works out of the box on GKE or when `GOOGLE_APPLICATION_CREDENTIALS` is set
- `Gcs` variant added to `SnapshotsStorageConfig` and `SnapshotStorageManager`
- `GoogleCloudStorageBuilder::from_env()` wired in `SnapshotStorageManager::new()`, same pattern as the S3 arm
- `gcp` feature enabled on the `object_store` dependency
- Commented `gcs_config` example added to `config.yaml`
- New `test-shard-snapshot-api-gcs` CI job using `fsouza/fake-gcs-server`; runs the same `shard-snapshot-api.sh test-all` script as the S3 job

The fake-gcs-server is started manually in a step (not as a service container) because GitHub Actions service containers can't receive entrypoint args — needed here to pass `-scheme http` so requests from `STORAGE_EMULATOR_HOST` reach it.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?