### PR TITLE
split read only vector store

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -21,7 +21,7 @@ mod tests {
         Distance, HnswConfig, HnswGlobalConfig, PayloadContainer, PayloadSchemaType,
         QuantizationConfig, VectorName,
     };
-    use segment::vector_storage::VectorStorage;
+    use segment::vector_storage::{VectorStorage, VectorStorageRead};
     use serde_json::Value;
     use shard::locked_segment::LockedSegment;
     use shard::operations::optimization::OptimizerThresholds;

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -22,8 +22,8 @@ use segment::index::sparse_index::sparse_vector_index::{
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::types::VectorStorageDatatype;
-use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -22,7 +22,7 @@ use segment::index::sparse_index::sparse_vector_index::{
 use segment::index::struct_payload_index::StructPayloadIndex;
 use segment::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use segment::types::VectorStorageDatatype;
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use sparse::index::inverted_index::InvertedIndex;

--- a/lib/segment/benches/sparse_vector_storage.rs
+++ b/lib/segment/benches/sparse_vector_storage.rs
@@ -10,9 +10,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
-use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use tempfile::Builder;
 

--- a/lib/segment/benches/sparse_vector_storage.rs
+++ b/lib/segment/benches/sparse_vector_storage.rs
@@ -10,7 +10,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -21,7 +21,7 @@ use crate::index::sparse_index::sparse_vector_index::{
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 /// Prepares a sparse vector index with a given iterator of sparse vectors
 pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -27,7 +27,7 @@ use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectorStorage, QuantizedVectors,
 };
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, VectorStorage, VectorStorageEnum,
+    DenseVectorStorage, MultiVectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 pub const ELEMENTS_PER_SUBGROUP: usize = 4;

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -738,7 +738,7 @@ mod tests {
     use crate::spaces::metric::Metric;
     use crate::spaces::simple::CosineMetric;
     use crate::types::Distance;
-    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage};
+    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorageRead};
 
     fn search_in_graph(
         query: &[VectorElementType],

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -611,7 +611,7 @@ mod tests {
     use crate::index::hnsw_index::graph_links::{GraphLinksFormat, normalize_links};
     use crate::index::hnsw_index::tests::create_graph_layer_fixture;
     use crate::types::Distance;
-    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage as _};
+    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorageRead as _};
 
     const M: usize = 8;
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
@@ -13,9 +13,7 @@ use crate::index::hnsw_index::graph_layers_builder::{GraphLayersBuilder, LockedL
 use crate::index::hnsw_index::links_container::{ItemsBuffer, LinksContainer};
 use crate::index::visited_pool::VisitedPool;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{
-    RawScorer, VectorStorageEnum, VectorStorageRead, new_raw_scorer,
-};
+use crate::vector_storage::{RawScorer, VectorStorageEnum, VectorStorageRead, new_raw_scorer};
 
 pub struct GraphLayersHealer<'a> {
     links_layers: Vec<LockedLayersContainer>,

--- a/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
@@ -13,7 +13,9 @@ use crate::index::hnsw_index::graph_layers_builder::{GraphLayersBuilder, LockedL
 use crate::index::hnsw_index::links_container::{ItemsBuffer, LinksContainer};
 use crate::index::visited_pool::VisitedPool;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{RawScorer, VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{
+    RawScorer, VectorStorageEnum, VectorStorageRead, new_raw_scorer,
+};
 
 pub struct GraphLayersHealer<'a> {
     links_layers: Vec<LockedLayersContainer>,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -69,7 +69,7 @@ use crate::types::{
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::DiscoverQuery;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead, new_raw_scorer};
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -16,7 +16,7 @@ use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsu
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
-    RawScorer, VectorStorage, VectorStorageEnum, check_deleted_condition, new_raw_scorer,
+    RawScorer, VectorStorageEnum, VectorStorageRead, check_deleted_condition, new_raw_scorer,
 };
 
 /// Scorers composition:

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -23,7 +23,7 @@ use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 #[derive(Debug)]
 pub struct PlainVectorIndex {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -22,7 +22,7 @@ use crate::types::{
     Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon,
     GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, Range, RangeInterface,
 };
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::VectorStorageRead;
 
 mod match_converter;
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -37,7 +37,9 @@ use crate::index::{PayloadIndex, VectorIndex};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, Filter, SearchParams};
 use crate::vector_storage::query::TransformInto;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum, check_deleted_condition};
+use crate::vector_storage::{
+    VectorStorage, VectorStorageEnum, VectorStorageRead, check_deleted_condition,
+};
 
 /// Whether to use the new compressed format.
 pub const USE_COMPRESSED: bool = true;

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -41,7 +41,7 @@ use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, Payload,
     PayloadContainer, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef, VectorNameBuf,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -19,7 +19,7 @@ use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, MinShould,
     OwnedPayloadRef, Payload, PayloadContainer, PayloadKeyType, VectorNameBuf,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 fn check_condition<F>(checker: &F, condition: &Condition) -> bool
 where

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -39,7 +39,7 @@ use crate::types::{
     PayloadKeyTypeRef, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
     SegmentType, SeqNumberType, VectorDataInfo, VectorName, VectorNameBuf, WithPayload, WithVector,
 };
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
 /// This is a basic implementation of the trait, meaning that it implements the _actual_ operations with data and not
 /// any kind of proxy or wrapping.

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -29,7 +29,7 @@ use crate::types::{
     SnapshotFormat, VectorName,
 };
 use crate::utils;
-use crate::vector_storage::VectorStorage;
+use crate::vector_storage::VectorStorageRead;
 
 impl Segment {
     /// Replace vectors in-place

--- a/lib/segment/src/segment/tests/test_vector_name_ops.rs
+++ b/lib/segment/src/segment/tests/test_vector_name_ops.rs
@@ -20,7 +20,7 @@ use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{
     Distance, HnswGlobalConfig, Indexes, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
-use crate::vector_storage::VectorStorage as _;
+use crate::vector_storage::VectorStorageRead as _;
 
 const DIM: usize = 4;
 const NUM_POINTS: usize = 5;

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -9,7 +9,7 @@ use common::types::PointOffsetType;
 
 use crate::data_types::named_vectors::CowVector;
 use crate::types::CompactExtendedPointId;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 const BATCH_SIZE: usize = 256;
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -53,7 +53,7 @@ use crate::types::{
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 /// Structure for constructing segment out of several other segments
 pub struct SegmentBuilder {

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -55,7 +55,7 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 pub const PAYLOAD_INDEX_PATH: &str = "payload_index";
 pub const VECTOR_STORAGE_PATH: &str = "vector_storage";

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -21,7 +21,7 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 const VECTORS_DIR_PATH: &str = "vectors";
@@ -93,7 +93,7 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
     }
 }
 
-impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorStorage<T> {
     fn distance(&self) -> Distance {
         self.distance
     }
@@ -123,6 +123,20 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice)))
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.get_bitslice()
+    }
+}
+
+impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStorage<T> {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -179,18 +193,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         Ok(self.set_deleted(key, true))
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.get_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -22,7 +22,9 @@ use crate::types::{Distance, VectorStorageDatatype};
 #[cfg(target_os = "linux")]
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectors;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
+use crate::vector_storage::{
+    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+};
 
 const VECTORS_PATH: &str = "matrix.dat";
 const DELETED_PATH: &str = "deleted.dat";

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -22,7 +22,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 #[cfg(target_os = "linux")]
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectors;
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 const VECTORS_PATH: &str = "matrix.dat";
 const DELETED_PATH: &str = "deleted.dat";
@@ -210,7 +210,7 @@ where
     }
 }
 
