### PR TITLE
refactor(payload_storage): generalize PayloadProvider over PayloadStorageRead

### DIFF
--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -14,6 +14,7 @@ use crate::index::field_index::null_index::NullIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
@@ -27,10 +28,10 @@ use crate::vector_storage::VectorStorageRead;
 mod match_converter;
 
 impl StructPayloadIndex {
-    pub fn condition_converter<'a>(
+    pub fn condition_converter<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         condition: &'a Condition,
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         hw_counter: &HardwareCounterCell,
     ) -> ConditionCheckerFn<'a> {
         let id_tracker = self.id_tracker.borrow();

--- a/lib/segment/src/index/query_optimization/optimizer.rs
+++ b/lib/segment/src/index/query_optimization/optimizer.rs
@@ -14,6 +14,7 @@ use crate::index::query_optimization::optimized_filter::{
 };
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, Filter, MinShould};
 
 impl StructPayloadIndex {
@@ -36,10 +37,10 @@ impl StructPayloadIndex {
     /// # Result
     ///
     /// Optimized query + Cardinality estimation
-    pub fn optimize_filter<'a>(
+    pub fn optimize_filter<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         filter: &'a Filter,
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<(OptimizedFilter<'a>, CardinalityEstimation)> {
@@ -105,10 +106,10 @@ impl StructPayloadIndex {
         ))
     }
 
-    pub fn convert_conditions<'a>(
+    pub fn convert_conditions<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         conditions: &'a [Condition],
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<(OptimizedCondition<'a>, CardinalityEstimation)>> {
@@ -130,10 +131,10 @@ impl StructPayloadIndex {
             .collect()
     }
 
-    fn optimize_should<'a>(
+    fn optimize_should<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         conditions: &'a [Condition],
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
@@ -146,11 +147,11 @@ impl StructPayloadIndex {
         Ok((conditions, combine_should_estimations(&estimations, total)))
     }
 
-    fn optimize_min_should<'a>(
+    fn optimize_min_should<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         conditions: &'a [Condition],
         min_count: usize,
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
@@ -171,10 +172,10 @@ impl StructPayloadIndex {
         ))
     }
 
-    fn optimize_must<'a>(
+    fn optimize_must<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         conditions: &'a [Condition],
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
@@ -187,10 +188,10 @@ impl StructPayloadIndex {
         Ok((conditions, combine_must_estimations(&estimations, total)))
     }
 
