### PR TITLE
refactor(field_index): migrate indexed_variable_retriever into FieldIndexRead

### DIFF
--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
@@ -10,8 +11,12 @@ use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
     PayloadFieldIndexRead, ValueIndexer,
 };
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{FieldCondition, PayloadKeyType};
+use crate::types::{
+    AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
+    ValueVariants,
+};
 
 pub struct ImmutableBoolIndex(MutableBoolIndex);
 
@@ -144,6 +149,50 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
         self.0.for_each_payload_block(threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        _hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        // Destructure explicitly (no `..`) so a new field added to
+        // `FieldCondition` forces this method to be revisited.
+        let FieldCondition {
+            key: _,
+            r#match,
+            range: _,
+            geo_radius: _,
+            geo_bounding_box: _,
+            geo_polygon: _,
+            values_count: _,
+            is_empty: _,
+            is_null: _,
+        } = condition;
+
+        let cond_match = r#match.as_ref()?;
+        match cond_match {
+            Match::Value(MatchValue {
+                value: ValueVariants::Bool(is_true),
+            }) => {
+                let is_true = *is_true;
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    self.check_values_any(point_id, is_true)
+                }))
+            }
+            Match::Value(MatchValue {
+                value: ValueVariants::String(_) | ValueVariants::Integer(_),
+            })
+            | Match::Any(MatchAny {
+                any: AnyVariants::Strings(_) | AnyVariants::Integers(_),
+            })
+            | Match::Except(MatchExcept {
+                except: AnyVariants::Strings(_) | AnyVariants::Integers(_),
+            })
+            | Match::Text(_)
+            | Match::TextAny(_)
+            | Match::Phrase(_) => None,
+        }
     }
 }
 

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -14,9 +14,7 @@ use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{
-    AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, ValueVariants,
-};
+use crate::types::FieldCondition;
 
 pub mod immutable_bool_index;
 pub mod mutable_bool_index;
@@ -226,47 +224,9 @@ impl PayloadFieldIndexRead for BoolIndex {
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
-        // Destructure explicitly (no `..`) so a new field added to
-        // `FieldCondition` forces this method to be revisited.
-        let FieldCondition {
-            key: _,
-            r#match,
-            range: _,
-            geo_radius: _,
-            geo_bounding_box: _,
-            geo_polygon: _,
-            values_count: _,
-            is_empty: _,
-            is_null: _,
-        } = condition;
-
-        let cond_match = r#match.as_ref()?;
-        let hw_counter = hw_acc.get_counter_cell();
-        // BoolIndex only serves Match::Value(Bool). `Match::Any` /
-        // `Match::Except` over booleans aren't supported by the legacy
-        // helpers either, so they return None here. Text variants are
-        // for FullTextIndex.
-        match cond_match {
-            Match::Value(MatchValue {
-                value: ValueVariants::Bool(is_true),
-            }) => {
-                let is_true = *is_true;
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    self.check_values_any(point_id, is_true, &hw_counter)
-                }))
-            }
-            Match::Value(MatchValue {
-                value: ValueVariants::String(_) | ValueVariants::Integer(_),
-            })
-            | Match::Any(MatchAny {
-                any: AnyVariants::Strings(_) | AnyVariants::Integers(_),
-            })
-            | Match::Except(MatchExcept {
-                except: AnyVariants::Strings(_) | AnyVariants::Integers(_),
-            })
-            | Match::Text(_)
-            | Match::TextAny(_)
-            | Match::Phrase(_) => None,
+        match self {
+            BoolIndex::Mmap(index) => index.condition_checker(condition, hw_acc),
+            BoolIndex::Immutable(index) => index.condition_checker(condition, hw_acc),
         }
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -3,13 +3,16 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use immutable_bool_index::ImmutableBoolIndex;
 use mutable_bool_index::MutableBoolIndex;
