### PR TITLE
TQ+ SIMD

### DIFF
--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -31,14 +31,14 @@ pub struct TurboQuantizer {
 pub struct ErrorCorrection {
     pub shift: Vec<f32>,
     pub scale: Vec<f32>,
-    /// Unsigned 16-bit quantized `D'_i² = 1 / scale_i²` per coordinate, used
+    /// Signed 16-bit quantized `D'_i² = 1 / scale_i²` per coordinate, used
     /// by the SIMD weighted-dot path of `score_symmetric_ec` for Bits2/Bits4.
-    /// `D'²_f32 ≈ d_prime_sq_u16[i] / weight_scale`. Values are clamped to
-    /// `[0, i16::MAX − 1]` so SIMD kernels can safely interpret them as
-    /// signed `i16` and use `_mm256_madd_epi16` / `vmlal_s16`. Recomputed
-    /// from `scale` rather than persisted — `scale` is the single source of
-    /// truth.
-    pub(super) d_prime_sq_u16: Vec<u16>,
+    /// `D'²_f32 ≈ d_prime_sq_i16[i] / weight_scale`. Values are non-negative
+    /// and clamped to `[0, i16::MAX − 1]` so SIMD kernels can use
+    /// `_mm256_madd_epi16` / `vmlal_s16` directly — the `i16` element type
+    /// makes that contract a type-system invariant. Recomputed from `scale`
+    /// rather than persisted — `scale` is the single source of truth.
+    pub(super) d_prime_sq_i16: Vec<i16>,
     /// `(i16::MAX − 1) / max(D'²)` — quantization scale. The 1-bit cap
     /// (vs. full u16) costs ~3e-5 relative precision but lets SIMD use
     /// signed `i16` multiply-adds. `1.0` if all `D'²` are effectively zero
@@ -96,23 +96,23 @@ impl ErrorCorrection {
             .collect();
         let max_d_prime_sq = d_prime_sq_f32.iter().copied().fold(0.0f32, f32::max);
         // Cap quantized values to `i16::MAX − 1` so SIMD kernels can
-        // interpret the storage as signed `i16` without sign flips. See
-        // `d_prime_sq_u16` field doc for the full rationale.
+        // multiply them as signed `i16` without sign flips. See
+        // `d_prime_sq_i16` field doc for the full rationale.
         const QUANT_CAP: i16 = i16::MAX - 1;
         let weight_scale = if max_d_prime_sq > f32::EPSILON {
             f32::from(QUANT_CAP) / max_d_prime_sq
         } else {
             1.0
         };
-        let d_prime_sq_u16: Vec<u16> = d_prime_sq_f32
+        let d_prime_sq_i16: Vec<i16> = d_prime_sq_f32
             .iter()
-            .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+            .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as i16)
             .collect();
 
         ErrorCorrection {
             shift,
             scale,
-            d_prime_sq_u16,
+            d_prime_sq_i16,
             weight_scale,
             mm_const,
         }
@@ -426,15 +426,15 @@ impl TurboQuantizer {
         ec: &ErrorCorrection,
     ) -> f32 {
         // Bits2 / Bits4: integer SIMD-amenable weighted dot. The kernel
-        // returns `Σ c_a_int · c_b_int · weights_u16` as i64; we divide back
+        // returns `Σ c_a_int · c_b_int · weights_i16` as i64; we divide back
         // by `weight_scale · CODEBOOK_SCALE²` to recover the f32 centroid dot.
         let (raw_int, codebook_scale_sq) = match self.bits {
             TQBits::Bits2 => (
-                score_2bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_u16),
+                score_2bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_i16),
                 CODEBOOK_SCALE_SQ_2BIT,
             ),
             TQBits::Bits4 => (
-                score_4bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_u16),
+                score_4bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_i16),
                 CODEBOOK_SCALE_SQ_4BIT,
             ),
             TQBits::Bits1 | TQBits::Bits1_5 => {

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -2,8 +2,9 @@ use crate::DistanceType;
 use crate::turboquant::encoding::TqVectorExtras;
 use crate::turboquant::rotation::HadamardRotation;
 use crate::turboquant::simd::{
-    Query1bitSimd, Query2bitSimd, Query4bitSimd, score_1bit_internal, score_2bit_internal,
-    score_4bit_internal,
+    CODEBOOK_SCALE_SQ_2BIT, CODEBOOK_SCALE_SQ_4BIT, Query1bitSimd, Query2bitSimd, Query4bitSimd,
+    score_1bit_internal, score_2bit_internal, score_2bit_internal_weighted, score_4bit_internal,
+    score_4bit_internal_weighted,
 };
 use crate::turboquant::{
     EncodedQueryTQ, EncodedQueryTQData, ErrorCorrectionMetadata, Metadata, TQBits, TQMode,
@@ -30,10 +31,19 @@ pub struct TurboQuantizer {
 pub struct ErrorCorrection {
     pub shift: Vec<f32>,
     pub scale: Vec<f32>,
-    /// `D'_i² = 1 / scale_i²` per coordinate. Used in the symmetric TQ+
-    /// scoring path's per-coord-weighted dot. Recomputed from `scale` rather
-    /// than persisted — `scale` is the single source of truth.
-    pub(super) d_prime_sq: Vec<f32>,
+    /// Unsigned 16-bit quantized `D'_i² = 1 / scale_i²` per coordinate, used
+    /// by the SIMD weighted-dot path of `score_symmetric_ec` for Bits2/Bits4.
+    /// `D'²_f32 ≈ d_prime_sq_u16[i] / weight_scale`. Values are clamped to
+    /// `[0, i16::MAX − 1]` so SIMD kernels can safely interpret them as
+    /// signed `i16` and use `_mm256_madd_epi16` / `vmlal_s16`. Recomputed
+    /// from `scale` rather than persisted — `scale` is the single source of
+    /// truth.
+    pub(super) d_prime_sq_u16: Vec<u16>,
+    /// `(i16::MAX − 1) / max(D'²)` — quantization scale. The 1-bit cap
+    /// (vs. full u16) costs ~3e-5 relative precision but lets SIMD use
+    /// signed `i16` multiply-adds. `1.0` if all `D'²` are effectively zero
+    /// (degenerate quantizer).
+    pub(super) weight_scale: f32,
     /// `⟨M, M⟩ = Σ shift²` global constant. Used in symmetric TQ+ scoring to
     /// cancel the double-counted `⟨M, M⟩` from `xm_a + xm_b`.
     pub(super) mm_const: f32,
@@ -68,7 +78,13 @@ impl ErrorCorrection {
             "ErrorCorrection shift/scale length mismatch",
         );
         let mm_const = shift.iter().map(|&s| s * s).sum();
-        let d_prime_sq = scale
+
+        // Build f32 D'² per coord, then quantize to u16 with a single global
+        // scale chosen from the largest D'². Per-coord precision lower bound:
+        // `1/weight_scale = max(D'²)/65534`; relative error on the smallest
+        // coord is `(min/max)·(1/65534)` — overwhelmingly tighter than f32
+        // precision in this dynamic range.
+        let d_prime_sq_f32: Vec<f32> = scale
             .iter()
             .map(|&s| {
                 if s.abs() > f32::EPSILON {
@@ -78,10 +94,26 @@ impl ErrorCorrection {
                 }
             })
             .collect();
+        let max_d_prime_sq = d_prime_sq_f32.iter().copied().fold(0.0f32, f32::max);
+        // Cap quantized values to `i16::MAX − 1` so SIMD kernels can
+        // interpret the storage as signed `i16` without sign flips. See
+        // `d_prime_sq_u16` field doc for the full rationale.
+        const QUANT_CAP: i16 = i16::MAX - 1;
+        let weight_scale = if max_d_prime_sq > f32::EPSILON {
+            f32::from(QUANT_CAP) / max_d_prime_sq
+        } else {
+            1.0
+        };
+        let d_prime_sq_u16: Vec<u16> = d_prime_sq_f32
+            .iter()
+            .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+            .collect();
+
         ErrorCorrection {
             shift,
             scale,
-            d_prime_sq,
+            d_prime_sq_u16,
+            weight_scale,
             mm_const,
         }
     }
@@ -393,37 +425,31 @@ impl TurboQuantizer {
         extra_v2: &TqVectorExtras<'_>,
         ec: &ErrorCorrection,
     ) -> f32 {
-        let centroids = self.bits.get_centroids();
-        let bit_size = self.bits.bit_size();
-        let mut reader1 = common::bitpacking::BitReader::new(data_v1);
-        reader1.set_bits(bit_size);
-        let mut reader2 = common::bitpacking::BitReader::new(data_v2);
-        reader2.set_bits(bit_size);
-
-        match self.bits {
+        // Bits2 / Bits4: integer SIMD-amenable weighted dot. The kernel
+        // returns `Σ c_a_int · c_b_int · weights_u16` as i64; we divide back
+        // by `weight_scale · CODEBOOK_SCALE²` to recover the f32 centroid dot.
+        let (raw_int, codebook_scale_sq) = match self.bits {
+            TQBits::Bits2 => (
+                score_2bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_u16),
+                CODEBOOK_SCALE_SQ_2BIT,
+            ),
+            TQBits::Bits4 => (
+                score_4bit_internal_weighted(data_v1, data_v2, &ec.d_prime_sq_u16),
+                CODEBOOK_SCALE_SQ_4BIT,
+            ),
             TQBits::Bits1 | TQBits::Bits1_5 => {
-                let mut sum: f32 = 0.0;
-                for _ in 0..self.padded_dim {
-                    let idx1: u8 = reader1.read();
-                    let idx2: u8 = reader2.read();
-                    sum += centroids[idx1 as usize] * centroids[idx2 as usize];
-                }
-                sum
+                // 1-bit TQ+ ignores `D'²` weighting and `xm`/`mm` corrections (see
+                // doc comment above `score_symmetric_ec`), so the score reduces to
+                // the plain centroid dot — exactly what `score_1bit_internal`
+                // computes via SIMD XOR-popcount. Reuse it.
+                return score_1bit_internal(data_v1, data_v2);
             }
-            TQBits::Bits2 | TQBits::Bits4 => {
-                let mut weighted: f32 = 0.0;
-                for i in 0..self.padded_dim {
-                    let idx1: u8 = reader1.read();
-                    let idx2: u8 = reader2.read();
-                    let c1 = centroids[idx1 as usize];
-                    let c2 = centroids[idx2 as usize];
-                    weighted += c1 * c2 * ec.d_prime_sq[i];
-                }
-                let xm_a = extra_v1.ec_correction();
-                let xm_b = extra_v2.ec_correction();
-                weighted + xm_a + xm_b - ec.mm_const
-            }
-        }
+        };
+        let weighted = raw_int as f32 / (ec.weight_scale * codebook_scale_sq);
+
+        let xm_a = extra_v1.ec_correction();
+        let xm_b = extra_v2.ec_correction();
+        weighted + xm_a + xm_b - ec.mm_const
     }
 
     /// Precompute the Hadamard rotation of `query` and hand it to the

--- a/lib/quantization/src/turboquant/simd/mod.rs
+++ b/lib/quantization/src/turboquant/simd/mod.rs
@@ -36,14 +36,20 @@ pub use query1bit::{Query1bitSimd, score_1bit_internal, score_1bit_internal_scal
 pub use query1bit::{
     score_1bit_internal_avx2, score_1bit_internal_avx512_vpopcntdq, score_1bit_internal_sse,
 };
-pub use query2bit::{Query2bitSimd, score_2bit_internal, score_2bit_internal_scalar};
+pub use query2bit::{
+    CODEBOOK_SCALE_SQ as CODEBOOK_SCALE_SQ_2BIT, Query2bitSimd, score_2bit_internal,
+    score_2bit_internal_scalar, score_2bit_internal_weighted, score_2bit_internal_weighted_scalar,
+};
 #[cfg(target_arch = "x86_64")]
 pub use query2bit::{
     score_2bit_internal_avx2, score_2bit_internal_avx512_vnni, score_2bit_internal_sse,
 };
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use query2bit::{score_2bit_internal_neon, score_2bit_internal_neon_sdot};
-pub use query4bit::{Query4bitSimd, score_4bit_internal, score_4bit_internal_scalar};
+pub use query4bit::{
+    CODEBOOK_SCALE_SQ as CODEBOOK_SCALE_SQ_4BIT, Query4bitSimd, score_4bit_internal,
+    score_4bit_internal_scalar, score_4bit_internal_weighted, score_4bit_internal_weighted_scalar,
+};
 #[cfg(target_arch = "x86_64")]
 pub use query4bit::{
     score_4bit_internal_avx2, score_4bit_internal_avx512_vnni, score_4bit_internal_sse,

--- a/lib/quantization/src/turboquant/simd/query2bit/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/arm.rs
@@ -323,6 +323,75 @@ pub unsafe fn score_2bit_internal_neon_sdot(a: &[u8], b: &[u8]) -> f32 {
     }
 }
 
+// ------------------------------------------------------------------
+// score_2bit_internal_weighted — TQ+ symmetric path. Same overflow
+// pattern as the 4-bit NEON weighted kernel (i64 acc via `vpaddlq_s32`
+// to avoid i32 saturation at large dim).
+// ------------------------------------------------------------------
+
+/// NEON weighted variant of [`super::score_2bit_internal`]. 16 coords per
+/// iteration; products go through `vmull_s8` then per-pair multiply by
+/// i16 weights (i16-capped from u16 storage) via `vmull_s16`, pair-summed
+/// into an i64 accumulator.
+///
+/// # Safety
+/// CPU must support `neon`.
+#[target_feature(enable = "neon")]
+pub unsafe fn score_2bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::aarch64::*;
+
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_2bit_internal_weighted_neon: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        4 * a.len(),
+        "score_2bit_internal_weighted_neon: weights length {} != 4 · a.len() {}",
+        weights.len(),
+        4 * a.len(),
+    );
+
+    unsafe {
+        let mut acc = vdupq_n_s64(0);
+
+        // 4 bytes per source = 16 coords per iter.
+        let n_full = a.len() / 4;
+        for i in 0..n_full {
+            let c_a = unpack_16_codes(a.as_ptr().add(i * 4));
+            let c_b = unpack_16_codes(b.as_ptr().add(i * 4));
+
+            let prod_lo = vmull_s8(vget_low_s8(c_a), vget_low_s8(c_b));
+            let prod_hi = vmull_high_s8(c_a, c_b);
+
+            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i).cast::<i16>());
+            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8).cast::<i16>());
+
+            let pw_a = vmull_s16(vget_low_s16(prod_lo), vget_low_s16(w_lo));
+            let pw_b = vmull_high_s16(prod_lo, w_lo);
+            let pw_c = vmull_s16(vget_low_s16(prod_hi), vget_low_s16(w_hi));
+            let pw_d = vmull_high_s16(prod_hi, w_hi);
+
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_a));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_b));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_c));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_d));
+        }
+
+        let simd_sum = vaddvq_s64(acc);
+        let simd_bytes = n_full * 4;
+        let tail = super::score_2bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[4 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand::SeedableRng as _;
@@ -330,8 +399,21 @@ mod tests {
 
     use super::super::super::shared::pack_codes;
     use super::super::shared::{PARITY_DIMS, random_inputs};
-    use super::super::{Query2bitSimd, score_2bit_internal_scalar};
-    use super::{score_2bit_internal_neon, score_2bit_internal_neon_sdot};
+    use super::super::{
+        Query2bitSimd, score_2bit_internal_scalar, score_2bit_internal_weighted_scalar,
+    };
+    use super::{
+        score_2bit_internal_neon, score_2bit_internal_neon_sdot, score_2bit_internal_weighted_neon,
+    };
+
+    /// Build deterministic i16-capped weights of length `4 · vec_bytes` for
+    /// parity tests of the 2-bit weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+        use rand::RngExt;
+        (0..4 * vec_bytes)
+            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .collect()
+    }
 
     #[test]
     fn test_neon_matches_scalar() {
@@ -396,6 +478,42 @@ mod tests {
                 let sdot = unsafe { score_2bit_internal_neon_sdot(&vec_a, &vec_b) };
                 assert_eq!(scalar, sdot, "score sdot parity fail at dim {dim}");
             }
+        }
+    }
+
+    /// Parity for the 2-bit weighted kernel: NEON must match the scalar
+    /// reference bit-exactly across our matryoshka corner-case dims.
+    #[test]
+    fn test_score_weighted_neon_matches_scalar() {
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let neon = unsafe { score_2bit_internal_weighted_neon(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, neon,
+                "weighted: scalar {scalar} != neon {neon} at dim {dim}"
+            );
+        }
+    }
+
+    /// Saturation-safety for the 2-bit weighted NEON kernel at 64K dims:
+    /// must match i64 scalar reference under worst-case inputs.
+    #[test]
+    fn test_score_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![3; dim];
+        let vec_a = pack_codes(&indices, 2);
+        let vec_b = pack_codes(&indices, 2);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+        unsafe {
+            let neon = score_2bit_internal_weighted_neon(&vec_a, &vec_b, &weights);
+            assert_eq!(scalar, neon, "weighted score neon overflow at dim={dim}");
         }
     }
 