-impl<T, S> VectorStorage for DenseVectorStorageImpl<T, S>
+impl<T, S> VectorStorageRead for DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
     S: UniversalRead<T>,
@@ -266,6 +266,24 @@ where
             .map(|vector| T::slice_to_float_cow(vector).into())
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.vectors.as_ref().unwrap().is_deleted_vector(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.vectors.as_ref().unwrap().deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.vectors.as_ref().unwrap().deleted_vector_bitslice()
+    }
+}
+
+impl<T, S> VectorStorage for DenseVectorStorageImpl<T, S>
+where
+    T: PrimitiveVectorElement,
+    S: UniversalRead<T>,
+{
     fn insert_vector(
         &mut self,
         _key: PointOffsetType,
@@ -353,18 +371,6 @@ where
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         Ok(self.vectors.as_mut().unwrap().delete(key))
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.vectors.as_ref().unwrap().is_deleted_vector(key)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.vectors.as_ref().unwrap().deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.vectors.as_ref().unwrap().deleted_vector_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -13,7 +13,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 /// Placeholder vector storage that contains no data.
 ///
@@ -96,7 +96,7 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
     }
 }
 
-impl VectorStorage for EmptyDenseVectorStorage {
+impl VectorStorageRead for EmptyDenseVectorStorage {
     fn distance(&self) -> Distance {
         self.distance
     }
@@ -122,6 +122,20 @@ impl VectorStorage for EmptyDenseVectorStorage {
         None
     }
 
+    fn is_deleted_vector(&self, _key: PointOffsetType) -> bool {
+        true
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.num_points
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted_bitvec.as_bitslice()
+    }
+}
+
+impl VectorStorage for EmptyDenseVectorStorage {
     fn insert_vector(
         &mut self,
         _key: PointOffsetType,
@@ -153,18 +167,6 @@ impl VectorStorage for EmptyDenseVectorStorage {
 
     fn delete_vector(&mut self, _key: PointOffsetType) -> OperationResult<bool> {
         Ok(false) // Already deleted
-    }
-
-    fn is_deleted_vector(&self, _key: PointOffsetType) -> bool {
-        true
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.num_points
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted_bitvec.as_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -13,7 +13,9 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
-use crate::vector_storage::{DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
+use crate::vector_storage::{
+    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+};
 
 /// Placeholder vector storage that contains no data.
 ///

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -15,7 +15,7 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 /// In-memory vector storage that is volatile
@@ -85,7 +85,7 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
     }
 }
 
-impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage<T> {
     fn distance(&self) -> Distance {
         self.distance
     }
@@ -114,6 +114,20 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
             .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get_bit(key as usize).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+}
+
+impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -156,17 +170,5 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         let is_deleted = !self.set_deleted(key, true);
         Ok(is_deleted)
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get_bit(key as usize).unwrap_or(false)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.as_bitslice()
     }
 }

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent, MemoryReporter};
 use crate::vector_storage::vector_storage_base::{
     DenseVectorStorage as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
+    VectorStorageRead as _,
 };
 
 /// Determine the file storage intent for mmap-based vector storage.

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -28,6 +28,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
 };
 use crate::vector_storage::{
     MultiVectorStorage, VectorOffset, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 const VECTORS_DIR_PATH: &str = "vectors";
@@ -213,7 +214,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     }
 }
 
-impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVectorStorage<T> {
     fn distance(&self) -> Distance {
         self.distance
     }
@@ -240,6 +241,20 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
         })
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.get_bitslice()
+    }
+}
+
+impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVectorStorage<T> {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -344,18 +359,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         Ok(self.set_deleted(key, true))
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.get_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -17,7 +17,7 @@ use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
-    MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 /// All fields are counting vectors and not dimensions.
@@ -238,7 +238,7 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     }
 }
 
-impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileMultiDenseVectorStorage<T> {
     fn distance(&self) -> Distance {
         self.distance
     }
@@ -265,6 +265,20 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorag
         })
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get_bit(key as usize).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+}
+
+impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorage<T> {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -307,17 +321,5 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorag
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
         let is_deleted = !self.set_deleted(key, true);
         Ok(is_deleted)
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get_bit(key as usize).unwrap_or(false)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.as_bitslice()
     }
 }

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::AtomicBool;
 
-use super::{VectorStorage as _, VectorStorageRead as _};
 use super::vector_storage_base::VectorStorageEnum;
+use super::{VectorStorage as _, VectorStorageRead as _};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use super::VectorStorage as _;
+use super::{VectorStorage as _, VectorStorageRead as _};
 use super::vector_storage_base::VectorStorageEnum;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -46,8 +46,8 @@ use crate::vector_storage::quantized::quantized_ram_storage::{
     QuantizedRamStorage, QuantizedRamStorageBuilder,
 };
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, RawScorer, RawScorerImpl, VectorStorage,
-    VectorStorageEnum,
+    DenseVectorStorage, MultiVectorStorage, RawScorer, RawScorerImpl, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 pub const QUANTIZED_CONFIG_PATH: &str = "quantized.config.json";

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
-use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 /// Placeholder sparse vector storage that contains no data.
 ///
