### PR TITLE
[UIO] Generic Roaring/Bitvec flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "duplicate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,6 +5397,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+]
+
+[[package]]
 name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6952,6 +6975,7 @@ dependencies = [
  "criterion",
  "data-encoding",
  "dataset",
+ "duplicate",
  "ecow",
  "env_logger",
  "fnv",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -113,6 +113,7 @@ macro_rules_attribute = "0.2.2"
 nom = "8.0.0"
 half = { workspace = true }
 roaring = { version = "0.11.4" }
+duplicate = "2.0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.5"

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -118,9 +118,17 @@ impl BitvecFlags {
     }
 }
 
+#[duplicate::duplicate_item(
+    tests_mod       S               cfg_predicate;
+    [tests_mmap]    [MmapFile]      [cfg(all())];
+    [tests_uring]   [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
 #[cfg(test)]
-mod tests {
+mod tests_mod {
     use common::types::PointOffsetType;
+    #[cfg_predicate]
+    use common::universal_io::S;
 
     use crate::common::flags::bitvec_flags::BitvecFlags;
     use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
@@ -134,7 +142,7 @@ mod tests {
 
         // Create and update flags
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             let mut bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
@@ -163,7 +171,7 @@ mod tests {
 
         // Verify bitmap consistency after reload
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let bitvec_flags = BitvecFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use common::bitvec::{BitSlice, BitVec};
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
 use super::dynamic_stored_flags::DynamicStoredFlags;
@@ -18,7 +17,7 @@ use crate::common::operation_error::OperationResult;
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 #[derive(Debug)]
-pub struct BitvecFlags<S = MmapFile> {
+pub struct BitvecFlags<S> {
     /// Buffered persisted flags.
     storage: BufferedDynamicFlags<S>,
 

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -7,6 +7,7 @@ use common::universal_io::MmapFile;
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
 use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
+use crate::common::flags::dynamic_stored_flags::UioDynamicFlags;
 use crate::common::operation_error::OperationResult;
 
 /// A buffered, growable, and persistent bitslice with a separate in-memory bitvec.
@@ -17,9 +18,9 @@ use crate::common::operation_error::OperationResult;
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 #[derive(Debug)]
-pub struct BitvecFlags {
+pub struct BitvecFlags<S = MmapFile> {
     /// Buffered persisted flags.
-    storage: BufferedDynamicFlags,
+    storage: BufferedDynamicFlags<S>,
 
     /// In-memory bitvec of true and false flags.
     bitvec: BitVec,
@@ -28,8 +29,11 @@ pub struct BitvecFlags {
     len: usize,
 }
 
-impl BitvecFlags {
-    pub fn new(dynamic_flags: DynamicStoredFlags<MmapFile>) -> OperationResult<Self> {
+impl<S> BitvecFlags<S>
+where
+    S: UioDynamicFlags,
+{
+    pub fn new(dynamic_flags: DynamicStoredFlags<S>) -> OperationResult<Self> {
         // load flags into memory
         let bitvec = BitVec::from_bitslice(&*dynamic_flags.get_bitslice()?);
 

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -130,11 +130,19 @@ fn reconcile_persisted_buffer(
         .retain(|point_id, a| persisted.get(point_id).is_none_or(|b| a != b));
 }
 
+#[duplicate::duplicate_item(
+    tests_mod       S               cfg_predicate;
+    [tests_mmap]    [MmapFile]      [cfg(all())];
+    [tests_uring]   [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
 #[cfg(test)]
-mod tests {
+mod tests_mod {
 
     use common::types::PointOffsetType;
-    use common::universal_io::MmapFile;
+
+    #[cfg_predicate]
+    use common::universal_io::S;
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
 
@@ -150,7 +158,7 @@ mod tests {
 
         // Start with smaller flags
         {
-            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(3).unwrap();
             mmap_flags.set(0, true).unwrap();
             mmap_flags.set(2, true).unwrap();
@@ -159,7 +167,7 @@ mod tests {
 
         // Grow and update with BufferedDynamicFlags
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -186,7 +194,7 @@ mod tests {
 
         // Verify growth persisted
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             assert_eq!(mmap_flags.len(), 9);
 
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
@@ -215,7 +223,7 @@ mod tests {
 
         // Create initial flags
         {
-            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(num_flags).unwrap();
 
             for (i, &value) in initial_flags.iter().enumerate() {
@@ -238,7 +246,7 @@ mod tests {
 
         // Apply updates and flush
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Verify initial state loaded correctly
@@ -260,7 +268,7 @@ mod tests {
 
         // Verify persistence
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Calculate expected final state
@@ -292,7 +300,7 @@ mod tests {
 
         // Initial empty state
         {
-            let mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             mmap_flags.flusher()().unwrap();
         }
 
@@ -307,7 +315,7 @@ mod tests {
         for (cycle_num, updates) in cycles.iter().enumerate() {
             // Apply updates and flush
             {
-                let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+                let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
                 // The flusher will handle length expansion as needed
@@ -323,7 +331,7 @@ mod tests {
 
             // Verify state after each cycle
             {
-                let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+                let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
                 for (i, &expected) in expected_state.iter().enumerate() {
@@ -352,7 +360,7 @@ mod tests {
 
         // Test with single true flag
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             buffered_flags.buffer_set(0, true);
@@ -363,7 +371,7 @@ mod tests {
 
         // Verify single flag persisted
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -387,7 +395,7 @@ mod tests {
 
         // Test with very sparse indices (large gaps)
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Set flags at sparse indices
@@ -402,7 +410,7 @@ mod tests {
 
         // Verify sparse indices persisted correctly
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -435,7 +443,7 @@ mod tests {
 
         // Create initial state
         {
-            let mut mmap_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
+            let mut mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             mmap_flags.set_len(10).unwrap();
             for i in 0..10 {
                 mmap_flags.set(i, i % 2 == 0).unwrap(); // Even indices true
@@ -445,7 +453,7 @@ mod tests {
 
         // Test overwriting existing flags multiple times
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             // Initial state: [true, false, true, false, true, false, true, false, true, false]
@@ -472,7 +480,7 @@ mod tests {
 
         // Verify final state (all false) persisted
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(mmap_flags);
 
             let flags = buffered_flags.storage.lock();

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 
@@ -17,7 +16,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 ///
 /// Changes are buffered until explicitly flushed.
 #[derive(Debug)]
-pub(crate) struct BufferedDynamicFlags<S = MmapFile> {
+pub(crate) struct BufferedDynamicFlags<S> {
     /// Persisted flags.
     storage: Arc<Mutex<DynamicStoredFlags<S>>>,
 

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -139,7 +139,6 @@ fn reconcile_persisted_buffer(
 mod tests_mod {
 
     use common::types::PointOffsetType;
-
     #[cfg_predicate]
     use common::universal_io::S;
     use rand::rngs::StdRng;

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -10,15 +10,16 @@ use parking_lot::{Mutex, RwLock};
 
 use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
+use crate::common::flags::dynamic_stored_flags::UioDynamicFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 
 /// A buffered wrapper around DynamicMmapFlags that provides manual flushing, without interface for reading.
 ///
 /// Changes are buffered until explicitly flushed.
 #[derive(Debug)]
-pub(crate) struct BufferedDynamicFlags {
+pub(crate) struct BufferedDynamicFlags<S = MmapFile> {
     /// Persisted flags.
-    storage: Arc<Mutex<DynamicStoredFlags<MmapFile>>>,
+    storage: Arc<Mutex<DynamicStoredFlags<S>>>,
 
     /// Pending changes to the storage flags.
     buffer: Arc<RwLock<AHashMap<PointOffsetType, bool>>>,
@@ -27,12 +28,15 @@ pub(crate) struct BufferedDynamicFlags {
     is_alive_flush_lock: IsAliveLock,
 }
 
-impl BufferedDynamicFlags {
-    pub fn new(mmap_flags: DynamicStoredFlags<MmapFile>) -> Self {
+impl<S> BufferedDynamicFlags<S>
+where
+    S: UioDynamicFlags,
+{
+    pub fn new(dynamic_flags: DynamicStoredFlags<S>) -> Self {
         let buffer = Arc::new(RwLock::new(AHashMap::new()));
         let is_alive_flush_lock = IsAliveLock::new();
         Self {
-            storage: Arc::new(Mutex::new(mmap_flags)),
+            storage: Arc::new(Mutex::new(dynamic_flags)),
             buffer,
             is_alive_flush_lock,
         }

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -7,7 +7,7 @@ use common::bitvec::BitSlice;
 use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, StoredStruct, UniversalWrite};
+use common::universal_io::{MmapFile, OpenOptions, StoredStruct, UniversalWrite};
 use fs_err as fs;
 use itertools::Either;
 
@@ -27,6 +27,9 @@ const STATUS_FILE_NAME: &str = "status.dat";
 fn status_file(directory: &Path) -> PathBuf {
     directory.join(STATUS_FILE_NAME)
 }
+
+pub trait UioDynamicFlags: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static {}
+impl<T> UioDynamicFlags for T where T: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static {}
 
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
@@ -58,7 +61,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags
 /// [3]: super::buffered_dynamic_flags::BufferedDynamicFlags
-pub struct DynamicStoredFlags<S> {
+pub struct DynamicStoredFlags<S = MmapFile> {
     /// On-disk BitSlice for flags
     flags: StoredBitSlice<S>,
     status: StoredStruct<S, DynamicFlagsStatus>,
@@ -84,7 +87,7 @@ fn file_size_for(num_flags: usize) -> usize {
 
 impl<S> DynamicStoredFlags<S>
 where
-    S: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static,
+    S: UioDynamicFlags,
 {
     pub fn len(&self) -> usize {
         self.status.len

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -7,7 +7,7 @@ use common::bitvec::BitSlice;
 use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, StoredStruct, UniversalWrite};
+use common::universal_io::{OpenOptions, StoredStruct, UniversalWrite};
 use fs_err as fs;
 use itertools::Either;
 
@@ -61,7 +61,7 @@ fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::bitvec_flags::BitvecFlags
 /// [3]: super::buffered_dynamic_flags::BufferedDynamicFlags
-pub struct DynamicStoredFlags<S = MmapFile> {
+pub struct DynamicStoredFlags<S> {
     /// On-disk BitSlice for flags
     flags: StoredBitSlice<S>,
     status: StoredStruct<S, DynamicFlagsStatus>,

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -303,11 +303,18 @@ where
     }
 }
 
+#[duplicate::duplicate_item(
+    tests_mod       S               cfg_predicate;
+    [tests_mmap]    [MmapFile]      [cfg(all())];
+    [tests_uring]   [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
 #[cfg(test)]
-mod tests {
+mod tests_mod {
     use std::iter;
 
-    use common::universal_io::MmapFile;
+    #[cfg_predicate]
+    use common::universal_io::S;
     use rand::prelude::StdRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
@@ -324,7 +331,7 @@ mod tests {
 
         {
             let mut dynamic_flags =
-                DynamicStoredFlags::<MmapFile>::open(dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             dynamic_flags.set_len(num_flags).unwrap();
             random_flags
                 .iter()
@@ -343,7 +350,7 @@ mod tests {
         }
 
         {
-            let dynamic_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), true).unwrap();
+            let dynamic_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             assert_eq!(dynamic_flags.status.len, num_flags * 2);
             for (i, flag) in random_flags.iter().enumerate() {
                 assert_eq!(dynamic_flags.get(i).unwrap(), *flag);
@@ -359,7 +366,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         // Create randomized dynamic mmap flags to test counting
-        let mut dynamic_flags = DynamicStoredFlags::<MmapFile>::open(dir.path(), true).unwrap();
+        let mut dynamic_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
         dynamic_flags.set_len(num_flags).unwrap();
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
         random_flags

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -28,8 +28,14 @@ fn status_file(directory: &Path) -> PathBuf {
     directory.join(STATUS_FILE_NAME)
 }
 
-pub trait UioDynamicFlags: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static {}
-impl<T> UioDynamicFlags for T where T: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static {}
+pub trait UioDynamicFlags:
+    UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static
+{
+}
+impl<T> UioDynamicFlags for T where
+    T: UniversalWrite<DynamicFlagsStatus> + UniversalWrite<u64> + Send + 'static
+{
+}
 
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
@@ -330,8 +336,7 @@ mod tests_mod {
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
 
         {
-            let mut dynamic_flags =
-                DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
+            let mut dynamic_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
             dynamic_flags.set_len(num_flags).unwrap();
             random_flags
                 .iter()

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -136,9 +136,17 @@ impl RoaringFlags {
     }
 }
 
+#[duplicate::duplicate_item(
+    tests_mod       S               cfg_predicate;
+    [tests_mmap]    [MmapFile]      [cfg(all())];
+    [tests_uring]   [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
 #[cfg(test)]
-mod tests {
+mod tests_mod {
     use common::types::PointOffsetType;
+    #[cfg_predicate]
+    use common::universal_io::S;
 
     use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
     use crate::common::flags::roaring_flags::RoaringFlags;
@@ -152,8 +160,8 @@ mod tests {
 
         // Create and update flags
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), false).unwrap();
-            let mut roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
+            let dynamic_flags = DynamicStoredFlags::<S>::open(dir.path(), false).unwrap();
+            let mut roaring_flags = RoaringFlags::new(dynamic_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
             for i in 16..20 {
@@ -172,7 +180,7 @@ mod tests {
 
         // Verify bitmap consistency after reload
         {
-            let mmap_flags = DynamicStoredFlags::open(dir.path(), true).unwrap();
+            let mmap_flags = DynamicStoredFlags::<S>::open(dir.path(), true).unwrap();
             let roaring_flags = RoaringFlags::new(mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -7,6 +7,7 @@ use roaring::RoaringBitmap;
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
 use super::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::Flusher;
+use crate::common::flags::dynamic_stored_flags::UioDynamicFlags;
 use crate::common::operation_error::OperationResult;
 
 /// A buffered, growable, and persistent bitslice with fast in-memory roaring bitmap.
@@ -16,9 +17,9 @@ use crate::common::operation_error::OperationResult;
 /// Changes are buffered until explicitly flushed.
 ///
 /// [1]: super::bitvec_flags::BitvecFlags
-pub struct RoaringFlags {
+pub struct RoaringFlags<S = MmapFile> {
     /// Buffered persisted flags.
-    storage: BufferedDynamicFlags,
+    storage: BufferedDynamicFlags<S>,
 
     /// In-memory bitmap of true flags.
     // Potential optimization: add a secondary bitmap for false values for faster iter_falses implementation.
@@ -28,8 +29,11 @@ pub struct RoaringFlags {
     len: usize,
 }
 
-impl RoaringFlags {
-    pub fn new(dynamic_flags: DynamicStoredFlags<MmapFile>) -> OperationResult<Self> {
+impl<S> RoaringFlags<S>
+where
+    S: UioDynamicFlags,
+{
+    pub fn new(dynamic_flags: DynamicStoredFlags<S>) -> OperationResult<Self> {
         // load flags into memory
         let bitmap = RoaringBitmap::from_sorted_iter(dynamic_flags.iter_trues()?)
             .expect("iter_trues iterates in sorted order");

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
 use roaring::RoaringBitmap;
 
 use super::buffered_dynamic_flags::BufferedDynamicFlags;
@@ -17,7 +16,7 @@ use crate::common::operation_error::OperationResult;
 /// Changes are buffered until explicitly flushed.
 ///
 /// [1]: super::bitvec_flags::BitvecFlags
-pub struct RoaringFlags<S = MmapFile> {
+pub struct RoaringFlags<S> {
     /// Buffered persisted flags.
     storage: BufferedDynamicFlags<S>,
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -8,7 +8,7 @@ use common::universal_io::MmapFile;
 use fs_err as fs;
 use roaring::RoaringBitmap;
 
-use crate::common::flags::dynamic_stored_flags::{DynamicStoredFlags};
+use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -4,10 +4,11 @@ use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use fs_err as fs;
 use roaring::RoaringBitmap;
 
-use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
+use crate::common::flags::dynamic_stored_flags::{DynamicStoredFlags};
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
@@ -26,12 +27,12 @@ pub struct MutableBoolIndex {
     indexed_count: usize,
     trues_count: usize,
     falses_count: usize,
-    storage: Storage,
+    storage: Storage<MmapFile>,
 }
 
-struct Storage {
-    trues_flags: RoaringFlags,
-    falses_flags: RoaringFlags,
+struct Storage<S> {
+    trues_flags: RoaringFlags<S>,
+    falses_flags: RoaringFlags<S>,
 }
 
 impl MutableBoolIndex {

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use fs_err as fs;
 use serde_json::Value;
 
@@ -25,15 +26,15 @@ const IS_NULL_DIRNAME: &str = "is_null";
 /// and buffers updates before persisting them to DynamicMmapFlags.
 pub struct MutableNullIndex {
     base_dir: PathBuf,
-    storage: Storage,
+    storage: Storage<MmapFile>,
     total_point_count: usize,
 }
 
-struct Storage {
+struct Storage<S> {
     /// Points which have at least one value
-    has_values_flags: RoaringFlags,
+    has_values_flags: RoaringFlags<S>,
     /// Points which have null values
-    is_null_flags: RoaringFlags,
+    is_null_flags: RoaringFlags<S>,
 }
 
 impl MutableNullIndex {

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -34,7 +34,7 @@ pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {
     ///
     /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
     /// depend on its length.
-    deleted: BitvecFlags,
+    deleted: BitvecFlags<MmapFile>,
     distance: Distance,
     deleted_count: usize,
     _phantom: std::marker::PhantomData<T>,

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -61,7 +61,7 @@ pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     ///
     /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
     /// depend on its length.
-    deleted: BitvecFlags,
+    deleted: BitvecFlags<MmapFile>,
     distance: Distance,
     multi_vector_config: MultiVectorConfig,
     deleted_count: usize,

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -7,6 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use fs_err as fs;
 use gridstore::Gridstore;
 use gridstore::config::{Compression, StorageOptions};
@@ -32,7 +33,7 @@ pub struct MmapSparseVectorStorage {
     ///
     /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
     /// depend on its length.
-    deleted: BitvecFlags,
+    deleted: BitvecFlags<MmapFile>,
     /// Current number of deleted vectors.
     deleted_count: usize,
     /// Maximum point offset in the storage + 1. This also means the total amount of point offsets


### PR DESCRIPTION
Builds on top of #8893 

Propagates the `S` generic backend into `RoaringFlags` and `BitvecFlags`.

Additionally, this PR increases test coverage so that we also test `IoUringFile` backed. This is a low-hanging fruit that uses `duplicate` crate to duplicate each test, but with a different backend. This is also easily extendible.