### PR TITLE
[UIO] Generic dynamic flags

### DIFF
--- a/lib/common/common/src/universal_io/wrappers/mod.rs
+++ b/lib/common/common/src/universal_io/wrappers/mod.rs
@@ -1,9 +1,11 @@
 mod buffered_update;
 mod read_only;
+mod stored_struct;
 mod typed;
 mod wrapped_pipeline;
 
 pub use buffered_update::SliceBufferedUpdateWrapper;
 pub use read_only::ReadOnly;
+pub use stored_struct::StoredStruct;
 pub use typed::TypedStorage;
 pub use wrapped_pipeline::WrappedReadPipeline;

--- a/lib/common/common/src/universal_io/wrappers/stored_struct.rs
+++ b/lib/common/common/src/universal_io/wrappers/stored_struct.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::is_alive_lock::IsAliveLock;
+use crate::universal_io::{
+    self, Flusher, OpenOptions, TypedStorage, UniversalRead, UniversalWrite,
+};
+
+/// A generic-storage wrapper for a type that should be possible to `read_whole` fairly cheaply.
+///
+/// It dereferences to a copy of the stored type in memory so that reads are fast.
+/// On flush, the entire in-memory state is written to disk.
+#[derive(Debug)]
+pub struct StoredStruct<S, T> {
+    inner: T,
+    storage: Arc<Mutex<TypedStorage<S, T>>>,
+    is_alive_lock: IsAliveLock,
+}
+
+impl<S, T> StoredStruct<S, T>
+where
+    T: bytemuck::Pod + Send,
+    S: UniversalWrite<T> + Send + 'static,
+{
+    pub fn open(path: impl AsRef<Path>, options: OpenOptions) -> universal_io::Result<Self> {
+        let storage = TypedStorage::open(path, options)?;
+        let inner = storage.read_whole()?[0];
+        Ok(Self {
+            inner,
+            storage: Arc::new(Mutex::new(storage)),
+            is_alive_lock: IsAliveLock::new(),
+        })
+    }
+
+    pub fn flusher(&self) -> Flusher {
+        let state = self.inner; // copy current state
+        let storage = Arc::downgrade(&self.storage);
+        let is_alive = self.is_alive_lock.handle();
+
+        Box::new(move || {
+            let (Some(_is_alive), Some(storage)) = (is_alive.lock_if_alive(), storage.upgrade())
+            else {
+                // Storage was dropped before executing the flusher
+                return Ok(());
+            };
+
+            let mut storage = storage.lock();
+            storage.write(0, &[state])?;
+            storage.flusher()()?;
+
+            Ok(())
+        })
+    }
+}
+
+impl<S, T> std::ops::Deref for StoredStruct<S, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<S, T> std::ops::DerefMut for StoredStruct<S, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -2,6 +2,7 @@ use std::hint::black_box;
 use std::iter;
 use std::sync::atomic::AtomicBool;
 
+use common::universal_io::MmapFile;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -20,7 +21,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
     let stopped = AtomicBool::new(false);
 
     // Build dynamic mmap flags with random deletions
