### PR TITLE
test: stabilize test_payload_strict_mode_upsert_no_local_shard

### DIFF
--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -164,8 +164,13 @@ def test_payload_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
 
     payload = {"country": "Germany", "city": "Berlin"}
 
-    for _ in range(32):
-        point = {"id": 1, "payload": payload, "vector": random_dense_vector()}
+    # Use unique point IDs across all phases. The mmap (gridstore) payload
+    # storage size estimate is bitmask-based: overwriting the same id keeps
+    # old blocks allocated until a periodic flush reclaims them, which makes
+    # a same-id test race the flush worker. Unique ids keep every block live,
+    # so the post-flush size still reflects all inserted points.
+    for i in range(32):
+        point = {"id": i, "payload": payload, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
 
     set_strict_mode(peer_urls[0], COLLECTION_NAME, {
@@ -175,12 +180,12 @@ def test_payload_strict_mode_upsert_no_local_shard(tmp_path: pathlib.Path):
 
     wait_for_strict_mode_enabled(peer_urls[1], COLLECTION_NAME)
 
-    for _ in range(32):
-        point = {"id": 2, "payload": payload, "vector": random_dense_vector()}
+    for i in range(32, 64):
+        point = {"id": i, "payload": payload, "vector": random_dense_vector()}
         upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader").raise_for_status()
 
-    for _ in range(32):
-        point = {"id": 3, "payload": payload, "vector": random_dense_vector()}
+    for i in range(64, 96):
+        point = {"id": i, "payload": payload, "vector": random_dense_vector()}
         res = upsert_points(peer_urls[0], [point], collection_name=COLLECTION_NAME, shard_key="non_leader")
         if not res.ok:
             assert "Max payload storage size" in res.json()['status']['error']


### PR DESCRIPTION
## Summary
- Replace same-id overwrite pattern with unique point IDs across all 3 phases of `test_payload_strict_mode_upsert_no_local_shard`.

## Why this was flaky
The test relied on `payload_storage_size` exceeding the 10 000-byte threshold by request 64 (last upsert of the `id=3` phase). Storage size for mmap (gridstore) payloads is bitmask-based: every `put_value` allocates a new 128 B block and the old block is only marked free during the next flush (`lib/gridstore/src/gridstore/mod.rs:498`). So 96 overwrites of 3 ids report ~12 KB *until* a flush, after which only the 3 live blocks (~384 B) remain.

The collection-size cache refreshes every 32 strict-mode checks (`lib/collection/src/common/collection_size_stats.rs:7`), and the flush worker fires every 5 s in test config (`config/development.yaml:30`). When the second cache refresh happened to land after the flush, the bitmask had been reclaimed and no upsert was rejected.

This is the same family of issue as #8922, but adding `wait=true` doesn't help here — that's already on, and it doesn't prevent the async flush.

## Fix
Insert unique ids 0..31 / 32..63 / 64..95 across the three phases. Every block stays live regardless of flush timing:
- Cache refresh at request 32 sees ~63 live blocks (8 064 B, under 10 000 → pass).
- Cache refresh at request 64 sees ~95 live blocks (12 160 B, over 10 000 → reject).

## Test plan
- [ ] CI: consensus test suite, in particular `test_payload_strict_mode_upsert_no_local_shard`, and ideally a stress run to verify it no longer flaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)