### PR TITLE
[UIO] Introduce `Populate` enum

### DIFF
--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -71,7 +71,7 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
         writeable: false,
         need_sequential: true,
         disk_parallel: None,
-        populate: Populate::Auto,
+        populate: Populate::No,
         advice: None,
         prevent_caching: Some(false),
     };

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -71,7 +71,7 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
         writeable: false,
         need_sequential: true,
         disk_parallel: None,
-        populate: Populate::No,
+        populate: Populate::Auto,
         advice: None,
         prevent_caching: Some(false),
     };

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use common::generic_consts::{Random, Sequential};
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
-use common::universal_io::{MmapFile, OpenOptions, ReadRange, UniversalRead};
+use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, UniversalRead};
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
 use rand::rngs::StdRng;
@@ -71,7 +71,7 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
         writeable: false,
         need_sequential: true,
         disk_parallel: None,
-        populate: Some(false),
+        populate: Populate::No,
         advice: None,
         prevent_caching: Some(false),
     };

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -63,7 +63,7 @@ impl UniversalRead for MmapFile {
         let mmap = open_mmap(
             path.as_ref(),
             writeable,
-            matches!(populate, Populate::Blocking), // only populate on explicit blocking request
+            populate.is_set(), // always populate on foreground
             advice.unwrap_or(AdviceSetting::Global),
         )?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -63,7 +63,7 @@ impl UniversalRead for MmapFile {
         let mmap = open_mmap(
             path.as_ref(),
             writeable,
-            populate.is_set(), // always populate on foreground
+            matches!(populate, Populate::Blocking), // only populate on explicit blocking request
             advice.unwrap_or(AdviceSetting::Global),
         )?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -60,10 +60,16 @@ impl UniversalRead for MmapFile {
             prevent_caching: _, // Whole point of mmap is to cache
         } = options;
 
+        let populate = match populate {
+            Populate::Auto | Populate::No => false, // don't populate by default
+            Populate::PreferBackground | // mmap does not yet implement background populate
+            Populate::Blocking => true,
+        };
+
         let mmap = open_mmap(
             path.as_ref(),
             writeable,
-            populate.is_set(), // always populate on foreground
+            populate,
             advice.unwrap_or(AdviceSetting::Global),
         )?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -63,7 +63,7 @@ impl UniversalRead for MmapFile {
         let mmap = open_mmap(
             path.as_ref(),
             writeable,
-            populate.unwrap_or_default(),
+            populate.is_set(), // always populate on foreground
             advice.unwrap_or(AdviceSetting::Global),
         )?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());
@@ -278,7 +278,7 @@ impl MmapFile {
                 writeable: false,
                 need_sequential: false,
                 disk_parallel: None,
-                populate: Some(false),
+                populate: Populate::No,
                 advice: Some(AdviceSetting::Advice(Advice::Normal)),
                 prevent_caching: None,
             },

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -31,6 +31,30 @@ pub enum UniversalKind {
     DiskCache,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub enum Populate {
+    #[default]
+    No,
+    Blocking,
+    PreferBackground,
+}
+
+impl Populate {
+    pub fn is_set(&self) -> bool {
+        matches!(self, Populate::Blocking | Populate::PreferBackground)
+    }
+}
+
+impl From<bool> for Populate {
+    fn from(populate: bool) -> Self {
+        if populate {
+            Populate::Blocking
+        } else {
+            Populate::No
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct OpenOptions {
     pub writeable: bool,
@@ -39,7 +63,7 @@ pub struct OpenOptions {
     /// If `None`, then use implementation-specific default.
     pub disk_parallel: Option<usize>,
     /// Populate RAM cache on open, if applicable for this implementation.
-    pub populate: Option<bool>,
+    pub populate: Populate,
     /// Use specific mmap advice.
     pub advice: Option<AdviceSetting>,
     /// Whether to try to prevent caching for reads.
@@ -52,7 +76,7 @@ impl Default for OpenOptions {
             writeable: true,
             need_sequential: true,
             disk_parallel: None,
-            populate: None,
+            populate: Populate::No,
             advice: None,
             prevent_caching: None,
         }
@@ -132,7 +156,7 @@ where
         writeable: false,
         need_sequential: false,
         disk_parallel: None,
-        populate: Some(false),
+        populate: Populate::No,
         advice: Some(AdviceSetting::Advice(Advice::Sequential)),
         prevent_caching: Some(false),
     };

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -33,16 +33,15 @@ pub enum UniversalKind {
 
 #[derive(Copy, Clone, Debug, Default)]
 pub enum Populate {
+    /// Let backend choose
     #[default]
+    Auto,
+    /// Do not populate
     No,
+    /// Populate on foreground
     Blocking,
+    /// Populate, but prefer to do it in the background
     PreferBackground,
-}
-
-impl Populate {
-    pub fn is_set(&self) -> bool {
-        matches!(self, Populate::Blocking | Populate::PreferBackground)
-    }
 }
 
 impl From<bool> for Populate {
@@ -76,7 +75,7 @@ impl Default for OpenOptions {
             writeable: true,
             need_sequential: true,
             disk_parallel: None,
-            populate: Populate::No,
+            populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
         }

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
-use common::universal_io::{Flusher, OpenOptions, TypedStorage, UniversalWrite};
+use common::universal_io::{Flusher, OpenOptions, TypedStorage, Populate, UniversalWrite};
 use itertools::Itertools;
 
 use super::{RegionId, StorageConfig};
@@ -106,7 +106,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(true),
+            populate: Populate::Blocking,
             advice: None,
             prevent_caching: None,
         };
@@ -129,7 +129,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(false),
+            populate: Populate::Blocking,
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
         };
@@ -164,7 +164,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(false),
+            populate: Populate::No,
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
         };

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
-use common::universal_io::{Flusher, OpenOptions, TypedStorage, Populate, UniversalWrite};
+use common::universal_io::{Flusher, OpenOptions, Populate, TypedStorage, UniversalWrite};
 use itertools::Itertools;
 
 use super::{RegionId, StorageConfig};

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -7,7 +7,7 @@ use ahash::AHashSet;
 use common::bitvec::BitSlice;
 use common::mmap::create_and_ensure_length;
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{MmapFile, OpenOptions, UniversalWrite};
+use common::universal_io::{MmapFile, OpenOptions, Populate, UniversalWrite};
 use gaps::{BitmaskGaps, RegionGaps};
 use itertools::Itertools;
 
@@ -22,7 +22,7 @@ const OPEN_OPTIONS: OpenOptions = OpenOptions {
     writeable: true,
     need_sequential: false,
     disk_parallel: None,
-    populate: Some(false),
+    populate: Populate::No,
     advice: None,
     prevent_caching: None,
 };

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -6,7 +6,7 @@ use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::universal_io::{
-    FileIndex, Flusher, OpenOptions, ReadRange, UniversalRead, UniversalWrite,
+    FileIndex, Flusher, OpenOptions, Populate, ReadRange, UniversalRead, UniversalWrite,
 };
 use itertools::Either;
 
@@ -60,7 +60,7 @@ impl<S: UniversalRead> Pages<S> {
             writeable: true,
             need_sequential: true,
             disk_parallel: None,
-            populate: Some(false),
+            populate: Populate::No,
             advice: None,
             prevent_caching: None,
         };

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -4,7 +4,7 @@ use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::universal_io::{
-    OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
+    OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
 };
 use smallvec::SmallVec;
 
@@ -21,7 +21,7 @@ fn tracker_open_options() -> OpenOptions {
         writeable: true,
         need_sequential: false,
         disk_parallel: None,
-        populate: Some(false),
+        populate: Populate::No,
         advice: Some(AdviceSetting::Advice(Advice::Random)),
         prevent_caching: None,
     }

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -7,7 +7,7 @@ use common::bitvec::BitSlice;
 use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, StoredStruct, UniversalWrite};
+use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalWrite};
 use fs_err as fs;
 use itertools::Either;
 
@@ -116,7 +116,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 disk_parallel: None,
-                populate: Some(false),
+                populate: Populate::No,
                 advice: None,
                 prevent_caching: None,
             },
@@ -160,7 +160,7 @@ where
 
         let options = OpenOptions {
             writeable: true,
-            populate: Some(populate),
+            populate: populate.into(),
             advice: Some(AdviceSetting::Global),
             ..Default::default()
         };

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -160,7 +160,7 @@ where
 
         let options = OpenOptions {
             writeable: true,
-            populate: populate.into(),
+            populate: Populate::from(populate),
             advice: Some(AdviceSetting::Global),
             ..Default::default()
         };

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -16,7 +16,9 @@ use common::bitvec::{BitSlice, BitVec};
 use common::mmap::create_and_ensure_length;
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, SliceBufferedUpdateWrapper, TypedStorage};
+use common::universal_io::{
+    MmapFile, OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage,
+};
 use fs_err::File;
 
 pub use self::deleted_storage::DELETED_FILE_NAME;
@@ -79,7 +81,7 @@ impl ImmutableIdTracker {
         let deleted_storage = MmapBitSlice::open(
             deleted_path(segment_path),
             OpenOptions {
-                populate: Some(true),
+                populate: Populate::Blocking,
                 ..OpenOptions::default()
             },
         )?;
@@ -95,7 +97,7 @@ impl ImmutableIdTracker {
                 writeable: true,
                 need_sequential: false,
                 disk_parallel: None,
-                populate: Some(true),
+                populate: Populate::Blocking,
                 advice: None,
                 prevent_caching: None,
             },
@@ -172,7 +174,7 @@ impl ImmutableIdTracker {
                 writeable: true,
                 need_sequential: false,
                 disk_parallel: None,
-                populate: Some(false),
+                populate: Populate::No,
                 advice: None,
                 prevent_caching: None,
             },

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -159,7 +159,7 @@ impl MmapInvertedIndex {
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(populate),
+            populate: populate.into(),
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -9,7 +9,7 @@ use common::mmap::{self, Advice, AdviceSetting, MmapSlice, create_and_ensure_len
 use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, UserData};
+use common::universal_io::{MmapFile, OpenOptions, Populate, UserData};
 use types::ZerocopyPostingValue;
 use uio_postings::UniversalPostings;
 
@@ -159,7 +159,7 @@ impl MmapInvertedIndex {
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: populate.into(),
+            populate: Populate::from(populate),
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -179,7 +179,7 @@ impl MmapInvertedIndex {
             &vocab_path,
             OpenOptions {
                 writeable: false,
-                populate: Some(populate),
+                populate: Populate::from(populate),
                 ..OpenOptions::default()
             },
         )?;

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -13,7 +13,9 @@ use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead};
+use common::universal_io::{
+    MmapFile, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+};
 use fs_err as fs;
 use memmap2::MmapMut;
 

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -13,7 +13,7 @@ use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, ReadRange, TypedStorage, UniversalRead};
+use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead};
 use fs_err as fs;
 use memmap2::MmapMut;
 
@@ -169,7 +169,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: populate.into(),
+            populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -169,7 +169,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(populate),
+            populate: populate.into(),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -9,7 +9,7 @@ use common::mmap::create_and_ensure_length;
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions};
+use common::universal_io::{MmapFile, OpenOptions, Populate};
 use fs_err as fs;
 
 use super::super::MapIndexKey;
@@ -44,7 +44,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &hashmap_path,
             OpenOptions {
                 writeable: false,
-                populate: Some(do_populate),
+                populate: Populate::from(do_populate),
                 ..OpenOptions::default()
             },
         )?;

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -7,7 +7,7 @@ use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, TypedStorage};
+use common::universal_io::{MmapFile, OpenOptions, Populate, TypedStorage};
 use fs_err as fs;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