--- a/lib/quantization/src/turboquant/simd/query2bit/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/arm.rs
@@ -331,13 +331,12 @@ pub unsafe fn score_2bit_internal_neon_sdot(a: &[u8], b: &[u8]) -> f32 {
 
 /// NEON weighted variant of [`super::score_2bit_internal`]. 16 coords per
 /// iteration; products go through `vmull_s8` then per-pair multiply by
-/// i16 weights (i16-capped from u16 storage) via `vmull_s16`, pair-summed
-/// into an i64 accumulator.
+/// i16 weights via `vmull_s16`, pair-summed into an i64 accumulator.
 ///
 /// # Safety
 /// CPU must support `neon`.
 #[target_feature(enable = "neon")]
-pub unsafe fn score_2bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_2bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::aarch64::*;
 
     assert_eq!(
@@ -367,8 +366,8 @@ pub unsafe fn score_2bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u
             let prod_lo = vmull_s8(vget_low_s8(c_a), vget_low_s8(c_b));
             let prod_hi = vmull_high_s8(c_a, c_b);
 
-            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i).cast::<i16>());
-            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8).cast::<i16>());
+            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i));
+            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8));
 
             let pw_a = vmull_s16(vget_low_s16(prod_lo), vget_low_s16(w_lo));
             let pw_b = vmull_high_s16(prod_lo, w_lo);
@@ -406,12 +405,12 @@ mod tests {
         score_2bit_internal_neon, score_2bit_internal_neon_sdot, score_2bit_internal_weighted_neon,
     };
 
-    /// Build deterministic i16-capped weights of length `4 · vec_bytes` for
-    /// parity tests of the 2-bit weighted kernel.
-    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+    /// Build deterministic non-negative i16 weights of length `4 · vec_bytes`
+    /// for parity tests of the 2-bit weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<i16> {
         use rand::RngExt;
         (0..4 * vec_bytes)
-            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .map(|_| rng.random_range(0..=i16::MAX))
             .collect()
     }
 
