### PR TITLE
TQ renormalization for L2 metric

### DIFF
--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -38,13 +38,20 @@ impl<'a> TqVectorExtras<'a> {
             DistanceType::Cosine => size_of::<f32>(),
             DistanceType::L1 | DistanceType::L2 => size_of::<f32>(),
         };
+        // L2 folds renormalization into `scaling_factor = l2 / cn` (like
+        // Dot/Cosine) but still needs the raw `l2_length` for the `||v||²`
+        // term in the L2 score formula — store it as a second f32.
+        let l2_length_size = match distance {
+            DistanceType::L2 => size_of::<f32>(),
+            DistanceType::Dot | DistanceType::Cosine | DistanceType::L1 => 0,
+        };
         let ec_correction_size = match mode {
             // TQ+ stores `xm = ⟨X, M⟩` per vector for the symmetric-scoring
             // slow path.
             TQMode::Plus => size_of::<f32>(),
             TQMode::Normal => 0,
         };
-        scaling_factor_size + ec_correction_size
+        scaling_factor_size + l2_length_size + ec_correction_size
     }
 
     /// Per-vector scaling factor that scoring multiplies into the centroid dot.
@@ -57,15 +64,35 @@ impl<'a> TqVectorExtras<'a> {
         f32::from_le_bytes(bytes)
     }
 
+    /// Original L2 length of the source vector (pre-rotation, pre-rescale).
+    /// Only present for [`DistanceType::L2`] — stored at offset 4 immediately
+    /// after `scaling_factor`. Needed because L2's `scaling_factor` already
+    /// folds in the renormalization (`l2 / cn`, matching Dot/Cosine), so the
+    /// raw `||v||²` term in the L2 score formula has to be recovered from a
+    /// separate field.
+    pub fn l2_length(&self) -> f32 {
+        debug_assert!(
+            self.src.len() >= 2 * size_of::<f32>(),
+            "l2_length is only stored for DistanceType::L2"
+        );
+        let off = size_of::<f32>();
+        let bytes: [u8; 4] = self.src[off..off + size_of::<f32>()]
+            .try_into()
+            .expect("expected 4 bytes for l2_length");
+        f32::from_le_bytes(bytes)
+    }
+
     /// TQ+ per-vector `⟨X, M⟩` correction. Only present when the quantizer
     /// was configured with [`TQMode::Plus`]; the caller is responsible for
     /// only calling this getter in that mode (validated via `debug_assert`).
