### PR TITLE
test: bump wait_for_peer_online timeout for recovery-with-user-transfers flaky test

### DIFF
--- a/tests/consensus_tests/test_collection_recovery_limits.py
+++ b/tests/consensus_tests/test_collection_recovery_limits.py
@@ -159,7 +159,12 @@ def test_collection_recovery_user_requests_above_limit(tmp_path: pathlib.Path):
 
     # Restart the peer, wait unil it is up
     peer_url = start_peer(killed_peer_dir, "peer_0_restarted.log", bootstrap_url, port=restart_port)
-    wait_for_peer_online(peer_url)
+    # Use a longer timeout: with 3 concurrent user-requested snapshot transfers running, the
+    # leader can fall behind on heartbeats and trigger raft elections. The recovery transfer's
+    # `RecoveryToPartial` proposal can be dropped during the leader election, and the retry
+    # path waits up to CONSENSUS_CONFIRM_TIMEOUT (10s) per attempt before retrying. Combined
+    # with sequential per-shard recovery (auto transfer limit = 1 × 3 shards), 30s is too tight.
+    wait_for_peer_online(peer_url, wait_for_timeout=60)
     recovering_peer_id = get_cluster_info(peer_url)["peer_id"]
 
     # We must see N_SHARDS transfers on our new node

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -857,9 +857,9 @@ def peer_is_online(peer_api_uri: str, path: str = "/readyz") -> bool:
         return False
 
 
-def wait_for_peer_online(peer_api_uri: str, path="/readyz"):
+def wait_for_peer_online(peer_api_uri: str, path="/readyz", wait_for_timeout=WAIT_TIME_SEC):
     try:
-        wait_for(peer_is_online, peer_api_uri, path=path)
+        wait_for(peer_is_online, peer_api_uri, path=path, wait_for_timeout=wait_for_timeout)
     except Exception as e:
         print_clusters_info([peer_api_uri])
         raise e


### PR DESCRIPTION
## Summary

`test_collection_recovery_user_requests_above_limit` is flaky on CI: it times out at `wait_for_peer_online(peer_url)` after the killed peer is restarted (`Timeout waiting for condition peer_is_online to be satisfied in 30 seconds`).

The 30 s `/readyz` budget is too tight for this specific test under load. From the failing run logs:

1. After the killed peer restarts, the test fires 3 concurrent user-requested snapshot transfers (10 000 points × 3 shards) from peer 0 → new peer 4. Peer 0 becomes busy enough that it stops sending raft heartbeats; peer 1 starts an election (term 2 → 3 → 4 across ~6 s).
2. The recovery WAL-delta transfer for shard 0 finishes its data stream at second ~7, then calls `recovered_switch_to_partial` to propose `RecoveryToPartial` through consensus. There is no leader at that moment, so raft logs `no leader at term 3; dropping proposal`.
3. `recovered_switch_to_partial` only does `proposal_sender.send(...)` and returns `Ok` regardless — the dropped proposal is invisible to the caller. The retry path then waits a full `CONSENSUS_CONFIRM_TIMEOUT` (10 s) on the recipient's `WaitForShardState` before retrying.
4. Recovery for shards 1 and 2 hasn't even started — they keep being postponed because shard 0 occupies the lone incoming-transfer slot. The test budget runs out before any of the 3 shards reach a healthy state, so `/readyz` keeps returning 503.

A 60 s budget comfortably covers the leader-churn worst case (one 10 s `wait_for_shard_state` timeout + retry + sequential recovery of the remaining shards) without papering over future regressions.

## Changes

- `wait_for_peer_online` now accepts an optional `wait_for_timeout`, defaulting to the existing `WAIT_TIME_SEC` so all other callers are unchanged.
- The one call inside `test_collection_recovery_user_requests_above_limit` passes 60 s, with a comment explaining why.

## Test plan
- [ ] CI runs `test_collection_recovery_user_requests_above_limit` repeatedly without the timeout failure.
- [ ] Other consensus tests using `wait_for_peer_online` (default timeout) continue to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)