@@ -507,8 +506,8 @@ mod tests {
         let indices: Vec<u8> = vec![3; dim];
         let vec_a = pack_codes(&indices, 2);
         let vec_b = pack_codes(&indices, 2);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
         unsafe {

--- a/lib/quantization/src/turboquant/simd/query2bit/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/mod.rs
@@ -366,9 +366,12 @@ pub(super) fn score_2bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
 }
 
 /// Weighted variant of [`score_2bit_internal`]: returns `Σ_j c[a[j]] · c[b[j]]
-/// · weights[j]` in centroid-float space. `weights` is u16-quantized `D'_j²`
-/// from TQ+ error correction; the caller divides the integer sum by
-/// `weight_scale · CODEBOOK_SCALE²` to recover the true f32 dot.
+/// · weights[j]` in centroid-float space. `weights` is i16-quantized `D'_j²`
+/// from TQ+ error correction (non-negative, capped at `i16::MAX − 1`); the
+/// caller divides the integer sum by `weight_scale · CODEBOOK_SCALE²` to
+/// recover the true f32 dot. The `i16` element type encodes the SIMD
+/// invariant directly — every backend can multiply via `vmull_s16` /
+/// `madd_epi16` without re-checking the high bit.
 ///
 /// Each input byte holds four 2-bit indices (lanes 0..=3 from LSB). `weights
 /// .len()` must equal `4 · a.len()`.
@@ -376,7 +379,7 @@ pub(super) fn score_2bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
 /// # Panics
 /// Panics if `a` and `b` have different lengths or if `weights` has the
 /// wrong length.
-pub fn score_2bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub fn score_2bit_internal_weighted(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     assert_eq!(
         a.len(),
         b.len(),
@@ -414,7 +417,7 @@ pub fn score_2bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 
 
 /// Scalar reference for [`score_2bit_internal_weighted`].
 #[inline]
-pub fn score_2bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub fn score_2bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     let mut acc: i64 = 0;
     for (i, (&byte_a, &byte_b)) in a.iter().zip(b.iter()).enumerate() {
         for k in 0..4 {
@@ -588,9 +591,8 @@ mod tests {
 
     /// Saturation-safety at 64K dims: every centroid index at max (`3`),
     /// every weight at `i16::MAX`. Same worst-case shape as the 4-bit
-    /// counterpart — `weights[i]` is u16-typed but SIMD reinterprets the
-    /// bytes as signed i16, so the contract caps quantized values at
-    /// `i16::MAX`. The i64 accumulator must hold the load.
+    /// counterpart — `weights[i]` is `i16` (the storage type is the
+    /// SIMD-load contract). The i64 accumulator must hold the load.
     ///
     /// Per-coord product:
     ///   `c_signed² × weight = 127² × 32 767 ≈ 5.28e8` (fits i32 with ~4× headroom).
@@ -601,8 +603,8 @@ mod tests {
         let indices: Vec<u8> = vec![3; dim]; // max-magnitude centroid
         let vec_a = pack_codes(&indices, 2);
         let vec_b = pack_codes(&indices, 2);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let raw_int = super::score_2bit_internal_weighted(&vec_a, &vec_b, &weights);
 
@@ -617,7 +619,8 @@ mod tests {
 
     /// `score_2bit_internal_weighted` should recover `Σ c[a[j]] · c[b[j]] ·
     /// D'_j²` after dividing by `weight_scale · CODEBOOK_SCALE²`.
-    /// Weights are u16-stored but i16-capped to match the SIMD contract.
+    /// Weights are quantized into the `i16` storage form the SIMD kernels
+    /// consume directly.
     #[test]
     fn test_score_2bit_internal_weighted_matches_reference() {
         use rand::RngExt;
@@ -637,9 +640,9 @@ mod tests {
             let max_w = weights_f32.iter().copied().fold(0.0f32, f32::max);
             const QUANT_CAP: i16 = i16::MAX - 1;
             let weight_scale = f32::from(QUANT_CAP) / max_w;
-            let weights_u16: Vec<u16> = weights_f32
+            let weights_i16: Vec<i16> = weights_f32
                 .iter()
-                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as i16)
                 .collect();
 
             let truth: f64 = idx_a
@@ -655,7 +658,7 @@ mod tests {
             let raw_int = super::score_2bit_internal_weighted(
                 &pack_codes(&idx_a, 2),
                 &pack_codes(&idx_b, 2),
-                &weights_u16,
+                &weights_i16,
             );
             let score = raw_int as f32 / (weight_scale * super::CODEBOOK_SCALE_SQ);
 

--- a/lib/quantization/src/turboquant/simd/query2bit/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/mod.rs
@@ -365,6 +365,74 @@ pub(super) fn score_2bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
     acc
 }
 
+/// Weighted variant of [`score_2bit_internal`]: returns `Σ_j c[a[j]] · c[b[j]]
+/// · weights[j]` in centroid-float space. `weights` is u16-quantized `D'_j²`
+/// from TQ+ error correction; the caller divides the integer sum by
+/// `weight_scale · CODEBOOK_SCALE²` to recover the true f32 dot.
+///
+/// Each input byte holds four 2-bit indices (lanes 0..=3 from LSB). `weights
+/// .len()` must equal `4 · a.len()`.
+///
+/// # Panics
+/// Panics if `a` and `b` have different lengths or if `weights` has the
+/// wrong length.
+pub fn score_2bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_2bit_internal_weighted: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        4 * a.len(),
+        "score_2bit_internal_weighted: weights length {} != 4 · a.len() {}",
+        weights.len(),
+        4 * a.len(),
+    );
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::is_x86_feature_detected!("avx2")
+            && std::is_x86_feature_detected!("ssse3")
+            && std::is_x86_feature_detected!("sse4.1")
+        {
+            return unsafe { x64::score_2bit_internal_weighted_avx2(a, b, weights) };
+        }
+        if std::is_x86_feature_detected!("ssse3") && std::is_x86_feature_detected!("sse4.1") {
+            return unsafe { x64::score_2bit_internal_weighted_sse(a, b, weights) };
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        return unsafe { arm::score_2bit_internal_weighted_neon(a, b, weights) };
+    }
+    #[allow(unreachable_code)]
+    score_2bit_internal_weighted_scalar(a, b, weights)
+}
+
+/// Scalar reference for [`score_2bit_internal_weighted`].
+#[inline]
+pub fn score_2bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    let mut acc: i64 = 0;
+    for (i, (&byte_a, &byte_b)) in a.iter().zip(b.iter()).enumerate() {
+        for k in 0..4 {
+            let shift = 2 * k;
+            let a_k = (byte_a >> shift) & 0x03;
+            let b_k = (byte_b >> shift) & 0x03;
+            let p = codebook_signed_i64(a_k) * codebook_signed_i64(b_k);
+            acc += p * i64::from(weights[4 * i + k]);
+        }
+    }
+    acc
+}
+
+/// Square of the codebook scale — the integer sum from
+/// [`score_2bit_internal_weighted`] is divided by `weight_scale ·
+/// CODEBOOK_SCALE_SQ` to get the f32 weighted dot.
+pub const CODEBOOK_SCALE_SQ: f32 = CODEBOOK_SCALE * CODEBOOK_SCALE;
+
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 mod arm;
 
@@ -372,9 +440,14 @@ mod arm;
 mod x64;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-pub use arm::{score_2bit_internal_neon, score_2bit_internal_neon_sdot};
+pub use arm::{
+    score_2bit_internal_neon, score_2bit_internal_neon_sdot, score_2bit_internal_weighted_neon,
+};
 #[cfg(target_arch = "x86_64")]
-pub use x64::{score_2bit_internal_avx2, score_2bit_internal_avx512_vnni, score_2bit_internal_sse};
+pub use x64::{
+    score_2bit_internal_avx2, score_2bit_internal_avx512_vnni, score_2bit_internal_sse,
+    score_2bit_internal_weighted_avx2, score_2bit_internal_weighted_sse,
+};
 
 /// 2-bit-specific test helpers.  Bit-width-agnostic helpers (`pack_codes`,
 /// `sample_normal_vec`, `encode_to_nearest_centroid`) live in
@@ -509,6 +582,86 @@ mod tests {
             assert!(
                 (expected - got).abs() < 0.5,
                 "scalar score {got} too far from centroid product {expected}",
+            );
+        }
+    }
+
+    /// Saturation-safety at 64K dims: every centroid index at max (`3`),
+    /// every weight at `i16::MAX`. Same worst-case shape as the 4-bit
+    /// counterpart — `weights[i]` is u16-typed but SIMD reinterprets the
+    /// bytes as signed i16, so the contract caps quantized values at
+    /// `i16::MAX`. The i64 accumulator must hold the load.
+    ///
+    /// Per-coord product:
+    ///   `c_signed² × weight = 127² × 32 767 ≈ 5.28e8` (fits i32 with ~4× headroom).
+    /// Total over 65 536 coords: `≈ 3.46e13` — fits i64.
+    #[test]
+    fn test_score_2bit_internal_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![3; dim]; // max-magnitude centroid
+        let vec_a = pack_codes(&indices, 2);
+        let vec_b = pack_codes(&indices, 2);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let raw_int = super::score_2bit_internal_weighted(&vec_a, &vec_b, &weights);
+
+        let c_max_signed = super::codebook_signed_i64(3);
+        let per_coord = c_max_signed * c_max_signed * i64::from(max_weight);
+        let expected = per_coord * dim as i64;
+        assert_eq!(
+            raw_int, expected,
+            "i64 sum overflow / mismatch at dim={dim} (per-coord={per_coord}, expected={expected}, got={raw_int})",
+        );
+    }
+
+    /// `score_2bit_internal_weighted` should recover `Σ c[a[j]] · c[b[j]] ·
+    /// D'_j²` after dividing by `weight_scale · CODEBOOK_SCALE²`.
+    /// Weights are u16-stored but i16-capped to match the SIMD contract.
+    #[test]
+    fn test_score_2bit_internal_weighted_matches_reference() {
+        use rand::RngExt;
+
+        let mut rng = StdRng::seed_from_u64(0xBADD00D);
+        let dim = 256;
+        let centroids = TQBits::Bits2.get_centroids();
+        let n_trials = 16;
+
+        for _ in 0..n_trials {
+            let raw_a = sample_normal_vec(&mut rng, dim);
+            let raw_b = sample_normal_vec(&mut rng, dim);
+            let idx_a = encode_to_nearest_centroid(centroids, &raw_a);
+            let idx_b = encode_to_nearest_centroid(centroids, &raw_b);
+
+            let weights_f32: Vec<f32> = (0..dim).map(|_| rng.random_range(0.0..4.0)).collect();
+            let max_w = weights_f32.iter().copied().fold(0.0f32, f32::max);
+            const QUANT_CAP: i16 = i16::MAX - 1;
+            let weight_scale = f32::from(QUANT_CAP) / max_w;
+            let weights_u16: Vec<u16> = weights_f32
+                .iter()
+                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+                .collect();
+
+            let truth: f64 = idx_a
+                .iter()
+                .zip(idx_b.iter())
+                .zip(weights_f32.iter())
+                .map(|((&a, &b), &w)| {
+                    f64::from(centroids[a as usize])
+                        * f64::from(centroids[b as usize])
+                        * f64::from(w)
+                })
+                .sum();
+            let raw_int = super::score_2bit_internal_weighted(
+                &pack_codes(&idx_a, 2),
+                &pack_codes(&idx_b, 2),
+                &weights_u16,
+            );
+            let score = raw_int as f32 / (weight_scale * super::CODEBOOK_SCALE_SQ);
+
+            assert!(
+                (truth as f32 - score).abs() < 16.0,
+                "weighted score {score} too far from reference {truth}",
             );
         }
     }

--- a/lib/quantization/src/turboquant/simd/query2bit/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/x64.rs
@@ -397,8 +397,7 @@ pub unsafe fn score_2bit_internal_avx2(a: &[u8], b: &[u8]) -> f32 {
 // ------------------------------------------------------------------
 // score_2bit_internal_weighted — TQ+ symmetric path with per-coord
 // `D'²` weighting. Same structure as the 4-bit weighted kernel: i16
-// weights (i16-capped from u16 storage) → `madd_epi16` pair-sum →
-// widen to i64 for accumulation.
+// weights → `madd_epi16` pair-sum → widen to i64 for accumulation.
 //
 // Per-coord product bound (2-bit codebook):
 //   |c_a · c_b · w| ≤ 127·127·32 766 ≈ 5.28e8
@@ -411,7 +410,7 @@ pub unsafe fn score_2bit_internal_avx2(a: &[u8], b: &[u8]) -> f32 {
 /// # Safety
 /// CPU must support `ssse3` and `sse4.1`.
 #[target_feature(enable = "sse4.1,ssse3")]
-pub unsafe fn score_2bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_2bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::x86_64::*;
 
     assert_eq!(
@@ -482,7 +481,7 @@ pub unsafe fn score_2bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u1
 /// # Safety
 /// CPU must support `avx2`, `ssse3`, `sse4.1`.
 #[target_feature(enable = "avx2,sse4.1,ssse3")]
-pub unsafe fn score_2bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_2bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::x86_64::*;
 
     assert_eq!(a.len(), b.len());
@@ -667,12 +666,12 @@ mod tests {
     };
     use super::*;
 
-    /// Build deterministic i16-capped weights of length `4 · vec_bytes` for
-    /// parity tests of the 2-bit weighted kernel.
-    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+    /// Build deterministic non-negative i16 weights of length `4 · vec_bytes`
+    /// for parity tests of the 2-bit weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<i16> {
         use rand::RngExt;
         (0..4 * vec_bytes)
-            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .map(|_| rng.random_range(0..=i16::MAX))
             .collect()
     }
 
@@ -856,8 +855,8 @@ mod tests {
         let indices: Vec<u8> = vec![3; dim];
         let vec_a = pack_codes(&indices, 2);
         let vec_b = pack_codes(&indices, 2);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
 

--- a/lib/quantization/src/turboquant/simd/query2bit/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query2bit/x64.rs
@@ -394,6 +394,191 @@ pub unsafe fn score_2bit_internal_avx2(a: &[u8], b: &[u8]) -> f32 {
     }
 }
 
+// ------------------------------------------------------------------
+// score_2bit_internal_weighted — TQ+ symmetric path with per-coord
+// `D'²` weighting. Same structure as the 4-bit weighted kernel: i16
+// weights (i16-capped from u16 storage) → `madd_epi16` pair-sum →
+// widen to i64 for accumulation.
+//
+// Per-coord product bound (2-bit codebook):
+//   |c_a · c_b · w| ≤ 127·127·32 766 ≈ 5.28e8
+//   madd pair sum: ≤ 2 · 5.28e8 ≈ 1.06e9 < i32::MAX ✓
+// Same i32 → i64 widening pattern as the 4-bit path.
+// ------------------------------------------------------------------
+
+/// SSE4.1 + SSSE3 weighted variant of [`super::score_2bit_internal`].
+///
+/// # Safety
+/// CPU must support `ssse3` and `sse4.1`.
+#[target_feature(enable = "sse4.1,ssse3")]
+pub unsafe fn score_2bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::x86_64::*;
+
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_2bit_internal_weighted_sse: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        4 * a.len(),
+        "score_2bit_internal_weighted_sse: weights length {} != 4 · a.len() {}",
+        weights.len(),
+        4 * a.len(),
+    );
+
+    unsafe {
+        let shift = _mm_set1_epi8(-128_i8);
+        let mut acc = _mm_setzero_si128(); // 2 i64 lanes
+
+        // 4 bytes from each source = 16 coords per iter.
+        let n_full = a.len() / 4;
+        for i in 0..n_full {
+            let c_a_u8 = unpack_16_codes_sse(a.as_ptr().add(i * 4));
+            let c_b_u8 = unpack_16_codes_sse(b.as_ptr().add(i * 4));
+            let c_a = _mm_xor_si128(c_a_u8, shift);
+            let c_b = _mm_xor_si128(c_b_u8, shift);
+
+            let c_a_lo = _mm_cvtepi8_epi16(c_a);
+            let c_a_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_a, 8));
+            let c_b_lo = _mm_cvtepi8_epi16(c_b);
+            let c_b_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_b, 8));
+
+            let prod_lo = _mm_mullo_epi16(c_a_lo, c_b_lo);
+            let prod_hi = _mm_mullo_epi16(c_a_hi, c_b_hi);
+
+            let w_lo = _mm_loadu_si128(weights.as_ptr().add(16 * i).cast::<__m128i>());
+            let w_hi = _mm_loadu_si128(weights.as_ptr().add(16 * i + 8).cast::<__m128i>());
+
+            let pw_lo = _mm_madd_epi16(prod_lo, w_lo);
+            let pw_hi = _mm_madd_epi16(prod_hi, w_hi);
+            let pw = _mm_add_epi32(pw_lo, pw_hi);
+
+            let pw_lo_i64 = _mm_cvtepi32_epi64(pw);
+            let pw_hi_i64 = _mm_cvtepi32_epi64(_mm_srli_si128(pw, 8));
+            acc = _mm_add_epi64(acc, pw_lo_i64);
+            acc = _mm_add_epi64(acc, pw_hi_i64);
+        }
+
+        let mut tmp = [0i64; 2];
+        _mm_storeu_si128(tmp.as_mut_ptr().cast::<__m128i>(), acc);
+        let simd_sum = tmp[0] + tmp[1];
+
+        let simd_bytes = n_full * 4;
+        let tail = super::score_2bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[4 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
+/// AVX2 weighted variant of [`super::score_2bit_internal`]. 32 coords per
+/// iteration (two 16-coord SSE chunks fed through one ymm madd).
+///
+/// # Safety
+/// CPU must support `avx2`, `ssse3`, `sse4.1`.
+#[target_feature(enable = "avx2,sse4.1,ssse3")]
+pub unsafe fn score_2bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::x86_64::*;
+
+    assert_eq!(a.len(), b.len());
+    assert_eq!(weights.len(), 4 * a.len());
+
+    unsafe {
+        let shift256 = _mm256_set1_epi8(-128_i8);
+        let mut acc = _mm256_setzero_si256(); // 4 i64 lanes
+
+        let n_chunks = a.len() / 4;
+        let n_pairs = n_chunks / 2;
+
+        // Process pairs of 4-byte chunks (32 coords) per iteration.
+        for p in 0..n_pairs {
+            let off_0 = 4 * (2 * p);
+            let off_1 = 4 * (2 * p + 1);
+            let c_a = _mm256_set_m128i(
+                unpack_16_codes_sse(a.as_ptr().add(off_1)),
+                unpack_16_codes_sse(a.as_ptr().add(off_0)),
+            );
+            let c_b = _mm256_set_m128i(
+                unpack_16_codes_sse(b.as_ptr().add(off_1)),
+                unpack_16_codes_sse(b.as_ptr().add(off_0)),
+            );
+            let c_a = _mm256_xor_si256(c_a, shift256);
+            let c_b = _mm256_xor_si256(c_b, shift256);
+
+            let c_a_lo = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(c_a));
+            let c_a_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(c_a, 1));
+            let c_b_lo = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(c_b));
+            let c_b_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(c_b, 1));
+
+            let prod_lo = _mm256_mullo_epi16(c_a_lo, c_b_lo);
+            let prod_hi = _mm256_mullo_epi16(c_a_hi, c_b_hi);
+
+            // Weights are laid out in coord order; for AVX2's interleaved
+            // pair-of-chunks layout we load `[chunk_0_weights, chunk_1_weights]`.
+            // Coords for (off_0, off_1) span weight indices `[16·(2p)..16·(2p+2)]`.
+            let w_lo = _mm256_loadu_si256(weights.as_ptr().add(16 * (2 * p)).cast::<__m256i>());
+            let w_hi =
+                _mm256_loadu_si256(weights.as_ptr().add(16 * (2 * p) + 16).cast::<__m256i>());
+
+            let pw_lo = _mm256_madd_epi16(prod_lo, w_lo);
+            let pw_hi = _mm256_madd_epi16(prod_hi, w_hi);
+            let pw = _mm256_add_epi32(pw_lo, pw_hi);
+
+            let pw_lo_i64 = _mm256_cvtepi32_epi64(_mm256_castsi256_si128(pw));
+            let pw_hi_i64 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(pw, 1));
+            acc = _mm256_add_epi64(acc, pw_lo_i64);
+            acc = _mm256_add_epi64(acc, pw_hi_i64);
+        }
+
+        // Hsum 4 i64 lanes.
+        let acc_lo = _mm256_castsi256_si128(acc);
+        let acc_hi = _mm256_extracti128_si256(acc, 1);
+        let summed = _mm_add_epi64(acc_lo, acc_hi);
+        let mut tmp = [0i64; 2];
+        _mm_storeu_si128(tmp.as_mut_ptr().cast::<__m128i>(), summed);
+        let mut simd_sum = tmp[0] + tmp[1];
+
+        // Trailing single chunk if `n_chunks` is odd.
+        if n_chunks % 2 == 1 {
+            let off = 4 * (2 * n_pairs);
+            let w_off = 16 * (2 * n_pairs);
+            let shift = _mm_set1_epi8(-128_i8);
+            let c_a = _mm_xor_si128(unpack_16_codes_sse(a.as_ptr().add(off)), shift);
+            let c_b = _mm_xor_si128(unpack_16_codes_sse(b.as_ptr().add(off)), shift);
+            let c_a_lo = _mm_cvtepi8_epi16(c_a);
+            let c_a_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_a, 8));
+            let c_b_lo = _mm_cvtepi8_epi16(c_b);
+            let c_b_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_b, 8));
+            let prod_lo = _mm_mullo_epi16(c_a_lo, c_b_lo);
+            let prod_hi = _mm_mullo_epi16(c_a_hi, c_b_hi);
+            let w_lo = _mm_loadu_si128(weights.as_ptr().add(w_off).cast::<__m128i>());
+            let w_hi = _mm_loadu_si128(weights.as_ptr().add(w_off + 8).cast::<__m128i>());
+            let pw = _mm_add_epi32(_mm_madd_epi16(prod_lo, w_lo), _mm_madd_epi16(prod_hi, w_hi));
+            let pw_lo_i64 = _mm_cvtepi32_epi64(pw);
+            let pw_hi_i64 = _mm_cvtepi32_epi64(_mm_srli_si128(pw, 8));
+            let mut t = [0i64; 2];
+            _mm_storeu_si128(
+                t.as_mut_ptr().cast::<__m128i>(),
+                _mm_add_epi64(pw_lo_i64, pw_hi_i64),
+            );
+            simd_sum += t[0] + t[1];
+        }
+
+        let simd_bytes = n_chunks * 4;
+        let tail = super::score_2bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[4 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
 /// AVX-512 + VNNI implementation — uses `VPDPWSSD` for fused i16×i16 MAC.
 ///
 /// # Safety
@@ -477,8 +662,19 @@ mod tests {
 
     use super::super::super::shared::pack_codes;
     use super::super::shared::{PARITY_DIMS, random_inputs};
-    use super::super::{Query2bitSimd, score_2bit_internal_scalar};
+    use super::super::{
+        Query2bitSimd, score_2bit_internal_scalar, score_2bit_internal_weighted_scalar,
+    };
     use super::*;
+
+    /// Build deterministic i16-capped weights of length `4 · vec_bytes` for
+    /// parity tests of the 2-bit weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+        use rand::RngExt;
+        (0..4 * vec_bytes)
+            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .collect()
+    }
 
     #[test]
     fn test_sse_matches_scalar() {
@@ -608,6 +804,72 @@ mod tests {
                 got.to_bits(),
                 "score avx512 mismatch at dim {dim}",
             );
+        }
+    }
+
+    /// Parity for the 2-bit weighted kernel: every x86 backend must match
+    /// the scalar reference bit-exactly across our matryoshka corner-case dims.
+    #[test]
+    fn test_score_weighted_sse_matches_scalar() {
+        if !std::is_x86_feature_detected!("ssse3") || !std::is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let sse = unsafe { score_2bit_internal_weighted_sse(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, sse,
+                "weighted: scalar {scalar} != sse {sse} at dim {dim}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_score_weighted_avx2_matches_scalar() {
+        if !std::is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let avx2 = unsafe { score_2bit_internal_weighted_avx2(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, avx2,
+                "weighted: scalar {scalar} != avx2 {avx2} at dim {dim}"
+            );
+        }
+    }
+
+    /// Saturation-safety for the 2-bit weighted kernel at 64K dims: every
+    /// x86 backend must match the i64 scalar reference under worst-case
+    /// inputs (max-magnitude codebook + max-magnitude i16 weight).
+    #[test]
+    fn test_score_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![3; dim];
+        let vec_a = pack_codes(&indices, 2);
+        let vec_b = pack_codes(&indices, 2);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let scalar = score_2bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+
+        unsafe {
+            if std::is_x86_feature_detected!("ssse3") && std::is_x86_feature_detected!("sse4.1") {
+                let sse = score_2bit_internal_weighted_sse(&vec_a, &vec_b, &weights);
+                assert_eq!(scalar, sse, "weighted score sse disagrees at dim={dim}");
+            }
+            if std::is_x86_feature_detected!("avx2") {
+                let avx2 = score_2bit_internal_weighted_avx2(&vec_a, &vec_b, &weights);
+                assert_eq!(scalar, avx2, "weighted score avx2 disagrees at dim={dim}");
+            }
         }
     }
 

--- a/lib/quantization/src/turboquant/simd/query4bit/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/arm.rs
@@ -352,11 +352,12 @@ pub unsafe fn score_4bit_internal_neon_sdot(a: &[u8], b: &[u8]) -> f32 {
 
 // ------------------------------------------------------------------
 // score_4bit_internal_weighted — TQ+ symmetric path with per-coord
-// `D'²` weighting. `weights[i]` is u16-quantized but i16-capped (see
-// `ErrorCorrection::d_prime_sq_u16` doc), so we treat the loaded bytes
-// as i16. Same overflow story as the x64 path: per-coord product up
-// to ~5.28e8, sum at dim=64 K reaches ~1.7e10 — must accumulate into
-// i64 lanes. We pair-sum i32 → i64 every iteration via `vpaddlq_s32`.
+// `D'²` weighting. `weights[i]` is `i16` (non-negative, capped at
+// `i16::MAX − 1` — see `ErrorCorrection::d_prime_sq_i16` doc), which
+// matches the SIMD load directly. Same overflow story as the x64
+// path: per-coord product up to ~5.28e8, sum at dim=64 K reaches
+// ~1.7e10 — must accumulate into i64 lanes. We pair-sum i32 → i64
+// every iteration via `vpaddlq_s32`.
 // ------------------------------------------------------------------
 
 /// NEON weighted variant of [`super::score_4bit_internal`]. 16 coords per
@@ -367,7 +368,7 @@ pub unsafe fn score_4bit_internal_neon_sdot(a: &[u8], b: &[u8]) -> f32 {
 /// # Safety
 /// CPU must support `neon`.
 #[target_feature(enable = "neon")]
-pub unsafe fn score_4bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_4bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::aarch64::*;
 
     assert_eq!(
@@ -411,8 +412,8 @@ pub unsafe fn score_4bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u
             let prod_hi = vmull_high_s8(c_a, c_b); // i16×8
 
             // Load 16 i16 weights = 2 q regs.
-            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i).cast::<i16>());
-            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8).cast::<i16>());
+            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i));
+            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8));
 
             // Multiply each i16 pair → i32. Each `vmull_s16` produces 4 i32 from
             // the low 4 i16 lanes; `vmull_high_s16` does the upper 4.
