### PR TITLE
refactor(index): introduce StructPayloadIndexReadView<P, I, V>

### DIFF
--- a/lib/segment/benches/boolean_filtering.rs
+++ b/lib/segment/benches/boolean_filtering.rs
@@ -77,7 +77,7 @@ pub fn struct_boolean_query_points(c: &mut Criterion) {
         b.iter(|| {
             let filter = random_bool_filter(&mut rng);
             result_size += struct_index
-                .query_points(&filter, &hw_counter, &is_stopped, None)
+                .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                 .unwrap()
                 .len();
             query_count += 1;
@@ -131,7 +131,7 @@ pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
         b.iter(|| {
             let filter = random_bool_filter(&mut rng);
             result_size += index
-                .query_points(&filter, &hw_counter, &is_stopped, None)
+                .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                 .unwrap()
                 .len();
             query_count += 1;

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -144,10 +144,10 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
 
     let filter = random_must_filter(&mut rng, 2);
     let cardinality = struct_index
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
-    let indexed_fields = struct_index.indexed_fields();
+    let indexed_fields = struct_index.with_view(|v| v.indexed_fields());
 
     eprintln!("cardinality = {cardinality:#?}");
     eprintln!("indexed_fields = {indexed_fields:#?}");
@@ -156,7 +156,7 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let filter = random_must_filter(&mut rng, 2);
             result_size += struct_index
-                .query_points(&filter, &hw_counter, &is_stopped, None)
+                .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                 .unwrap()
                 .len();
             query_count += 1;
@@ -175,13 +175,11 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
             let sample = (0..CHECK_SAMPLE_SIZE)
                 .map(|_| rng.random_range(0..NUM_POINTS) as PointOffsetType)
                 .collect_vec();
-            let context = struct_index.filter_context(&filter, &hw_counter).unwrap();
-
-            let filtered_sample = sample
-                .into_iter()
-                .filter(|id| context.check(*id))
-                .collect_vec();
-            result_size += filtered_sample.len();
+            let filtered_count = struct_index.with_view(|v| {
+                let context = v.filter_context(&filter, &hw_counter).unwrap();
+                sample.into_iter().filter(|id| context.check(*id)).count()
+            });
+            result_size += filtered_count;
             query_count += 1;
         })
     });

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -94,8 +94,14 @@ fn range_filtering(c: &mut Criterion) {
         .unwrap();
 
     // make sure all points are indexed
-    assert_eq!(index.indexed_points(&FLT_KEY.parse().unwrap()), NUM_POINTS);
-    assert_eq!(index.indexed_points(&INT_KEY.parse().unwrap()), NUM_POINTS);
+    assert_eq!(
+        index.with_view(|v| v.indexed_points(&FLT_KEY.parse().unwrap())),
+        NUM_POINTS,
+    );
+    assert_eq!(
+        index.with_view(|v| v.indexed_points(&INT_KEY.parse().unwrap())),
+        NUM_POINTS,
+    );
 
     let mut result_size = 0;
     let mut query_count = 0;
@@ -105,7 +111,7 @@ fn range_filtering(c: &mut Criterion) {
             || random_range_filter(&mut rng, FLT_KEY),
             |filter| {
                 result_size += index
-                    .query_points(&filter, &hw_counter, &is_stopped, None)
+                    .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                     .unwrap()
                     .len();
                 query_count += 1;
@@ -119,7 +125,7 @@ fn range_filtering(c: &mut Criterion) {
             || random_range_filter(&mut rng, INT_KEY),
             |filter| {
                 result_size += index
-                    .query_points(&filter, &hw_counter, &is_stopped, None)
+                    .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                     .unwrap()
                     .len();
                 query_count += 1;
@@ -148,7 +154,7 @@ fn range_filtering(c: &mut Criterion) {
             || random_range_filter(&mut rng, FLT_KEY),
             |filter| {
                 result_size += index
-                    .query_points(&filter, &hw_counter, &is_stopped, None)
+                    .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                     .unwrap()
                     .len();
                 query_count += 1;
@@ -162,7 +168,7 @@ fn range_filtering(c: &mut Criterion) {
             || random_range_filter(&mut rng, INT_KEY),
             |filter| {
                 result_size += index
-                    .query_points(&filter, &hw_counter, &is_stopped, None)
+                    .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
                     .unwrap()
                     .len();
                 query_count += 1;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -281,7 +281,7 @@ impl HNSWIndex {
         let progress_main_graph = build_main_graph.then(|| progress.subtask("main_graph"));
         let additional_links_params: Option<(ProgressTracker, Vec<(ProgressTracker, JsonPath)>)> =
             (payload_m.m > 0)
-                .then(|| payload_index_ref.indexed_fields())
+                .then(|| payload_index_ref.with_view(|v| v.indexed_fields()))
                 .filter(|fields| !fields.is_empty())
                 .map(|fields| {
                     let progress_additional_links = progress.subtask("additional_links");
@@ -678,11 +678,9 @@ impl HNSWIndex {
                     Ok(())
                 };
 
-                payload_index_ref.for_each_payload_block(
-                    &field,
-                    full_scan_threshold,
-                    &mut process_block,
-                )?;
+                payload_index_ref.with_view(|v| {
+                    v.for_each_payload_block(&field, full_scan_threshold, &mut process_block)
+                })?;
             }
 
             let indexed_payload_vectors = indexed_vectors_set.count_ones();
@@ -766,12 +764,11 @@ impl HNSWIndex {
 
         let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
-        let cardinality_estimation =
-            payload_index.estimate_cardinality(&filter, &disposed_hw_counter)?;
         let point_mappings = id_tracker.point_mappings();
 
-        Ok(payload_index
-            .iter_filtered_points(
+        payload_index.with_view(|v| {
+            let cardinality_estimation = v.estimate_cardinality(&filter, &disposed_hw_counter)?;
+            Ok(v.iter_filtered_points(
                 &filter,
                 id_tracker,
                 &point_mappings,
@@ -782,6 +779,7 @@ impl HNSWIndex {
             )?
             .filter(|&point_id| !deleted_bitslice.get_bit(point_id as usize).unwrap_or(false))
             .collect())
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1086,7 +1084,7 @@ impl HNSWIndex {
                 1.0
             } else {
                 let query_point_cardinality =
-                    payload_index.estimate_cardinality(filter, &hw_counter)?;
+                    payload_index.with_view(|v| v.estimate_cardinality(filter, &hw_counter))?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
@@ -1114,79 +1112,83 @@ impl HNSWIndex {
                 return Ok(None);
             };
 
-            // Quantized vectors are "link vectors"
-            let link_scorer_filtered = FilteredScorer::new(
-                vector.to_owned(),
-                &vector_storage,
-                Some(quantized_vectors),
-                filter
-                    .map(|f| {
-                        payload_index
-                            .filter_context(f, &hw_counter)
-                            .map(BoxCow::Owned)
-                    })
-                    .transpose()?,
-                deleted_points,
-                vector_query_context.hardware_counter(),
-            )?;
-            let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
-                return Ok(None);
-            };
+            payload_index.with_view(|payload_index_view| {
+                // Quantized vectors are "link vectors"
+                let link_scorer_filtered = FilteredScorer::new(
+                    vector.to_owned(),
+                    &vector_storage,
+                    Some(quantized_vectors),
+                    filter
+                        .map(|f| {
+                            payload_index_view
+                                .filter_context(f, &hw_counter)
+                                .map(BoxCow::Owned)
+                        })
+                        .transpose()?,
+                    deleted_points,
+                    vector_query_context.hardware_counter(),
+                )?;
+                let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
+                    return Ok(None);
+                };
 
-            // Full vectors are "base vectors"
-            let base_scorer = new_raw_scorer(
-                vector.to_owned(),
-                &vector_storage,
-                vector_query_context.hardware_counter(),
-            )?;
-            let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
-                return Ok(None);
-            };
+                // Full vectors are "base vectors"
+                let base_scorer = new_raw_scorer(
+                    vector.to_owned(),
+                    &vector_storage,
+                    vector_query_context.hardware_counter(),
+                )?;
+                let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
+                    return Ok(None);
+                };
 
-            Ok(Some(self.graph.search_with_vectors(
-                top,
-                std::cmp::max(ef, oversampled_top),
-                &link_scorer_filtered,
-                &link_scorer_filtered_bytes,
-                base_scorer_bytes,
-                custom_entry_points,
-                &vector_query_context.is_stopped(),
-            )?))
+                Ok(Some(self.graph.search_with_vectors(
+                    top,
+                    std::cmp::max(ef, oversampled_top),
+                    &link_scorer_filtered,
+                    &link_scorer_filtered_bytes,
+                    base_scorer_bytes,
+                    custom_entry_points,
+                    &vector_query_context.is_stopped(),
+                )?))
+            })
         };
 
         let regular_search = || -> OperationResult<Vec<ScoredPointOffset>> {
-            let filter_context = filter
-                .map(|f| payload_index.filter_context(f, &hw_counter))
-                .transpose()?;
-            let points_scorer = Self::construct_search_scorer(
-                vector,
-                &vector_storage,
-                quantized_vectors.as_ref(),
-                deleted_points,
-                params,
-                vector_query_context.hardware_counter(),
-                filter_context,
-            )?;
+            payload_index.with_view(|payload_index_view| {
+                let filter_context = filter
+                    .map(|f| payload_index_view.filter_context(f, &hw_counter))
+                    .transpose()?;
+                let points_scorer = Self::construct_search_scorer(
+                    vector,
+                    &vector_storage,
+                    quantized_vectors.as_ref(),
+                    deleted_points,
+                    params,
+                    vector_query_context.hardware_counter(),
+                    filter_context,
+                )?;
 
-            let search_result = self.graph.search(
-                oversampled_top,
-                ef,
-                algorithm,
-                points_scorer,
-                custom_entry_points,
-                &is_stopped,
-            )?;
+                let search_result = self.graph.search(
+                    oversampled_top,
+                    ef,
+                    algorithm,
+                    points_scorer,
+                    custom_entry_points,
+                    &is_stopped,
+                )?;
 
-            postprocess_search_result(
-                search_result,
-                id_tracker.deleted_point_bitslice(),
-                &vector_storage,
-                quantized_vectors.as_ref(),
-                vector,
-                params,
-                top,
-                vector_query_context.hardware_counter(),
-            )
+                postprocess_search_result(
+                    search_result,
+                    id_tracker.deleted_point_bitslice(),
+                    &vector_storage,
+                    quantized_vectors.as_ref(),
+                    vector,
+                    params,
+                    top,
+                    vector_query_context.hardware_counter(),
+                )
+            })
         };
 
         // Try to use graph with vectors first.
@@ -1310,20 +1312,29 @@ impl HNSWIndex {
 
         let id_tracker = self.id_tracker.borrow();
         let payload_index = self.payload_index.borrow();
-        let query_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
         let point_mappings = id_tracker.point_mappings();
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-        let filtered_points = payload_index.iter_filtered_points(
-            filter,
-            &*id_tracker,
-            &point_mappings,
-            &query_cardinality,
-            hw_counter,
-            is_stopped,
-            // No deferred filtering here since it's HNSW index.
-            None,
-        )?;
-        self.search_plain_batched(vectors, filtered_points, top, params, vector_query_context)
+        let filtered_points: Vec<PointOffsetType> = payload_index.with_view(|v| {
+            let query_cardinality = v.estimate_cardinality(filter, hw_counter)?;
+            v.iter_filtered_points(
+                filter,
+                &*id_tracker,
+                &point_mappings,
+                &query_cardinality,
+                hw_counter,
+                is_stopped,
+                // No deferred filtering here since it's HNSW index.
+                None,
+            )
+            .map(|it| it.collect())
+        })?;
+        self.search_plain_batched(
+            vectors,
+            filtered_points.into_iter(),
+            top,
+            params,
+            vector_query_context,
+        )
     }
 
     fn discover_search_with_graph(
@@ -1521,8 +1532,8 @@ impl VectorIndexRead for HNSWIndex {
 
                 let hw_counter = query_context.hardware_counter();
 
-                let query_point_cardinality =
-                    payload_index.estimate_cardinality(query_filter, &hw_counter)?;
+                let query_point_cardinality = payload_index
+                    .with_view(|v| v.estimate_cardinality(query_filter, &hw_counter))?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
@@ -1555,16 +1566,21 @@ impl VectorIndexRead for HNSWIndex {
                     );
                 }
 
-                let filter_context = payload_index.filter_context(query_filter, &hw_counter)?;
+                // Fast cardinality estimation is not enough, do sample estimation of cardinality.
+                // The filter context's lifetime is tied to the view, so the sample check
+                // must run inside `with_view` -- the recursive search dispatches re-borrow
+                // payload_index on their own.
+                let use_graph = payload_index.with_view(|v| {
+                    let filter_context = v.filter_context(query_filter, &hw_counter)?;
+                    Ok::<_, OperationError>(sample_check_cardinality(
+                        id_tracker.sample_ids(Some(vector_storage.deleted_vector_bitslice())),
+                        |idx| filter_context.check(idx),
+                        self.config.full_scan_threshold,
+                        available_vector_count, // Check cardinality among available vectors
+                    ))
+                })?;
 
-                // Fast cardinality estimation is not enough, do sample estimation of cardinality
-                let id_tracker = self.id_tracker.borrow();
-                if sample_check_cardinality(
-                    id_tracker.sample_ids(Some(vector_storage.deleted_vector_bitslice())),
-                    |idx| filter_context.check(idx),
-                    self.config.full_scan_threshold,
-                    available_vector_count, // Check cardinality among available vectors
-                ) {
+                if use_graph {
                     // if cardinality is high enough - use HNSW index
                     let _timer =
                         ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -71,8 +71,10 @@ impl PlainVectorIndex {
         let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
 
         if let Some(payload_filter) = filter {
-            let payload_index = self.payload_index.borrow();
-            let cardinality = payload_index.estimate_cardinality(payload_filter, hw_counter)?;
+            let cardinality = self
+                .payload_index
+                .borrow()
+                .with_view(|v| v.estimate_cardinality(payload_filter, hw_counter))?;
             let scan_size = vector_size_bytes.saturating_mul(cardinality.max);
             Ok(scan_size <= indexing_threshold_bytes)
         } else {
@@ -139,13 +141,9 @@ impl VectorIndexRead for PlainVectorIndex {
 
         let mut search_results = match filter {
             Some(filter) => {
-                let payload_index = self.payload_index.borrow();
-                let filtered_ids_vec = payload_index.query_points(
-                    filter,
-                    &hw_counter,
-                    &is_stopped,
-                    deferred_internal_id,
-                )?;
+                let filtered_ids_vec = self.payload_index.borrow().with_view(|v| {
+                    v.query_points(filter, &hw_counter, &is_stopped, deferred_internal_id)
+                })?;
                 batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
             }
             None => batch_searcher.peek_top_all(&is_stopped, deferred_internal_id)?,

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -1,205 +1,17 @@
-use std::collections::HashMap;
-
-use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use match_converter::get_match_checkers;
 use ordered_float::OrderedFloat;
-use serde_json::Value;
 
-use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndex;
 use crate::index::field_index::null_index::NullIndex;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
-use crate::index::query_optimization::payload_provider::PayloadProvider;
-use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::payload_storage::PayloadStorageRead;
-use crate::payload_storage::query_checker::{
-    check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
-    select_nested_indexes,
-};
 use crate::types::{
-    Condition, DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon,
-    GeoRadius, IntPayloadType, OwnedPayloadRef, PayloadContainer, Range, RangeInterface,
+    DateTimePayloadType, FieldCondition, FloatPayloadType, GeoBoundingBox, GeoPolygon, GeoRadius,
+    IntPayloadType, Range, RangeInterface,
 };
-use crate::vector_storage::VectorStorageRead;
 
 mod match_converter;
-
-impl StructPayloadIndex {
-    pub fn condition_converter<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        condition: &'a Condition,
-        payload_provider: PayloadProvider<P>,
-        hw_counter: &HardwareCounterCell,
-    ) -> ConditionCheckerFn<'a> {
-        let id_tracker = self.id_tracker.borrow();
-        let field_indexes = &self.field_indexes;
-        match condition {
-            Condition::Field(field_condition) => field_indexes
-                .get(&field_condition.key)
-                .and_then(|indexes| {
-                    indexes.iter().find_map(move |index| {
-                        let hw_acc = hw_counter.new_accumulator();
-                        field_condition_index(index, field_condition, hw_acc)
-                    })
-                })
-                .unwrap_or_else(|| {
-                    let hw = hw_counter.fork();
-                    Box::new(move |point_id| {
-                        payload_provider.with_payload(
-                            point_id,
-                            |payload| {
-                                check_field_condition(field_condition, &payload, field_indexes, &hw)
-                                    .unwrap(/* TODO(uio): handle errors */)
-                            },
-                            &hw,
-                        )
-                    })
-                }),
-            // Use dedicated null index for `is_empty` check if it is available
-            // Otherwise we might use another index just to check if a field is not empty, if we
-            // don't have an indexed value we must still check the payload to see if its empty
-            Condition::IsEmpty(is_empty) => {
-                let field_indexes = field_indexes.get(&is_empty.is_empty.key);
-
-                let (primary_null_index, fallback_index) = field_indexes
-                    .map(|field_indexes| get_is_empty_indexes(field_indexes))
-                    .unwrap_or((None, None));
-
-                if let Some(null_index) = primary_null_index {
-                    get_null_index_is_empty_checker(null_index, true)
-                } else {
-                    // Fallback to reading payload, in case we don't yet have null-index
-                    let hw = hw_counter.fork();
-                    let fallback = Box::new(move |point_id| {
-                        payload_provider.with_payload(
-                            point_id,
-                            |payload| check_is_empty_condition(is_empty, &payload),
-                            &hw,
-                        )
-                    });
-
-                    if let Some(fallback_index) = fallback_index {
-                        get_fallback_is_empty_checker(fallback_index, true, fallback)
-                    } else {
-                        fallback
-                    }
-                }
-            }
-
-            Condition::IsNull(is_null) => {
-                let field_indexes = field_indexes.get(&is_null.is_null.key);
-
-                let is_null_checker = field_indexes.and_then(|field_indexes| {
-                    field_indexes
-                        .iter()
-                        .find_map(|index| get_is_null_checker(index, true))
-                });
-
-                if let Some(checker) = is_null_checker {
-                    checker
-                } else {
-                    // Fallback to reading payload
-                    let hw = hw_counter.fork();
-                    Box::new(move |point_id| {
-                        payload_provider.with_payload(
-                            point_id,
-                            |payload| check_is_null_condition(is_null, &payload),
-                            &hw,
-                        )
-                    })
-                }
-            }
-            // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
-            Condition::HasId(has_id) => {
-                let segment_ids: AHashSet<_> = has_id
-                    .has_id
-                    .iter()
-                    .filter_map(|external_id| id_tracker.internal_id(*external_id))
-                    .collect();
-                Box::new(move |point_id| segment_ids.contains(&point_id))
-            }
-            Condition::HasVector(has_vector) => {
-                if let Some(vector_storage) =
-                    self.vector_storages.get(&has_vector.has_vector).cloned()
-                {
-                    Box::new(move |point_id| !vector_storage.borrow().is_deleted_vector(point_id))
-                } else {
-                    Box::new(|_point_id| false)
-                }
-            }
-            Condition::Nested(nested) => {
-                // Select indexes for nested fields. Trim nested part from key, so
-                // that nested condition can address fields without nested part.
-
-                // Example:
-                // Index for field `nested.field` will be stored under key `nested.field`
-                // And we have a query:
-                // {
-                //   "nested": {
-                //     "path": "nested",
-                //     "filter": {
-                //         ...
-                //         "match": {"key": "field", "value": "value"}
-                //     }
-                //   }
-
-                // In this case we want to use `nested.field`, but we only have `field` in query.
-                // Therefore we need to trim `nested` part from key. So that query executor
-                // can address proper index for nested field.
-                let nested_path = nested.array_key();
-
-                let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
-
-                let hw = hw_counter.fork();
-                Box::new(move |point_id| {
-                    payload_provider.with_payload(
-                        point_id,
-                        |payload| {
-                            let field_values = payload.get_value(&nested_path);
-
-                            for value in field_values {
-                                if let Value::Object(object) = value {
-                                    let get_payload = || OwnedPayloadRef::from(object);
-                                    if check_payload(
-                                        Box::new(get_payload),
-                                        // None because has_id in nested is not supported. So retrieving
-                                        // IDs through the tracker would always return None.
-                                        None,
-                                        // Same as above, nested conditions don't support has_vector.
-                                        &HashMap::new(),
-                                        &nested.nested.filter,
-                                        point_id,
-                                        &nested_indexes,
-                                        &hw,
-                                    ) {
-                                        // If at least one nested object matches, return true
-                                        return true;
-                                    }
-                                }
-                            }
-                            false
-                        },
-                        &hw,
-                    )
-                })
-            }
-            Condition::CustomIdChecker(cond) => {
-                let segment_ids: AHashSet<_> = id_tracker
-                    .point_mappings()
-                    .iter_external()
-                    .filter(|&point_id| cond.0.check(point_id))
-                    .filter_map(|external_id| id_tracker.internal_id(external_id))
-                    .collect();
-
-                Box::new(move |internal_id| segment_ids.contains(&internal_id))
-            }
-            Condition::Filter(_) => unreachable!(),
-        }
-    }
-}
 
 pub fn field_condition_index<'a>(
     index: &'a FieldIndex,
@@ -402,7 +214,9 @@ pub fn get_datetime_range_checkers(
     }
 }
 
-fn get_is_empty_indexes(indexes: &[FieldIndex]) -> (Option<&NullIndex>, Option<&FieldIndex>) {
+pub(in crate::index) fn get_is_empty_indexes(
+    indexes: &[FieldIndex],
+) -> (Option<&NullIndex>, Option<&FieldIndex>) {
     let mut primary_null_index: Option<&NullIndex> = None;
     let mut fallback_index: Option<&FieldIndex> = None;
 
@@ -420,14 +234,14 @@ fn get_is_empty_indexes(indexes: &[FieldIndex]) -> (Option<&NullIndex>, Option<&
     (primary_null_index, fallback_index)
 }
 
-fn get_null_index_is_empty_checker(
+pub(in crate::index) fn get_null_index_is_empty_checker(
     null_index: &NullIndex,
     is_empty: bool,
 ) -> ConditionCheckerFn<'_> {
     Box::new(move |point_id: PointOffsetType| null_index.values_is_empty(point_id) == is_empty)
 }
 
-fn get_fallback_is_empty_checker<'a>(
+pub(in crate::index) fn get_fallback_is_empty_checker<'a>(
     index: &'a FieldIndex,
     is_empty: bool,
     fallback_checker: ConditionCheckerFn<'a>,
@@ -466,7 +280,10 @@ fn get_is_empty_checker(index: &FieldIndex, is_empty: bool) -> Option<ConditionC
     }
 }
 
-fn get_is_null_checker(index: &FieldIndex, is_null: bool) -> Option<ConditionCheckerFn<'_>> {
+pub(in crate::index) fn get_is_null_checker(
+    index: &FieldIndex,
+    is_null: bool,
+) -> Option<ConditionCheckerFn<'_>> {
     match index {
         FieldIndex::NullIndex(null_index) => Some(Box::new(move |point_id: PointOffsetType| {
             null_index.values_is_null(point_id) == is_null

--- a/lib/segment/src/index/query_optimization/mod.rs
+++ b/lib/segment/src/index/query_optimization/mod.rs
@@ -1,5 +1,4 @@
 pub mod condition_converter;
 pub mod optimized_filter;
-pub mod optimizer;
 pub mod payload_provider;
 pub mod rescore_formula;

--- a/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/mod.rs
@@ -1,5 +1,5 @@
 mod formula_scorer;
 pub mod parsed_formula;
-mod value_retriever;
+pub(crate) mod value_retriever;
 
 pub use formula_scorer::FormulaScorer;

--- a/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/value_retriever.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -7,45 +7,13 @@ use serde_json::{Number, Value};
 use crate::common::utils::MultiValue;
 use crate::index::field_index::FieldIndex;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
-use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::{DateTimePayloadType, PayloadContainer, UuidPayloadType};
 
 pub type VariableRetrieverFn<'a> = Box<dyn Fn(PointOffsetType) -> MultiValue<Value> + 'a>;
 
-impl StructPayloadIndex {
-    /// Prepares optimized functions to extract each of the variables, given a point id.
-    pub(crate) fn retrievers_map<'a, 'q>(
-        &'a self,
-        variables: HashSet<JsonPath>,
-        hw_counter: &'q HardwareCounterCell,
-    ) -> HashMap<JsonPath, VariableRetrieverFn<'q>>
-    where
-        'a: 'q,
-    {
-        let payload_provider = PayloadProvider::new(self.payload.clone());
-
-        // prepare extraction of the variables from field indices or payload.
-        let mut var_retrievers = HashMap::new();
-        for key in variables {
-            let payload_provider = payload_provider.clone();
-
-            let retriever = variable_retriever(
-                &self.field_indexes,
-                &key,
-                payload_provider.clone(),
-                hw_counter,
-            );
-
-            var_retrievers.insert(key, retriever);
-        }
-
-        var_retrievers
-    }
-}
-
-fn variable_retriever<'a, 'q, P: PayloadStorageRead + 'q>(
+pub(crate) fn variable_retriever<'a, 'q, P: PayloadStorageRead + 'q>(
     indices: &'a HashMap<JsonPath, Vec<FieldIndex>>,
     json_path: &JsonPath,
     payload_provider: PayloadProvider<P>,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -282,9 +282,11 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     ) -> OperationResult<CardinalityEstimation> {
         let vector_storage = self.vector_storage.borrow();
         let id_tracker = self.id_tracker.borrow();
-        let payload_index = self.payload_index.borrow();
         let available_vector_count = vector_storage.available_vector_count();
-        let query_point_cardinality = payload_index.estimate_cardinality(filter, hw_counter)?;
+        let query_point_cardinality = self
+            .payload_index
+            .borrow()
+            .with_view(|v| v.estimate_cardinality(filter, hw_counter))?;
         Ok(adjust_to_available_vectors(
             query_point_cardinality,
             available_vector_count,
@@ -321,17 +323,18 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let hw_counter = vector_query_context.hardware_counter();
         let mut results = match filter {
             Some(filter) => {
-                let payload_index = self.payload_index.borrow();
                 let filtered_points = match prefiltered_points {
                     // `prefiltered_points` always contains visible points only so we don't need additional filtering here.
                     Some(filtered_points) => filtered_points.iter().copied(),
                     None => {
-                        let filtered_points = payload_index.query_points(
-                            filter,
-                            &hw_counter,
-                            &is_stopped,
-                            vector_query_context.deferred_internal_id(),
-                        )?;
+                        let filtered_points = self.payload_index.borrow().with_view(|v| {
+                            v.query_points(
+                                filter,
+                                &hw_counter,
+                                &is_stopped,
+                                vector_query_context.deferred_internal_id(),
+                            )
+                        })?;
                         *prefiltered_points = Some(filtered_points);
                         prefiltered_points.as_ref().unwrap().iter().copied()
                     }
@@ -356,7 +359,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     ) -> OperationResult<Vec<ScoredPointOffset>> {
         let vector_storage = self.vector_storage.borrow();
         let id_tracker = self.id_tracker.borrow();
-        let payload_index = self.payload_index.borrow();
 
         let is_stopped = vector_query_context.is_stopped();
 
@@ -373,12 +375,14 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             // so no additional filtering is required in that case.
             Some(filtered_points) => filtered_points.iter(),
             None => {
-                let filtered_points = payload_index.query_points(
-                    filter,
-                    &hw_counter,
-                    &is_stopped,
-                    vector_query_context.deferred_internal_id(),
-                )?;
+                let filtered_points = self.payload_index.borrow().with_view(|v| {
+                    v.query_points(
+                        filter,
+                        &hw_counter,
+                        &is_stopped,
+                        vector_query_context.deferred_internal_id(),
+                    )
+                })?;
                 *prefiltered_points = Some(filtered_points);
                 prefiltered_points.as_ref().unwrap().iter()
             }
@@ -450,14 +454,13 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         );
 
         match filter {
-            Some(filter) => {
-                let payload_index = self.payload_index.borrow();
-                let filter_context = payload_index.filter_context(filter, &hw_counter)?;
+            Some(filter) => self.payload_index.borrow().with_view(|v| {
+                let filter_context = v.filter_context(filter, &hw_counter)?;
                 let matches_filter_condition = |idx: PointOffsetType| -> bool {
                     not_deleted_condition(idx) && filter_context.check(idx)
                 };
                 Ok(search_context.search(&matches_filter_condition))
-            }
+            }),
             None => Ok(search_context.search(&not_deleted_condition)),
         }
     }

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -1,7 +1,8 @@
 mod build;
-mod filtering;
 mod payload_index;
-mod payload_index_read;
+mod read_view;
+
+pub use read_view::StructPayloadIndexReadView;
 
 #[cfg(test)]
 mod tests;
@@ -349,5 +350,29 @@ impl StructPayloadIndex {
             }
         }
         Ok(())
+    }
+
+    /// Run a closure with a borrowed read-only view of this index.
+    ///
+    /// The view borrows `id_tracker` (and the payload `Arc`) for the
+    /// duration of the closure, collapsing the per-method
+    /// `AtomicRefCell::borrow()` cost into a single up-front borrow.
+    /// All `PayloadIndexRead` methods are available on the view.
+    pub fn with_view<R>(
+        &self,
+        f: impl FnOnce(
+            StructPayloadIndexReadView<'_, PayloadStorageEnum, IdTrackerEnum, VectorStorageEnum>,
+        ) -> R,
+    ) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let view = StructPayloadIndexReadView {
+            payload: &self.payload,
+            id_tracker: &*id_tracker,
+            vector_storages: &self.vector_storages,
+            field_indexes: &self.field_indexes,
+            config: &self.config,
+            visited_pool: &self.visited_pool,
+        };
+        f(view)
     }
 }

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -9,9 +9,9 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::FieldIndex;
 use crate::index::payload_config::PayloadFieldSchemaWithIndexType;
-use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
+use crate::index::{BuildIndexResult, PayloadIndex};
 use crate::json_path::JsonPath;
-use crate::payload_storage::PayloadStorage;
+use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
 use crate::types::{
     Payload, PayloadContainer, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
 };
@@ -165,7 +165,10 @@ impl PayloadIndex for StructPayloadIndex {
                 .set(point_id, payload, hw_counter)?;
         };
 
-        let updated_payload = self.get_payload(point_id, hw_counter)?;
+        // Re-read the payload after the write so field indexes see the merged
+        // value. Inlined `get_payload` to avoid going through `with_view` from
+        // a `&mut self` write path.
+        let updated_payload = self.payload.borrow().get(point_id, hw_counter)?;
         for (field, field_index) in &mut self.field_indexes {
             if !field.is_affected_by_value_set(&payload.0, key.as_ref()) {
                 continue;

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+
+use ahash::AHashSet;
+use common::counter::hardware_counter::HardwareCounterCell;
+use serde_json::Value;
+
+use super::StructPayloadIndexReadView;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::query_optimization::condition_converter::{
+    field_condition_index, get_fallback_is_empty_checker, get_is_empty_indexes,
+    get_is_null_checker, get_null_index_is_empty_checker,
+};
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::payload_provider::PayloadProvider;
+use crate::payload_storage::PayloadStorageRead;
+use crate::payload_storage::query_checker::{
+    check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
+    select_nested_indexes,
+};
+use crate::types::{Condition, OwnedPayloadRef, PayloadContainer};
+use crate::vector_storage::VectorStorageRead;
+
+impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
+    pub fn condition_converter<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        condition: &'b Condition,
+        payload_provider: PayloadProvider<S>,
+        hw_counter: &HardwareCounterCell,
+    ) -> ConditionCheckerFn<'b> {
+        let id_tracker = self.id_tracker;
+        let field_indexes = self.field_indexes;
+        match condition {
+            Condition::Field(field_condition) => field_indexes
+                .get(&field_condition.key)
+                .and_then(|indexes| {
+                    indexes.iter().find_map(move |index| {
+                        let hw_acc = hw_counter.new_accumulator();
+                        field_condition_index(index, field_condition, hw_acc)
+                    })
+                })
+                .unwrap_or_else(|| {
+                    let hw = hw_counter.fork();
+                    Box::new(move |point_id| {
+                        payload_provider.with_payload(
+                            point_id,
+                            |payload| {
+                                check_field_condition(field_condition, &payload, field_indexes, &hw)
+                                    .unwrap(/* TODO(uio): handle errors */)
+                            },
+                            &hw,
+                        )
+                    })
+                }),
+            // Use dedicated null index for `is_empty` check if it is available
+            // Otherwise we might use another index just to check if a field is not empty, if we
+            // don't have an indexed value we must still check the payload to see if its empty
+            Condition::IsEmpty(is_empty) => {
+                let field_indexes = field_indexes.get(&is_empty.is_empty.key);
+
+                let (primary_null_index, fallback_index) = field_indexes
+                    .map(|field_indexes| get_is_empty_indexes(field_indexes))
+                    .unwrap_or((None, None));
+
+                if let Some(null_index) = primary_null_index {
+                    get_null_index_is_empty_checker(null_index, true)
+                } else {
+                    // Fallback to reading payload, in case we don't yet have null-index
+                    let hw = hw_counter.fork();
+                    let fallback = Box::new(move |point_id| {
+                        payload_provider.with_payload(
+                            point_id,
+                            |payload| check_is_empty_condition(is_empty, &payload),
+                            &hw,
+                        )
+                    });
+
+                    if let Some(fallback_index) = fallback_index {
+                        get_fallback_is_empty_checker(fallback_index, true, fallback)
+                    } else {
+                        fallback
+                    }
+                }
+            }
+
+            Condition::IsNull(is_null) => {
+                let field_indexes = field_indexes.get(&is_null.is_null.key);
+
+                let is_null_checker = field_indexes.and_then(|field_indexes| {
+                    field_indexes
+                        .iter()
+                        .find_map(|index| get_is_null_checker(index, true))
+                });
+
+                if let Some(checker) = is_null_checker {
+                    checker
+                } else {
+                    // Fallback to reading payload
+                    let hw = hw_counter.fork();
+                    Box::new(move |point_id| {
+                        payload_provider.with_payload(
+                            point_id,
+                            |payload| check_is_null_condition(is_null, &payload),
+                            &hw,
+                        )
+                    })
+                }
+            }
+            // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
+            Condition::HasId(has_id) => {
+                let segment_ids: AHashSet<_> = has_id
+                    .has_id
+                    .iter()
+                    .filter_map(|external_id| id_tracker.internal_id(*external_id))
+                    .collect();
+                Box::new(move |point_id| segment_ids.contains(&point_id))
+            }
+            Condition::HasVector(has_vector) => {
+                if let Some(vector_storage) =
+                    self.vector_storages.get(&has_vector.has_vector).cloned()
+                {
+                    Box::new(move |point_id| !vector_storage.borrow().is_deleted_vector(point_id))
+                } else {
+                    Box::new(|_point_id| false)
+                }
+            }
+            Condition::Nested(nested) => {
+                // Select indexes for nested fields. Trim nested part from key, so
+                // that nested condition can address fields without nested part.
+
+                // Example:
+                // Index for field `nested.field` will be stored under key `nested.field`
+                // And we have a query:
+                // {
+                //   "nested": {
+                //     "path": "nested",
+                //     "filter": {
+                //         ...
+                //         "match": {"key": "field", "value": "value"}
+                //     }
+                //   }
+
+                // In this case we want to use `nested.field`, but we only have `field` in query.
+                // Therefore we need to trim `nested` part from key. So that query executor
+                // can address proper index for nested field.
+                let nested_path = nested.array_key();
+
+                let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
+
+                let hw = hw_counter.fork();
+                Box::new(move |point_id| {
+                    payload_provider.with_payload(
+                        point_id,
+                        |payload| {
+                            let field_values = payload.get_value(&nested_path);
+
+                            for value in field_values {
+                                if let Value::Object(object) = value {
+                                    let get_payload = || OwnedPayloadRef::from(object);
+                                    if check_payload(
+                                        Box::new(get_payload),
+                                        // None because has_id in nested is not supported. So retrieving
+                                        // IDs through the tracker would always return None.
+                                        None,
+                                        // Same as above, nested conditions don't support has_vector.
+                                        &HashMap::new(),
+                                        &nested.nested.filter,
+                                        point_id,
+                                        &nested_indexes,
+                                        &hw,
+                                    ) {
+                                        // If at least one nested object matches, return true
+                                        return true;
+                                    }
+                                }
+                            }
+                            false
+                        },
+                        &hw,
+                    )
+                })
+            }
+            Condition::CustomIdChecker(cond) => {
+                let segment_ids: AHashSet<_> = id_tracker
+                    .point_mappings()
+                    .iter_external()
+                    .filter(|&point_id| cond.0.check(point_id))
+                    .filter_map(|external_id| id_tracker.internal_id(external_id))
+                    .collect();
+
+                Box::new(move |internal_id| segment_ids.contains(&internal_id))
+            }
+            Condition::Filter(_) => unreachable!(),
+        }
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
-use super::StructPayloadIndex;
+use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
@@ -9,10 +9,16 @@ use crate::index::field_index::{CardinalityEstimation, PrimaryCondition, Resolve
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::json_path::JsonPath;
+use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition};
 use crate::vector_storage::VectorStorageRead;
 
-impl StructPayloadIndex {
+impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
     pub fn estimate_field_condition(
         &self,
         condition: &FieldCondition,
@@ -38,11 +44,11 @@ impl StructPayloadIndex {
             .transpose()
     }
 
-    pub(super) fn query_field<'a>(
-        &'a self,
-        condition: &'a PrimaryCondition,
-        hw_counter: &'a HardwareCounterCell,
-    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+    pub(super) fn query_field<'q>(
+        &'q self,
+        condition: &'q PrimaryCondition,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'q>>> {
         match condition {
             PrimaryCondition::Condition(field_condition) => {
                 let Some(field_indexes) = self.field_indexes.get(&field_condition.key) else {
@@ -62,11 +68,11 @@ impl StructPayloadIndex {
         }
     }
 
-    pub fn struct_filtered_context<'a>(
-        &'a self,
-        filter: &'a Filter,
+    pub fn struct_filtered_context<'q>(
+        &'q self,
+        filter: &'q Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<StructFilterContext<'a>> {
+    ) -> OperationResult<StructFilterContext<'q>> {
         let payload_provider = PayloadProvider::new(self.payload.clone());
 
         let (optimized_filter, _) = self.optimize_filter(
@@ -108,10 +114,9 @@ impl StructPayloadIndex {
             }
             Condition::HasId(has_id) => {
                 let point_ids = has_id.has_id.clone();
-                let id_tracker = self.id_tracker.borrow();
                 let resolved_point_offsets: Vec<PointOffsetType> = point_ids
                     .iter()
-                    .filter_map(|external_id| id_tracker.internal_id(*external_id))
+                    .filter_map(|external_id| self.id_tracker.internal_id(*external_id))
                     .collect();
                 let num_ids = resolved_point_offsets.len();
                 CardinalityEstimation {
@@ -139,9 +144,9 @@ impl StructPayloadIndex {
                 .estimate_field_condition(field_condition, nested_path, hw_counter)?
                 .unwrap_or_else(|| CardinalityEstimation::unknown(self.available_point_count())),
 
-            Condition::CustomIdChecker(cond) => cond
-                .0
-                .estimate_cardinality(self.id_tracker.borrow().available_point_count()),
+            Condition::CustomIdChecker(cond) => {
+                cond.0.estimate_cardinality(self.available_point_count())
+            }
         })
     }
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -1,0 +1,63 @@
+mod condition_converter;
+mod filtering;
+mod optimizer;
+mod payload_index_read;
+mod value_retriever;
+
+#[cfg(test)]
+#[cfg(feature = "testing")]
+mod tests;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+
+use crate::common::utils::IndexesMap;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::payload_config::PayloadConfig;
+use crate::index::visited_pool::VisitedPool;
+use crate::payload_storage::PayloadStorageRead;
+use crate::types::VectorNameBuf;
+use crate::vector_storage::VectorStorageRead;
+
+/// Read-only view over a [`StructPayloadIndex`].
+///
+/// Constructed via [`StructPayloadIndex::with_view`]. Implements
+/// [`PayloadIndexRead`] for any payload storage / id tracker /
+/// vector storage that implement the corresponding read traits, so
+/// it can also be built directly over read-only backends without
+/// going through the writable [`StructPayloadIndex`].
+///
+/// Holds exactly the fields that `PayloadIndexRead` needs and no
+/// more. Build-side helpers (`build_field_indexes`, the selector
+/// machinery, `path`, `is_appendable`) stay on `StructPayloadIndex`.
+///
+/// [`StructPayloadIndex`]: crate::index::struct_payload_index::StructPayloadIndex
+/// [`StructPayloadIndex::with_view`]: crate::index::struct_payload_index::StructPayloadIndex::with_view
+/// [`PayloadIndexRead`]: crate::index::PayloadIndexRead
+pub struct StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
+    pub(crate) payload: &'a Arc<AtomicRefCell<P>>,
+    pub(crate) id_tracker: &'a I,
+    pub(crate) vector_storages: &'a HashMap<VectorNameBuf, Arc<AtomicRefCell<V>>>,
+    pub(crate) field_indexes: &'a IndexesMap,
+    pub(crate) config: &'a PayloadConfig,
+    pub(crate) visited_pool: &'a VisitedPool,
+}
+
+impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
+    /// Number of available points -- excludes soft-deleted points.
+    pub fn available_point_count(&self) -> usize {
+        self.id_tracker.available_point_count()
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -3,7 +3,9 @@ use std::cmp::Reverse;
 use common::counter::hardware_counter::HardwareCounterCell;
 use itertools::Itertools;
 
+use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
+use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::query_estimator::{
     combine_min_should_estimations, combine_must_estimations, combine_should_estimations,
@@ -13,11 +15,16 @@ use crate::index::query_optimization::optimized_filter::{
     OptimizedCondition, OptimizedFilter, OptimizedMinShould,
 };
 use crate::index::query_optimization::payload_provider::PayloadProvider;
-use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, Filter, MinShould};
+use crate::vector_storage::VectorStorageRead;
 
-impl StructPayloadIndex {
+impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
     /// Converts user-provided filtering condition into optimized representation
     ///
     /// Optimizations:
@@ -37,13 +44,13 @@ impl StructPayloadIndex {
     /// # Result
     ///
     /// Optimized query + Cardinality estimation
-    pub fn optimize_filter<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        filter: &'a Filter,
-        payload_provider: PayloadProvider<P>,
+    pub fn optimize_filter<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        filter: &'b Filter,
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(OptimizedFilter<'a>, CardinalityEstimation)> {
+    ) -> OperationResult<(OptimizedFilter<'b>, CardinalityEstimation)> {
         let mut filter_estimations: Vec<CardinalityEstimation> = vec![];
 
         let optimized_filter = OptimizedFilter {
@@ -106,13 +113,13 @@ impl StructPayloadIndex {
         ))
     }
 
-    pub fn convert_conditions<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        conditions: &'a [Condition],
-        payload_provider: PayloadProvider<P>,
+    pub fn convert_conditions<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        conditions: &'b [Condition],
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Vec<(OptimizedCondition<'a>, CardinalityEstimation)>> {
+    ) -> OperationResult<Vec<(OptimizedCondition<'b>, CardinalityEstimation)>> {
         conditions
             .iter()
             .map(|condition| match condition {
@@ -131,13 +138,13 @@ impl StructPayloadIndex {
             .collect()
     }
 
-    fn optimize_should<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        conditions: &'a [Condition],
-        payload_provider: PayloadProvider<P>,
+    fn optimize_should<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        conditions: &'b [Condition],
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
         let mut converted =
             self.convert_conditions(conditions, payload_provider, total, hw_counter)?;
         // More probable conditions first
@@ -147,14 +154,14 @@ impl StructPayloadIndex {
         Ok((conditions, combine_should_estimations(&estimations, total)))
     }
 
-    fn optimize_min_should<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        conditions: &'a [Condition],
+    fn optimize_min_should<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        conditions: &'b [Condition],
         min_count: usize,
-        payload_provider: PayloadProvider<P>,
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
         let mut converted =
             self.convert_conditions(conditions, payload_provider, total, hw_counter)?;
         // More probable conditions first if min_count < number of conditions
@@ -172,13 +179,13 @@ impl StructPayloadIndex {
         ))
     }
 
-    fn optimize_must<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        conditions: &'a [Condition],
-        payload_provider: PayloadProvider<P>,
+    fn optimize_must<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        conditions: &'b [Condition],
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
         let mut converted =
             self.convert_conditions(conditions, payload_provider, total, hw_counter)?;
         // Less probable conditions first
@@ -188,13 +195,13 @@ impl StructPayloadIndex {
         Ok((conditions, combine_must_estimations(&estimations, total)))
     }
 
-    fn optimize_must_not<'a, P: PayloadStorageRead + 'a>(
-        &'a self,
-        conditions: &'a [Condition],
-        payload_provider: PayloadProvider<P>,
+    fn optimize_must_not<'b, S: PayloadStorageRead + 'b>(
+        &'b self,
+        conditions: &'b [Condition],
+        payload_provider: PayloadProvider<S>,
         total: usize,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'a>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
         let mut converted =
             self.convert_conditions(conditions, payload_provider, total, hw_counter)?;
         // More probable conditions first, as it will be reverted

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -8,7 +8,7 @@ use common::either_variant::EitherVariant;
 use common::iterator_ext::IteratorExt;
 use common::types::{PointOffsetType, ScoreType};
 
-use super::StructPayloadIndex;
+use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::index::PayloadIndexRead;
@@ -24,10 +24,16 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
 };
+use crate::vector_storage::VectorStorageRead;
 
-impl PayloadIndexRead for StructPayloadIndex {
+impl<'a, P, I, V> PayloadIndexRead for StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
     fn indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
-        self.config().indices.to_schemas()
+        self.config.indices.to_schemas()
     }
 
     fn estimate_cardinality(
@@ -63,12 +69,11 @@ impl PayloadIndexRead for StructPayloadIndex {
     ) -> OperationResult<Vec<PointOffsetType>> {
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
         let query_cardinality = self.estimate_cardinality(filter, hw_counter)?;
-        let id_tracker = self.id_tracker.borrow();
-        let point_mappings = id_tracker.point_mappings();
+        let point_mappings = self.id_tracker.point_mappings();
         let result = self
             .iter_filtered_points(
                 filter,
-                &*id_tracker,
+                self.id_tracker,
                 &point_mappings,
                 &query_cardinality,
                 hw_counter,
@@ -135,16 +140,16 @@ impl PayloadIndexRead for StructPayloadIndex {
         ))
     }
 
-    fn iter_filtered_points<'a, I: IdTrackerRead>(
-        &'a self,
-        filter: &'a Filter,
-        id_tracker: &'a I,
-        point_mappings: &'a PointMappingsRefEnum<'a>,
-        query_cardinality: &'a CardinalityEstimation,
-        hw_counter: &'a HardwareCounterCell,
-        is_stopped: &'a AtomicBool,
+    fn iter_filtered_points<'b, IT: IdTrackerRead>(
+        &'b self,
+        filter: &'b Filter,
+        id_tracker: &'b IT,
+        point_mappings: &'b PointMappingsRefEnum<'b>,
+        query_cardinality: &'b CardinalityEstimation,
+        hw_counter: &'b HardwareCounterCell,
+        is_stopped: &'b AtomicBool,
         deferred_internal_id: Option<PointOffsetType>,
-    ) -> OperationResult<impl Iterator<Item = PointOffsetType> + 'a> {
+    ) -> OperationResult<impl Iterator<Item = PointOffsetType> + 'b> {
         if query_cardinality.primary_clauses.is_empty() {
             let full_scan_iterator = point_mappings.iter_internal_visible(deferred_internal_id);
 
@@ -232,11 +237,11 @@ impl PayloadIndexRead for StructPayloadIndex {
         })
     }
 
-    fn filter_context<'a>(
-        &'a self,
-        filter: &'a Filter,
+    fn filter_context<'b>(
+        &'b self,
+        filter: &'b Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn FilterContext + 'a>> {
+    ) -> OperationResult<Box<dyn FilterContext + 'b>> {
         Ok(Box::new(self.struct_filtered_context(filter, hw_counter)?))
     }
 

--- a/lib/segment/src/index/struct_payload_index/read_view/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/tests.rs
@@ -1,0 +1,64 @@
+//! Smoke tests that construct `StructPayloadIndexReadView` directly,
+//! without going through `StructPayloadIndex::with_view`.
+//!
+//! Proves the view is genuinely decoupled from the writable index --
+//! exactly the property that PR 4 needs to wire a read-only segment
+//! through the view.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
+
+use crate::common::utils::IndexesMap;
+use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
+use crate::index::PayloadIndexRead;
+use crate::index::payload_config::PayloadConfig;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::index::visited_pool::VisitedPool;
+use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
+use crate::types::{Filter, VectorNameBuf};
+use crate::vector_storage::VectorStorageEnum;
+
+/// Build a view directly over in-memory backends and exercise the
+/// `PayloadIndexRead` surface. No `StructPayloadIndex` involved.
+#[test]
+fn smoke_view_over_in_memory_backends() {
+    let payload: Arc<AtomicRefCell<InMemoryPayloadStorage>> =
+        Arc::new(AtomicRefCell::new(InMemoryPayloadStorage::default()));
+    let id_tracker = InMemoryIdTracker::new();
+    let vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>> =
+        HashMap::new();
+    let field_indexes = IndexesMap::new();
+    let config = PayloadConfig::default();
+    let visited_pool = VisitedPool::new();
+
+    let view: StructPayloadIndexReadView<'_, _, _, VectorStorageEnum> =
+        StructPayloadIndexReadView {
+            payload: &payload,
+            id_tracker: &id_tracker,
+            vector_storages: &vector_storages,
+            field_indexes: &field_indexes,
+            config: &config,
+            visited_pool: &visited_pool,
+        };
+
+    let hw_counter = HardwareCounterCell::new();
+    let is_stopped = AtomicBool::new(false);
+
+    // `indexed_fields` reads from `config.indices`.
+    let indexed = view.indexed_fields();
+    assert!(indexed.is_empty(), "no indexed fields configured");
+
+    // `query_points` over an empty filter on an empty tracker returns nothing.
+    let empty_filter = Filter::default();
+    let result = view
+        .query_points(&empty_filter, &hw_counter, &is_stopped, None)
+        .expect("query_points");
+    assert!(result.is_empty(), "no points in tracker");
+
+    // `available_point_count` (inherent helper) reflects the empty tracker.
+    assert_eq!(view.available_point_count(), 0);
+}

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever.rs
@@ -1,0 +1,49 @@
+use std::collections::{HashMap, HashSet};
+
+use common::counter::hardware_counter::HardwareCounterCell;
+
+use super::StructPayloadIndexReadView;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::query_optimization::payload_provider::PayloadProvider;
+use crate::index::query_optimization::rescore_formula::value_retriever::{
+    VariableRetrieverFn, variable_retriever,
+};
+use crate::json_path::JsonPath;
+use crate::payload_storage::PayloadStorageRead;
+use crate::vector_storage::VectorStorageRead;
+
+impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+where
+    P: PayloadStorageRead,
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+{
+    /// Prepares optimized functions to extract each of the variables, given a point id.
+    pub(crate) fn retrievers_map<'b, 'q>(
+        &'b self,
+        variables: HashSet<JsonPath>,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> HashMap<JsonPath, VariableRetrieverFn<'q>>
+    where
+        'b: 'q,
+    {
+        let payload_provider = PayloadProvider::new(self.payload.clone());
+
+        // prepare extraction of the variables from field indices or payload.
+        let mut var_retrievers = HashMap::new();
+        for key in variables {
+            let payload_provider = payload_provider.clone();
+
+            let retriever = variable_retriever(
+                self.field_indexes,
+                &key,
+                payload_provider.clone(),
+                hw_counter,
+            );
+
+            var_retrievers.insert(key, retriever);
+        }
+
+        var_retrievers
+    }
+}

--- a/lib/segment/src/segment/as_view.rs
+++ b/lib/segment/src/segment/as_view.rs
@@ -9,16 +9,22 @@ impl Segment {
         let payload_index = self.payload_index.borrow();
         let payload_storage = self.payload_storage.borrow();
 
-        let view = SegmentReadViewFor {
-            id_tracker: id_tracker.deref(),
-            payload_index: payload_index.deref(),
-            payload_storage: payload_storage.deref(),
-            vector_data: &self.vector_data,
-            segment_config: &self.segment_config,
-            deferred_point_status: self.deferred_point_status.as_ref(),
-            appendable_flag: self.appendable_flag,
-        };
+        // Nest the payload-index view inside the segment view so reads on
+        // the segment view go through `StructPayloadIndexReadView`'s
+        // `PayloadIndexRead` impl. The inner `with_view` borrows the index's
+        // `id_tracker` cell once for the closure scope.
+        payload_index.with_view(|payload_index_view| {
+            let view = SegmentReadViewFor {
+                id_tracker: id_tracker.deref(),
+                payload_index: &payload_index_view,
+                payload_storage: payload_storage.deref(),
+                vector_data: &self.vector_data,
+                segment_config: &self.segment_config,
+                deferred_point_status: self.deferred_point_status.as_ref(),
+                appendable_flag: self.appendable_flag,
+            };
 
-        f(view)
+            f(view)
+        })
     }
 }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -264,7 +264,9 @@ impl ReadSegmentEntry for Segment {
         self.appendable_flag
     }
     fn get_indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
-        self.payload_index.borrow().indexed_fields()
+        self.payload_index
+            .borrow()
+            .with_view(|v| v.indexed_fields())
     }
 
     fn vector_names(&self) -> HashSet<VectorNameBuf> {

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -14,12 +14,13 @@ use std::collections::HashMap;
 
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::PayloadIndexRead;
-use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::segment::vector_data_read::VectorDataRead;
 use crate::segment::{DeferredPointStatus, VectorData};
 use crate::types::{PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
+use crate::vector_storage::VectorStorageEnum;
 
 /// This structure serves as a generic representation of data
 /// necessary for all read operations on a segment.
@@ -46,8 +47,13 @@ where
 /// Concrete `SegmentReadView` instantiation that wraps a regular [`Segment`].
 ///
 /// [`Segment`]: crate::segment::Segment
-pub type SegmentReadViewFor<'s> =
-    SegmentReadView<'s, IdTrackerEnum, StructPayloadIndex, PayloadStorageEnum, VectorData>;
+pub type SegmentReadViewFor<'s> = SegmentReadView<
+    's,
+    IdTrackerEnum,
+    StructPayloadIndexReadView<'s, PayloadStorageEnum, IdTrackerEnum, VectorStorageEnum>,
+    PayloadStorageEnum,
+    VectorData,
+>;
 
 #[allow(unused, dead_code)]
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -446,7 +446,10 @@ impl Segment {
         &mut self,
         desired_schemas: &HashMap<PayloadKeyType, PayloadFieldSchema>,
     ) -> OperationResult<()> {
-        let schema_applied = self.payload_index.borrow().indexed_fields();
+        let schema_applied = self
+            .payload_index
+            .borrow()
+            .with_view(|v| v.indexed_fields());
         let schema_config = desired_schemas;
 
         // Create or update payload indices if they don't match configuration

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -375,7 +375,7 @@ impl SegmentBuilder {
             let old_internal_id = point_data.internal_id;
 
             let other_payload = payloads[point_data.segment_index.get() as usize]
-                .get_payload_sequential(old_internal_id, &hw_counter)?; // Internal operation, no measurement needed!
+                .with_view(|v| v.get_payload_sequential(old_internal_id, &hw_counter))?; // Internal operation, no measurement needed!
 
             match self
                 .id_tracker
@@ -436,7 +436,7 @@ impl SegmentBuilder {
         }
 
         for payload in payloads {
-            for (field, payload_schema) in payload.indexed_fields() {
+            for (field, payload_schema) in payload.with_view(|v| v.indexed_fields()) {
                 self.indexed_fields.insert(field, payload_schema);
             }
         }

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -94,9 +94,11 @@ fn exact_search_test() {
     let borrowed_payload_index = payload_index_ptr.borrow();
     let mut blocks = Vec::new();
     borrowed_payload_index
-        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
-            blocks.push(block);
-            Ok(())
+        .with_view(|v| {
+            v.for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
         })
         .unwrap();
     for block in &blocks {
@@ -111,7 +113,7 @@ fn exact_search_test() {
         let px = payload_index_ptr.borrow();
         let filter = Filter::new_must(Condition::Field(block.condition.clone()));
         let points = px
-            .query_points(&filter, &hw_counter, &is_stopped, None)
+            .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
             .unwrap();
         for point in points {
             coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);

--- a/lib/segment/tests/integration/filtering_context_check.rs
+++ b/lib/segment/tests/integration/filtering_context_check.rs
@@ -28,14 +28,16 @@ fn test_filtering_context_consistency() {
         let filter = random_filter(&mut rng, 3);
 
         let plain_filter_context = plain_index.filter_context(&filter, &hw_counter).unwrap();
-        let struct_filter_context = struct_index.filter_context(&filter, &hw_counter).unwrap();
-
         let plain_result = (0..NUM_POINTS)
             .filter(|point_id| plain_filter_context.check(*point_id as PointOffsetType))
             .collect_vec();
-        let struct_result = (0..NUM_POINTS)
-            .filter(|point_id| struct_filter_context.check(*point_id as PointOffsetType))
-            .collect_vec();
+
+        let struct_result = struct_index.with_view(|v| {
+            let struct_filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+            (0..NUM_POINTS)
+                .filter(|point_id| struct_filter_context.check(*point_id as PointOffsetType))
+                .collect_vec()
+        });
         assert_eq!(plain_result, struct_result, "filter: {filter:#?}");
     }
 }

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -117,9 +117,11 @@ fn _test_filterable_hnsw(
     let borrowed_payload_index = payload_index_ptr.borrow();
     let mut blocks = Vec::new();
     borrowed_payload_index
-        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
-            blocks.push(block);
-            Ok(())
+        .with_view(|v| {
+            v.for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
         })
         .unwrap();
     for block in &blocks {
@@ -134,7 +136,7 @@ fn _test_filterable_hnsw(
     for block in &blocks {
         let filter = Filter::new_must(Condition::Field(block.condition.clone()));
         let points = px
-            .query_points(&filter, &hw_counter, &stopped, None)
+            .with_view(|v| v.query_points(&filter, &hw_counter, &stopped, None))
             .unwrap();
         for point in points {
             coverage.insert(point, coverage.get(&point).unwrap_or(&0) + 1);
@@ -307,9 +309,11 @@ fn test_hnsw_search_top_zero(#[case] num_vectors: u64, #[case] full_scan_thresho
     let borrowed_payload_index = payload_index_ptr.borrow();
     let mut blocks = Vec::new();
     borrowed_payload_index
-        .for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
-            blocks.push(block);
-            Ok(())
+        .with_view(|v| {
+            v.for_each_payload_block(&JsonPath::new(int_key), indexing_threshold, &mut |block| {
+                blocks.push(block);
+                Ok(())
+            })
         })
         .unwrap();
     for block in &blocks {

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -144,15 +144,16 @@ fn test_filtering_context_consistency() {
         );
 
         let nested_filter_0 = Filter::new_must(nested_condition_0);
-        let res0 = index
-            .query_points(&nested_filter_0, &hw_counter, &is_stopped, None)
-            .unwrap();
-
-        let filter_context = index.filter_context(&nested_filter_0, &hw_counter).unwrap();
-
-        let check_res0: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-            .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
-            .collect();
+        let (res0, check_res0) = index.with_view(|v| {
+            let res0 = v
+                .query_points(&nested_filter_0, &hw_counter, &is_stopped, None)
+                .unwrap();
+            let filter_context = v.filter_context(&nested_filter_0, &hw_counter).unwrap();
+            let check_res0: Vec<_> = (0..NUM_POINTS as PointOffsetType)
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .collect();
+            (res0, check_res0)
+        });
 
         assert_eq!(res0, check_res0);
         assert!(!res0.is_empty());
@@ -184,15 +185,16 @@ fn test_filtering_context_consistency() {
 
         let nested_filter_1 = Filter::new_must(nested_condition_1);
 
-        let res1 = index
-            .query_points(&nested_filter_1, &hw_counter, &is_stopped, None)
-            .unwrap();
-
-        let filter_context = index.filter_context(&nested_filter_1, &hw_counter).unwrap();
-
-        let check_res1: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-            .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
-            .collect();
+        let (res1, check_res1) = index.with_view(|v| {
+            let res1 = v
+                .query_points(&nested_filter_1, &hw_counter, &is_stopped, None)
+                .unwrap();
+            let filter_context = v.filter_context(&nested_filter_1, &hw_counter).unwrap();
+            let check_res1: Vec<_> = (0..NUM_POINTS as PointOffsetType)
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .collect();
+            (res1, check_res1)
+        });
 
         assert_eq!(res1, check_res1);
 
@@ -221,15 +223,16 @@ fn test_filtering_context_consistency() {
 
         let nested_filter_2 = Filter::new_must(nested_condition_2);
 
-        let res2 = index
-            .query_points(&nested_filter_2, &hw_counter, &is_stopped, None)
-            .unwrap();
-
-        let filter_context = index.filter_context(&nested_filter_2, &hw_counter).unwrap();
-
-        let check_res2: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-            .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
-            .collect();
+        let (res2, check_res2) = index.with_view(|v| {
+            let res2 = v
+                .query_points(&nested_filter_2, &hw_counter, &is_stopped, None)
+                .unwrap();
+            let filter_context = v.filter_context(&nested_filter_2, &hw_counter).unwrap();
+            let check_res2: Vec<_> = (0..NUM_POINTS as PointOffsetType)
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .collect();
+            (res2, check_res2)
+        });
 
         assert_eq!(res2, check_res2);
 
@@ -268,15 +271,16 @@ fn test_filtering_context_consistency() {
             must_not: None,
         };
 
-        let res3 = index
-            .query_points(&nested_filter_3, &hw_counter, &is_stopped, None)
-            .unwrap();
-
-        let filter_context = index.filter_context(&nested_filter_3, &hw_counter).unwrap();
-
-        let check_res3: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-            .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
-            .collect();
+        let (res3, check_res3) = index.with_view(|v| {
+            let res3 = v
+                .query_points(&nested_filter_3, &hw_counter, &is_stopped, None)
+                .unwrap();
+            let filter_context = v.filter_context(&nested_filter_3, &hw_counter).unwrap();
+            let check_res3: Vec<_> = (0..NUM_POINTS as PointOffsetType)
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .collect();
+            (res3, check_res3)
+        });
 
         assert_eq!(res3, check_res3);
         assert!(!res3.is_empty());

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -520,7 +520,7 @@ fn validate_geo_filter(test_segments: &TestSegments, query_filter: Filter) -> Re
             .plain_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&query_filter, &hw_counter)
+            .with_view(|v| v.estimate_cardinality(&query_filter, &hw_counter))
             .unwrap();
 
         ensure!(estimation.min <= estimation.exp, "{estimation:#?}");
@@ -552,7 +552,7 @@ fn validate_geo_filter(test_segments: &TestSegments, query_filter: Filter) -> Re
             .struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&query_filter, &hw_counter)
+            .with_view(|v| v.estimate_cardinality(&query_filter, &hw_counter))
             .unwrap();
 
         ensure!(estimation.min <= estimation.exp, "{estimation:#?}");
@@ -622,21 +622,21 @@ fn test_is_empty_conditions(test_segments: &TestSegments) -> Result<()> {
         .struct_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     let estimation_plain = test_segments
         .plain_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     let plain_result = test_segments
         .plain_segment
         .payload_index
         .borrow()
-        .query_points(&filter, &hw_counter, &is_stopped, None)
+        .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
         .unwrap();
 
     let real_number = plain_result.len();
@@ -646,7 +646,7 @@ fn test_is_empty_conditions(test_segments: &TestSegments) -> Result<()> {
         .struct_segment
         .payload_index
         .borrow()
-        .query_points(&filter, &hw_counter, &is_stopped, None)
+        .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped, None))
         .unwrap()
         .into_iter()
         // null index does not track deleted points, so we need to filter them out here. In callsites,
@@ -745,22 +745,24 @@ fn test_cardinality_estimation(test_segments: &TestSegments) -> Result<()> {
         .struct_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
     let payload_index = test_segments.struct_segment.payload_index.borrow();
-    let filter_context = payload_index.filter_context(&filter, &hw_counter).unwrap();
-    let exact = test_segments
-        .struct_segment
-        .id_tracker
-        .borrow()
-        .point_mappings()
-        .iter_internal()
-        .filter(|x| filter_context.check(*x))
-        .collect_vec()
-        .len();
+    let exact = payload_index.with_view(|v| {
+        let filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+        test_segments
+            .struct_segment
+            .id_tracker
+            .borrow()
+            .point_mappings()
+            .iter_internal()
+            .filter(|x| filter_context.check(*x))
+            .collect_vec()
+            .len()
+    });
 
     eprintln!("exact = {exact:#?}");
     eprintln!("estimation = {estimation:#?}");
@@ -792,7 +794,7 @@ fn test_root_nested_array_filter_cardinality_estimation() {
     let estimation = struct_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     // not empty primary clauses
@@ -807,7 +809,7 @@ fn test_root_nested_array_filter_cardinality_estimation() {
 
     match primary_clause {
         PrimaryCondition::Condition(field_condition) => {
-            assert_eq!(*field_condition, Box::new(expected_primary_clause));
+            assert_eq!(**field_condition, expected_primary_clause);
         }
         o => panic!("unexpected primary clause: {o:?}"),
     }
@@ -815,15 +817,17 @@ fn test_root_nested_array_filter_cardinality_estimation() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload_index = struct_segment.payload_index.borrow();
-    let filter_context = payload_index.filter_context(&filter, &hw_counter).unwrap();
-    let exact = struct_segment
-        .id_tracker
-        .borrow()
-        .point_mappings()
-        .iter_internal()
-        .filter(|x| filter_context.check(*x))
-        .collect_vec()
-        .len();
+    let exact = payload_index.with_view(|v| {
+        let filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+        struct_segment
+            .id_tracker
+            .borrow()
+            .point_mappings()
+            .iter_internal()
+            .filter(|x| filter_context.check(*x))
+            .collect_vec()
+            .len()
+    });
 
     eprintln!("exact = {exact:#?}");
     eprintln!("estimation = {estimation:#?}");
@@ -858,7 +862,7 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
     let estimation = struct_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     // not empty primary clauses
@@ -876,7 +880,7 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
 
     match primary_clause {
         PrimaryCondition::Condition(field_condition) => {
-            assert_eq!(*field_condition, Box::new(expected_primary_clause));
+            assert_eq!(**field_condition, expected_primary_clause);
         }
         o => panic!("unexpected primary clause: {o:?}"),
     }
@@ -884,15 +888,17 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload_index = struct_segment.payload_index.borrow();
-    let filter_context = payload_index.filter_context(&filter, &hw_counter).unwrap();
-    let exact = struct_segment
-        .id_tracker
-        .borrow()
-        .point_mappings()
-        .iter_internal()
-        .filter(|x| filter_context.check(*x))
-        .collect_vec()
-        .len();
+    let exact = payload_index.with_view(|v| {
+        let filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+        struct_segment
+            .id_tracker
+            .borrow()
+            .point_mappings()
+            .iter_internal()
+            .filter(|x| filter_context.check(*x))
+            .collect_vec()
+            .len()
+    });
 
     eprintln!("exact = {exact:#?}");
     eprintln!("estimation = {estimation:#?}");
@@ -952,7 +958,7 @@ fn test_struct_payload_index(test_segments: &TestSegments) -> Result<()> {
             .struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&query_filter, &hw_counter)
+            .with_view(|v| v.estimate_cardinality(&query_filter, &hw_counter))
             .unwrap();
 
         ensure!(estimation.min <= estimation.exp, "{estimation:#?}");
@@ -1156,7 +1162,7 @@ fn test_struct_payload_index_nested_fields() {
         let estimation = struct_segment
             .payload_index
             .borrow()
-            .estimate_cardinality(&query_filter, &hw_counter)
+            .with_view(|v| v.estimate_cardinality(&query_filter, &hw_counter))
             .unwrap();
 
         assert!(estimation.min <= estimation.exp, "{estimation:#?}");
@@ -1224,7 +1230,7 @@ fn test_update_payload_index_type() {
     // set field to Integer type
     index.set_indexed(&field, Integer, &hw_counter).unwrap();
     assert_eq!(
-        *index.indexed_fields().get(&field).unwrap(),
+        *index.with_view(|v| v.indexed_fields()).get(&field).unwrap(),
         FieldType(Integer)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
@@ -1234,7 +1240,7 @@ fn test_update_payload_index_type() {
     // update field to Keyword type
     index.set_indexed(&field, Keyword, &hw_counter).unwrap();
     assert_eq!(
-        *index.indexed_fields().get(&field).unwrap(),
+        *index.with_view(|v| v.indexed_fields()).get(&field).unwrap(),
         FieldType(Keyword)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
@@ -1243,7 +1249,7 @@ fn test_update_payload_index_type() {
     // set field to Integer type (again)
     index.set_indexed(&field, Integer, &hw_counter).unwrap();
     assert_eq!(
-        *index.indexed_fields().get(&field).unwrap(),
+        *index.with_view(|v| v.indexed_fields()).get(&field).unwrap(),
         FieldType(Integer)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
@@ -1410,7 +1416,7 @@ fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Resu
         .struct_segment
         .payload_index
         .borrow()
-        .estimate_cardinality(&filter, &hw_counter)
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
         .unwrap();
 
     ensure!(estimation.primary_clauses.len() == 1);
@@ -1419,7 +1425,7 @@ fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Resu
 
         match clause {
             PrimaryCondition::Condition(field_condition) => {
-                ensure!(*field_condition == Box::new(expected_primary_clause));
+                ensure!(**field_condition == expected_primary_clause);
             }
             o => panic!("unexpected primary clause: {o:?}"),
         }
@@ -1428,16 +1434,18 @@ fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Resu
     let hw_counter = HardwareCounterCell::new();
 
     let payload_index = test_segments.struct_segment.payload_index.borrow();
-    let filter_context = payload_index.filter_context(&filter, &hw_counter).unwrap();
-    let exact = test_segments
-        .struct_segment
-        .id_tracker
-        .borrow()
-        .point_mappings()
-        .iter_internal()
-        .filter(|x| filter_context.check(*x))
-        .collect_vec()
-        .len();
+    let exact = payload_index.with_view(|v| {
+        let filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+        test_segments
+            .struct_segment
+            .id_tracker
+            .borrow()
+            .point_mappings()
+            .iter_internal()
+            .filter(|x| filter_context.check(*x))
+            .collect_vec()
+            .len()
+    });
 
     eprintln!("exact = {exact:#?}");
     eprintln!("estimation = {estimation:#?}");

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -410,7 +410,7 @@ fn sparse_vector_index_ram_filtered_search() {
 
     // assert payload field index created and empty
     let payload_index = sparse_vector_index.payload_index().borrow();
-    let indexed_fields = payload_index.indexed_fields();
+    let indexed_fields = payload_index.with_view(|v| v.indexed_fields());
     assert_eq!(
         *indexed_fields.get(&JsonPath::new(field_name)).unwrap(),
         FieldType(Keyword)


### PR DESCRIPTION
## Summary

Introduces `StructPayloadIndexReadView<'a, P, I, V>` -- a borrowed read-only view over `StructPayloadIndex` generic over the payload storage, id tracker, and vector storage backends. All read-method bodies move from the owning struct onto the view, which becomes the sole `PayloadIndexRead` implementor for this index.

The owning struct exposes `with_view(|v| ...)` (mirrors `Segment::with_view`); consumers that previously called `payload_index.borrow().read_method(...)` now go through `payload_index.borrow().with_view(|v| v.read_method(...))`.

## Why

Read-only segments (PR 4 / future work) need to plug their own concrete read-only payload storage / id tracker / vector storage triple into the same search/filter/cardinality machinery the writable index uses. The view shape makes that possible without duplicating any read code.

## Design highlights

- **View struct holds exactly what `PayloadIndexRead` needs** -- nothing more. \`path\` and \`is_appendable\` are deliberately not on the view; build-side helpers stay on the writable struct.
- **\`P\` keeps the \`Arc\` shape (asymmetric vs \`I\` and \`V\`)** because \`PayloadProvider<P>::new(...)\` (PR #8968) takes \`Arc<AtomicRefCell<P>>\` so that returned \`FormulaScorer<'q>\` / \`Box<dyn FilterContext + 'a>\` can outlive the caller. \`I\` is held as \`&I\` so the cell is collapsed at the \`with_view\` boundary, saving a per-method atomic op.
- **Generic, not \`dyn\`, throughout** -- consistent with the codebase convention; \`dyn IdTrackerRead\` would not satisfy \`I: IdTrackerRead\` bounds in callees without an explicit blanket impl.
- **Cascade is bounded**: only files under \`struct_payload_index/read_view/\`, \`segment/read_view/\`, and the small set of HNSW/sparse/plain/segment_ops call sites are affected. \`StructPayloadIndex\`, \`Segment\`, and the vector-index types do **not** gain a generic parameter.

## Module layout

Read paths now live under \`lib/segment/src/index/struct_payload_index/read_view/\`:

| File | Contents |
|------|----------|
| \`mod.rs\` | View struct + module wiring |
| \`payload_index_read.rs\` | \`impl PayloadIndexRead for view\` |
| \`filtering.rs\` | \`struct_filtered_context\`, \`condition_cardinality\`, \`query_field\`, \`estimate_field_condition\` |
| \`condition_converter.rs\` | impl block from \`query_optimization/\` |
| \`optimizer.rs\` | impl block from \`query_optimization/\` |
| \`value_retriever.rs\` | impl block from \`query_optimization/\` |
| \`tests.rs\` | Smoke test that builds the view directly |

\`build_field_indexes\` and \`clear_index_for_point\` stay on \`StructPayloadIndex\` -- the former is read-shaped but only has write-side callers and pulls in the \`selector\` machinery, which would force \`path\` + \`is_appendable\` into the view if we moved it.

## Smoke test

\`read_view/tests.rs\` constructs a \`StructPayloadIndexReadView\` directly over \`InMemoryPayloadStorage\` + \`InMemoryIdTracker\` + an empty vector-storage map -- **no \`StructPayloadIndex\` involved** -- and exercises \`indexed_fields()\`, \`query_points()\`, and \`available_point_count()\`. Proves the view is genuinely decoupled.

## Stacking note

This PR is stacked on **#8969** (drop \`PayloadIndex: PayloadIndexRead\` super-trait). The base branch above is \`generall/payload-index-trait-split\`; once #8969 lands on \`dev\`, please rebase this onto \`dev\` and re-target.

## Test plan

- [x] \`cargo build --workspace --tests --benches\` -- green
- [x] \`cargo test -p segment --lib\` -- 666 passed (665 + 1 new smoke test), 0 failed
- [x] \`cargo test -p segment --tests\` -- 120 integration tests pass
- [x] \`cargo test -p storage --lib\` -- 44 passed
- [x] \`cargo test -p collection --lib\` -- 197 passed
- [x] \`cargo clippy -p segment --tests --benches\` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)