### PR TITLE
Introduce default update timeout

### DIFF
--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -1217,8 +1217,12 @@ pub async fn update(
     let UpdateParams {
         wait,
         ordering,
-        timeout: _,
+        timeout,
     } = params;
+
+    // Default missing timeout to the inter-node update timeout so REST/gRPC
+    // user requests can't wait indefinitely on a vanished client.
+    let timeout = timeout.or_else(|| Some(toc.get_channel_service().request_timeout()));
 
     // Use wait_override if present, otherwise fall back to the wait boolean
     let wait =
@@ -1270,7 +1274,7 @@ pub async fn update(
         collection_name,
         OperationWithClockTag::new(operation, clock_tag),
         wait,
-        params.timeout,
+        timeout,
         ordering,
         shard_selector,
         auth,


### PR DESCRIPTION
Default the update timeout for REST and gRPC user requests to the inter-node request_timeout (60s) when the client doesn't supply one, so a vanished client can't leave the wait phase running forever.

# Why

Actix-web doesn't cancel handler futures on client disconnect, and Qdrant has no server-side cap on the update wait when ?timeout= is omitted.

Without a default, a disconnected client leaves await_update_result and the deferred-points loop hanging until the operation completes naturally.

# Change

In src/common/update.rs::update() (the choke point all do_*_points helpers funnel through), fall back to toc.get_channel_service().request_timeout() when params.timeout is None.

Internal maintenance callers (clean.rs, sharding_keys.rs, resharding cleanup, update_all_local) bypass this function and call ShardReplicaSet::update_local directly, so they keep None = wait forever for long-running operations like index creation.
