### PR TITLE
refactor(segment): migrate facets to SegmentReadView (step 8)

### DIFF
--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -40,11 +40,87 @@ pub trait FacetIndex {
     ) -> OperationResult<()>;
 }
 
+/// Read-only abstraction over a per-key facet index.
+///
+/// Mirrors the inherent methods of [`FacetIndexEnum`] so that facet code
+/// can be written against any concrete facet-index representation (today
+/// the appendable `FacetIndexEnum`; tomorrow whatever the read-only
+/// segment exposes).
+pub trait FacetIndexRead {
+    fn for_points_values(
+        &self,
+        points: impl Iterator<Item = PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
+    ) -> OperationResult<()>;
+
+    fn for_each_value(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()>;
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(
+            FacetValueRef<'_>,
+            &mut dyn Iterator<Item = PointOffsetType>,
+        ) -> OperationResult<()>,
+    ) -> OperationResult<()>;
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
+    ) -> OperationResult<()>;
+}
+
 pub enum FacetIndexEnum<'a> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
     Bool(&'a BoolIndex),
+}
+
+impl<'a> FacetIndexRead for FacetIndexEnum<'a> {
+    fn for_points_values(
+        &self,
+        points: impl Iterator<Item = PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
+    ) -> OperationResult<()> {
+        FacetIndexEnum::for_points_values(self, points, hw_counter, f)
+    }
+
+    fn for_each_value(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        FacetIndexEnum::for_each_value(self, hw_counter, deferred_internal_id, f)
+    }
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(
+            FacetValueRef<'_>,
+            &mut dyn Iterator<Item = PointOffsetType>,
+        ) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        FacetIndexEnum::for_each_value_map(self, hw_counter, f)
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        FacetIndexEnum::for_each_count_per_value(self, deferred_internal_id, f)
+    }
 }
 
 impl<'a> FacetIndexEnum<'a> {

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -38,43 +38,35 @@ pub trait FacetIndex {
         deferred_internal_id: Option<PointOffsetType>,
         f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
     ) -> OperationResult<()>;
-}
 
-/// Read-only abstraction over a per-key facet index.
-///
-/// Mirrors the inherent methods of [`FacetIndexEnum`] so that facet code
-/// can be written against any concrete facet-index representation (today
-/// the appendable `FacetIndexEnum`; tomorrow whatever the read-only
-/// segment exposes).
-pub trait FacetIndexRead {
-    fn for_points_values(
-        &self,
-        points: impl Iterator<Item = PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-        f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
-    ) -> OperationResult<()>;
-
-    fn for_each_value(
+    /// Like [`for_each_value`] but skips values whose only points are deferred.
+    ///
+    /// When `deferred_internal_id` is `None`, this is equivalent to
+    /// [`for_each_value`]. When `Some(threshold)`, a value is reported only if
+    /// it has at least one point with internal id `< threshold`.
+    fn for_each_visible_value(
         &self,
         hw_counter: &HardwareCounterCell,
         deferred_internal_id: Option<PointOffsetType>,
-        f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
-    ) -> OperationResult<()>;
+        mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match deferred_internal_id {
+            Some(deferred_internal_id) => {
+                self.for_each_value_map(hw_counter, |facet_value, id_iter| {
+                    let has_visible_point = id_iter
+                        .take_while(|&id| id < deferred_internal_id)
+                        .next()
+                        .is_some();
 
-    fn for_each_value_map(
-        &self,
-        hw_counter: &HardwareCounterCell,
-        f: impl FnMut(
-            FacetValueRef<'_>,
-            &mut dyn Iterator<Item = PointOffsetType>,
-        ) -> OperationResult<()>,
-    ) -> OperationResult<()>;
-
-    fn for_each_count_per_value(
-        &self,
-        deferred_internal_id: Option<PointOffsetType>,
-        f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
-    ) -> OperationResult<()>;
+                    if has_visible_point {
+                        f(facet_value)?;
+                    }
+                    Ok(())
+                })
+            }
+            None => self.for_each_value(f),
+        }
+    }
 }
 
 pub enum FacetIndexEnum<'a> {
@@ -84,47 +76,8 @@ pub enum FacetIndexEnum<'a> {
     Bool(&'a BoolIndex),
 }
 
