### PR TITLE
fix: handle empty local_shards in check_collection_cluster

### DIFF
--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -654,7 +654,14 @@ def check_some_replicas_not_active(peer_api_uri: str, collection_name: str) -> b
 def check_collection_cluster(peer_url, collection_name):
     res = requests.get(f"{peer_url}/collections/{collection_name}/cluster", timeout=10)
     assert_http_ok(res)
-    return res.json()["result"]['local_shards'][0]
+    local_shards = res.json()["result"]['local_shards']
+    # During snapshot shard transfer recovery the existing local shard is
+    # temporarily taken before the snapshot is installed, so `local_shards` may
+    # be empty for a brief window. Report it as a non-Active state so callers
+    # poll again instead of crashing with IndexError.
+    if not local_shards:
+        return {'state': 'Absent', 'points_count': 0}
+    return local_shards[0]
 
 
 def check_strict_mode_enabled(peer_api_uri: str, collection_name: str) -> bool:


### PR DESCRIPTION
## Summary
- `test_triple_replication` was flaky on CI with `IndexError: list index out of range`.
- Root cause: when the killed leader is restarted, the cluster recovers it via a *snapshot* shard transfer. `clear_local_for_snapshot_recovery` (`lib/collection/src/shards/replica_set/snapshots.rs`) takes the local shard before the new snapshot is installed, so for a brief window `cluster_info` returns `local_shards: []`. The test helper `check_collection_cluster` blindly indexed `[0]` and crashed.
- Fix: when `local_shards` is empty, return `{'state': 'Absent', 'points_count': 0}` so all three call sites (`test_triple_replication`, `test_two_follower_nodes_down`, `test_write_ordering`) treat it as not-yet-converged and retry within their existing 10s budget.

Logs from a failing run (`peer_0_restarted.log`) show the race clearly:
- `11:55:58.997889` — flush worker stopped (existing shard taken)
- `11:55:59.096830` — test's `GET /collections/.../cluster` returns 200 with empty `local_shards` → IndexError
- `11:55:59.205160` — snapshot recovery completes

No production code changed.

## Test plan
- [x] CI consensus test suite passes
- [ ] `test_triple_replication` no longer reports `IndexError` under load (helper now polls instead of crashing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)