@@ -453,12 +454,12 @@ mod tests {
         score_4bit_internal_neon, score_4bit_internal_neon_sdot, score_4bit_internal_weighted_neon,
     };
 
-    /// Build deterministic i16-capped weights of length `2 · vec_bytes` for
-    /// parity tests of the weighted kernel.
-    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+    /// Build deterministic non-negative i16 weights of length `2 · vec_bytes`
+    /// for parity tests of the weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<i16> {
         use rand::RngExt;
         (0..2 * vec_bytes)
-            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .map(|_| rng.random_range(0..=i16::MAX))
             .collect()
     }
 
@@ -568,8 +569,8 @@ mod tests {
         let indices: Vec<u8> = vec![15; dim];
         let vec_a = pack_codes(&indices, 4);
         let vec_b = pack_codes(&indices, 4);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
         unsafe {

--- a/lib/quantization/src/turboquant/simd/query4bit/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/arm.rs
@@ -350,6 +350,95 @@ pub unsafe fn score_4bit_internal_neon_sdot(a: &[u8], b: &[u8]) -> f32 {
     }
 }
 
+// ------------------------------------------------------------------
+// score_4bit_internal_weighted — TQ+ symmetric path with per-coord
+// `D'²` weighting. `weights[i]` is u16-quantized but i16-capped (see
+// `ErrorCorrection::d_prime_sq_u16` doc), so we treat the loaded bytes
+// as i16. Same overflow story as the x64 path: per-coord product up
+// to ~5.28e8, sum at dim=64 K reaches ~1.7e10 — must accumulate into
+// i64 lanes. We pair-sum i32 → i64 every iteration via `vpaddlq_s32`.
+// ------------------------------------------------------------------
+
+/// NEON weighted variant of [`super::score_4bit_internal`]. 16 coords per
+/// iteration; products go through `vmull_s8` (i8 → i16) then per-pair
+/// multiply by i16 weights via `vmull_s16` (i16 → i32), pair-summed into
+/// an i64 accumulator.
+///
+/// # Safety
+/// CPU must support `neon`.
+#[target_feature(enable = "neon")]
+pub unsafe fn score_4bit_internal_weighted_neon(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::aarch64::*;
+
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_4bit_internal_weighted_neon: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        2 * a.len(),
+        "score_4bit_internal_weighted_neon: weights length {} != 2 · a.len() {}",
+        weights.len(),
+        2 * a.len(),
+    );
+
+    unsafe {
+        let codebook = vld1q_s8(CODEBOOK_I8.as_ptr());
+        let mut acc = vdupq_n_s64(0); // 2 i64 lanes
+        let nibble_mask = vdup_n_u8(0x0F);
+
+        // 8 bytes per source = 16 coords per iter.
+        let n_full = a.len() / 8;
+        for i in 0..n_full {
+            let va = vld1_u8(a.as_ptr().add(i * 8));
+            let va_lo = vand_u8(va, nibble_mask);
+            let va_hi = vshr_n_u8(va, 4);
+            let a_idx = vcombine_u8(vzip1_u8(va_lo, va_hi), vzip2_u8(va_lo, va_hi));
+
+            let vb = vld1_u8(b.as_ptr().add(i * 8));
+            let vb_lo = vand_u8(vb, nibble_mask);
+            let vb_hi = vshr_n_u8(vb, 4);
+            let b_idx = vcombine_u8(vzip1_u8(vb_lo, vb_hi), vzip2_u8(vb_lo, vb_hi));
+
+            let c_a = vqtbl1q_s8(codebook, a_idx);
+            let c_b = vqtbl1q_s8(codebook, b_idx);
+
+            // c_a × c_b in i16 (max 16129 fits — same bound as the unweighted kernel).
+            let prod_lo = vmull_s8(vget_low_s8(c_a), vget_low_s8(c_b)); // i16×8
+            let prod_hi = vmull_high_s8(c_a, c_b); // i16×8
+
+            // Load 16 i16 weights = 2 q regs.
+            let w_lo = vld1q_s16(weights.as_ptr().add(16 * i).cast::<i16>());
+            let w_hi = vld1q_s16(weights.as_ptr().add(16 * i + 8).cast::<i16>());
+
+            // Multiply each i16 pair → i32. Each `vmull_s16` produces 4 i32 from
+            // the low 4 i16 lanes; `vmull_high_s16` does the upper 4.
+            let pw_a = vmull_s16(vget_low_s16(prod_lo), vget_low_s16(w_lo)); // i32×4
+            let pw_b = vmull_high_s16(prod_lo, w_lo); // i32×4
+            let pw_c = vmull_s16(vget_low_s16(prod_hi), vget_low_s16(w_hi)); // i32×4
+            let pw_d = vmull_high_s16(prod_hi, w_hi); // i32×4
+
+            // Pair-sum each i32×4 → i64×2 and accumulate.
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_a));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_b));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_c));
+            acc = vaddq_s64(acc, vpaddlq_s32(pw_d));
+        }
+
+        let simd_sum = vaddvq_s64(acc);
+        let simd_bytes = n_full * 8;
+        let tail = super::score_4bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[2 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand::SeedableRng as _;
@@ -357,8 +446,21 @@ mod tests {
 
     use super::super::super::shared::pack_codes;
     use super::super::shared::{PARITY_DIMS, random_inputs};
-    use super::super::{Query4bitSimd, score_4bit_internal_scalar};
-    use super::{score_4bit_internal_neon, score_4bit_internal_neon_sdot};
+    use super::super::{
+        Query4bitSimd, score_4bit_internal_scalar, score_4bit_internal_weighted_scalar,
+    };
+    use super::{
+        score_4bit_internal_neon, score_4bit_internal_neon_sdot, score_4bit_internal_weighted_neon,
+    };
+
+    /// Build deterministic i16-capped weights of length `2 · vec_bytes` for
+    /// parity tests of the weighted kernel.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+        use rand::RngExt;
+        (0..2 * vec_bytes)
+            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .collect()
+    }
 
     #[test]
     fn test_neon_matches_scalar() {
@@ -437,6 +539,42 @@ mod tests {
                     "score: scalar {scalar} != sdot {sdot} at dim {dim}"
                 );
             }
+        }
+    }
+
+    /// Parity for the weighted kernel: NEON must match the scalar reference
+    /// bit-exactly across our matryoshka corner-case dims.
+    #[test]
+    fn test_score_weighted_neon_matches_scalar() {
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let neon = unsafe { score_4bit_internal_weighted_neon(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, neon,
+                "weighted: scalar {scalar} != neon {neon} at dim {dim}"
+            );
+        }
+    }
+
+    /// Saturation-safety for the weighted NEON kernel at 64K dims: must
+    /// match i64 scalar reference under worst-case inputs.
+    #[test]
+    fn test_score_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![15; dim];
+        let vec_a = pack_codes(&indices, 4);
+        let vec_b = pack_codes(&indices, 4);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+        unsafe {
+            let neon = score_4bit_internal_weighted_neon(&vec_a, &vec_b, &weights);
+            assert_eq!(scalar, neon, "weighted score neon overflow at dim={dim}");
         }
     }
 

