### PR TITLE
Mmap payload index hardening

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -524,7 +524,7 @@ impl InvertedIndex for MmapInvertedIndex {
         }
 
         self.storage.deleted_points.set(idx as usize, true);
-        self.active_points_count -= 1;
+        self.active_points_count = self.active_points_count.saturating_sub(1);
         true
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index.rs
@@ -168,7 +168,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
         {
             let points_map_file = create_and_ensure_length(
                 &points_map_path,
-                dynamic_index.points_map.len() * std::mem::size_of::<PointKeyValue>(),
+                dynamic_index.points_map.len() * size_of::<PointKeyValue>(),
             )?;
             let points_map_file = unsafe { MmapMut::map_mut(&points_map_file)? };
             let mut points_map = unsafe { MmapSlice::<PointKeyValue>::try_from(points_map_file)? };
@@ -180,7 +180,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                     .values()
                     .map(|v| v.len())
                     .sum::<usize>()
-                    * std::mem::size_of::<PointOffsetType>(),
+                    * size_of::<PointOffsetType>(),
             )?;
             let points_map_ids_file = unsafe { MmapMut::map_mut(&points_map_ids_file)? };
             let mut points_map_ids =
@@ -206,7 +206,7 @@ impl<S: StoredGeoMapIndexStorage> StoredGeoMapIndex<S> {
                 std::cmp::min(
                     dynamic_index.points_per_hash.len(),
                     dynamic_index.values_per_hash.len(),
-                ) * std::mem::size_of::<Counts>(),
+                ) * size_of::<Counts>(),
             )?;
             let counts_per_hash_file = unsafe { MmapMut::map_mut(&counts_per_hash_file)? };
             let mut counts_per_hash =

--- a/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index.rs
@@ -1,6 +1,5 @@
 use std::borrow::{Borrow, Cow};
 use std::iter;
-use std::mem::size_of;
 use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -441,5 +441,10 @@ mod tests {
             vec![0, 2],
         );
         assert_eq!(reopened_index.count_indexed_points(), 3);
+
+        // Direct API parity: deleted point reads as empty; live points don't.
+        assert!(reopened_index.values_is_empty(1));
+        assert!(!reopened_index.values_is_empty(0));
+        assert!(!reopened_index.values_is_empty(2));
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index.rs
@@ -116,7 +116,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> MmapNum
         {
             let pairs_file = create_and_ensure_length(
                 &pairs_path,
-                in_memory_index.map.len() * std::mem::size_of::<Point<T>>(),
+                in_memory_index.map.len() * size_of::<Point<T>>(),
             )?;
             let pairs_mmap = unsafe { MmapMut::map_mut(&pairs_file)? };
             let mut pairs = unsafe { MmapSlice::<Point<T>>::try_from(pairs_mmap)? };


### PR DESCRIPTION
Hardening sweep across the mmap-side of the immutable payload index stack.

- Safe saturating_sub for active_points_count decrement in `MmapInvertedIndex::remove`.
- Use the prelude `size_of` in mmap_geo_index.rs 
- Direct API parity assertions in `immutable_null_index::test_remove_reopen`.
