### PR TITLE
Tolerate consensus apply timeouts in test_rejoin_cluster create loops

### DIFF
--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -151,6 +151,7 @@ def create_collection(
     sparse_vectors=True,
     default_segment_number=None,
     on_disk_payload=None,
+    fail_on_error=True,
 ):
     payload = {
         "vectors": {"size": DENSE_VECTOR_SIZE, "distance": "Dot"},
@@ -175,7 +176,8 @@ def create_collection(
         json=payload,
         headers=headers,
     )
-    assert_http_ok(r_batch)
+    if fail_on_error:
+        assert_http_ok(r_batch)
 
 
 def drop_collection(peer_url, collection="test_collection", timeout=10, headers={}):

--- a/tests/consensus_tests/test_cluster_rejoin.py
+++ b/tests/consensus_tests/test_cluster_rejoin.py
@@ -40,8 +40,10 @@ def test_rejoin_cluster(tmp_path: pathlib.Path, uris_in_env):
         print(f"creating collection {i}")
         # Drop test_collection
         drop_collection(peer_api_uris[0], "test_collection", timeout=5)
-        # Re-create test_collection
-        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
+        # Re-create test_collection. The 3s timeout is intentionally tight to keep the loop
+        # fast; under CI load the consensus apply can exceed it even though the operation
+        # eventually commits, so we tolerate an HTTP timeout here.
+        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3, fail_on_error=False)
         # Collection might not be ready yet, we don't care
         upsert_random_points(peer_api_uris[0], 100)
         print(f"before recovery end {i}")
@@ -70,8 +72,8 @@ def test_rejoin_cluster(tmp_path: pathlib.Path, uris_in_env):
         print(f"after recovery start {i}")
         # Drop test_collection
         drop_collection(peer_api_uris[0], "test_collection", timeout=5)
-        # Re-create test_collection
-        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3)
+        # Re-create test_collection. Same rationale as above for tolerating HTTP timeouts.
+        create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICA, timeout=3, fail_on_error=False)
         upsert_random_points(peer_api_uris[0], 500, fail_on_error=False)
         print(f"after recovery end {i}")
         res = requests.get(f"{new_url}/collections")


### PR DESCRIPTION
## Summary

The `test_rejoin_cluster[True/False]` test is flaky on CI. The rapid drop/create loops use intentionally short 3s timeouts to accumulate Raft log entries quickly, but under CI I/O load the consensus apply for `CreateCollection` can exceed 3s while segment setup competes with background flushes from `test_collection2`. The API then returns 500 even though the consensus operation commits and applies right after.

Concrete trace from a recent failure: WAL append at `T+0.13s`, hard-state commit at `T+0.17s`, `Creating collection` log at `T+0.49s`, segment loads finish at `T+2.16s`, then a ~1.85s gap with only background `test_collection2` flushes, then the timeout fires at `T+3.97s` — followed 47ms later by `Successfully applied consensus operation entry. Index: 81. Result: true`.

The matching `upsert_random_points` calls in the same loops already pass `fail_on_error=False`. This PR threads the same flag through `create_collection` and uses it for the two rapid-fire loops. Final assertions (`wait_for_all_replicas_active(..., "test_collection2")`) still validate the rejoin behavior end-to-end.

## Test plan

- [x] CI: `test_rejoin_cluster[True]` and `test_rejoin_cluster[False]` pass
- [x] Other consensus tests still pass (unchanged callers all pass `fail_on_error` defaulted to `True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)