### PR TITLE
[ai] add a debug_assert on shard_number

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -79,6 +79,8 @@ impl Collection {
                     // the count after adding the shard). A replay converges to
                     // the same value instead of incrementing again.
                     ShardingMethod::Auto => {
+                        resharding_key
+                            .debug_assert_targets_last_shard(config.params.shard_number.get());
                         let new_shard_number = resharding_key
                             .shard_id
                             .checked_add(1)
@@ -213,6 +215,8 @@ impl Collection {
                     // replay converges to the same value instead of
                     // decrementing again.
                     ShardingMethod::Auto => {
+                        resharding_key
+                            .debug_assert_targets_last_shard(config.params.shard_number.get());
                         let new_shard_number = NonZeroU32::new(resharding_key.shard_id)
                             .expect("cannot have zero shards after finishing resharding down");
                         if config.params.shard_number != new_shard_number {
@@ -297,6 +301,8 @@ impl Collection {
                 // after removing the shard). A replay converges to the same
                 // value instead of decrementing again.
                 ShardingMethod::Auto => {
+                    resharding_key
+                        .debug_assert_targets_last_shard(config.params.shard_number.get());
                     let new_shard_number = NonZeroU32::new(resharding_key.shard_id)
                         .expect("cannot have zero shards after aborting resharding up");
                     if config.params.shard_number != new_shard_number {

--- a/lib/collection/src/shards/resharding.rs
+++ b/lib/collection/src/shards/resharding.rs
@@ -98,6 +98,23 @@ pub struct ReshardKey {
     pub shard_key: Option<ShardKey>,
 }
 
+impl ReshardKey {
+    /// Pin the auto-sharding invariant that resharding always targets the
+    /// last shard id. `shard_number` must equal `shard_id` or `shard_id + 1`;
+    /// any other value would silently corrupt the count via the id-derived
+    /// `shard_number` update.
+    pub(crate) fn debug_assert_targets_last_shard(&self, shard_number: u32) {
+        let shard_id = self.shard_id;
+        debug_assert!(
+            shard_id
+                .checked_add(1)
+                .is_some_and(|next| shard_number == shard_id || shard_number == next),
+            "auto-sharding resharding must target the last shard id; \
+             shard_number={shard_number} shard_id={shard_id}",
+        );
+    }
+}
+
 impl fmt::Display for ReshardKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}/{:?}", self.peer_id, self.shard_id, self.shard_key)


### PR DESCRIPTION
Check that shard_number is either shard_id or shard_id + 1. Fires if in future for some reason we'll allow removing a shard "in the middle".