-    fn optimize_must_not<'a>(
+    fn optimize_must_not<'a, P: PayloadStorageRead + 'a>(
         &'a self,
         conditions: &'a [Condition],
-        payload_provider: PayloadProvider,
+        payload_provider: PayloadProvider<P>,
         total: usize,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {

--- a/lib/segment/src/index/query_optimization/payload_provider.rs
+++ b/lib/segment/src/index/query_optimization/payload_provider.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -6,21 +5,26 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
 use crate::payload_storage::PayloadStorageRead;
-use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::types::{OwnedPayloadRef, Payload};
+use crate::types::OwnedPayloadRef;
 
-#[derive(Clone)]
-pub struct PayloadProvider {
-    payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>,
-    empty_payload: Payload,
+pub struct PayloadProvider<P: PayloadStorageRead> {
+    payload_storage: Arc<AtomicRefCell<P>>,
 }
 
-impl PayloadProvider {
-    pub fn new(payload_storage: Arc<AtomicRefCell<PayloadStorageEnum>>) -> Self {
+// Manual `Clone` impl: derive would require `P: Clone`, which is not the
+// case for `PayloadStorageEnum`. Cloning the provider is just an `Arc`
+// bump, no `P: Clone` needed.
+impl<P: PayloadStorageRead> Clone for PayloadProvider<P> {
+    fn clone(&self) -> Self {
         Self {
-            payload_storage,
-            empty_payload: Default::default(),
+            payload_storage: Arc::clone(&self.payload_storage),
         }
+    }
+}
+
+impl<P: PayloadStorageRead> PayloadProvider<P> {
+    pub fn new(payload_storage: Arc<AtomicRefCell<P>>) -> Self {
+        Self { payload_storage }
     }
 
     pub fn with_payload<F, G>(
@@ -32,39 +36,19 @@ impl PayloadProvider {
     where
         F: FnOnce(OwnedPayloadRef) -> G,
     {
-        let payload_storage_guard = self.payload_storage.borrow();
-        let payload_ptr_opt = match payload_storage_guard.deref() {
-            #[cfg(feature = "testing")]
-            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
-                s.payload_ptr(point_id).map(OwnedPayloadRef::from)
-            }
-            // Warn: Possible panic here
-            // Currently, it is possible that `read_payload` fails with Err,
-            // but it seems like a very rare possibility which might only happen
-            // if something is wrong with disk or storage is corrupted.
-            //
-            // In both cases it means that service can't be of use any longer.
-            // It is as good as dead. Therefore it is tolerable to just panic here.
-            // Downside is - API user won't be notified of the failure.
-            // It will just timeout.
-            //
-            // The alternative:
-            // Rewrite condition checking code to support error reporting.
-            // Which may lead to slowdown and assumes a lot of changes.
-            PayloadStorageEnum::MmapPayloadStorage(s) => {
-                let payload = s
-                    .get(point_id, hw_counter)
-                    .unwrap_or_else(|err| panic!("Payload storage is corrupted: {err}"));
-                Some(OwnedPayloadRef::from(payload))
-            }
-        };
-
-        let payload = if let Some(payload_ptr) = payload_ptr_opt {
-            payload_ptr
-        } else {
-            OwnedPayloadRef::from(&self.empty_payload)
-        };
-
+        let guard = self.payload_storage.borrow();
+        // ToDo(uio): expose error instead of panic
+        // Same panic-on-error policy as the previous Mmap branch -- preserves
+        // behaviour. Currently it is possible for `payload_ref` to fail with
+        // Err in the on-disk case, but this only happens if the disk or
+        // storage is corrupted, in which case the service is no longer
+        // usable. Tolerable to panic; downside is the API user is not
+        // notified of the failure -- it just times out. The alternative
+        // would be to rewrite condition checking to support error reporting,
+        // which would require pervasive changes.
+        let payload = guard
+            .payload_ref(point_id, hw_counter)
+            .unwrap_or_else(|err| panic!("Payload storage is corrupted: {err}"));
         callback(payload)
     }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -9,6 +9,7 @@ use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::json_path::JsonPath;
+use crate::payload_storage::PayloadStorageRead;
 use crate::types::{DateTimePayloadType, PayloadContainer, UuidPayloadType};
 
 pub type VariableRetrieverFn<'a> = Box<dyn Fn(PointOffsetType) -> MultiValue<Value> + 'a>;
@@ -44,10 +45,10 @@ impl StructPayloadIndex {
     }
 }
 
-fn variable_retriever<'a, 'q>(
+fn variable_retriever<'a, 'q, P: PayloadStorageRead + 'q>(
     indices: &'a HashMap<JsonPath, Vec<FieldIndex>>,
     json_path: &JsonPath,
-    payload_provider: PayloadProvider,
+    payload_provider: PayloadProvider<P>,
     hw_counter: &'q HardwareCounterCell,
 ) -> VariableRetrieverFn<'q>
 where
@@ -68,11 +69,11 @@ where
         })
 }
 
-fn payload_variable_retriever(
-    payload_provider: PayloadProvider,
+fn payload_variable_retriever<'a, P: PayloadStorageRead + 'a>(
+    payload_provider: PayloadProvider<P>,
     json_path: JsonPath,
-    hw_counter: &HardwareCounterCell,
-) -> VariableRetrieverFn<'_> {
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
     let retriever_fn = move |point_id: PointOffsetType| {
         payload_provider.with_payload(
             point_id,
@@ -241,7 +242,7 @@ mod tests {
     use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
     use crate::types::Payload;
 
-    pub fn fixture_payload_provider() -> PayloadProvider {
+    pub fn fixture_payload_provider() -> PayloadProvider<PayloadStorageEnum> {
         // Create an in-memory payload storage and populate it with some payload maps containing numbers and geo points.
         let mut in_memory_storage = InMemoryPayloadStorage::default();
 

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -9,7 +9,7 @@ use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::Payload;
+use crate::types::{OwnedPayloadRef, Payload};
 
 impl PayloadStorageRead for InMemoryPayloadStorage {
     fn get(
@@ -30,6 +30,17 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
     ) -> OperationResult<Payload> {
         // In memory => No optimizations available.
         self.get(point_id, hw_counter)
+    }
+
+    fn payload_ref(
+        &self,
+        point_id: PointOffsetType,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<OwnedPayloadRef<'_>> {
+        Ok(self
+            .payload_ptr(point_id)
+            .map(OwnedPayloadRef::from)
+            .unwrap_or_else(|| OwnedPayloadRef::from(Payload::default())))
     }
 
     fn iter<F>(&self, mut callback: F, _hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -12,7 +12,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{Payload, PayloadKeyTypeRef};
+use crate::types::{OwnedPayloadRef, Payload, PayloadKeyTypeRef};
 
 const STORAGE_PATH: &str = "payload_storage";
 
@@ -106,6 +106,15 @@ impl PayloadStorageRead for MmapPayloadStorage {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
+    }
+
+    fn payload_ref(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<OwnedPayloadRef<'_>> {
+        let payload = self.get(point_offset, hw_counter)?;
+        Ok(OwnedPayloadRef::from(payload))
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
-use crate::types::{Filter, Payload};
+use crate::types::{Filter, OwnedPayloadRef, Payload};
 
 /// Read-only trait for payload data storage.
 ///
@@ -26,6 +26,20 @@ pub trait PayloadStorageRead {
         point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
+
+    /// Return a borrowed or owned reference to the payload for `point_offset`.
+    ///
+    /// In-memory implementations should return `OwnedPayloadRef::Ref(...)` to
+    /// avoid a clone on the hot path. On-disk implementations may materialise
+    /// a copy and return `OwnedPayloadRef::Owned(...)`.
+    ///
+    /// For points without payload, return an empty payload via
+    /// `OwnedPayloadRef::Owned(...)` so the caller never has to handle `None`.
+    fn payload_ref(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<OwnedPayloadRef<'_>>;
 
     /// Iterate over all stored payload and apply the provided callback.
     /// Stop iteration if callback returns false or error.

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -11,7 +11,7 @@ use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::mmap_payload_storage::MmapPayloadStorage;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::Payload;
+use crate::types::{OwnedPayloadRef, Payload};
 
 #[derive(Debug)]
 pub enum PayloadStorageEnum {
@@ -57,6 +57,20 @@ impl PayloadStorageRead for PayloadStorageEnum {
                 s.get_sequential(point_offset, hw_counter)
             }
             PayloadStorageEnum::MmapPayloadStorage(s) => s.get_sequential(point_offset, hw_counter),
+        }
+    }
+
+    fn payload_ref(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<OwnedPayloadRef<'_>> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                s.payload_ref(point_offset, hw_counter)
+            }
+            PayloadStorageEnum::MmapPayloadStorage(s) => s.payload_ref(point_offset, hw_counter),
         }
     }
 

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -6,7 +6,7 @@ use common::universal_io::UniversalRead;
 use crate::common::operation_error::OperationResult;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
-use crate::types::Payload;
+use crate::types::{OwnedPayloadRef, Payload};
 
 impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     fn get(
@@ -32,6 +32,15 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
             Some(payload) => Ok(payload),
             None => Ok(Default::default()),
         }
+    }
+
+    fn payload_ref(
+        &self,
+        point_offset: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<OwnedPayloadRef<'_>> {
+        let payload = self.get(point_offset, hw_counter)?;
+        Ok(OwnedPayloadRef::from(payload))
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>


### PR DESCRIPTION
## Summary

- Adds `payload_ref(point_offset, hw_counter) -> OwnedPayloadRef<'_>` to the `PayloadStorageRead` trait, with impls for `InMemoryPayloadStorage` (zero-copy `Ref` via `payload_ptr`), `MmapPayloadStorage` and `ReadOnlyPayloadStorage<S>` (materialised `Owned`), and `PayloadStorageEnum` (variant dispatch).
- Generalises `PayloadProvider` from `Arc<AtomicRefCell<PayloadStorageEnum>>` to `PayloadProvider<P: PayloadStorageRead>` with `Arc<AtomicRefCell<P>>`. Drops the `PayloadStorageEnum` `match` from `with_payload`; dispatch now goes through the trait's `payload_ref`. Manual `Clone` impl avoids requiring `P: Clone`.
- Threads `<P: PayloadStorageRead + 'a>` through the consuming signatures in `query_optimization/`: `optimize_filter`, `convert_conditions`, `optimize_should/min_should/must/must_not`, `condition_converter`, `variable_retriever`, `payload_variable_retriever`. The `+ 'a` bound is needed because the returned `OptimizedFilter<'a>` / `ConditionCheckerFn<'a>` / `VariableRetrieverFn<'a>` contain boxed closures that capture the provider.
- Cascade stops at the box: `StructFilterContext<'a>`, `FormulaScorer<'a>`, and the rest of the search machinery are unaffected.
- All construction sites in `struct_payload_index/` continue to compile unchanged -- type inference picks `P = PayloadStorageEnum` from the `Arc` they hold.

## Why

This is preparatory work for a generic, read-only view over `StructPayloadIndex` (mirroring `SegmentReadView`). With `PayloadProvider` tied to the enum, no read path could be expressed over a non-enum payload storage. After this change a `StructPayloadIndexReadView<'a, P: PayloadStorageRead>` becomes possible without duplicating the search/filter/cardinality machinery.

The cascade analysis (`<P>` reaching only `query_optimization/`, never `struct_payload_index/`, `segment/`, or vector indexes) was the deciding factor for going generic over `dyn`. `dyn PayloadStorageRead` is also blocked today by the trait's generic `iter` method (not object-safe) and by `AtomicRefCell` not implementing `CoerceUnsized`.

## Test plan

- [x] `cargo build --workspace` -- green
- [x] `cargo test -p segment --lib` -- 665 passed, 0 failed
- [x] `cargo test -p storage --lib` -- 44 passed
- [x] `cargo test -p collection --lib` -- 197 passed
- [x] `cargo clippy -p segment --tests` -- clean
- [x] `cargo test -p segment --lib value_retriever` -- both formula-scorer retrieval tests (from-payload + from-index) pass

## Behaviour parity

- The panic-on-corruption policy that lived in the old Mmap branch of `PayloadProvider::with_payload` is preserved verbatim and now applies uniformly across storage backends. In-memory storage's `payload_ref` is infallible.
- In-memory hot path remains zero-copy (`OwnedPayloadRef::Ref(...)` via `payload_ptr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)