+use serde_json::Value;
 
 use super::facet_index::FacetIndex;
 use super::{PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer};
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::utils::MultiValue;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, ValueVariants,
@@ -157,6 +160,22 @@ impl From<ImmutableBoolIndex> for BoolIndex {
     #[inline]
     fn from(index: ImmutableBoolIndex) -> Self {
         BoolIndex::Immutable(index)
+    }
+}
+
+impl BoolIndex {
+    /// Produce a closure that maps a point id to its indexed bool
+    /// values as JSON `Value`s. Used by `FieldIndex::value_retriever`.
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_point_values(point_id)
+                .into_iter()
+                .map(Value::Bool)
+                .collect()
+        })
     }
 }
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::types::PointOffsetType;
@@ -15,8 +16,12 @@ use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadBlockCondition, PayloadFieldIndex,
     PayloadFieldIndexRead, PrimaryCondition, ValueIndexer,
 };
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{FieldCondition, Match, MatchValue, PayloadKeyType, ValueVariants};
+use crate::types::{
+    AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
+    ValueVariants,
+};
 
 const TRUES_DIRNAME: &str = "trues";
 const FALSES_DIRNAME: &str = "falses";
@@ -511,6 +516,50 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         // just two possible blocks: true and false
         handle_block(self.trues_count, true, key.clone())?;
         handle_block(self.falses_count, false, key)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        _hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        // Destructure explicitly (no `..`) so a new field added to
+        // `FieldCondition` forces this method to be revisited.
+        let FieldCondition {
+            key: _,
+            r#match,
+            range: _,
+            geo_radius: _,
+            geo_bounding_box: _,
+            geo_polygon: _,
+            values_count: _,
+            is_empty: _,
+            is_null: _,
+        } = condition;
+
+        let cond_match = r#match.as_ref()?;
+        match cond_match {
+            Match::Value(MatchValue {
+                value: ValueVariants::Bool(is_true),
+            }) => {
+                let is_true = *is_true;
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    self.check_values_any(point_id, is_true)
+                }))
+            }
+            Match::Value(MatchValue {
+                value: ValueVariants::String(_) | ValueVariants::Integer(_),
+            })
+            | Match::Any(MatchAny {
+                any: AnyVariants::Strings(_) | AnyVariants::Integers(_),
+            })
+            | Match::Except(MatchExcept {
+                except: AnyVariants::Strings(_) | AnyVariants::Integers(_),
+            })
+            | Match::Text(_)
+            | Match::TextAny(_)
+            | Match::Phrase(_) => None,
+        }
     }
 }
 

--- a/lib/segment/src/index/field_index/field_index_base/field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index.rs
@@ -3,13 +3,14 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use serde_json::Value;
+use serde_json::{Number, Value};
 
 use super::FieldIndexRead;
 use super::payload_field_index::{PayloadFieldIndex, PayloadFieldIndexRead};
 use super::value_indexer::ValueIndexer;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::common::utils::MultiValue;
 use crate::index::field_index::bool_index::BoolIndex;
 use crate::index::field_index::facet_index::{FacetIndex, FacetIndexEnum};
 use crate::index::field_index::full_text_index::text_index::{
@@ -24,6 +25,7 @@ use crate::index::field_index::numeric_index::{
 use crate::index::payload_config::{
     FullPayloadIndexType, IndexMutability, PayloadIndexType, StorageType,
 };
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchPhrase,
@@ -406,6 +408,115 @@ impl FieldIndexRead for FieldIndex {
             FieldIndex::UuidIndex(index) => index.values_is_empty(point_id),
             FieldIndex::UuidMapIndex(index) => index.values_is_empty(point_id),
             FieldIndex::NullIndex(index) => index.values_is_empty(point_id),
+        }
+    }
+
+    fn value_retriever<'a, 'q>(
+        &'a self,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> Option<VariableRetrieverFn<'q>>
+    where
+        'a: 'q,
+    {
+        match self {
+            FieldIndex::IntIndex(numeric_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    numeric_index
+                        .get_values(point_id)
+                        .into_iter()
+                        .flatten()
+                        .map(|v| Value::Number(Number::from(v)))
+                        .collect()
+                },
+            )),
+            FieldIndex::IntMapIndex(map_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    map_index
+                        .get_values(point_id, hw_counter)
+                        .into_iter()
+                        .flatten()
+                        .map(|v| Value::Number(Number::from(*v)))
+                        .collect()
+                },
+            )),
+            FieldIndex::FloatIndex(numeric_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    numeric_index
+                        .get_values(point_id)
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|v| Some(Value::Number(Number::from_f64(v)?)))
+                        .collect()
+                },
+            )),
+            FieldIndex::DatetimeIndex(numeric_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    numeric_index
+                        .get_values(point_id)
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|v| {
+                            serde_json::to_value(DateTimePayloadType::from_timestamp(v)?).ok()
+                        })
+                        .collect()
+                },
+            )),
+            FieldIndex::KeywordIndex(keyword_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    keyword_index
+                        .get_values(point_id, hw_counter)
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|v| serde_json::to_value(v).ok())
+                        .collect()
+                },
+            )),
+            FieldIndex::GeoIndex(geo_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    geo_index
+                        .get_values(point_id)
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|v| serde_json::to_value(v).ok())
+                        .collect()
+                },
+            )),
+            FieldIndex::BoolIndex(bool_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    bool_index
+                        .get_point_values(point_id)
+                        .into_iter()
+                        .map(Value::Bool)
+                        .collect()
+                },
+            )),
+            FieldIndex::UuidMapIndex(uuid_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    uuid_index
+                        .get_values(point_id, hw_counter)
+                        .into_iter()
+                        .flatten()
+                        .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
+                        .collect()
+                },
+            )),
+            FieldIndex::UuidIndex(uuid_index) => Some(Box::new(
+                move |point_id: PointOffsetType| -> MultiValue<Value> {
+                    uuid_index
+                        .get_values(point_id)
+                        .into_iter()
+                        .flatten()
+                        .map(|value| Value::String(UuidPayloadType::from_u128(value).to_string()))
+                        .collect()
+                },
+            )),
+            // FullTextIndex: caller falls back to payload — text values
+            // are easier to read directly than reconstruct from the
+            // inverted index.
+            FieldIndex::FullTextIndex(_) => None,
+            // NullIndex: no underlying values to return; another index
+            // on the same field is expected to provide them.
+            FieldIndex::NullIndex(_) => None,
         }
     }
 

