### PR TITLE
Fix panic on optimization after named vector delete + recreate

### DIFF
--- a/lib/collection/src/collection/vector_name_schema.rs
+++ b/lib/collection/src/collection/vector_name_schema.rs
@@ -37,6 +37,11 @@ impl Collection {
         self.update_all_local(operation, WaitUntil::from(false), hw_acc, true)
             .await?;
 
+        // Refresh shard optimizers so the cached `SegmentOptimizerConfig` picks up the
+        // new vector schema. Otherwise optimization-built destination segments use the
+        // stale dim and panic on dim mismatch when copying from sources with the new dim.
+        self.recreate_optimizers_blocking().await?;
+
         Ok(())
     }
 
@@ -58,6 +63,11 @@ impl Collection {
             true, // Delete even in dead shards
         )
         .await?;
+
+        // Refresh shard optimizers so the cached `SegmentOptimizerConfig` drops the
+        // removed vector. Without this, optimization keeps allocating storage for it
+        // using the old config.
+        self.recreate_optimizers_blocking().await?;
 
         Ok(())
     }

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -88,7 +88,10 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
     }
 
     fn get_dense<P: AccessPattern>(&self, _key: PointOffsetType) -> Cow<'_, [VectorElementType]> {
-        debug_assert!(false, "get_dense called on EmptyDenseVectorStorage");
+        // All slots are deleted; downstream paths (e.g. optimization's
+        // `update_from`) still need a properly-sized placeholder per slot so
+        // the destination's index→offset layout stays aligned. The deletion
+        // flag from `is_deleted_vector` keeps the placeholder from being read.
         Cow::Owned(vec![0.0; self.dim])
     }
 }
@@ -111,7 +114,7 @@ impl VectorStorage for EmptyDenseVectorStorage {
     }
 
     fn get_vector<P: AccessPattern>(&self, _key: PointOffsetType) -> CowVector<'_> {
-        debug_assert!(false, "get_vector called on EmptyDenseVectorStorage");
+        // See `get_dense` for why we return a sized placeholder rather than asserting.
         CowVector::from(vec![0.0; self.dim])
     }
 


### PR DESCRIPTION
Fixes two panics reproducible via `tests/openapi/test_named_vector_crud.py::test_delete_recreate_*_vector_scroll`, which exercises delete + recreate of a named vector with a different dimension on a populated collection (introduced in #8605).

# The bug

After DELETE /collections/{c}/vectors/{name} followed by PUT with a new size, the next background optimization panics. Two distinct issues were stacked on this path:

1. get_vector called on `EmptyDenseVectorStorage` (debug builds)

`EmptyDenseVectorStorage` is the placeholder used on immutable segments when a named vector exists in the schema but has no data yet (#8605). 

It contracted that get_vector/get_dense should never be called and asserted accordingly.
But `BatchedVectorReader::refill_buffer` reads every source slot during optimization — including deleted ones — to keep the destination's index→offset layout aligned. 

The fallback returning `vec![0.0; self.dim]` is correct (the deletion flag prevents the value from being read back); the assertion was overly strict.

2. index N out of range in `ImmutableDenseVectors::delete`

Each shard's `SegmentOptimizerConfig` (built once via optimizers_builder::build_optimizers) caches plain_dense_vector_config keyed by vector name with each vector's dim. 

Collection::create_named_vector / delete_named_vector updated collection_config.params and propagated to segments via update_all_local, but never refreshed this cache.

Result: after recreating vec_a with a new dim, segments held `EmptyDenseVectorStorage(new_dim)` while the optimizer still saw the old dim. segment_optimizer.rs:206 clones from the stale cache to size the destination, then update_from writes new_dim-sized vectors into a file expecting old_dim slots, the reopened num_vectors is computed against the wrong dim, and delete() overflows the deleted-flags BitSlice.

The bulk-update path in collection_meta_ops.rs::update_collection already handles this with `recreate_optimizers_blocking();` the single-vector CRUD path was missing the same call.

# The fix

- vector_name_schema.rs — call recreate_optimizers_blocking() after both create_named_vector and delete_named_vector, matching the existing bulk-update pattern. This rebuilds each shard's optimizer with the
  current schema before further optimizations run.
- empty_dense_vector_storage.rs — drop the debug_assert!(false, ...) in get_vector and get_dense. The fallback (vec![0.0; self.dim]) is the right behavior; replaced the assertion with comments explaining why
  this code path is legitimate.

# Test plan

- cargo check -p collection -p segment (passes)
- uv --project tests run pytest tests/openapi/test_named_vector_crud.py (debug build) — both panics gone
- cargo test -p segment empty_dense — existing EmptyDense unit tests still pass