--- a/lib/quantization/src/turboquant/simd/query4bit/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/mod.rs
@@ -441,6 +441,72 @@ pub(super) fn score_4bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
     acc
 }
 
+/// Weighted variant of [`score_4bit_internal`]: returns `Σ_j c[a[j]] · c[b[j]]
+/// · weights[j]` in centroid-float space. `weights` is u16-quantized `D'_j²`
+/// from TQ+ error correction; the caller divides the integer sum by
+/// `weight_scale · CODEBOOK_SCALE²` to recover the true f32 dot.
+///
+/// Each input byte holds two 4-bit indices (low nibble = even lane, high
+/// nibble = odd lane). `weights.len()` must equal `2 · a.len()`.
+///
+/// # Panics
+/// Panics if `a` and `b` have different lengths or if `weights` has the
+/// wrong length.
+pub fn score_4bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_4bit_internal_weighted: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        2 * a.len(),
+        "score_4bit_internal_weighted: weights length {} != 2 · a.len() {}",
+        weights.len(),
+        2 * a.len(),
+    );
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            return unsafe { x64::score_4bit_internal_weighted_avx2(a, b, weights) };
+        }
+        if std::is_x86_feature_detected!("sse4.1") && std::is_x86_feature_detected!("ssse3") {
+            return unsafe { x64::score_4bit_internal_weighted_sse(a, b, weights) };
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        return unsafe { arm::score_4bit_internal_weighted_neon(a, b, weights) };
+    }
+    #[allow(unreachable_code)]
+    score_4bit_internal_weighted_scalar(a, b, weights)
+}
+
+/// Scalar reference for [`score_4bit_internal_weighted`].
+#[inline]
+pub fn score_4bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    let mut acc: i64 = 0;
+    for (i, (&byte_a, &byte_b)) in a.iter().zip(b.iter()).enumerate() {
+        let a_lo = byte_a & 0x0F;
+        let a_hi = byte_a >> 4;
+        let b_lo = byte_b & 0x0F;
+        let b_hi = byte_b >> 4;
+        let p_lo = codebook_signed_i64(a_lo) * codebook_signed_i64(b_lo);
+        let p_hi = codebook_signed_i64(a_hi) * codebook_signed_i64(b_hi);
+        acc += p_lo * i64::from(weights[2 * i]);
+        acc += p_hi * i64::from(weights[2 * i + 1]);
+    }
+    acc
+}
+
+/// Square of the codebook scale — the integer sum from
+/// [`score_4bit_internal_weighted`] is divided by `weight_scale ·
+/// CODEBOOK_SCALE_SQ` to get the f32 weighted dot.
+pub const CODEBOOK_SCALE_SQ: f32 = CODEBOOK_SCALE * CODEBOOK_SCALE;
+
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 mod arm;
 