-impl<'a> FacetIndexRead for FacetIndexEnum<'a> {
+impl<'a> FacetIndex for FacetIndexEnum<'a> {
     fn for_points_values(
-        &self,
-        points: impl Iterator<Item = PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-        f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
-    ) -> OperationResult<()> {
-        FacetIndexEnum::for_points_values(self, points, hw_counter, f)
-    }
-
-    fn for_each_value(
-        &self,
-        hw_counter: &HardwareCounterCell,
-        deferred_internal_id: Option<PointOffsetType>,
-        f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
-    ) -> OperationResult<()> {
-        FacetIndexEnum::for_each_value(self, hw_counter, deferred_internal_id, f)
-    }
-
-    fn for_each_value_map(
-        &self,
-        hw_counter: &HardwareCounterCell,
-        f: impl FnMut(
-            FacetValueRef<'_>,
-            &mut dyn Iterator<Item = PointOffsetType>,
-        ) -> OperationResult<()>,
-    ) -> OperationResult<()> {
-        FacetIndexEnum::for_each_value_map(self, hw_counter, f)
-    }
-
-    fn for_each_count_per_value(
-        &self,
-        deferred_internal_id: Option<PointOffsetType>,
-        f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
-    ) -> OperationResult<()> {
-        FacetIndexEnum::for_each_count_per_value(self, deferred_internal_id, f)
-    }
-}
-
-impl<'a> FacetIndexEnum<'a> {
-    pub fn for_points_values(
         &self,
         points: impl Iterator<Item = PointOffsetType>,
         hw_counter: &HardwareCounterCell,
@@ -146,36 +99,19 @@ impl<'a> FacetIndexEnum<'a> {
         }
     }
 
-    pub fn for_each_value(
+    fn for_each_value(
         &self,
-        hw_counter: &HardwareCounterCell,
-        deferred_internal_id: Option<PointOffsetType>,
-        mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+        f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        match deferred_internal_id {
-            Some(deferred_internal_id) => {
-                self.for_each_value_map(hw_counter, |facet_value, id_iter| {
-                    let has_visible_point = id_iter
-                        .take_while(|&id| id < deferred_internal_id)
-                        .next()
-                        .is_some();
-
-                    if has_visible_point {
-                        f(facet_value)?;
-                    }
-                    Ok(())
-                })
-            }
-            None => match self {
-                FacetIndexEnum::Keyword(index) => FacetIndex::for_each_value(*index, f),
-                FacetIndexEnum::Int(index) => FacetIndex::for_each_value(*index, f),
-                FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value(*index, f),
-                FacetIndexEnum::Bool(index) => FacetIndex::for_each_value(*index, f),
-            },
+        match self {
+            FacetIndexEnum::Keyword(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::Int(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::Bool(index) => FacetIndex::for_each_value(*index, f),
         }
     }
 
-    pub fn for_each_value_map(
+    fn for_each_value_map(
         &self,
         hw_counter: &HardwareCounterCell,
         f: impl FnMut(
@@ -191,7 +127,7 @@ impl<'a> FacetIndexEnum<'a> {
         }
     }
 
-    pub fn for_each_count_per_value(
+    fn for_each_count_per_value(
         &self,
         deferred_internal_id: Option<PointOffsetType>,
         f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -25,6 +25,7 @@ mod stored_point_to_values;
 mod tests;
 mod utils;
 
+pub use facet_index::FacetIndexRead;
 pub use field_index_base::*;
 
 use crate::utils::maybe_arc::MaybeArc;

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -25,7 +25,7 @@ mod stored_point_to_values;
 mod tests;
 mod utils;
 
-pub use facet_index::FacetIndexRead;
+pub use facet_index::FacetIndex;
 pub use field_index_base::*;
 
 use crate::utils::maybe_arc::MaybeArc;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -20,6 +21,7 @@ use parking_lot::Mutex;
 use rand::Rng;
 use rayon::ThreadPool;
 use rayon::prelude::*;
+use sparse::common::types::DimId;
 
 #[cfg(feature = "gpu")]
 use super::gpu::gpu_devices_manager::LockedGpuDevice;
@@ -1604,6 +1606,14 @@ impl VectorIndexRead for HNSWIndex {
         self.vector_storage
             .borrow()
             .size_of_available_vectors_in_bytes()
+    }
+
+    fn fill_idf_statistics(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
+    ) {
+        // HNSW (dense) index doesn't track IDF.
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1615,6 +1615,10 @@ impl VectorIndexRead for HNSWIndex {
     ) {
         // HNSW (dense) index doesn't track IDF.
     }
+
+    fn is_index(&self) -> bool {
+        true
+    }
 }
 
 impl VectorIndex for HNSWIndex {

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -2,11 +2,14 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::PointOffsetType;
+use common::types::{PointOffsetType, ScoreType};
 use serde_json::Value;
 
 use super::field_index::{FacetIndex, FieldIndex, NumericFieldIndexRead};
+use super::query_optimization::rescore_formula::FormulaScorerRead;
+use super::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
@@ -85,6 +88,16 @@ pub trait PayloadIndexRead {
     /// Used by faceting to enumerate values and per-value point sets. The
     /// concrete facet-index type is opaque per implementation.
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_>;
+
+    /// Build a per-query formula scorer that evaluates the given parsed
+    /// formula against this index's payload, using the prefetch scores as
+    /// extra inputs.
+    fn formula_scorer<'q>(
+        &'q self,
+        parsed_formula: &'q ParsedFormula,
+        prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
+        hw_counter: &'q HardwareCounterCell,
+    ) -> OperationResult<impl FormulaScorerRead + 'q>;
 
     /// Iterate point offsets that match the filter.
     ///

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
-use super::field_index::{FieldIndex, NumericFieldIndexRead};
+use super::field_index::{FacetIndexRead, FieldIndex, NumericFieldIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
@@ -79,6 +79,12 @@ pub trait PayloadIndexRead {
     /// The concrete numeric-index type is opaque so each implementation can
     /// expose its own internal representation.
     fn numeric_index_for(&self, key: &PayloadKeyType) -> Option<impl NumericFieldIndexRead + '_>;
+
+    /// Look up a facet index for the given payload key, if one exists.
+    ///
+    /// Used by faceting to enumerate values and per-value point sets. The
+    /// concrete facet-index type is opaque per implementation.
+    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndexRead + '_>;
 
     /// Iterate point offsets that match the filter.
     ///

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -8,7 +8,7 @@ use common::types::{PointOffsetType, ScoreType};
 use serde_json::Value;
 
 use super::field_index::{FacetIndex, FieldIndex, NumericFieldIndexRead};
-use super::query_optimization::rescore_formula::FormulaScorerRead;
+use super::query_optimization::rescore_formula::FormulaScorer;
 use super::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
@@ -97,7 +97,7 @@ pub trait PayloadIndexRead {
         parsed_formula: &'q ParsedFormula,
         prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
         hw_counter: &'q HardwareCounterCell,
-    ) -> OperationResult<impl FormulaScorerRead + 'q>;
+    ) -> OperationResult<FormulaScorer<'q>>;
 
     /// Iterate point offsets that match the filter.
     ///

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
-use super::field_index::{FacetIndexRead, FieldIndex, NumericFieldIndexRead};
+use super::field_index::{FacetIndex, FieldIndex, NumericFieldIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
@@ -84,7 +84,7 @@ pub trait PayloadIndexRead {
     ///
     /// Used by faceting to enumerate values and per-value point sets. The
     /// concrete facet-index type is opaque per implementation.
-    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndexRead + '_>;
+    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_>;
 
     /// Iterate point offsets that match the filter.
     ///

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -16,6 +16,7 @@ use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
+use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 pub enum BuildIndexResult {
@@ -88,6 +89,9 @@ pub trait PayloadIndexRead {
     /// Used by faceting to enumerate values and per-value point sets. The
     /// concrete facet-index type is opaque per implementation.
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_>;
+
+    /// Per-field-index telemetry data.
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry>;
 
     /// Build a per-query formula scorer that evaluates the given parsed
     /// formula against this index's payload, using the prefetch scores as

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -15,8 +15,10 @@ use super::payload_config::PayloadFieldSchemaWithIndexType;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, PointMappingsRefEnum};
+use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::{
-    CardinalityEstimation, NumericFieldIndex, NumericFieldIndexRead, PayloadBlockCondition,
+    CardinalityEstimation, FacetIndexRead, NumericFieldIndex, NumericFieldIndexRead,
+    PayloadBlockCondition,
 };
 use crate::index::payload_config::PayloadConfig;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
@@ -163,6 +165,11 @@ impl PayloadIndexRead for PlainPayloadIndex {
     fn numeric_index_for(&self, _key: &PayloadKeyType) -> Option<impl NumericFieldIndexRead + '_> {
         // Plain index has no field indexes; the type tag is just a placeholder.
         None::<NumericFieldIndex<'_>>
+    }
+
+    fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndexRead + '_> {
+        // Plain index has no field indexes; the type tag is just a placeholder.
+        None::<FacetIndexEnum<'_>>
     }
 
     fn iter_filtered_points<'a, I: IdTrackerRead>(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -17,7 +17,7 @@ use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::{
-    CardinalityEstimation, FacetIndexRead, NumericFieldIndex, NumericFieldIndexRead,
+    CardinalityEstimation, FacetIndex, NumericFieldIndex, NumericFieldIndexRead,
     PayloadBlockCondition,
 };
 use crate::index::payload_config::PayloadConfig;
@@ -167,7 +167,7 @@ impl PayloadIndexRead for PlainPayloadIndex {
         None::<NumericFieldIndex<'_>>
     }
 
-    fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndexRead + '_> {
+    fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndex + '_> {
         // Plain index has no field indexes; the type tag is just a placeholder.
         None::<FacetIndexEnum<'_>>
     }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -3,17 +3,18 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
-use common::types::PointOffsetType;
+use common::types::{PointOffsetType, ScoreType};
 use fs_err as fs;
 use schemars::_serde_json::Value;
 
 use super::field_index::FieldIndex;
 use super::payload_config::PayloadFieldSchemaWithIndexType;
 use crate::common::Flusher;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::{
@@ -21,6 +22,8 @@ use crate::index::field_index::{
     PayloadBlockCondition,
 };
 use crate::index::payload_config::PayloadConfig;
+use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
+use crate::index::query_optimization::rescore_formula::{FormulaScorer, FormulaScorerRead};
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
@@ -170,6 +173,17 @@ impl PayloadIndexRead for PlainPayloadIndex {
     fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndex + '_> {
         // Plain index has no field indexes; the type tag is just a placeholder.
         None::<FacetIndexEnum<'_>>
+    }
+
+    fn formula_scorer<'q>(
+        &'q self,
+        _parsed_formula: &'q ParsedFormula,
+        _prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
+        _hw_counter: &'q HardwareCounterCell,
+    ) -> OperationResult<impl FormulaScorerRead + 'q> {
+        Err::<FormulaScorer<'q>, _>(OperationError::service_error(
+            "Formula scoring is not supported by PlainPayloadIndex",
+        ))
     }
 
     fn iter_filtered_points<'a, I: IdTrackerRead>(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -27,6 +27,7 @@ use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFor
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
+use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
@@ -173,6 +174,11 @@ impl PayloadIndexRead for PlainPayloadIndex {
     fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndex + '_> {
         // Plain index has no field indexes; the type tag is just a placeholder.
         None::<FacetIndexEnum<'_>>
+    }
+
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+        // Plain index has no field indexes to report telemetry for.
+        Vec::new()
     }
 
     fn formula_scorer<'q>(

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -22,8 +22,8 @@ use crate::index::field_index::{
     PayloadBlockCondition,
 };
 use crate::index::payload_config::PayloadConfig;
+use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use crate::index::query_optimization::rescore_formula::{FormulaScorer, FormulaScorerRead};
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
@@ -180,8 +180,8 @@ impl PayloadIndexRead for PlainPayloadIndex {
         _parsed_formula: &'q ParsedFormula,
         _prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
         _hw_counter: &'q HardwareCounterCell,
-    ) -> OperationResult<impl FormulaScorerRead + 'q> {
-        Err::<FormulaScorer<'q>, _>(OperationError::service_error(
+    ) -> OperationResult<FormulaScorer<'q>> {
+        Err(OperationError::service_error(
             "Formula scoring is not supported by PlainPayloadIndex",
         ))
     }

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -204,6 +204,10 @@ impl VectorIndexRead for PlainVectorIndex {
     ) {
         // Plain (dense) index doesn't track IDF.
     }
+
+    fn is_index(&self) -> bool {
+        false
+    }
 }
 
 impl VectorIndex for PlainVectorIndex {

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -5,6 +6,7 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use parking_lot::Mutex;
+use sparse::common::types::DimId;
 
 use super::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::common::BYTES_IN_KB;
@@ -193,6 +195,14 @@ impl VectorIndexRead for PlainVectorIndex {
         self.vector_storage
             .borrow()
             .size_of_available_vectors_in_bytes()
+    }
+
+    fn fill_idf_statistics(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
+    ) {
+        // Plain (dense) index doesn't track IDF.
     }
 }
 

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -21,6 +21,16 @@ use crate::types::{DateTimePayloadType, GeoPoint};
 const DEFAULT_SCORE: PreciseScore = 0.0;
 const DEFAULT_DECAY_TARGET: PreciseScore = 0.0;
 
+/// Read-only abstraction over a formula scorer.
+///
+/// Implemented by the appendable [`FormulaScorer`] today; a future
+/// `ReadOnlySegment` will provide its own concrete scorer with the same
+/// `score(point_id)` shape so the rescore-with-formula code path can be
+/// shared.
+pub trait FormulaScorerRead {
+    fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType>;
+}
+
 /// A scorer to evaluate the same formula for many points
 pub struct FormulaScorer<'a> {
     /// The formula to evaluate
@@ -57,46 +67,27 @@ impl FriendlyName for DateTimePayloadType {
     }
 }
 
-impl StructPayloadIndex {
-    pub fn formula_scorer<'s, 'q>(
-        &'s self,
-        parsed_formula: &'q ParsedFormula,
-        prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
-        hw_counter: &'q HardwareCounterCell,
-    ) -> OperationResult<FormulaScorer<'q>>
-    where
-        's: 'q,
-    {
-        let ParsedFormula {
-            payload_vars,
-            conditions,
-            defaults,
+impl<'a> FormulaScorer<'a> {
+    pub(crate) fn new(
+        formula: ParsedExpression,
+        prefetches_scores: &'a [AHashMap<PointOffsetType, ScoreType>],
+        payload_retrievers: HashMap<JsonPath, VariableRetrieverFn<'a>>,
+        condition_checkers: Vec<OptimizedCondition<'a>>,
+        defaults: HashMap<VariableId, Value>,
+    ) -> Self {
+        FormulaScorer {
             formula,
-        } = parsed_formula;
-
-        let payload_retrievers = self.retrievers_map(payload_vars.clone(), hw_counter);
-
-        let payload_provider = PayloadProvider::new(self.payload.clone());
-        let total = self.available_point_count();
-        let condition_checkers = self
-            .convert_conditions(conditions, payload_provider, total, hw_counter)?
-            .into_iter()
-            .map(|(checker, _estimation)| checker)
-            .collect();
-
-        Ok(FormulaScorer {
-            formula: formula.clone(),
             prefetches_scores,
             payload_retrievers,
             condition_checkers,
-            defaults: defaults.clone(),
-        })
+            defaults,
+        }
     }
 }
 
-impl FormulaScorer<'_> {
+impl FormulaScorerRead for FormulaScorer<'_> {
     /// Evaluate the formula for the given point
-    pub fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType> {
+    fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType> {
         self.eval_expression(&self.formula, point_id)
             .and_then(|score| {
                 let score_f32 = score as f32;
@@ -108,7 +99,9 @@ impl FormulaScorer<'_> {
                 Ok(score_f32)
             })
     }
+}
 
+impl FormulaScorer<'_> {
     /// Evaluate the expression recursively
     fn eval_expression(
         &self,

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -21,16 +21,6 @@ use crate::types::{DateTimePayloadType, GeoPoint};
 const DEFAULT_SCORE: PreciseScore = 0.0;
 const DEFAULT_DECAY_TARGET: PreciseScore = 0.0;
 
-/// Read-only abstraction over a formula scorer.
-///
-/// Implemented by the appendable [`FormulaScorer`] today; a future
-/// `ReadOnlySegment` will provide its own concrete scorer with the same
-/// `score(point_id)` shape so the rescore-with-formula code path can be
-/// shared.
-pub trait FormulaScorerRead {
-    fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType>;
-}
-
 /// A scorer to evaluate the same formula for many points
 pub struct FormulaScorer<'a> {
     /// The formula to evaluate
@@ -85,9 +75,9 @@ impl<'a> FormulaScorer<'a> {
     }
 }
 
-impl FormulaScorerRead for FormulaScorer<'_> {
+impl FormulaScorer<'_> {
     /// Evaluate the formula for the given point
-    fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType> {
+    pub fn score(&self, point_id: PointOffsetType) -> OperationResult<ScoreType> {
         self.eval_expression(&self.formula, point_id)
             .and_then(|score| {
                 let score_f32 = score as f32;
@@ -99,9 +89,7 @@ impl FormulaScorerRead for FormulaScorer<'_> {
                 Ok(score_f32)
             })
     }
-}
 
-impl FormulaScorer<'_> {
     /// Evaluate the expression recursively
     fn eval_expression(
         &self,

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -2,19 +2,16 @@ use std::collections::HashMap;
 use std::ops::Neg;
 
 use ahash::AHashMap;
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
 use geo::{Distance, Haversine};
 use serde_json::Value;
 
 use super::parsed_formula::{
-    DatetimeExpression, DecayKind, ParsedExpression, ParsedFormula, PreciseScore, VariableId,
+    DatetimeExpression, DecayKind, ParsedExpression, PreciseScore, VariableId,
 };
 use super::value_retriever::VariableRetrieverFn;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::query_optimization::optimized_filter::{OptimizedCondition, check_condition};
-use crate::index::query_optimization::payload_provider::PayloadProvider;
-use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::json_path::JsonPath;
 use crate::types::{DateTimePayloadType, GeoPoint};
 

--- a/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
@@ -1,3 +1,5 @@
 mod formula_scorer;
 pub mod parsed_formula;
 mod value_retriever;
+
+pub use formula_scorer::{FormulaScorer, FormulaScorerRead};

--- a/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
@@ -2,4 +2,4 @@ mod formula_scorer;
 pub mod parsed_formula;
 mod value_retriever;
 
-pub use formula_scorer::{FormulaScorer, FormulaScorerRead};
+pub use formula_scorer::FormulaScorer;

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -15,7 +15,7 @@ pub type VariableRetrieverFn<'a> = Box<dyn Fn(PointOffsetType) -> MultiValue<Val
 
 impl StructPayloadIndex {
     /// Prepares optimized functions to extract each of the variables, given a point id.
-    pub(super) fn retrievers_map<'a, 'q>(
+    pub(crate) fn retrievers_map<'a, 'q>(
         &'a self,
         variables: HashSet<JsonPath>,
         hw_counter: &'q HardwareCounterCell,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -621,6 +621,10 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
             }
         }
     }
+
+    fn is_index(&self) -> bool {
+        true
+    }
 }
 
 impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedIndex> {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -546,23 +546,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             }
         }
     }
-
-    // Update statistics for idf-dot similarity
-    pub fn fill_idf_statistics(
-        &self,
-        idf: &mut HashMap<DimId, usize>,
-        hw_counter: &HardwareCounterCell,
-    ) {
-        for (dim_id, count) in idf.iter_mut() {
-            if let Some(remapped_dim_id) = self.indices_tracker.remap_index(*dim_id)
-                && let Some(posting_list_len) = self
-                    .inverted_index
-                    .posting_list_len(&remapped_dim_id, hw_counter)
-            {
-                *count += posting_list_len
-            }
-        }
-    }
 }
 
 impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInvertedIndex> {
@@ -620,6 +603,23 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
         self.inverted_index.total_sparse_vectors_size()
+    }
+
+    /// Update statistics for idf-dot similarity.
+    fn fill_idf_statistics(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
+    ) {
+        for (dim_id, count) in idf.iter_mut() {
+            if let Some(remapped_dim_id) = self.indices_tracker.remap_index(*dim_id)
+                && let Some(posting_list_len) = self
+                    .inverted_index
+                    .posting_list_len(&remapped_dim_id, hw_counter)
+            {
+                *count += posting_list_len
+            }
+        }
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -32,8 +32,8 @@ use crate::index::field_index::{
 use crate::index::payload_config::{self, PayloadConfig};
 use crate::index::query_estimator::estimate_filter;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
+use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use crate::index::query_optimization::rescore_formula::{FormulaScorer, FormulaScorerRead};
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::index::visited_pool::VisitedPool;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
@@ -635,7 +635,7 @@ impl PayloadIndexRead for StructPayloadIndex {
         parsed_formula: &'q ParsedFormula,
         prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
         hw_counter: &'q HardwareCounterCell,
-    ) -> OperationResult<impl FormulaScorerRead + 'q> {
+    ) -> OperationResult<FormulaScorer<'q>> {
         let ParsedFormula {
             payload_vars,
             conditions,

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -25,8 +25,8 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::{
-    CardinalityEstimation, FieldIndex, NumericFieldIndexRead, PayloadBlockCondition,
-    PrimaryCondition,
+    CardinalityEstimation, FacetIndexRead, FieldIndex, NumericFieldIndexRead,
+    PayloadBlockCondition, PrimaryCondition,
 };
 use crate::index::payload_config::{self, PayloadConfig};
 use crate::index::query_estimator::estimate_filter;
@@ -619,6 +619,12 @@ impl PayloadIndexRead for StructPayloadIndex {
         self.field_indexes
             .get(key)
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
+    }
+
+    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndexRead + '_> {
+        self.field_indexes
+            .get(key)
+            .and_then(|index| index.iter().find_map(|index| index.as_facet_index()))
     }
 
     fn iter_filtered_points<'a, I: IdTrackerRead>(

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -453,18 +453,6 @@ impl StructPayloadIndex {
         })
     }
 
-    pub fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
-        self.field_indexes
-            .iter()
-            .flat_map(|(name, field)| -> Vec<PayloadIndexTelemetry> {
-                field
-                    .iter()
-                    .map(|field| field.get_telemetry_data().set_name(name.to_string()))
-                    .collect()
-            })
-            .collect()
-    }
-
     fn clear_index_for_point(&mut self, point_id: PointOffsetType) -> OperationResult<()> {
         for (_, field_indexes) in self.field_indexes.iter_mut() {
             for index in field_indexes {
@@ -622,6 +610,18 @@ impl PayloadIndexRead for StructPayloadIndex {
         self.field_indexes
             .get(key)
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
+    }
+
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+        self.field_indexes
+            .iter()
+            .flat_map(|(name, field)| -> Vec<PayloadIndexTelemetry> {
+                field
+                    .iter()
+                    .map(|field| field.get_telemetry_data().set_name(name.to_string()))
+                    .collect()
+            })
+            .collect()
     }
 
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_> {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -25,8 +25,8 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::IndexesMap;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::{
-    CardinalityEstimation, FacetIndexRead, FieldIndex, NumericFieldIndexRead,
-    PayloadBlockCondition, PrimaryCondition,
+    CardinalityEstimation, FacetIndex, FieldIndex, NumericFieldIndexRead, PayloadBlockCondition,
+    PrimaryCondition,
 };
 use crate::index::payload_config::{self, PayloadConfig};
 use crate::index::query_estimator::estimate_filter;
@@ -621,7 +621,7 @@ impl PayloadIndexRead for StructPayloadIndex {
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
     }
 
-    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndexRead + '_> {
+    fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_> {
         self.field_indexes
             .get(key)
             .and_then(|index| index.iter().find_map(|index| index.as_facet_index()))

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -4,13 +4,14 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
+use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::defaults::log_load_timing;
 use common::either_variant::EitherVariant;
 use common::iterator_ext::IteratorExt;
-use common::types::PointOffsetType;
+use common::types::{PointOffsetType, ScoreType};
 use fs_err as fs;
 use schemars::_serde_json::Value;
 
@@ -31,6 +32,8 @@ use crate::index::field_index::{
 use crate::index::payload_config::{self, PayloadConfig};
 use crate::index::query_estimator::estimate_filter;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
+use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
+use crate::index::query_optimization::rescore_formula::{FormulaScorer, FormulaScorerRead};
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::index::visited_pool::VisitedPool;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
@@ -625,6 +628,38 @@ impl PayloadIndexRead for StructPayloadIndex {
         self.field_indexes
             .get(key)
             .and_then(|index| index.iter().find_map(|index| index.as_facet_index()))
+    }
+
+    fn formula_scorer<'q>(
+        &'q self,
+        parsed_formula: &'q ParsedFormula,
+        prefetches_scores: &'q [AHashMap<PointOffsetType, ScoreType>],
+        hw_counter: &'q HardwareCounterCell,
+    ) -> OperationResult<impl FormulaScorerRead + 'q> {
+        let ParsedFormula {
+            payload_vars,
+            conditions,
+            defaults,
+            formula,
+        } = parsed_formula;
+
+        let payload_retrievers = self.retrievers_map(payload_vars.clone(), hw_counter);
+
+        let payload_provider = PayloadProvider::new(self.payload.clone());
+        let total = self.available_point_count();
+        let condition_checkers = self
+            .convert_conditions(conditions, payload_provider, total, hw_counter)?
+            .into_iter()
+            .map(|(checker, _estimation)| checker)
+            .collect();
+
+        Ok(FormulaScorer::new(
+            formula.clone(),
+            prefetches_scores,
+            payload_retrievers,
+            condition_checkers,
+            defaults.clone(),
+        ))
     }
 
     fn iter_filtered_points<'a, I: IdTrackerRead>(

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -47,13 +47,14 @@ pub trait VectorIndexRead {
 
     /// Augment the IDF stats for the given dimensions.
     ///
-    /// Default is a no-op: only sparse-vector indexes track IDF.
+    /// Most indexes don't track IDF and should provide an empty body. Sparse-
+    /// vector indexes are the only ones that contribute. No default is provided
+    /// on purpose so a new index implementation cannot silently skip this.
     fn fill_idf_statistics(
         &self,
-        _idf: &mut HashMap<DimId, usize>,
-        _hw_counter: &HardwareCounterCell,
-    ) {
-    }
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
+    );
 }
 
 /// Trait for vector index with mutating operations.

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -44,6 +44,16 @@ pub trait VectorIndexRead {
 
     /// Total size of all searchable vectors in bytes.
     fn size_of_searchable_vectors_in_bytes(&self) -> usize;
+
+    /// Augment the IDF stats for the given dimensions.
+    ///
+    /// Default is a no-op: only sparse-vector indexes track IDF.
+    fn fill_idf_statistics(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
+    ) {
+    }
 }
 
 /// Trait for vector index with mutating operations.
@@ -156,47 +166,6 @@ impl VectorIndexEnum {
         };
         Ok(())
     }
-
-    pub fn fill_idf_statistics(
-        &self,
-        idf: &mut HashMap<DimId, usize>,
-        hw_counter: &HardwareCounterCell,
-    ) {
-        match self {
-            Self::Plain(_) | Self::Hnsw(_) => (),
-            Self::SparseRam(index) => index.fill_idf_statistics(idf, hw_counter),
-            Self::SparseImmutableRam(index) => index.fill_idf_statistics(idf, hw_counter),
-            Self::SparseMmap(index) => index.fill_idf_statistics(idf, hw_counter),
-            Self::SparseCompressedImmutableRamF32(index) => {
-                index.fill_idf_statistics(idf, hw_counter)
-            }
-            Self::SparseCompressedImmutableRamF16(index) => {
-                index.fill_idf_statistics(idf, hw_counter)
-            }
-            Self::SparseCompressedImmutableRamU8(index) => {
-                index.fill_idf_statistics(idf, hw_counter)
-            }
-            Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
-            Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
-            Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
-        }
-    }
-
-    pub fn indexed_vectors(&self) -> usize {
-        match self {
-            Self::Plain(index) => index.indexed_vector_count(),
-            Self::Hnsw(index) => index.indexed_vector_count(),
-            Self::SparseRam(index) => index.inverted_index().vector_count(),
-            Self::SparseImmutableRam(index) => index.inverted_index().vector_count(),
-            Self::SparseMmap(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedImmutableRamF32(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedImmutableRamF16(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedImmutableRamU8(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedMmapF32(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedMmapF16(index) => index.inverted_index().vector_count(),
-            Self::SparseCompressedMmapU8(index) => index.inverted_index().vector_count(),
-        }
-    }
 }
 
 impl VectorIndexRead for VectorIndexEnum {
@@ -302,6 +271,31 @@ impl VectorIndexRead for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
+        }
+    }
+
+    fn fill_idf_statistics(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
+    ) {
+        match self {
+            Self::Plain(_) | Self::Hnsw(_) => (),
+            Self::SparseRam(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseImmutableRam(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseMmap(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
         }
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -55,6 +55,11 @@ pub trait VectorIndexRead {
         idf: &mut HashMap<DimId, usize>,
         hw_counter: &HardwareCounterCell,
     );
+
+    /// Whether this is a "real" index rather than a plain (full-scan) one.
+    ///
+    /// Used by reporting code to decide whether to count vectors as indexed.
+    fn is_index(&self) -> bool;
 }
 
 /// Trait for vector index with mutating operations.
@@ -100,22 +105,6 @@ pub enum VectorIndexEnum {
 }
 
 impl VectorIndexEnum {
-    pub fn is_index(&self) -> bool {
-        match self {
-            Self::Plain(_) => false,
-            Self::Hnsw(_) => true,
-            Self::SparseRam(_) => true,
-            Self::SparseImmutableRam(_) => true,
-            Self::SparseMmap(_) => true,
-            Self::SparseCompressedImmutableRamF32(_) => true,
-            Self::SparseCompressedImmutableRamF16(_) => true,
-            Self::SparseCompressedImmutableRamU8(_) => true,
-            Self::SparseCompressedMmapF32(_) => true,
-            Self::SparseCompressedMmapF16(_) => true,
-            Self::SparseCompressedMmapU8(_) => true,
-        }
-    }
-
     /// Returns true if underlying storage is configured to be stored on disk without
     /// actively holding data in RAM
     pub fn is_on_disk(&self) -> bool {
@@ -272,6 +261,22 @@ impl VectorIndexRead for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
+        }
+    }
+
+    fn is_index(&self) -> bool {
+        match self {
+            Self::Plain(_) => false,
+            Self::Hnsw(_) => true,
+            Self::SparseRam(_) => true,
+            Self::SparseImmutableRam(_) => true,
+            Self::SparseMmap(_) => true,
+            Self::SparseCompressedImmutableRamF32(_) => true,
+            Self::SparseCompressedImmutableRamF16(_) => true,
+            Self::SparseCompressedImmutableRamU8(_) => true,
+            Self::SparseCompressedMmapF32(_) => true,
+            Self::SparseCompressedMmapF16(_) => true,
+            Self::SparseCompressedMmapU8(_) => true,
         }
     }
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -25,16 +25,15 @@ use crate::entry::entry_point::{
 };
 use crate::id_tracker::{IdTracker, IdTrackerRead, PointMappingsGuard};
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
-use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead, VectorIndexRead};
+use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
-use crate::payload_storage::PayloadStorageRead;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
-    ExtendedPointId, Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType,
-    PayloadKeyTypeRef, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
-    SegmentType, SeqNumberType, VectorDataInfo, VectorName, VectorNameBuf, WithPayload, WithVector,
+    ExtendedPointId, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
+    PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
+    VectorName, VectorNameBuf, WithPayload, WithVector,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageRead};
+use crate::vector_storage::VectorStorage;
 
 /// This is a basic implementation of the trait, meaning that it implements the _actual_ operations with data and not
 /// any kind of proxy or wrapping.
@@ -248,96 +247,13 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn size_info(&self) -> SegmentInfo {
-        let num_vectors = self
-            .vector_data
-            .values()
-            .map(|data| data.vector_storage.borrow().available_vector_count())
-            .sum();
-
-        let mut total_average_vectors_size_bytes: usize = 0;
-
-        let vector_data_info: HashMap<_, _> = self
-            .vector_data
-            .iter()
-            .map(|(key, vector_data)| {
-                let vector_storage = vector_data.vector_storage.borrow();
-                let num_vectors = vector_storage.available_vector_count();
-                let vector_index = vector_data.vector_index.borrow();
-                let is_indexed = vector_index.is_index();
-
-                let average_vector_size_bytes = vector_index
-                    .size_of_searchable_vectors_in_bytes()
-                    .checked_div(num_vectors)
-                    .unwrap_or(0);
-                total_average_vectors_size_bytes += average_vector_size_bytes;
-
-                let vector_data_info = VectorDataInfo {
-                    num_vectors,
-                    num_indexed_vectors: if is_indexed {
-                        vector_index.indexed_vector_count()
-                    } else {
-                        0
-                    },
-                    num_deleted_vectors: vector_storage.deleted_vector_count(),
-                };
-                (key.clone(), vector_data_info)
-            })
-            .collect();
-
-        let num_indexed_vectors = if self.segment_type == SegmentType::Indexed {
-            self.vector_data
-                .values()
-                .map(|data| data.vector_index.borrow().indexed_vector_count())
-                .sum()
-        } else {
-            0
-        };
-
-        let vectors_size_bytes = total_average_vectors_size_bytes * self.available_point_count();
-
-        // Unwrap and default to 0 here because the RocksDB storage is the only faillible one, and we will remove it eventually.
-        let payloads_size_bytes = self
-            .payload_storage
-            .borrow()
-            .get_storage_size_bytes()
-            .unwrap_or(0);
-
-        SegmentInfo {
-            uuid: self.segment_uuid(),
-            segment_type: self.segment_type,
-            num_vectors,
-            num_indexed_vectors,
-            num_points: self.available_point_count(),
-            num_deferred_points: Some(self.deferred_point_count()),
-            num_deleted_deferred_points: Some(self.deferred_deleted_count().unwrap_or_default()),
-            num_deleted_vectors: self.deleted_point_count(),
-            vectors_size_bytes,  // Considers vector storage, but not indices
-            payloads_size_bytes, // Considers payload storage, but not indices
-            ram_usage_bytes: 0,  // ToDo: Implement
-            disk_usage_bytes: 0, // ToDo: Implement
-            is_appendable: self.appendable_flag,
-            index_schema: HashMap::new(),
-            vector_data: vector_data_info,
-            deferred_internal_id: self.deferred_internal_id(),
-        }
+        self.with_view(|view| {
+            view.build_size_info(self.uuid, self.segment_type, self.appendable_flag)
+        })
     }
 
     fn info(&self) -> SegmentInfo {
-        let payload_index = self.payload_index.borrow();
-        let schema = payload_index
-            .indexed_fields()
-            .into_iter()
-            .map(|(key, index_schema)| {
-                let points_count = payload_index.indexed_points(&key);
-                let index_info = PayloadIndexInfo::new(index_schema, points_count);
-                (key, index_info)
-            })
-            .collect();
-
-        let mut info = self.size_info();
-        info.index_schema = schema;
-
-        info
+        self.with_view(|view| view.build_info(self.uuid, self.segment_type, self.appendable_flag))
     }
 
     fn config(&self) -> &SegmentConfig {
@@ -356,22 +272,15 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
-        let vector_index_searches: Vec<_> = self
-            .vector_data
-            .iter()
-            .map(|(k, v)| {
-                let mut telemetry = v.vector_index.borrow().get_telemetry_data(detail);
-                telemetry.index_name = Some(k.clone());
-                telemetry
-            })
-            .collect();
-
-        SegmentTelemetry {
-            info: self.info(),
-            config: self.config().clone(),
-            vector_index_searches,
-            payload_field_indices: self.payload_index.borrow().get_telemetry_data(),
-        }
+        self.with_view(|view| {
+            view.build_telemetry(
+                self.uuid,
+                self.segment_type,
+                self.appendable_flag,
+                &self.segment_config,
+                detail,
+            )
+        })
     }
 
     fn fill_query_context(&self, query_context: &mut QueryContext) {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -353,7 +353,7 @@ impl ReadSegmentEntry for Segment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<std::collections::BTreeSet<FacetValue>> {
-        self.facet_values(key, filter, is_stopped, hw_counter)
+        self.with_view(|view| view.facet_values(key, filter, is_stopped, hw_counter))
     }
 
     fn facet(
@@ -362,7 +362,7 @@ impl ReadSegmentEntry for Segment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
-        self.approximate_facet(request, is_stopped, hw_counter)
+        self.with_view(|view| view.approximate_facet(request, is_stopped, hw_counter))
     }
 
     fn segment_uuid(&self) -> Uuid {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -81,32 +81,7 @@ impl ReadSegmentEntry for Segment {
         ctx: Arc<FormulaContext>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPoint>> {
-        let FormulaContext {
-            formula,
-            prefetches_results,
-            limit,
-            score_threshold,
-            is_stopped,
-        } = &*ctx;
-
-        let internal_results = self.do_rescore_with_formula(
-            formula,
-            prefetches_results,
-            *limit,
-            *score_threshold,
-            is_stopped,
-            hw_counter,
-        )?;
-
-        self.with_view(|view| {
-            view.process_search_result(
-                internal_results,
-                &false.into(),
-                &false.into(),
-                hw_counter,
-                is_stopped,
-            )
-        })
+        self.with_view(|view| view.rescore_with_formula(ctx, hw_counter))
     }
 
     fn vector(

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -11,17 +11,13 @@ use uuid::Uuid;
 
 use super::Segment;
 use crate::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
-use crate::common::{
-    Flusher, check_named_vectors, check_query_vectors, check_stopped, check_vector_name,
-};
+use crate::common::{Flusher, check_named_vectors, check_vector_name};
 use crate::data_types::build_index_result::BuildFieldIndexResult;
 use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
-use crate::data_types::query_context::{
-    FormulaContext, QueryContext, QueryIdfStats, SegmentQueryContext,
-};
-use crate::data_types::segment_record::{NamedVectorsOwned, SegmentRecord};
+use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
+use crate::data_types::segment_record::SegmentRecord;
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::{
@@ -66,37 +62,18 @@ impl ReadSegmentEntry for Segment {
         params: Option<&SearchParams>,
         query_context: &SegmentQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
-        check_query_vectors(vector_name, query_vectors, &self.segment_config)?;
-        let vector_data = &self
-            .vector_data
-            .get(vector_name)
-            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
-        let vector_query_context =
-            query_context.get_vector_context(vector_name, self.deferred_internal_id());
-        let internal_results = vector_data.vector_index.borrow().search(
-            query_vectors,
-            filter,
-            top,
-            params,
-            &vector_query_context,
-        )?;
-
-        check_stopped(&vector_query_context.is_stopped())?;
-
-        let hw_counter = vector_query_context.hardware_counter();
-
-        internal_results
-            .into_iter()
-            .map(|internal_result| {
-                self.process_search_result(
-                    internal_result,
-                    with_payload,
-                    with_vector,
-                    &hw_counter,
-                    &vector_query_context.is_stopped(),
-                )
-            })
-            .collect()
+        self.with_view(|view| {
+            view.search_batch(
+                vector_name,
+                query_vectors,
+                with_payload,
+                with_vector,
+                filter,
+                top,
+                params,
+                query_context,
+            )
+        })
     }
 
     fn rescore_with_formula(
@@ -121,13 +98,15 @@ impl ReadSegmentEntry for Segment {
             hw_counter,
         )?;
 
-        self.process_search_result(
-            internal_results,
-            &false.into(),
-            &false.into(),
-            hw_counter,
-            is_stopped,
-        )
+        self.with_view(|view| {
+            view.process_search_result(
+                internal_results,
+                &false.into(),
+                &false.into(),
+                hw_counter,
+                is_stopped,
+            )
+        })
     }
 
     fn vector(
@@ -170,96 +149,16 @@ impl ReadSegmentEntry for Segment {
         is_stopped: &AtomicBool,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
-        let mut records = AHashMap::with_capacity(point_ids.len());
-
-        // Filter out deferred points. This is done in two stages to prevent cloning `point_ids` and iterating more that needed
-        // but still satisfy rusts ownership constraints.
-        let behavior_allows_filtering = !deferred_behavior.include_all_points();
-        let filter_deferred = self.has_deferred_points() && behavior_allows_filtering;
-        let filtered_point_ids = filter_deferred.then(|| {
-            point_ids
-                .iter()
-                .filter(|&&point_id| !self.point_is_deferred(point_id))
-                .copied()
-                .collect::<Vec<_>>()
-        });
-
-        // Stage two: Select the correct slice and shadow `point_ids`.
-        let point_ids = filtered_point_ids.as_deref().unwrap_or(point_ids);
-
-        let mut update_record_vector =
-            |vector_name: &VectorNameBuf,
-             point_id: PointIdType,
-             vector_internal: VectorInternal| {
-                let point_record = records
-                    .entry(point_id)
-                    .or_insert_with(|| SegmentRecord::empty(point_id));
-
-                point_record
-                    .vectors
-                    .get_or_insert_with(NamedVectorsOwned::default)
-                    .push((vector_name.clone(), vector_internal));
-            };
-
-        match with_vector {
-            WithVector::Bool(true) => {
-                for vector_name in self.vector_data.keys() {
-                    self.with_view(|view| {
-                        view.read_vectors(
-                            vector_name,
-                            point_ids,
-                            hw_counter,
-                            is_stopped,
-                            |point_id, vec| {
-                                update_record_vector(vector_name, point_id, vec);
-                            },
-                        )
-                    })?;
-                }
-            }
-            WithVector::Bool(false) => {
-                // Do not display empty `vectors: {}` if disabled
-                for &point_id in point_ids {
-                    let point_record = records
-                        .entry(point_id)
-                        .or_insert_with(|| SegmentRecord::empty(point_id));
-                    point_record.vectors = None;
-                }
-            }
-            WithVector::Selector(selector) => {
-                for vector_name in selector {
-                    self.with_view(|view| {
-                        view.read_vectors(
-                            vector_name,
-                            point_ids,
-                            hw_counter,
-                            is_stopped,
-                            |point_id, vec| {
-                                update_record_vector(vector_name, point_id, vec);
-                            },
-                        )
-                    })?;
-                }
-            }
-        }
-
-        for &point_id in point_ids {
-            let payload = if with_payload.enable {
-                if let Some(selector) = &with_payload.payload_selector {
-                    Some(selector.process(self.payload(point_id, hw_counter)?))
-                } else {
-                    Some(self.payload(point_id, hw_counter)?)
-                }
-            } else {
-                None
-            };
-            let point_record = records
-                .entry(point_id)
-                .or_insert_with(|| SegmentRecord::empty(point_id));
-            point_record.payload = payload;
-        }
-
-        Ok(records)
+        self.with_view(|view| {
+            view.retrieve(
+                point_ids,
+                with_payload,
+                with_vector,
+                hw_counter,
+                is_stopped,
+                deferred_behavior,
+            )
+        })
     }
 
     fn read_filtered<'a>(
@@ -501,30 +400,7 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn fill_query_context(&self, query_context: &mut QueryContext) {
-        query_context.add_available_point_count(self.available_point_count_without_deferred());
-        let hw_acc = query_context.hardware_usage_accumulator();
-        let hw_counter = hw_acc.get_counter_cell();
-
-        let QueryIdfStats {
-            idf,
-            indexed_vectors,
-        } = query_context.mut_idf_stats();
-
-        for (vector_name, idf) in idf.iter_mut() {
-            if let Some(vector_data) = self.vector_data.get(vector_name) {
-                let vector_index = vector_data.vector_index.borrow();
-
-                let indexed_vector_count = vector_index.indexed_vectors();
-
-                if let Some(count) = indexed_vectors.get_mut(vector_name) {
-                    *count += indexed_vector_count;
-                } else {
-                    indexed_vectors.insert(vector_name.clone(), indexed_vector_count);
-                }
-
-                vector_index.fill_idf_statistics(idf, &hw_counter);
-            }
-        }
+        self.with_view(|view| view.fill_query_context(query_context));
     }
 
     fn point_is_deferred(&self, point_id: PointIdType) -> bool {

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -1,5 +1,4 @@
 mod entry;
-mod facet;
 mod formula_rescore;
 pub mod memory;
 mod search;

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -1,5 +1,4 @@
 mod entry;
-mod formula_rescore;
 pub mod memory;
 mod search;
 mod segment_ops;

--- a/lib/segment/src/segment/read_view/facet.rs
+++ b/lib/segment/src/segment/read_view/facet.rs
@@ -9,7 +9,7 @@ use crate::common::operation_error::{OperationError, OperationResult, check_proc
 use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
-use crate::index::field_index::FacetIndexRead;
+use crate::index::field_index::FacetIndex;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;
@@ -168,11 +168,15 @@ where
                 values.extend(iter.map(|v| v.to_owned()));
             })?;
         } else {
-            facet_index.for_each_value(hw_counter, self.deferred_internal_id(), |value_ref| {
-                check_process_stopped(is_stopped)?;
-                values.insert(value_ref.to_owned());
-                Ok(())
-            })?;
+            facet_index.for_each_visible_value(
+                hw_counter,
+                self.deferred_internal_id(),
+                |value_ref| {
+                    check_process_stopped(is_stopped)?;
+                    values.insert(value_ref.to_owned());
+                    Ok(())
+                },
+            )?;
         };
 
         Ok(values)

--- a/lib/segment/src/segment/read_view/facet.rs
+++ b/lib/segment/src/segment/read_view/facet.rs
@@ -5,48 +5,60 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 
-use super::Segment;
-use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::facets::{FacetParams, FacetValue};
-use crate::entry::ReadSegmentEntry;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
+use crate::index::field_index::FacetIndexRead;
 use crate::json_path::JsonPath;
-use crate::payload_storage::FilterContext;
+use crate::payload_storage::PayloadStorageRead;
+use crate::segment::read_view::SegmentReadView;
+use crate::segment::vector_data_read::VectorDataRead;
 use crate::types::Filter;
 
-impl Segment {
-    pub(super) fn approximate_facet(
+impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
+where
+    TIdT: IdTrackerRead,
+    TPI: PayloadIndexRead,
+    TPS: PayloadStorageRead,
+    TVD: VectorDataRead,
+{
+    pub fn approximate_facet(
         &self,
         request: &FacetParams,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
-        let payload_index = self.payload_index.borrow();
-
-        // Shortcut if this segment has no points, prevent division by zero later
-        let available_points = self.available_point_count();
+        // Shortcut if this segment has no points; prevent division by zero later.
+        let available_points = self.id_tracker.available_point_count();
         if available_points == 0 {
             return Ok(HashMap::new());
         }
 
-        let facet_index = payload_index.get_facet_index(&request.key)?;
+        let facet_index = self
+            .payload_index
+            .facet_index_for(&request.key)
+            .ok_or_else(|| OperationError::MissingMapIndexForFacet {
+                key: request.key.to_string(),
+            })?;
         let context;
 
         // We can't just select top values, because we need to aggregate across segments,
         // which we can't assume to select the same best top.
         //
-        // We need all values to be able to aggregate correctly across segments
+        // We need all values to be able to aggregate correctly across segments.
         let mut hits = HashMap::new();
 
         if let Some(filter) = &request.filter {
-            let id_tracker = self.id_tracker.borrow();
-            let filter_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
+            let filter_cardinality = self
+                .payload_index
+                .estimate_cardinality(filter, hw_counter)?;
 
             let percentage_filtered = filter_cardinality.exp as f64 / available_points as f64;
 
             // TODO(facets): define a better estimate for this decision, the question is:
-            // What is more expensive, to hash the same value excessively or to check with filter too many times?
+            // What is more expensive, to hash the same value excessively or to check with filter
+            // too many times?
             //
             // For now this is defined from some rudimentary benchmarking two scenarios:
             // - a collection with few keys
@@ -54,31 +66,30 @@ impl Segment {
             let use_iterative_approach = percentage_filtered < 0.3;
 
             if use_iterative_approach {
-                // go over the filtered points and aggregate the values
-                // aka. read from other indexes
-                let point_mappings = id_tracker.point_mappings();
-                let points = payload_index
+                // Go over the filtered points and aggregate the values (read from other indexes).
+                let point_mappings = self.id_tracker.point_mappings();
+                let points = self
+                    .payload_index
                     .iter_filtered_points(
                         filter,
-                        &*id_tracker,
+                        self.id_tracker,
                         &point_mappings,
                         &filter_cardinality,
                         hw_counter,
                         is_stopped,
                         self.deferred_internal_id(),
                     )?
-                    .filter(|&point_id| !id_tracker.is_deleted_point(point_id));
+                    .filter(|&point_id| !self.id_tracker.is_deleted_point(point_id));
                 facet_index.for_points_values(points, hw_counter, |_point_id, iter| {
                     iter.unique().for_each(|value| {
                         *hits.entry(value.to_owned()).or_insert(0) += 1;
                     });
                 })?;
             } else {
-                // go over the values and filter the points
-                // aka. read from facet index
+                // Go over the values and filter the points (read from facet index).
                 //
                 // This is more similar to a full-scan, but we won't be hashing so many times.
-                context = payload_index.struct_filtered_context(filter, hw_counter)?;
+                context = self.payload_index.filter_context(filter, hw_counter)?;
 
                 let max_id = self.deferred_internal_id().unwrap_or(PointOffsetType::MAX);
 
@@ -108,7 +119,7 @@ impl Segment {
                 })?;
             }
         } else {
-            // just count how many points each value has
+            // Just count how many points each value has.
             facet_index.for_each_count_per_value(self.deferred_internal_id(), |hit| {
                 check_process_stopped(is_stopped)?;
                 if hit.count > 0 {
@@ -121,34 +132,38 @@ impl Segment {
         Ok(hits)
     }
 
-    pub(super) fn facet_values(
+    pub fn facet_values(
         &self,
         key: &JsonPath,
         filter: Option<&Filter>,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<BTreeSet<FacetValue>> {
-        let payload_index = self.payload_index.borrow();
-
-        let facet_index = payload_index.get_facet_index(key)?;
+        let facet_index = self.payload_index.facet_index_for(key).ok_or_else(|| {
+            OperationError::MissingMapIndexForFacet {
+                key: key.to_string(),
+            }
+        })?;
         let mut values = BTreeSet::new();
 
         if let Some(filter) = filter {
-            let id_tracker = self.id_tracker.borrow();
-            let filter_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
-            let point_mappings = id_tracker.point_mappings();
+            let filter_cardinality = self
+                .payload_index
+                .estimate_cardinality(filter, hw_counter)?;
+            let point_mappings = self.id_tracker.point_mappings();
 
-            let points = payload_index
+            let points = self
+                .payload_index
                 .iter_filtered_points(
                     filter,
-                    &*id_tracker,
+                    self.id_tracker,
                     &point_mappings,
                     &filter_cardinality,
                     hw_counter,
                     is_stopped,
                     self.deferred_internal_id(),
                 )?
-                .filter(|&point_id| !id_tracker.is_deleted_point(point_id));
+                .filter(|&point_id| !self.id_tracker.is_deleted_point(point_id));
             facet_index.for_points_values(points, hw_counter, |_point_id, iter| {
                 values.extend(iter.map(|v| v.to_owned()));
             })?;

--- a/lib/segment/src/segment/read_view/formula_rescore.rs
+++ b/lib/segment/src/segment/read_view/formula_rescore.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ahash::{AHashMap, AHashSet};
@@ -6,14 +7,27 @@ use common::iterator_ext::IteratorExt;
 use common::types::{ScoreType, ScoredPointOffset};
 use itertools::{Either, Itertools};
 
-use super::Segment;
 use crate::common::operation_error::OperationResult;
+use crate::data_types::query_context::FormulaContext;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::PayloadIndexRead;
+use crate::index::query_optimization::rescore_formula::FormulaScorerRead;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
+use crate::payload_storage::PayloadStorageRead;
+use crate::segment::read_view::SegmentReadView;
+use crate::segment::vector_data_read::VectorDataRead;
 use crate::types::ScoredPoint;
 
-impl Segment {
-    /// Rescores points of the prefetches, and returns the internal ids with the scores.
-    pub(super) fn do_rescore_with_formula(
+impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
+where
+    TIdT: IdTrackerRead,
+    TPI: PayloadIndexRead,
+    TPS: PayloadStorageRead,
+    TVD: VectorDataRead,
+{
+    /// Rescores points of the prefetches and returns the internal ids with the
+    /// scores.
+    fn do_rescore_with_formula(
         &self,
         formula: &ParsedFormula,
         prefetches_scores: &[Vec<ScoredPoint>],
@@ -22,19 +36,19 @@ impl Segment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        // Dedup point offsets into a hashset
+        // Dedup point offsets into a hashset.
         let mut points_to_rescore =
             AHashSet::with_capacity(prefetches_scores.first().map_or(0, |scores| scores.len()));
 
-        // Transform prefetches results into a hashmap for faster lookup,
+        // Transform prefetches results into a hashmap for faster lookup.
         let prefetches_scores = prefetches_scores
             .iter()
             .map(|scores| {
                 scores
                     .iter()
                     .filter_map(|point| {
-                        // Discard points without internal ids
-                        let internal_id = self.get_internal_id(point.id)?;
+                        // Discard points without internal ids.
+                        let internal_id = self.id_tracker.internal_id(point.id)?;
 
                         // filter_map side effect: keep all uniquely seen point offsets.
                         points_to_rescore.insert(internal_id);
@@ -45,10 +59,11 @@ impl Segment {
             })
             .collect::<Vec<_>>();
 
-        let index_ref = self.payload_index.borrow();
-        let scorer = index_ref.formula_scorer(formula, &prefetches_scores, hw_counter)?;
+        let scorer = self
+            .payload_index
+            .formula_scorer(formula, &prefetches_scores, hw_counter)?;
 
-        // Perform rescoring
+        // Perform rescoring.
         let mut error = None;
         let rescored_iter = points_to_rescore
             .into_iter()
@@ -60,7 +75,7 @@ impl Segment {
                         score: new_score,
                     }),
                     Err(err) => {
-                        // in case there is an error, defer handling it and continue
+                        // In case there is an error, defer handling it and continue.
                         error = Some(err);
                         is_stopped.store(true, Ordering::Relaxed);
                         None
@@ -68,14 +83,14 @@ impl Segment {
                 }
             });
 
-        // Handle score threshold
+        // Handle score threshold.
         let rescored = match score_threshold {
             Some(threshold) => {
                 Either::Left(rescored_iter.filter(move |point| point.score >= threshold))
             }
             None => Either::Right(rescored_iter),
         }
-        .k_largest(limit) // Keep only the top k results
+        .k_largest(limit) // Keep only the top k results.
         .collect();
 
         if let Some(err) = error {
@@ -83,5 +98,36 @@ impl Segment {
         }
 
         Ok(rescored)
+    }
+
+    pub fn rescore_with_formula(
+        &self,
+        ctx: Arc<FormulaContext>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Vec<ScoredPoint>> {
+        let FormulaContext {
+            formula,
+            prefetches_results,
+            limit,
+            score_threshold,
+            is_stopped,
+        } = &*ctx;
+
+        let internal_results = self.do_rescore_with_formula(
+            formula,
+            prefetches_results,
+            *limit,
+            *score_threshold,
+            is_stopped,
+            hw_counter,
+        )?;
+
+        self.process_search_result(
+            internal_results,
+            &false.into(),
+            &false.into(),
+            hw_counter,
+            is_stopped,
+        )
     }
 }

--- a/lib/segment/src/segment/read_view/formula_rescore.rs
+++ b/lib/segment/src/segment/read_view/formula_rescore.rs
@@ -11,7 +11,6 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::FormulaContext;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
-use crate::index::query_optimization::rescore_formula::FormulaScorerRead;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;

--- a/lib/segment/src/segment/read_view/info.rs
+++ b/lib/segment/src/segment/read_view/info.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use common::types::TelemetryDetail;
+use uuid::Uuid;
+
+use crate::id_tracker::IdTrackerRead;
+use crate::index::{PayloadIndexRead, VectorIndexRead};
+use crate::payload_storage::PayloadStorageRead;
+use crate::segment::read_view::SegmentReadView;
+use crate::segment::vector_data_read::VectorDataRead;
+use crate::telemetry::SegmentTelemetry;
+use crate::types::{PayloadIndexInfo, SegmentConfig, SegmentInfo, SegmentType, VectorDataInfo};
+use crate::vector_storage::VectorStorageRead;
+
+impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
+where
+    TIdT: IdTrackerRead,
+    TPI: PayloadIndexRead,
+    TPS: PayloadStorageRead,
+    TVD: VectorDataRead,
+{
+    /// Build a `SegmentInfo` describing this segment's storage. The trivial
+    /// segment-level fields (`uuid`, `segment_type`, `is_appendable`) come from
+    /// the caller — typically the segment-type-specific direct getters.
+    ///
+    /// `index_schema` is left empty; use [`build_info`] to also populate it.
+    pub fn build_size_info(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+    ) -> SegmentInfo {
+        let mut total_average_vectors_size_bytes: usize = 0;
+        let mut num_vectors_total: usize = 0;
+        let mut num_indexed_vectors_total: usize = 0;
+        let segment_is_indexed = segment_type == SegmentType::Indexed;
+
+        let vector_data_info: HashMap<_, _> = self
+            .vector_data
+            .iter()
+            .map(|(key, vector_data)| {
+                let vector_storage = vector_data.vector_storage();
+                let vector_index = vector_data.vector_index();
+                let num_vectors = vector_storage.available_vector_count();
+                num_vectors_total += num_vectors;
+
+                let average_vector_size_bytes = vector_index
+                    .size_of_searchable_vectors_in_bytes()
+                    .checked_div(num_vectors)
+                    .unwrap_or(0);
+                total_average_vectors_size_bytes += average_vector_size_bytes;
+
+                let indexed_vector_count = vector_index.indexed_vector_count();
+                let num_indexed_vectors = if vector_index.is_index() {
+                    indexed_vector_count
+                } else {
+                    0
+                };
+                if segment_is_indexed {
+                    num_indexed_vectors_total += indexed_vector_count;
+                }
+
+                let info = VectorDataInfo {
+                    num_vectors,
+                    num_indexed_vectors,
+                    num_deleted_vectors: vector_storage.deleted_vector_count(),
+                };
+                (key.clone(), info)
+            })
+            .collect();
+
+        let vectors_size_bytes =
+            total_average_vectors_size_bytes * self.id_tracker.available_point_count();
+
+        // Unwrap and default to 0 here because the RocksDB storage is the only fallible one,
+        // and we will remove it eventually.
+        let payloads_size_bytes = self.payload_storage.get_storage_size_bytes().unwrap_or(0);
+
+        SegmentInfo {
+            uuid,
+            segment_type,
+            num_vectors: num_vectors_total,
+            num_indexed_vectors: num_indexed_vectors_total,
+            num_points: self.id_tracker.available_point_count(),
+            num_deferred_points: Some(self.deferred_point_count()),
+            num_deleted_deferred_points: Some(self.deferred_deleted_count().unwrap_or_default()),
+            num_deleted_vectors: self.id_tracker.deleted_point_count(),
+            vectors_size_bytes,  // Considers vector storage, but not indices.
+            payloads_size_bytes, // Considers payload storage, but not indices.
+            ram_usage_bytes: 0,  // ToDo: Implement.
+            disk_usage_bytes: 0, // ToDo: Implement.
+            is_appendable,
+            index_schema: HashMap::new(),
+            vector_data: vector_data_info,
+            deferred_internal_id: self.deferred_internal_id(),
+        }
+    }
+
+    /// Like [`build_size_info`] but additionally populates `index_schema`.
+    pub fn build_info(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+    ) -> SegmentInfo {
+        let mut info = self.build_size_info(uuid, segment_type, is_appendable);
+        info.index_schema = self
+            .payload_index
+            .indexed_fields()
+            .into_iter()
+            .map(|(key, index_schema)| {
+                let points_count = self.payload_index.indexed_points(&key);
+                let index_info = PayloadIndexInfo::new(index_schema, points_count);
+                (key, index_info)
+            })
+            .collect();
+        info
+    }
+
+    /// Build the segment-level telemetry payload.
+    pub fn build_telemetry(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+        config: &SegmentConfig,
+        detail: TelemetryDetail,
+    ) -> SegmentTelemetry {
+        let vector_index_searches = self
+            .vector_data
+            .iter()
+            .map(|(name, vector_data)| {
+                let mut telemetry = vector_data.vector_index().get_telemetry_data(detail);
+                telemetry.index_name = Some(name.clone());
+                telemetry
+            })
+            .collect();
+
+        SegmentTelemetry {
+            info: self.build_info(uuid, segment_type, is_appendable),
+            config: config.clone(),
+            vector_index_searches,
+            payload_field_indices: self.payload_index.get_telemetry_data(),
+        }
+    }
+}

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -4,6 +4,7 @@ mod order_by;
 mod payload;
 mod sampling;
 mod scroll;
+mod search;
 mod segment_ops;
 mod vectors;
 

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -1,5 +1,6 @@
 mod deferred;
 mod facet;
+mod formula_rescore;
 mod order_by;
 mod payload;
 mod sampling;

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -1,6 +1,7 @@
 mod deferred;
 mod facet;
 mod formula_rescore;
+mod info;
 mod order_by;
 mod payload;
 mod sampling;

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -1,4 +1,5 @@
 mod deferred;
+mod facet;
 mod order_by;
 mod payload;
 mod sampling;

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -1,0 +1,283 @@
+use std::sync::atomic::AtomicBool;
+
+use ahash::AHashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::{DeferredBehavior, ScoredPointOffset};
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::{check_query_vectors, check_stopped};
+use crate::data_types::query_context::{QueryContext, QueryIdfStats, SegmentQueryContext};
+use crate::data_types::segment_record::{NamedVectorsOwned, SegmentRecord};
+use crate::data_types::vectors::{QueryVector, VectorInternal, VectorStructInternal};
+use crate::id_tracker::IdTrackerRead;
+use crate::index::{PayloadIndexRead, VectorIndexRead};
+use crate::payload_storage::PayloadStorageRead;
+use crate::segment::read_view::SegmentReadView;
+use crate::segment::vector_data_read::VectorDataRead;
+use crate::types::{
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SearchParams, VectorName, VectorNameBuf,
+    WithPayload, WithVector,
+};
+
+impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
+where
+    TIdT: IdTrackerRead,
+    TPI: PayloadIndexRead,
+    TPS: PayloadStorageRead,
+    TVD: VectorDataRead,
+{
+    /// Reads records from the segment for the given external point IDs,
+    /// optionally enriched with vectors and payload.
+    pub fn retrieve(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
+        let mut records = AHashMap::with_capacity(point_ids.len());
+
+        // Filter out deferred points. This is done in two stages to prevent cloning `point_ids`
+        // and iterating more than needed but still satisfy Rust's ownership constraints.
+        let behavior_allows_filtering = !deferred_behavior.include_all_points();
+        let filter_deferred = self.has_deferred_points() && behavior_allows_filtering;
+        let filtered_point_ids = filter_deferred.then(|| {
+            point_ids
+                .iter()
+                .filter(|&&point_id| !self.point_is_deferred(point_id))
+                .copied()
+                .collect::<Vec<_>>()
+        });
+
+        // Stage two: select the correct slice and shadow `point_ids`.
+        let point_ids = filtered_point_ids.as_deref().unwrap_or(point_ids);
+
+        let mut update_record_vector =
+            |vector_name: &VectorNameBuf,
+             point_id: PointIdType,
+             vector_internal: VectorInternal| {
+                let point_record = records
+                    .entry(point_id)
+                    .or_insert_with(|| SegmentRecord::empty(point_id));
+
+                point_record
+                    .vectors
+                    .get_or_insert_with(NamedVectorsOwned::default)
+                    .push((vector_name.clone(), vector_internal));
+            };
+
+        match with_vector {
+            WithVector::Bool(true) => {
+                for vector_name in self.vector_data.keys() {
+                    self.read_vectors(
+                        vector_name,
+                        point_ids,
+                        hw_counter,
+                        is_stopped,
+                        |point_id, vec| {
+                            update_record_vector(vector_name, point_id, vec);
+                        },
+                    )?;
+                }
+            }
+            WithVector::Bool(false) => {
+                // Do not display empty `vectors: {}` if disabled.
+                for &point_id in point_ids {
+                    let point_record = records
+                        .entry(point_id)
+                        .or_insert_with(|| SegmentRecord::empty(point_id));
+                    point_record.vectors = None;
+                }
+            }
+            WithVector::Selector(selector) => {
+                for vector_name in selector {
+                    self.read_vectors(
+                        vector_name,
+                        point_ids,
+                        hw_counter,
+                        is_stopped,
+                        |point_id, vec| {
+                            update_record_vector(vector_name, point_id, vec);
+                        },
+                    )?;
+                }
+            }
+        }
+
+        for &point_id in point_ids {
+            let payload = if with_payload.enable {
+                if let Some(selector) = &with_payload.payload_selector {
+                    Some(selector.process(self.payload(point_id, hw_counter)?))
+                } else {
+                    Some(self.payload(point_id, hw_counter)?)
+                }
+            } else {
+                None
+            };
+            let point_record = records
+                .entry(point_id)
+                .or_insert_with(|| SegmentRecord::empty(point_id));
+            point_record.payload = payload;
+        }
+
+        Ok(records)
+    }
+
+    /// Converts raw `ScoredPointOffset` search results into user-facing
+    /// `ScoredPoint`s. Deferred points are filtered out.
+    pub fn process_search_result(
+        &self,
+        internal_result: Vec<ScoredPointOffset>,
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<Vec<ScoredPoint>> {
+        let (point_ids, scored_offsets): (Vec<_>, Vec<_>) = internal_result
+            .into_iter()
+            .filter_map(|scored_point_offset| {
+                let point_offset = scored_point_offset.idx;
+                let point_id = self.id_tracker.external_id(point_offset);
+                // This can happen if a point was modified between retrieving and post-processing,
+                // but this function locks the segment so it can't be modified during execution.
+                debug_assert!(
+                    point_id.is_some(),
+                    "Point with internal ID {point_offset} not found in id tracker"
+                );
+                point_id.map(|id| (id, scored_point_offset))
+            })
+            .unzip();
+
+        let mut segment_records = self.retrieve(
+            &point_ids,
+            with_payload,
+            with_vector,
+            hw_counter,
+            is_stopped,
+            DeferredBehavior::Exclude,
+        )?;
+
+        let mut results = Vec::with_capacity(point_ids.len());
+
+        for (point_id, scored_offset) in point_ids.into_iter().zip(scored_offsets) {
+            let ScoredPointOffset {
+                idx: point_offset,
+                score: point_score,
+            } = scored_offset;
+
+            let record = segment_records.remove(&point_id);
+
+            // It is still possible for scored points to have duplicates for some reason, so we
+            // probably don't want to return error in release mode. We also don't want to copy all
+            // data just to handle this unexpected case.
+            let Some(record) = record else {
+                debug_assert!(
+                    false,
+                    "Record for point ID {point_id} not found during search result processing"
+                );
+                continue;
+            };
+
+            let point_version =
+                self.id_tracker
+                    .internal_version(point_offset)
+                    .ok_or_else(|| {
+                        OperationError::service_error(format!(
+                            "Corrupter id_tracker, no version for point {point_id}"
+                        ))
+                    })?;
+
+            let SegmentRecord {
+                id,
+                vectors,
+                payload,
+            } = record;
+
+            results.push(ScoredPoint {
+                id,
+                version: point_version,
+                score: point_score,
+                payload,
+                vector: vectors.map(VectorStructInternal::from),
+                shard_key: None,
+                order_value: None,
+            });
+        }
+
+        Ok(results)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn search_batch(
+        &self,
+        vector_name: &VectorName,
+        query_vectors: &[&QueryVector],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &SegmentQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPoint>>> {
+        check_query_vectors(vector_name, query_vectors, self.segment_config)?;
+        let vector_data = self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
+        let vector_query_context =
+            query_context.get_vector_context(vector_name, self.deferred_internal_id());
+        let internal_results = vector_data.vector_index().search(
+            query_vectors,
+            filter,
+            top,
+            params,
+            &vector_query_context,
+        )?;
+
+        check_stopped(&vector_query_context.is_stopped())?;
+
+        let hw_counter = vector_query_context.hardware_counter();
+
+        internal_results
+            .into_iter()
+            .map(|internal_result| {
+                self.process_search_result(
+                    internal_result,
+                    with_payload,
+                    with_vector,
+                    &hw_counter,
+                    &vector_query_context.is_stopped(),
+                )
+            })
+            .collect()
+    }
+
+    pub fn fill_query_context(&self, query_context: &mut QueryContext) {
+        query_context.add_available_point_count(self.available_point_count_without_deferred());
+        let hw_acc = query_context.hardware_usage_accumulator();
+        let hw_counter = hw_acc.get_counter_cell();
+
+        let QueryIdfStats {
+            idf,
+            indexed_vectors,
+        } = query_context.mut_idf_stats();
+
+        for (vector_name, idf) in idf.iter_mut() {
+            if let Some(vector_data) = self.vector_data.get(vector_name) {
+                let vector_index = vector_data.vector_index();
+
+                let indexed_vector_count = vector_index.indexed_vector_count();
+
+                if let Some(count) = indexed_vectors.get_mut(vector_name) {
+                    *count += indexed_vector_count;
+                } else {
+                    indexed_vectors.insert(vector_name.clone(), indexed_vector_count);
+                }
+
+                vector_index.fill_idf_statistics(idf, &hw_counter);
+            }
+        }
+    }
+}

--- a/lib/segment/src/segment/search.rs
+++ b/lib/segment/src/segment/search.rs
@@ -1,111 +1,20 @@
-use std::sync::atomic::AtomicBool;
-
-use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, ScoredPointOffset};
-
+#[cfg(feature = "testing")]
 use super::Segment;
-use crate::common::operation_error::{OperationError, OperationResult};
+#[cfg(feature = "testing")]
+use crate::common::operation_error::OperationResult;
 #[cfg(feature = "testing")]
 use crate::data_types::query_context::QueryContext;
-use crate::data_types::segment_record::SegmentRecord;
 #[cfg(feature = "testing")]
 use crate::data_types::vectors::QueryVector;
-use crate::data_types::vectors::VectorStructInternal;
+#[cfg(feature = "testing")]
 use crate::entry::ReadSegmentEntry;
-use crate::id_tracker::IdTrackerRead;
 #[cfg(feature = "testing")]
-use crate::types::VectorName;
-#[cfg(feature = "testing")]
-use crate::types::{Filter, SearchParams};
-use crate::types::{ScoredPoint, WithPayload, WithVector};
+use crate::types::{Filter, ScoredPoint, SearchParams, VectorName, WithPayload, WithVector};
 
+#[cfg(feature = "testing")]
 impl Segment {
-    /// Converts raw ScoredPointOffset search result into ScoredPoint result
-    ///
-    /// Doesn't filter deferred points.
-    pub(super) fn process_search_result(
-        &self,
-        internal_result: Vec<ScoredPointOffset>,
-        with_payload: &WithPayload,
-        with_vector: &WithVector,
-        hw_counter: &HardwareCounterCell,
-        is_stopped: &AtomicBool,
-    ) -> OperationResult<Vec<ScoredPoint>> {
-        let id_tracker = self.id_tracker.borrow();
-        let (point_ids, scored_offsets): (Vec<_>, Vec<_>) = internal_result
-            .into_iter()
-            .filter_map(|scored_point_offset| {
-                let point_offset = scored_point_offset.idx;
-                let point_id = id_tracker.external_id(point_offset);
-                // This can happen if point was modified between retrieving and post-processing
-                // But this function locks the segment, so it can't be modified during its execution
-                debug_assert!(
-                    point_id.is_some(),
-                    "Point with internal ID {point_offset} not found in id tracker"
-                );
-                point_id.map(|id| (id, scored_point_offset))
-            })
-            .unzip();
-
-        let mut segment_records = self.retrieve(
-            &point_ids,
-            with_payload,
-            with_vector,
-            hw_counter,
-            is_stopped,
-            DeferredBehavior::Exclude,
-        )?;
-
-        let mut results = Vec::with_capacity(point_ids.len());
-
-        for (point_id, scored_offset) in point_ids.into_iter().zip(scored_offsets) {
-            let ScoredPointOffset {
-                idx: point_offset,
-                score: point_score,
-            } = scored_offset;
-
-            let record = segment_records.remove(&point_id);
-
-            // It is still possible, that for some reason scored points have duplicates
-            // so we probably don't want to return error in release mode.
-            // We also don't want to copy all data just to handle this unexpected case.
-            let Some(record) = record else {
-                debug_assert!(
-                    false,
-                    "Record for point ID {point_id} not found during search result processing"
-                );
-                continue;
-            };
-
-            let point_version = id_tracker.internal_version(point_offset).ok_or_else(|| {
-                OperationError::service_error(format!(
-                    "Corrupter id_tracker, no version for point {point_id}"
-                ))
-            })?;
-
-            let SegmentRecord {
-                id,
-                vectors,
-                payload,
-            } = record;
-
-            results.push(ScoredPoint {
-                id,
-                version: point_version,
-                score: point_score,
-                payload,
-                vector: vectors.map(VectorStructInternal::from),
-                shard_key: None,
-                order_value: None,
-            });
-        }
-
-        Ok(results)
-    }
-
     /// This function is a simplified version of `search_batch` intended for testing purposes.
     #[allow(clippy::too_many_arguments)]
-    #[cfg(feature = "testing")]
     pub fn search(
         &self,
         vector_name: &VectorName,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -603,12 +603,6 @@ impl Segment {
             .as_ref()
             .map(|i| i.deferred_internal_id)
     }
-
-    pub(crate) fn deferred_deleted_count(&self) -> Option<usize> {
-        self.deferred_point_status
-            .as_ref()
-            .map(|i| i.deferred_deleted_count)
-    }
 }
 
 fn restore_snapshot_in_place(snapshot_path: &Path) -> OperationResult<()> {


### PR DESCRIPTION
## Summary

Step 8 of the `SegmentReadView` migration. Stacked on top of #8878.

Three commits:

### 1. Trait extension on `PayloadIndexRead`

Add `facet_index_for(key) -> Option<impl FacetIndex + '_>`. Implemented on `StructPayloadIndex` (delegates to existing `get_facet_index` logic) and `PlainPayloadIndex` (always `None`).

Initially landed with a separate `FacetIndexRead` trait, then collapsed onto the existing `FacetIndex` trait (see commit 3) — the only divergence was the deferred-aware `for_each_value` semantics, now lifted onto `FacetIndex` as a default method `for_each_visible_value`.

### 2. Step 8 — migrate facets

Move `segment/facet.rs` → `read_view/facet.rs`:
- `approximate_facet`
- `facet_values`

Both now go through trait methods (`facet_index_for`, `filter_context`) instead of inherent calls (`get_facet_index`, `struct_filtered_context`).

`Segment::unique_values` and `Segment::facet` collapse to single `with_view` delegators. The legacy `segment/facet.rs` is deleted.

### 3. Drop `FacetIndexRead`, reuse `FacetIndex`

`FacetIndexRead` was almost identical to `FacetIndex`. The only divergence — `for_each_value` taking deferred-aware args — is now a default method `for_each_visible_value` on `FacetIndex` itself. `FacetIndexEnum` impls `FacetIndex` directly.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p segment --lib` — 644 passed, 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)