### PR TITLE
refactor(segment): migrate info/size_info/telemetry to SegmentReadView (step 11)

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -1615,6 +1615,10 @@ impl VectorIndexRead for HNSWIndex {
     ) {
         // HNSW (dense) index doesn't track IDF.
     }
+
+    fn is_index(&self) -> bool {
+        true
+    }
 }
 
 impl VectorIndex for HNSWIndex {

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -16,6 +16,7 @@ use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::json_path::JsonPath;
 use crate::payload_storage::FilterContext;
+use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 pub enum BuildIndexResult {
@@ -88,6 +89,9 @@ pub trait PayloadIndexRead {
     /// Used by faceting to enumerate values and per-value point sets. The
     /// concrete facet-index type is opaque per implementation.
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_>;
+
+    /// Per-field-index telemetry data.
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry>;
 
     /// Build a per-query formula scorer that evaluates the given parsed
     /// formula against this index's payload, using the prefetch scores as

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -27,6 +27,7 @@ use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFor
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{ConditionCheckerSS, FilterContext};
+use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
@@ -173,6 +174,11 @@ impl PayloadIndexRead for PlainPayloadIndex {
     fn facet_index_for(&self, _key: &JsonPath) -> Option<impl FacetIndex + '_> {
         // Plain index has no field indexes; the type tag is just a placeholder.
         None::<FacetIndexEnum<'_>>
+    }
+
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+        // Plain index has no field indexes to report telemetry for.
+        Vec::new()
     }
 
     fn formula_scorer<'q>(

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -204,6 +204,10 @@ impl VectorIndexRead for PlainVectorIndex {
     ) {
         // Plain (dense) index doesn't track IDF.
     }
+
+    fn is_index(&self) -> bool {
+        false
+    }
 }
 
 impl VectorIndex for PlainVectorIndex {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -621,6 +621,10 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
             }
         }
     }
+
+    fn is_index(&self) -> bool {
+        true
+    }
 }
 
 impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedIndex> {

--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -453,18 +453,6 @@ impl StructPayloadIndex {
         })
     }
 
-    pub fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
-        self.field_indexes
-            .iter()
-            .flat_map(|(name, field)| -> Vec<PayloadIndexTelemetry> {
-                field
-                    .iter()
-                    .map(|field| field.get_telemetry_data().set_name(name.to_string()))
-                    .collect()
-            })
-            .collect()
-    }
-
     fn clear_index_for_point(&mut self, point_id: PointOffsetType) -> OperationResult<()> {
         for (_, field_indexes) in self.field_indexes.iter_mut() {
             for index in field_indexes {
@@ -622,6 +610,18 @@ impl PayloadIndexRead for StructPayloadIndex {
         self.field_indexes
             .get(key)
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
+    }
+
+    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+        self.field_indexes
+            .iter()
+            .flat_map(|(name, field)| -> Vec<PayloadIndexTelemetry> {
+                field
+                    .iter()
+                    .map(|field| field.get_telemetry_data().set_name(name.to_string()))
+                    .collect()
+            })
+            .collect()
     }
 
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_> {

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -55,6 +55,11 @@ pub trait VectorIndexRead {
         idf: &mut HashMap<DimId, usize>,
         hw_counter: &HardwareCounterCell,
     );
+
+    /// Whether this is a "real" index rather than a plain (full-scan) one.
+    ///
+    /// Used by reporting code to decide whether to count vectors as indexed.
+    fn is_index(&self) -> bool;
 }
 
 /// Trait for vector index with mutating operations.
@@ -100,22 +105,6 @@ pub enum VectorIndexEnum {
 }
 
 impl VectorIndexEnum {
-    pub fn is_index(&self) -> bool {
-        match self {
-            Self::Plain(_) => false,
-            Self::Hnsw(_) => true,
-            Self::SparseRam(_) => true,
-            Self::SparseImmutableRam(_) => true,
-            Self::SparseMmap(_) => true,
-            Self::SparseCompressedImmutableRamF32(_) => true,
-            Self::SparseCompressedImmutableRamF16(_) => true,
-            Self::SparseCompressedImmutableRamU8(_) => true,
-            Self::SparseCompressedMmapF32(_) => true,
-            Self::SparseCompressedMmapF16(_) => true,
-            Self::SparseCompressedMmapU8(_) => true,
-        }
-    }
-
     /// Returns true if underlying storage is configured to be stored on disk without
     /// actively holding data in RAM
     pub fn is_on_disk(&self) -> bool {
@@ -272,6 +261,22 @@ impl VectorIndexRead for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
+        }
+    }
+
+    fn is_index(&self) -> bool {
+        match self {
+            Self::Plain(_) => false,
+            Self::Hnsw(_) => true,
+            Self::SparseRam(_) => true,
+            Self::SparseImmutableRam(_) => true,
+            Self::SparseMmap(_) => true,
+            Self::SparseCompressedImmutableRamF32(_) => true,
+            Self::SparseCompressedImmutableRamF16(_) => true,
+            Self::SparseCompressedImmutableRamU8(_) => true,
+            Self::SparseCompressedMmapF32(_) => true,
+            Self::SparseCompressedMmapF16(_) => true,
+            Self::SparseCompressedMmapU8(_) => true,
         }
     }
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -25,16 +25,15 @@ use crate::entry::entry_point::{
 };
 use crate::id_tracker::{IdTracker, IdTrackerRead, PointMappingsGuard};
 use crate::index::field_index::{CardinalityEstimation, FieldIndex};
-use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead, VectorIndexRead};
+use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
-use crate::payload_storage::PayloadStorageRead;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
-    ExtendedPointId, Filter, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadKeyType,
-    PayloadKeyTypeRef, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo,
-    SegmentType, SeqNumberType, VectorDataInfo, VectorName, VectorNameBuf, WithPayload, WithVector,
+    ExtendedPointId, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
+    PointIdType, ScoredPoint, SearchParams, SegmentConfig, SegmentInfo, SegmentType, SeqNumberType,
+    VectorName, VectorNameBuf, WithPayload, WithVector,
 };
