### PR TITLE
refactor: split PayloadFieldIndex into read + write traits

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
@@ -8,7 +8,7 @@ use super::mutable_bool_index::MutableBoolIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
-    ValueIndexer,
+    PayloadFieldIndexRead, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -112,20 +112,10 @@ impl ImmutableBoolIndex {
     }
 }
 
-impl PayloadFieldIndex for ImmutableBoolIndex {
+impl PayloadFieldIndexRead for ImmutableBoolIndex {
     #[inline]
     fn count_indexed_points(&self) -> usize {
         self.0.count_indexed_points()
-    }
-
-    #[inline]
-    fn wipe(self) -> OperationResult<()> {
-        self.0.wipe()
-    }
-
-    #[inline]
-    fn files(&self) -> Vec<PathBuf> {
-        self.0.files()
     }
 
     #[inline]
@@ -154,6 +144,18 @@ impl PayloadFieldIndex for ImmutableBoolIndex {
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
         self.0.for_each_payload_block(threshold, key, f)
+    }
+}
+
+impl PayloadFieldIndex for ImmutableBoolIndex {
+    #[inline]
+    fn wipe(self) -> OperationResult<()> {
+        self.0.wipe()
+    }
+
+    #[inline]
+    fn files(&self) -> Vec<PathBuf> {
+        self.0.files()
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -4,7 +4,7 @@ use immutable_bool_index::ImmutableBoolIndex;
 use mutable_bool_index::MutableBoolIndex;
 
 use super::facet_index::FacetIndex;
-use super::{PayloadFieldIndex, ValueIndexer};
+use super::{PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::payload_config::{IndexMutability, StorageType};
@@ -155,39 +155,11 @@ impl From<ImmutableBoolIndex> for BoolIndex {
     }
 }
 
-impl PayloadFieldIndex for BoolIndex {
+impl PayloadFieldIndexRead for BoolIndex {
     fn count_indexed_points(&self) -> usize {
         match self {
             BoolIndex::Mmap(index) => index.count_indexed_points(),
             BoolIndex::Immutable(index) => index.count_indexed_points(),
-        }
-    }
-
-    fn wipe(self) -> OperationResult<()> {
-        match self {
-            BoolIndex::Mmap(index) => index.wipe(),
-            BoolIndex::Immutable(index) => index.wipe(),
-        }
-    }
-
-    fn flusher(&self) -> crate::common::Flusher {
-        match self {
-            BoolIndex::Mmap(index) => index.flusher(),
-            BoolIndex::Immutable(index) => index.flusher(),
-        }
-    }
-
-    fn files(&self) -> Vec<std::path::PathBuf> {
-        match self {
-            BoolIndex::Mmap(index) => index.files(),
-            BoolIndex::Immutable(index) => index.files(),
-        }
-    }
-
-    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
-        match self {
-            BoolIndex::Mmap(index) => index.immutable_files(),
-            BoolIndex::Immutable(index) => index.immutable_files(),
         }
     }
 
@@ -222,6 +194,36 @@ impl PayloadFieldIndex for BoolIndex {
         match self {
             BoolIndex::Mmap(index) => index.for_each_payload_block(threshold, key, f),
             BoolIndex::Immutable(index) => index.for_each_payload_block(threshold, key, f),
+        }
+    }
+}
+
+impl PayloadFieldIndex for BoolIndex {
+    fn wipe(self) -> OperationResult<()> {
+        match self {
+            BoolIndex::Mmap(index) => index.wipe(),
+            BoolIndex::Immutable(index) => index.wipe(),
+        }
+    }
+
+    fn flusher(&self) -> crate::common::Flusher {
+        match self {
+            BoolIndex::Mmap(index) => index.flusher(),
+            BoolIndex::Immutable(index) => index.flusher(),
+        }
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            BoolIndex::Mmap(index) => index.files(),
+            BoolIndex::Immutable(index) => index.files(),
+        }
+    }
+
+    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            BoolIndex::Mmap(index) => index.immutable_files(),
+            BoolIndex::Immutable(index) => index.immutable_files(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -13,7 +13,7 @@ use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
-    PrimaryCondition, ValueIndexer,
+    PayloadFieldIndexRead, PrimaryCondition, ValueIndexer,
 };
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVariants};
@@ -394,10 +394,6 @@ impl ValueIndexer for MutableBoolIndex {
 }
 
 impl PayloadFieldIndex for MutableBoolIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.indexed_count
-    }
-
     fn wipe(self) -> OperationResult<()> {
         let base_dir = self.base_dir.clone();
         // drop mmap handles before deleting files
@@ -440,6 +436,12 @@ impl PayloadFieldIndex for MutableBoolIndex {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         Vec::new() // everything is mutable
+    }
+}
+
+impl PayloadFieldIndexRead for MutableBoolIndex {
+    fn count_indexed_points(&self) -> usize {
+        self.indexed_count
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/field_index_base/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/mod.rs
@@ -5,5 +5,5 @@ mod value_indexer;
 
 pub use builder::{FieldIndexBuilder, FieldIndexBuilderTrait};
 pub use field_index::FieldIndex;
-pub use payload_field_index::PayloadFieldIndex;
+pub use payload_field_index::{PayloadFieldIndex, PayloadFieldIndexRead};
 pub use value_indexer::ValueIndexer;

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -8,19 +8,14 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::types::{FieldCondition, PayloadKeyType};
 
-pub trait PayloadFieldIndex {
+/// Read-only operations available on every payload field index.
+///
+/// Split out from [`PayloadFieldIndex`] so consumers that only need to query
+/// the index (filtering, cardinality, payload-block iteration) can take a
+/// `&dyn PayloadFieldIndexRead` without depending on storage-lifecycle methods.
+pub trait PayloadFieldIndexRead {
     /// Return number of points with at least one value indexed in here
     fn count_indexed_points(&self) -> usize;
-
-    /// Remove db content or files of the current payload index
-    fn wipe(self) -> OperationResult<()>;
-
-    /// Return function that flushes all pending updates to disk.
-    fn flusher(&self) -> Flusher;
-
-    fn files(&self) -> Vec<PathBuf>;
-
-    fn immutable_files(&self) -> Vec<PathBuf>;
 
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type
@@ -46,4 +41,20 @@ pub trait PayloadFieldIndex {
         key: PayloadKeyType,
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()>;
+}
+
+/// Storage-lifecycle operations on top of [`PayloadFieldIndexRead`].
+///
+/// Owners of the index implement this; read-only consumers can depend on the
+/// supertrait alone.
+pub trait PayloadFieldIndex: PayloadFieldIndexRead {
+    /// Remove db content or files of the current payload index
+    fn wipe(self) -> OperationResult<()>;
+
+    /// Return function that flushes all pending updates to disk.
+    fn flusher(&self) -> Flusher;
+
+    fn files(&self) -> Vec<PathBuf>;
+
+    fn immutable_files(&self) -> Vec<PathBuf>;
 }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index.rs
@@ -299,7 +299,7 @@ mod tests {
         use common::counter::hardware_counter::HardwareCounterCell;
         use common::types::PointOffsetType;
 
-        use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
+        use crate::index::field_index::{PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer};
 
         let payloads: Vec<_> = vec![
             serde_json::json!(

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -12,7 +12,7 @@ use tempfile::{Builder, TempDir};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::index::TextIndexParams;
 use crate::fixtures::payload_fixtures::random_full_text_payload;
-use crate::index::field_index::field_index_base::PayloadFieldIndex;
+use crate::index::field_index::field_index_base::{PayloadFieldIndex, PayloadFieldIndexRead};
 use crate::index::field_index::full_text_index::inverted_index::{
     ARRAY_BOUNDARY_SENTINEL, Document, ParsedQuery, TokenId, TokenSet,
 };

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -21,7 +21,7 @@ use crate::index::field_index::full_text_index::inverted_index::Document;
 use crate::index::field_index::full_text_index::tokenizers::TokenizerTextKind;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
-    ValueIndexer,
+    PayloadFieldIndexRead, ValueIndexer,
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::telemetry::PayloadIndexTelemetry;
@@ -501,10 +501,6 @@ impl ValueIndexer for FullTextIndex {
 }
 
 impl PayloadFieldIndex for FullTextIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.points_count()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         match self {
             Self::Mutable(index) => index.wipe(),
@@ -535,6 +531,12 @@ impl PayloadFieldIndex for FullTextIndex {
             Self::Immutable(index) => index.immutable_files(),
             Self::Mmap(index) => index.immutable_files(),
         }
+    }
+}
+
+impl PayloadFieldIndexRead for FullTextIndex {
+    fn count_indexed_points(&self) -> usize {
+        self.points_count()
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -21,7 +21,8 @@ use crate::index::field_index::geo_hash::{
 };
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
+    PrimaryCondition, ValueIndexer,
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::telemetry::PayloadIndexTelemetry;
@@ -505,10 +506,6 @@ impl FieldIndexBuilderTrait for GeoMapIndexGridstoreBuilder {
 }
 
 impl PayloadFieldIndex for GeoMapIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.points_count()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         match self {
             GeoMapIndex::Mutable(index) => index.wipe(),
@@ -539,6 +536,12 @@ impl PayloadFieldIndex for GeoMapIndex {
             GeoMapIndex::Immutable(index) => index.immutable_files(),
             GeoMapIndex::Storage(index) => index.immutable_files(),
         }
+    }
+}
+
+impl PayloadFieldIndexRead for GeoMapIndex {
+    fn count_indexed_points(&self) -> usize {
+        self.points_count()
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -30,7 +30,8 @@ use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::utils::value_to_integer;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
+    PrimaryCondition, ValueIndexer,
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_estimator::combine_should_estimations;
@@ -720,10 +721,6 @@ where
 }
 
 impl PayloadFieldIndex for MapIndex<str> {
-    fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
@@ -738,6 +735,12 @@ impl PayloadFieldIndex for MapIndex<str> {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         self.immutable_files()
+    }
+}
+
+impl PayloadFieldIndexRead for MapIndex<str> {
+    fn count_indexed_points(&self) -> usize {
+        self.get_indexed_points()
     }
 
     fn filter<'a>(
@@ -870,10 +873,6 @@ impl PayloadFieldIndex for MapIndex<str> {
 }
 
 impl PayloadFieldIndex for MapIndex<UuidIntType> {
-    fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
@@ -888,6 +887,12 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         self.immutable_files()
+    }
+}
+
+impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
+    fn count_indexed_points(&self) -> usize {
+        self.get_indexed_points()
     }
 
     fn filter<'a>(
@@ -1074,10 +1079,6 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
 }
 
 impl PayloadFieldIndex for MapIndex<IntPayloadType> {
-    fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         self.wipe()
     }
@@ -1092,6 +1093,12 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         self.immutable_files()
+    }
+}
+
+impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
+    fn count_indexed_points(&self) -> usize {
+        self.get_indexed_points()
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -8,6 +8,7 @@ use super::mutable_null_index::MutableNullIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
+    PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -103,20 +104,10 @@ impl ImmutableNullIndex {
     }
 }
 
-impl PayloadFieldIndex for ImmutableNullIndex {
+impl PayloadFieldIndexRead for ImmutableNullIndex {
     #[inline]
     fn count_indexed_points(&self) -> usize {
         self.0.count_indexed_points()
-    }
-
-    #[inline]
-    fn wipe(self) -> OperationResult<()> {
-        self.0.wipe()
-    }
-
-    #[inline]
-    fn files(&self) -> Vec<PathBuf> {
-        self.0.files()
     }
 
     #[inline]
@@ -145,6 +136,18 @@ impl PayloadFieldIndex for ImmutableNullIndex {
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
         self.0.for_each_payload_block(threshold, key, f)
+    }
+}
+
+impl PayloadFieldIndex for ImmutableNullIndex {
+    #[inline]
+    fn wipe(self) -> OperationResult<()> {
+        self.0.wipe()
+    }
+
+    #[inline]
+    fn files(&self) -> Vec<PathBuf> {
+        self.0.files()
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -7,7 +7,7 @@ pub use immutable_null_index::ImmutableNullIndex;
 pub use mutable_null_index::MutableNullIndex;
 use serde_json::Value;
 
-use super::PayloadFieldIndex;
+use super::{PayloadFieldIndex, PayloadFieldIndexRead};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::telemetry::PayloadIndexTelemetry;
@@ -123,39 +123,11 @@ impl NullIndex {
     }
 }
 
-impl PayloadFieldIndex for NullIndex {
+impl PayloadFieldIndexRead for NullIndex {
     fn count_indexed_points(&self) -> usize {
         match self {
             NullIndex::Mutable(mutable) => mutable.count_indexed_points(),
             NullIndex::Immutable(immutable) => immutable.count_indexed_points(),
-        }
-    }
-
-    fn wipe(self) -> OperationResult<()> {
-        match self {
-            NullIndex::Mutable(mutable) => mutable.wipe(),
-            NullIndex::Immutable(immutable) => immutable.wipe(),
-        }
-    }
-
-    fn flusher(&self) -> crate::common::Flusher {
-        match self {
-            NullIndex::Mutable(mutable) => mutable.flusher(),
-            NullIndex::Immutable(immutable) => immutable.flusher(),
-        }
-    }
-
-    fn files(&self) -> Vec<std::path::PathBuf> {
-        match self {
-            NullIndex::Mutable(mutable) => mutable.files(),
-            NullIndex::Immutable(immutable) => immutable.files(),
-        }
-    }
-
-    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
-        match self {
-            NullIndex::Mutable(mutable) => mutable.immutable_files(),
-            NullIndex::Immutable(immutable) => immutable.immutable_files(),
         }
     }
 
@@ -192,6 +164,36 @@ impl PayloadFieldIndex for NullIndex {
         match self {
             NullIndex::Mutable(mutable) => mutable.for_each_payload_block(threshold, key, f),
             NullIndex::Immutable(immutable) => immutable.for_each_payload_block(threshold, key, f),
+        }
+    }
+}
+
+impl PayloadFieldIndex for NullIndex {
+    fn wipe(self) -> OperationResult<()> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.wipe(),
+            NullIndex::Immutable(immutable) => immutable.wipe(),
+        }
+    }
+
+    fn flusher(&self) -> crate::common::Flusher {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.flusher(),
+            NullIndex::Immutable(immutable) => immutable.flusher(),
+        }
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.files(),
+            NullIndex::Immutable(immutable) => immutable.files(),
+        }
+    }
+
+    fn immutable_files(&self) -> Vec<std::path::PathBuf> {
+        match self {
+            NullIndex::Mutable(mutable) => mutable.immutable_files(),
+            NullIndex::Immutable(immutable) => immutable.immutable_files(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -13,7 +13,7 @@ use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
-    PrimaryCondition,
+    PayloadFieldIndexRead, PrimaryCondition,
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::telemetry::PayloadIndexTelemetry;
@@ -264,10 +264,6 @@ impl MutableNullIndex {
 }
 
 impl PayloadFieldIndex for MutableNullIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.storage.has_values_flags.len()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         let base_dir = self.base_dir.clone();
         // drop mmap handles before deleting files
@@ -297,6 +293,12 @@ impl PayloadFieldIndex for MutableNullIndex {
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         Vec::new() // everything is mutable
+    }
+}
+
+impl PayloadFieldIndexRead for MutableNullIndex {
+    fn count_indexed_points(&self) -> usize {
+        self.storage.has_values_flags.len()
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -39,7 +39,8 @@ use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{
-    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PrimaryCondition, ValueIndexer,
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
+    PrimaryCondition, ValueIndexer,
 };
 use crate::index::key_encoding::{
     decode_f64_key_ascending, decode_i64_key_ascending, decode_u128_key_ascending,
@@ -807,10 +808,6 @@ impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> PayloadFi
 where
     Vec<T>: Blob,
 {
-    fn count_indexed_points(&self) -> usize {
-        self.get_points_count()
-    }
-
     fn wipe(self) -> OperationResult<()> {
         match self {
             NumericIndexInner::Mutable(index) => index.wipe(),
@@ -829,6 +826,16 @@ where
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         NumericIndexInner::immutable_files(self)
+    }
+}
+
+impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> PayloadFieldIndexRead
+    for NumericIndexInner<T>
+where
+    Vec<T>: Blob,
+{
+    fn count_indexed_points(&self) -> usize {
+        self.get_points_count()
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -851,7 +851,7 @@ fn test_empty_cardinality(#[case] index_type: IndexType) {
 /// `lib/segment/src/segment/tests/test_immutable_payload_index_files.rs`.
 #[test]
 fn test_remove_reopen() {
-    use crate::index::field_index::PayloadFieldIndex;
+    use crate::index::field_index::PayloadFieldIndexRead;
 
     let hw_acc = HwMeasurementAcc::new();
     let hw_counter = hw_acc.get_counter_cell();


### PR DESCRIPTION
## Summary
- Split `PayloadFieldIndex` into a read-only supertrait `PayloadFieldIndexRead` (carrying `count_indexed_points`, `filter`, `estimate_cardinality`, `for_each_payload_block`) and the existing `PayloadFieldIndex: PayloadFieldIndexRead` for storage-lifecycle methods (`wipe`, `flusher`, `files`, `immutable_files`).
- Mirrors the existing `IdTracker` / `IdTrackerRead` split — lets read-only consumers depend on the query surface without pulling in storage-lifecycle methods.
- Updated all 11 impls (`numeric_index`, `map_index` x3, `null_index` x3, `bool_index` x3, `full_text_index`, `geo_index`) to split into two `impl` blocks.
- Adjusted test imports that call read-side methods (`numeric_index/tests.rs`, `full_text_index/tests/test_congruence.rs`, `mutable_text_index.rs`).

Pure refactor — no behavior changes. Trait-object users (`&dyn PayloadFieldIndex`) still get all methods through the supertrait.

## Test plan
- [x] \`cargo check -p segment\`
- [x] \`cargo check -p segment --tests\`
- [ ] CI: full workspace build + segment unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)