### PR TITLE
[gridstore, UIO] Simplify `OptionalPointer`

### DIFF
--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -12,7 +12,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{OptionalPointer, PointOffset, Tracker, ValuePointer};
+use crate::tracker::{PointOffset, Tracker, ValuePointer};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -12,7 +12,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PointOffset, Tracker, ValuePointer};
+use crate::tracker::{OptionalPointer, PointOffset, Tracker, ValuePointer};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -69,11 +69,11 @@ impl OptionalPointer {
         }
     }
 
-    pub fn pointer(&self) -> Option<&ValuePointer> {
+    pub fn to_option(self) -> Option<ValuePointer> {
         if self.discriminant == Self::OPTIONAL_NONE {
             None
         } else {
-            Some(&self.value)
+            Some(self.value)
         }
     }
 }
@@ -338,21 +338,18 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     /// Get the raw value at the given point offset
-    fn get_raw(&self, point_offset: PointOffset) -> Result<Option<Option<ValuePointer>>> {
-        let start_offset = std::mem::size_of::<TrackerHeader>()
-            + point_offset as usize * std::mem::size_of::<Optional<ValuePointer>>();
-        let end_offset = start_offset + std::mem::size_of::<Optional<ValuePointer>>();
-        let storage_len = self.storage.len::<u8>()?;
+    fn get_raw(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>> {
+        let start_offset =
+            size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
+        let end_offset = start_offset + size_of::<OptionalPointer>();
+        let storage_len = UniversalRead::<u8>::len(&self.storage)?;
         if end_offset as u64 > storage_len {
             return Ok(None);
         }
-        let bytes = self.storage.read::<Random, u8>(ReadRange {
-            byte_offset: start_offset as u64,
-            length: std::mem::size_of::<Optional<ValuePointer>>() as u64,
-        })?;
-        #[expect(deprecated, reason = "legacy code")]
-        let opt: &Optional<ValuePointer> = unsafe { transmute_from_u8(bytes.as_ref()) };
-        Ok(Some(opt.is_some().copied()))
+        let opt: OptionalPointer = self
+            .storage
+            .read::<Random>(ReadRange::one(start_offset as u64))?[0];
+        Ok(opt.to_option())
     }
 
     /// Get the page pointer at the given point offset
@@ -361,12 +358,12 @@ impl<S: UniversalRead> Tracker<S> {
             // Pending update exists but is empty, should not happen, fall back to real data
             Some(pending) if pending.is_empty() => {
                 debug_assert!(false, "pending updates must not be empty");
-                Ok(self.get_raw(point_offset)?.and_then(|o| o))
+                self.get_raw(point_offset)
             }
             // Use set from pending updates
             Some(pending) => Ok(pending.current),
             // No pending update, use real data
-            None => Ok(self.get_raw(point_offset)?.and_then(|o| o)),
+            None => self.get_raw(point_offset),
         }
     }
 
@@ -413,7 +410,7 @@ impl<S: UniversalRead> Tracker<S> {
             <S as UniversalRead<OptionalPointer>>::read_multi_iter::<Random, _>(reads)?
         {
             let (i, opt) = read_result?;
-            result[i] = opt[0].pointer().copied();
+            result[i] = opt[0].to_option();
         }
 
         Ok(result)
@@ -520,7 +517,7 @@ where
                 // Write to store a new pointer
                 Some(new_pointer) => {
                     // Mark any existing pointer for removal to free its blocks
-                    if let Some(Some(old_pointer)) = self.get_raw(point_offset)? {
+                    if let Some(old_pointer) = self.get_raw(point_offset)? {
                         old_pointers.push(old_pointer);
                     }
 
@@ -718,20 +715,20 @@ mod tests {
 
         assert_eq!(
             tracker.get_raw(0).unwrap(),
-            Some(Some(ValuePointer::new(1, 1, 1)))
+            Some(ValuePointer::new(1, 1, 1))
         );
         assert_eq!(
             tracker.get_raw(1).unwrap(),
-            Some(Some(ValuePointer::new(2, 2, 2)))
+            Some(ValuePointer::new(2, 2, 2))
         );
         assert_eq!(
             tracker.get_raw(2).unwrap(),
-            Some(Some(ValuePointer::new(3, 3, 3)))
+            Some(ValuePointer::new(3, 3, 3))
         );
-        assert_eq!(tracker.get_raw(3).unwrap(), Some(None)); // intermediate empty slot
+        assert_eq!(tracker.get_raw(3).unwrap(), None); // intermediate empty slot
         assert_eq!(
             tracker.get_raw(10).unwrap(),
-            Some(Some(ValuePointer::new(10, 10, 10)))
+            Some(ValuePointer::new(10, 10, 10))
         );
         assert_eq!(tracker.get_raw(100_000).unwrap(), None); // out of bounds
 
@@ -740,7 +737,7 @@ mod tests {
         tracker.write_pending_and_flush_internal().unwrap();
 
         // the value has been cleared but the entry is still there
-        assert_eq!(tracker.get_raw(1).unwrap(), Some(None));
+        assert_eq!(tracker.get_raw(1).unwrap(), None);
         assert_eq!(tracker.get(1).unwrap(), None);
 
         assert_eq!(tracker.mapping_len().unwrap(), 3);
@@ -965,7 +962,7 @@ mod tests {
 
         let none_data = AlignedData([0; _]);
         let none_val: &OptionalPointer = bytemuck::cast_ref(&none_data.0);
-        assert!(none_val.pointer().is_none());
+        assert!(none_val.to_option().is_none());
 
         let some_data = AlignedData([
             1, 0, 0, 0, // discriminant with padding
@@ -976,8 +973,8 @@ mod tests {
         let some_val: &OptionalPointer = bytemuck::cast_ref(&some_data.0);
         // N.B. fails on a big-endian machine.
         assert_eq!(
-            some_val.pointer(),
-            Some(&ValuePointer {
+            some_val.to_option(),
+            Some(ValuePointer {
                 page_id: 0x11223344,
                 block_offset: 0x55667788,
                 length: 0xAABBCCDD,

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -3,8 +3,6 @@ use std::path::{Path, PathBuf};
 use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
-#[expect(deprecated, reason = "legacy code")]
-use common::mmap::{transmute_from_u8, transmute_to_u8};
 use common::universal_io::{
     OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
 };
@@ -35,7 +33,7 @@ fn tracker_open_options() -> OpenOptions {
 /// Please note that it uses 32-bit tag so that there's no padding before `ValuePointer`.
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-pub struct OptionalPointer {
+struct OptionalPointer {
     discriminant: u32,
     value: ValuePointer,
 }
@@ -224,7 +222,7 @@ impl PointerUpdates {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 struct TrackerHeader {
     next_pointer_offset: u32,
@@ -285,14 +283,15 @@ impl<S: UniversalRead> Tracker<S> {
     fn read_header(storage: &S) -> Result<TrackerHeader> {
         let header_bytes = storage.read::<Random, u8>(ReadRange {
             byte_offset: 0,
-            length: std::mem::size_of::<TrackerHeader>() as u64,
+            length: size_of::<TrackerHeader>() as u64,
         })?;
-        #[expect(deprecated, reason = "legacy code")]
-        Ok(*unsafe { transmute_from_u8::<TrackerHeader>(header_bytes.as_ref()) })
+        Ok(*bytemuck::from_bytes::<TrackerHeader>(
+            header_bytes.as_ref(),
+        ))
     }
 
     fn open_storage(path: &Path) -> Result<S> {
-        let storage = match <S as UniversalRead<u8>>::open(path, tracker_open_options()) {
+        let storage = match S::open(path, tracker_open_options()) {
             Err(UniversalIoError::NotFound { .. }) => {
                 return Err(GridstoreError::service_error(format!(
                     "Tracker file does not exist: {}",
@@ -342,13 +341,15 @@ impl<S: UniversalRead> Tracker<S> {
         let start_offset =
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
         let end_offset = start_offset + size_of::<OptionalPointer>();
-        let storage_len = UniversalRead::<u8>::len(&self.storage)?;
+        let storage_len = self.storage.len()?;
         if end_offset as u64 > storage_len {
             return Ok(None);
         }
-        let opt: OptionalPointer = self
-            .storage
-            .read::<Random>(ReadRange::one(start_offset as u64))?[0];
+        let bytes = self.storage.read::<Random>(ReadRange {
+            byte_offset: start_offset as u64,
+            length: size_of::<OptionalPointer>() as u64,
+        })?;
+        let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
         Ok(opt.to_option())
     }
 
@@ -399,18 +400,23 @@ impl<S: UniversalRead> Tracker<S> {
                 continue;
             }
 
-            storage_reads.push((i, ReadRange::one(start_offset as u64)));
+            storage_reads.push((
+                i,
+                ReadRange {
+                    byte_offset: start_offset as u64,
+                    length: item_size as u64,
+                },
+            ));
         }
 
         let reads = storage_reads
             .iter()
             .map(|(i, range)| (*i, &self.storage, *range));
 
-        for read_result in
-            <S as UniversalRead<OptionalPointer>>::read_multi_iter::<Random, _>(reads)?
-        {
-            let (i, opt) = read_result?;
-            result[i] = opt[0].to_option();
+        for read_result in S::read_multi_iter::<Random, _>(reads)? {
+            let (i, bytes) = read_result?;
+            let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
+            result[i] = opt.to_option();
         }
 
         Ok(result)
@@ -432,7 +438,7 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     pub fn populate(&self) -> Result<()> {
-        UniversalRead::<u8>::populate(&self.storage).map_err(Into::into)
+        self.storage.populate().map_err(Into::into)
     }
 
     /// Get the length of the mapping
@@ -482,7 +488,7 @@ where
             "Size hint is too small"
         );
         create_and_ensure_length(&path, size)?;
-        let storage = <S as UniversalRead<u8>>::open(&path, tracker_open_options())?;
+        let storage = S::open(&path, tracker_open_options())?;
         let header = TrackerHeader::default();
         let pending_updates = AHashMap::new();
         let mut page_tracker = Self {
@@ -552,7 +558,7 @@ where
     }
 
     pub fn flusher(&self) -> crate::gridstore::Flusher {
-        let inner = UniversalWrite::<u8>::flusher(&self.storage);
+        let inner = self.storage.flusher();
         Box::new(move || inner().map_err(Into::into))
     }
 
@@ -560,15 +566,13 @@ where
     pub fn write_pending_and_flush_internal(&mut self) -> Result<Vec<ValuePointer>> {
         let pending_updates = std::mem::take(&mut self.pending_updates);
         let res = self.write_pending(pending_updates)?;
-        UniversalWrite::<u8>::flusher(&self.storage)()?;
+        self.storage.flusher()()?;
         Ok(res)
     }
 
     /// Write the current page header to the storage
     fn write_header(&mut self) -> Result<()> {
-        #[expect(deprecated, reason = "legacy code")]
-        let header_bytes = unsafe { transmute_to_u8(&self.header) };
-        self.storage.write(0, header_bytes)?;
+        self.storage.write(0, bytemuck::bytes_of(&self.header))?;
         Ok(())
     }
 
@@ -585,20 +589,20 @@ where
         }
 
         let point_offset = point_offset as usize;
-        let start_offset = std::mem::size_of::<TrackerHeader>()
-            + point_offset * std::mem::size_of::<OptionalPointer>();
-        let end_offset = start_offset + std::mem::size_of::<OptionalPointer>();
+        let start_offset = size_of::<TrackerHeader>() + point_offset * size_of::<OptionalPointer>();
+        let end_offset = start_offset + size_of::<OptionalPointer>();
 
         // Grow tracker file if it isn't big enough
         if storage_len < end_offset {
-            UniversalWrite::<u8>::flusher(&self.storage)()?;
+            self.storage.flusher()()?;
             let new_size = end_offset.next_power_of_two();
             create_and_ensure_length(&self.path, new_size)?;
-            self.storage = <S as UniversalRead<u8>>::open(&self.path, tracker_open_options())?;
+            self.storage = S::open(&self.path, tracker_open_options())?;
         }
 
         let pointer = OptionalPointer::from(pointer);
-        self.storage.write(start_offset as u64, &[pointer])?;
+        self.storage
+            .write(start_offset as u64, bytemuck::bytes_of(&pointer))?;
         Ok(())
     }
 

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -9,7 +9,6 @@ use common::universal_io::{
     OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
 };
 use smallvec::SmallVec;
-use zerocopy::FromZeros;
 
 use crate::Result;
 use crate::error::GridstoreError;
@@ -30,21 +29,19 @@ fn tracker_open_options() -> OpenOptions {
     }
 }
 
-/// A type similar to [`std::option::Option`], but with stable layout. It is intended to be compatible with older
+/// A type similar to [`std::option::Option<ValuePointer>`], but with stable layout. It is intended to be compatible with older
 /// gridstore files, but it is well-defined, unlike [`std::option::Option`].
 ///
-/// Please note that it uses 32-bit tag and is intended to be used for `ValuePointer` without padding bytes.
-///
-/// If `T` is a POD type, then `Optional<T>` is a POD type.
-#[derive(Copy, Clone, zerocopy::FromBytes)]
+/// Please note that it uses 32-bit tag so that there's no padding before `ValuePointer`.
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-struct Optional<T> {
+pub struct OptionalPointer {
     discriminant: u32,
-    value: T,
+    value: ValuePointer,
 }
 
-impl<T: FromZeros> From<Option<T>> for Optional<T> {
-    fn from(value: Option<T>) -> Self {
+impl From<Option<ValuePointer>> for OptionalPointer {
+    fn from(value: Option<ValuePointer>) -> Self {
         match value {
             Some(value) => Self::some(value),
             None => Self::none(),
@@ -52,7 +49,7 @@ impl<T: FromZeros> From<Option<T>> for Optional<T> {
     }
 }
 
-impl<T: FromZeros> Optional<T> {
+impl OptionalPointer {
     const OPTIONAL_NONE: u32 = 0;
     const OPTIONAL_SOME: u32 = 1;
 
@@ -60,19 +57,19 @@ impl<T: FromZeros> Optional<T> {
     pub fn none() -> Self {
         Self {
             discriminant: Self::OPTIONAL_NONE,
-            value: FromZeros::new_zeroed(),
+            value: bytemuck::Zeroable::zeroed(),
         }
     }
 
     /// Some is 1 for the discriminant, and value is stored as is.
-    pub const fn some(value: T) -> Self {
+    pub const fn some(value: ValuePointer) -> Self {
         Self {
             discriminant: Self::OPTIONAL_SOME,
             value,
         }
     }
 
-    pub fn is_some(&self) -> Option<&T> {
+    pub fn pointer(&self) -> Option<&ValuePointer> {
         if self.discriminant == Self::OPTIONAL_NONE {
             None
         } else {
@@ -81,7 +78,7 @@ impl<T: FromZeros> Optional<T> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, zerocopy::FromBytes)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct ValuePointer {
     /// Which page the value is stored in
@@ -295,7 +292,7 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     fn open_storage(path: &Path) -> Result<S> {
-        let storage = match S::open(path, tracker_open_options()) {
+        let storage = match <S as UniversalRead<u8>>::open(path, tracker_open_options()) {
             Err(UniversalIoError::NotFound { .. }) => {
                 return Err(GridstoreError::service_error(format!(
                     "Tracker file does not exist: {}",
@@ -380,7 +377,7 @@ impl<S: UniversalRead> Tracker<S> {
     /// updates and out-of-range offsets are handled before/after the batch
     /// read, mirroring [`get`](Self::get).
     pub fn get_batch(&self, point_offsets: &[PointOffset]) -> Result<Vec<Option<ValuePointer>>> {
-        let item_size = std::mem::size_of::<Optional<ValuePointer>>();
+        let item_size = std::mem::size_of::<OptionalPointer>();
         let header_size = std::mem::size_of::<TrackerHeader>();
         let storage_len = self.storage.len::<u8>()?;
 
@@ -405,24 +402,18 @@ impl<S: UniversalRead> Tracker<S> {
                 continue;
             }
 
-            storage_reads.push((
-                i,
-                ReadRange {
-                    byte_offset: start_offset as u64,
-                    length: item_size as u64,
-                },
-            ));
+            storage_reads.push((i, ReadRange::one(start_offset as u64)));
         }
 
         let reads = storage_reads
             .iter()
             .map(|(i, range)| (*i, &self.storage, *range));
 
-        for read_result in S::read_multi_iter::<Random, u8, _>(reads)? {
-            let (i, bytes) = read_result?;
-            #[expect(deprecated, reason = "legacy code")]
-            let opt: &Optional<ValuePointer> = unsafe { transmute_from_u8(bytes.as_ref()) };
-            result[i] = opt.is_some().copied();
+        for read_result in
+            <S as UniversalRead<OptionalPointer>>::read_multi_iter::<Random, _>(reads)?
+        {
+            let (i, opt) = read_result?;
+            result[i] = opt[0].pointer().copied();
         }
 
         Ok(result)
@@ -444,7 +435,7 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     pub fn populate(&self) -> Result<()> {
-        self.storage.populate().map_err(Into::into)
+        UniversalRead::<u8>::populate(&self.storage).map_err(Into::into)
     }
 
     /// Get the length of the mapping
@@ -480,7 +471,7 @@ impl<S: UniversalRead> Tracker<S> {
 // Write operations and constructors -- require UniversalWrite
 impl<S> Tracker<S>
 where
-    S: UniversalRead + UniversalWrite,
+    S: UniversalWrite,
 {
     const DEFAULT_SIZE: usize = 1024 * 1024; // 1MB
 
@@ -494,7 +485,7 @@ where
             "Size hint is too small"
         );
         create_and_ensure_length(&path, size)?;
-        let storage = S::open(&path, tracker_open_options())?;
+        let storage = <S as UniversalRead<u8>>::open(&path, tracker_open_options())?;
         let header = TrackerHeader::default();
         let pending_updates = AHashMap::new();
         let mut page_tracker = Self {
@@ -564,7 +555,7 @@ where
     }
 
     pub fn flusher(&self) -> crate::gridstore::Flusher {
-        let inner = self.storage.flusher();
+        let inner = UniversalWrite::<u8>::flusher(&self.storage);
         Box::new(move || inner().map_err(Into::into))
     }
 
@@ -572,7 +563,7 @@ where
     pub fn write_pending_and_flush_internal(&mut self) -> Result<Vec<ValuePointer>> {
         let pending_updates = std::mem::take(&mut self.pending_updates);
         let res = self.write_pending(pending_updates)?;
-        self.storage.flusher()()?;
+        UniversalWrite::<u8>::flusher(&self.storage)()?;
         Ok(res)
     }
 
@@ -598,21 +589,19 @@ where
 
         let point_offset = point_offset as usize;
         let start_offset = std::mem::size_of::<TrackerHeader>()
-            + point_offset * std::mem::size_of::<Optional<ValuePointer>>();
-        let end_offset = start_offset + std::mem::size_of::<Optional<ValuePointer>>();
+            + point_offset * std::mem::size_of::<OptionalPointer>();
+        let end_offset = start_offset + std::mem::size_of::<OptionalPointer>();
 
         // Grow tracker file if it isn't big enough
         if storage_len < end_offset {
-            self.storage.flusher()()?;
+            UniversalWrite::<u8>::flusher(&self.storage)()?;
             let new_size = end_offset.next_power_of_two();
             create_and_ensure_length(&self.path, new_size)?;
-            self.storage = S::open(&self.path, tracker_open_options())?;
+            self.storage = <S as UniversalRead<u8>>::open(&self.path, tracker_open_options())?;
         }
 
-        let pointer: Optional<_> = pointer.into();
-        #[expect(deprecated, reason = "legacy code")]
-        let pointer_bytes = unsafe { transmute_to_u8(&pointer) };
-        self.storage.write(start_offset as u64, pointer_bytes)?;
+        let pointer = OptionalPointer::from(pointer);
+        self.storage.write(start_offset as u64, &[pointer])?;
         Ok(())
     }
 
@@ -649,14 +638,12 @@ where
 mod tests {
     use std::path::PathBuf;
 
-    #[expect(deprecated, reason = "legacy code")]
-    use common::mmap::transmute_from_u8;
     use common::universal_io::MmapFile;
     use rstest::rstest;
     use tempfile::Builder;
 
     use super::{PointerUpdates, Tracker, ValuePointer};
-    use crate::tracker::{BlockOffset, Optional, PageId};
+    use crate::tracker::{BlockOffset, OptionalPointer, PageId};
 
     type TestTracker = Tracker<MmapFile>;
 
@@ -969,17 +956,16 @@ mod tests {
     #[test]
     fn test_option_value_pointer_layout() {
         #[repr(align(4))]
-        struct AlignedData([u8; std::mem::size_of::<Optional<ValuePointer>>()]);
+        struct AlignedData([u8; std::mem::size_of::<OptionalPointer>()]);
 
         assert_eq!(
-            std::mem::size_of::<Optional<ValuePointer>>(),
+            std::mem::size_of::<OptionalPointer>(),
             std::mem::size_of::<Option<ValuePointer>>()
         );
 
         let none_data = AlignedData([0; _]);
-        #[expect(deprecated, reason = "legacy code")]
-        let none_val: &Optional<ValuePointer> = unsafe { transmute_from_u8(&none_data.0) };
-        assert!(none_val.is_some().is_none());
+        let none_val: &OptionalPointer = bytemuck::cast_ref(&none_data.0);
+        assert!(none_val.pointer().is_none());
 
         let some_data = AlignedData([
             1, 0, 0, 0, // discriminant with padding
@@ -987,11 +973,10 @@ mod tests {
             0x88, 0x77, 0x66, 0x55, // block_offset
             0xDD, 0xCC, 0xBB, 0xAA, // length
         ]);
-        #[expect(deprecated, reason = "legacy code")]
-        let some_val: &Optional<ValuePointer> = unsafe { transmute_from_u8(&some_data.0) };
+        let some_val: &OptionalPointer = bytemuck::cast_ref(&some_data.0);
         // N.B. fails on a big-endian machine.
         assert_eq!(
-            some_val.is_some(),
+            some_val.pointer(),
             Some(&ValuePointer {
                 page_id: 0x11223344,
                 block_offset: 0x55667788,
@@ -1004,12 +989,12 @@ mod tests {
     #[ignore = "contains undefined behavior"]
     fn test_layout_compatibility() {
         assert_eq!(
-            std::mem::size_of::<Optional<ValuePointer>>(),
+            std::mem::size_of::<OptionalPointer>(),
             std::mem::size_of::<Option<ValuePointer>>()
         );
 
         let old_none = Option::<ValuePointer>::None;
-        let new_none = Optional::<ValuePointer>::none();
+        let new_none = OptionalPointer::none();
 
         // KLUDGE: actually this is UNDEFINED BEHAVIOR because old_one type contains padding bytes.
         // But we don't have any better option.
@@ -1024,7 +1009,7 @@ mod tests {
             block_offset: BLOCK_OFFSET,
             length: LENGTH,
         });
-        let new_value = Optional::some(ValuePointer::new(PAGE_ID, BLOCK_OFFSET, LENGTH));
+        let new_value = OptionalPointer::some(ValuePointer::new(PAGE_ID, BLOCK_OFFSET, LENGTH));
 
         // KLUDGE: actually this is UNDEFINED BEHAVIOR because old_one type contains padding bytes.
         // But we don't have any better option.

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -55,7 +55,7 @@ impl OptionalPointer {
     pub fn none() -> Self {
         Self {
             discriminant: Self::OPTIONAL_NONE,
-            value: bytemuck::Zeroable::zeroed(),
+            value: ValuePointer::new(0, 0, 0),
         }
     }
 

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -281,13 +281,8 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     fn read_header(storage: &S) -> Result<TrackerHeader> {
-        let header_bytes = storage.read::<Random, u8>(ReadRange {
-            byte_offset: 0,
-            length: size_of::<TrackerHeader>() as u64,
-        })?;
-        Ok(*bytemuck::from_bytes::<TrackerHeader>(
-            header_bytes.as_ref(),
-        ))
+        let header = storage.read::<Random, TrackerHeader>(ReadRange::one(0))?[0];
+        Ok(header)
     }
 
     fn open_storage(path: &Path) -> Result<S> {
@@ -341,15 +336,13 @@ impl<S: UniversalRead> Tracker<S> {
         let start_offset =
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
         let end_offset = start_offset + size_of::<OptionalPointer>();
-        let storage_len = self.storage.len()?;
+        let storage_len = self.storage.len::<u8>()?;
         if end_offset as u64 > storage_len {
             return Ok(None);
         }
-        let bytes = self.storage.read::<Random>(ReadRange {
-            byte_offset: start_offset as u64,
-            length: size_of::<OptionalPointer>() as u64,
-        })?;
-        let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
+        let opt = self
+            .storage
+            .read::<Random, OptionalPointer>(ReadRange::one(start_offset as u64))?[0];
         Ok(opt.to_option())
     }
 
@@ -400,23 +393,16 @@ impl<S: UniversalRead> Tracker<S> {
                 continue;
             }
 
-            storage_reads.push((
-                i,
-                ReadRange {
-                    byte_offset: start_offset as u64,
-                    length: item_size as u64,
-                },
-            ));
+            storage_reads.push((i, ReadRange::one(start_offset as u64)));
         }
 
         let reads = storage_reads
             .iter()
             .map(|(i, range)| (*i, &self.storage, *range));
 
-        for read_result in S::read_multi_iter::<Random, _>(reads)? {
-            let (i, bytes) = read_result?;
-            let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
-            result[i] = opt.to_option();
+        for read_result in S::read_multi_iter::<Random, OptionalPointer, _>(reads)? {
+            let (i, opt_slice) = read_result?;
+            result[i] = opt_slice[0].to_option();
         }
 
         Ok(result)
@@ -572,7 +558,7 @@ where
 
     /// Write the current page header to the storage
     fn write_header(&mut self) -> Result<()> {
-        self.storage.write(0, bytemuck::bytes_of(&self.header))?;
+        self.storage.write(0, &[self.header])?;
         Ok(())
     }
 
@@ -601,8 +587,7 @@ where
         }
 
         let pointer = OptionalPointer::from(pointer);
-        self.storage
-            .write(start_offset as u64, bytemuck::bytes_of(&pointer))?;
+        self.storage.write(start_offset as u64, &[pointer])?;
         Ok(())
     }
 


### PR DESCRIPTION
The type for interacting with optional stored pointers was `Optional<ValuePointer>`. But since generics can't derive `bytemuck::Pod` cleanly, handling this type required reading `[u8]` from storage, and then transmuting. 

This PR simplifies implementation by making the optional type concrete: `OptionalPointer`. This lets the storage backend do the cast via bytemuck, and gets rid of the "legacy code" lint suppression.

Additionally, removes one layer of option from `get_raw`: `Result<Option<Option<ValuePointer>>>` to `Result<Option<ValuePointer>>` 