### PR TITLE
refactor: introduce FieldIndexRead trait

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
@@ -1,0 +1,91 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use serde_json::Value;
+
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::facet_index::FacetIndex;
+use crate::index::field_index::numeric_index::NumericFieldIndexRead;
+use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
+use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, PayloadKeyType};
+
+/// Read-only access surface of [`FieldIndex`](super::FieldIndex).
+///
+/// Mirrors the per-variant read methods that
+/// [`StructPayloadIndexReadView`] and its helpers reach through
+/// [`IndexesMap`]. Lifecycle methods (`wipe`, `flusher`, `files`,
+/// …) and per-point write methods (`add_point`, `remove_point`)
+/// stay inherent on `FieldIndex`.
+///
+/// Helpers that destructure `FieldIndex` to reach a variant-specific
+/// predicate on the underlying typed index keep taking `&FieldIndex`
+/// directly — this trait only captures the uniform surface.
+///
+/// [`StructPayloadIndexReadView`]: crate::index::struct_payload_index::StructPayloadIndexReadView
+/// [`IndexesMap`]: crate::common::utils::IndexesMap
+pub trait FieldIndexRead {
+    /// Number of points with at least one value in this index.
+    fn count_indexed_points(&self) -> usize;
+
+    /// Iterator of point offsets matching `condition`. `None` if the
+    /// condition can't be evaluated by this index type.
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>>;
+
+    /// Cardinality estimation for `condition`. `Ok(None)` if the
+    /// condition can't be evaluated by this index type.
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>>;
+
+    /// Iterate payload blocks of at least `threshold` points.
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()>;
+
+    /// Per-index telemetry snapshot.
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+
+    /// Number of values for `point_id`.
+    fn values_count(&self, point_id: PointOffsetType) -> usize;
+
+    /// True if `point_id` has zero values in this index.
+    fn values_is_empty(&self, point_id: PointOffsetType) -> bool;
+
+    /// Index-aware check for conditions that need parameters held by
+    /// the index (today: full-text tokenizers).
+    ///
+    /// Returns `Ok(None)` for index types that don't have such
+    /// conditions, `Ok(Some(true))` if the condition is satisfied,
+    /// `Ok(Some(false))` if it is not.
+    fn special_check_condition(
+        &self,
+        condition: &FieldCondition,
+        payload_value: &Value,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>>;
+
+    /// Borrowed numeric view, if this index is numeric.
+    ///
+    /// The concrete numeric-index type is opaque per implementation —
+    /// this matches the shape of [`PayloadIndexRead::numeric_index_for`].
+    ///
+    /// [`PayloadIndexRead::numeric_index_for`]: crate::index::PayloadIndexRead::numeric_index_for
+    fn as_numeric(&self) -> Option<impl NumericFieldIndexRead + '_>;
+
+    /// Borrowed facet view, if this index supports faceting.
+    ///
+    /// The concrete facet-index type is opaque per implementation —
+    /// this matches the shape of [`PayloadIndexRead::facet_index_for`].
+    ///
+    /// [`PayloadIndexRead::facet_index_for`]: crate::index::PayloadIndexRead::facet_index_for
+    fn as_facet_index(&self) -> Option<impl FacetIndex + '_>;
+}

--- a/lib/segment/src/index/field_index/field_index_base/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/mod.rs
@@ -1,9 +1,11 @@
 mod builder;
 mod field_index;
+mod field_index_read;
 mod payload_field_index;
 mod value_indexer;
 
 pub use builder::{FieldIndexBuilder, FieldIndexBuilderTrait};
 pub use field_index::FieldIndex;
+pub use field_index_read::FieldIndexRead;
 pub use payload_field_index::{PayloadFieldIndex, PayloadFieldIndexRead};
 pub use value_indexer::ValueIndexer;


### PR DESCRIPTION
## Summary

Mirror the `PayloadFieldIndex` / `PayloadFieldIndexRead` split (#8966) one layer up at the `FieldIndex` enum level. `FieldIndexRead` names the uniform read-only surface that `StructPayloadIndexReadView` and its helpers reach through `IndexesMap`:

- `count_indexed_points`, `filter`, `estimate_cardinality`, `for_each_payload_block`
- `get_telemetry_data`, `values_count`, `values_is_empty`, `special_check_condition`
- `as_numeric`, `as_facet_index`

Lifecycle / disk methods (`flusher`, `files`, `is_on_disk`, `populate`, `clear_cache`, `ram_usage_bytes`, `get_full_index_type`) and write methods (`add_point`, `remove_point`, `wipe`) stay off the trait — they have no read-side callers.

This PR is **trait declaration only** — no impl, no consumers, purely additive. Two follow-up PRs (already planned) will:

1. `impl FieldIndexRead for FieldIndex` and remove the now-duplicated inherent methods so call sites resolve through the trait.
2. Migrate `get_fallback_is_empty_checker` to a `FieldIndexRead` bound. Variant-destructuring helpers (`field_condition_index`, `match_converter`, `get_range_*`, `get_geo_*`, `indexed_variable_retriever`) keep `&FieldIndex` — they reach into variant-specific predicates on the underlying typed indexes that aren't on the uniform trait.

### Why generics on `as_numeric` / `as_facet_index`

Both methods use return-position `impl Trait` (`Option<impl NumericFieldIndexRead + '_>` / `Option<impl FacetIndex + '_>`), matching the shape `PayloadIndexRead::numeric_index_for` / `facet_index_for` already use. The concrete numeric/facet types stay opaque per implementation. Consequence: `FieldIndexRead` is **not object-safe**; follow-up consumers will use a generic bound (`<I: FieldIndexRead + ?Sized>`) rather than `&dyn FieldIndexRead`. Static dispatch, no v-table — same approach as `PayloadIndexRead`.

## Test plan

- [x] `cargo build -p segment`
- [x] `cargo build --workspace`
- [ ] No new tests in this PR — trait has no callers yet. Coverage lands with the impl in the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)