@@ -72,7 +72,7 @@ impl SparseVectorStorage for EmptySparseVectorStorage {
     }
 }
 
-impl VectorStorage for EmptySparseVectorStorage {
+impl VectorStorageRead for EmptySparseVectorStorage {
     fn distance(&self) -> Distance {
         SPARSE_VECTOR_DISTANCE
     }
@@ -98,6 +98,20 @@ impl VectorStorage for EmptySparseVectorStorage {
         None
     }
 
+    fn is_deleted_vector(&self, _key: PointOffsetType) -> bool {
+        true
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.num_points
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted_bitvec.as_bitslice()
+    }
+}
+
+impl VectorStorage for EmptySparseVectorStorage {
     fn insert_vector(
         &mut self,
         _key: PointOffsetType,
@@ -129,18 +143,6 @@ impl VectorStorage for EmptySparseVectorStorage {
 
     fn delete_vector(&mut self, _key: PointOffsetType) -> OperationResult<bool> {
         Ok(false) // Already deleted
-    }
-
-    fn is_deleted_vector(&self, _key: PointOffsetType) -> bool {
-        true
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.num_points
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted_bitvec.as_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -14,7 +14,9 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
-use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
+use crate::vector_storage::{
+    SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+};
 
 /// Placeholder sparse vector storage that contains no data.
 ///

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -19,7 +19,7 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::VectorStorageDatatype;
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
-use crate::vector_storage::{SparseVectorStorage, VectorStorage};
+use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageRead};
 
 const DELETED_DIRNAME: &str = "deleted";
 const STORAGE_DIRNAME: &str = "store";
@@ -216,7 +216,7 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
     }
 }
 
-impl VectorStorage for MmapSparseVectorStorage {
+impl VectorStorageRead for MmapSparseVectorStorage {
     fn distance(&self) -> crate::types::Distance {
         super::SPARSE_VECTOR_DISTANCE
     }
@@ -248,6 +248,20 @@ impl VectorStorage for MmapSparseVectorStorage {
         }
     }
 
+    fn is_deleted_vector(&self, key: common::types::PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.get_bitslice()
+    }
+}
+
+impl VectorStorage for MmapSparseVectorStorage {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -320,18 +334,6 @@ impl VectorStorage for MmapSparseVectorStorage {
         self.update_stored(key, None, &hw_counter)?;
 
         Ok(was_deleted)
-    }
-
-    fn is_deleted_vector(&self, key: common::types::PointOffsetType) -> bool {
-        self.deleted.get(key)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.get_bitslice()
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -13,7 +13,9 @@ use crate::common::operation_error::{OperationError, OperationResult, check_proc
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
+use crate::vector_storage::{
+    SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+};
 
 pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
 

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -13,7 +13,7 @@ use crate::common::operation_error::{OperationError, OperationResult, check_proc
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
 
@@ -131,7 +131,7 @@ impl SparseVectorStorage for VolatileSparseVectorStorage {
     }
 }
 
-impl VectorStorage for VolatileSparseVectorStorage {
+impl VectorStorageRead for VolatileSparseVectorStorage {
     fn distance(&self) -> Distance {
         SPARSE_VECTOR_DISTANCE
     }
@@ -164,6 +164,20 @@ impl VectorStorage for VolatileSparseVectorStorage {
         }
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get_bit(key as usize).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+}
+
+impl VectorStorage for VolatileSparseVectorStorage {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -211,17 +225,5 @@ impl VectorStorage for VolatileSparseVectorStorage {
             self.update_stored(key, true, old_vector.as_ref());
         }
         Ok(is_deleted)
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get_bit(key as usize).unwrap_or(false)
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.deleted.as_bitslice()
     }
 }

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -15,7 +15,7 @@ use crate::types::Distance;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage_with_uring;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
-use crate::vector_storage::vector_storage_base::VectorStorage;
+use crate::vector_storage::vector_storage_base::{VectorStorage, VectorStorageRead};
 
 #[test]
 fn async_raw_scorer_cosine() -> Result<()> {

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -29,7 +29,7 @@ use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_de
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
 };
-use crate::vector_storage::vector_storage_base::VectorStorage;
+use crate::vector_storage::vector_storage_base::{VectorStorage, VectorStorageRead};
 
 const DIMS: usize = 128;
 const NUM_POINTS: usize = 600;

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -17,7 +17,9 @@ use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_de
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
 };
-use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::{
+    DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, VectorStorageRead, new_raw_scorer,
+};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points = [

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -19,7 +19,7 @@ use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_full;
 use crate::vector_storage::multi_dense::volatile_multi_dense_vector_storage::new_volatile_multi_dense_vector_storage;
 use crate::vector_storage::{
-    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum,
+    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 #[derive(Clone, Copy)]

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::new_volatile_sparse_vector_storage;
-use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     let points: Vec<SparseVector> = vec![

--- a/lib/segment/src/vector_storage/tests/utils.rs
+++ b/lib/segment/src/vector_storage/tests/utils.rs
@@ -5,7 +5,7 @@ use rand::seq::IteratorRandom;
 
 use crate::data_types::vectors::VectorElementType;
 use crate::id_tracker::IdTracker;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
 
 pub type Result<T, E = Error> = result::Result<T, E>;
 pub type Error = Box<dyn error::Error>;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -57,10 +57,15 @@ impl VectorOffset for VectorOffsetType {
     }
 }
 
-/// Trait for vector storage
-/// El - type of vector element, expected numerical type
-/// Storage operates with internal IDs (`PointOffsetType`), which always starts with zero and have no skips
-pub trait VectorStorage {
+/// Read-only trait for vector storage.
+///
+/// Defines all read operations on vector storage. Search and retrieval logic
+/// only requires this trait, which makes it possible to implement read-only
+/// segments without duplicating storage code.
+///
+/// Storage operates with internal IDs (`PointOffsetType`), which always starts
+/// with zero and have no skips.
+pub trait VectorStorageRead {
     fn distance(&self) -> Distance;
 
     fn datatype(&self) -> VectorStorageDatatype;
@@ -74,11 +79,11 @@ pub trait VectorStorage {
 
     /// Get the number of available vectors, considering deleted points and vectors
     ///
-    /// This uses [`VectorStorage::total_vector_count`] and [`VectorStorage::deleted_vector_count`] internally.
+    /// This uses [`VectorStorageRead::total_vector_count`] and [`VectorStorageRead::deleted_vector_count`] internally.
     ///
     /// # Warning
     ///
-    /// This number may not always be accurate. See warning in [`VectorStorage::deleted_vector_count`] documentation.
+    /// This number may not always be accurate. See warning in [`VectorStorageRead::deleted_vector_count`] documentation.
     fn available_vector_count(&self) -> usize {
         self.total_vector_count()
             .saturating_sub(self.deleted_vector_count())
@@ -103,6 +108,37 @@ pub trait VectorStorage {
     /// Get the vector by the given key if it exists
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>>;
 
+    /// Check whether the vector at the given key is flagged as deleted
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool;
+
+    /// Get the number of deleted vectors, considering deleted points and vectors
+    ///
+    /// Vectors may be deleted at two levels, as point or as vector. Deleted points should
+    /// propagate to deleting the vectors. That means that the deleted vector count includes the
+    /// number of deleted points as well.
+    ///
+    /// This includes any vectors that were deleted at creation.
+    ///
+    /// # Warning
+    ///
+    /// In some very exceptional cases it is possible for this count not to include some deleted
+    /// points. That may happen when flushing a segment to disk fails. This should be recovered
+    /// when loading/recovering the segment, but that isn't guaranteed. You should therefore use
+    /// the deleted count with care.
+    fn deleted_vector_count(&self) -> usize;
+
+    /// Get [`BitSlice`] representation for deleted vectors with deletion flags
+    ///
+    /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
+    /// vectors in this segment.
+    fn deleted_vector_bitslice(&self) -> &BitSlice;
+}
+
+/// Trait for vector storage with mutating operations.
+///
+/// El - type of vector element, expected numerical type
+/// Storage operates with internal IDs (`PointOffsetType`), which always starts with zero and have no skips
+pub trait VectorStorage: VectorStorageRead {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -134,34 +170,9 @@ pub trait VectorStorage {
     ///
     /// Returns true if the vector was not deleted before and is now deleted
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool>;
-
-    /// Check whether the vector at the given key is flagged as deleted
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool;
-
-    /// Get the number of deleted vectors, considering deleted points and vectors
-    ///
-    /// Vectors may be deleted at two levels, as point or as vector. Deleted points should
-    /// propagate to deleting the vectors. That means that the deleted vector count includes the
-    /// number of deleted points as well.
-    ///
-    /// This includes any vectors that were deleted at creation.
-    ///
-    /// # Warning
-    ///
-    /// In some very exceptional cases it is possible for this count not to include some deleted
-    /// points. That may happen when flushing a segment to disk fails. This should be recovered
-    /// when loading/recovering the segment, but that isn't guaranteed. You should therefore use
-    /// the deleted count with care.
-    fn deleted_vector_count(&self) -> usize;
-
-    /// Get [`BitSlice`] representation for deleted vectors with deletion flags
-    ///
-    /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
-    /// vectors in this segment.
-    fn deleted_vector_bitslice(&self) -> &BitSlice;
 }
 
-pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
+pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]>;
@@ -200,7 +211,7 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
     }
 }
 
-pub trait SparseVectorStorage: VectorStorage {
+pub trait SparseVectorStorage: VectorStorageRead {
     fn get_sparse<P: AccessPattern>(&self, key: PointOffsetType) -> OperationResult<SparseVector>;
     fn get_sparse_opt<P: AccessPattern>(
         &self,
@@ -216,7 +227,7 @@ pub trait SparseVectorStorage: VectorStorage {
         F: FnMut(usize, SparseVector);
 }
 
-pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorage {
+pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T>;
@@ -584,7 +595,7 @@ impl VectorStorageEnum {
     }
 }
 
-impl VectorStorage for VectorStorageEnum {
+impl VectorStorageRead for VectorStorageEnum {
     fn distance(&self) -> Distance {
         match self {
             VectorStorageEnum::DenseVolatile(v) => v.distance(),
@@ -847,6 +858,116 @@ impl VectorStorage for VectorStorageEnum {
         }
     }
 
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseMemmapByte(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.is_deleted_vector(key),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.is_deleted_vector(key),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.is_deleted_vector(key),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.is_deleted_vector(key),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.is_deleted_vector(key),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::EmptyDense(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::EmptySparse(v) => v.is_deleted_vector(key),
+        }
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_count(),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.deleted_vector_count(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.deleted_vector_count(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.deleted_vector_count(),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
+            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.deleted_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::EmptyDense(v) => v.deleted_vector_count(),
+            VectorStorageEnum::EmptySparse(v) => v.deleted_vector_count(),
+        }
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_bitslice(),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.deleted_vector_bitslice(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.deleted_vector_bitslice(),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.deleted_vector_bitslice(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::EmptyDense(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::EmptySparse(v) => v.deleted_vector_bitslice(),
+        }
+    }
+}
+
+impl VectorStorage for VectorStorageEnum {
     fn insert_vector(
         &mut self,
         key: PointOffsetType,
@@ -1093,114 +1214,6 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.delete_vector(key),
             VectorStorageEnum::EmptyDense(v) => v.delete_vector(key),
             VectorStorageEnum::EmptySparse(v) => v.delete_vector(key),
-        }
-    }
-
-    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.is_deleted_vector(key),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.is_deleted_vector(key),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::DenseMemmap(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::DenseMemmapByte(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.is_deleted_vector(key),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.is_deleted_vector(key),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.is_deleted_vector(key),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.is_deleted_vector(key),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::MultiDenseVolatile(v) => v.is_deleted_vector(key),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.is_deleted_vector(key),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::EmptyDense(v) => v.is_deleted_vector(key),
-            VectorStorageEnum::EmptySparse(v) => v.is_deleted_vector(key),
-        }
-    }
-
-    fn deleted_vector_count(&self) -> usize {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_count(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_count(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_count(),
-            VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_count(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_count(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_count(),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.deleted_vector_count(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.deleted_vector_count(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.deleted_vector_count(),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_count(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_count(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
-            VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
-            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
-            VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_count(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.deleted_vector_count(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.deleted_vector_count(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_count(),
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_count(),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
-            VectorStorageEnum::EmptyDense(v) => v.deleted_vector_count(),
-            VectorStorageEnum::EmptySparse(v) => v.deleted_vector_count(),
-        }
-    }
-
-    fn deleted_vector_bitslice(&self) -> &BitSlice {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.deleted_vector_bitslice(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.deleted_vector_bitslice(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_bitslice(),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.deleted_vector_bitslice(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.deleted_vector_bitslice(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.deleted_vector_bitslice(),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_bitslice(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.deleted_vector_bitslice(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::EmptyDense(v) => v.deleted_vector_bitslice(),
-            VectorStorageEnum::EmptySparse(v) => v.deleted_vector_bitslice(),
         }
     }
 }

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -11,7 +11,7 @@ use segment::segment_constructor::simple_segment_constructor::{
     VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment,
 };
 use segment::types::{Distance, HnswGlobalConfig};
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageRead;
 use tempfile::Builder;
 
 #[test]

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -22,7 +22,7 @@ use segment::types::{
     PayloadSchemaType, Range, SearchParams, SegmentConfig, SeqNumberType, VectorDataConfig,
     VectorStorageType,
 };
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageRead;
 use tempfile::Builder;
 
 /// Check all cases with single vector per multi and several vectors per multi

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -32,7 +32,7 @@ use segment::types::{
     SegmentConfig, SeqNumberType, SparseVectorDataConfig, SparseVectorStorageType, VectorName,
     VectorStorageDatatype,
 };
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::{fixture_for_all_indices, payload_json};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};

--- a/lib/shard/src/optimizers/vacuum_optimizer.rs
+++ b/lib/shard/src/optimizers/vacuum_optimizer.rs
@@ -9,7 +9,7 @@ use segment::entry::ReadSegmentEntry;
 use segment::index::VectorIndex;
 use segment::segment::Segment;
 use segment::types::HnswGlobalConfig;
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageRead;
 
 use super::config::SegmentOptimizerConfig;
 use super::segment_optimizer::{OptimizationPlanner, SegmentOptimizer};

--- a/lib/shard/src/query/mmr/lazy_matrix.rs
+++ b/lib/shard/src/query/mmr/lazy_matrix.rs
@@ -5,7 +5,7 @@ use common::types::{PointOffsetType, ScoreType};
 use segment::common::operation_error::OperationResult;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 #[cfg(debug_assertions)]
-use segment::vector_storage::VectorStorage;
+use segment::vector_storage::VectorStorageRead;
 use segment::vector_storage::{RawScorer, VectorStorageEnum, new_raw_scorer};
 
 /// Compute the similarity matrix lazily.

--- a/lib/shard/src/query/mmr/mod.rs
+++ b/lib/shard/src/query/mmr/mod.rs
@@ -15,7 +15,9 @@ use segment::types::{Distance, MultiVectorConfig, ScoredPoint};
 use segment::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use segment::vector_storage::multi_dense::volatile_multi_dense_vector_storage::new_volatile_multi_dense_vector_storage;
 use segment::vector_storage::sparse::volatile_sparse_vector_storage::new_volatile_sparse_vector_storage;
-use segment::vector_storage::{VectorStorage as _, VectorStorageEnum, new_raw_scorer};
+use segment::vector_storage::{
+    VectorStorage as _, VectorStorageEnum, VectorStorageRead as _, new_raw_scorer,
+};
 
 use self::lazy_matrix::LazyMatrix;
 use super::MmrInternal;


### PR DESCRIPTION
# Motivation

We are on the quest to implement read-only version of the segment without duplicating any code.
To achive this, we want to use `view` pattern:

- we create an ephemeral `View` data strucure, which would only hold references to actual segment components in a form of `impl Trait`
- This view data strucutre should be the only place where search functions are implemented, so we don't duplicate any search logic code
- View data structure should be possible to construct from both: regular Segment and ReadOnlySegment.

## Steps

### Separate traits of segment components into Read + everything else


To achieve this, the first step would be to split traits of segment components into `Read` and `EverythingElse` traits.
The same way as it is done for `IdTrackerRead` and `IdTracker: IdTrackerRead` traits.
This way, we can achieve read-only version of the segment without duplicating any code.

#### Step 1: Vector Storage (this PR)

- Investigate VectorStorage trait, split it into `Read` and `EverythingElse` traits same way as id tracker
- investigate `ReadSegmentEntry for Segment` and check that there are no functions used from VectorStorage which are not part of `Read` trait

---


AI summary:

```
  Trait split in lib/segment/src/vector_storage/vector_storage_base.rs:
  - New VectorStorageRead trait with read-only methods: distance, datatype, is_on_disk, total_vector_count, available_vector_count, get_vector, read_vectors, get_vector_opt,
  is_deleted_vector, deleted_vector_count, deleted_vector_bitslice
  - VectorStorage: VectorStorageRead keeps mutating + persistence methods: insert_vector, update_from, flusher, files, immutable_files, delete_vector
  - Sub-traits DenseVectorStorage, SparseVectorStorage, MultiVectorStorage now bound on VectorStorageRead (they only have read methods)

  Impl splits for each storage (Empty/Volatile/Appendable + Dense/Sparse/Multi variants and VectorStorageEnum): each impl VectorStorage for X was split into a read-only impl
  VectorStorageRead for X and a mutating impl VectorStorage for X.

  Import updates across ~30 files to bring VectorStorageRead into scope where read methods are called.

  ReadSegmentEntry for Segment audit (lib/segment/src/segment/entry.rs): the only VectorStorage calls are read-only — available_vector_count, deleted_vector_count, total_vector_count,
  is_deleted_vector, read_vectors, is_on_disk, get_vector_opt, files, immutable_files — all of which now live on VectorStorageRead (or in the case of files/immutable_files, only used by
  snapshot paths, which are not part of ReadSegmentEntry). So the read trait is sufficient for read operations on a View.

```
