### PR TITLE
Fix strict-mode disable race

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -172,26 +172,42 @@ impl Collection {
     }
 
     /// Updates the strict mode configuration and saves it to disk.
+    ///
+    /// Order matters: rate limiters on each shard are updated *before* the new
+    /// `strict_mode_config` is published to `self.collection_config`. Otherwise
+    /// readers of `info()` could observe `enabled=false` while a search arriving
+    /// on the same peer is still rejected by a not-yet-cleared rate limiter
+    /// (or vice versa for an enable).
     pub async fn update_strict_mode_config(
         &self,
         strict_mode_diff: StrictModeConfig,
     ) -> CollectionResult<()> {
+        // Compute the new strict-mode config without yet exposing it.
+        let new_strict_mode_config = {
+            let config = self.collection_config.read().await;
+            if let Some(current) = config.strict_mode_config.as_ref() {
+                current.update(&strict_mode_diff)
+            } else {
+                strict_mode_diff
+            }
+        };
+
+        // Apply rate-limiter changes to every shard first, so the visible config
+        // never lies about the active rate limit.
+        {
+            let shard_holder = self.shards_holder.write().await;
+            let updates = shard_holder.all_shards().map(|replica_set| {
+                replica_set.on_strict_mode_config_update(&new_strict_mode_config)
+            });
+            future::try_join_all(updates).await?;
+        }
+
+        // Publish the new config and persist it.
         {
             let mut config = self.collection_config.write().await;
-            if let Some(current_config) = config.strict_mode_config.as_mut() {
-                *current_config = current_config.update(&strict_mode_diff);
-            } else {
-                config.strict_mode_config = Some(strict_mode_diff);
-            }
+            config.strict_mode_config = Some(new_strict_mode_config);
         }
-        // update collection config
         self.collection_config.read().await.save(&self.path)?;
-        // apply config change to all shards
-        let shard_holder = self.shards_holder.write().await;
-        let updates = shard_holder
-            .all_shards()
-            .map(|replica_set| replica_set.on_strict_mode_config_update());
-        future::try_join_all(updates).await?;
         Ok(())
     }
 

--- a/lib/collection/src/shards/dummy_shard.rs
+++ b/lib/collection/src/shards/dummy_shard.rs
@@ -7,7 +7,8 @@ use common::types::DeferredBehavior;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, SizeStats, WithPayload, WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, ScoredPoint, SizeStats, StrictModeConfig, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use shard::count::CountRequestInternal;
 use shard::operations::CollectionUpdateOperations;
@@ -49,7 +50,7 @@ impl DummyShard {
         Ok(())
     }
 
