### PR TITLE
Keep UniversalRead<u8> bound, do bytemuck conversion at call site

### DIFF
--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -12,7 +12,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{OptionalPointer, PointOffset, Tracker, ValuePointer};
+use crate::tracker::{PointOffset, Tracker, ValuePointer};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {
@@ -31,17 +31,14 @@ pub(super) fn decompress_lz4(value: &[u8]) -> Vec<u8> {
 /// [`Tracker<S>`]).
 ///
 /// Constructed from either [`super::Gridstore`] or [`super::GridstoreReader`].
-pub struct GridstoreView<'a, V, S: UniversalRead<u8> + UniversalRead<OptionalPointer>> {
+pub struct GridstoreView<'a, V, S: UniversalRead<u8>> {
     pub(super) config: &'a StorageConfig,
     pub(super) tracker: &'a Tracker<S>,
     pub(super) pages: &'a Pages<S>,
     pub(super) _value_type: std::marker::PhantomData<V>,
 }
 
-impl<'a, V, S> GridstoreView<'a, V, S>
-where
-    S: UniversalRead<u8> + UniversalRead<OptionalPointer>,
-{
+impl<'a, V, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     pub(crate) fn new(
         config: &'a StorageConfig,
         tracker: &'a Tracker<S>,
@@ -77,7 +74,7 @@ where
     }
 }
 
