### PR TITLE
Fix missed-wakeup race in SaveOnDisk::wait_for

### DIFF
--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -144,7 +144,8 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             Self::save_data_to(&self.path, &output)?;
             let mut write_data = RwLockUpgradableReadGuard::upgrade(read_data);
             *write_data = output;
-            self.change_notification.notify_all();
+            drop(write_data);
+            self.notify_change();
             Ok(true)
         } else {
             Ok(false)
@@ -160,8 +161,21 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
         let mut write_data = RwLockUpgradableReadGuard::upgrade(read_data);
 
         *write_data = data_copy;
-        self.change_notification.notify_all();
+        drop(write_data);
+        self.notify_change();
         Ok(output)
+    }
+
+    /// Wake up any threads waiting in [`Self::wait_for`].
+    ///
+    /// Acquires `notification_lock` around `notify_all` so that a waiter
+    /// cannot miss the notification while it is in the window between
+    /// releasing its read guard on `data` and parking on the condvar: the
+    /// waiter holds `notification_lock` across that gap, so this call blocks
+    /// until the waiter has actually parked.
+    fn notify_change(&self) {
+        let _guard = self.notification_lock.lock();
+        self.change_notification.notify_all();
     }
 
     fn save_data_to(path: impl Into<PathBuf>, data: &T) -> Result<(), Error> {

--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -1,8 +1,6 @@
 use std::io::{BufReader, BufWriter, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-#[cfg(test)]
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
@@ -21,12 +19,6 @@ pub struct SaveOnDisk<T> {
     notification_lock: Mutex<()>,
     data: RwLock<T>,
     path: PathBuf,
-    /// Test-only knob: number of milliseconds to sleep inside `wait_for`
-    /// after releasing the read guard on `data` but before parking on the
-    /// condvar. Used to widen the missed-wakeup race window deterministically.
-    /// See `test_wait_for_no_missed_wakeup`.
-    #[cfg(test)]
-    test_pre_park_sleep_ms: AtomicU64,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -64,8 +56,6 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             notification_lock: Default::default(),
             data: RwLock::new(data),
             path,
-            #[cfg(test)]
-            test_pre_park_sleep_ms: AtomicU64::new(0),
         })
     }
 
@@ -78,29 +68,11 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             notification_lock: Default::default(),
             data: RwLock::new(data),
             path: path.into(),
-            #[cfg(test)]
-            test_pre_park_sleep_ms: AtomicU64::new(0),
         };
 
         data.save()?;
 
         Ok(data)
-    }
-
-    /// Test-only: insert a sleep inside `wait_for` between releasing the
-    /// read guard on `data` and parking on the condvar. Widens the
-    /// missed-wakeup race window for `test_wait_for_no_missed_wakeup`.
-    #[cfg(test)]
-    pub fn test_set_pre_park_sleep_ms(&self, ms: u64) {
-        self.test_pre_park_sleep_ms.store(ms, Ordering::SeqCst);
-    }
-
-    #[cfg(test)]
-    fn test_pre_park_sleep(&self) {
-        let ms = self.test_pre_park_sleep_ms.load(Ordering::Relaxed);
-        if ms > 0 {
-            std::thread::sleep(Duration::from_millis(ms));
-        }
     }
 
     /// Wait for a condition on data to be true.
@@ -126,8 +98,6 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             RwLockReadGuard::unlocked(&mut data_read_guard, || {
                 // Move the guard in so it gets unlocked before we re-lock the RwLock read guard
                 let mut guard = notification_guard;
-                #[cfg(test)]
-                self.test_pre_park_sleep();
                 self.change_notification.wait_for(&mut guard, remaining);
             });
         }
@@ -302,45 +272,6 @@ mod tests {
         });
 
         assert!(!counter.wait_for(|counter| *counter > 5, Duration::from_millis(300)));
