### PR TITLE
Add ordering parameter to gRPC create/delete vector name

### DIFF
--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -391,6 +391,8 @@ message CreateVectorNameRequest {
   }
   // If set, overrides global timeout setting for this request. Unit is seconds.
   optional uint64 timeout = 6;
+  // Write ordering guarantees
+  optional WriteOrdering ordering = 7;
 }
 
 message DeleteVectorNameRequest {
@@ -402,6 +404,8 @@ message DeleteVectorNameRequest {
   string vector_name = 3;
   // If set, overrides global timeout setting for this request. Unit is seconds.
   optional uint64 timeout = 4;
+  // Write ordering guarantees
+  optional WriteOrdering ordering = 5;
 }
 
 message PayloadIncludeSelector {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5623,6 +5623,9 @@ pub struct CreateVectorNameRequest {
     /// If set, overrides global timeout setting for this request. Unit is seconds.
     #[prost(uint64, optional, tag = "6")]
     pub timeout: ::core::option::Option<u64>,
+    /// Write ordering guarantees
+    #[prost(message, optional, tag = "7")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
     /// Configuration for the new vector - either dense or sparse
     #[prost(oneof = "create_vector_name_request::VectorConfig", tags = "4, 5")]
     #[validate(nested)]
@@ -5664,6 +5667,9 @@ pub struct DeleteVectorNameRequest {
     /// If set, overrides global timeout setting for this request. Unit is seconds.
     #[prost(uint64, optional, tag = "4")]
     pub timeout: ::core::option::Option<u64>,
+    /// Write ordering guarantees
+    #[prost(message, optional, tag = "5")]
+    pub ordering: ::core::option::Option<WriteOrdering>,
 }
 #[derive(serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -503,6 +503,7 @@ pub fn internal_create_vector_name(
     create: shard::operations::CreateVectorName,
     wait: WaitUntil,
     wait_timeout: Option<u64>,
+    ordering: Option<WriteOrdering>,
 ) -> api::grpc::qdrant::CreateVectorNameInternal {
     api::grpc::qdrant::CreateVectorNameInternal {
         shard_id,
@@ -514,6 +515,7 @@ pub fn internal_create_vector_name(
             vector_name: create.vector_name,
             vector_config: Some(create.config.into()),
             timeout: wait_timeout,
+            ordering: ordering.map(write_ordering_to_proto),
         }),
     }
 }
@@ -525,6 +527,7 @@ pub fn internal_delete_vector_name(
     delete: shard::operations::DeleteVectorName,
     wait: WaitUntil,
     wait_timeout: Option<u64>,
+    ordering: Option<WriteOrdering>,
 ) -> api::grpc::qdrant::DeleteVectorNameInternal {
     api::grpc::qdrant::DeleteVectorNameInternal {
         shard_id,
@@ -535,6 +538,7 @@ pub fn internal_delete_vector_name(
             wait: Some(wait.needs_callback()),
             vector_name: delete.vector_name,
             timeout: wait_timeout,
+            ordering: ordering.map(write_ordering_to_proto),
         }),
     }
 }

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -457,6 +457,7 @@ impl RemoteShard {
                                 create,
                                 wait,
                                 timeout,
+                                ordering,
                             );
                             Update::CreateVectorName(request)
                         }
@@ -468,6 +469,7 @@ impl RemoteShard {
                                 delete,
                                 wait,
                                 timeout,
+                                ordering,
                             );
                             Update::DeleteVectorName(request)
                         }
@@ -843,6 +845,7 @@ impl RemoteShard {
                         create,
                         wait,
                         timeout,
+                        ordering,
                     );
                     self.with_points_client(|mut client| async move {
                         client
@@ -860,6 +863,7 @@ impl RemoteShard {
                         delete,
                         wait,
                         timeout,
+                        ordering,
                     );
                     self.with_points_client(|mut client| async move {
                         client

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -1033,6 +1033,7 @@ pub async fn create_vector_name(
         vector_name,
         vector_config,
         timeout,
+        ordering,
     } = request;
 
     let config = segment::data_types::vector_name_config::VectorNameConfig::try_from(
@@ -1048,7 +1049,7 @@ pub async fn create_vector_name(
         vector_name,
         config,
         internal_params,
-        UpdateParams::from_grpc(wait, None, timeout)?,
+        UpdateParams::from_grpc(wait, ordering, timeout)?,
         auth,
         request_hw_counter.get_counter(),
     )
@@ -1070,6 +1071,7 @@ pub async fn create_vector_name_internal(
         vector_name,
         vector_config,
         timeout,
+        ordering,
     } = request;
 
     let config = segment::data_types::vector_name_config::VectorNameConfig::try_from(
@@ -1093,7 +1095,7 @@ pub async fn create_vector_name_internal(
         &collection_name,
         operation,
         internal_params,
-        UpdateParams::from_grpc(wait, None, timeout)?,
+        UpdateParams::from_grpc(wait, ordering, timeout)?,
         None,
         auth,
         HwMeasurementAcc::disposable(),
@@ -1115,6 +1117,7 @@ pub async fn delete_vector_name_internal(
         wait,
         vector_name,
         timeout,
+        ordering,
     } = request;
 
     let operation = CollectionUpdateOperations::VectorNameOperation(
@@ -1129,7 +1132,7 @@ pub async fn delete_vector_name_internal(
         &collection_name,
         operation,
         internal_params,
-        UpdateParams::from_grpc(wait, None, timeout)?,
+        UpdateParams::from_grpc(wait, ordering, timeout)?,
         None,
         auth,
         HwMeasurementAcc::disposable(),
@@ -1152,6 +1155,7 @@ pub async fn delete_vector_name(
         wait,
         vector_name,
         timeout,
+        ordering,
     } = request;
 
     let timing = Instant::now();
@@ -1160,7 +1164,7 @@ pub async fn delete_vector_name(
         collection_name,
         vector_name,
         internal_params,
-        UpdateParams::from_grpc(wait, None, timeout)?,
+        UpdateParams::from_grpc(wait, ordering, timeout)?,
         auth,
         request_hw_counter.get_counter(),
     )


### PR DESCRIPTION
## Summary
- Add optional `WriteOrdering` field to `CreateVectorNameRequest` and `DeleteVectorNameRequest` in the gRPC proto so they match the REST API surface.
- Wire `ordering` through tonic handlers (`create_vector_name`, `create_vector_name_internal`, `delete_vector_name`, `delete_vector_name_internal`) and the remote-shard forwarding helpers (`internal_create_vector_name` / `internal_delete_vector_name`).

## Test plan
- [ ] `cargo check --bin qdrant`
- [ ] Manual gRPC call with `ordering` set verifies it propagates to update path

🤖 Generated with [Claude Code](https://claude.com/claude-code)