--- a/lib/segment/src/index/field_index/field_index_base/field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index.rs
@@ -3,14 +3,13 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use serde_json::{Number, Value};
+use serde_json::Value;
 
 use super::FieldIndexRead;
 use super::payload_field_index::{PayloadFieldIndex, PayloadFieldIndexRead};
 use super::value_indexer::ValueIndexer;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
-use crate::common::utils::MultiValue;
 use crate::index::field_index::bool_index::BoolIndex;
 use crate::index::field_index::facet_index::{FacetIndex, FacetIndexEnum};
 use crate::index::field_index::full_text_index::text_index::{
@@ -418,98 +417,21 @@ impl FieldIndexRead for FieldIndex {
     where
         'a: 'q,
     {
+        // Per-variant value-to-`Value` conversion lives on each typed
+        // index as an inherent `value_retriever` method (see e.g.
+        // `NumericIndex<IntPayloadType, DateTimePayloadType>::value_retriever`).
+        // This dispatch is mechanical — adding a `FieldIndex` variant
+        // forces a compile error here.
         match self {
-            FieldIndex::IntIndex(numeric_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    numeric_index
-                        .get_values(point_id)
-                        .into_iter()
-                        .flatten()
-                        .map(|v| Value::Number(Number::from(v)))
-                        .collect()
-                },
-            )),
-            FieldIndex::IntMapIndex(map_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    map_index
-                        .get_values(point_id, hw_counter)
-                        .into_iter()
-                        .flatten()
-                        .map(|v| Value::Number(Number::from(*v)))
-                        .collect()
-                },
-            )),
-            FieldIndex::FloatIndex(numeric_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    numeric_index
-                        .get_values(point_id)
-                        .into_iter()
-                        .flatten()
-                        .filter_map(|v| Some(Value::Number(Number::from_f64(v)?)))
-                        .collect()
-                },
-            )),
-            FieldIndex::DatetimeIndex(numeric_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    numeric_index
-                        .get_values(point_id)
-                        .into_iter()
-                        .flatten()
-                        .filter_map(|v| {
-                            serde_json::to_value(DateTimePayloadType::from_timestamp(v)?).ok()
-                        })
-                        .collect()
-                },
-            )),
-            FieldIndex::KeywordIndex(keyword_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    keyword_index
-                        .get_values(point_id, hw_counter)
-                        .into_iter()
-                        .flatten()
-                        .filter_map(|v| serde_json::to_value(v).ok())
-                        .collect()
-                },
-            )),
-            FieldIndex::GeoIndex(geo_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    geo_index
-                        .get_values(point_id)
-                        .into_iter()
-                        .flatten()
-                        .filter_map(|v| serde_json::to_value(v).ok())
-                        .collect()
-                },
-            )),
-            FieldIndex::BoolIndex(bool_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    bool_index
-                        .get_point_values(point_id)
-                        .into_iter()
-                        .map(Value::Bool)
-                        .collect()
-                },
-            )),
-            FieldIndex::UuidMapIndex(uuid_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    uuid_index
-                        .get_values(point_id, hw_counter)
-                        .into_iter()
-                        .flatten()
-                        .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
-                        .collect()
-                },
-            )),
-            FieldIndex::UuidIndex(uuid_index) => Some(Box::new(
-                move |point_id: PointOffsetType| -> MultiValue<Value> {
-                    uuid_index
-                        .get_values(point_id)
-                        .into_iter()
-                        .flatten()
-                        .map(|value| Value::String(UuidPayloadType::from_u128(value).to_string()))
-                        .collect()
-                },
-            )),
+            FieldIndex::IntIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::DatetimeIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::IntMapIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::KeywordIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::FloatIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::GeoIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::BoolIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::UuidIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::UuidMapIndex(index) => Some(index.value_retriever(hw_counter)),
             // FullTextIndex: caller falls back to payload — text values
             // are easier to read directly than reconstruct from the
             // inverted index.

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
@@ -9,6 +9,7 @@ use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::numeric_index::NumericFieldIndexRead;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
@@ -113,6 +114,23 @@ pub trait FieldIndexRead {
         self.get_payload_field_index_read()
             .condition_checker(condition, hw_acc)
     }
