### PR TITLE
[ai] Use event listener in SaveOnDisk to fix data race without locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "event-listener",
  "fs-err",
  "fs_extra",
  "io-uring",

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -22,6 +22,7 @@ bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
 chrono = { workspace = true }
+event-listener = "5.4"
 fs-err = { workspace = true }
 fs_extra = { workspace = true }
 itertools = { workspace = true }

--- a/lib/common/common/src/save_on_disk.rs
+++ b/lib/common/common/src/save_on_disk.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 
 use atomicwrites::OverwriteBehavior::AllowOverwrite;
 use atomicwrites::{AtomicFile, Error as AtomicWriteError};
+use event_listener::{Event, Listener};
 use fs_err::{File, tokio as tokio_fs};
-use parking_lot::{Condvar, Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use serde::{Deserialize, Serialize};
 
 use crate::tar_ext;
@@ -15,8 +16,7 @@ use crate::tar_ext;
 /// when write guard is dropped.
 #[derive(Debug, Default)]
 pub struct SaveOnDisk<T> {
-    change_notification: Condvar,
-    notification_lock: Mutex<()>,
+    change_notification: Event,
     data: RwLock<T>,
     path: PathBuf,
 }
@@ -52,8 +52,7 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             init()
         };
         Ok(Self {
-            change_notification: Condvar::new(),
-            notification_lock: Default::default(),
+            change_notification: Event::new(),
             data: RwLock::new(data),
             path,
         })
@@ -64,8 +63,7 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     /// If data already exists on disk, it will be immediately overwritten.
     pub fn new(path: impl Into<PathBuf>, data: T) -> Result<Self, Error> {
         let data = Self {
-            change_notification: Condvar::new(),
-            notification_lock: Default::default(),
+            change_notification: Event::new(),
             data: RwLock::new(data),
             path: path.into(),
         };
@@ -85,21 +83,21 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
     {
         let deadline = std::time::Instant::now() + timeout;
         loop {
+            // Subscribe before reading the value: any notification sent after
+            // `listen()` returns is guaranteed to wake this listener, even if
+            // we have not yet called `wait`. This closes the missed-wakeup gap
+            // between the predicate check and parking.
+            let listener = self.change_notification.listen();
+            if check(&self.data.read()) {
+                return true;
+            }
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
             if remaining.is_zero() {
                 return false;
             }
-            let mut data_read_guard = self.data.read();
-            if check(&data_read_guard) {
-                return true;
+            if listener.wait_timeout(remaining).is_none() {
+                return check(&self.data.read());
             }
-            let notification_guard = self.notification_lock.lock();
-            // Based on https://github.com/Amanieu/parking_lot/issues/165
-            RwLockReadGuard::unlocked(&mut data_read_guard, || {
-                // Move the guard in so it gets unlocked before we re-lock the RwLock read guard
-                let mut guard = notification_guard;
-                self.change_notification.wait_for(&mut guard, remaining);
-            });
         }
     }
 
@@ -115,7 +113,7 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
             let mut write_data = RwLockUpgradableReadGuard::upgrade(read_data);
             *write_data = output;
             drop(write_data);
-            self.notify_change();
+            self.change_notification.notify(usize::MAX);
             Ok(true)
         } else {
             Ok(false)
@@ -132,20 +130,8 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Clone> SaveOnDisk<T> {
 
         *write_data = data_copy;
         drop(write_data);
-        self.notify_change();
+        self.change_notification.notify(usize::MAX);
         Ok(output)
-    }
-
-    /// Wake up any threads waiting in [`Self::wait_for`].
-    ///
-    /// Acquires `notification_lock` around `notify_all` so that a waiter
-    /// cannot miss the notification while it is in the window between
-    /// releasing its read guard on `data` and parking on the condvar: the
-    /// waiter holds `notification_lock` across that gap, so this call blocks
-    /// until the waiter has actually parked.
-    fn notify_change(&self) {
-        let _guard = self.notification_lock.lock();
-        self.change_notification.notify_all();
     }
 
     fn save_data_to(path: impl Into<PathBuf>, data: &T) -> Result<(), Error> {


### PR DESCRIPTION
Improves <https://github.com/qdrant/qdrant/pull/8847>

Uses [`EventListener`](https://docs.rs/event-listener/latest/event_listener/index.html) to solve the data race without notification locks.

This critically:
- for read/wait: subscribe to notifications first, check predicate, then wait on subscribed notification
- for writes: change value, then emit notification

The subscribe-check-and-then-wait mechanism can also be implemented with the stdlib [`Condvar`](https://doc.rust-lang.org/std/sync/struct.Condvar.html) but requires extra logic around it with a counter. Using the above mentioned event listener is much nicer.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
3. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
4. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
