### PR TITLE
Callback-based InvertedIndex::for_each_token_id

### DIFF
--- a/lib/common/common/src/iterator_ext/mod.rs
+++ b/lib/common/common/src/iterator_ext/mod.rs
@@ -59,6 +59,20 @@ pub trait IteratorExt: Iterator {
             std::hint::black_box(p);
         });
     }
+
+    /// [`Iterator::any()`] but for fallible predicates.
+    fn try_any<F, E>(&mut self, mut f: F) -> Result<bool, E>
+    where
+        F: FnMut(Self::Item) -> Result<bool, E>,
+        Self: Sized,
+    {
+        self.find_map(|item| match f(item) {
+            Ok(true) => Some(Ok(true)),
+            Ok(false) => None,
+            Err(e) => Some(Err(e)),
+        })
+        .unwrap_or(Ok(false))
+    }
 }
 
 impl<I: Iterator> IteratorExt for I {}
@@ -127,4 +141,27 @@ pub fn check_exact_size_iterator_len<I: ExactSizeIterator>(mut iter: I) {
     }
     assert!(iter.next().is_none());
     assert_eq!(iter.len(), 0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_any() {
+        let is_even = |n: i32| match n {
+            n if n < 0 => Err("negative"),
+            n => Ok(n % 2 == 0),
+        };
+
+        assert_eq!([1, 3, 4, 5].into_iter().try_any(is_even), Ok(true));
+        assert_eq!([1, 3, 5, 7].into_iter().try_any(is_even), Ok(false));
+        assert_eq!(std::iter::empty().try_any(is_even), Ok(false));
+        assert_eq!([1, 3, -1, 4].into_iter().try_any(is_even), Err("negative"));
+
+        // Short-circuits on first `Ok(true)` without evaluating the rest.
+        let mut iter = [1, 2, 3, -1].into_iter();
+        assert_eq!(iter.try_any(is_even), Ok(true));
+        assert_eq!(iter.next(), Some(3));
+    }
 }