+    /// Stored as the trailing 4 bytes of the extras blob — the only field
+    /// whose offset can shift (L2 stores an extra `centroid_norm` before it).
     pub fn ec_correction(&self) -> f32 {
         debug_assert!(
             self.src.len() >= 2 * size_of::<f32>(),
             "ec_correction is only stored for TQMode::Plus"
         );
-        let off = size_of::<f32>();
+        let off = self.src.len() - size_of::<f32>();
         let bytes: [u8; 4] = self.src[off..off + size_of::<f32>()]
             .try_into()
             .expect("expected 4 bytes for ec_correction");
@@ -184,7 +211,10 @@ impl TurboQuantizer {
 
     /// Encodes the given raw extras values and appends them to `buf`.
     /// `ec_correction` (`xm = ⟨X, M⟩`) is required when the quantizer is in
-    /// [`TQMode::Plus`] and ignored otherwise.
+    /// [`TQMode::Plus`] and ignored otherwise. `centroid_norm` is required for
+    /// Dot/Cosine/L2 — for all three it's folded into the merged
+    /// `scaling_factor = l2_length / centroid_norm`. L2 additionally stores
+    /// the raw `l2_length` separately so scoring can recover the `||v||²` term.
     pub(super) fn pack_extras_into(
         &self,
         l2_length: Option<f32>,
@@ -193,13 +223,20 @@ impl TurboQuantizer {
         buf: &mut Vec<u8>,
     ) {
         let scaling_factor = match self.distance {
-            DistanceType::Dot | DistanceType::Cosine => {
+            DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
                 l2_length.unwrap_or(1.0) / centroid_norm.unwrap()
             }
-            DistanceType::L1 | DistanceType::L2 => l2_length.unwrap(),
+            DistanceType::L1 => l2_length.unwrap(),
         };
 
         buf.extend(&scaling_factor.to_le_bytes());
+
+        // L2 stores the raw `l2_length` separately: `scaling_factor` already
+        // folds in renormalization, but the `||v_a||² + ||v_b||²` part of the
+        // score formula still needs the un-divided lengths.
+        if matches!(self.distance, DistanceType::L2) {
+            buf.extend(&l2_length.unwrap().to_le_bytes());
+        }
 
         if matches!(self.mode, TQMode::Plus) {
             buf.extend(&ec_correction.unwrap_or(0.0).to_le_bytes());
@@ -226,12 +263,15 @@ mod tests {
 
     /// `(l2_length, centroid_norm, expected_scaling_factor)` per distance:
     /// the first two are the raw inputs to `pack_extras_into`; the third is
-    /// the merged f32 that `scaling_factor()` should read back.
+    /// the merged f32 that `scaling_factor()` should read back. For L2 the
+    /// merged `scaling_factor` is `l2/cn` (like Dot/Cosine) and the raw
+    /// `l2_length` is roundtripped via the dedicated `l2_length()` getter.
     fn example_extras(distance: DistanceType) -> (Option<f32>, Option<f32>, f32) {
         match distance {
             DistanceType::Dot => (Some(1.25), Some(15.5), 1.25 / 15.5),
             DistanceType::Cosine => (None, Some(0.875), 1.0 / 0.875),
-            DistanceType::L1 | DistanceType::L2 => (Some(1.3), None, 1.3),
+            DistanceType::L2 => (Some(1.3), Some(8.0), 1.3 / 8.0),
+            DistanceType::L1 => (Some(1.3), None, 1.3),
         }
     }
 
@@ -276,6 +316,14 @@ mod tests {
                         expected_scaling,
                         "scaling_factor roundtrip (bits={bits:?}, mode={mode:?}, distance={distance:?})",
                     );
+                    if matches!(distance, DistanceType::L2) {
+                        let expected_l2 = l2_length.expect("L2 must supply l2_length");
+                        assert_eq!(
+                            extras.l2_length(),
+                            expected_l2,
+                            "l2_length roundtrip (bits={bits:?}, mode={mode:?}, distance={distance:?})",
+                        );
+                    }
                     if let Some(expected) = expected_ec {
                         assert_eq!(
                             extras.ec_correction(),

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -18,9 +18,6 @@ pub struct TurboQuantizer {
     pub(super) distance: DistanceType,
     pub(super) padded_dim: usize,
     pub(super) error_correction: Option<ErrorCorrection>,
-
-    // Pre-calculated `sqrt(dim)` used in L2 scoring.
-    dim_sqrt: f32,
 }
 
 /// TQ+ per-coordinate shift+scale: pulls each rotated, length-rescaled
@@ -130,7 +127,6 @@ impl TurboQuantizer {
     ) -> Self {
         let padded_dim = Self::padded_dim(dim, bits);
         let rotation = HadamardRotation::new(padded_dim);
-        let dim_sqrt = (padded_dim as f32).sqrt();
         TurboQuantizer {
             rotation,
             bits,
@@ -138,7 +134,6 @@ impl TurboQuantizer {
             distance,
             padded_dim,
             error_correction,
-            dim_sqrt,
         }
     }
 
@@ -249,7 +244,7 @@ impl TurboQuantizer {
         // the renormalized denominator equals padded_dim — i.e. renorm is a
         // no-op for these degenerate inputs, preserving baseline behavior.
         let centroid_norm = match self.distance {
-            DistanceType::Dot => Some(self.compute_centroid_norm(buf, scale)),
+            DistanceType::Dot | DistanceType::L2 => Some(self.compute_centroid_norm(buf, scale)),
             DistanceType::Cosine => {
                 let rotated_l2_sq: f64 = buf.iter().map(|&x| x * x).sum();
                 if rotated_l2_sq < 1e-12 {
@@ -258,7 +253,7 @@ impl TurboQuantizer {
                     Some(self.compute_centroid_norm(buf, scale))
                 }
             }
-            DistanceType::L1 | DistanceType::L2 => None,
+            DistanceType::L1 => None,
         };
 
         let mut extras_bytes = Vec::with_capacity(TqVectorExtras::size_for(
@@ -313,10 +308,13 @@ impl TurboQuantizer {
         // bytes twice for every dequantize call.
         let unpacked: Vec<f64> = unpacked_iter.collect();
 
-        // Stored field is `l2/cn_quant` (`l2 == 1.0` for Cosine).
-        // To recover the original l2 length, we need to `* cn_quant` measured
-        // in the same space `cn` was stored in. For TQ+ that's the EC-reverted
-        // (rescaled) space, matching `compute_centroid_norm`'s convention.
+        // Stored `scaling_factor` is `l2/cn_quant` for Dot/Cosine/L2 (`l2 ==
+        // 1.0` for Cosine). To recover the original l2 length we either
+        // multiply by `cn_quant` recomputed from the unpacked centroids
+        // (Dot/Cosine — `l2` isn't stored separately) or read the dedicated
+        // `l2_length` field (L2 stores it directly, no recompute needed).
+        // For TQ+, `cn_quant` is measured in the EC-reverted (rescaled) space,
+        // matching `compute_centroid_norm`'s convention.
         let recovered_l2 = match self.distance {
             DistanceType::Dot | DistanceType::Cosine => {
                 let cn_quant = match &self.error_correction {
@@ -333,7 +331,8 @@ impl TurboQuantizer {
                 };
                 scaling_factor * cn_quant
             }
-            DistanceType::L1 | DistanceType::L2 => scaling_factor,
+            DistanceType::L2 => f64::from(extras.l2_length()),
+            DistanceType::L1 => scaling_factor,
         };
 
         let scale = recovered_l2 / (self.padded_dim as f64).sqrt();
@@ -382,11 +381,15 @@ impl TurboQuantizer {
         match self.distance {
             DistanceType::Cosine | DistanceType::Dot => raw_dot * v1_scale * v2_scale,
             DistanceType::L2 => {
-                // For L2, the "dot" we calculated is actually ||v1||² + ||v2||² - 2*||v1||*||v2||*<v1_normalized, v2_normalized>>,
-                // so we need to do some extra math to recover the actual <v1, v2>.
-                // Note that `v*_scale` is equal to ||v*||² for L2 distance metric.
-                v1_scale * v1_scale + v2_scale * v2_scale
-                    - 2.0 * v1_scale * v2_scale * raw_dot / self.padded_dim as f32
+                // ||v1 - v2||² = ||v1||² + ||v2||² - 2·⟨v1, v2⟩.
+                // `v*_scale = l2 / cn` already folds renorm in, so the cross
+                // term `2 · raw_dot · sf_a · sf_b` reconstructs `2·⟨v1, v2⟩`
+                // exactly the way Dot/Cosine do. `l2_length` is fetched
+                // separately for the `||v||²` term — we can't read it back
+                // out of `sf` without `cn`.
+                let l2_a = extra_v1.l2_length();
+                let l2_b = extra_v2.l2_length();
+                l2_a * l2_a + l2_b * l2_b - 2.0 * v1_scale * v2_scale * raw_dot
             }
             DistanceType::L1 => {
                 // Fallback case for L1, where we need to fully dequantize both vectors.
@@ -546,11 +549,14 @@ impl TurboQuantizer {
                 dot * scaling_factor
             }
             DistanceType::L2 => {
-                let l2 = vector_extras.scaling_factor();
-                // For L2, the "dot" we calculated is actually ||query||² + ||v||² - 2*||v||²*<query, v_normalized>>,
-                // so we need to do some extra math to recover the actual <query, v>.
+                // ||q - v||² = ||q||² + ||v||² - 2·⟨q, v⟩.
+                // `scaling_factor = l2 / cn` folds renorm in, so `dot · sf`
+                // reconstructs `⟨q, v⟩`. Query side isn't quantized → no `cn`
+                // factor on that side. `l2_length` is the raw `||v||`.
+                let scaling_factor = vector_extras.scaling_factor();
+                let l2 = vector_extras.l2_length();
                 let query_l2 = query.l2_norm.unwrap_or(1.0);
-                query_l2 * query_l2 + l2 * l2 - 2.0 * l2 * dot / self.dim_sqrt
+                query_l2 * query_l2 + l2 * l2 - 2.0 * dot * scaling_factor
             }
             DistanceType::L1 => {
                 let mut deq_v: Vec<f64> = self.dequantize(vec);


### PR DESCRIPTION
This PR adds renormalization for L2 score in TQ.

Currently renormalization is skipped for L2. It's also correct by math, but renormalization gives improvements for recall.

It's nice to include into 1.18 version because this PR changes the format of quantized vector (adds one float for L2 metric).

`mean-precision` diff forr `gist-960-euclidean` using vector-db-bench (HNSW, no rescore, no oversampling):
4bit TQ: 0.7130 -> 0.73498
2bit TQ: 0.5081 -> 0.62124
1.5bit TQ: 0.1234 -> 0.218
1bit TQ: 0.1131 -> 0.2146
Low 1bit case is fine - BQ has almost 0 precision here.