@@ -448,9 +514,14 @@ mod arm;
 mod x64;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-pub use arm::{score_4bit_internal_neon, score_4bit_internal_neon_sdot};
+pub use arm::{
+    score_4bit_internal_neon, score_4bit_internal_neon_sdot, score_4bit_internal_weighted_neon,
+};
 #[cfg(target_arch = "x86_64")]
-pub use x64::{score_4bit_internal_avx2, score_4bit_internal_avx512_vnni, score_4bit_internal_sse};
+pub use x64::{
+    score_4bit_internal_avx2, score_4bit_internal_avx512_vnni, score_4bit_internal_sse,
+    score_4bit_internal_weighted_avx2, score_4bit_internal_weighted_sse,
+};
 
 /// 4-bit-specific test helpers.  Bit-width-agnostic helpers (`pack_codes`,
 /// `sample_normal_vec`, `encode_to_nearest_centroid`) live in
@@ -676,6 +747,100 @@ mod tests {
             assert!(
                 (truth as f32 - score).abs() < 2.0,
                 "score {score} too far from centroid-product truth {truth}",
+            );
+        }
+    }
+
+    /// Saturation-safety at 64K dims: every centroid index at max (`15`),
+    /// every weight at `i16::MAX`. `weights[i]` is u16-typed but SIMD
+    /// reinterprets the bytes as signed i16 (`madd_epi16` / `vmull_s16`),
+    /// so the contract caps quantized values at `i16::MAX`. This is the
+    /// worst-case integer load the weighted kernel can see, and the i64
+    /// accumulator must absorb it.
+    ///
+    /// Per-coord product:
+    ///   `c_signed² × weight = 127² × 32 767 = 16 129 × 32 767 ≈ 5.28e8`
+    /// (fits i32 with ~4× headroom). Total over 65 536 coords:
+    /// `≈ 3.46e13` — fits i64 (~2.7e5× headroom; signed i64 max ≈ 9.2e18).
+    #[test]
+    fn test_score_4bit_internal_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![15; dim]; // max-magnitude centroid
+        let vec_a = pack_codes(&indices, 4);
+        let vec_b = pack_codes(&indices, 4);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let raw_int = super::score_4bit_internal_weighted(&vec_a, &vec_b, &weights);
+
+        // Worst-case integer ground truth: every coord contributes
+        // `c_signed² × max_weight`, summed over `dim`. Any SIMD i32-lane
+        // accumulator overflow would manifest here as a wrap-around.
+        let c_max_signed = super::codebook_signed_i64(15);
+        let per_coord = c_max_signed * c_max_signed * i64::from(max_weight);
+        let expected = per_coord * dim as i64;
+        assert_eq!(
+            raw_int, expected,
+            "i64 sum overflow / mismatch at dim={dim} (per-coord={per_coord}, expected={expected}, got={raw_int})",
+        );
+    }
+
+    /// `score_4bit_internal_weighted` should recover `Σ c[a[j]] · c[b[j]] ·
+    /// D'_j²` up to:
+    ///   1. the i8 codebook quantization step (≈ 0.022 per centroid), and
+    ///   2. the i16 weight quantization step (relative ≤ 1/(i16::MAX-1)).
+    ///
+    /// Reconstruction is `int_sum / (weight_scale · CODEBOOK_SCALE²)`.
+    #[test]
+    fn test_score_4bit_internal_weighted_matches_reference() {
+        use rand::RngExt;
+
+        let mut rng = StdRng::seed_from_u64(0xCAFE);
+        let centroids = TQBits::Bits4.get_centroids();
+        let dim = 256;
+        let n_trials = 32;
+
+        for _ in 0..n_trials {
+            let raw_a = sample_normal_vec(&mut rng, dim);
+            let raw_b = sample_normal_vec(&mut rng, dim);
+            let idx_a = encode_to_nearest_centroid(centroids, &raw_a);
+            let idx_b = encode_to_nearest_centroid(centroids, &raw_b);
+
+            // Random weights in [0, 4) f32, quantized to u16 storage but
+            // i16-capped — matches `ErrorCorrection::new` (SIMD reads
+            // weights as signed i16, so values must stay in `[0, i16::MAX]`).
+            let weights_f32: Vec<f32> = (0..dim).map(|_| rng.random_range(0.0..4.0)).collect();
+            let max_w = weights_f32.iter().copied().fold(0.0f32, f32::max);
+            const QUANT_CAP: i16 = i16::MAX - 1;
+            let weight_scale = f32::from(QUANT_CAP) / max_w;
+            let weights_u16: Vec<u16> = weights_f32
+                .iter()
+                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+                .collect();
+
+            let truth: f64 = idx_a
+                .iter()
+                .zip(idx_b.iter())
+                .zip(weights_f32.iter())
+                .map(|((&ia, &ib), &w)| {
+                    f64::from(centroids[ia as usize])
+                        * f64::from(centroids[ib as usize])
+                        * f64::from(w)
+                })
+                .sum();
+            let raw_int = super::score_4bit_internal_weighted(
+                &pack_codes(&idx_a, 4),
+                &pack_codes(&idx_b, 4),
+                &weights_u16,
+            );
+            let score = raw_int as f32 / (weight_scale * super::CODEBOOK_SCALE_SQ);
+
+            // Per-coord error budget ≈ |c|² · max_w / 65534 + 2·|c|·Δc·w.
+            // For dim=256 with weights up to 4 and centroids up to ~2.7 the
+            // RMS bound is ≲ √d · 0.5 ≈ 8 — generous slack at 16.
+            assert!(
+                (truth as f32 - score).abs() < 16.0,
+                "weighted score {score} too far from reference {truth}",
             );
         }
     }

--- a/lib/quantization/src/turboquant/simd/query4bit/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/mod.rs
@@ -442,9 +442,12 @@ pub(super) fn score_4bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
 }
 
 /// Weighted variant of [`score_4bit_internal`]: returns `Σ_j c[a[j]] · c[b[j]]
-/// · weights[j]` in centroid-float space. `weights` is u16-quantized `D'_j²`
-/// from TQ+ error correction; the caller divides the integer sum by
-/// `weight_scale · CODEBOOK_SCALE²` to recover the true f32 dot.
+/// · weights[j]` in centroid-float space. `weights` is i16-quantized `D'_j²`
+/// from TQ+ error correction (non-negative, capped at `i16::MAX − 1`); the
+/// caller divides the integer sum by `weight_scale · CODEBOOK_SCALE²` to
+/// recover the true f32 dot. The `i16` element type encodes the SIMD
+/// invariant directly — every backend can multiply via `vmull_s16` /
+/// `madd_epi16` without re-checking the high bit.
 ///
 /// Each input byte holds two 4-bit indices (low nibble = even lane, high
 /// nibble = odd lane). `weights.len()` must equal `2 · a.len()`.