-        handle.join().unwrap();
-    }
-
-    /// Reproduces a missed-wakeup race in `wait_for`.
-    ///
-    /// `wait_for` releases its read guard on `data` and only afterwards parks
-    /// on the condvar. If `notify_all` fires in that small gap, the waiter
-    /// never sees the notification and waits the full timeout — even though
-    /// the condition is already true.
-    ///
-    /// To make the race deterministic we install a `test_pre_park_sleep_ms`
-    /// hook on the waiter: it sleeps 100ms after releasing the read guard but
-    /// before parking on the condvar. The writer thread fires its
-    /// `notify_all` inside that window, so the unfixed code reliably misses
-    /// it and `wait_for` hits its timeout.
-    #[test]
-    fn test_wait_for_no_missed_wakeup() {
-        let dir = Builder::new().prefix("test").tempdir().unwrap();
-        let counter_file = dir.path().join("counter");
-        let counter: Arc<SaveOnDisk<u32>> =
-            Arc::new(SaveOnDisk::load_or_init_default(counter_file).unwrap());
-        counter.test_set_pre_park_sleep_ms(100);
-
-        let counter_copy = counter.clone();
-        let handle = thread::spawn(move || {
-            // Wait long enough for the main thread to have released its read
-            // guard on `data` and entered the pre-park sleep window. With the
-            // 100ms pre-park sleep above, 30ms here lands the writer's
-            // notify_all squarely inside that window.
-            sleep(Duration::from_millis(30));
-            counter_copy.write(|counter| *counter = 1).unwrap();
-        });
-
-        // Use a 500ms timeout so a missed wakeup is unambiguous: success
-        // means the notification was delivered, timeout means it was lost.
-        assert!(
-            counter.wait_for(|counter| *counter > 0, Duration::from_millis(500)),
-            "wait_for timed out — notification was lost",
-        );
         handle.join().unwrap();
     }
 }

--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -1,6 +1,8 @@
 use std::io::{BufReader, BufWriter, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
@@ -19,6 +21,12 @@ pub struct SaveOnDisk<T> {
     notification_lock: Mutex<()>,
     data: RwLock<T>,
     path: PathBuf,
+    /// Test-only knob: number of milliseconds to sleep inside `wait_for`
+    /// after releasing the read guard on `data` but before parking on the
+    /// condvar. Used to widen the missed-wakeup race window deterministically.
+    /// See `test_wait_for_no_missed_wakeup`.
+    #[cfg(test)]
+    test_pre_park_sleep_ms: AtomicU64,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -56,6 +64,8 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             notification_lock: Default::default(),
             data: RwLock::new(data),
             path,
+            #[cfg(test)]
+            test_pre_park_sleep_ms: AtomicU64::new(0),
         })
     }
 
@@ -68,11 +78,29 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             notification_lock: Default::default(),
             data: RwLock::new(data),
             path: path.into(),
+            #[cfg(test)]
+            test_pre_park_sleep_ms: AtomicU64::new(0),
         };
 
         data.save()?;
 
         Ok(data)
+    }
+
+    /// Test-only: insert a sleep inside `wait_for` between releasing the
+    /// read guard on `data` and parking on the condvar. Widens the
+    /// missed-wakeup race window for `test_wait_for_no_missed_wakeup`.
+    #[cfg(test)]
+    pub fn test_set_pre_park_sleep_ms(&self, ms: u64) {
+        self.test_pre_park_sleep_ms.store(ms, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn test_pre_park_sleep(&self) {
+        let ms = self.test_pre_park_sleep_ms.load(Ordering::Relaxed);
+        if ms > 0 {
+            std::thread::sleep(Duration::from_millis(ms));
+        }
     }
 
     /// Wait for a condition on data to be true.
@@ -98,6 +126,8 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             RwLockReadGuard::unlocked(&mut data_read_guard, || {
                 // Move the guard in so it gets unlocked before we re-lock the RwLock read guard
                 let mut guard = notification_guard;
+                #[cfg(test)]
+                self.test_pre_park_sleep();
                 self.change_notification.wait_for(&mut guard, remaining);
             });
         }
@@ -258,6 +288,45 @@ mod tests {
         });
 
         assert!(!counter.wait_for(|counter| *counter > 5, Duration::from_millis(300)));
