### PR TITLE
fix(replica_set): release local read guard around deferred-points wait

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -35,24 +35,34 @@ use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::update_handler::{OperationData, UpdateSignal};
 use crate::update_workers::internal_update_result::InternalUpdateResult;
 
-#[async_trait]
-impl ShardOperation for LocalShard {
-    /// Imply interior mutability.
-    /// Performs update operation on this collection asynchronously.
-    /// Explicitly waits for result to be updated.
+/// Outcome of submitting an update to the worker queue.
+pub enum SubmitOutcome {
+    /// Operation was written to the WAL and dispatched to the update worker.
+    /// Awaiting the embedded receiver yields the operation's result.
+    Submitted {
+        operation_id: segment::types::SeqNumberType,
+        receiver: Option<oneshot::Receiver<CollectionResult<InternalUpdateResult>>>,
+        clock_tag: Option<crate::operations::ClockTag>,
+    },
+    /// Operation was rejected because of an outdated clock; nothing was queued.
+    ClockRejected {
+        clock_tag: Option<crate::operations::ClockTag>,
+    },
+}
+
+impl LocalShard {
+    /// Submit an update to the worker queue without waiting for completion.
     ///
-    /// # Cancel safety
-    ///
-    /// This method is cancel safe.
-    async fn update(
+    /// Holds locks only for the brief WAL write + channel send. The returned
+    /// [`SubmitOutcome::Submitted`] carries an owned `oneshot::Receiver` that
+    /// can be awaited via [`await_update_result`] after dropping any outer
+    /// read guards on the replica set.
+    pub async fn submit_update(
         &self,
         mut operation: OperationWithClockTag,
         wait: WaitUntil,
-        timeout: Option<Duration>,
         hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<UpdateResult> {
-        // `LocalShard::update` only has a single cancel safe `await`, WAL operations are blocking,
-        // and update is applied by a separate task, so, surprisingly, this method is cancel safe. :D
+    ) -> CollectionResult<SubmitOutcome> {
         let (callback_sender, callback_receiver) = if wait.needs_callback() {
             let (tx, rx) = oneshot::channel();
             (Some(tx), Some(rx))
@@ -71,89 +81,137 @@ impl ShardOperation for LocalShard {
             ));
         }
 
-        let operation_id = {
-            let _update_lock = self.update_lock.read().await;
-            let pending_operations_count = self.update_queue_length();
+        let _update_lock = self.update_lock.read().await;
+        let pending_operations_count = self.update_queue_length();
 
-            let update_sender = self.update_sender.load();
-            let channel_permit = update_sender.reserve().await?;
+        let update_sender = self.update_sender.load();
+        let channel_permit = update_sender.reserve().await?;
 
-            // It is *critical* to hold `_wal_lock` while sending operation to the update handler!
-            //
-            // TODO: Refactor `lock_and_write`, so this is less terrible? :/
-            let (operation_id, _wal_lock) = match self.wal.lock_and_write(&mut operation).await {
-                Ok(id_and_lock) => id_and_lock,
+        // It is *critical* to hold `_wal_lock` while sending operation to the update handler!
+        //
+        // TODO: Refactor `lock_and_write`, so this is less terrible? :/
+        let (operation_id, _wal_lock) = match self.wal.lock_and_write(&mut operation).await {
+            Ok(id_and_lock) => id_and_lock,
 
-                Err(shard::wal::WalError::ClockRejected) => {
-                    // Propagate clock rejection to operation sender
-                    return Ok(UpdateResult {
-                        operation_id: None,
-                        status: UpdateStatus::ClockRejected,
-                        clock_tag: operation.clock_tag,
-                    });
-                }
+            Err(shard::wal::WalError::ClockRejected) => {
+                // Propagate clock rejection to operation sender
+                return Ok(SubmitOutcome::ClockRejected {
+                    clock_tag: operation.clock_tag,
+                });
+            }
 
-                Err(err) => return Err(err.into()),
-            };
-
-            // If there are too many pending operations, don't keep operation data in RAM.
-            // Instead, read operation data from the WAL when processing the operation.
-            let keep_operation_in_ram = pending_operations_count < DEFAULT_UPDATE_QUEUE_RAM_BUFFER;
-            let operation = keep_operation_in_ram.then_some(Box::new(operation.operation));
-
-            channel_permit.send(UpdateSignal::Operation(OperationData {
-                op_num: operation_id,
-                operation,
-                sender: callback_sender,
-                wait_for_deferred: wait.wait_for_deferred(),
-                hw_measurements: hw_measurement_acc.clone(),
-            }));
-
-            operation_id
+            Err(err) => return Err(err.into()),
         };
 
-        match (callback_receiver, timeout) {
-            // Wait indefinitely
-            (Some(receiver), None) => {
-                let _ = receiver.await??;
+        // If there are too many pending operations, don't keep operation data in RAM.
+        // Instead, read operation data from the WAL when processing the operation.
+        let keep_operation_in_ram = pending_operations_count < DEFAULT_UPDATE_QUEUE_RAM_BUFFER;
+        let clock_tag = operation.clock_tag;
+        let operation_in_ram = keep_operation_in_ram.then_some(Box::new(operation.operation));
+
+        channel_permit.send(UpdateSignal::Operation(OperationData {
+            op_num: operation_id,
+            operation: operation_in_ram,
+            sender: callback_sender,
+            wait_for_deferred: wait.wait_for_deferred(),
+            hw_measurements: hw_measurement_acc,
+        }));
+
+        Ok(SubmitOutcome::Submitted {
+            operation_id,
+            receiver: callback_receiver,
+            clock_tag,
+        })
+    }
+}
+
+/// Wait for an update previously dispatched via [`LocalShard::submit_update`].
+///
+/// The future is `'static` on its inputs (no borrow on the originating shard),
+/// so the caller can drop replica-set read guards before awaiting it.
+pub async fn await_update_result(
+    outcome: SubmitOutcome,
+    timeout: Option<Duration>,
+) -> CollectionResult<UpdateResult> {
+    let (operation_id, receiver, clock_tag) = match outcome {
+        SubmitOutcome::Submitted {
+            operation_id,
+            receiver,
+            clock_tag,
+        } => (operation_id, receiver, clock_tag),
+        SubmitOutcome::ClockRejected { clock_tag } => {
+            return Ok(UpdateResult {
+                operation_id: None,
+                status: UpdateStatus::ClockRejected,
+                clock_tag,
+            });
+        }
+    };
+
+    match (receiver, timeout) {
+        // Wait indefinitely
+        (Some(receiver), None) => {
+            let _ = receiver.await??;
+            Ok(UpdateResult {
+                operation_id: Some(operation_id),
+                status: UpdateStatus::Completed,
+                clock_tag,
+            })
+        }
+        // Wait for timeout
+        (Some(receiver), Some(timeout)) => match tokio::time::timeout(timeout, receiver).await {
+            Ok(res) => {
+                let InternalUpdateResult { op_num, status } = res??;
+                debug_assert_eq!(
+                    op_num, operation_id,
+                    "Operation ID from WAL should match the one received from update worker"
+                );
                 Ok(UpdateResult {
-                    operation_id: Some(operation_id),
-                    status: UpdateStatus::Completed,
-                    clock_tag: operation.clock_tag,
+                    operation_id: Some(op_num),
+                    status,
+                    clock_tag,
                 })
             }
-            // Wait for timeout
-            (Some(receiver), Some(timeout)) => {
-                match tokio::time::timeout(timeout, receiver).await {
-                    Ok(res) => {
-                        let InternalUpdateResult { op_num, status } = res??;
-                        debug_assert_eq!(
-                            op_num, operation_id,
-                            "Operation ID from WAL should match the one received from update worker"
-                        );
-                        Ok(UpdateResult {
-                            operation_id: Some(op_num),
-                            status,
-                            clock_tag: operation.clock_tag,
-                        })
-                    }
-                    Err(elapsed) => {
-                        let _elapsed: Elapsed = elapsed;
-                        Ok(UpdateResult {
-                            operation_id: Some(operation_id),
-                            status: UpdateStatus::WaitTimeout,
-                            clock_tag: operation.clock_tag,
-                        })
-                    }
-                }
+            Err(elapsed) => {
+                let _elapsed: Elapsed = elapsed;
+                Ok(UpdateResult {
+                    operation_id: Some(operation_id),
+                    status: UpdateStatus::WaitTimeout,
+                    clock_tag,
+                })
             }
-            // Don't wait at all
-            (None, _) => Ok(UpdateResult {
-                operation_id: Some(operation_id),
-                status: UpdateStatus::Acknowledged,
-                clock_tag: operation.clock_tag,
-            }),
-        }
+        },
+        // Don't wait at all
+        (None, _) => Ok(UpdateResult {
+            operation_id: Some(operation_id),
+            status: UpdateStatus::Acknowledged,
+            clock_tag,
+        }),
+    }
+}
+
+#[async_trait]
+impl ShardOperation for LocalShard {
+    /// Imply interior mutability.
+    /// Performs update operation on this collection asynchronously.
+    /// Explicitly waits for result to be updated.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    async fn update(
+        &self,
+        operation: OperationWithClockTag,
+        wait: WaitUntil,
+        timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<UpdateResult> {
+        // `LocalShard::update` only has a single cancel safe `await`, WAL operations are blocking,
+        // and update is applied by a separate task, so, surprisingly, this method is cancel safe. :D
+        let outcome = self
+            .submit_update(operation, wait, hw_measurement_acc)
+            .await?;
+        await_update_result(outcome, timeout).await
     }
 
     /// This call is rate limited by the read rate limiter.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1084,16 +1084,10 @@ impl ShardReplicaSet {
             .collect()
     }
 
-    /// Check whether a peer is registered as `active`.
-    /// Unknown peers are not active.
-    fn peer_is_active(&self, peer_id: PeerId) -> bool {
-        // This is used *exclusively* during `execute_*_read_operation`, and so it *should* consider
-        // `ReshardingScaleDown` replicas
-        let is_active = self
-            .peer_state(peer_id)
-            .is_some_and(ReplicaState::is_active);
-
-        is_active && !self.is_locally_disabled(peer_id)
+    /// Check if peer is suitable for rate limiting
+    fn peer_is_write_rate_limitable(&self, peer_id: PeerId) -> bool {
+        self.peer_state(peer_id)
+            .is_some_and(ReplicaState::is_write_rate_limitable)
     }
 
     fn peer_is_readable(&self, peer_id: PeerId) -> bool {

--- a/lib/collection/src/shards/replica_set/replica_set_state.rs
+++ b/lib/collection/src/shards/replica_set/replica_set_state.rs
@@ -279,4 +279,39 @@ impl ReplicaState {
             | ReplicaState::ActiveRead => false,
         }
     }
+
+    pub fn is_listener(self) -> bool {
+        match self {
+            ReplicaState::Listener => true,
+            ReplicaState::Active
+            | ReplicaState::Dead
+            | ReplicaState::Partial
+            | ReplicaState::Initializing
+            | ReplicaState::PartialSnapshot
+            | ReplicaState::Recovery
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown
+            | ReplicaState::ActiveRead
+            | ReplicaState::ManualRecovery => false,
+        }
+    }
+
+    /// Does write rate limiting applicable for this state?
+    /// E.g. during resharding we expect more internal ops, so
+    /// we can't write rate limit the shard.
+    pub fn is_write_rate_limitable(self) -> bool {
+        match self {
+            ReplicaState::Active => true,
+            ReplicaState::Dead
+            | ReplicaState::Partial
+            | ReplicaState::Initializing
+            | ReplicaState::Listener
+            | ReplicaState::PartialSnapshot
+            | ReplicaState::Recovery
+            | ReplicaState::Resharding
+            | ReplicaState::ReshardingScaleDown
+            | ReplicaState::ActiveRead
+            | ReplicaState::ManualRecovery => false,
+        }
+    }
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -9,7 +9,7 @@ use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio_util::task::AbortOnDropHandle;
 
-use super::{ShardReplicaSet, clock_set};
+use super::{RemoteShard, ShardReplicaSet, clock_set};
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
 use crate::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
@@ -319,17 +319,25 @@ impl ShardReplicaSet {
         // multiple parallel updates in a way that is *guaranteed* not to introduce inconsistencies
         // between nodes, so this method is not cancel safe.
 
-        let remotes = self.remotes.read().await;
+        // Snapshot the remote shards into owned values, then drop the read guard so
+        // we don't hold `remotes.read()` across the long update await. Holding it
+        // would deadlock with `add_remote`'s `remotes.write()` on the consensus
+        // apply path (e.g. when starting a shard transfer concurrently with a
+        // wait=true update that's parked on a deferred-points wait).
+        let (updatable_remote_shards, total_remotes) = {
+            let remotes = self.remotes.read().await;
+            let updatable: Vec<RemoteShard> = remotes
+                .iter()
+                .filter(|rs| self.is_peer_updatable(rs.peer_id))
+                .cloned()
+                .collect();
+            (updatable, remotes.len())
+        };
+
         let local = self.local.read().await;
-        let replica_count = usize::from(local.is_some()) + remotes.len();
+        let replica_count = usize::from(local.is_some()) + total_remotes;
 
         let this_peer_id = self.this_peer_id();
-
-        // Target all remote peers that can receive updates
-        let updatable_remote_shards: Vec<_> = remotes
-            .iter()
-            .filter(|rs| self.is_peer_updatable(rs.peer_id))
-            .collect();
 
         // Local is defined and can receive updates
         let local_is_updatable = local.is_some() && self.is_peer_updatable(this_peer_id);
@@ -382,11 +390,12 @@ impl ShardReplicaSet {
 
             let hw_acc = hw_measurement_acc.clone();
             let remote_update = async move {
+                let peer_id = remote.peer_id;
                 remote
                     .update(operation, wait, timeout, hw_acc)
                     .await
-                    .map(|ok| (remote.peer_id, ok))
-                    .map_err(|err| (remote.peer_id, err))
+                    .map(|ok| (peer_id, ok))
+                    .map_err(|err| (peer_id, err))
             };
 
             update_futures.push(remote_update.right_future());
@@ -404,7 +413,6 @@ impl ShardReplicaSet {
         };
 
         drop(local);
-        drop(remotes);
 
         let write_consistency_factor = self
             .collection_config

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::num::NonZeroUsize;
 use std::ops::Deref as _;
 use std::time::Duration;
 
@@ -359,67 +361,95 @@ impl ShardReplicaSet {
         let current_clock_tick = clock.tick_once();
         let clock_tag = ClockTag::new(this_peer_id, clock.id() as _, current_clock_tick);
         let operation = OperationWithClockTag::new(operation, Some(clock_tag));
+        let is_listener = self
+            .peer_state(this_peer_id)
+            .is_some_and(ReplicaState::is_listener);
 
-        let mut update_futures = Vec::with_capacity(updatable_remote_shards.len() + 1);
+        let local_wait = if is_listener { WaitUntil::Wal } else { wait };
 
-        if let Some(local) = local.deref()
-            && self.is_peer_updatable(this_peer_id)
+        // Rate-limit local writes on Active replica, while we still hold the read guard.
+        if local_is_updatable
+            && self.peer_is_write_rate_limitable(this_peer_id)
+            && let Some(shard) = local.deref()
         {
-            let local_wait = if self.peer_state(this_peer_id) == Some(ReplicaState::Listener) {
-                WaitUntil::Wal
-            } else {
-                wait
-            };
+            self.check_operation_write_rate_limiter(&hw_measurement_acc, shard, &operation)
+                .await?;
+        }
 
-            if self.peer_is_active(this_peer_id) {
-                // Check write rate limiter before proceeding if replica active
-                self.check_operation_write_rate_limiter(&hw_measurement_acc, local, &operation)
+        let update_concurrency = self.shared_storage_config.update_concurrency;
+
+        // Build remote update futures up front; they're identical between the
+        // two local-dispatch paths and don't borrow from the local read guard.
+        let remote_futures: Vec<_> = updatable_remote_shards
+            .into_iter()
+            .map(|remote| {
+                let operation = operation.clone();
+                let hw_acc = hw_measurement_acc.clone();
+                async move {
+                    let peer_id = remote.peer_id;
+                    remote
+                        .update(operation, wait, timeout, hw_acc)
+                        .await
+                        .map(|ok| (peer_id, ok))
+                        .map_err(|err| (peer_id, err))
+                }
+            })
+            .collect();
+
+        // For a plain `Shard::Local`, submit the operation while the read
+        // guard is held (brief), then drop the guard before awaiting
+        // completion. Holding the guard across a deferred-points wait would
+        // deadlock concurrent shard transfers that need `local.write()`.
+        // Proxy variants are transient and keep the inline-await path.
+        let all_res: Vec<Result<(PeerId, UpdateResult), (PeerId, CollectionError)>> = match local
+            .deref()
+        {
+            Some(Shard::Local(local_shard)) if local_is_updatable => {
+                let outcome = local_shard
+                    .submit_update(operation, local_wait, hw_measurement_acc)
                     .await?;
+                drop(local);
+
+                let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
+                let local_update = async move {
+                    await_update_result(outcome, timeout)
+                        .await
+                        .map(|ok| (this_peer_id, ok))
+                        .map_err(|err| (this_peer_id, err))
+                };
+                update_futures.push(local_update.left_future());
+                update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
+
+                run_update_futures(update_futures, update_concurrency).await
             }
+            None
+            | Some(Shard::Local(_))
+            | Some(Shard::Proxy(_))
+            | Some(Shard::ForwardProxy(_))
+            | Some(Shard::QueueProxy(_))
+            | Some(Shard::Dummy(_)) => {
+                let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
 
-            let operation = operation.clone();
+                if let Some(shard) = local.deref()
+                    && local_is_updatable
+                {
+                    let local_update = async move {
+                        shard
+                            .get()
+                            .update(operation, local_wait, timeout, hw_measurement_acc)
+                            .await
+                            .map(|ok| (this_peer_id, ok))
+                            .map_err(|err| (this_peer_id, err))
+                    };
+                    update_futures.push(local_update.left_future());
+                }
+                update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
 
-            let hw_acc = hw_measurement_acc.clone();
-            let local_update = async move {
-                local
-                    .get()
-                    .update(operation, local_wait, timeout, hw_acc)
-                    .await
-                    .map(|ok| (this_peer_id, ok))
-                    .map_err(|err| (this_peer_id, err))
-            };
-
-            update_futures.push(local_update.left_future());
-        }
-
-        for remote in updatable_remote_shards {
-            let operation = operation.clone();
-
-            let hw_acc = hw_measurement_acc.clone();
-            let remote_update = async move {
-                let peer_id = remote.peer_id;
-                remote
-                    .update(operation, wait, timeout, hw_acc)
-                    .await
-                    .map(|ok| (peer_id, ok))
-                    .map_err(|err| (peer_id, err))
-            };
-
-            update_futures.push(remote_update.right_future());
-        }
-
-        let all_res: Vec<Result<_, _>> = match self.shared_storage_config.update_concurrency {
-            Some(concurrency) => {
-                futures::stream::iter(update_futures)
-                    .buffer_unordered(concurrency.get())
-                    .collect()
-                    .await
+                let res = run_update_futures(update_futures, update_concurrency).await;
+                drop(local);
+                res
             }
-
-            None => FuturesUnordered::from_iter(update_futures).collect().await,
         };
-
-        drop(local);
 
         let write_consistency_factor = self
             .collection_config
@@ -803,6 +833,25 @@ impl ShardReplicaSet {
             Some(local) => local.plunge_async().await.map(Some),
             None => Ok(None),
         }
+    }
+}
+
+/// Drive a batch of update futures, optionally limiting concurrency.
+async fn run_update_futures<F>(
+    update_futures: Vec<F>,
+    update_concurrency: Option<NonZeroUsize>,
+) -> Vec<Result<(PeerId, UpdateResult), (PeerId, CollectionError)>>
+where
+    F: Future<Output = Result<(PeerId, UpdateResult), (PeerId, CollectionError)>>,
+{
+    match update_concurrency {
+        Some(concurrency) => {
+            futures::stream::iter(update_futures)
+                .buffer_unordered(concurrency.get())
+                .collect()
+                .await
+        }
+        None => FuturesUnordered::from_iter(update_futures).collect().await,
     }
 }
 

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -13,6 +13,7 @@ use super::{RemoteShard, ShardReplicaSet, clock_set};
 use crate::operations::point_ops::WriteOrdering;
 use crate::operations::types::{CollectionError, CollectionResult, UpdateResult, UpdateStatus};
 use crate::operations::{ClockTag, CollectionUpdateOperations, OperationWithClockTag};
+use crate::shards::local_shard::shard_ops::await_update_result;
 use crate::shards::replica_set::clock_set::ClockGuard;
 use crate::shards::replica_set::replica_set_state::{ReplicaSetState, ReplicaState};
 use crate::shards::shard::{PeerId, Shard};
@@ -48,7 +49,7 @@ impl ShardReplicaSet {
 
         let local = self.local.read().await;
 
-        let Some(local) = local.deref() else {
+        let Some(shard) = local.deref() else {
             return Ok(None);
         };
 
@@ -61,74 +62,80 @@ impl ShardReplicaSet {
             hw_measurement = HwMeasurementAcc::disposable();
         }
 
-        let result = match state {
-            ReplicaState::Active => {
-                // Rate limit update operations on Active replica
-                self.check_operation_write_rate_limiter(&hw_measurement, local, &operation)
-                    .await?;
-                local
-                    .get()
-                    .update(operation, wait, timeout, hw_measurement)
-                    .await
-            }
-
-            // Force apply the operation no matter the state
-            _ if force => {
-                local
-                    .get()
-                    .update(operation, wait, timeout, hw_measurement)
-                    .await
-            }
-
-            ReplicaState::Partial
+        // Decide whether to apply the operation in the current replica state.
+        // `force` and a force-tagged clock both bypass the recovery-state guard.
+        let accepts_operation = match state {
+            ReplicaState::Active
+            | ReplicaState::Partial
             | ReplicaState::Initializing
+            | ReplicaState::Listener
             | ReplicaState::Resharding
             | ReplicaState::ReshardingScaleDown
-            | ReplicaState::ActiveRead => {
-                local
-                    .get()
-                    .update(operation, wait, timeout, hw_measurement)
-                    .await
-            }
-
-            ReplicaState::Listener => {
-                local
-                    .get()
-                    .update(operation, WaitUntil::Wal, None, hw_measurement)
-                    .await
-            }
-
-            ReplicaState::PartialSnapshot | ReplicaState::Recovery
-                if operation.clock_tag.is_some_and(|tag| tag.force) =>
-            {
-                local
-                    .get()
-                    .update(operation, wait, timeout, hw_measurement)
-                    .await
-            }
-
+            | ReplicaState::ActiveRead => true,
+            // Recovery states only accept updates with an explicit force flag.
             ReplicaState::PartialSnapshot | ReplicaState::Recovery => {
-                if log::log_enabled!(log::Level::Debug) {
-                    if let Some(ids) = operation.operation.point_ids() {
-                        log::debug!(
-                            "Operation affecting point IDs {ids:?} rejected on this peer, force flag required in recovery state",
-                        );
-                    } else {
-                        log::debug!(
-                            "Operation {operation:?} rejected on this peer, force flag required in recovery state",
-                        );
-                    }
-                }
-
-                return Ok(None);
+                force || operation.clock_tag.is_some_and(|tag| tag.force)
             }
+            // Dead/ManualRecovery only accept updates when the caller forces.
+            ReplicaState::Dead | ReplicaState::ManualRecovery => force,
+        };
 
-            ReplicaState::Dead | ReplicaState::ManualRecovery => {
-                return Ok(None);
+        if !accepts_operation {
+            if matches!(
+                state,
+                ReplicaState::PartialSnapshot | ReplicaState::Recovery
+            ) && log::log_enabled!(log::Level::Debug)
+            {
+                if let Some(ids) = operation.operation.point_ids() {
+                    log::debug!(
+                        "Operation affecting point IDs {ids:?} rejected on this peer, force flag required in recovery state",
+                    );
+                } else {
+                    log::debug!(
+                        "Operation {operation:?} rejected on this peer, force flag required in recovery state",
+                    );
+                }
+            }
+            return Ok(None);
+        }
+
+        // Listener replicas only durably ack to WAL; everything else honours
+        // the caller-supplied wait/timeout. `force` overrides this — the
+        // caller takes responsibility for choosing the wait semantics.
+        let (effective_wait, effective_timeout) = if state.is_listener() {
+            (WaitUntil::Wal, None)
+        } else {
+            (wait, timeout)
+        };
+
+        // Rate limit update operations on Active replica.
+        if state.is_write_rate_limitable() {
+            self.check_operation_write_rate_limiter(&hw_measurement, shard, &operation)
+                .await?;
+        }
+
+        // For a plain `Shard::Local`, submit the operation while the read
+        // guard is held (brief), then drop the guard before awaiting
+        // completion. Holding the guard across a deferred-points wait would
+        // deadlock concurrent shard transfers that need `local.write()`.
+        // Proxy variants are transient and keep the inline-await path.
+        let result = match shard {
+            Shard::Local(local_shard) => {
+                let outcome = local_shard
+                    .submit_update(operation, effective_wait, hw_measurement)
+                    .await?;
+                drop(local);
+                await_update_result(outcome, effective_timeout).await?
+            }
+            Shard::Proxy(_) | Shard::ForwardProxy(_) | Shard::QueueProxy(_) | Shard::Dummy(_) => {
+                shard
+                    .get()
+                    .update(operation, effective_wait, effective_timeout, hw_measurement)
+                    .await?
             }
         };
 
-        result.map(Some)
+        Ok(Some(result))
     }
 
     /// # Cancel safety

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -401,55 +401,54 @@ impl ShardReplicaSet {
         // completion. Holding the guard across a deferred-points wait would
         // deadlock concurrent shard transfers that need `local.write()`.
         // Proxy variants are transient and keep the inline-await path.
-        let all_res: Vec<Result<(PeerId, UpdateResult), (PeerId, CollectionError)>> = match local
-            .deref()
-        {
-            Some(Shard::Local(local_shard)) if local_is_updatable => {
-                let outcome = local_shard
-                    .submit_update(operation, local_wait, hw_measurement_acc)
-                    .await?;
-                drop(local);
+        let all_res: Vec<Result<(PeerId, UpdateResult), (PeerId, CollectionError)>> =
+            match local.deref() {
+                Some(Shard::Local(local_shard)) if local_is_updatable => {
+                    let outcome = local_shard
+                        .submit_update(operation, local_wait, hw_measurement_acc)
+                        .await?;
+                    drop(local);
 
-                let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
-                let local_update = async move {
-                    await_update_result(outcome, timeout)
-                        .await
-                        .map(|ok| (this_peer_id, ok))
-                        .map_err(|err| (this_peer_id, err))
-                };
-                update_futures.push(local_update.left_future());
-                update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
-
-                run_update_futures(update_futures, update_concurrency).await
-            }
-            None
-            | Some(Shard::Local(_))
-            | Some(Shard::Proxy(_))
-            | Some(Shard::ForwardProxy(_))
-            | Some(Shard::QueueProxy(_))
-            | Some(Shard::Dummy(_)) => {
-                let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
-
-                if let Some(shard) = local.deref()
-                    && local_is_updatable
-                {
+                    let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
                     let local_update = async move {
-                        shard
-                            .get()
-                            .update(operation, local_wait, timeout, hw_measurement_acc)
+                        await_update_result(outcome, timeout)
                             .await
                             .map(|ok| (this_peer_id, ok))
                             .map_err(|err| (this_peer_id, err))
                     };
                     update_futures.push(local_update.left_future());
-                }
-                update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
+                    update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
 
-                let res = run_update_futures(update_futures, update_concurrency).await;
-                drop(local);
-                res
-            }
-        };
+                    run_update_futures(update_futures, update_concurrency).await
+                }
+                None
+                | Some(Shard::Local(_))
+                | Some(Shard::Proxy(_))
+                | Some(Shard::ForwardProxy(_))
+                | Some(Shard::QueueProxy(_))
+                | Some(Shard::Dummy(_)) => {
+                    let mut update_futures = Vec::with_capacity(remote_futures.len() + 1);
+
+                    if let Some(shard) = local.deref()
+                        && local_is_updatable
+                    {
+                        let local_update = async move {
+                            shard
+                                .get()
+                                .update(operation, local_wait, timeout, hw_measurement_acc)
+                                .await
+                                .map(|ok| (this_peer_id, ok))
+                                .map_err(|err| (this_peer_id, err))
+                        };
+                        update_futures.push(local_update.left_future());
+                    }
+                    update_futures.extend(remote_futures.into_iter().map(|f| f.right_future()));
+
+                    let res = run_update_futures(update_futures, update_concurrency).await;
+                    drop(local);
+                    res
+                }
+            };
 
         let write_consistency_factor = self
             .collection_config

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -102,8 +102,7 @@ impl ShardReplicaSet {
         }
 
         // Listener replicas only durably ack to WAL; everything else honours
-        // the caller-supplied wait/timeout. `force` overrides this — the
-        // caller takes responsibility for choosing the wait semantics.
+        // the caller-supplied wait/timeout.
         let (effective_wait, effective_timeout) = if state.is_listener() {
             (WaitUntil::Wal, None)
         } else {

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -159,7 +159,7 @@ impl UpdateWorkers {
                     }
 
                     if wait_for_deferred && prevent_unoptimized {
-                        if let Some(feedback) = sender {
+                        if let Some(mut feedback) = sender {
                             // Detach the deferred-points wait so only the originating
                             // client waits — the update queue keeps draining.
                             let segments = segments.clone();
@@ -173,7 +173,7 @@ impl UpdateWorkers {
                                     &optimize_sender,
                                     &mut optimization_finished_receiver,
                                     &cancel,
-                                    Some(&feedback),
+                                    &mut feedback,
                                 )
                                 .await
                                 {
@@ -243,18 +243,9 @@ impl UpdateWorkers {
         optimize_sender: &Sender<OptimizerSignal>,
         optimization_finished_receiver: &mut watch::Receiver<()>,
         cancel: &CancellationToken,
-        feedback_sender: Option<&oneshot::Sender<CollectionResult<InternalUpdateResult>>>,
+        feedback_sender: &mut oneshot::Sender<CollectionResult<InternalUpdateResult>>,
     ) -> CollectionResult<()> {
         loop {
-            // If the caller dropped their receiver (e.g. client timeout),
-            // stop waiting since there is no one left to report to.
-            if feedback_sender.is_some_and(|s| s.is_closed()) {
-                log::debug!("wait_for_deferred_points_ready: caller no longer waiting");
-                return Err(CollectionError::cancelled(
-                    "Deferred points wait interrupted: caller timed out",
-                ));
-            }
-
             let locked_segments = segments.clone();
             let has_deferred_points =
                 AbortOnDropHandle::new(tokio::task::spawn_blocking(move || {
@@ -278,8 +269,11 @@ impl UpdateWorkers {
             let _ = optimize_sender.try_send(OptimizerSignal::Nop);
 
             // Wait for the optimizer to check conditions or complete an optimization.
-            // Also check cancellation so we don't block forever if the update handler
-            // is restarted (e.g. config change via consensus).
+            // Also wake up if the update handler is restarted (e.g. config change via
+            // consensus) or the caller's receiver is dropped (e.g. update_local's
+            // outer timeout fired). Without the `closed()` branch, this select would
+            // park forever under max_optimization_threads=0 (the optimizer skips
+            // without notifying), leaking the detached task.
             log::debug!("waiting for optimization to allow updates");
             tokio::select! {
                 biased;
@@ -287,6 +281,12 @@ impl UpdateWorkers {
                     log::debug!("wait_for_deferred_points_ready: update worker cancelled");
                     return Err(CollectionError::cancelled(
                         "Deferred points wait interrupted: update worker restarted"
+                    ));
+                }
+                _ = feedback_sender.closed() => {
+                    log::debug!("wait_for_deferred_points_ready: caller no longer waiting");
+                    return Err(CollectionError::cancelled(
+                        "Deferred points wait interrupted: caller timed out",
                     ));
                 }
                 result = optimization_finished_receiver.changed() => {

--- a/tests/consensus_tests/test_shard_transfer_deferred.py
+++ b/tests/consensus_tests/test_shard_transfer_deferred.py
@@ -110,13 +110,17 @@ def trigger_upsert_wait_true(source_uri, total_points):
     The config change (enabling optimizers) propagates through Raft and restarts
     the update workers, cancelling the old worker's deferred wait loop. Retries
     handle the transition period where the old worker may return wait_timeout.
+
+    A `timeout` query parameter is set so the server reports per-shard
+    wait_timeout in the response body (HTTP 200) instead of converting it
+    into a top-level 408 error — see point_ops.rs `is_user_timeout`.
     """
     for attempt in range(10):
         try:
             r = requests.put(
-                f"{source_uri}/collections/{COLLECTION_NAME}/points?wait=true",
+                f"{source_uri}/collections/{COLLECTION_NAME}/points?wait=true&timeout=10",
                 json={"points": make_points(total_points + 1, 1)},
-                timeout=30,
+                timeout=60,
             )
         except requests.exceptions.ReadTimeout:
             # Server still processing, retry — the update is durably applied regardless


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/8860>

There are 3 fixes, in this PR, here is a history:

(I)

It seems, that `wait_for_deferred_points_ready` was not properly checking that `feedback_sender` is closed.
There were a situation, when `feedback_sender` was closed, but neither cancel token (which works only on worker thread itself) nor `optimization_finished_receiver` (as optimizers were disabled) were not triggering.

As a result, even with specified timeout, we could never finish `wait_for_deferred_points_ready`.

The fix is to include `feedback_sender` into proper await place. This, however, didn't completely solve the problem in test (it could only solve problem, if user specified server-side timeout, and not client-side):

(II)

Apparently, when client closes connection to update operation, it doesn't cancel the future and, therefore, doesn't cancel callback_sender passed to update worker.
As a result, it create another:

If we have remote shard, it can stuck waiting for update result for up to 60 seconds, which will block the list of remotes, and potentially block the consensus (that happens in `test_shard_transfer_with_hung_deferred_wait_does_not_deadlock`, and is fixed by snapshoting references to remote shards, as it is done in this PR).

(III)

Third problem happens, when we realize, that update operation can still be blocked for a long time, even with previous changes and timeout (60 seconds).
The submitter of update operation might await indefinitelly (worst case) or up to 60 seconds (expected case).

This is too long, as we are now blocking local shard read lock for longer than before (and longer than necessary) for a simple await.

The solution: split operaionss into submit(fast) and await(slow, but doesn't actually require lock) operation.

