### PR TITLE
feat(segment): add ReadOnlyPayloadStorage backed by GridstoreReader

### DIFF
--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -85,10 +85,10 @@ impl MmapPayloadStorage {
 impl PayloadStorageRead for MmapPayloadStorage {
     fn get(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
-        match self.storage.get_value::<Random>(point_id, hw_counter)? {
+        match self.storage.get_value::<Random>(point_offset, hw_counter)? {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
@@ -96,10 +96,13 @@ impl PayloadStorageRead for MmapPayloadStorage {
 
     fn get_sequential(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
-        match self.storage.get_value::<Sequential>(point_id, hw_counter)? {
+        match self
+            .storage
+            .get_value::<Sequential>(point_offset, hw_counter)?
+        {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }

--- a/lib/segment/src/payload_storage/mod.rs
+++ b/lib/segment/src/payload_storage/mod.rs
@@ -8,6 +8,8 @@ pub mod mmap_payload_storage;
 mod payload_storage_base;
 pub mod payload_storage_enum;
 pub mod query_checker;
+#[allow(dead_code)]
+pub mod read_only;
 #[cfg(test)]
 mod tests;
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -17,13 +17,13 @@ use crate::types::{Filter, Payload};
 pub trait PayloadStorageRead {
     fn get(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
 
     fn get_sequential(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
 

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -36,25 +36,27 @@ impl From<MmapPayloadStorage> for PayloadStorageEnum {
 impl PayloadStorageRead for PayloadStorageEnum {
     fn get(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         match self {
             #[cfg(feature = "testing")]
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.get(point_id, hw_counter),
-            PayloadStorageEnum::MmapPayloadStorage(s) => s.get(point_id, hw_counter),
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.get(point_offset, hw_counter),
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.get(point_offset, hw_counter),
         }
     }
 
     fn get_sequential(
         &self,
-        point_id: PointOffsetType,
+        point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         match self {
             #[cfg(feature = "testing")]
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => s.get_sequential(point_id, hw_counter),
-            PayloadStorageEnum::MmapPayloadStorage(s) => s.get_sequential(point_id, hw_counter),
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                s.get_sequential(point_offset, hw_counter)
+            }
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.get_sequential(point_offset, hw_counter),
         }
     }
 

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -1,0 +1,10 @@
+mod payload_storage_read;
+
+use gridstore::GridstoreReader;
+
+use crate::types::Payload;
+
+pub struct ReadOnlyPayloadStorage {
+    storage: GridstoreReader<Payload>,
+    populate: bool,
+}

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -1,0 +1,55 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::{Random, Sequential};
+use common::types::PointOffsetType;
+
+use crate::common::operation_error::OperationResult;
+use crate::payload_storage::PayloadStorageRead;
+use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
+use crate::types::Payload;
+
+impl PayloadStorageRead for ReadOnlyPayloadStorage {
+    fn get(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        match self.storage.get_value::<Random>(point_offset, hw_counter)? {
+            Some(payload) => Ok(payload),
+            None => Ok(Default::default()),
+        }
+    }
+
+    fn get_sequential(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Payload> {
+        match self
+            .storage
+            .get_value::<Sequential>(point_offset, hw_counter)?
+        {
+            Some(payload) => Ok(payload),
+            None => Ok(Default::default()),
+        }
+    }
+
+    fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>
+    where
+        F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
+    {
+        let max_id = self.storage.max_point_offset();
+        self.storage.iter(
+            max_id,
+            |point_id, payload| callback(point_id, &payload),
+            hw_counter.ref_payload_io_read_counter(),
+        )
+    }
+
+    fn get_storage_size_bytes(&self) -> OperationResult<usize> {
+        Ok(self.storage.get_storage_size_bytes())
+    }
+
+    fn is_on_disk(&self) -> bool {
+        !self.populate
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `ReadOnlyPayloadStorage`, a read-only payload storage that wraps `GridstoreReader<Payload>` and implements `PayloadStorageRead`.
- Rename the `point_id` parameter to `point_offset` on `PayloadStorageRead::get`/`get_sequential` (and impls) for consistency with the underlying gridstore API.

## Test plan
- [ ] `cargo check -p segment`
- [ ] CI (fmt, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)