### PR TITLE
Numeric index hardening

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index.rs
@@ -25,6 +25,8 @@ pub struct ImmutableNumericIndex<T: Encodable + Numericable + StoredValue + Defa
     point_to_values: ImmutablePointToValues<T>,
     // Backing storage, source of state, persists deletions
     storage: Storage<T>,
+    /// Snapshot of approximate RAM usage at construction time.
+    /// Not refreshed on `remove_point`.
     cached_ram_usage_bytes: usize,
 }
 
@@ -72,16 +74,18 @@ impl<T: Encodable + Numericable> NumericKeySortedVec<T> {
             deleted,
             deleted_count: _,
         } = self;
-        data.capacity() * std::mem::size_of::<Point<T>>()
-            + deleted.capacity().div_ceil(u8::BITS as usize)
+        data.capacity() * size_of::<Point<T>>() + deleted.capacity().div_ceil(u8::BITS as usize)
     }
 
     fn from_btree_set(map: BTreeSet<Point<T>>) -> Self {
-        Self {
+        let result = Self {
             deleted: BitVec::repeat(false, map.len()),
             data: map.into_iter().collect(),
             deleted_count: 0,
-        }
+        };
+        // Invariant relied on by the iterators (see `next` / `next_back`).
+        debug_assert_eq!(result.deleted.len(), result.data.len());
+        result
     }
 
     fn len(&self) -> usize {
@@ -181,7 +185,14 @@ impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> Immutable
 where
     Vec<T>: Blob,
 {
-    /// Open and load immutable numeric index from mmap storage
+    /// Open and load immutable numeric index from mmap storage.
+    ///
+    /// NOTE: returns `Self` (infallible) while sibling
+    /// `ImmutableMapIndex::open_mmap` / `ImmutableGeoMapIndex::open_mmap` /
+    /// `ImmutableFullTextIndex::open_mmap` return `OperationResult<Self>`.
+    /// Numeric's body has no fallible reads to propagate (`from_mmap` is
+    /// infallible; `clear_cache` errors are warn-and-continue, matching the
+    /// other variants).
     pub(super) fn open_mmap(index: MmapNumericIndex<T>) -> Self {
         // Load in-memory index from mmap storage
         let InMemoryNumericIndex {
@@ -257,11 +268,8 @@ where
     }
 
     pub fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        Some(Box::new(
-            self.point_to_values
-                .get_values(idx)
-                .map(|iter| iter.copied())?,
-        ))
+        let iter = self.point_to_values.get_values(idx)?;
+        Some(Box::new(iter.copied()))
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
@@ -318,7 +326,7 @@ where
                 removed_count += 1;
             }
             if removed_count > 0 {
-                self.points_count -= 1;
+                self.points_count = self.points_count.saturating_sub(1);
             }
         }
         self.point_to_values.remove_point(idx);

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -843,3 +843,63 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
         HwMeasurementAcc::new(),
     );
 }
+
+/// Reopen an immutable numeric index with an id-tracker deletion bitslice and
+/// verify the deleted points are excluded from counts and queries. Locks the
+/// open-time deletion path that the milestone-49 fix exposed in the map index
+/// loader (see `immutable_map_index.rs:99-102`); cf. the integration test in
+/// `lib/segment/src/segment/tests/test_immutable_payload_index_files.rs`.
+#[test]
+fn test_remove_reopen() {
+    use crate::index::field_index::PayloadFieldIndex;
+
+    let hw_acc = HwMeasurementAcc::new();
+    let hw_counter = hw_acc.get_counter_cell();
+    let (temp_dir, mut builder) = get_index_builder(IndexType::Mmap);
+    let values = [10.0_f64, 20.0, 30.0, 40.0];
+    for (idx, val) in values.iter().enumerate() {
+        builder
+            .add_point(idx as PointOffsetType, &[&Value::from(*val)], &hw_counter)
+            .unwrap();
+    }
+    // Persist on-disk state, then drop so the upcoming reopen sees only the
+    // files (no in-memory state holding handles).
+    let built = builder.finalize().unwrap();
+    drop(built);
+
+    // Reopen as immutable (RamMmap) with points 1 and 3 marked deleted by
+    // the id-tracker. The immutable open path must observe these deletions
+    // through the deleted bitslice argument.
+    let deleted = deleted_with(&[1, 3]);
+    let index = open_index_from_disk(temp_dir.path(), IndexType::RamMmap, &deleted);
+
+    // Deletions reflected in the indexed-point count.
+    assert_eq!(index.inner().count_indexed_points(), 2);
+
+    // Range query covering all four original values returns only the live
+    // ones; deleted points must be filtered out by the immutable index.
+    let range = Range {
+        lt: None,
+        gt: None,
+        gte: Some(OrderedFloat(0.0)),
+        lte: Some(OrderedFloat(100.0)),
+    };
+    let mut hits: Vec<_> = index
+        .inner()
+        .filter(
+            &FieldCondition::new_range(JsonPath::new("unused"), range),
+            &hw_counter,
+        )
+        .unwrap()
+        .unwrap()
+        .collect();
+    hits.sort();
+    assert_eq!(hits, vec![0, 2]);
+
+    // Per-point queries: deleted points report no values; live points still
+    // see their original value.
+    assert_eq!(index.values_count(0), 1);
+    assert_eq!(index.values_count(1), 0);
+    assert_eq!(index.values_count(2), 1);
+    assert_eq!(index.values_count(3), 0);
+}


### PR DESCRIPTION
Extra hardening for the immutable numeric index.

- Saturating_sub for points_count decrement in `remove_point`.
- Lock the NumericKeySortedVec length invariant.
- Simplify get_values. Same behavior, easier to read.
- Document cached_ram_usage_bytes snapshot semantics.
- Document the signature inconsistency for `open_mmap`.
- New `test_remove_reopen`.