--- a/lib/segment/src/index/field_index/field_index_base.rs
+++ b/lib/segment/src/index/field_index/field_index_base.rs
@@ -173,8 +173,8 @@ impl FieldIndex {
         condition: &FieldCondition,
         payload_value: &Value,
         hw_counter: &HardwareCounterCell,
-    ) -> Option<bool> {
-        match self {
+    ) -> OperationResult<Option<bool>> {
+        Ok(match self {
             FieldIndex::IntIndex(_) => None,
             FieldIndex::DatetimeIndex(_) => None,
             FieldIndex::IntMapIndex(_) => None,
@@ -182,19 +182,19 @@ impl FieldIndex {
             FieldIndex::FloatIndex(_) => None,
             FieldIndex::GeoIndex(_) => None,
             FieldIndex::BoolIndex(_) => None,
-            FieldIndex::FullTextIndex(full_text_index) => match &condition.r#match {
-                Some(Match::Text(MatchText { text })) => Some(
-                    full_text_index.check_payload_match::<false>(payload_value, text, hw_counter),
-                ),
-                Some(Match::Phrase(MatchPhrase { phrase })) => Some(
-                    full_text_index.check_payload_match::<true>(payload_value, phrase, hw_counter),
-                ),
+            FieldIndex::FullTextIndex(index) => match &condition.r#match {
+                Some(Match::Text(MatchText { text })) => {
+                    Some(index.check_payload_match::<false>(payload_value, text, hw_counter)?)
+                }
+                Some(Match::Phrase(MatchPhrase { phrase })) => {
+                    Some(index.check_payload_match::<true>(payload_value, phrase, hw_counter)?)
+                }
                 _ => None,
             },
             FieldIndex::UuidIndex(_) => None,
             FieldIndex::UuidMapIndex(_) => None,
             FieldIndex::NullIndex(_) => None,
-        }
+        })
     }
 
     fn get_payload_field_index(&self) -> &dyn PayloadFieldIndex {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -347,8 +347,14 @@ impl InvertedIndex for ImmutableInvertedIndex {
         self.points_count
     }
 
-    fn get_token_id(&self, token: &str, _: &HardwareCounterCell) -> Option<TokenId> {
-        self.vocab.get(token).copied()
+    fn for_each_token_id<'a, Meta>(
+        &self,
+        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        _: &HardwareCounterCell,
+        mut f: impl FnMut(Meta, Option<TokenId>),
+    ) -> OperationResult<()> {
+        tokens.for_each(|(meta, token)| f(meta, self.vocab.get(token).copied()));
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -614,19 +614,27 @@ impl InvertedIndex for MmapInvertedIndex {
         self.active_points_count
     }
 
-    fn get_token_id(&self, token: &str, hw_counter: &HardwareCounterCell) -> Option<TokenId> {
-        if self.is_on_disk {
-            hw_counter.payload_index_io_read_counter().incr_delta(
-                READ_ENTRY_OVERHEAD + size_of::<TokenId>(), // Avoid check overhead and assume token is always read
-            );
-        }
+    fn for_each_token_id<'a, Meta>(
+        &self,
+        mut tokens: impl Iterator<Item = (Meta, &'a str)>,
+        hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(Meta, Option<TokenId>),
+    ) -> OperationResult<()> {
+        tokens.try_for_each(|(meta, token)| {
+            if self.is_on_disk {
+                hw_counter.payload_index_io_read_counter().incr_delta(
+                    READ_ENTRY_OVERHEAD + size_of::<TokenId>(), // Avoid check overhead and assume token is always read
+                );
+            }
 
-        self.storage
-            .vocab
-            .get(token)
-            .ok()
-            .flatten()
-            .and_then(<[TokenId]>::first)
-            .copied()
+            let token_id = self
+                .storage
+                .vocab
+                .get(token.as_ref())?
+                .and_then(<[TokenId]>::first)
+                .copied();
+            f(meta, token_id);
+            Ok(())
+        })
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -10,7 +10,6 @@ mod postings_iterator;
 use std::cmp::min;
 use std::collections::HashMap;
 
-use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Itertools;
@@ -71,14 +70,6 @@ impl TokenSet {
             return false;
         }
         subset.0.iter().any(|token| self.contains(token))
-    }
-}
-
-impl From<AHashSet<TokenId>> for TokenSet {
-    fn from(tokens: AHashSet<TokenId>) -> Self {
-        let sorted_unique = tokens.into_iter().sorted_unstable().collect();
-
-        Self(sorted_unique)
     }
 }
 
@@ -399,7 +390,13 @@ pub trait InvertedIndex {
 
     fn points_count(&self) -> usize;
 
-    fn get_token_id(&self, token: &str, hw_counter: &HardwareCounterCell) -> Option<TokenId>;
+    /// Resolve token -> token_id and call the closure for each token_id.
+    fn for_each_token_id<'a, Meta>(
+        &self,
+        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(Meta, Option<TokenId>),
+    ) -> OperationResult<()>;
 }
 
 #[cfg(test)]
@@ -434,26 +431,35 @@ mod tests {
     }
 
     /// Tries to parse a query. If there is an unknown id to a token, returns `None`
-    fn to_parsed_query(
-        query: Vec<String>,
-        token_to_id: impl Fn(String) -> Option<TokenId>,
-    ) -> Option<ParsedQuery> {
-        let tokens = query
-            .into_iter()
-            .map(token_to_id)
-            .collect::<Option<TokenSet>>()?;
+    fn to_parsed_query(token_ids: &[Option<TokenId>]) -> Option<ParsedQuery> {
+        let tokens = token_ids.iter().copied().collect::<Option<TokenSet>>()?;
         Some(ParsedQuery::AllTokens(tokens))
     }
 
-    fn to_parsed_query_any(
-        query: Vec<String>,
-        token_to_id: impl Fn(String) -> Option<TokenId>,
-    ) -> Option<ParsedQuery> {
-        let tokens = query
-            .into_iter()
-            .map(token_to_id)
-            .collect::<Option<TokenSet>>()?;
+    fn to_parsed_query_any(token_ids: &[Option<TokenId>]) -> Option<ParsedQuery> {
+        let tokens = token_ids.iter().copied().collect::<Option<TokenSet>>()?;
         Some(ParsedQuery::AnyTokens(tokens))
+    }
+
+    fn parse_all<I: InvertedIndex>(
+        queries: &[Vec<String>],
+        index: &I,
+        hw_counter: &HardwareCounterCell,
+    ) -> Vec<Option<ParsedQuery>> {
+        queries
+            .iter()
+            .flat_map(|query| {
+                let mut ids = vec![None; query.len()];
+                index
+                    .for_each_token_id(
+                        query.iter().map(String::as_str).enumerate(),
+                        hw_counter,
+                        |i, id| ids[i] = id,
+                    )
+                    .unwrap();
+                [to_parsed_query(&ids), to_parsed_query_any(&ids)]
+            })
+            .collect()
     }
 
     fn mutable_inverted_index(
@@ -557,10 +563,15 @@ mod tests {
         let imm_mmap = ImmutableInvertedIndex::try_from(&mmap).unwrap();
 
         // Check same vocabulary
-        for (token, token_id) in &immutable.vocab {
-            assert_eq!(mmap.get_token_id(token, &hw_counter), Some(*token_id));
-            assert_eq!(imm_mmap.get_token_id(token, &hw_counter), Some(*token_id));
-        }
+        let assert_same_id = |expected: TokenId, actual: Option<TokenId>| {
+            assert_eq!(actual, Some(expected));
+        };
+        let vocab_iter = || immutable.vocab.iter().map(|(t, id)| (*id, t.as_str()));
+        mmap.for_each_token_id(vocab_iter(), &hw_counter, assert_same_id)
+            .unwrap();
+        imm_mmap
+            .for_each_token_id(vocab_iter(), &hw_counter, assert_same_id)
+            .unwrap();
 
         // Check same postings
         for token_id in 0..immutable.postings.len() as TokenId {
@@ -630,43 +641,9 @@ mod tests {
 
         let queries: Vec<_> = (0..100).map(|_| generate_query()).collect();
 
-        let mut_parsed_queries: Vec<_> = queries
-            .iter()
-            .cloned()
-            .flat_map(|query| {
-                vec![
-                    to_parsed_query(query.clone(), |token| mut_index.vocab.get(&token).copied()),
-                    to_parsed_query_any(query, |token| mut_index.vocab.get(&token).copied()),
-                ]
-            })
-            .collect();
-        let mmap_parsed_queries: Vec<_> = queries
-            .iter()
-            .cloned()
-            .flat_map(|query| {
-                vec![
-                    to_parsed_query(query.clone(), |token| {
-                        mmap_index.get_token_id(&token, &hw_counter)
-                    }),
-                    to_parsed_query_any(query, |token| {
-                        mmap_index.get_token_id(&token, &hw_counter)
-                    }),
-                ]
-            })
-            .collect();
-        let imm_mmap_parsed_queries: Vec<_> = queries
-            .into_iter()
-            .flat_map(|query| {
-                vec![
-                    to_parsed_query(query.clone(), |token| {
-                        imm_mmap_index.get_token_id(&token, &hw_counter)
-                    }),
-                    to_parsed_query_any(query, |token| {
-                        imm_mmap_index.get_token_id(&token, &hw_counter)
-                    }),
-                ]
-            })
-            .collect();
+        let mut_parsed_queries = parse_all(&queries, &mut_index, &hw_counter);
+        let mmap_parsed_queries = parse_all(&queries, &mmap_index, &hw_counter);
+        let imm_mmap_parsed_queries = parse_all(&queries, &imm_mmap_index, &hw_counter);
 
         check_query_congruence(
             &mut_parsed_queries,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
@@ -287,8 +287,14 @@ impl InvertedIndex for MutableInvertedIndex {
         self.points_count
     }
 
-    fn get_token_id(&self, token: &str, _hw_counter: &HardwareCounterCell) -> Option<TokenId> {
-        self.vocab.get(token).copied()
+    fn for_each_token_id<'a, Meta>(
+        &self,
+        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        _: &HardwareCounterCell,
+        mut f: impl FnMut(Meta, Option<TokenId>),
+    ) -> OperationResult<()> {
+        tokens.for_each(|(meta, token)| f(meta, self.vocab.get(token).copied()));
+        Ok(())
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -186,7 +186,10 @@ fn test_prefix_search() {
 
     let res: Vec<_> = index.query("ROBO", &hw_counter).unwrap().collect();
 
-    let query = index.parse_text_query("ROBO", &hw_counter).unwrap();
+    let query = index
+        .parse_text_query("ROBO", &hw_counter)
+        .unwrap()
+        .unwrap();
 
     for idx in res.iter().copied() {
         assert!(index.check_match(&query, idx).unwrap());
@@ -197,7 +200,12 @@ fn test_prefix_search() {
     let res: Vec<_> = index.query("q231", &hw_counter).unwrap().collect();
     assert!(res.is_empty());
 
-    assert!(index.parse_text_query("q231", &hw_counter).is_none());
+    assert!(
+        index
+            .parse_text_query("q231", &hw_counter)
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
@@ -258,6 +266,7 @@ fn test_phrase_matching() {
         // Test regular text matching (should match documents containing all tokens regardless of order)
         let text_query = index
             .parse_text_query("quick brown fox", &hw_counter)
+            .unwrap()
             .unwrap();
         assert!(index.check_match(&text_query, 0).unwrap());
         assert!(index.check_match(&text_query, 1).unwrap());
@@ -277,6 +286,7 @@ fn test_phrase_matching() {
         // Test phrase matching (should only match documents with exact phrase in order)
         let phrase_query = index
             .parse_phrase_query("quick brown fox", &hw_counter)
+            .unwrap()
             .unwrap();
         assert!(index.check_match(&phrase_query, 0).unwrap());
         assert!(index.check_match(&phrase_query, 2).unwrap());
@@ -295,6 +305,7 @@ fn test_phrase_matching() {
         // Test phrase that doesn't exist
         let missing_query = index
             .parse_phrase_query("fox brown quick", &hw_counter)
+            .unwrap()
             .unwrap();
         let missing_results: Vec<_> = index
             .filter_query(missing_query, &hw_counter)
@@ -305,13 +316,16 @@ fn test_phrase_matching() {
         assert_eq!(missing_results.len(), 0);
 
         // Test valid phrase up to a token that doesn't exist
-        let query_with_unknown_token = index.parse_phrase_query("quick brown bird", &hw_counter);
+        let query_with_unknown_token = index
+            .parse_phrase_query("quick brown bird", &hw_counter)
+            .unwrap();
         // the phrase query is not valid because it contains an unknown token
         assert!(query_with_unknown_token.is_none());
 
         // Test repeated words
         let phrase_query = index
             .parse_phrase_query("brown brown fox", &hw_counter)
+            .unwrap()
             .unwrap();
         assert!(index.check_match(&phrase_query, 4).unwrap());
 
@@ -383,7 +397,10 @@ fn test_ascii_folding_in_full_text_index_word() {
     }
 
     // ASCII-only queries should match only when folding is enabled
-    let query_enabled = index_enabled.parse_text_query("acao", &hw_counter).unwrap();
+    let query_enabled = index_enabled
+        .parse_text_query("acao", &hw_counter)
+        .unwrap()
+        .unwrap();
     assert!(index_enabled.check_match(&query_enabled, 0).unwrap());
 
     let results_enabled: Vec<_> = index_enabled
@@ -392,7 +409,9 @@ fn test_ascii_folding_in_full_text_index_word() {
         .collect();
     assert!(results_enabled.contains(&0));
 
-    let query_disabled_opt = index_disabled.parse_text_query("acao", &hw_counter);
+    let query_disabled_opt = index_disabled
+        .parse_text_query("acao", &hw_counter)
+        .unwrap();
     // Query might still parse, but should not match anything
     if let Some(query_disabled) = query_disabled_opt {
         let results_disabled: Vec<_> = index_disabled
@@ -403,7 +422,10 @@ fn test_ascii_folding_in_full_text_index_word() {
     }
 
     // Non-folded query must work in both
-    let query_acento = index_enabled.parse_text_query("ação", &hw_counter).unwrap();
+    let query_acento = index_enabled
+        .parse_text_query("ação", &hw_counter)
+        .unwrap()
+        .unwrap();
     assert!(index_enabled.check_match(&query_acento, 0).unwrap());
     let results_acento: Vec<_> = index_enabled
         .filter_query(query_acento, &hw_counter)
@@ -413,6 +435,7 @@ fn test_ascii_folding_in_full_text_index_word() {
 
     let query_acento2 = index_disabled
         .parse_text_query("ação", &hw_counter)
+        .unwrap()
         .unwrap();
     let results_acento2: Vec<_> = index_disabled
         .filter_query(query_acento2, &hw_counter)

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -14,7 +14,7 @@ use crate::data_types::index::TextIndexParams;
 use crate::fixtures::payload_fixtures::random_full_text_payload;
 use crate::index::field_index::field_index_base::PayloadFieldIndex;
 use crate::index::field_index::full_text_index::inverted_index::{
-    Document, InvertedIndex, ParsedQuery, TokenId, TokenSet,
+    Document, ParsedQuery, TokenId, TokenSet,
 };
 use crate::index::field_index::full_text_index::mmap_text_index::FullTextMmapIndexBuilder;
 use crate::index::field_index::full_text_index::mutable_text_index::MutableFullTextIndex;
@@ -223,38 +223,29 @@ fn build_random_index(
     (index, temp_dir, db)
 }
 
-/// Tries to parse a query. If there is an unknown id to a token, returns `None`
-pub fn to_parsed_query(
-    query: &[String],
-    is_phrase: bool,
-    token_to_id: impl Fn(&str) -> Option<TokenId>,
-) -> Option<ParsedQuery> {
-    let tokens = query.iter().map(|token| token_to_id(token.as_str()));
-
-    let parsed = match is_phrase {
-        false => ParsedQuery::AllTokens(tokens.collect::<Option<TokenSet>>()?),
-        true => ParsedQuery::Phrase(tokens.collect::<Option<Document>>()?),
-    };
-
-    Some(parsed)
-}
-
 pub fn parse_query(query: &[String], is_phrase: bool, index: &FullTextIndex) -> ParsedQuery {
     let hw_counter = HardwareCounterCell::disposable();
-    match index {
-        FullTextIndex::Mutable(index) => {
-            let token_to_id = |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-            to_parsed_query(query, is_phrase, token_to_id).unwrap()
-        }
-        FullTextIndex::Immutable(index) => {
-            let token_to_id = |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-            to_parsed_query(query, is_phrase, token_to_id).unwrap()
-        }
-        FullTextIndex::Mmap(index) => {
-            let token_to_id = |token: &str| index.inverted_index.get_token_id(token, &hw_counter);
-            to_parsed_query(query, is_phrase, token_to_id).unwrap()
-        }
+    let tokens = resolve_tokens(index, query, &hw_counter).into_iter();
+    match is_phrase {
+        false => ParsedQuery::AllTokens(tokens.collect::<Option<TokenSet>>().unwrap()),
+        true => ParsedQuery::Phrase(tokens.collect::<Option<Document>>().unwrap()),
     }
+}
+
+fn resolve_tokens<S: AsRef<str>>(
+    index: &FullTextIndex,
+    tokens: &[S],
+    hw_counter: &HardwareCounterCell,
+) -> Vec<Option<TokenId>> {
+    let mut ids = vec![None; tokens.len()];
+    index
+        .for_each_token_id(
+            tokens.iter().map(|s| s.as_ref()).enumerate(),
+            hw_counter,
+            |i, id| ids[i] = id,
+        )
+        .unwrap();
+    ids
 }
 
 #[rstest]
@@ -330,14 +321,11 @@ fn test_congruence(
             );
         }
 
-        assert_eq!(
-            index_a.get_token("doesnotexist", &hw_counter),
-            index_b.get_token("doesnotexist", &hw_counter),
-        );
-        assert!(
-            index_a.get_token(&keywords[0], &hw_counter).is_some()
-                == index_b.get_token(&keywords[0], &hw_counter).is_some(),
-        );
+        let probe_tokens = ["doesnotexist", keywords[0].as_str()];
+        let probe_a = resolve_tokens(index_a, &probe_tokens, &hw_counter);
+        let probe_b = resolve_tokens(index_b, &probe_tokens, &hw_counter);
+        assert_eq!(probe_a[0], probe_b[0]);
+        assert_eq!(probe_a[1].is_some(), probe_b[1].is_some());
 
         for query_range in [0..1, 2..4, 5..9, 0..10] {
             let keywords = &keywords[query_range];

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use ahash::AHashSet;
+use ahash::AHashMap;
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -17,6 +18,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::index::TextIndexParams;
 use crate::index::field_index::full_text_index::inverted_index::Document;
+use crate::index::field_index::full_text_index::tokenizers::TokenizerTextKind;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
     ValueIndexer,
@@ -110,15 +112,16 @@ impl FullTextIndex {
         }
     }
 
-    pub(super) fn get_token(
+    pub(super) fn for_each_token_id<'a, Meta>(
         &self,
-        token: &str,
+        iter: impl Iterator<Item = (Meta, &'a str)>,
         hw_counter: &HardwareCounterCell,
-    ) -> Option<TokenId> {
+        f: impl FnMut(Meta, Option<TokenId>),
+    ) -> OperationResult<()> {
         match self {
-            Self::Mutable(index) => index.inverted_index.get_token_id(token, hw_counter),
-            Self::Immutable(index) => index.inverted_index.get_token_id(token, hw_counter),
-            Self::Mmap(index) => index.inverted_index.get_token_id(token, hw_counter),
+            Self::Mutable(index) => index.inverted_index.for_each_token_id(iter, hw_counter, f),
+            Self::Immutable(index) => index.inverted_index.for_each_token_id(iter, hw_counter, f),
+            Self::Mmap(index) => index.inverted_index.for_each_token_id(iter, hw_counter, f),
         }
     }
 
@@ -247,78 +250,96 @@ impl FullTextIndex {
         }
     }
 
-    /// Tries to parse a phrase query. If there are any unseen tokens, returns `None`
-    ///
-    /// Preserves token order
+    /// Parse as [`TokenizerTextKind::Document`] and return [`ParsedQuery::Phrase`].
+    /// Returns [`None`] if there are any unseen tokens.
     pub fn parse_phrase_query(
         &self,
         phrase: &str,
         hw_counter: &HardwareCounterCell,
-    ) -> Option<ParsedQuery> {
+    ) -> OperationResult<Option<ParsedQuery>> {
         let document = self.parse_document(phrase, hw_counter)?;
-        Some(ParsedQuery::Phrase(document))
+        Ok(document.map(ParsedQuery::Phrase))
     }
 
-    /// Tries to parse a query. If there are any unseen tokens, returns `None`
-    ///
-    /// Tokens are made unique
+    /// Parse as [`TokenizerTextKind::Query`] and return [`ParsedQuery::AllTokens`].
+    /// Returns [`None`] if there are any unseen tokens.
     pub fn parse_text_query(
         &self,
         text: &str,
         hw_counter: &HardwareCounterCell,
-    ) -> Option<ParsedQuery> {
-        let mut tokens = AHashSet::new();
-        self.get_tokenizer().tokenize_query(text, |token| {
-            tokens.insert(self.get_token(token.as_ref(), hw_counter));
-        });
-        let tokens = tokens.into_iter().collect::<Option<TokenSet>>()?;
-        Some(ParsedQuery::AllTokens(tokens))
+    ) -> OperationResult<Option<ParsedQuery>> {
+        let tokenset: Option<TokenSet> = self
+            .resolve_tokens(TokenizerTextKind::Query, text, hw_counter)?
+            .into_values()
+            .collect::<Option<TokenSet>>();
+        Ok(tokenset.map(ParsedQuery::AllTokens))
     }
 
+    /// Parse as [`TokenizerTextKind::Query`] and return [`ParsedQuery::AnyTokens`].
+    /// Unseen tokens are ignored. Never returns [`None`].
     pub fn parse_text_any_query(
         &self,
         text: &str,
         hw_counter: &HardwareCounterCell,
-    ) -> Option<ParsedQuery> {
-        let mut tokens = AHashSet::new();
-        self.get_tokenizer().tokenize_query(text, |token| {
-            if let Some(token_id) = self.get_token(token.as_ref(), hw_counter) {
-                tokens.insert(token_id);
-            }
-        });
-        let tokens = tokens.into_iter().collect::<TokenSet>();
-        Some(ParsedQuery::AnyTokens(tokens))
+    ) -> OperationResult<Option<ParsedQuery>> {
+        let tokenset = self.parse_tokenset(TokenizerTextKind::Query, text, hw_counter)?;
+        Ok(Some(ParsedQuery::AnyTokens(tokenset)))
     }
 
-    pub fn parse_tokenset(&self, text: &str, hw_counter: &HardwareCounterCell) -> TokenSet {
-        let mut tokenset = AHashSet::new();
-        self.get_tokenizer().tokenize_doc(text, |token| {
-            if let Some(token_id) = self.get_token(token.as_ref(), hw_counter) {
-                tokenset.insert(token_id);
-            }
-        });
-        TokenSet::from(tokenset)
+    /// Parse as provided [`TokenizerTextKind`] and return [`TokenSet`].
+    /// Unseen tokens are ignored.
+    fn parse_tokenset(
+        &self,
+        kind: TokenizerTextKind,
+        text: &str,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<TokenSet> {
+        let token_ids = self.resolve_tokens(kind, text, hw_counter)?.into_values();
+        Ok(token_ids.flatten().collect())
     }
 
-    /// Parse document
-    ///
-    /// If there are any unseen tokens, returns `None`
-    pub fn parse_document(&self, text: &str, hw_counter: &HardwareCounterCell) -> Option<Document> {
+    /// Tokenize the `text` and return a map of token -> token_id.
+    /// Missing tokens will have [`None`] as token_id.
+    fn resolve_tokens<'a>(
+        &self,
+        kind: TokenizerTextKind,
+        text: &'a str,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<AHashMap<Cow<'a, str>, Option<TokenId>>> {
+        let mut token_map = AHashMap::new();
+        self.get_tokenizer().tokenize(kind, text, |token| {
+            token_map.insert(token, None);
+        });
+        let iter = token_map
+            .iter_mut()
+            .map(|(token, cell)| (cell, token.as_ref()));
+        self.for_each_token_id(iter, hw_counter, |cell, token_id| *cell = token_id)?;
+        Ok(token_map)
+    }
+
+    /// Parse as [`TokenizerTextKind::Document`] and return a [`Document`].
+    /// Returns [`None`] if there are any unseen tokens.
+    pub fn parse_document(
+        &self,
+        text: &str,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<Document>> {
         let mut document_tokens = Vec::new();
-        let mut unknow_token = false;
-        self.get_tokenizer().tokenize_doc(text, |token| {
-            if let Some(token_id) = self.get_token(token.as_ref(), hw_counter) {
-                document_tokens.push(token_id);
-            } else {
-                unknow_token = true
-            }
-        });
-        // Bail out if the text contains unknown token
-        if unknow_token {
-            None
-        } else {
-            Some(Document::new(document_tokens))
+        let token_map = self.resolve_tokens(TokenizerTextKind::Document, text, hw_counter)?;
+        if token_map.values().any(|token_id| token_id.is_none()) {
+            return Ok(None);
         }
+
+        self.get_tokenizer()
+            .tokenize(TokenizerTextKind::Document, text, |token| {
+                let token_id = token_map
+                    .get(&token)
+                    .expect("token should be in map")
+                    .expect("token_id should be set for all tokens");
+                document_tokens.push(token_id);
+            });
+
+        Ok(Some(Document::new(document_tokens)))
     }
 
     #[cfg(test)]
@@ -327,7 +348,7 @@ impl FullTextIndex {
         query: &'a str,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
-        let Some(parsed_query) = self.parse_text_query(query, hw_counter) else {
+        let Some(parsed_query) = self.parse_text_query(query, hw_counter)? else {
             return Ok(Box::new(std::iter::empty()));
         };
         self.filter_query(parsed_query, hw_counter)
@@ -339,31 +360,33 @@ impl FullTextIndex {
         payload_value: &serde_json::Value,
         text: &str,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         let query_opt = if IS_PHRASE {
-            self.parse_phrase_query(text, hw_counter)
+            self.parse_phrase_query(text, hw_counter)?
         } else {
-            self.parse_text_query(text, hw_counter)
+            self.parse_text_query(text, hw_counter)?
         };
 
         let Some(query) = query_opt else {
-            return false;
+            return Ok(false);
         };
 
         FullTextIndex::get_values(payload_value)
             .iter()
-            .any(|value| match &query {
+            .try_any(|value| match &query {
                 ParsedQuery::AllTokens(query) => {
-                    let tokenset = self.parse_tokenset(value, hw_counter);
-                    tokenset.has_subset(query)
+                    let tokenset =
+                        self.parse_tokenset(TokenizerTextKind::Document, value, hw_counter)?;
+                    Ok(tokenset.has_subset(query))
                 }
                 ParsedQuery::Phrase(query) => {
-                    let document = self.parse_document(value, hw_counter);
-                    document.is_some_and(|doc| doc.has_phrase(query))
+                    let document = self.parse_document(value, hw_counter)?;
+                    Ok(document.is_some_and(|doc| doc.has_phrase(query)))
                 }
                 ParsedQuery::AnyTokens(query) => {
-                    let tokenset = self.parse_tokenset(value, hw_counter);
-                    tokenset.has_any(query)
+                    let tokenset =
+                        self.parse_tokenset(TokenizerTextKind::Document, value, hw_counter)?;
+                    Ok(tokenset.has_any(query))
                 }
             })
     }
@@ -508,7 +531,7 @@ impl PayloadFieldIndex for FullTextIndex {
                 self.parse_phrase_query(phrase, hw_counter)
             }
             _ => return Ok(None),
-        };
+        }?;
 
         let Some(parsed_query) = parsed_query_opt else {
             return Ok(Some(Box::new(std::iter::empty())));
@@ -528,7 +551,7 @@ impl PayloadFieldIndex for FullTextIndex {
                 self.parse_phrase_query(phrase, hw_counter)
             }
             _ => return Ok(None),
-        };
+        }?;
 
         let Some(parsed_query) = parsed_query_opt else {
             return Ok(Some(CardinalityEstimation::exact(0)));

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -159,6 +159,11 @@ pub struct Tokenizer {
     tokens_processor: TokensProcessor,
 }
 
+pub enum TokenizerTextKind {
+    Query,
+    Document,
+}
+
 impl Tokenizer {
     pub fn new_from_text_index_params(params: &TextIndexParams) -> Self {
         let TextIndexParams {
@@ -198,34 +203,33 @@ impl Tokenizer {
         }
     }
 
-    pub fn tokenize_doc<'a, C: FnMut(Cow<'a, str>)>(&'a self, text: &'a str, callback: C) {
-        match self.tokenizer_type {
-            TokenizerType::Whitespace => {
-                WhiteSpaceTokenizer::tokenize(text, &self.tokens_processor, callback)
-            }
-            TokenizerType::Word => WordTokenizer::tokenize(text, &self.tokens_processor, callback),
-            TokenizerType::Multilingual => {
-                MultilingualTokenizer::tokenize(text, &self.tokens_processor, callback)
-            }
-            TokenizerType::Prefix => {
-                PrefixTokenizer::tokenize(text, &self.tokens_processor, callback)
-            }
+    pub fn tokenize<'a, C: FnMut(Cow<'a, str>)>(
+        &self,
+        kind: TokenizerTextKind,
+        text: &'a str,
+        callback: C,
+    ) {
+        let Self {
+            tokenizer_type,
+            tokens_processor: tp,
+        } = self;
+        match tokenizer_type {
+            TokenizerType::Whitespace => WhiteSpaceTokenizer::tokenize(text, tp, callback),
+            TokenizerType::Word => WordTokenizer::tokenize(text, tp, callback),
+            TokenizerType::Multilingual => MultilingualTokenizer::tokenize(text, tp, callback),
+            TokenizerType::Prefix => match kind {
+                TokenizerTextKind::Document => PrefixTokenizer::tokenize(text, tp, callback),
+                TokenizerTextKind::Query => PrefixTokenizer::tokenize_query(text, tp, callback),
+            },
         }
     }
 
+    pub fn tokenize_doc<'a, C: FnMut(Cow<'a, str>)>(&'a self, text: &'a str, callback: C) {
+        self.tokenize(TokenizerTextKind::Document, text, callback);
+    }
+
     pub fn tokenize_query<'a, C: FnMut(Cow<'a, str>)>(&'a self, text: &'a str, callback: C) {
-        match self.tokenizer_type {
-            TokenizerType::Whitespace => {
-                WhiteSpaceTokenizer::tokenize(text, &self.tokens_processor, callback)
-            }
-            TokenizerType::Word => WordTokenizer::tokenize(text, &self.tokens_processor, callback),
-            TokenizerType::Multilingual => {
-                MultilingualTokenizer::tokenize(text, &self.tokens_processor, callback)
-            }
-            TokenizerType::Prefix => {
-                PrefixTokenizer::tokenize_query(text, &self.tokens_processor, callback)
-            }
-        }
+        self.tokenize(TokenizerTextKind::Query, text, callback);
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/multilingual.rs
@@ -19,11 +19,7 @@ const DEFAULT_NORMALIZER: NormalizerOption = NormalizerOption {
 pub struct MultilingualTokenizer;
 
 impl MultilingualTokenizer {
-    pub fn tokenize<'a, C: FnMut(Cow<'a, str>)>(
-        input: &'a str,
-        config: &'a TokensProcessor,
-        cb: C,
-    ) {
+    pub fn tokenize<'a, C: FnMut(Cow<'a, str>)>(input: &'a str, config: &TokensProcessor, cb: C) {
         let script = detect_script_of_language(input);
 
         // If the script of the input is latin and we don't need to stem early, tokenize as-is.
@@ -43,7 +39,7 @@ impl MultilingualTokenizer {
     }
 
     // Tokenize input using charabia. Automatically applies stemming and filters stopwords if configured.
-    fn tokenize_charabia<'a, C>(input: &'a str, tokens_processor: &'a TokensProcessor, mut cb: C)
+    fn tokenize_charabia<'a, C>(input: &'a str, tokens_processor: &TokensProcessor, mut cb: C)
     where
         C: FnMut(Cow<'a, str>),
     {

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -51,6 +51,7 @@ impl StructPayloadIndex {
                             point_id,
                             |payload| {
                                 check_field_condition(field_condition, &payload, field_indexes, &hw)
+                                    .unwrap(/* TODO(uio): handle errors */)
                             },
                             &hw,
                         )

--- a/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
@@ -276,12 +276,17 @@ fn get_match_text_checker(
                 TextQueryType::TextAny => full_text_index.parse_text_any_query(&text, &hw_counter),
             };
 
-            let Some(parsed_query) = query_opt else {
-                return Some(Box::new(|_| false));
+            let parsed_query = match query_opt {
+                Ok(Some(query)) => query,
+                Ok(None) => return Some(Box::new(|_| false)),
+                Err(_) => {
+                    // FIXME(uio): don't silently ignore errors. Log error? Update ConditionCheckerFn?
+                    return Some(Box::new(|_| false));
+                }
             };
 
             Some(Box::new(move |point_id: PointOffsetType| {
-                // FIXME: don't silently ignore errors. Log error? Update ConditionCheckerFn?
+                // FIXME(uio): don't silently ignore errors. Log error? Update ConditionCheckerFn?
                 full_text_index
                     .check_match(&parsed_query, point_id)
                     .unwrap_or(false)

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -9,6 +9,7 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
+use crate::common::operation_error::OperationResult;
 use crate::common::utils::{IndexesMap, check_is_empty, check_is_null};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::field_index::FieldIndex;
@@ -130,7 +131,8 @@ where
             get_payload().deref(),
             field_indexes,
             hw_counter,
-        ),
+        )
+        .unwrap(/* TODO(uio): handle errors */),
         Condition::IsEmpty(is_empty) => check_is_empty_condition(is_empty, get_payload().deref()),
         Condition::IsNull(is_null) => check_is_null_condition(is_null, get_payload().deref()),
         Condition::HasId(has_id) => id_tracker
@@ -189,7 +191,7 @@ pub fn check_field_condition<R>(
     payload: &impl PayloadContainer,
     field_indexes: &HashMap<PayloadKeyType, R>,
     hw_counter: &HardwareCounterCell,
-) -> bool
+) -> OperationResult<bool>
 where
     R: AsRef<Vec<FieldIndex>>,
 {
@@ -197,7 +199,7 @@ where
     let field_indexes = field_indexes.get(&field_condition.key);
 
     if field_values.is_empty() {
-        return field_condition.check_empty();
+        return Ok(field_condition.check_empty());
     }
 
     // This covers a case, when a field index affects the result of the condition.
@@ -206,11 +208,11 @@ where
             let mut index_checked = false;
             for index in field_indexes.as_ref() {
                 if let Some(index_check_res) =
-                    index.special_check_condition(field_condition, p, hw_counter)
+                    index.special_check_condition(field_condition, p, hw_counter)?
                 {
                     if index_check_res {
                         // If at least one object matches the condition, we can return true
-                        return true;
+                        return Ok(true);
                     }
                     index_checked = true;
                     // If index check of the condition returned something, we don't need to check
@@ -222,14 +224,14 @@ where
                 // If none of the indexes returned anything, we need to check the condition
                 // against the payload
                 if field_condition.check(p) {
-                    return true;
+                    return Ok(true);
                 }
             }
         }
-        false
+        Ok(false)
     } else {
         // Fallback to regular condition check if there are no indexes for the field
-        field_values.into_iter().any(|p| field_condition.check(p))
+        Ok(field_values.into_iter().any(|p| field_condition.check(p)))
     }
 }
 


### PR DESCRIPTION
Preparation refactoring for `UniversalHashMap`.

This PR replaces `InvertedIndex::get_token_id` (non-batched, infallible) with `InvertedIndex::for_each_token_id` (batched, returns `OperationResult`).

---

Caveat: these changes cause some potential changes in performance. Summarized:

- (not minor) `FullTextIndex::parse_document`:
  - Before this PR:
    1. Tokenize into a sequence of `Cow<str>`.
    2. Resolve ids and collect into `Vec<u32>`.
  - This PR:
    1. Tokenize into a sequence of `Cow<str>`.
    2. Collect tokens into `AHashMap<Cow<str>, Option<u32>>`. (!)
    3. Resolve ids in-place using batched API.
    4. Tokenize again (!) and collect into `Vec<u32>`.
- (minor) `FullTextIndex::parse_text_query`, `FullTextIndex::parse_text_any_query`:
  - Before this PR:
    1. Tokenize into a sequence of `Cow<str>`.
    2. Resolve ids and collect them into `AHashSet<Option<u32>>`
    3. `Vec::collect()` and `Vec::sort_unstable()`. (see `impl From<AHashSet<u32>> for TokenSet {`)
  - This PR:
    1. Tokenize into a sequence of `Cow<str>`.
    2. Collect tokens into `AHashMap<Cow<str>, Option<u32>>`.
    3. Resolve ids in-place using batched API.
    4. `Vec::collect()` + `Vec::sort_unstable()` + `Vec::dedup()`. (see `impl FromIterator<TokenId> for TokenSet {`)

In other words, the new logic performs more allocations and lookups.
Why: to deduplicate token strings before performing batched reads.
I believe that deduplication would be cheaper than extra read requests in case of duplicated tokens.
If it's an issue, I can rewrite `parse_document` to be faster but less readable.

