### PR TITLE
Refactor quantized multi-vector scorers for io_uring support

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
@@ -16,37 +14,25 @@ use crate::vector_storage::quantized::quantized_multivector_storage::{
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedMultiCustomQueryScorer<
-    'a,
-    TElement,
-    TMetric,
-    QuantizedStorage,
-    OffsetStorage,
-    TQuery,
-> where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
+pub struct QuantizedMultiCustomQueryScorer<'a, QuantizedStorage, OffsetStorage, TQuery>
+where
     QuantizedStorage: quantization::EncodedVectors,
     OffsetStorage: MultivectorOffsetsStorage,
     TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
     query: TQuery,
     quantized_multivector_storage: &'a QuantizedMultivectorStorage<QuantizedStorage, OffsetStorage>,
-    metric: PhantomData<TMetric>,
-    element: PhantomData<TElement>,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery>
-    QuantizedMultiCustomQueryScorer<'a, TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery>
+impl<'a, QuantizedStorage, OffsetStorage, TQuery>
+    QuantizedMultiCustomQueryScorer<'a, QuantizedStorage, OffsetStorage, TQuery>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     QuantizedStorage: quantization::EncodedVectors,
     OffsetStorage: MultivectorOffsetsStorage,
     TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
-    pub fn new_multi<TOriginalQuery, TInputQuery>(
+    pub fn new_multi<TElement, TMetric, TOriginalQuery, TInputQuery>(
         raw_query: TInputQuery,
         quantized_multivector_storage: &'a QuantizedMultivectorStorage<
             QuantizedStorage,
@@ -56,6 +42,8 @@ where
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement>,
         TOriginalQuery: Query<TypedMultiDenseVector<TElement>>
             + TransformInto<
                 TQuery,
@@ -98,30 +86,19 @@ where
         Self {
             query,
             quantized_multivector_storage,
-            metric: PhantomData,
-            element: PhantomData,
             hardware_counter,
         }
     }
 }
 
-impl<TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery> QueryScorer
-    for QuantizedMultiCustomQueryScorer<
-        '_,
-        TElement,
-        TMetric,
-        QuantizedStorage,
-        OffsetStorage,
-        TQuery,
-    >
+impl<QuantizedStorage, OffsetStorage, TQuery> QueryScorer
+    for QuantizedMultiCustomQueryScorer<'_, QuantizedStorage, OffsetStorage, TQuery>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     QuantizedStorage: quantization::EncodedVectors,
     OffsetStorage: MultivectorOffsetsStorage,
     TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
-    type TVector = [TElement];
+    type TVector = ();
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let multi_vector_offset = self.quantized_multivector_storage.get_offset(idx);
@@ -138,7 +115,7 @@ where
         })
     }
 
