### PR TITLE
Text index hardening

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index.rs
@@ -13,6 +13,8 @@ pub struct ImmutableFullTextIndex {
     pub(super) inverted_index: ImmutableInvertedIndex,
     // Backing storage, source of state, persists deletions
     pub(super) storage: Storage,
+    /// Snapshot of approximate RAM usage at construction time.
+    /// Not refreshed on `remove_point`.
     cached_ram_usage_bytes: usize,
 }
 
@@ -39,6 +41,9 @@ impl ImmutableFullTextIndex {
         Ok(result)
     }
 
+    /// Apply the deletion to both `inverted_index` (the in-RAM cache used
+    /// by queries) and `storage` (keeps the mmap's `points_count()` in
+    /// sync; not persisted — id-tracker re-supplies on reload).
     pub fn remove_point(&mut self, id: PointOffsetType) {
         if self.inverted_index.remove(id) {
             match self.storage {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -283,7 +283,7 @@ impl InvertedIndex for ImmutableInvertedIndex {
             return false; // Already removed or never actually existed
         }
         self.point_to_tokens_count[idx as usize] = 0;
-        self.points_count -= 1;
+        self.points_count = self.points_count.saturating_sub(1);
         true
     }
 
@@ -541,14 +541,12 @@ impl ImmutableInvertedIndex {
 
         let postings_bytes = postings.ram_usage_bytes();
         // HashMap per-slot overhead: hash (u64) + metadata pointer
-        let hashmap_entry_overhead = std::mem::size_of::<u64>() + std::mem::size_of::<usize>();
+        let hashmap_entry_overhead = size_of::<u64>() + size_of::<usize>();
         let vocab_base_bytes = vocab.capacity()
-            * (std::mem::size_of::<String>()
-                + std::mem::size_of::<TokenId>()
-                + hashmap_entry_overhead);
+            * (size_of::<String>() + size_of::<TokenId>() + hashmap_entry_overhead);
         // Account for actual heap-allocated string data
         let vocab_heap_bytes: usize = vocab.keys().map(|s| s.capacity()).sum();
-        let pttc_bytes = point_to_tokens_count.capacity() * std::mem::size_of::<usize>();
+        let pttc_bytes = point_to_tokens_count.capacity() * size_of::<usize>();
         postings_bytes + vocab_base_bytes + vocab_heap_bytes + pttc_bytes
     }
 }


### PR DESCRIPTION
Hardening pass for `ImmutableFullTextIndex` and `ImmutableInvertedIndex`.

- Safe saturating_sub for points_count decrement in `ImmutableInvertedIndex::remove`.
- Document `cached_ram_usage_bytes` snapshot semantics.
- Use the prelude `size_of`.