+
+    /// Build a closure that extracts this index's values for a given
+    /// point as a [`MultiValue<Value>`](crate::common::utils::MultiValue).
+    ///
+    /// Returns `None` when this index can't serve point-level value
+    /// retrieval — `FullTextIndex` (callers fall back to payload) and
+    /// `NullIndex` (no underlying values to return).
+    ///
+    /// Used by rescore-formula value lookup; mirrors the shape of
+    /// [`Self::condition_checker`] (build a closure once, invoke per
+    /// point).
+    fn value_retriever<'a, 'q>(
+        &'a self,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> Option<VariableRetrieverFn<'q>>
+    where
+        'a: 'q;
 
     /// Borrowed numeric view, if this index is numeric.
     ///

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -54,9 +54,7 @@ pub trait PayloadFieldIndexRead {
         &'a self,
         _condition: &FieldCondition,
         _hw_acc: HwMeasurementAcc,
-    ) -> Option<ConditionCheckerFn<'a>> {
-        None
-    }
+    ) -> Option<ConditionCheckerFn<'a>>;
 }
 
 /// Storage-lifecycle operations on top of [`PayloadFieldIndexRead`].

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -16,6 +16,7 @@ use self::mutable_geo_index::MutableGeoMapIndex;
 use super::FieldIndexBuilderTrait;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::utils::MultiValue;
 use crate::index::field_index::geo_hash::{
     GeoHash, circle_hashes, common_hash_prefix, geo_hash_to_box, polygon_hashes,
     polygon_hashes_estimation, rectangle_hashes,
@@ -27,6 +28,7 @@ use crate::index::field_index::{
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -452,6 +454,23 @@ impl ValueIndexer for GeoMapIndex {
                 Ok(())
             }
         }
+    }
+}
+
+impl GeoMapIndex {
+    /// Produce a closure that maps a point id to its indexed geo
+    /// points as JSON `Value`s. Used by `FieldIndex::value_retriever`.
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|v| serde_json::to_value(v).ok())
+                .collect()
+        })
     }
 }
 

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -17,7 +17,7 @@ use gridstore::Blob;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use mmap_map_index::MmapMapIndex;
-use serde_json::Value;
+use serde_json::{Number, Value};
 use uuid::Uuid;
 
 use self::immutable_map_index::ImmutableMapIndex;
@@ -27,6 +27,7 @@ use super::facet_index::FacetIndex;
 use super::stored_point_to_values::StoredValue;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::utils::MultiValue;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::field_index::utils::value_to_integer;
