### PR TITLE
test: fix flaky test_consensus_snapshot_create_collection voter race

### DIFF
--- a/tests/consensus_tests/test_consensus_compaction.py
+++ b/tests/consensus_tests/test_consensus_compaction.py
@@ -151,6 +151,11 @@ def test_consensus_snapshot_create_collection(tmp_path: pathlib.Path, replicatio
     # Start cluster
     peers, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, extra_env=env)
 
+    # Wait until all peers have been promoted from learner to voter, so killing
+    # the last peer leaves a 2-of-3 voter quorum. Otherwise the survivors may
+    # be {leader voter, learner} and consensus stalls.
+    wait_for(all_peers_are_voters, peers)
+
     # Get last peer ID
     last_peer_id = get_cluster_info(peers[-1])['peer_id']
 

--- a/tests/consensus_tests/test_learners_promoted_to_voters.py
+++ b/tests/consensus_tests/test_learners_promoted_to_voters.py
@@ -6,16 +6,6 @@ from .utils import *
 N_PEERS = 5
 
 
-def all_peers_are_voters(peer_api_uris: [str]) -> bool:
-    try:
-        for uri in peer_api_uris:
-            if not get_cluster_info(uri)["raft_info"]["is_voter"]:
-                return False
-        return True
-    except requests.exceptions.ConnectionError:
-        return False
-
-
 def test_collection_after_peers_added(tmp_path: pathlib.Path):
     assert_project_root()
     peer_dirs = make_peer_folders(tmp_path, N_PEERS)

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -518,6 +518,16 @@ def all_nodes_respond(peer_api_uris: [str]) -> bool:
     return True
 
 
+def all_peers_are_voters(peer_api_uris: [str]) -> bool:
+    try:
+        for uri in peer_api_uris:
+            if not get_cluster_info(uri)["raft_info"]["is_voter"]:
+                return False
+        return True
+    except requests.exceptions.ConnectionError:
+        return False
+
+
 def collection_exists_on_all_peers(collection_name: str, peer_api_uris: [str]) -> bool:
     for uri in peer_api_uris:
         r = requests.get(f"{uri}/collections")


### PR DESCRIPTION
## Summary
- `test_consensus_snapshot_create_collection` killed the last peer right after `start_cluster`. `start_cluster` only waits for a uniform leader/peer-count, not for learner→voter promotion.
- If the last peer caught up first, the leader promoted it to voter while the other peer was still a learner. Killing it left voters `[leader, dead]`, learners `[alive]` — quorum 2/2 with 1 alive, so the subsequent `CreateCollection` couldn't commit and timed out after 10s.
- Wait for `all_peers_are_voters` after `start_cluster` so killing one peer leaves a 2-of-3 voter quorum. Promoted the existing local helper in `test_learners_promoted_to_voters.py` into `utils.py` for reuse.

Captured failure: `tests/consensus_tests/test_consensus_compaction.py::test_consensus_snapshot_create_collection[2]` returned 500 `Waiting for consensus operation commit failed. Timeout set at: 10 seconds`. The same race applies to `[1]` (lower probability, same fix).

## Test plan
- [ ] CI passes
- [ ] Run `pytest tests/consensus_tests/test_consensus_compaction.py::test_consensus_snapshot_create_collection -k 2 --count=20` locally to confirm the race is gone
- [ ] `test_learners_promoted_to_voters` still passes after the helper move

🤖 Generated with [Claude Code](https://claude.com/claude-code)