@@ -118,7 +118,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(do_populate),
+            populate: Populate::from(do_populate),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -8,7 +8,7 @@ use common::ext::ResultOptionExt;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, create_and_ensure_length, open_write_mmap};
 use common::types::PointOffsetType;
-use common::universal_io::{self, ReadOnly, ReadRange, UniversalRead};
+use common::universal_io::{self, Populate, ReadOnly, ReadRange, UniversalRead};
 use zerocopy::IntoBytes;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -169,7 +169,7 @@ where
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: populate.into(),
+            populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -169,7 +169,7 @@ where
             writeable: false,
             need_sequential: false,
             disk_parallel: None,
-            populate: Some(populate),
+            populate: populate.into(),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use ahash::AHashMap;
 use common::mmap::{AdviceSetting, MULTI_MMAP_IS_SUPPORTED, create_and_ensure_length};
 use common::universal_io::{
-    OpenOptions, TypedStorage, UniversalIoError, UniversalRead, UniversalWrite,
+    OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead, UniversalWrite,
 };
 use fs_err as fs;
 
@@ -56,7 +56,7 @@ pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
                 writeable,
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
                 disk_parallel: None,
-                populate: Some(populate),
+                populate: populate.into(),
                 advice: Some(advice),
                 prevent_caching: None,
             },
