### PR TITLE
Geo index hardening

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index.rs
@@ -169,10 +169,10 @@ impl ImmutableGeoMapIndex {
                 .points_values_count
                 .saturating_sub(removed_geo_points.len());
 
-            let removed_geo_hashes: Vec<_> = removed_geo_points
-                .into_iter()
-                .map(|geo_point| encode_max_precision(geo_point.lon.0, geo_point.lat.0).unwrap())
-                .collect();
+            let mut removed_geo_hashes = Vec::with_capacity(removed_geo_points.len());
+            for geo_point in removed_geo_points {
+                removed_geo_hashes.push(encode_max_precision(geo_point.lon.0, geo_point.lat.0)?);
+            }
             for &removed_geo_hash in &removed_geo_hashes {
                 index.decrement_hash_value_counts(removed_geo_hash);
             }
@@ -284,13 +284,15 @@ impl ImmutableGeoMapIndex {
             return Ok(());
         }
 
-        self.points_count -= 1;
-        self.points_values_count -= removed_geo_points.len();
+        self.points_count = self.points_count.saturating_sub(1);
+        self.points_values_count = self
+            .points_values_count
+            .saturating_sub(removed_geo_points.len());
         let mut removed_geo_hashes = Vec::with_capacity(removed_geo_points.len());
 
         for removed_geo_point in removed_geo_points {
             let removed_geo_hash: GeoHash =
-                encode_max_precision(removed_geo_point.lon.0, removed_geo_point.lat.0).unwrap();
+                encode_max_precision(removed_geo_point.lon.0, removed_geo_point.lat.0)?;
             removed_geo_hashes.push(removed_geo_hash);
 
             match self.storage {

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -231,7 +231,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                     .point_to_values
                     .len()
                     .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<usize>()),
+                    .next_multiple_of(size_of::<u64>()),
             )?;
             let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
             deleted.set_ascending_bits_batch(


### PR DESCRIPTION
Extra hardening for the geo indexes.

- Propagate encode_max_precision errors instead of panicking on corrupt geo data
- Use saturating_sub for points_count / points_values_count in remove_point
- Round deleted.bin size to size_of::<u64>() instead of size_of::<usize>() so 8-byte alignment holds on 32-bit targets