-    let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+    let mut dynamic_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
     dynamic_flags.set_len(FLAG_COUNT).unwrap();
     dynamic_flags
         .set_ascending_bits(

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
-use segment::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use segment::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use segment::common::operation_error::check_process_stopped;
 use tempfile::tempdir;
 
@@ -20,7 +20,7 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
     let stopped = AtomicBool::new(false);
 
     // Build dynamic mmap flags with random deletions
-    let mut dynamic_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+    let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
     dynamic_flags.set_len(FLAG_COUNT).unwrap();
     dynamic_flags
         .set_ascending_bits(

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -4,7 +4,7 @@ use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
-use super::dynamic_mmap_flags::DynamicMmapFlags;
+use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 
@@ -28,7 +28,7 @@ pub struct BitvecFlags {
 }
 
 impl BitvecFlags {
-    pub fn new(mmap_flags: DynamicMmapFlags) -> OperationResult<Self> {
+    pub fn new(mmap_flags: DynamicStoredFlags) -> OperationResult<Self> {
         // load flags into memory
         let bitvec = BitVec::from_bitslice(&*mmap_flags.get_bitslice()?);
 
@@ -122,7 +122,7 @@ mod tests {
     use common::types::PointOffsetType;
 
     use crate::common::flags::bitvec_flags::BitvecFlags;
-    use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+    use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 
     #[test]
     fn test_roaring_flags_consistency_after_persistence() {
@@ -133,7 +133,7 @@ mod tests {
 
         // Create and update flags
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             let mut bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
@@ -162,7 +162,7 @@ mod tests {
 
         // Verify bitmap consistency after reload
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
 use super::dynamic_stored_flags::DynamicStoredFlags;
@@ -28,17 +29,17 @@ pub struct BitvecFlags {
 }
 
 impl BitvecFlags {
-    pub fn new(mmap_flags: DynamicStoredFlags) -> OperationResult<Self> {
+    pub fn new(dynamic_flags: DynamicStoredFlags<MmapFile>) -> OperationResult<Self> {
         // load flags into memory
-        let bitvec = BitVec::from_bitslice(&*mmap_flags.get_bitslice()?);
+        let bitvec = BitVec::from_bitslice(&*dynamic_flags.get_bitslice()?);
 
-        if let Err(err) = mmap_flags.clear_cache() {
+        if let Err(err) = dynamic_flags.clear_cache() {
             log::warn!("Failed to clear bitslice cache: {err}");
         }
 
         Ok(Self {
-            len: mmap_flags.len(),
-            storage: BufferedDynamicFlags::new(mmap_flags),
+            len: dynamic_flags.len(),
+            storage: BufferedDynamicFlags::new(dynamic_flags),
             bitvec,
         })
     }

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 
-use super::dynamic_mmap_flags::DynamicMmapFlags;
+use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 
@@ -17,7 +17,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 #[derive(Debug)]
 pub(crate) struct BufferedDynamicFlags {
     /// Persisted flags.
-    storage: Arc<Mutex<DynamicMmapFlags>>,
+    storage: Arc<Mutex<DynamicStoredFlags>>,
 
     /// Pending changes to the storage flags.
     buffer: Arc<RwLock<AHashMap<PointOffsetType, bool>>>,
@@ -27,7 +27,7 @@ pub(crate) struct BufferedDynamicFlags {
 }
 
 impl BufferedDynamicFlags {
-    pub fn new(mmap_flags: DynamicMmapFlags) -> Self {
+    pub fn new(mmap_flags: DynamicStoredFlags) -> Self {
         let buffer = Arc::new(RwLock::new(AHashMap::new()));
         let is_alive_flush_lock = IsAliveLock::new();
         Self {
@@ -133,7 +133,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use crate::common::flags::buffered_dynamic_flags::BufferedDynamicFlags;
-    use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+    use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 
     #[test]
     fn test_buffered_flags_growth_persistence() {
@@ -144,7 +144,7 @@ mod tests {
 
         // Start with smaller flags
         {
-            let mut mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             mmap_flags.set_len(3).unwrap();
             mmap_flags.set(0, true).unwrap();
             mmap_flags.set(2, true).unwrap();
@@ -153,7 +153,7 @@ mod tests {
 
         // Grow and update with BufferedDynamicFlags
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -180,7 +180,7 @@ mod tests {
 
         // Verify growth persisted
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             assert_eq!(mmap_flags.len(), 9);
 
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
@@ -209,7 +209,7 @@ mod tests {
 
         // Create initial flags
         {
-            let mut mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             mmap_flags.set_len(num_flags).unwrap();
 
             for (i, &value) in initial_flags.iter().enumerate() {
@@ -232,7 +232,7 @@ mod tests {
 
         // Apply updates and flush
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Verify initial state loaded correctly
@@ -254,7 +254,7 @@ mod tests {
 
         // Verify persistence
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Calculate expected final state
@@ -286,7 +286,7 @@ mod tests {
 
         // Initial empty state
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             mmap_flags.flusher()().unwrap();
         }
 
@@ -301,7 +301,7 @@ mod tests {
         for (cycle_num, updates) in cycles.iter().enumerate() {
             // Apply updates and flush
             {
-                let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+                let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
                 // The flusher will handle length expansion as needed
@@ -317,7 +317,7 @@ mod tests {
 
             // Verify state after each cycle
             {
-                let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+                let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
                 for (i, &expected) in expected_state.iter().enumerate() {
@@ -346,7 +346,7 @@ mod tests {
 
         // Test with single true flag
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             buffered_flags.buffer_set(0, true);
@@ -357,7 +357,7 @@ mod tests {
 
         // Verify single flag persisted
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -381,7 +381,7 @@ mod tests {
 
         // Test with very sparse indices (large gaps)
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Set flags at sparse indices
@@ -396,7 +396,7 @@ mod tests {
 
         // Verify sparse indices persisted correctly
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -429,7 +429,7 @@ mod tests {
 
         // Create initial state
         {
-            let mut mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             mmap_flags.set_len(10).unwrap();
             for i in 0..10 {
                 mmap_flags.set(i, i % 2 == 0).unwrap(); // Even indices true
@@ -439,7 +439,7 @@ mod tests {
 
         // Test overwriting existing flags multiple times
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Initial state: [true, false, true, false, true, false, true, false, true, false]
@@ -466,7 +466,7 @@ mod tests {
 
         // Verify final state (all false) persisted
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 
@@ -17,7 +18,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 #[derive(Debug)]
 pub(crate) struct BufferedDynamicFlags {
     /// Persisted flags.
-    storage: Arc<Mutex<DynamicStoredFlags>>,
+    storage: Arc<Mutex<DynamicStoredFlags<MmapFile>>>,
 
     /// Pending changes to the storage flags.
     buffer: Arc<RwLock<AHashMap<PointOffsetType, bool>>>,
@@ -27,7 +28,7 @@ pub(crate) struct BufferedDynamicFlags {
 }
 
 impl BufferedDynamicFlags {
-    pub fn new(mmap_flags: DynamicStoredFlags) -> Self {
+    pub fn new(mmap_flags: DynamicStoredFlags<MmapFile>) -> Self {
         let buffer = Arc::new(RwLock::new(AHashMap::new()));
         let is_alive_flush_lock = IsAliveLock::new();
         Self {
@@ -129,6 +130,7 @@ fn reconcile_persisted_buffer(
 mod tests {
 
     use common::types::PointOffsetType;
+    use common::universal_io::MmapFile;
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
 
@@ -144,7 +146,7 @@ mod tests {
 
         // Start with smaller flags
         {
-            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(3).unwrap();
             mmap_flags.set(0, true).unwrap();
             mmap_flags.set(2, true).unwrap();
@@ -209,7 +211,7 @@ mod tests {
 
         // Create initial flags
         {
-            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(num_flags).unwrap();
 
             for (i, &value) in initial_flags.iter().enumerate() {
@@ -286,7 +288,7 @@ mod tests {
 
         // Initial empty state
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
             mmap_flags.flusher()().unwrap();
         }
 
@@ -429,7 +431,7 @@ mod tests {
 
         // Create initial state
         {
-            let mut mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(10).unwrap();
             for i in 0..10 {
                 mmap_flags.set(i, i % 2 == 0).unwrap(); // Even indices true

--- a/lib/segment/src/common/flags/dynamic_mmap_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_mmap_flags.rs
@@ -30,7 +30,7 @@ fn status_file(directory: &Path) -> PathBuf {
 }
 
 #[repr(C)]
-struct DynamicMmapStatus {
+struct DynamicFlagsStatus {
     /// Amount of flags (bits)
     len: usize,
 
@@ -42,7 +42,7 @@ struct DynamicMmapStatus {
 fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
     let status_file = status_file(directory);
     if !status_file.exists() {
-        let length = std::mem::size_of::<DynamicMmapStatus>();
+        let length = std::mem::size_of::<DynamicFlagsStatus>();
         create_and_ensure_length(&status_file, length)?;
     }
     Ok(open_write_mmap(&status_file, AdviceSetting::Global, false)?)
@@ -50,14 +50,18 @@ fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
 
 /// Mutable persisted bitslice. This uses no buffering for updates.
 ///
-/// For buffered variants, check [`RoaringFlags`][1] or [`BitvecFlags`][2]
+/// For buffered variants, check
+/// - [`RoaringFlags`][1] - with a RoaringBitmap for reads
+/// - [`BitvecFlags`][2] - with a BitVec for reads
+/// - [`BufferedDynamicFlags`][3] - no reads, only buffered persistance
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags
+/// [3]: super::buffered_dynamic_flags::BufferedDynamicFlags
 pub struct DynamicMmapFlags {
     /// On-disk BitSlice for flags
     flags: StoredBitSlice<MmapFile>,
-    status: MmapType<DynamicMmapStatus>,
+    status: MmapType<DynamicFlagsStatus>,
     directory: PathBuf,
 }
 
@@ -90,7 +94,7 @@ impl DynamicMmapFlags {
     pub fn open(directory: &Path, populate: bool) -> OperationResult<Self> {
         fs::create_dir_all(directory)?;
         let status_mmap = ensure_status_file(directory)?;
-        let mut status: MmapType<DynamicMmapStatus> = unsafe { MmapType::try_from(status_mmap)? };
+        let mut status: MmapType<DynamicFlagsStatus> = unsafe { MmapType::try_from(status_mmap)? };
 
         if status.current_file_id != 0 {
             // Migrate

--- a/lib/segment/src/common/flags/dynamic_mmap_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_mmap_flags.rs
@@ -4,13 +4,12 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::mmap::{AdviceSetting, MmapType, create_and_ensure_length, open_write_mmap};
+use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions};
+use common::universal_io::{MmapFile, OpenOptions, StoredStruct};
 use fs_err as fs;
 use itertools::Either;
-use memmap2::MmapMut;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -29,6 +28,7 @@ fn status_file(directory: &Path) -> PathBuf {
     directory.join(STATUS_FILE_NAME)
 }
 
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 struct DynamicFlagsStatus {
     /// Amount of flags (bits)
@@ -39,13 +39,13 @@ struct DynamicFlagsStatus {
     current_file_id: usize,
 }
 
-fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
+fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
     let status_file = status_file(directory);
     if !status_file.exists() {
         let length = std::mem::size_of::<DynamicFlagsStatus>();
         create_and_ensure_length(&status_file, length)?;
     }
-    Ok(open_write_mmap(&status_file, AdviceSetting::Global, false)?)
+    Ok(status_file)
 }
 
 /// Mutable persisted bitslice. This uses no buffering for updates.
@@ -61,7 +61,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<MmapMut> {
 pub struct DynamicMmapFlags {
     /// On-disk BitSlice for flags
     flags: StoredBitSlice<MmapFile>,
-    status: MmapType<DynamicFlagsStatus>,
+    status: StoredStruct<MmapFile, DynamicFlagsStatus>,
     directory: PathBuf,
 }
 
@@ -93,8 +93,19 @@ impl DynamicMmapFlags {
 
     pub fn open(directory: &Path, populate: bool) -> OperationResult<Self> {
         fs::create_dir_all(directory)?;
-        let status_mmap = ensure_status_file(directory)?;
-        let mut status: MmapType<DynamicFlagsStatus> = unsafe { MmapType::try_from(status_mmap)? };
+        let status_path = ensure_status_file(directory)?;
+
+        let mut status: StoredStruct<MmapFile, DynamicFlagsStatus> = StoredStruct::open(
+            &status_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                disk_parallel: None,
+                populate: Some(false),
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
 
         if status.current_file_id != 0 {
             // Migrate

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -58,14 +58,14 @@ fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags
 /// [3]: super::buffered_dynamic_flags::BufferedDynamicFlags
-pub struct DynamicMmapFlags {
+pub struct DynamicStoredFlags {
     /// On-disk BitSlice for flags
     flags: StoredBitSlice<MmapFile>,
     status: StoredStruct<MmapFile, DynamicFlagsStatus>,
     directory: PathBuf,
 }
 
-impl fmt::Debug for DynamicMmapFlags {
+impl fmt::Debug for DynamicStoredFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DynamicMmapFlags")
             .field("flags", &self.flags)
@@ -82,7 +82,7 @@ fn file_size_for(num_flags: usize) -> usize {
     max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
 }
 
-impl DynamicMmapFlags {
+impl DynamicStoredFlags {
     pub fn len(&self) -> usize {
         self.status.len
     }
@@ -316,7 +316,7 @@ mod tests {
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
 
         {
-            let mut dynamic_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             dynamic_flags.set_len(num_flags).unwrap();
             random_flags
                 .iter()
@@ -335,7 +335,7 @@ mod tests {
         }
 
         {
-            let dynamic_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let dynamic_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             assert_eq!(dynamic_flags.status.len, num_flags * 2);
             for (i, flag) in random_flags.iter().enumerate() {
                 assert_eq!(dynamic_flags.get(i).unwrap(), *flag);
@@ -351,7 +351,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         // Create randomized dynamic mmap flags to test counting
-        let mut dynamic_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+        let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
         dynamic_flags.set_len(num_flags).unwrap();
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
         random_flags

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -53,7 +53,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
 /// For buffered variants, check
 /// - [`RoaringFlags`][1] - with a RoaringBitmap for reads
 /// - [`BitvecFlags`][2] - with a BitVec for reads
-/// - [`BufferedDynamicFlags`][3] - no reads, only buffered persistance
+/// - [`BufferedDynamicFlags`][3] - no reads, only buffered persistence
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
 use common::mmap::{AdviceSetting, create_and_ensure_length};
-use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
+use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, StoredStruct};
+use common::universal_io::{OpenOptions, StoredStruct, UniversalWrite};
 use fs_err as fs;
 use itertools::Either;
 
@@ -30,7 +30,7 @@ fn status_file(directory: &Path) -> PathBuf {
 
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-struct DynamicFlagsStatus {
+pub struct DynamicFlagsStatus {
     /// Amount of flags (bits)
     len: usize,
 
@@ -58,14 +58,14 @@ fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags
 /// [3]: super::buffered_dynamic_flags::BufferedDynamicFlags
-pub struct DynamicStoredFlags {
+pub struct DynamicStoredFlags<S> {
     /// On-disk BitSlice for flags
-    flags: StoredBitSlice<MmapFile>,
-    status: StoredStruct<MmapFile, DynamicFlagsStatus>,
+    flags: StoredBitSlice<S>,
+    status: StoredStruct<S, DynamicFlagsStatus>,
     directory: PathBuf,
 }
 
-impl fmt::Debug for DynamicStoredFlags {
+impl<S: fmt::Debug> fmt::Debug for DynamicStoredFlags<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DynamicMmapFlags")
             .field("flags", &self.flags)
@@ -82,7 +82,10 @@ fn file_size_for(num_flags: usize) -> usize {
     max(MINIMAL_MMAP_SIZE, number_of_bytes.next_power_of_two())
 }
 
-impl DynamicStoredFlags {
+impl<S> DynamicStoredFlags<S>
+where
+    S: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static,
+{
     pub fn len(&self) -> usize {
         self.status.len
     }
@@ -95,7 +98,7 @@ impl DynamicStoredFlags {
         fs::create_dir_all(directory)?;
         let status_path = ensure_status_file(directory)?;
 
-        let mut status: StoredStruct<MmapFile, DynamicFlagsStatus> = StoredStruct::open(
+        let mut status: StoredStruct<S, DynamicFlagsStatus> = StoredStruct::open(
             &status_path,
             OpenOptions {
                 writeable: true,
@@ -130,7 +133,7 @@ impl DynamicStoredFlags {
         num_flags: usize,
         directory: &Path,
         populate: bool,
-    ) -> OperationResult<MmapBitSlice> {
+    ) -> OperationResult<StoredBitSlice<S>> {
         let capacity_bytes = file_size_for(num_flags);
         let path = directory.join(FLAGS_FILE);
 
@@ -149,7 +152,7 @@ impl DynamicStoredFlags {
             advice: Some(AdviceSetting::Global),
             ..Default::default()
         };
-        let flags = MmapBitSlice::open(&path, options)?;
+        let flags = StoredBitSlice::open(&path, options)?;
         Ok(flags)
     }
 
@@ -301,6 +304,7 @@ impl DynamicStoredFlags {
 mod tests {
     use std::iter;
 
+    use common::universal_io::MmapFile;
     use rand::prelude::StdRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
@@ -316,7 +320,8 @@ mod tests {
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
 
         {
-            let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mut dynamic_flags =
+                DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
             dynamic_flags.set_len(num_flags).unwrap();
             random_flags
                 .iter()
@@ -335,7 +340,7 @@ mod tests {
         }
 
         {
-            let dynamic_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let dynamic_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), true).unwrap();
             assert_eq!(dynamic_flags.status.len, num_flags * 2);
             for (i, flag) in random_flags.iter().enumerate() {
                 assert_eq!(dynamic_flags.get(i).unwrap(), *flag);
@@ -351,7 +356,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         // Create randomized dynamic mmap flags to test counting
-        let mut dynamic_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+        let mut dynamic_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), true).unwrap();
         dynamic_flags.set_len(num_flags).unwrap();
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
         random_flags

--- a/lib/segment/src/common/flags/mod.rs
+++ b/lib/segment/src/common/flags/mod.rs
@@ -8,5 +8,5 @@
 
 pub mod bitvec_flags;
 mod buffered_dynamic_flags;
-pub mod dynamic_mmap_flags;
+pub mod dynamic_stored_flags;
 pub mod roaring_flags;

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -4,7 +4,7 @@ use common::types::PointOffsetType;
 use roaring::RoaringBitmap;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
-use super::dynamic_mmap_flags::DynamicMmapFlags;
+use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 
@@ -28,7 +28,7 @@ pub struct RoaringFlags {
 }
 
 impl RoaringFlags {
-    pub fn new(mmap_flags: DynamicMmapFlags) -> OperationResult<Self> {
+    pub fn new(mmap_flags: DynamicStoredFlags) -> OperationResult<Self> {
         // load flags into memory
         let bitmap = RoaringBitmap::from_sorted_iter(mmap_flags.iter_trues()?)
             .expect("iter_trues iterates in sorted order");
@@ -139,7 +139,7 @@ impl RoaringFlags {
 mod tests {
     use common::types::PointOffsetType;
 
-    use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+    use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
     use crate::common::flags::roaring_flags::RoaringFlags;
 
     #[test]
@@ -151,7 +151,7 @@ mod tests {
 
         // Create and update flags
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
             let mut roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
@@ -171,7 +171,7 @@ mod tests {
 
         // Verify bitmap consistency after reload
         {
-            let mmap_flags = DynamicMmapFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
             let roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use roaring::RoaringBitmap;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
@@ -28,18 +29,18 @@ pub struct RoaringFlags {
 }
 
 impl RoaringFlags {
-    pub fn new(mmap_flags: DynamicStoredFlags) -> OperationResult<Self> {
+    pub fn new(dynamic_flags: DynamicStoredFlags<MmapFile>) -> OperationResult<Self> {
         // load flags into memory
-        let bitmap = RoaringBitmap::from_sorted_iter(mmap_flags.iter_trues()?)
+        let bitmap = RoaringBitmap::from_sorted_iter(dynamic_flags.iter_trues()?)
             .expect("iter_trues iterates in sorted order");
 
-        if let Err(err) = mmap_flags.clear_cache() {
+        if let Err(err) = dynamic_flags.clear_cache() {
             log::warn!("Failed to clear bitslice cache: {err}");
         }
 
         Ok(Self {
-            len: mmap_flags.len(),
-            storage: BufferedDynamicFlags::new(mmap_flags),
+            len: dynamic_flags.len(),
+            storage: BufferedDynamicFlags::new(dynamic_flags),
             bitmap,
         })
     }

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -7,7 +7,7 @@ use common::types::PointOffsetType;
 use fs_err as fs;
 use roaring::RoaringBitmap;
 
-use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
@@ -69,12 +69,12 @@ impl MutableBoolIndex {
 
         // Trues bitslice
         let trues_path = path.join(TRUES_DIRNAME);
-        let trues_slice = DynamicMmapFlags::open(&trues_path, false)?;
+        let trues_slice = DynamicStoredFlags::open(&trues_path, false)?;
         let trues_flags = RoaringFlags::new(trues_slice)?;
 
         // Falses bitslice
         let falses_path = path.join(FALSES_DIRNAME);
-        let falses_slice = DynamicMmapFlags::open(&falses_path, false)?;
+        let falses_slice = DynamicStoredFlags::open(&falses_path, false)?;
         let falses_flags = RoaringFlags::new(falses_slice)?;
 
         let trues_count = trues_flags.count_trues();

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -7,7 +7,7 @@ use fs_err as fs;
 use serde_json::Value;
 
 use crate::common::Flusher;
-use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
@@ -97,11 +97,11 @@ impl MutableNullIndex {
         })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
-        let has_values_mmap = DynamicMmapFlags::open(&has_values_path, false)?;
+        let has_values_mmap = DynamicStoredFlags::open(&has_values_path, false)?;
         let has_values_flags = RoaringFlags::new(has_values_mmap)?;
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
-        let is_null_mmap = DynamicMmapFlags::open(&is_null_path, false)?;
+        let is_null_mmap = DynamicStoredFlags::open(&is_null_path, false)?;
         let is_null_flags = RoaringFlags::new(is_null_mmap)?;
 
         let storage = Storage {

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -13,7 +13,7 @@ use fs_err as fs;
 
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
-use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::operation_error::{OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -254,7 +254,7 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 
     let vectors = ChunkedVectors::open(&vectors_path, dim, madvise, Some(populate))?;
 
-    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
+    let deleted = BitvecFlags::new(DynamicStoredFlags::open(&deleted_path, populate)?)?;
     let deleted_count = deleted.count_trues();
 
     Ok(AppendableMmapDenseVectorStorage {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -13,7 +13,7 @@ use fs_err as fs;
 
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
-use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -515,7 +515,7 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     let vectors = ChunkedVectors::open(&vectors_path, dim, madvise, Some(populate))?;
     let offsets = ChunkedVectors::open(&offsets_path, 1, madvise, Some(populate))?;
 
-    let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
+    let deleted = BitvecFlags::new(DynamicStoredFlags::open(&deleted_path, populate)?)?;
     let deleted_count = deleted.count_trues();
 
     Ok(AppendableMmapMultiDenseVectorStorage {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -13,7 +13,7 @@ use gridstore::config::{Compression, StorageOptions};
 use sparse::common::sparse_vector::SparseVector;
 
 use crate::common::flags::bitvec_flags::BitvecFlags;
-use crate::common::flags::dynamic_mmap_flags::DynamicMmapFlags;
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
@@ -65,7 +65,7 @@ impl MmapSparseVectorStorage {
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
-        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
+        let deleted = BitvecFlags::new(DynamicStoredFlags::open(&deleted_path, populate)?)?;
 
         let deleted_count = deleted.count_trues();
         let next_point_offset = deleted
@@ -106,7 +106,7 @@ impl MmapSparseVectorStorage {
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
-        let deleted = BitvecFlags::new(DynamicMmapFlags::open(&deleted_path, populate)?)?;
+        let deleted = BitvecFlags::new(DynamicStoredFlags::open(&deleted_path, populate)?)?;
 
         Ok(Self {
             storage,


### PR DESCRIPTION
Finishes refactoring for `DynamicMmapFlags`, which is now renamed to `DynamicStoredFlags<S>`, where `S` is the storage backend.

As a bonus, this PR introduces `StoredStruct`, a wrapper to interact with a lightweight type like the `status` type, which only contains `len: usize`, but we still need to persist it. It keeps an in-memory copy that gets written entirely on flush.