+        handle.join().unwrap();
+    }
+
+    /// Reproduces a missed-wakeup race in `wait_for`.
+    ///
+    /// `wait_for` releases its read guard on `data` and only afterwards parks
+    /// on the condvar. If `notify_all` fires in that small gap, the waiter
+    /// never sees the notification and waits the full timeout — even though
+    /// the condition is already true.
+    ///
+    /// To make the race deterministic we install a `test_pre_park_sleep_ms`
+    /// hook on the waiter: it sleeps 100ms after releasing the read guard but
+    /// before parking on the condvar. The writer thread fires its
+    /// `notify_all` inside that window, so the unfixed code reliably misses
+    /// it and `wait_for` hits its timeout.
+    #[test]
+    fn test_wait_for_no_missed_wakeup() {
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
+        let counter_file = dir.path().join("counter");
+        let counter: Arc<SaveOnDisk<u32>> =
+            Arc::new(SaveOnDisk::load_or_init_default(counter_file).unwrap());
+        counter.test_set_pre_park_sleep_ms(100);
+
+        let counter_copy = counter.clone();
+        let handle = thread::spawn(move || {
+            // Wait long enough for the main thread to have released its read
+            // guard on `data` and entered the pre-park sleep window. With the
+            // 100ms pre-park sleep above, 30ms here lands the writer's
+            // notify_all squarely inside that window.
+            sleep(Duration::from_millis(30));
+            counter_copy.write(|counter| *counter = 1).unwrap();
+        });
+
+        // Use a 500ms timeout so a missed wakeup is unambiguous: success
+        // means the notification was delivered, timeout means it was lost.
+        assert!(
+            counter.wait_for(|counter| *counter > 0, Duration::from_millis(500)),
+            "wait_for timed out — notification was lost",
+        );
         handle.join().unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Fixes a missed-wakeup race in `SaveOnDisk::wait_for` (`lib/common/common/src/save_on_disk.rs`) that surfaces in CI as the flaky `tests/consensus_tests/test_resharding_extras.py::test_fix_reshard_down_without_shard_key` (and any other consensus path that calls `wait_for_shard_key_activation`).

`write` / `write_optional` were calling `change_notification.notify_all()` *without* holding `notification_lock`. A waiter that had released its read guard on `data` but had not yet parked on the condvar would miss the notification and wait the full timeout — even though the condition was already true.

In the failing run, the leader applies `SetShardReplicaState (Initializing → Active)` for all 4 replicas in ~10ms; every duplicate proposal that arrives afterwards fails the precondition check, so no further `replica_state.write()` happens. A single missed wakeup in this window then forces `wait_for_shard_key_activation` to time out 9.81s later, producing the 408 response observed in CI.

The fix introduces a small `notify_change()` helper that takes `notification_lock` around `notify_all`. Since the waiter holds `notification_lock` across the release-and-park gap, the writer's notify now blocks until the waiter has actually parked, guaranteeing delivery. This matches the standard `parking_lot::Condvar` pattern.

## Commits

The change is split into three commits to make the bug visible in CI:

1. `test: reproduce missed-wakeup race in SaveOnDisk::wait_for` — adds `test_wait_for_no_missed_wakeup` plus a `#[cfg(test)]`-only `test_set_pre_park_sleep_ms` hook that injects a 100ms sleep inside `wait_for` between releasing the read guard on `data` and parking on the condvar. Widens the race window from nanoseconds to a clearly observable size; the new test fails on this commit alone, demonstrating the bug.
2. `fix: prevent missed wakeup in SaveOnDisk::wait_for` — adds the `notify_change()` helper, drops the data write guard before notifying. Test from commit 1 now passes; instrumentation untouched.
3. `test: remove missed-wakeup race instrumentation` — deletes the `#[cfg(test)]` hook and the test that depended on it.

## Test plan

- [x] `cargo test -p common --lib save_on_disk` — passes after commit 2 and commit 3.
- [x] `cargo check --workspace` — clean.
- [ ] Re-run `tests/consensus_tests/test_resharding_extras.py::test_fix_reshard_down_without_shard_key` in CI; expected to no longer flake on this race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)