@@ -37,11 +38,12 @@ use crate::index::field_index::{
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_estimator::combine_should_estimations;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
-    PayloadKeyType, UuidIntType, ValueVariants,
+    PayloadKeyType, UuidIntType, UuidPayloadType, ValueVariants,
 };
 
 pub mod immutable_map_index;
@@ -1619,6 +1621,56 @@ impl ValueIndexer for MapIndex<UuidIntType> {
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         self.remove_point(id)
+    }
+}
+
+// Per-K value retrievers — produce a closure that maps a point id to
+// its indexed keyword/int/uuid values as JSON `Value`s. The conversion
+// is K-specific, so each MapIndex variant has its own inherent impl.
+// `FieldIndex::value_retriever` dispatches here per variant.
+
+impl MapIndex<str> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id, hw_counter)
+                .into_iter()
+                .flatten()
+                .filter_map(|v| serde_json::to_value(v).ok())
+                .collect()
+        })
+    }
+}
+
+impl MapIndex<IntPayloadType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id, hw_counter)
+                .into_iter()
+                .flatten()
+                .map(|v| Value::Number(Number::from(*v)))
+                .collect()
+        })
+    }
+}
+
+impl MapIndex<UuidIntType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id, hw_counter)
+                .into_iter()
+                .flatten()
+                .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
+                .collect()
+        })
     }
 }
 

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
@@ -11,6 +12,7 @@ use crate::index::field_index::{
     PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
@@ -136,6 +138,38 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
         self.0.for_each_payload_block(threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        _hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        // Destructure explicitly (no `..`) so a new field added to
+        // `FieldCondition` forces this method to be revisited.
+        let FieldCondition {
+            key: _,
+            r#match: _,
+            range: _,
+            geo_radius: _,
+            geo_bounding_box: _,
+            geo_polygon: _,
+            values_count: _,
+            is_empty,
+            is_null,
+        } = condition;
+
+        if let Some(is_empty) = *is_empty {
+            return Some(Box::new(move |point_id: PointOffsetType| {
+                self.values_is_empty(point_id) == is_empty
+            }));
+        }
+        if let Some(is_null) = *is_null {
+            return Some(Box::new(move |point_id: PointOffsetType| {
+                self.values_is_null(point_id) == is_null
+            }));
+        }
+        None
     }
 }
 

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -173,33 +173,12 @@ impl PayloadFieldIndexRead for NullIndex {
     fn condition_checker<'a>(
         &'a self,
         condition: &FieldCondition,
-        _hw_acc: HwMeasurementAcc,
+        hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
-        // Destructure explicitly (no `..`) so a new field added to
-        // `FieldCondition` forces this method to be revisited.
-        let FieldCondition {
-            key: _,
-            r#match: _,
-            range: _,
-            geo_radius: _,
-            geo_bounding_box: _,
-            geo_polygon: _,
-            values_count: _,
-            is_empty,
-            is_null,
-        } = condition;
-
-        if let Some(is_empty) = *is_empty {
-            return Some(Box::new(move |point_id: PointOffsetType| {
-                self.values_is_empty(point_id) == is_empty
-            }));
+        match self {
+            NullIndex::Mutable(mutable) => mutable.condition_checker(condition, hw_acc),
+            NullIndex::Immutable(immutable) => immutable.condition_checker(condition, hw_acc),
         }
-        if let Some(is_null) = *is_null {
-            return Some(Box::new(move |point_id: PointOffsetType| {
-                self.values_is_null(point_id) == is_null
-            }));
-        }
-        None
     }
 }
 

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::MmapFile;
@@ -16,6 +17,7 @@ use crate::index::field_index::{
     PayloadFieldIndexRead, PrimaryCondition,
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
@@ -420,6 +422,38 @@ impl PayloadFieldIndexRead for MutableNullIndex {
     ) -> OperationResult<()> {
         // No payload blocks
         Ok(())
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        _hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        // Destructure explicitly (no `..`) so a new field added to
+        // `FieldCondition` forces this method to be revisited.
+        let FieldCondition {
+            key: _,
+            r#match: _,
+            range: _,
+            geo_radius: _,
+            geo_bounding_box: _,
+            geo_polygon: _,
+            values_count: _,
+            is_empty,
+            is_null,
+        } = condition;
+
+        if let Some(is_empty) = *is_empty {
+            return Some(Box::new(move |point_id: PointOffsetType| {
+                self.values_is_empty(point_id) == is_empty
+            }));
+        }
+        if let Some(is_null) = *is_null {
+            return Some(Box::new(move |point_id: PointOffsetType| {
+                self.values_is_null(point_id) == is_null
+            }));
+        }
+        None
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -27,7 +27,7 @@ use mutable_numeric_index::{InMemoryNumericIndex, MutableNumericIndex};
 use ordered_float::OrderedFloat;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde_json::Value;
+use serde_json::{Number, Value};
 use uuid::Uuid;
 
 use self::immutable_numeric_index::ImmutableNumericIndex;
@@ -36,6 +36,7 @@ use super::stored_point_to_values::StoredValue;
 use super::utils::{check_boundaries, value_to_integer};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::utils::MultiValue;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
@@ -49,6 +50,7 @@ use crate::index::key_encoding::{
 };
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     DateTimePayloadType, FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchValue,
@@ -1200,6 +1202,71 @@ impl NumericIndexIntoInnerValue<UuidIntType, UuidPayloadType>
 {
     fn into_inner_value(value: UuidPayloadType) -> UuidIntType {
         value.as_u128()
+    }
+}
+
+// Per-(T, U) value retrievers — produce a closure that maps a point id
+// to its indexed values as JSON `Value`s. The conversion is U-specific
+// (the second type param), so each numeric variant has its own inherent
+// impl. `FieldIndex::value_retriever` dispatches here per variant.
+
+impl NumericIndex<IntPayloadType, IntPayloadType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id)
+                .into_iter()
+                .flatten()
+                .map(|v| Value::Number(Number::from(v)))
+                .collect()
+        })
+    }
+}
+
+impl NumericIndex<IntPayloadType, DateTimePayloadType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|v| serde_json::to_value(DateTimePayloadType::from_timestamp(v)?).ok())
+                .collect()
+        })
+    }
+}
+
+impl NumericIndex<FloatPayloadType, FloatPayloadType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|v| Some(Value::Number(Number::from_f64(v)?)))
+                .collect()
+        })
+    }
+}
+
+impl NumericIndex<UuidIntType, UuidPayloadType> {
+    pub fn value_retriever<'a>(
+        &'a self,
+        _hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+            self.get_values(point_id)
+                .into_iter()
+                .flatten()
+                .map(|value| Value::String(UuidPayloadType::from_u128(value).to_string()))
+                .collect()
+        })
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
@@ -2,15 +2,15 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use serde_json::{Number, Value};
+use serde_json::Value;
 
 use crate::common::utils::MultiValue;
