### PR TITLE
Draft: Use approximate Gridstore bitmask size in telemetry to speed it up

### DIFF
--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use common::types::{DetailsLevel, TelemetryDetail};
 use segment::common::operation_time_statistics::OperationDurationStatistics;
-use segment::types::SizeStats;
+use segment::types::{SegmentInfo, SizeStats};
 use segment::vector_storage::common::get_async_scorer;
 use shard::common::stopping_guard::StoppingGuard;
 use tokio_util::task::AbortOnDropHandle;
@@ -21,8 +21,11 @@ impl LocalShard {
     ) -> CollectionResult<LocalShardTelemetry> {
         let start = std::time::Instant::now();
         let segments = self.segments.clone();
-        let segments_data = if detail.level < DetailsLevel::Level4 {
-            Ok((vec![], HashMap::default()))
+        let segments_data: CollectionResult<(Vec<_>, HashMap<_, _>, Option<SizeStats>)> = if detail
+            .level
+            < DetailsLevel::Level4
+        {
+            Ok((vec![], HashMap::default(), None))
         } else {
             let locked_collection_config = self.collection_config.clone();
             let is_stopped_guard = StoppingGuard::new();
@@ -40,9 +43,10 @@ impl LocalShard {
                 };
 
                 let mut segments_telemetry = Vec::with_capacity(segments.len());
+                let mut size_stats = SizeStats::default();
                 for segment in segments.iter() {
                     if is_stopped.load(Ordering::Relaxed) {
-                        return Ok((vec![], HashMap::default()));
+                        return Ok((vec![], HashMap::default(), None));
                     }
 
                     // blocking sync lock
@@ -50,19 +54,25 @@ impl LocalShard {
                         return Err(CollectionError::timeout(timeout, "shard telemetry"));
                     };
 
-                    segments_telemetry.push(segment_guard.get_telemetry_data(detail))
+                    let segment_telemetry = segment_guard.get_telemetry_data(detail);
+                    accumulate_size_stats(&mut size_stats, &segment_telemetry.info);
+                    segments_telemetry.push(segment_telemetry);
                 }
 
                 let collection_config = locked_collection_config.blocking_read();
                 let indexed_only_excluded_vectors =
                     indexed_only::get_index_only_excluded_vectors(&segments, &collection_config);
 
-                Ok((segments_telemetry, indexed_only_excluded_vectors))
+                Ok((
+                    segments_telemetry,
+                    indexed_only_excluded_vectors,
+                    Some(size_stats),
+                ))
             });
             AbortOnDropHandle::new(handle).await?
         };
 
-        let (segments, index_only_excluded_vectors) = segments_data?;
+        let (segments, index_only_excluded_vectors, size_stats) = segments_data?;
         let total_optimized_points = self.total_optimized_points.load(Ordering::Relaxed);
 
         let optimizations: OperationDurationStatistics = self
@@ -80,15 +90,23 @@ impl LocalShard {
         let status = self
             .get_optimization_status(timeout.saturating_sub(start.elapsed()))
             .await?;
+
+        // Reuse size stats already harvested from the per-segment telemetry
+        // walk above; otherwise (lower detail levels, or interrupted walk) do
+        // a dedicated walk.
         let SizeStats {
             num_vectors,
             num_vectors_by_name,
             vectors_size_bytes,
             payloads_size_bytes,
             num_points,
-        } = self
-            .get_size_stats(timeout.saturating_sub(start.elapsed()))
-            .await?;
+        } = match size_stats {
+            Some(stats) => stats,
+            None => {
+                self.get_size_stats(timeout.saturating_sub(start.elapsed()))
+                    .await?
+            }
+        };
 
         Ok(LocalShardTelemetry {
             variant_name: None,
@@ -176,5 +194,28 @@ impl LocalShard {
             })
         });
         AbortOnDropHandle::new(stats).await?
+    }
+}
+
+/// Fold a single segment's [`SegmentInfo`] into the running [`SizeStats`].
+///
+/// `SizeStats` is destructured exhaustively (no `..`) so that adding a
+/// field to it forces a compile error here, prompting an explicit
+/// decision about whether the new field should be aggregated.
+fn accumulate_size_stats(stats: &mut SizeStats, info: &SegmentInfo) {
+    let SizeStats {
+        num_vectors,
+        num_vectors_by_name,
+        vectors_size_bytes,
+        payloads_size_bytes,
+        num_points,
+    } = stats;
+
+    *num_points += info.num_points;
+    *num_vectors += info.num_vectors;
+    *vectors_size_bytes += info.vectors_size_bytes;
+    *payloads_size_bytes += info.payloads_size_bytes;
+    for (vector_name, vector_data) in info.vector_data.iter() {
+        *num_vectors_by_name.get_or_insert_default(vector_name) += vector_data.num_vectors;
     }
 }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -367,6 +367,15 @@ impl<V: Blob> Gridstore<V> {
         self.bitmask.read().get_storage_size_bytes()
     }
 
+    /// Return the storage size in bytes (approximate: total page capacity).
+    ///
+    /// Cheap O(1) read of the page count. Prefer this over
+    /// [`Self::get_storage_size_bytes`] in hot paths (e.g. telemetry/segment
+    /// info aggregation) where byte-precise occupancy is not required.
+    pub fn get_storage_size_bytes_approx(&self) -> usize {
+        self.pages.read().num_pages() * self.config.page_size_bytes
+    }
+
     pub fn get_value<P: AccessPattern>(
         &self,
         point_offset: PointOffset,

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -119,7 +119,9 @@ impl PayloadStorageRead for MmapPayloadStorage {
     }
 
     fn get_storage_size_bytes(&self) -> OperationResult<usize> {
-        Ok(self.storage.get_storage_size_bytes()?)
+        // Approximate (page capacity) is sufficient for telemetry/segment info
+        // aggregation, and avoids walking the entire bitmask on every call.
+        Ok(self.storage.get_storage_size_bytes_approx())
     }
 
     fn is_on_disk(&self) -> bool {


### PR DESCRIPTION
Telemetry includes storage sizes. For Gridstore based structures we walk over the bitmask. This becomes expensive when having many Gridstore instances on a big cluster.

This reduces the cost by reporting capacity instead, making it a O(1) call.

Secondly, the `get_telemetry_data` function did all this counting work twice. It now reuses size statistics from the first iteration if available, to only fetch the storage size details once.

### Tasks
- [ ] Needs further testing to evaluate this solution

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
