### PR TITLE
test: fix flaky test_cluster_metadata by polling for consensus

### DIFF
--- a/tests/consensus_tests/test_cluster_metadata.py
+++ b/tests/consensus_tests/test_cluster_metadata.py
@@ -1,10 +1,7 @@
 import pathlib
-from time import sleep
 from typing import Any
 
 from .utils import *
-
-CONSENSUS_WAIT_SECONDS = 0.5
 
 def test_cluster_metadata(tmp_path: pathlib.Path):
     assert_project_root()
@@ -38,26 +35,31 @@ def test_cluster_metadata(tmp_path: pathlib.Path):
     for key in ['string', 'array', 'object']:
         resp = requests.delete(f"{peer_api_uris[0]}/cluster/metadata/keys/{key}")
         assert_http_ok(resp)
-        sleep(CONSENSUS_WAIT_SECONDS)
         get_metadata_key(peer_api_uris, key, None)
 
     # Get (empty) metadata key list
     get_metadata_keys(peer_api_uris, [])
 
 def get_metadata_keys(peer_uris: list[str], keys: list[str]):
+    expected = set(keys)
     for peer_uri in peer_uris:
-        resp = requests.get(f"{peer_uri}/cluster/metadata/keys")
-        assert_http_ok(resp)
-        assert set(resp.json()['result']) == set(keys)
+        wait_for(_metadata_keys_match, peer_uri, expected)
+
+def _metadata_keys_match(peer_uri: str, expected: set) -> bool:
+    resp = requests.get(f"{peer_uri}/cluster/metadata/keys")
+    assert_http_ok(resp)
+    return set(resp.json()['result']) == expected
 
 def put_metadata_key(peer_uris: list[str], key: str, value: Any):
     resp = requests.put(f"{peer_uris[0]}/cluster/metadata/keys/{key}", json=value)
     assert_http_ok(resp)
-    sleep(CONSENSUS_WAIT_SECONDS)
     get_metadata_key(peer_uris, key, value)
 
 def get_metadata_key(peer_uris: list[str], key: str, expected_value: Any):
     for peer_uri in peer_uris:
-        resp = requests.get(f"{peer_uri}/cluster/metadata/keys/{key}")
-        assert_http_ok(resp)
-        assert resp.json()['result'] == expected_value
+        wait_for(_metadata_key_matches, peer_uri, key, expected_value)
+
+def _metadata_key_matches(peer_uri: str, key: str, expected_value: Any) -> bool:
+    resp = requests.get(f"{peer_uri}/cluster/metadata/keys/{key}")
+    assert_http_ok(resp)
+    return resp.json()['result'] == expected_value


### PR DESCRIPTION
## Summary
- `test_cluster_metadata` waited a fixed `sleep(0.5)` after each PUT/DELETE before asserting the new value on every peer. Under CI load the raft apply on followers can take longer than that, and a stale read fails the test.
- Captured failure: leader appended index 14 (the `object` delete) at `15:11:41.876`; follower received the entry at `15:11:41.879`, got the commit at `15:11:42.266`, but didn't *apply* it until `15:11:42.396` — 1 ms after the test's GET arrived. The GET returned the pre-delete object value.
- Replace the fixed sleeps with `wait_for`-based polling on each per-peer read, so each assertion retries until the expected value is observed (or the standard 30s timeout).

## Test plan
- [ ] CI passes `tests/consensus_tests/test_cluster_metadata.py`
- [ ] Run the test in a loop locally to confirm it is no longer flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)