-use crate::index::field_index::FieldIndex;
+use crate::index::field_index::{FieldIndex, FieldIndexRead};
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::{DateTimePayloadType, PayloadContainer, UuidPayloadType};
+use crate::types::PayloadContainer;
 
 pub(super) fn variable_retriever<'a, 'q, P: PayloadStorageRead + 'q>(
     indices: &'a HashMap<JsonPath, Vec<FieldIndex>>,
@@ -26,7 +26,7 @@ where
         .and_then(|indices| {
             indices
                 .iter()
-                .find_map(|index| indexed_variable_retriever(index, hw_counter))
+                .find_map(|index| index.value_retriever(hw_counter))
         })
         // TODO(scoreboost): optimize by reusing the same payload for all variables?
         .unwrap_or_else(|| {
@@ -69,123 +69,6 @@ fn payload_variable_retriever<'a, P: PayloadStorageRead + 'a>(
         )
     };
     Box::new(retriever_fn)
-}
-
-/// Returns function to extract all the values a point has in the index
-///
-/// If there is no appropriate index, returns None
-fn indexed_variable_retriever<'a, 'q>(
-    index: &'a FieldIndex,
-    hw_counter: &'q HardwareCounterCell,
-) -> Option<VariableRetrieverFn<'q>>
-where
-    'a: 'q,
-{
-    match index {
-        FieldIndex::IntIndex(numeric_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                numeric_index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten()
-                    .map(|v| Value::Number(Number::from(v)))
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::IntMapIndex(map_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                map_index
-                    .get_values(point_id, hw_counter)
-                    .into_iter()
-                    .flatten()
-                    .map(|v| Value::Number(Number::from(*v)))
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::FloatIndex(numeric_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                numeric_index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|v| Some(Value::Number(Number::from_f64(v)?)))
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::DatetimeIndex(numeric_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                numeric_index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|v| {
-                        serde_json::to_value(DateTimePayloadType::from_timestamp(v)?).ok()
-                    })
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::KeywordIndex(keyword_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                keyword_index
-                    .get_values(point_id, hw_counter)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|v| serde_json::to_value(v).ok())
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::GeoIndex(geo_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                geo_index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|v| serde_json::to_value(v).ok())
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-
-        FieldIndex::BoolIndex(bool_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                bool_index
-                    .get_point_values(point_id)
-                    .into_iter()
-                    .map(Value::Bool)
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::UuidMapIndex(uuid_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                uuid_index
-                    .get_values(point_id, hw_counter)
-                    .into_iter()
-                    .flatten()
-                    .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::UuidIndex(uuid_index) => {
-            let extract_fn = move |point_id: PointOffsetType| -> MultiValue<Value> {
-                uuid_index
-                    .get_values(point_id)
-                    .into_iter()
-                    .flatten()
-                    .map(|value| Value::String(UuidPayloadType::from_u128(value).to_string()))
-                    .collect()
-            };
-            Some(Box::new(extract_fn))
-        }
-        FieldIndex::FullTextIndex(_) => None, // Better get it from the payload
-        FieldIndex::NullIndex(_) => None,     // There should be other index for the same field
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up to the [condition-checker-migration sub-plan](https://github.com/qdrant/qdrant/tree/dev/docs/plans/field-index-read-trait/condition-checker-migration). Two-step refactor that moves point-value retrieval into the typed indexes:

1. **First commit** — introduce `FieldIndexRead::value_retriever`, replacing the read view's `indexed_variable_retriever` helper that destructured `FieldIndex` variants.
2. **Second commit** — push the per-variant value-to-`Value` conversion bodies out of `FieldIndex`'s impl and into each typed index as inherent methods. `FieldIndex::value_retriever` collapses to a thin 11-arm dispatch.

After both commits, the read view's `value_retriever/helpers.rs` no longer destructures `FieldIndex`, **and** `FieldIndex`'s impl block holds only mechanical dispatch (no index-specific logic). The same shape as `wipe`, `get_telemetry_data`, `add_point` etc.

**Stacked on #8985 → #8984 → #8983 → #8982 → #8981 → #8980 → #8979 → #8978 → dev.**

## Where things live now

| Typed index | Inherent method | Conversion |
|-------------|----------------|------------|
| `NumericIndex<IntPayloadType, IntPayloadType>` | `value_retriever` | `Value::Number(Number::from(v))` |
| `NumericIndex<IntPayloadType, DateTimePayloadType>` | `value_retriever` | `DateTimePayloadType::from_timestamp(v)` → JSON |
| `NumericIndex<FloatPayloadType, FloatPayloadType>` | `value_retriever` | `Value::Number(Number::from_f64(v)?)` |
| `NumericIndex<UuidIntType, UuidPayloadType>` | `value_retriever` | `UuidPayloadType::from_u128(v).to_string()` |
| `MapIndex<str>` (Keyword) | `value_retriever` | `Value::String` |
| `MapIndex<IntPayloadType>` (IntMap) | `value_retriever` | `Value::Number(Number::from(*v))` |
| `MapIndex<UuidIntType>` (UuidMap) | `value_retriever` | `Value::String` (UUID) |
| `GeoMapIndex` | `value_retriever` | `serde_json::to_value` |
| `BoolIndex` | `value_retriever` | `Value::Bool` |
| `FullTextIndex` | (none) | `FieldIndex` returns `None` — caller falls back to payload |
| `NullIndex` | (none) | `FieldIndex` returns `None` — no underlying values |

`FieldIndex::value_retriever` is now 14 lines — a `match self { … }` that delegates per variant.

## Test plan

- [x] `cargo build --workspace --tests` (clean)
- [x] `cargo nextest run -p segment` — 786/786 pass
- [x] `cargo +nightly fmt --all -- --check`

## Stats

- First commit: `+134 / -122` (across 3 files; `helpers.rs` shrinks from 189 to 73 lines non-test)
- Second commit: `+175 / -96` (across 5 files; `field_index.rs` shrinks by ~100 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