-    fn score(&self, _v2: &[TElement]) -> ScoreType {
+    fn score(&self, _v2: &()) -> ScoreType {
         unimplemented!("This method is not expected to be called for quantized scorer");
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
+use quantization::EncodedVectors;
 
 use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -10,43 +11,57 @@ use crate::data_types::vectors::{MultiDenseVectorInternal, TypedMultiDenseVector
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
-    MultivectorOffset, MultivectorOffsets,
+    MultivectorOffset, MultivectorOffsets, MultivectorOffsetsStorage, QuantizedMultivectorStorage,
 };
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedMultiCustomQueryScorer<'a, TElement, TMetric, TEncodedVectors, TQuery>
-where
+pub struct QuantizedMultiCustomQueryScorer<
+    'a,
+    TElement,
+    TMetric,
+    QuantizedStorage,
+    OffsetStorage,
+    TQuery,
+> where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets,
-    TQuery: Query<TEncodedVectors::EncodedQuery>,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
+    TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
     query: TQuery,
-    quantized_multivector_storage: &'a TEncodedVectors,
+    quantized_multivector_storage: &'a QuantizedMultivectorStorage<QuantizedStorage, OffsetStorage>,
     metric: PhantomData<TMetric>,
     element: PhantomData<TElement>,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TElement, TMetric, TEncodedVectors, TQuery>
-    QuantizedMultiCustomQueryScorer<'a, TElement, TMetric, TEncodedVectors, TQuery>
+impl<'a, TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery>
+    QuantizedMultiCustomQueryScorer<'a, TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery>
 where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets,
-    TQuery: Query<TEncodedVectors::EncodedQuery>,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
+    TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
     pub fn new_multi<TOriginalQuery, TInputQuery>(
         raw_query: TInputQuery,
-        quantized_multivector_storage: &'a TEncodedVectors,
+        quantized_multivector_storage: &'a QuantizedMultivectorStorage<
+            QuantizedStorage,
+            OffsetStorage,
+        >,
         quantization_config: &QuantizationConfig,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
         TOriginalQuery: Query<TypedMultiDenseVector<TElement>>
-            + TransformInto<TQuery, TypedMultiDenseVector<TElement>, TEncodedVectors::EncodedQuery>
-            + Clone,
+            + TransformInto<
+                TQuery,
+                TypedMultiDenseVector<TElement>,
+                Vec<QuantizedStorage::EncodedQuery>,
+            > + Clone,
         TInputQuery: Query<MultiDenseVectorInternal>
             + TransformInto<TOriginalQuery, MultiDenseVectorInternal, TypedMultiDenseVector<TElement>>,
     {
@@ -90,13 +105,21 @@ where
     }
 }
 
-impl<TElement, TMetric, TEncodedVectors, TQuery> QueryScorer
-    for QuantizedMultiCustomQueryScorer<'_, TElement, TMetric, TEncodedVectors, TQuery>
+impl<TElement, TMetric, QuantizedStorage, OffsetStorage, TQuery> QueryScorer
+    for QuantizedMultiCustomQueryScorer<
+        '_,
+        TElement,
+        TMetric,
+        QuantizedStorage,
+        OffsetStorage,
+        TQuery,
+    >
 where
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets,
-    TQuery: Query<TEncodedVectors::EncodedQuery>,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
+    TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
     type TVector = [TElement];
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -100,6 +100,29 @@ where
 {
     type TVector = ();
 
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(ids.len(), scores.len());
+
+        self.hardware_counter
+            .vector_io_read()
+            .incr_delta(size_of::<MultivectorOffset>() * ids.len());
+
+        for (idx, offset) in self.quantized_multivector_storage.iter_offsets(ids) {
+            self.hardware_counter.vector_io_read().incr_delta(
+                self.quantized_multivector_storage.quantized_vector_size() * offset.count as usize,
+            );
+
+            scores[idx] = self.query.score_by(|query| {
+                // quantized multivector storage handles CPU hardware counter
+                self.quantized_multivector_storage.score_multi(
+                    query,
+                    offset,
+                    &self.hardware_counter,
+                )
+            });
+        }
+    }
+
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let multi_vector_offset = self.quantized_multivector_storage.get_offset(idx);
         let sub_vectors_count = multi_vector_offset.count as usize;

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
+use quantization::EncodedVectors;
 
 use super::quantized_query_scorer::InternalScorerUnsupported;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -10,26 +11,32 @@ use crate::data_types::vectors::MultiDenseVectorInternal;
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
-    MultivectorOffset, MultivectorOffsets,
+    MultivectorOffset, MultivectorOffsets, MultivectorOffsetsStorage, QuantizedMultivectorStorage,
 };
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedMultiQueryScorer<'a, TEncodedVectors>
+pub struct QuantizedMultiQueryScorer<'a, QuantizedStorage, OffsetStorage>
 where
-    TEncodedVectors: quantization::EncodedVectors,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
 {
-    query: TEncodedVectors::EncodedQuery,
-    quantized_multivector_storage: &'a TEncodedVectors,
+    query: Vec<QuantizedStorage::EncodedQuery>,
+    quantized_multivector_storage: &'a QuantizedMultivectorStorage<QuantizedStorage, OffsetStorage>,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TEncodedVectors> QuantizedMultiQueryScorer<'a, TEncodedVectors>
+impl<'a, QuantizedStorage, OffsetStorage>
+    QuantizedMultiQueryScorer<'a, QuantizedStorage, OffsetStorage>
 where
-    TEncodedVectors: quantization::EncodedVectors,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
 {
     pub fn new_multi<TElement, TMetric>(
         raw_query: &MultiDenseVectorInternal,
-        quantized_multivector_storage: &'a TEncodedVectors,
+        quantized_multivector_storage: &'a QuantizedMultivectorStorage<
+            QuantizedStorage,
+            OffsetStorage,
+        >,
         quantization_config: &QuantizationConfig,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
@@ -63,7 +70,10 @@ where
 
     pub fn new_internal(
         point_id: PointOffsetType,
-        quantized_multivector_storage: &'a TEncodedVectors,
+        quantized_multivector_storage: &'a QuantizedMultivectorStorage<
+            QuantizedStorage,
+            OffsetStorage,
+        >,
         mut hardware_counter: HardwareCounterCell,
     ) -> Result<Self, InternalScorerUnsupported> {
         let Some(query) = quantized_multivector_storage.encode_internal_vector(point_id) else {
@@ -81,9 +91,11 @@ where
     }
 }
 
-impl<TEncodedVectors> QueryScorer for QuantizedMultiQueryScorer<'_, TEncodedVectors>
+impl<QuantizedStorage, OffsetStorage> QueryScorer
+    for QuantizedMultiQueryScorer<'_, QuantizedStorage, OffsetStorage>
 where
-    TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets,
+    QuantizedStorage: quantization::EncodedVectors,
+    OffsetStorage: MultivectorOffsetsStorage,
 {
     type TVector = ();
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -99,6 +99,27 @@ where
 {
     type TVector = ();
 
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(ids.len(), scores.len());
+
+        self.hardware_counter
+            .vector_io_read()
+            .incr_delta(size_of::<MultivectorOffset>() * ids.len());
+
+        for (idx, offset) in self.quantized_multivector_storage.iter_offsets(ids) {
+            self.hardware_counter.vector_io_read().incr_delta(
+                self.quantized_multivector_storage.quantized_vector_size() * offset.count as usize,
+            );
+
+            // quantized multivector storage handles CPU hardware counter
+            scores[idx] = self.quantized_multivector_storage.score_multi(
+                &self.query,
+                offset,
+                &self.hardware_counter,
+            );
+        }
+    }
+
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let multi_vector_offset = self.quantized_multivector_storage.get_offset(idx);
         let sub_vectors_count = multi_vector_offset.count as usize;

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -380,18 +380,27 @@ where
         }
     }
 
+    pub fn score_multi(
+        &self,
+        query: &[QuantizedStorage::EncodedQuery],
+        offset: MultivectorOffset,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => {
+                self.score_point_max_similarity(query, offset, hw_counter)
+            }
+        }
+    }
+
     /// Custom `score_max_similarity` implementation for quantized vectors
     fn score_point_max_similarity(
         &self,
-        query: &Vec<QuantizedStorage::EncodedQuery>,
-        vector_index: PointOffsetType,
+        query: &[QuantizedStorage::EncodedQuery],
+        offset: MultivectorOffset,
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
-        let offset = self.offsets.get_offset(vector_index);
-
-        let offsets: SmallVec<[_; 8]> = (offset.start..offset.start + offset.count)
-            .into_iter()
-            .collect();
+        let offsets: SmallVec<[_; 8]> = (offset.start..offset.start + offset.count).collect();
 
         let mut max_sim: SmallVec<[_; 8]> = SmallVec::new();
         max_sim.resize(query.len(), ScoreType::NEG_INFINITY);
@@ -399,7 +408,7 @@ where
         self.quantized_storage
             .for_each_in_batch(&offsets, |_, vector| {
                 for (query_idx, query) in query.iter().enumerate() {
-                    let sim = self.quantized_storage.score(&query, vector, hw_counter);
+                    let sim = self.quantized_storage.score(query, vector, hw_counter);
 
                     if max_sim[query_idx] < sim {
                         max_sim[query_idx] = sim;
@@ -493,9 +502,8 @@ where
         i: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
-        match self.multi_vector_config.comparator {
-            MultiVectorComparator::MaxSim => self.score_point_max_similarity(query, i, hw_counter),
-        }
+        let offset = self.offsets.get_offset(i);
+        self.score_multi(query, offset, hw_counter)
     }
 
     fn score_internal(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -38,11 +38,21 @@ pub struct MultivectorOffset {
 
 pub trait MultivectorOffsets {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset;
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)>;
 }
 
 #[allow(clippy::len_without_is_empty)]
 pub trait MultivectorOffsetsStorage: Sized {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset;
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)>;
 
     fn len(&self) -> usize;
 
@@ -95,6 +105,13 @@ impl MultivectorOffsetsStorageRam {
 impl MultivectorOffsetsStorage for MultivectorOffsetsStorageRam {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets[idx as usize]
+    }
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
+        ids.iter().map(|&id| self.get_offset(id)).enumerate()
     }
 
     fn len(&self) -> usize {
@@ -173,6 +190,13 @@ impl MultivectorOffsetsStorageMmap {
 impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets[idx as usize]
+    }
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
+        ids.iter().map(|&id| self.get_offset(id)).enumerate()
     }
 
     fn len(&self) -> usize {
@@ -263,6 +287,19 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageChunkedMmap {
             .get::<Random>(idx as VectorOffsetType)
             .and_then(|offsets| offsets.first().copied())
             .unwrap_or_default()
+    }
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
+        self.data.iter(ids).map(|(idx, offset)| {
+            let [offset] = offset.as_ref() else {
+                unreachable!("multi-vector offsets are stored as a single-element slice");
+            };
+
+            (idx, *offset)
+        })
     }
 
     fn len(&self) -> usize {
@@ -591,6 +628,13 @@ where
 {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         self.offsets.get_offset(idx)
+    }
+
+    fn iter_offsets(
+        &self,
+        ids: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
+        self.offsets.iter_offsets(ids)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -11,6 +11,7 @@ use fs_err as fs;
 use memmap2::MmapMut;
 use quantization::EncodedVectors;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType};
@@ -350,22 +351,26 @@ where
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
         let offset = self.offsets.get_offset(vector_index);
-        let mut sum = 0.0;
-        for inner_query in query {
-            let mut max_sim = ScoreType::NEG_INFINITY;
-            // manual `max_by` for performance
-            for i in 0..offset.count {
-                let sim =
-                    self.quantized_storage
-                        .score_point(inner_query, offset.start + i, hw_counter);
-                if sim > max_sim {
-                    max_sim = sim;
+
+        let offsets: SmallVec<[_; 8]> = (offset.start..offset.start + offset.count)
+            .into_iter()
+            .collect();
+
+        let mut max_sim: SmallVec<[_; 8]> = SmallVec::new();
+        max_sim.resize(query.len(), ScoreType::NEG_INFINITY);
+
+        self.quantized_storage
+            .for_each_in_batch(&offsets, |_, vector| {
+                for (query_idx, query) in query.iter().enumerate() {
+                    let sim = self.quantized_storage.score(&query, vector, hw_counter);
+
+                    if max_sim[query_idx] < sim {
+                        max_sim[query_idx] = sim;
+                    }
                 }
-            }
-            // sum of max similarity
-            sum += max_sim;
-        }
-        sum
+            });
+
+        max_sim.into_iter().sum()
     }
 
     /// Custom `score_max_similarity` implementation for quantized vectors

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -286,7 +286,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
                     reco_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::new_multi::<TElement, TMetric, _, _>(
                         RecoBestScoreQuery::from(reco_query),
                         quantized_multivector_storage,
                         quantization_config,
@@ -298,7 +298,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
                     reco_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::new_multi::<TElement, TMetric, _, _>(
                         RecoSumScoresQuery::from(reco_query),
                         quantized_multivector_storage,
                         quantization_config,
@@ -310,7 +310,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let discover_query: DiscoverQuery<MultiDenseVectorInternal> =
                     discover_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::new_multi::<TElement, TMetric, _, _>(
                         discover_query,
                         quantized_multivector_storage,
                         quantization_config,
@@ -322,7 +322,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let context_query: ContextQuery<MultiDenseVectorInternal> =
                     context_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::new_multi::<TElement, TMetric, _, _>(
                         context_query,
                         quantized_multivector_storage,
                         quantization_config,
@@ -334,7 +334,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let feedback_query: NaiveFeedbackQuery<MultiDenseVectorInternal> =
                     feedback_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::new_multi::<TElement, TMetric, _, _>(
                         feedback_query.into_query(),
                         quantized_multivector_storage,
                         quantization_config,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -286,7 +286,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
                     reco_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
                         RecoBestScoreQuery::from(reco_query),
                         quantized_multivector_storage,
                         quantization_config,
@@ -298,7 +298,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let reco_query: RecoQuery<MultiDenseVectorInternal> =
                     reco_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
                         RecoSumScoresQuery::from(reco_query),
                         quantized_multivector_storage,
                         quantization_config,
@@ -310,7 +310,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let discover_query: DiscoverQuery<MultiDenseVectorInternal> =
                     discover_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
                         discover_query,
                         quantized_multivector_storage,
                         quantization_config,
@@ -322,7 +322,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let context_query: ContextQuery<MultiDenseVectorInternal> =
                     context_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
                         context_query,
                         quantized_multivector_storage,
                         quantization_config,
@@ -334,7 +334,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 let feedback_query: NaiveFeedbackQuery<MultiDenseVectorInternal> =
                     feedback_query.transform_into()?;
                 let query_scorer =
-                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _>::new_multi(
+                    QuantizedMultiCustomQueryScorer::<TElement, TMetric, _, _, _>::new_multi(
                         feedback_query.into_query(),
                         quantized_multivector_storage,
                         quantization_config,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -15,7 +15,9 @@ use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, Manhat
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
 use crate::vector_storage::quantized::quantized_multi_custom_query_scorer::QuantizedMultiCustomQueryScorer;
 use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
-use crate::vector_storage::quantized::quantized_multivector_storage::MultivectorOffsets;
+use crate::vector_storage::quantized::quantized_multivector_storage::{
+    MultivectorOffsetsStorage, QuantizedMultivectorStorage,
+};
 use crate::vector_storage::query::{
     ContextQuery, DiscoverQuery, NaiveFeedbackQuery, RecoBestScoreQuery, RecoQuery,
     RecoSumScoresQuery, TransformInto,
@@ -129,40 +131,40 @@ impl<'a> QuantizedScorerBuilder<'a> {
                 self.new_quantized_scorer::<TElement, TMetric>(storage)
             }
             QuantizedVectorStorage::ScalarRamMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::ScalarMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::ScalarChunkedMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::PQRamMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::PQMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::PQChunkedMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::BinaryRamMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::BinaryMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::BinaryChunkedMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::TQRamMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::TQMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
             QuantizedVectorStorage::TQChunkedMmapMulti(storage) => {
-                self.new_multi_quantized_scorer::<TElement, TMetric>(storage)
+                self.new_multi_quantized_scorer::<TElement, TMetric, _, _>(storage)
             }
         }
     }
@@ -248,13 +250,18 @@ impl<'a> QuantizedScorerBuilder<'a> {
         }
     }
 
-    fn new_multi_quantized_scorer<TElement, TMetric>(
+    fn new_multi_quantized_scorer<TElement, TMetric, QuantizedStorage, OffsetStorage>(
         self,
-        quantized_multivector_storage: &'a (impl EncodedVectors + MultivectorOffsets),
+        quantized_multivector_storage: &'a QuantizedMultivectorStorage<
+            QuantizedStorage,
+            OffsetStorage,
+        >,
     ) -> OperationResult<Box<dyn RawScorer + 'a>>
     where
         TElement: PrimitiveVectorElement,
         TMetric: Metric<TElement> + 'a,
+        QuantizedStorage: quantization::EncodedVectors + 'a,
+        OffsetStorage: MultivectorOffsetsStorage + 'a,
     {
         let Self {
             quantized_storage: _same_as_quantized_storage_in_args,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -16,7 +16,8 @@ use quantization::{EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8};
 use serde::{Deserialize, Serialize};
 
 use super::quantized_multivector_storage::{
-    MultivectorOffset, MultivectorOffsetsStorageMmap, QuantizedMultivectorStorage,
+    MultivectorOffset, MultivectorOffsetsStorage, MultivectorOffsetsStorageMmap,
+    QuantizedMultivectorStorage,
 };
 use super::quantized_scorer_builder::QuantizedScorerBuilder;
 use crate::common::Flusher;
@@ -38,7 +39,7 @@ use crate::vector_storage::quantized::quantized_mmap_storage::{
 };
 use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
-    MultivectorOffsets, MultivectorOffsetsStorageChunkedMmap, MultivectorOffsetsStorageRam,
+    MultivectorOffsetsStorageChunkedMmap, MultivectorOffsetsStorageRam,
 };
 use crate::vector_storage::quantized::quantized_query_scorer::{
     InternalScorerUnsupported, QuantizedQueryScorer,
@@ -393,11 +394,15 @@ impl QuantizedVectors {
             Ok(Box::new(RawScorerImpl { query_scorer }))
         }
 
-        fn build_multi<'a, TEncodedVectors: quantization::EncodedVectors + MultivectorOffsets>(
+        fn build_multi<'a, QuantizedStorage, OffsetStorage>(
             point_id: PointOffsetType,
-            quantized_data: &'a TEncodedVectors,
+            quantized_data: &'a QuantizedMultivectorStorage<QuantizedStorage, OffsetStorage>,
             hardware_counter: HardwareCounterCell,
-        ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported> {
+        ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported>
+        where
+            QuantizedStorage: quantization::EncodedVectors + 'a,
+            OffsetStorage: MultivectorOffsetsStorage + 'a,
+        {
             let query_scorer = QuantizedMultiQueryScorer::new_internal(
                 point_id,
                 quantized_data,


### PR DESCRIPTION
This is partial `universal_io`-fication of quantized multi-vector scorers. The solution is still not optimal for `io_uring`, but it improves a few places where easy wins are possible.

I fought it for a whole week, and it's simply impossible to implement *without adding insane complexity*. The only viable solution, is to implement "spliced reads", like was initially implemented in #8791.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