@@ -452,7 +455,7 @@ pub(super) fn score_4bit_internal_integer(a: &[u8], b: &[u8]) -> i64 {
 /// # Panics
 /// Panics if `a` and `b` have different lengths or if `weights` has the
 /// wrong length.
-pub fn score_4bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub fn score_4bit_internal_weighted(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     assert_eq!(
         a.len(),
         b.len(),
@@ -487,7 +490,7 @@ pub fn score_4bit_internal_weighted(a: &[u8], b: &[u8], weights: &[u16]) -> i64 
 
 /// Scalar reference for [`score_4bit_internal_weighted`].
 #[inline]
-pub fn score_4bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub fn score_4bit_internal_weighted_scalar(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     let mut acc: i64 = 0;
     for (i, (&byte_a, &byte_b)) in a.iter().zip(b.iter()).enumerate() {
         let a_lo = byte_a & 0x0F;
@@ -752,9 +755,8 @@ mod tests {
     }
 
     /// Saturation-safety at 64K dims: every centroid index at max (`15`),
-    /// every weight at `i16::MAX`. `weights[i]` is u16-typed but SIMD
-    /// reinterprets the bytes as signed i16 (`madd_epi16` / `vmull_s16`),
-    /// so the contract caps quantized values at `i16::MAX`. This is the
+    /// every weight at `i16::MAX`. `weights[i]` is `i16` (the storage type
+    /// matches the SIMD load — `madd_epi16` / `vmull_s16`). This is the
     /// worst-case integer load the weighted kernel can see, and the i64
     /// accumulator must absorb it.
     ///
@@ -768,8 +770,8 @@ mod tests {
         let indices: Vec<u8> = vec![15; dim]; // max-magnitude centroid
         let vec_a = pack_codes(&indices, 4);
         let vec_b = pack_codes(&indices, 4);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let raw_int = super::score_4bit_internal_weighted(&vec_a, &vec_b, &weights);
 
@@ -806,16 +808,16 @@ mod tests {
             let idx_a = encode_to_nearest_centroid(centroids, &raw_a);
             let idx_b = encode_to_nearest_centroid(centroids, &raw_b);
 
-            // Random weights in [0, 4) f32, quantized to u16 storage but
-            // i16-capped — matches `ErrorCorrection::new` (SIMD reads
-            // weights as signed i16, so values must stay in `[0, i16::MAX]`).
+            // Random weights in [0, 4) f32, quantized into the `i16` storage
+            // form the SIMD kernels consume directly — matches
+            // `ErrorCorrection::new` (values capped to `[0, i16::MAX − 1]`).
             let weights_f32: Vec<f32> = (0..dim).map(|_| rng.random_range(0.0..4.0)).collect();
             let max_w = weights_f32.iter().copied().fold(0.0f32, f32::max);
             const QUANT_CAP: i16 = i16::MAX - 1;
             let weight_scale = f32::from(QUANT_CAP) / max_w;
-            let weights_u16: Vec<u16> = weights_f32
+            let weights_i16: Vec<i16> = weights_f32
                 .iter()
-                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as u16)
+                .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as i16)
                 .collect();
 
             let truth: f64 = idx_a
@@ -831,7 +833,7 @@ mod tests {
             let raw_int = super::score_4bit_internal_weighted(
                 &pack_codes(&idx_a, 4),
                 &pack_codes(&idx_b, 4),
-                &weights_u16,
+                &weights_i16,
             );
             let score = raw_int as f32 / (weight_scale * super::CODEBOOK_SCALE_SQ);
 

--- a/lib/quantization/src/turboquant/simd/query4bit/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/x64.rs
@@ -453,6 +453,210 @@ pub unsafe fn score_4bit_internal_avx512_vnni(a: &[u8], b: &[u8]) -> f32 {
     }
 }
 
+// ------------------------------------------------------------------
+// score_4bit_internal_weighted — TQ+ symmetric path with per-coord
+// `D'²` weighting. `weights[i]` is u16-quantized but i16-capped (see
+// `ErrorCorrection::d_prime_sq_u16` doc), so we treat the loaded bytes
+// as i16 and use the very efficient `madd_epi16` pair-sum.
+//
+// Per-coord product bound:
+//   |c_a · c_b · w| ≤ 128·128·32 766 ≈ 5.37e8
+//   madd pair sum: ≤ 2 · 5.37e8 ≈ 1.07e9 < i32::MAX (2.15e9) ✓
+// At dim=64 K the i32 sum reaches ≈ 1.7e10 — overflow if accumulated
+// in i32. We widen each `madd_epi16` result to i64 lanes immediately
+// (`_mm256_cvtepi32_epi64`) and accumulate into an i64 ymm reg, with
+// far enough headroom for any practical dim.
+// ------------------------------------------------------------------
+
+/// SSE4.1 + SSSE3 weighted variant of [`super::score_4bit_internal`].
+///
+/// # Safety
+/// CPU must support `ssse3` and `sse4.1`.
+#[target_feature(enable = "sse4.1,ssse3")]
+pub unsafe fn score_4bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::x86_64::*;
+
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_4bit_internal_weighted_sse: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        2 * a.len(),
+        "score_4bit_internal_weighted_sse: weights length {} != 2 · a.len() {}",
+        weights.len(),
+        2 * a.len(),
+    );
+
+    unsafe {
+        let codebook_i8 = _mm_xor_si128(
+            _mm_loadu_si128(CODEBOOK_U8.as_ptr().cast::<__m128i>()),
+            _mm_set1_epi8(-128i8),
+        );
+        let nibble_mask = _mm_set1_epi8(0x0F);
+        let mut acc = _mm_setzero_si128(); // 2 i64 lanes
+
+        // 8 bytes from each source = 16 coords per iter.
+        let n_full = a.len() / 8;
+        for i in 0..n_full {
+            let va = _mm_loadl_epi64(a.as_ptr().add(i * 8).cast::<__m128i>());
+            let va_lo = _mm_and_si128(va, nibble_mask);
+            let va_hi = _mm_and_si128(_mm_srli_epi16(va, 4), nibble_mask);
+            let a_idx = _mm_unpacklo_epi8(va_lo, va_hi);
+            let c_a_i8 = _mm_shuffle_epi8(codebook_i8, a_idx);
+
+            let vb = _mm_loadl_epi64(b.as_ptr().add(i * 8).cast::<__m128i>());
+            let vb_lo = _mm_and_si128(vb, nibble_mask);
+            let vb_hi = _mm_and_si128(_mm_srli_epi16(vb, 4), nibble_mask);
+            let b_idx = _mm_unpacklo_epi8(vb_lo, vb_hi);
+            let c_b_i8 = _mm_shuffle_epi8(codebook_i8, b_idx);
+
+            // Widen i8×16 → i16×8 (low half only — the high half is zero
+            // because `unpacklo_epi8` placed all 16 indices in the low 16
+            // bytes already; for SSE we process 16 coords per iter via two
+            // halves of the i8 register).
+            let c_a_lo = _mm_cvtepi8_epi16(c_a_i8);
+            let c_a_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_a_i8, 8));
+            let c_b_lo = _mm_cvtepi8_epi16(c_b_i8);
+            let c_b_hi = _mm_cvtepi8_epi16(_mm_srli_si128(c_b_i8, 8));
+
+            // c_a × c_b in i16 (max 16129 fits).
+            let prod_lo = _mm_mullo_epi16(c_a_lo, c_b_lo);
+            let prod_hi = _mm_mullo_epi16(c_a_hi, c_b_hi);
+
+            // Load 16 i16 weights = 32 bytes = 2 xmm regs.
+            let w_lo = _mm_loadu_si128(weights.as_ptr().add(16 * i).cast::<__m128i>());
+            let w_hi = _mm_loadu_si128(weights.as_ptr().add(16 * i + 8).cast::<__m128i>());
+
+            // Pair-sum (prod[2k]·w[2k] + prod[2k+1]·w[2k+1]) → 4 i32 lanes each.
+            let pw_lo = _mm_madd_epi16(prod_lo, w_lo);
+            let pw_hi = _mm_madd_epi16(prod_hi, w_hi);
+            let pw = _mm_add_epi32(pw_lo, pw_hi);
+
+            // Widen 4 i32 → 2 i64 + 2 i64, accumulate.
+            let pw_lo_i64 = _mm_cvtepi32_epi64(pw);
+            let pw_hi_i64 = _mm_cvtepi32_epi64(_mm_srli_si128(pw, 8));
+            acc = _mm_add_epi64(acc, pw_lo_i64);
+            acc = _mm_add_epi64(acc, pw_hi_i64);
+        }
+
+        // Hsum 2 i64 lanes.
+        let mut tmp = [0i64; 2];
+        _mm_storeu_si128(tmp.as_mut_ptr().cast::<__m128i>(), acc);
+        let simd_sum = tmp[0] + tmp[1];
+
+        // Tail.
+        let simd_bytes = n_full * 8;
+        let tail = super::score_4bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[2 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
+/// AVX2 weighted variant of [`super::score_4bit_internal`]. 32 coords per
+/// iteration; `madd_epi16` pair-sums i16 weighted products into i32 lanes
+/// then widens to i64 for accumulation.
+///
+/// # Safety
+/// CPU must support `avx2`.
+#[target_feature(enable = "avx2")]
+pub unsafe fn score_4bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+    use core::arch::x86_64::*;
+
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "score_4bit_internal_weighted_avx2: vector length mismatch ({} vs {})",
+        a.len(),
+        b.len(),
+    );
+    assert_eq!(
+        weights.len(),
+        2 * a.len(),
+        "score_4bit_internal_weighted_avx2: weights length {} != 2 · a.len() {}",
+        weights.len(),
+        2 * a.len(),
+    );
+
+    unsafe {
+        let codebook_i8_128 = _mm_xor_si128(
+            _mm_loadu_si128(CODEBOOK_U8.as_ptr().cast::<__m128i>()),
+            _mm_set1_epi8(-128i8),
+        );
+        let codebook_i8 = _mm256_broadcastsi128_si256(codebook_i8_128);
+        let nibble_mask = _mm_set1_epi8(0x0F);
+        let mut acc = _mm256_setzero_si256(); // 4 i64 lanes
+
+        // 16 bytes from each source = 32 coords per iter.
+        let n_iters = a.len() / 16;
+        for i in 0..n_iters {
+            let va = _mm_loadu_si128(a.as_ptr().add(16 * i).cast::<__m128i>());
+            let va_lo = _mm_and_si128(va, nibble_mask);
+            let va_hi = _mm_and_si128(_mm_srli_epi16(va, 4), nibble_mask);
+            let a_idx_0 = _mm_unpacklo_epi8(va_lo, va_hi);
+            let a_idx_1 = _mm_unpackhi_epi8(va_lo, va_hi);
+            let a_idx_256 = _mm256_inserti128_si256(_mm256_castsi128_si256(a_idx_0), a_idx_1, 1);
+            let c_a_i8 = _mm256_shuffle_epi8(codebook_i8, a_idx_256);
+
+            let vb = _mm_loadu_si128(b.as_ptr().add(16 * i).cast::<__m128i>());
+            let vb_lo = _mm_and_si128(vb, nibble_mask);
+            let vb_hi = _mm_and_si128(_mm_srli_epi16(vb, 4), nibble_mask);
+            let b_idx_0 = _mm_unpacklo_epi8(vb_lo, vb_hi);
+            let b_idx_1 = _mm_unpackhi_epi8(vb_lo, vb_hi);
+            let b_idx_256 = _mm256_inserti128_si256(_mm256_castsi128_si256(b_idx_0), b_idx_1, 1);
+            let c_b_i8 = _mm256_shuffle_epi8(codebook_i8, b_idx_256);
+
+            // Widen i8×32 → i16×16 + i16×16.
+            let c_a_lo = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(c_a_i8));
+            let c_a_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(c_a_i8, 1));
+            let c_b_lo = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(c_b_i8));
+            let c_b_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(c_b_i8, 1));
+
+            // c_a × c_b in i16 (max 16129 fits).
+            let prod_lo = _mm256_mullo_epi16(c_a_lo, c_b_lo);
+            let prod_hi = _mm256_mullo_epi16(c_a_hi, c_b_hi);
+
+            // Load 32 i16 weights = 64 bytes = 2 ymm regs.
+            let w_lo = _mm256_loadu_si256(weights.as_ptr().add(32 * i).cast::<__m256i>());
+            let w_hi = _mm256_loadu_si256(weights.as_ptr().add(32 * i + 16).cast::<__m256i>());
+
+            // Pair-sum into i32: 8 i32 lanes per madd.
+            let pw_lo = _mm256_madd_epi16(prod_lo, w_lo);
+            let pw_hi = _mm256_madd_epi16(prod_hi, w_hi);
+            let pw = _mm256_add_epi32(pw_lo, pw_hi);
+
+            // Widen 8 i32 → 4 i64 + 4 i64, accumulate.
+            let pw_lo_i64 = _mm256_cvtepi32_epi64(_mm256_castsi256_si128(pw));
+            let pw_hi_i64 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(pw, 1));
+            acc = _mm256_add_epi64(acc, pw_lo_i64);
+            acc = _mm256_add_epi64(acc, pw_hi_i64);
+        }
+
+        // Hsum 4 i64 lanes.
+        let acc_lo = _mm256_castsi256_si128(acc);
+        let acc_hi = _mm256_extracti128_si256(acc, 1);
+        let summed = _mm_add_epi64(acc_lo, acc_hi);
+        let mut tmp = [0i64; 2];
+        _mm_storeu_si128(tmp.as_mut_ptr().cast::<__m128i>(), summed);
+        let simd_sum = tmp[0] + tmp[1];
+
+        // Tail.
+        let simd_bytes = n_iters * 16;
+        let tail = super::score_4bit_internal_weighted_scalar(
+            &a[simd_bytes..],
+            &b[simd_bytes..],
+            &weights[2 * simd_bytes..],
+        );
+        simd_sum + tail
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand::SeedableRng as _;
@@ -460,10 +664,23 @@ mod tests {
 
     use super::super::super::shared::pack_codes;
     use super::super::shared::{PARITY_DIMS, random_inputs};
-    use super::super::{Query4bitSimd, score_4bit_internal_scalar};
+    use super::super::{
+        Query4bitSimd, score_4bit_internal_scalar, score_4bit_internal_weighted_scalar,
+    };
     use super::{
         score_4bit_internal_avx2, score_4bit_internal_avx512_vnni, score_4bit_internal_sse,
+        score_4bit_internal_weighted_avx2, score_4bit_internal_weighted_sse,
     };
+
+    /// Build deterministic i16-capped weights of length `2 · vec_bytes` for
+    /// parity tests of the weighted kernels.  Same shape as the SIMD contract
+    /// (signed-i16 reinterpretation of u16 storage).
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+        use rand::RngExt;
+        (0..2 * vec_bytes)
+            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .collect()
+    }
 
     #[test]
     fn test_sse_matches_scalar() {
@@ -606,6 +823,72 @@ mod tests {
                 scalar, vnni512,
                 "score: scalar {scalar} != avx512_vnni {vnni512} at dim {dim}"
             );
+        }
+    }
+
+    /// Parity for the weighted kernel: every x86 backend must match the
+    /// scalar reference bit-exactly across our matryoshka corner-case dims.
+    #[test]
+    fn test_score_weighted_sse_matches_scalar() {
+        if !std::is_x86_feature_detected!("ssse3") || !std::is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let sse = unsafe { score_4bit_internal_weighted_sse(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, sse,
+                "weighted: scalar {scalar} != sse {sse} at dim {dim}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_score_weighted_avx2_matches_scalar() {
+        if !std::is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in PARITY_DIMS {
+            let (_, vec_a) = random_inputs(&mut rng, dim);
+            let (_, vec_b) = random_inputs(&mut rng, dim);
+            let weights = random_weights(&mut rng, vec_a.len());
+            let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+            let avx2 = unsafe { score_4bit_internal_weighted_avx2(&vec_a, &vec_b, &weights) };
+            assert_eq!(
+                scalar, avx2,
+                "weighted: scalar {scalar} != avx2 {avx2} at dim {dim}"
+            );
+        }
+    }
+
+    /// Saturation-safety for the weighted kernel: every x86 backend at 64K
+    /// dims with worst-case inputs (max-magnitude codebook + max-magnitude
+    /// i16 weight) must match the i64 scalar reference.
+    #[test]
+    fn test_score_weighted_saturation_safety_64k() {
+        let dim = 65_536;
+        let indices: Vec<u8> = vec![15; dim];
+        let vec_a = pack_codes(&indices, 4);
+        let vec_b = pack_codes(&indices, 4);
+        let max_weight: u16 = i16::MAX as u16;
+        let weights: Vec<u16> = vec![max_weight; dim];
+
+        let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
+
+        unsafe {
+            if std::is_x86_feature_detected!("ssse3") && std::is_x86_feature_detected!("sse4.1") {
+                let sse = score_4bit_internal_weighted_sse(&vec_a, &vec_b, &weights);
+                assert_eq!(scalar, sse, "weighted score sse disagrees at dim={dim}");
+            }
+            if std::is_x86_feature_detected!("avx2") {
+                let avx2 = score_4bit_internal_weighted_avx2(&vec_a, &vec_b, &weights);
+                assert_eq!(scalar, avx2, "weighted score avx2 disagrees at dim={dim}");
+            }
         }
     }
 

--- a/lib/quantization/src/turboquant/simd/query4bit/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query4bit/x64.rs
@@ -455,9 +455,10 @@ pub unsafe fn score_4bit_internal_avx512_vnni(a: &[u8], b: &[u8]) -> f32 {
 
 // ------------------------------------------------------------------
 // score_4bit_internal_weighted — TQ+ symmetric path with per-coord
-// `D'²` weighting. `weights[i]` is u16-quantized but i16-capped (see
-// `ErrorCorrection::d_prime_sq_u16` doc), so we treat the loaded bytes
-// as i16 and use the very efficient `madd_epi16` pair-sum.
+// `D'²` weighting. `weights[i]` is `i16` (non-negative, capped at
+// `i16::MAX − 1` — see `ErrorCorrection::d_prime_sq_i16` doc), which
+// matches the SIMD load directly and feeds the very efficient
+// `madd_epi16` pair-sum.
 //
 // Per-coord product bound:
 //   |c_a · c_b · w| ≤ 128·128·32 766 ≈ 5.37e8
@@ -473,7 +474,7 @@ pub unsafe fn score_4bit_internal_avx512_vnni(a: &[u8], b: &[u8]) -> f32 {
 /// # Safety
 /// CPU must support `ssse3` and `sse4.1`.
 #[target_feature(enable = "sse4.1,ssse3")]
-pub unsafe fn score_4bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_4bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::x86_64::*;
 
     assert_eq!(
@@ -566,7 +567,7 @@ pub unsafe fn score_4bit_internal_weighted_sse(a: &[u8], b: &[u8], weights: &[u1
 /// # Safety
 /// CPU must support `avx2`.
 #[target_feature(enable = "avx2")]
-pub unsafe fn score_4bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[u16]) -> i64 {
+pub unsafe fn score_4bit_internal_weighted_avx2(a: &[u8], b: &[u8], weights: &[i16]) -> i64 {
     use core::arch::x86_64::*;
 
     assert_eq!(
@@ -672,13 +673,12 @@ mod tests {
         score_4bit_internal_weighted_avx2, score_4bit_internal_weighted_sse,
     };
 
-    /// Build deterministic i16-capped weights of length `2 · vec_bytes` for
-    /// parity tests of the weighted kernels.  Same shape as the SIMD contract
-    /// (signed-i16 reinterpretation of u16 storage).
-    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<u16> {
+    /// Build deterministic non-negative i16 weights of length `2 · vec_bytes`
+    /// for parity tests of the weighted kernels.
+    fn random_weights(rng: &mut StdRng, vec_bytes: usize) -> Vec<i16> {
         use rand::RngExt;
         (0..2 * vec_bytes)
-            .map(|_| rng.random_range(0..=i16::MAX as u16))
+            .map(|_| rng.random_range(0..=i16::MAX))
             .collect()
     }
 
@@ -875,8 +875,8 @@ mod tests {
         let indices: Vec<u8> = vec![15; dim];
         let vec_a = pack_codes(&indices, 4);
         let vec_b = pack_codes(&indices, 4);
-        let max_weight: u16 = i16::MAX as u16;
-        let weights: Vec<u16> = vec![max_weight; dim];
+        let max_weight: i16 = i16::MAX;
+        let weights: Vec<i16> = vec![max_weight; dim];
 
         let scalar = score_4bit_internal_weighted_scalar(&vec_a, &vec_b, &weights);
 


### PR DESCRIPTION
Last gap in TQ baseline: SIMD for TQ+

Sanity-check on using vector-db-bench.
Dataset: DBPEDIA 100K

  |                      | ARM recall | ARM RPS | ARM Index | x86 recall | x86 RPS | x86 Index |
  | -------------------- | ---------- | ------- | --------- | ---------- | ------- | --------- |
  | DBPEDIA TQ+ 4bit     | 0.929      | 246     | 25        | 0.932      | 1275    | 25        |                                             
  | DBPEDIA TQ 4bit      | 0.913      | 171     | 20        | 0.913      | 1275    | 20        |                                             
  | DBPEDIA TQ+ 2bit     | 0.846      | 199     | 25        | 0.844      | 1277    | 25        |                                             
  | DBPEDIA TQ 2bit      | 0.787      | 236     | 20        | 0.787      | 1291    | 20        |                                             
  | DBPEDIA TQ+ 1.5bit   | 0.770      | 238     | 25        | 0.768      | 1264    | 30        |                                             
  | DBPEDIA TQ 1.5bit    | 0.691      | 296     | 25        | 0.687      | 1286    | 20        |                                             
  | DBPEDIA TQ+ 1bit     | 0.744      | 400     | 20        | 0.743      | 1274    | 20        |                                             
  | DBPEDIA TQ 1bit      | 0.633      | 282     | 15        | 0.634      | 1298    | 15        |                                             
  | DBPEDIA BQ           | 0.611      | 184     | 20        | 0.610      | 1258    | 10        |                                             
  | DBPEDIA BQ asym      | 0.704      | 224     | 20        | 0.705      | 1269    | 10        |                                             
  | DBPEDIA BQ 2bit      | 0.735      | 225     | 15        | 0.735      | 1279    | 15        |                                             
  | DBPEDIA SQ           | 0.883      | 259     | 20        | 0.882      | 1280    | 20        |                                             
  | DBPEDIA orig         | 0.960      | 193     | 35        | 0.957      | 1213    | 45        |     