-use crate::vector_storage::{VectorStorage, VectorStorageRead};
+use crate::vector_storage::VectorStorage;
 
 /// This is a basic implementation of the trait, meaning that it implements the _actual_ operations with data and not
 /// any kind of proxy or wrapping.
@@ -248,96 +247,13 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn size_info(&self) -> SegmentInfo {
-        let num_vectors = self
-            .vector_data
-            .values()
-            .map(|data| data.vector_storage.borrow().available_vector_count())
-            .sum();
-
-        let mut total_average_vectors_size_bytes: usize = 0;
-
-        let vector_data_info: HashMap<_, _> = self
-            .vector_data
-            .iter()
-            .map(|(key, vector_data)| {
-                let vector_storage = vector_data.vector_storage.borrow();
-                let num_vectors = vector_storage.available_vector_count();
-                let vector_index = vector_data.vector_index.borrow();
-                let is_indexed = vector_index.is_index();
-
-                let average_vector_size_bytes = vector_index
-                    .size_of_searchable_vectors_in_bytes()
-                    .checked_div(num_vectors)
-                    .unwrap_or(0);
-                total_average_vectors_size_bytes += average_vector_size_bytes;
-
-                let vector_data_info = VectorDataInfo {
-                    num_vectors,
-                    num_indexed_vectors: if is_indexed {
-                        vector_index.indexed_vector_count()
-                    } else {
-                        0
-                    },
-                    num_deleted_vectors: vector_storage.deleted_vector_count(),
-                };
-                (key.clone(), vector_data_info)
-            })
-            .collect();
-
-        let num_indexed_vectors = if self.segment_type == SegmentType::Indexed {
-            self.vector_data
-                .values()
-                .map(|data| data.vector_index.borrow().indexed_vector_count())
-                .sum()
-        } else {
-            0
-        };
-
-        let vectors_size_bytes = total_average_vectors_size_bytes * self.available_point_count();
-
-        // Unwrap and default to 0 here because the RocksDB storage is the only faillible one, and we will remove it eventually.
-        let payloads_size_bytes = self
-            .payload_storage
-            .borrow()
-            .get_storage_size_bytes()
-            .unwrap_or(0);
-
-        SegmentInfo {
-            uuid: self.segment_uuid(),
-            segment_type: self.segment_type,
-            num_vectors,
-            num_indexed_vectors,
-            num_points: self.available_point_count(),
-            num_deferred_points: Some(self.deferred_point_count()),
-            num_deleted_deferred_points: Some(self.deferred_deleted_count().unwrap_or_default()),
-            num_deleted_vectors: self.deleted_point_count(),
-            vectors_size_bytes,  // Considers vector storage, but not indices
-            payloads_size_bytes, // Considers payload storage, but not indices
-            ram_usage_bytes: 0,  // ToDo: Implement
-            disk_usage_bytes: 0, // ToDo: Implement
-            is_appendable: self.appendable_flag,
-            index_schema: HashMap::new(),
-            vector_data: vector_data_info,
-            deferred_internal_id: self.deferred_internal_id(),
-        }
+        self.with_view(|view| {
+            view.build_size_info(self.uuid, self.segment_type, self.appendable_flag)
+        })
     }
 
     fn info(&self) -> SegmentInfo {
-        let payload_index = self.payload_index.borrow();
-        let schema = payload_index
-            .indexed_fields()
-            .into_iter()
-            .map(|(key, index_schema)| {
-                let points_count = payload_index.indexed_points(&key);
-                let index_info = PayloadIndexInfo::new(index_schema, points_count);
-                (key, index_info)
-            })
-            .collect();
-
-        let mut info = self.size_info();
-        info.index_schema = schema;
-
-        info
+        self.with_view(|view| view.build_info(self.uuid, self.segment_type, self.appendable_flag))
     }
 
     fn config(&self) -> &SegmentConfig {
@@ -356,22 +272,15 @@ impl ReadSegmentEntry for Segment {
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
-        let vector_index_searches: Vec<_> = self
-            .vector_data
-            .iter()
-            .map(|(k, v)| {
-                let mut telemetry = v.vector_index.borrow().get_telemetry_data(detail);
-                telemetry.index_name = Some(k.clone());
-                telemetry
-            })
-            .collect();
-
-        SegmentTelemetry {
-            info: self.info(),
-            config: self.config().clone(),
-            vector_index_searches,
-            payload_field_indices: self.payload_index.borrow().get_telemetry_data(),
-        }
+        self.with_view(|view| {
+            view.build_telemetry(
+                self.uuid,
+                self.segment_type,
+                self.appendable_flag,
+                &self.segment_config,
+                detail,
+            )
+        })
     }
 
     fn fill_query_context(&self, query_context: &mut QueryContext) {

--- a/lib/segment/src/segment/read_view/info.rs
+++ b/lib/segment/src/segment/read_view/info.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use common::types::TelemetryDetail;
+use uuid::Uuid;
+
+use crate::id_tracker::IdTrackerRead;
+use crate::index::{PayloadIndexRead, VectorIndexRead};
+use crate::payload_storage::PayloadStorageRead;
+use crate::segment::read_view::SegmentReadView;
+use crate::segment::vector_data_read::VectorDataRead;
+use crate::telemetry::SegmentTelemetry;
+use crate::types::{PayloadIndexInfo, SegmentConfig, SegmentInfo, SegmentType, VectorDataInfo};
+use crate::vector_storage::VectorStorageRead;
+
+impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
+where
+    TIdT: IdTrackerRead,
+    TPI: PayloadIndexRead,
+    TPS: PayloadStorageRead,
+    TVD: VectorDataRead,
+{
+    /// Build a `SegmentInfo` describing this segment's storage. The trivial
+    /// segment-level fields (`uuid`, `segment_type`, `is_appendable`) come from
+    /// the caller — typically the segment-type-specific direct getters.
+    ///
+    /// `index_schema` is left empty; use [`build_info`] to also populate it.
+    pub fn build_size_info(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+    ) -> SegmentInfo {
+        let mut total_average_vectors_size_bytes: usize = 0;
+        let mut num_vectors_total: usize = 0;
+        let mut num_indexed_vectors_total: usize = 0;
+        let segment_is_indexed = segment_type == SegmentType::Indexed;
+
+        let vector_data_info: HashMap<_, _> = self
+            .vector_data
+            .iter()
+            .map(|(key, vector_data)| {
+                let vector_storage = vector_data.vector_storage();
+                let vector_index = vector_data.vector_index();
+                let num_vectors = vector_storage.available_vector_count();
+                num_vectors_total += num_vectors;
+
+                let average_vector_size_bytes = vector_index
+                    .size_of_searchable_vectors_in_bytes()
+                    .checked_div(num_vectors)
+                    .unwrap_or(0);
+                total_average_vectors_size_bytes += average_vector_size_bytes;
+
+                let indexed_vector_count = vector_index.indexed_vector_count();
+                let num_indexed_vectors = if vector_index.is_index() {
+                    indexed_vector_count
+                } else {
+                    0
+                };
+                if segment_is_indexed {
+                    num_indexed_vectors_total += indexed_vector_count;
+                }
+
+                let info = VectorDataInfo {
+                    num_vectors,
+                    num_indexed_vectors,
+                    num_deleted_vectors: vector_storage.deleted_vector_count(),
+                };
+                (key.clone(), info)
+            })
+            .collect();
+
+        let vectors_size_bytes =
+            total_average_vectors_size_bytes * self.id_tracker.available_point_count();
+
+        // Unwrap and default to 0 here because the RocksDB storage is the only fallible one,
+        // and we will remove it eventually.
+        let payloads_size_bytes = self.payload_storage.get_storage_size_bytes().unwrap_or(0);
+
+        SegmentInfo {
+            uuid,
+            segment_type,
+            num_vectors: num_vectors_total,
+            num_indexed_vectors: num_indexed_vectors_total,
+            num_points: self.id_tracker.available_point_count(),
+            num_deferred_points: Some(self.deferred_point_count()),
+            num_deleted_deferred_points: Some(self.deferred_deleted_count().unwrap_or_default()),
+            num_deleted_vectors: self.id_tracker.deleted_point_count(),
+            vectors_size_bytes,  // Considers vector storage, but not indices.
+            payloads_size_bytes, // Considers payload storage, but not indices.
+            ram_usage_bytes: 0,  // ToDo: Implement.
+            disk_usage_bytes: 0, // ToDo: Implement.
+            is_appendable,
+            index_schema: HashMap::new(),
+            vector_data: vector_data_info,
+            deferred_internal_id: self.deferred_internal_id(),
+        }
+    }
+
+    /// Like [`build_size_info`] but additionally populates `index_schema`.
+    pub fn build_info(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+    ) -> SegmentInfo {
+        let mut info = self.build_size_info(uuid, segment_type, is_appendable);
+        info.index_schema = self
+            .payload_index
+            .indexed_fields()
+            .into_iter()
+            .map(|(key, index_schema)| {
+                let points_count = self.payload_index.indexed_points(&key);
+                let index_info = PayloadIndexInfo::new(index_schema, points_count);
+                (key, index_info)
+            })
+            .collect();
+        info
+    }
+
+    /// Build the segment-level telemetry payload.
+    pub fn build_telemetry(
+        &self,
+        uuid: Uuid,
+        segment_type: SegmentType,
+        is_appendable: bool,
+        config: &SegmentConfig,
+        detail: TelemetryDetail,
+    ) -> SegmentTelemetry {
+        let vector_index_searches = self
+            .vector_data
+            .iter()
+            .map(|(name, vector_data)| {
+                let mut telemetry = vector_data.vector_index().get_telemetry_data(detail);
+                telemetry.index_name = Some(name.clone());
+                telemetry
+            })
+            .collect();
+
+        SegmentTelemetry {
+            info: self.build_info(uuid, segment_type, is_appendable),
+            config: config.clone(),
+            vector_index_searches,
+            payload_field_indices: self.payload_index.get_telemetry_data(),
+        }
+    }
+}

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -1,6 +1,7 @@
 mod deferred;
 mod facet;
 mod formula_rescore;
+mod info;
 mod order_by;
 mod payload;
 mod sampling;

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -603,12 +603,6 @@ impl Segment {
             .as_ref()
             .map(|i| i.deferred_internal_id)
     }
-
-    pub(crate) fn deferred_deleted_count(&self) -> Option<usize> {
-        self.deferred_point_status
-            .as_ref()
-            .map(|i| i.deferred_deleted_count)
-    }
 }
 
 fn restore_snapshot_in_place(snapshot_path: &Path) -> OperationResult<()> {


### PR DESCRIPTION
## Summary

Step 11 of the `SegmentReadView` migration — the final logical step. Stacked on top of #8881.

Two commits.

### 1. Trait extensions (no defaults — every implementor must opt in)

- **`VectorIndexRead::is_index`** — distinguishes a real index from a plain full-scan one. Moved out of inherent `VectorIndexEnum::is_index` into the trait. Explicit impls on Plain (false), HNSW (true), Sparse* (true).
- **`PayloadIndexRead::get_telemetry_data`** — per-field-index telemetry. Moved out of inherent `StructPayloadIndex::get_telemetry_data` into the trait impl. `PlainPayloadIndex` returns an empty Vec.

### 2. Step 11 — migration

New `read_view/info.rs` exposes builder methods:
- `build_size_info(uuid, segment_type, is_appendable)`
- `build_info(uuid, segment_type, is_appendable)` — same plus `index_schema`
- `build_telemetry(uuid, segment_type, is_appendable, config, detail)`

The trivial segment-level fields (`uuid`, `segment_type`, `is_appendable`, `config`) are passed in by the caller — they stay direct on each segment-type rather than going through the view. Everything else (vector data breakdown, payloads size, deferred counts, vector-index telemetry, payload-field telemetry, …) is computed once inside the view through the read traits.

`Segment::size_info`, `info`, and `get_telemetry_data` collapse to one-line `with_view` delegators that pass in the trivial fields.

Cleanup: `Segment::deferred_deleted_count` is now unused (the view has its own equivalent helper); deleted.

## End of plan

This is the final step. After merge of #8867 → #8868 → … → #8881 → this, `impl ReadSegmentEntry for Segment` is fully a list of `with_view` delegators (plus the trivial getters that stay direct: `version`, `is_proxy`, `vector_names`, `is_appendable`, `get_indexed_fields`, `segment_uuid`, `segment_type`, `config`, plus `all_vectors` whose `NamedVectors<'_>` lifetime invariance fights the view borrow). All the heavy lifting lives on `SegmentReadView` and is parametrised over the four read traits (`IdTrackerRead`, `PayloadIndexRead`, `PayloadStorageRead`, `VectorDataRead`) — ready to be reused by `ReadOnlySegment`.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p segment --lib` — 644 passed, 0 failed
- [x] `mold -run cargo clippy --workspace --all-targets` — 0 warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)