-    pub fn on_strict_mode_config_update(&mut self) {}
+    pub fn on_strict_mode_config_update(&mut self, _new_strict_mode: &StrictModeConfig) {}
 
     pub fn get_telemetry_data(&self) -> LocalShardTelemetry {
         LocalShardTelemetry {

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -11,8 +11,8 @@ use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
-    WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, StrictModeConfig,
+    WithPayload, WithPayloadInterface, WithVector,
 };
 use shard::count::CountRequestInternal;
 use shard::retrieve::record_internal::RecordInternal;
@@ -412,8 +412,9 @@ impl ForwardProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
-    pub async fn on_strict_mode_config_update(&mut self) {
-        self.wrapped_shard.on_strict_mode_config_update().await
+    pub fn on_strict_mode_config_update(&mut self, new_strict_mode: &StrictModeConfig) {
+        self.wrapped_shard
+            .on_strict_mode_config_update(new_strict_mode)
     }
 
     pub fn trigger_optimizers(&self) {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -49,7 +49,7 @@ use segment::index::field_index::{CardinalityEstimation, EstimationMerge};
 use segment::segment_constructor::{build_segment, load_segment, normalize_segment_dir};
 use segment::types::{
     Filter, PayloadIndexInfo, PayloadKeyType, PointIdType, SegmentConfig, SegmentType,
-    SeqNumberType,
+    SeqNumberType, StrictModeConfig,
 };
 use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles};
 use shard::operations::CollectionUpdateOperations;
@@ -911,13 +911,14 @@ impl LocalShard {
 
     /// Apply shard's strict mode configuration update
     /// - Update read and write rate limiters
-    pub async fn on_strict_mode_config_update(&mut self) {
-        let config = self.collection_config.read().await;
-
-        let strict_mode = config
-            .strict_mode_config
-            .as_ref()
-            .filter(|cfg| cfg.enabled == Some(true));
+    ///
+    /// The new strict-mode config is passed in explicitly rather than read from
+    /// `self.collection_config` so the caller can apply rate-limiter changes
+    /// before publishing the new config to readers of `self.collection_config`.
+    /// That order ensures `info()` never reports the new strict-mode state
+    /// while the rate limiters are still on the old one.
+    pub fn on_strict_mode_config_update(&mut self, new_strict_mode: &StrictModeConfig) {
+        let strict_mode = Some(new_strict_mode).filter(|cfg| cfg.enabled == Some(true));
 
         let read_rate_limit_per_min = strict_mode.and_then(|cfg| cfg.read_rate_limit);
         let write_rate_limit_per_min = strict_mode.and_then(|cfg| cfg.write_rate_limit);

--- a/lib/collection/src/shards/proxy_shard.rs
+++ b/lib/collection/src/shards/proxy_shard.rs
@@ -12,8 +12,8 @@ use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
-    WithPayloadInterface, WithVector,
+    ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, StrictModeConfig,
+    WithPayload, WithPayloadInterface, WithVector,
 };
 use shard::count::CountRequestInternal;
 use shard::retrieve::record_internal::RecordInternal;
@@ -97,8 +97,9 @@ impl ProxyShard {
         self.wrapped_shard.on_optimizer_config_update().await
     }
 
-    pub async fn on_strict_mode_config_update(&mut self) {
-        self.wrapped_shard.on_strict_mode_config_update().await;
+    pub fn on_strict_mode_config_update(&mut self, new_strict_mode: &StrictModeConfig) {
+        self.wrapped_shard
+            .on_strict_mode_config_update(new_strict_mode);
     }
 
     pub fn trigger_optimizers(&self) {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -11,7 +11,7 @@ use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, SizeStats, SnapshotFormat, WithPayload,
+    ExtendedPointId, Filter, ScoredPoint, SizeStats, SnapshotFormat, StrictModeConfig, WithPayload,
     WithPayloadInterface, WithVector,
 };
 use semver::Version;
@@ -192,11 +192,10 @@ impl QueueProxyShard {
             .await
     }
 
-    pub async fn on_strict_mode_config_update(&mut self) {
+    pub fn on_strict_mode_config_update(&mut self, new_strict_mode: &StrictModeConfig) {
         self.inner_mut_unchecked()
             .wrapped_shard
-            .on_strict_mode_config_update()
-            .await
+            .on_strict_mode_config_update(new_strict_mode)
     }
 
     pub fn trigger_optimizers(&self) {

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -20,7 +20,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use replica_set_state::{ReplicaSetState, ReplicaState};
-use segment::types::{ExtendedPointId, Filter, SeqNumberType, ShardKey};
+use segment::types::{ExtendedPointId, Filter, SeqNumberType, ShardKey, StrictModeConfig};
 use serde::{Deserialize, Serialize};
 use shard::operations::optimization::{
     OptimizationsRequestOptions, OptimizationsResponse, OptimizationsSummary,
@@ -931,9 +931,12 @@ impl ShardReplicaSet {
     ///
     /// The actual rate limiters live on `LocalShard`, so this just delegates
     /// while we hold the local-shard write lock.
-    pub(crate) async fn on_strict_mode_config_update(&self) -> CollectionResult<()> {
+    pub(crate) async fn on_strict_mode_config_update(
+        &self,
+        new_strict_mode: &StrictModeConfig,
+    ) -> CollectionResult<()> {
         if let Some(shard) = self.local.write().await.as_mut() {
-            shard.on_strict_mode_config_update().await;
+            shard.on_strict_mode_config_update(new_strict_mode);
         }
         Ok(())
     }

--- a/lib/collection/src/shards/shard.rs
+++ b/lib/collection/src/shards/shard.rs
@@ -10,7 +10,7 @@ use common::types::TelemetryDetail;
 use futures::future::Either;
 use parking_lot::Mutex as ParkingMutex;
 use segment::index::field_index::CardinalityEstimation;
-use segment::types::{Filter, SeqNumberType, SizeStats, SnapshotFormat};
+use segment::types::{Filter, SeqNumberType, SizeStats, SnapshotFormat, StrictModeConfig};
 use shard::snapshots::snapshot_manifest::SnapshotManifest;
 use tokio::sync::oneshot;
 
@@ -204,13 +204,17 @@ impl Shard {
         }
     }
 
-    pub async fn on_strict_mode_config_update(&mut self) {
+    pub fn on_strict_mode_config_update(&mut self, new_strict_mode: &StrictModeConfig) {
         match self {
-            Shard::Local(local_shard) => local_shard.on_strict_mode_config_update().await,
-            Shard::Proxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
-            Shard::ForwardProxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
-            Shard::QueueProxy(proxy_shard) => proxy_shard.on_strict_mode_config_update().await,
-            Shard::Dummy(dummy_shard) => dummy_shard.on_strict_mode_config_update(),
+            Shard::Local(local_shard) => local_shard.on_strict_mode_config_update(new_strict_mode),
+            Shard::Proxy(proxy_shard) => proxy_shard.on_strict_mode_config_update(new_strict_mode),
+            Shard::ForwardProxy(proxy_shard) => {
+                proxy_shard.on_strict_mode_config_update(new_strict_mode)
+            }
+            Shard::QueueProxy(proxy_shard) => {
+                proxy_shard.on_strict_mode_config_update(new_strict_mode)
+            }
+            Shard::Dummy(dummy_shard) => dummy_shard.on_strict_mode_config_update(new_strict_mode),
         }
     }
 


### PR DESCRIPTION
This PR fixes the flaky [test_shard_transfer_rate_limiting](https://github.com/qdrant/qdrant/actions/runs/25422741186/job/74568591377?pr=8889).

`Collection::update_strict_mode_config` published the new `strict_mode_config` to `self.collection_config` before applying the rate-limiter change to local shards.

During that window `info()` reported the new state while `LocalShard::read_rate_limiter` was still on the old one, causing searches to return 429 Read rate limit exceeded after a successful disable.

# Fix

Invert the ordering: compute the merged `StrictModeConfig`, push it into every shard's rate limiter, then update `self.collection_config` and persist. 

`LocalShard::on_strict_mode_config_update` now takes the new config as a parameter instead of re-reading the shared `Arc<RwLock<CollectionConfigInternal>>`.