-impl<'a, V: Blob, S: UniversalRead<u8> + UniversalRead<OptionalPointer>> GridstoreView<'a, V, S> {
+impl<'a, V: Blob, S: UniversalRead<u8>> GridstoreView<'a, V, S> {
     pub(super) fn compress(&self, value: Vec<u8>) -> Vec<u8> {
         match self.config.compression {
             Compression::None => value,

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -3,8 +3,6 @@ use std::path::{Path, PathBuf};
 use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
-#[expect(deprecated, reason = "legacy code")]
-use common::mmap::{transmute_from_u8, transmute_to_u8};
 use common::universal_io::{
     OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
 };
@@ -35,7 +33,7 @@ fn tracker_open_options() -> OpenOptions {
 /// Please note that it uses 32-bit tag so that there's no padding before `ValuePointer`.
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-pub struct OptionalPointer {
+struct OptionalPointer {
     discriminant: u32,
     value: ValuePointer,
 }
@@ -224,7 +222,7 @@ impl PointerUpdates {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 struct TrackerHeader {
     next_pointer_offset: u32,
@@ -265,7 +263,7 @@ impl<S> Tracker<S> {
 }
 
 // Read operations -- only require UniversalRead
-impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
+impl<S: UniversalRead<u8>> Tracker<S> {
     /// Open an existing PageTracker at the given path
     /// If the file does not exist, return an error
     pub fn open(path: &Path) -> Result<Self> {
@@ -285,14 +283,15 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
     fn read_header(storage: &S) -> Result<TrackerHeader> {
         let header_bytes = storage.read::<Random>(ReadRange {
             byte_offset: 0,
-            length: std::mem::size_of::<TrackerHeader>() as u64,
+            length: size_of::<TrackerHeader>() as u64,
         })?;
-        #[expect(deprecated, reason = "legacy code")]
-        Ok(*unsafe { transmute_from_u8::<TrackerHeader>(header_bytes.as_ref()) })
+        Ok(*bytemuck::from_bytes::<TrackerHeader>(
+            header_bytes.as_ref(),
+        ))
     }
 
     fn open_storage(path: &Path) -> Result<S> {
-        let storage = match <S as UniversalRead<u8>>::open(path, tracker_open_options()) {
+        let storage = match S::open(path, tracker_open_options()) {
             Err(UniversalIoError::NotFound { .. }) => {
                 return Err(GridstoreError::service_error(format!(
                     "Tracker file does not exist: {}",
@@ -342,13 +341,15 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
         let start_offset =
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
         let end_offset = start_offset + size_of::<OptionalPointer>();
-        let storage_len = UniversalRead::<u8>::len(&self.storage)?;
+        let storage_len = self.storage.len()?;
         if end_offset as u64 > storage_len {
             return Ok(None);
         }
-        let opt: OptionalPointer = self
-            .storage
-            .read::<Random>(ReadRange::one(start_offset as u64))?[0];
+        let bytes = self.storage.read::<Random>(ReadRange {
+            byte_offset: start_offset as u64,
+            length: size_of::<OptionalPointer>() as u64,
+        })?;
+        let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
         Ok(opt.to_option())
     }
 
@@ -376,7 +377,7 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
     pub fn get_batch(&self, point_offsets: &[PointOffset]) -> Result<Vec<Option<ValuePointer>>> {
         let item_size = size_of::<OptionalPointer>();
         let header_size = size_of::<TrackerHeader>();
-        let storage_len = UniversalRead::<u8>::len(&self.storage)?;
+        let storage_len = self.storage.len()?;
 
         let mut result: Vec<Option<ValuePointer>> = vec![None; point_offsets.len()];
         let mut storage_reads: Vec<(usize, ReadRange)> = Vec::with_capacity(point_offsets.len());
@@ -399,18 +400,23 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
                 continue;
             }
 
-            storage_reads.push((i, ReadRange::one(start_offset as u64)));
+            storage_reads.push((
+                i,
+                ReadRange {
+                    byte_offset: start_offset as u64,
+                    length: item_size as u64,
+                },
+            ));
         }
 
         let reads = storage_reads
             .iter()
             .map(|(i, range)| (*i, &self.storage, *range));
 
-        for read_result in
-            <S as UniversalRead<OptionalPointer>>::read_multi_iter::<Random, _>(reads)?
-        {
-            let (i, opt) = read_result?;
-            result[i] = opt[0].to_option();
+        for read_result in S::read_multi_iter::<Random, _>(reads)? {
+            let (i, bytes) = read_result?;
+            let opt: &OptionalPointer = bytemuck::from_bytes(bytes.as_ref());
+            result[i] = opt.to_option();
         }
 
         Ok(result)
@@ -432,7 +438,7 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
     }
 
     pub fn populate(&self) -> Result<()> {
-        UniversalRead::<u8>::populate(&self.storage).map_err(Into::into)
+        self.storage.populate().map_err(Into::into)
     }
 
     /// Get the length of the mapping
@@ -458,16 +464,14 @@ impl<S: UniversalRead<u8> + UniversalRead<OptionalPointer>> Tracker<S> {
     /// Return the size of the underlying file
     #[cfg(test)]
     pub fn mmap_file_size(&self) -> Result<usize> {
-        UniversalRead::<u8>::len(&self.storage)
-            .map(|u| u as usize)
-            .map_err(Into::into)
+        self.storage.len().map(|u| u as usize).map_err(Into::into)
     }
 }
 
 // Write operations and constructors -- require UniversalWrite
 impl<S> Tracker<S>
 where
-    S: UniversalWrite<u8> + UniversalWrite<OptionalPointer>,
+    S: UniversalRead<u8> + UniversalWrite<u8>,
 {
     const DEFAULT_SIZE: usize = 1024 * 1024; // 1MB
 
@@ -481,7 +485,7 @@ where
             "Size hint is too small"
         );
         create_and_ensure_length(&path, size)?;
-        let storage = <S as UniversalRead<u8>>::open(&path, tracker_open_options())?;
+        let storage = S::open(&path, tracker_open_options())?;
         let header = TrackerHeader::default();
         let pending_updates = AHashMap::new();
         let mut page_tracker = Self {
@@ -551,7 +555,7 @@ where
     }
 
     pub fn flusher(&self) -> crate::gridstore::Flusher {
-        let inner = UniversalWrite::<u8>::flusher(&self.storage);
+        let inner = self.storage.flusher();
         Box::new(move || inner().map_err(Into::into))
     }
 
@@ -559,15 +563,13 @@ where
     pub fn write_pending_and_flush_internal(&mut self) -> Result<Vec<ValuePointer>> {
         let pending_updates = std::mem::take(&mut self.pending_updates);
         let res = self.write_pending(pending_updates)?;
-        UniversalWrite::<u8>::flusher(&self.storage)()?;
+        self.storage.flusher()()?;
         Ok(res)
     }
 
     /// Write the current page header to the storage
     fn write_header(&mut self) -> Result<()> {
-        #[expect(deprecated, reason = "legacy code")]
-        let header_bytes = unsafe { transmute_to_u8(&self.header) };
-        self.storage.write(0, header_bytes)?;
+        self.storage.write(0, bytemuck::bytes_of(&self.header))?;
         Ok(())
     }
 
@@ -578,26 +580,26 @@ where
         point_offset: PointOffset,
         pointer: Option<ValuePointer>,
     ) -> Result<()> {
-        let storage_len = UniversalRead::<u8>::len(&self.storage)? as usize;
+        let storage_len = self.storage.len()? as usize;
         if pointer.is_none() && point_offset as usize >= storage_len {
             return Ok(());
         }
 
         let point_offset = point_offset as usize;
-        let start_offset = std::mem::size_of::<TrackerHeader>()
-            + point_offset * std::mem::size_of::<OptionalPointer>();
-        let end_offset = start_offset + std::mem::size_of::<OptionalPointer>();
+        let start_offset = size_of::<TrackerHeader>() + point_offset * size_of::<OptionalPointer>();
+        let end_offset = start_offset + size_of::<OptionalPointer>();
 
         // Grow tracker file if it isn't big enough
         if storage_len < end_offset {
-            UniversalWrite::<u8>::flusher(&self.storage)()?;
+            self.storage.flusher()()?;
             let new_size = end_offset.next_power_of_two();
             create_and_ensure_length(&self.path, new_size)?;
-            self.storage = <S as UniversalRead<u8>>::open(&self.path, tracker_open_options())?;
+            self.storage = S::open(&self.path, tracker_open_options())?;
         }
 
         let pointer = OptionalPointer::from(pointer);
-        self.storage.write(start_offset as u64, &[pointer])?;
+        self.storage
+            .write(start_offset as u64, bytemuck::bytes_of(&pointer))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The switch to `bytemuck::Pod` for `OptionalPointer` (and now `TrackerHeader`) is nice, but I think having two `T`s on `S` (`UniversalRead<u8> + UniversalRead<OptionalPointer>` / `UniversalWrite<u8> + UniversalWrite<OptionalPointer>`) creates too much turbofish noise — every method that exists on both impls (`flusher`, `len`, `populate`, `open`) has to be disambiguated with `UniversalWrite::<u8>::flusher(&self.storage)` / `<S as UniversalRead<u8>>::open(...)` etc., which is hard to read.

I'd prefer doing the conversion manually at the call site instead. Since `OptionalPointer` already derives `bytemuck::Pod`, we can keep the storage bound as plain `UniversalRead<u8>` / `UniversalWrite<u8>` and use:

- `bytemuck::from_bytes::<OptionalPointer>(bytes.as_ref())` for reads (returns `&T`, runtime-checks alignment — same shape and assumption as the original `transmute_from_u8`)
- `bytemuck::bytes_of(&pointer)` for writes

This keeps the unsafe-transmute removal from the previous two commits (and additionally drops the legacy `transmute_*` for `TrackerHeader` too), but all the explicit-turbofish noise goes away — `self.storage.flusher()`, `self.storage.len()`, `S::open(...)` everywhere.

Net change vs. branch HEAD: same safety improvement, no extra trait bounds, no turbofish.

## Test plan

- [x] `cargo test -p gridstore` — all 58 tests pass (20 tracker, 38 gridstore)
- [x] `cargo check -p gridstore` clean
- [ ] Decide whether the `read_multi_iter` `&OptionalPointer` -> `to_option()` is worth the small per-entry copy vs. the typed-storage approach (negligible at 16 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)