### PR TITLE
`UniversalRead` cleanup

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -66,7 +66,10 @@ impl<T> UniversalReadFileOps for CachedSlice<T> {
     }
 }
 
-impl<T: bytemuck::Pod> UniversalRead<T> for CachedSlice<T> {
+impl<T> UniversalRead<T> for CachedSlice<T>
+where
+    T: bytemuck::Pod,
+{
     type ReadPipeline<'a, Meta>
         = DiskCacheReadPipeline<'a, T, Meta>
     where
@@ -122,12 +125,16 @@ impl<T: bytemuck::Pod> UniversalRead<T> for CachedSlice<T> {
     }
 }
 
-pub struct DiskCacheReadPipeline<'a, T: bytemuck::Pod, Meta> {
-    result: Option<(Meta, Cow<'a, [T]>)>,
+pub struct DiskCacheReadPipeline<'file, T, Meta>
+where
+    T: bytemuck::Pod,
+{
+    result: Option<(Meta, Cow<'file, [T]>)>,
 }
 
-impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
-    for DiskCacheReadPipeline<'a, T, Meta>
+impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for DiskCacheReadPipeline<'file, T, Meta>
+where
+    T: bytemuck::Pod,
 {
     type File = CachedSlice<T>;
 
@@ -139,7 +146,12 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         self.result.is_none()
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'a CachedSlice<T>, range: ReadRange) -> Result<()>
+    fn schedule<P>(
+        &mut self,
+        meta: Meta,
+        file: &'file CachedSlice<T>,
+        range: ReadRange,
+    ) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -150,7 +162,7 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'a, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
         Ok(self.result.take())
     }
 }

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -158,6 +158,7 @@ where
         if self.result.is_some() {
             return Err(UniversalIoError::QueueIsFull);
         }
+
         self.result = Some((meta, file.read::<Random>(range)?));
         Ok(())
     }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -20,7 +20,6 @@ use self::pool::*;
 use self::runtime::*;
 use super::*;
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::read::UniversalReadPipeline;
 
 #[derive(Debug)]
 pub struct IoUringFile {
@@ -162,16 +161,20 @@ where
         P: AccessPattern,
     {
         let mut squeue = self.runtime.io_uring.submission();
+
         if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
             return Err(UniversalIoError::QueueIsFull);
         }
+
         let entry = self
             .runtime
             .state
             .read(meta, file.fd(), range, file.direct_io);
+
         unsafe {
             squeue.push(&entry).expect("submission queue is not full");
         }
+
         Ok(())
     }
 

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -49,7 +49,10 @@ impl UniversalReadFileOps for IoUringFile {
     }
 }
 
-impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
+impl<T> UniversalRead<T> for IoUringFile
+where
+    T: bytemuck::Pod,
+{
     type ReadPipeline<'a, Meta> = IoUringPipeline<'a, T, Meta>;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -130,12 +133,16 @@ impl<T: bytemuck::Pod + 'static> UniversalRead<T> for IoUringFile {
     }
 }
 
-pub struct IoUringPipeline<'a, T: bytemuck::Pod, Meta> {
-    runtime: IoUringRuntime<'a, T, Meta>,
+pub struct IoUringPipeline<'file, T, Meta>
+where
+    T: bytemuck::Pod,
+{
+    runtime: IoUringRuntime<'file, T, Meta>,
 }
 
-impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
-    for IoUringPipeline<'a, T, Meta>
+impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for IoUringPipeline<'file, T, Meta>
+where
+    T: bytemuck::Pod,
 {
     type File = IoUringFile;
 
@@ -150,7 +157,7 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'a IoUringFile, range: ReadRange) -> Result<()>
+    fn schedule<P>(&mut self, meta: Meta, file: &'file IoUringFile, range: ReadRange) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -168,7 +175,7 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'a, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
         if self.runtime.completion_is_empty() {
             let has_pending = !self.runtime.io_uring.submission().is_empty();
             if !has_pending && self.runtime.in_progress == 0 {
@@ -186,7 +193,10 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
     }
 }
 
-impl<T: bytemuck::Pod + 'static> UniversalWrite<T> for IoUringFile {
+impl<T> UniversalWrite<T> for IoUringFile
+where
+    T: bytemuck::Pod,
+{
     fn write(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
         let bytes = bytemuck::cast_slice(items);
         self.file.write_all_at(bytes, byte_offset)?;

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -129,12 +129,13 @@ where
     }
 }
 
-pub struct MmapReadPipeline<'a, T, Meta> {
-    result: Option<(Meta, &'a [T])>,
+pub struct MmapReadPipeline<'file, T, Meta> {
+    result: Option<(Meta, &'file [T])>,
 }
 
-impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
-    for MmapReadPipeline<'a, T, Meta>
+impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for MmapReadPipeline<'file, T, Meta>
+where
+    T: bytemuck::Pod,
 {
     type File = MmapFile;
 
@@ -146,7 +147,7 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         self.result.is_none()
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'a MmapFile, range: ReadRange) -> Result<()>
+    fn schedule<P>(&mut self, meta: Meta, file: &'file MmapFile, range: ReadRange) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -157,7 +158,7 @@ impl<'a, T: bytemuck::Pod, Meta> UniversalReadPipeline<'a, T, Meta>
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'a, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
         let result = self.result.take();
         Ok(result.map(|(meta, items)| (meta, Cow::Borrowed(items))))
     }

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -154,6 +154,7 @@ where
         if self.result.is_some() {
             return Err(UniversalIoError::QueueIsFull);
         }
+
         self.result = Some((meta, read(file.as_bytes::<P>(), range)?));
         Ok(())
     }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -7,7 +7,7 @@ pub mod io_uring;
 pub mod local_file_ops;
 pub mod mmap;
 pub mod read;
-mod wrappers;
+pub mod wrappers;
 pub mod write;
 
 use std::path::Path;
@@ -19,7 +19,7 @@ pub use self::file_ops::UniversalReadFileOps;
 #[cfg(target_os = "linux")]
 pub use self::io_uring::*;
 pub use self::mmap::*;
-pub use self::read::UniversalRead;
+pub use self::read::*;
 pub use self::wrappers::*;
 pub use self::write::UniversalWrite;
 use crate::mmap::{Advice, AdviceSetting};

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -8,10 +8,13 @@ use crate::universal_io::file_ops::UniversalReadFileOps;
 /// Interface for accessing files in a universal way, abstracting away possible
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
 #[expect(clippy::len_without_is_empty)]
-pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
-    type ReadPipeline<'a, Meta>: UniversalReadPipeline<'a, T, Meta, File = Self>
+pub trait UniversalRead<T>: UniversalReadFileOps
+where
+    T: Copy + 'static,
+{
+    type ReadPipeline<'file, Meta>: UniversalReadPipeline<'file, T, Meta, File = Self>
     where
-        Self: 'a;
+        Self: 'file;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>;
 
@@ -30,11 +33,14 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
         })
     }
 
-    fn read_batch<'a, P: AccessPattern, Meta: 'a>(
-        &'a self,
+    fn read_batch<P, Meta>(
+        &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+    {
         for record in self.read_iter::<P, Meta>(ranges)? {
             let (meta, data) = record?;
             callback(meta, &data)?;
@@ -44,10 +50,13 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
 
     /// Like [`read_batch`](Self::read_batch), but returns a fallible iterator instead of
     /// accepting a callback.
-    fn read_iter<P: AccessPattern, Meta>(
+    fn read_iter<P, Meta>(
         &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>> {
+    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+    where
+        P: AccessPattern,
+    {
         let reads = ranges
             .into_iter()
             .map(move |(meta, range)| (meta, self, range));
@@ -67,11 +76,12 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
     fn clear_ram_cache(&self) -> Result<()>;
 
     /// Read from multiple files in a single operation.
-    fn read_multi<'a, P: AccessPattern, Meta: 'a>(
+    fn read_multi<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
         mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         for record in Self::read_multi_iter::<P, Meta>(reads)? {
@@ -83,10 +93,11 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
 
     /// Like [`read_multi`](Self::read_multi), but returns a fallible iterator instead of
     /// accepting a callback.
-    fn read_multi_iter<'a, P: AccessPattern, Meta>(
+    fn read_multi_iter<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
     ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         let mut pipeline = Self::ReadPipeline::<'a, Meta>::new()?;
@@ -110,8 +121,11 @@ pub trait UniversalRead<T: Copy + 'static>: UniversalReadFileOps {
     // When adding provided methods, don't forget to update impls in crate::universal_io::wrappers::*.
 }
 
-pub trait UniversalReadPipeline<'a, T: Copy + 'static, Meta>: Sized {
-    type File: 'a;
+pub trait UniversalReadPipeline<'file, T, Meta>: Sized
+where
+    T: Copy + 'static,
+{
+    type File: 'file;
 
     fn new() -> Result<Self>;
 
@@ -124,11 +138,11 @@ pub trait UniversalReadPipeline<'a, T: Copy + 'static, Meta>: Sized {
     ///
     /// Should be called only when [`UniversalReadPipeline::can_schedule()`] is
     /// `true`. Returns [`UniversalIoError::QueueIsFull`] otherwise.
-    fn schedule<P>(&mut self, meta: Meta, file: &'a Self::File, range: ReadRange) -> Result<()>
+    fn schedule<P>(&mut self, meta: Meta, file: &'file Self::File, range: ReadRange) -> Result<()>
     where
         P: AccessPattern;
 
     /// Block until any of the scheduled operations is completed and consume its
     /// result.
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'a, [T]>)>>;
+    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>>;
 }

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -26,11 +26,12 @@ where
     /// Implementations may override this to avoid the two accesses that would result from
     /// `len()` followed by `read(0..len())`. Default implementation does exactly that.
     fn read_whole(&self) -> Result<Cow<'_, [T]>> {
-        let n = self.len()?;
-        self.read::<Sequential>(ReadRange {
+        let range = ReadRange {
             byte_offset: 0,
-            length: n,
-        })
+            length: self.len()?,
+        };
+
+        self.read::<Sequential>(range)
     }
 
     fn read_batch<P, Meta>(
@@ -45,6 +46,7 @@ where
             let (meta, data) = record?;
             callback(meta, &data)?;
         }
+
         Ok(())
     }
 
@@ -60,6 +62,7 @@ where
         let reads = ranges
             .into_iter()
             .map(move |(meta, range)| (meta, self, range));
+
         Self::read_multi_iter::<P, Meta>(reads)
     }
 
@@ -88,6 +91,7 @@ where
             let (meta, items) = record?;
             callback(meta, &items)?;
         }
+
         Ok(())
     }
 
@@ -102,17 +106,21 @@ where
     {
         let mut pipeline = Self::ReadPipeline::<'a, Meta>::new()?;
         let mut reads = reads.into_iter();
+
         let iter = std::iter::from_fn(move || {
             while pipeline.can_schedule()
                 && let Some(read) = reads.next()
             {
                 let (meta, file, range) = read;
+
                 if let Err(err) = pipeline.schedule::<P>(meta, file, range) {
                     return Some(Err(err));
                 }
             }
+
             pipeline.wait().transpose()
         });
+
         Ok(iter)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/buffered_update.rs
+++ b/lib/common/common/src/universal_io/wrappers/buffered_update.rs
@@ -13,9 +13,10 @@ use crate::universal_io::{Flusher, UniversalIoError, UniversalWrite};
 ///
 /// WARN: this structure is expected to be write-only.
 #[derive(Debug)]
-pub struct SliceBufferedUpdateWrapper<S: UniversalWrite<T>, T: Copy>
+pub struct SliceBufferedUpdateWrapper<S, T>
 where
-    T: 'static,
+    S: UniversalWrite<T>,
+    T: Copy + 'static,
 {
     slice: Arc<RwLock<S>>,
     len: u64,
@@ -23,9 +24,10 @@ where
     is_alive_lock: IsAliveLock,
 }
 
-impl<S: UniversalWrite<T>, T: Copy> SliceBufferedUpdateWrapper<S, T>
+impl<S, T> SliceBufferedUpdateWrapper<S, T>
 where
-    T: 'static,
+    S: UniversalWrite<T>,
+    T: Copy + 'static,
 {
     pub fn new(slice_storage: S) -> Result<Self, UniversalIoError> {
         let len = slice_storage.len()?;
@@ -54,7 +56,7 @@ where
 impl<S, T> SliceBufferedUpdateWrapper<S, T>
 where
     S: UniversalWrite<T> + Send + Sync + 'static,
-    T: Sync + Send + Copy + Clone + PartialEq + 'static,
+    T: Copy + Clone + PartialEq + Sync + Send + 'static,
 {
     pub fn flusher(&self) -> Flusher {
         let updates = {

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -105,6 +105,7 @@ where
         let reads = reads
             .into_iter()
             .map(|(meta, file, range)| (meta, &file.0, range));
+
         S::read_multi::<P, _>(reads, callback)
     }
 
@@ -119,6 +120,7 @@ where
         let it = reads
             .into_iter()
             .map(|(meta, file, range)| (meta, &file.0, range));
+
         S::read_multi_iter::<P, _>(it)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -33,10 +33,10 @@ where
     S: UniversalRead<T>,
     T: Copy + 'static,
 {
-    type ReadPipeline<'a, Meta>
-        = WrappedReadPipeline<'a, Self, S::ReadPipeline<'a, Meta>>
+    type ReadPipeline<'file, Meta>
+        = WrappedReadPipeline<'file, Self, S::ReadPipeline<'file, Meta>>
     where
-        Self: 'a;
+        Self: 'file;
 
     #[inline]
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -56,19 +56,25 @@ where
     }
 
     #[inline]
-    fn read_batch<'a, P: AccessPattern, Meta: 'a>(
+    fn read_batch<'a, P, Meta>(
         &'a self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+    {
         self.0.read_batch::<P, Meta>(ranges, callback)
     }
 
     #[inline]
-    fn read_iter<P: AccessPattern, Meta>(
+    fn read_iter<P, Meta>(
         &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>> {
+    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+    where
+        P: AccessPattern,
+    {
         self.0.read_iter::<P, Meta>(ranges)
     }
 
@@ -88,11 +94,12 @@ where
     }
 
     #[inline]
-    fn read_multi<'a, P: AccessPattern, Meta: 'a>(
+    fn read_multi<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         let reads = reads
@@ -102,10 +109,11 @@ where
     }
 
     #[inline]
-    fn read_multi_iter<'a, P: AccessPattern, Meta>(
+    fn read_multi_iter<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
     ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         let it = reads

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -56,8 +56,8 @@ where
     }
 
     #[inline]
-    fn read_batch<'a, P, Meta>(
-        &'a self,
+    fn read_batch<P, Meta>(
+        &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()>

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -78,8 +78,8 @@ where
     }
 
     #[inline]
-    fn read_batch<'a, P, Meta>(
-        &'a self,
+    fn read_batch<P, Meta>(
+        &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()>

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -124,12 +124,11 @@ where
         P: AccessPattern,
         Self: 'a,
     {
-        S::read_multi::<'a, P, Meta>(
-            reads
-                .into_iter()
-                .map(|(meta, file, range)| (meta, &file.inner, range)),
-            callback,
-        )
+        let reads = reads
+            .into_iter()
+            .map(|(meta, file, range)| (meta, &file.inner, range));
+
+        S::read_multi::<'a, P, Meta>(reads, callback)
     }
 
     #[inline]
@@ -143,6 +142,7 @@ where
         let reads = reads
             .into_iter()
             .map(|(meta, file, range)| (meta, &file.inner, range));
+
         S::read_multi_iter::<P, _>(reads)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -34,7 +34,10 @@ impl<S, T> TypedStorage<S, T> {
     }
 }
 
-impl<S: UniversalRead<T>, T: Copy + 'static> UniversalReadFileOps for TypedStorage<S, T> {
+impl<S, T> UniversalReadFileOps for TypedStorage<S, T>
+where
+    S: UniversalReadFileOps,
+{
     #[inline]
     fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
         S::list_files(prefix_path)
@@ -46,11 +49,15 @@ impl<S: UniversalRead<T>, T: Copy + 'static> UniversalReadFileOps for TypedStora
     }
 }
 
-impl<S: UniversalRead<T>, T: Copy + 'static> UniversalRead<T> for TypedStorage<S, T> {
-    type ReadPipeline<'a, Meta>
-        = WrappedReadPipeline<'a, Self, S::ReadPipeline<'a, Meta>>
+impl<S, T> UniversalRead<T> for TypedStorage<S, T>
+where
+    S: UniversalRead<T>,
+    T: Copy + 'static,
+{
+    type ReadPipeline<'file, Meta>
+        = WrappedReadPipeline<'file, Self, S::ReadPipeline<'file, Meta>>
     where
-        Self: 'a;
+        Self: 'file;
 
     #[inline]
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -71,19 +78,25 @@ impl<S: UniversalRead<T>, T: Copy + 'static> UniversalRead<T> for TypedStorage<S
     }
 
     #[inline]
-    fn read_batch<'a, P: AccessPattern, Meta: 'a>(
+    fn read_batch<'a, P, Meta>(
         &'a self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+    {
         self.inner.read_batch::<P, Meta>(ranges, callback)
     }
 
     #[inline]
-    fn read_iter<P: AccessPattern, Meta>(
+    fn read_iter<P, Meta>(
         &self,
         ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>> {
+    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+    where
+        P: AccessPattern,
+    {
         self.inner.read_iter::<P, Meta>(ranges)
     }
 
@@ -103,11 +116,12 @@ impl<S: UniversalRead<T>, T: Copy + 'static> UniversalRead<T> for TypedStorage<S
     }
 
     #[inline]
-    fn read_multi<'a, P: AccessPattern, Meta: 'a>(
+    fn read_multi<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
         callback: impl FnMut(Meta, &[T]) -> Result<()>,
     ) -> Result<()>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         S::read_multi::<'a, P, Meta>(
@@ -119,10 +133,11 @@ impl<S: UniversalRead<T>, T: Copy + 'static> UniversalRead<T> for TypedStorage<S
     }
 
     #[inline]
-    fn read_multi_iter<'a, P: AccessPattern, Meta>(
+    fn read_multi_iter<'a, P, Meta>(
         reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
     ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
     where
+        P: AccessPattern,
         Self: 'a,
     {
         let reads = reads
@@ -136,7 +151,11 @@ impl<S: UniversalRead<T>, T: Copy + 'static> UniversalRead<T> for TypedStorage<S
     }
 }
 
-impl<S: UniversalWrite<T>, T: Copy + 'static> UniversalWrite<T> for TypedStorage<S, T> {
+impl<S, T> UniversalWrite<T> for TypedStorage<S, T>
+where
+    S: UniversalWrite<T>,
+    T: Copy + 'static,
+{
     #[inline]
     fn write(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()> {
         self.inner.write(byte_offset, data)


### PR DESCRIPTION
Simple cleanup, to make generic parameter soup easier to read. 😵‍💫

No logic changes, just rename and shuffle stuff around and add some newlines.

- Rename `UniversalReadPipeline` lifetime from `'a` into `'file`
- Use explicit `where` clauses everywhere
- Remove some unnecessary lifetimes/trait bounds/imports
- Add a some newlines in dense code blocks

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