@@ -87,7 +87,7 @@ pub fn create_chunk<T: bytemuck::Pod, S: UniversalWrite>(
             writeable: true,
             need_sequential: *MULTI_MMAP_IS_SUPPORTED,
             disk_parallel: None,
-            populate: Some(false), // don't populate newly created chunk, as it's empty and will be filled later
+            populate: Populate::No, // don't populate newly created chunk, as it's empty and will be filled later
             advice: None,
             prevent_caching: None,
         },

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -56,7 +56,7 @@ pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
                 writeable,
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
                 disk_parallel: None,
-                populate: populate.into(),
+                populate: Populate::from(populate),
                 advice: Some(advice),
                 prevent_caching: None,
             },

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -123,7 +123,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 disk_parallel: None,
-                populate: Populate::from(populate.unwrap_or_default()),
+                populate: populate.map(Populate::from).unwrap_or_default(),
                 advice: None,
                 prevent_caching: None,
             },

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::atomic_save_json;
 use common::mmap::AdviceSetting;
-use common::universal_io::{OpenOptions, StoredStruct, UniversalWrite};
+use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalWrite};
 use fs_err as fs;
 use num_traits::AsPrimitive;
 
@@ -123,7 +123,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 disk_parallel: None,
-                populate,
+                populate: Populate::from(populate.unwrap_or_default()),
                 advice: None,
                 prevent_caching: None,
             },

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -10,7 +10,8 @@ use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions as UniversalOpenOptions, ReadOnly, ReadRange, TypedStorage, UniversalRead,
+    MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange, TypedStorage,
+    UniversalRead,
 };
 use fs_err::{File, OpenOptions};
 
@@ -59,7 +60,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
             writeable: false,
             need_sequential: true,
             disk_parallel: None,
-            populate: populate.into(),
+            populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,
         };

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -59,7 +59,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
             writeable: false,
             need_sequential: true,
             disk_parallel: None,
-            populate: Some(populate),
+            populate: populate.into(),
             advice: None,
             prevent_caching: None,
         };


### PR DESCRIPTION
We want to be able to populate on background, so we can load many structures concurrently. 

This PR makes the first step by defining a `Populate::PreferBackground` open option which is not yet used.