### PR TITLE
Fix 8935 match except dev

### DIFF
--- a/lib/edge/src/reexports.rs
+++ b/lib/edge/src/reexports.rs
@@ -75,7 +75,5 @@ pub mod internal {
 
 /// Re-export from external crates used by Qdrant.
 pub mod external {
-    pub use ordered_float;
-    pub use serde_json;
-    pub use uuid;
+    pub use {ordered_float, serde_json, uuid};
 }

--- a/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
@@ -177,7 +177,7 @@ fn get_match_except_checker(
     hw_acc: HwMeasurementAcc,
 ) -> Option<ConditionCheckerFn<'_>> {
     if matches!(index, FieldIndex::NullIndex(_))
-        || (matches!(except, AnyVariants::Strings(_))
+        || (matches!(&except, AnyVariants::Strings(_))
             && matches!(index, FieldIndex::FullTextIndex(_)))
     {
         // Full-text index tokenizes values, while MatchExcept currently has exact-string semantics.

--- a/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter/match_converter.rs
@@ -176,6 +176,16 @@ fn get_match_except_checker(
     index: &FieldIndex,
     hw_acc: HwMeasurementAcc,
 ) -> Option<ConditionCheckerFn<'_>> {
+    if matches!(index, FieldIndex::NullIndex(_))
+        || (matches!(except, AnyVariants::Strings(_))
+            && matches!(index, FieldIndex::FullTextIndex(_)))
+    {
+        // Full-text index tokenizes values, while MatchExcept currently has exact-string semantics.
+        // Null index can only reason about emptiness.
+        // In both cases, let payload-level matcher evaluate exact values.
+        return None;
+    }
+
     let checker: Option<ConditionCheckerFn> = match (except, index) {
         (AnyVariants::Strings(list), FieldIndex::KeywordIndex(index)) => {
             let hw_counter = hw_acc.get_counter_cell();

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -17,7 +17,8 @@ use rand::{RngExt, SeedableRng};
 use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::index::{
     FloatIndexParams, FloatIndexType, IntegerIndexParams, IntegerIndexType, KeywordIndexParams,
-    KeywordIndexType, TextIndexParams, TextIndexType,
+    KeywordIndexType, StopwordsInterface, StopwordsSet, TextIndexParams, TextIndexType,
+    TokenizerType,
 };
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
 use segment::entry::entry_point::{NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry};
@@ -45,7 +46,8 @@ use segment::types::{
     AnyVariants, Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoLineString,
     GeoPoint, GeoPolygon, GeoRadius, HnswConfig, HnswGlobalConfig, Indexes, IsEmptyCondition,
     Match, Payload, PayloadField, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
-    Range, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType, WithPayload,
+    Range, SegmentConfig, SeqNumberType, ValueVariants, VectorDataConfig, VectorStorageType,
+    WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tempfile::{Builder, TempDir};
@@ -1181,6 +1183,120 @@ fn test_struct_payload_index_nested_fields() {
                 );
                 assert!((r1.score - r2.score) < 0.0001)
             });
+    }
+}
+
+#[test]
+fn test_match_except_fulltext_consistency_with_unindexed_and_keyword() {
+    fn collect_ids(except: Vec<String>, index_mode: &str) -> Vec<u64> {
+        let dir = Builder::new()
+            .prefix("segment_match_except_fulltext")
+            .tempdir()
+            .unwrap();
+        let mut segment = build_simple_segment(dir.path(), 2, Distance::Dot).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+        let title_key = JsonPath::new("title");
+
+        for (idx, title) in [
+            (1_u64, "the the"),
+            (2_u64, "theory lesson"),
+            (3_u64, "alpha beta"),
+            (4_u64, ""),
+        ] {
+            segment
+                .upsert_point(
+                    idx as SeqNumberType,
+                    idx.into(),
+                    only_default_vector(&[1.0, 0.0]),
+                    &hw_counter,
+                )
+                .unwrap();
+            segment
+                .set_full_payload(
+                    idx as SeqNumberType,
+                    idx.into(),
+                    &payload_json! { "title": title },
+                    &hw_counter,
+                )
+                .unwrap();
+        }
+
+        match index_mode {
+            "no_index" => {}
+            "keyword" => {
+                segment
+                    .create_field_index(
+                        10,
+                        &title_key,
+                        Some(&FieldParams(PayloadSchemaParams::Keyword(KeywordIndexParams {
+                            r#type: KeywordIndexType::Keyword,
+                            is_tenant: None,
+                            on_disk: None,
+                            enable_hnsw: None,
+                        }))),
+                        &hw_counter,
+                    )
+                    .unwrap();
+            }
+            "fulltext" => {
+                segment
+                    .create_field_index(
+                        10,
+                        &title_key,
+                        Some(&FieldParams(PayloadSchemaParams::Text(TextIndexParams {
+                            r#type: TextIndexType::Text,
+                            tokenizer: TokenizerType::Word,
+                            min_token_len: None,
+                            max_token_len: None,
+                            lowercase: Some(true),
+                            ascii_folding: None,
+                            phrase_matching: None,
+                            stopwords: Some(StopwordsInterface::Set(StopwordsSet {
+                                languages: None,
+                                custom: Some(["the".to_string()].into_iter().collect()),
+                            })),
+                            on_disk: None,
+                            stemmer: None,
+                            enable_hnsw: None,
+                        }))),
+                        &hw_counter,
+                    )
+                    .unwrap();
+            }
+            _ => panic!("unsupported index_mode"),
+        }
+
+        let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+            title_key,
+            Match::new_except(AnyVariants::Strings(except.into_iter().collect())),
+        )));
+        let is_stopped = AtomicBool::new(false);
+        let mut ids = segment
+            .payload_index
+            .borrow()
+            .query_points(&filter, &hw_counter, &is_stopped, None)
+            .unwrap()
+            .into_iter()
+            .map(|offset| match segment.id_tracker.borrow().external_id(offset).unwrap() {
+                segment::types::ExtendedPointId::NumId(id) => id,
+                segment::types::ExtendedPointId::Uuid(_) => panic!("unexpected uuid id"),
+            })
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
+    }
+
+    for index_mode in ["no_index", "keyword", "fulltext"] {
+        assert_eq!(
+            collect_ids(vec!["zzz".to_string()], index_mode),
+            vec![1, 2, 3, 4],
+            "index_mode={index_mode}, except=['zzz']"
+        );
+        assert_eq!(
+            collect_ids(vec!["alpha beta".to_string()], index_mode),
+            vec![1, 2, 4],
+            "index_mode={index_mode}, except=['alpha beta']"
+        );
     }
 }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1206,7 +1206,7 @@ fn test_match_except_fulltext_consistency_with_unindexed_and_keyword() {
             segment
                 .upsert_point(
                     idx as SeqNumberType,
-                    idx.into(),
+                    segment::types::PointIdType::from(idx),
                     only_default_vector(&[1.0, 0.0]),
                     &hw_counter,
                 )
@@ -1214,7 +1214,7 @@ fn test_match_except_fulltext_consistency_with_unindexed_and_keyword() {
             segment
                 .set_full_payload(
                     idx as SeqNumberType,
-                    idx.into(),
+                    segment::types::PointIdType::from(idx),
                     &payload_json! { "title": title },
                     &hw_counter,
                 )

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1228,12 +1228,14 @@ fn test_match_except_fulltext_consistency_with_unindexed_and_keyword() {
                     .create_field_index(
                         10,
                         &title_key,
-                        Some(&FieldParams(PayloadSchemaParams::Keyword(KeywordIndexParams {
-                            r#type: KeywordIndexType::Keyword,
-                            is_tenant: None,
-                            on_disk: None,
-                            enable_hnsw: None,
-                        }))),
+                        Some(&FieldParams(PayloadSchemaParams::Keyword(
+                            KeywordIndexParams {
+                                r#type: KeywordIndexType::Keyword,
+                                is_tenant: None,
+                                on_disk: None,
+                                enable_hnsw: None,
+                            },
+                        ))),
                         &hw_counter,
                     )
                     .unwrap();
@@ -1277,10 +1279,12 @@ fn test_match_except_fulltext_consistency_with_unindexed_and_keyword() {
             .query_points(&filter, &hw_counter, &is_stopped, None)
             .unwrap()
             .into_iter()
-            .map(|offset| match segment.id_tracker.borrow().external_id(offset).unwrap() {
-                segment::types::ExtendedPointId::NumId(id) => id,
-                segment::types::ExtendedPointId::Uuid(_) => panic!("unexpected uuid id"),
-            })
+            .map(
+                |offset| match segment.id_tracker.borrow().external_id(offset).unwrap() {
+                    segment::types::ExtendedPointId::NumId(id) => id,
+                    segment::types::ExtendedPointId::Uuid(_) => panic!("unexpected uuid id"),
+                },
+            )
             .collect::<Vec<_>>();
         ids.sort_unstable();
         ids

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -5,7 +5,6 @@ use ::common::tempfile_ext::MaybeTempPath;
 use actix_multipart::form::MultipartForm;
 use actix_multipart::form::tempfile::TempFile;
 use actix_web::{Responder, Result, delete, get, post, put, web};
-use actix_web_validator as valid;
 use collection::common::file_utils::move_file;
 use collection::common::sha_256;
 use collection::common::snapshot_stream::SnapshotStream;
@@ -15,7 +14,6 @@ use collection::operations::snapshot_ops::{
 use collection::operations::types::CollectionError;
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::shard_holder::shard_not_found_error;
-use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use futures::{FutureExt as _, StreamExt as _, TryFutureExt as _};
 use reqwest::Url;
@@ -36,6 +34,7 @@ use storage::rbac::AccessRequirements;
 use tokio::io::AsyncWriteExt as _;
 use uuid::Uuid;
 use validator::Validate;
+use {actix_web_validator as valid, fs_err as fs};
 
 use super::{
     CollectionPath, CollectionShardPath, CollectionShardSnapshotPath, CollectionSnapshotPath,


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description

Fixes Issue #8935.

This PR fixes `MatchExcept` behavior on full-text indexed string fields, which diverged from unindexed/keyword behavior.

Root cause:
- In `match_converter`, `MatchExcept` could fall back to a generic `values_count(point_id) > 0` checker when no index-specific checker was available.
- That fallback is not valid for `FullTextIndex` and `NullIndex`:
  - It drops tokenless / stopword-only values for full-text.
  - It ignores exact-string semantics for multi-word exclusions.

Fix:
- Updated `lib/segment/src/index/query_optimization/condition_converter/match_converter.rs` so `MatchExcept` does not use index-based shortcut logic for:
  - `FieldIndex::FullTextIndex` with string `except`
  - `FieldIndex::NullIndex`
- For full-text, the guard now borrows `except` (`matches!(&except, AnyVariants::Strings(_))`) to avoid moving it before later use.
- In these cases, evaluation falls back to payload-level matching, preserving exact `MatchExcept` semantics and aligning results across index modes.

Tests:
- Added regression coverage in the existing integration suite (no new test file):
  - `lib/segment/tests/integration/payload_index_test.rs`
  - `test_match_except_fulltext_consistency_with_unindexed_and_keyword`
- The test validates consistent behavior across `no_index`, `keyword`, and `fulltext` for:
  - `except=["zzz"]` -> `[1,2,3,4]`
  - `except=["alpha beta"]` -> `[1,2,4]`
- Updated test style per review feedback by replacing implicit `idx.into()` with explicit `PointIdType::from(idx)`.

Local verification run:
- `cargo test -p segment --test integration payload_index_test::test_match_except_fulltext_consistency_with_unindexed_and_keyword -- --exact --nocapture`
- `cargo test -p segment --test integration payload_index_test::test_read_operations -- --exact`
- `cargo test -p segment --test integration filtering_context_check::test_filtering_context_consistency -- --exact`
- `cargo +nightly fmt --all`
- `cargo clippy --workspace --all-features`

### Contributing with AI Disclosure

Commits in this PR:
- [AI] `fix(segment): make MatchExcept on fulltext consistent with unindexed/keyword semantics`
- [AI] `style: run rustfmt`
- [manual] `fix(segment): address review feedback on match_except test and guard`

Initial prompts used:
- Reproduce issue #8935 (`MatchExcept` inconsistency on fulltext) and implement a minimal, correct fix in the segment query optimization path.
- Add regression coverage in existing integration tests (avoid creating a new test file).
- Align with review feedback:
  - borrow `except` in the fulltext/null guard (`matches!(&except, ...)`)
  - replace `idx.into()` with explicit `PointIdType::from(idx)` in the regression test.
