### PR TITLE
refactor(read_view): make StructPayloadIndexReadView generic over F: FieldIndexRead

### DIFF
--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -350,7 +350,13 @@ impl StructPayloadIndex {
     pub fn with_view<R>(
         &self,
         f: impl FnOnce(
-            StructPayloadIndexReadView<'_, PayloadStorageEnum, IdTrackerEnum, VectorStorageEnum>,
+            StructPayloadIndexReadView<
+                '_,
+                PayloadStorageEnum,
+                IdTrackerEnum,
+                VectorStorageEnum,
+                FieldIndex,
+            >,
         ) -> R,
     ) -> R {
         let id_tracker = self.id_tracker.borrow();

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -17,11 +17,12 @@ use crate::payload_storage::query_checker::{
 use crate::types::{Condition, FieldCondition, OwnedPayloadRef, PayloadContainer};
 use crate::vector_storage::VectorStorageRead;
 
-impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     pub fn condition_converter<'b, S: PayloadStorageRead + 'b>(
         &'b self,

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -15,11 +15,12 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition};
 use crate::vector_storage::VectorStorageRead;
 
-impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     pub fn estimate_field_condition(
         &self,

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -13,12 +13,12 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 
-use crate::common::utils::IndexesMap;
 use crate::id_tracker::IdTrackerRead;
+use crate::index::field_index::FieldIndexRead;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::VectorNameBuf;
+use crate::types::{PayloadKeyType, VectorNameBuf};
 use crate::vector_storage::VectorStorageRead;
 
 /// Read-only view over a [`StructPayloadIndex`].
@@ -29,6 +29,12 @@ use crate::vector_storage::VectorStorageRead;
 /// it can also be built directly over read-only backends without
 /// going through the writable [`StructPayloadIndex`].
 ///
+/// Generic over `F: FieldIndexRead` so the view depends only on the
+/// read-only trait surface, not the concrete [`FieldIndex`] enum.
+/// `StructPayloadIndex::with_view` instantiates `F = FieldIndex`;
+/// other consumers can plug in any type that implements
+/// `FieldIndexRead`.
+///
 /// Holds exactly the fields that `PayloadIndexRead` needs and no
 /// more. Build-side helpers (`build_field_indexes`, the selector
 /// machinery, `path`, `is_appendable`) stay on `StructPayloadIndex`.
@@ -36,25 +42,28 @@ use crate::vector_storage::VectorStorageRead;
 /// [`StructPayloadIndex`]: crate::index::struct_payload_index::StructPayloadIndex
 /// [`StructPayloadIndex::with_view`]: crate::index::struct_payload_index::StructPayloadIndex::with_view
 /// [`PayloadIndexRead`]: crate::index::PayloadIndexRead
-pub struct StructPayloadIndexReadView<'a, P, I, V>
+/// [`FieldIndex`]: crate::index::field_index::FieldIndex
+pub struct StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     pub(crate) payload: &'a Arc<AtomicRefCell<P>>,
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storages: &'a HashMap<VectorNameBuf, Arc<AtomicRefCell<V>>>,
-    pub(crate) field_indexes: &'a IndexesMap,
+    pub(crate) field_indexes: &'a HashMap<PayloadKeyType, Vec<F>>,
     pub(crate) config: &'a PayloadConfig,
     pub(crate) visited_pool: &'a VisitedPool,
 }
 
-impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     /// Number of available points -- excludes soft-deleted points.
     pub fn available_point_count(&self) -> usize {

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
-use crate::index::field_index::CardinalityEstimation;
+use crate::index::field_index::{CardinalityEstimation, FieldIndexRead};
 use crate::index::query_estimator::{
     combine_min_should_estimations, combine_must_estimations, combine_should_estimations,
     invert_estimation,
@@ -19,11 +19,12 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, Filter, MinShould};
 use crate::vector_storage::VectorStorageRead;
 
-impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     /// Converts user-provided filtering condition into optimized representation
     ///

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -28,11 +28,12 @@ use crate::types::{
 };
 use crate::vector_storage::VectorStorageRead;
 
-impl<'a, P, I, V> PayloadIndexRead for StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> PayloadIndexRead for StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     fn indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
         self.config.indices.to_schemas()

--- a/lib/segment/src/index/struct_payload_index/read_view/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/tests.rs
@@ -35,7 +35,7 @@ fn smoke_view_over_in_memory_backends() {
     let config = PayloadConfig::default();
     let visited_pool = VisitedPool::new();
 
-    let view: StructPayloadIndexReadView<'_, _, _, VectorStorageEnum> =
+    let view: StructPayloadIndexReadView<'_, _, _, VectorStorageEnum, _> =
         StructPayloadIndexReadView {
             payload: &payload,
             id_tracker: &id_tracker,

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
@@ -5,20 +5,22 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use crate::common::utils::MultiValue;
-use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::PayloadContainer;
 
-pub(super) fn variable_retriever<'a, 'q, P: PayloadStorageRead + 'q>(
-    indices: &'a HashMap<JsonPath, Vec<FieldIndex>>,
+pub(super) fn variable_retriever<'a, 'q, P, F>(
+    indices: &'a HashMap<JsonPath, Vec<F>>,
     json_path: &JsonPath,
     payload_provider: PayloadProvider<P>,
     hw_counter: &'q HardwareCounterCell,
 ) -> VariableRetrieverFn<'q>
 where
+    P: PayloadStorageRead + 'q,
+    F: FieldIndexRead,
     'a: 'q,
 {
     indices
@@ -148,7 +150,8 @@ mod tests {
     fn test_variable_retriever_from_payload() {
         let payload_provider = fixture_payload_provider();
 
-        let no_indices = Default::default();
+        // No indices — pick FieldIndex as the concrete F for type inference.
+        let no_indices: HashMap<_, Vec<FieldIndex>> = Default::default();
 
         let hw_counter = Default::default();
 

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/mod.rs
@@ -7,17 +7,19 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use self::helpers::variable_retriever;
 use super::StructPayloadIndexReadView;
 use crate::id_tracker::IdTrackerRead;
+use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::vector_storage::VectorStorageRead;
 
-impl<'a, P, I, V> StructPayloadIndexReadView<'a, P, I, V>
+impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
 where
     P: PayloadStorageRead,
     I: IdTrackerRead,
     V: VectorStorageRead,
+    F: FieldIndexRead,
 {
     /// Prepares optimized functions to extract each of the variables, given a point id.
     pub(crate) fn retrievers_map<'b, 'q>(

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -12,7 +12,7 @@ use common::types::PointOffsetType;
 use crate::common::operation_error::OperationResult;
 use crate::common::utils::{IndexesMap, check_is_empty, check_is_null};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
-use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::index::field_index::FieldIndexRead;
 use crate::payload_storage::condition_checker::ValueChecker;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::payload_storage::{ConditionChecker, PayloadStorageRead};
@@ -96,12 +96,13 @@ where
     }
 }
 
-pub fn select_nested_indexes<'a, R>(
+pub fn select_nested_indexes<'a, R, FI>(
     nested_path: &PayloadKeyType,
     field_indexes: &'a HashMap<PayloadKeyType, R>,
-) -> HashMap<PayloadKeyType, &'a Vec<FieldIndex>>
+) -> HashMap<PayloadKeyType, &'a Vec<FI>>
 where
-    R: AsRef<Vec<FieldIndex>>,
+    FI: FieldIndexRead,
+    R: AsRef<Vec<FI>>,
 {
     let nested_indexes: HashMap<_, _> = field_indexes
         .iter()
@@ -113,7 +114,7 @@ where
     nested_indexes
 }
 
-pub fn check_payload<'a, R>(
+pub fn check_payload<'a, R, FI>(
     get_payload: Box<dyn Fn() -> OwnedPayloadRef<'a> + 'a>,
     id_tracker: Option<&IdTrackerEnum>,
     vector_storages: &HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
@@ -123,7 +124,8 @@ pub fn check_payload<'a, R>(
     hw_counter: &HardwareCounterCell,
 ) -> bool
 where
-    R: AsRef<Vec<FieldIndex>>,
+    FI: FieldIndexRead,
+    R: AsRef<Vec<FI>>,
 {
     let checker = |condition: &Condition| match condition {
         Condition::Field(field_condition) => check_field_condition(
@@ -186,14 +188,15 @@ pub fn check_is_null_condition(is_null: &IsNullCondition, payload: &impl Payload
     check_is_null(payload.get_value(&is_null.is_null.key).iter().copied())
 }
 
-pub fn check_field_condition<R>(
+pub fn check_field_condition<R, FI>(
     field_condition: &FieldCondition,
     payload: &impl PayloadContainer,
     field_indexes: &HashMap<PayloadKeyType, R>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<bool>
 where
-    R: AsRef<Vec<FieldIndex>>,
+    FI: FieldIndexRead,
+    R: AsRef<Vec<FI>>,
 {
     let field_values = payload.get_value(&field_condition.key);
     let field_indexes = field_indexes.get(&field_condition.key);
@@ -312,6 +315,7 @@ mod tests {
     use super::*;
     use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
     use crate::id_tracker::{IdTracker, IdTrackerEnum};
+    use crate::index::field_index::FieldIndex;
     use crate::json_path::JsonPath;
     use crate::payload_json;
     use crate::payload_storage::PayloadStorage;

--- a/lib/segment/src/segment/read_view/mod.rs
+++ b/lib/segment/src/segment/read_view/mod.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::PayloadIndexRead;
+use crate::index::field_index::FieldIndex;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
@@ -50,7 +51,13 @@ where
 pub type SegmentReadViewFor<'s> = SegmentReadView<
     's,
     IdTrackerEnum,
-    StructPayloadIndexReadView<'s, PayloadStorageEnum, IdTrackerEnum, VectorStorageEnum>,
+    StructPayloadIndexReadView<
+        's,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
     PayloadStorageEnum,
     VectorData,
 >;


### PR DESCRIPTION
## Summary

The read view's `field_indexes` was concretely typed as `&IndexesMap = &HashMap<PayloadKeyType, Vec<FieldIndex>>`. Replace the `FieldIndex` with a generic parameter `F: FieldIndexRead`, so the view advertises a dependency on the trait surface rather than the concrete enum.

`StructPayloadIndex::with_view` instantiates `F = FieldIndex`; any future consumer that implements `FieldIndexRead` (e.g. a read-only segment with a narrower field-index representation) can plug in directly.

## What changed

1. **`StructPayloadIndexReadView`** gains a fourth generic parameter `F` bound by `FieldIndexRead`. `field_indexes` is now `&HashMap<PayloadKeyType, Vec<F>>`. All five impl blocks across `read_view/` propagate the `F` generic.

2. **`check_field_condition` / `select_nested_indexes` / `check_payload`** in `payload_storage/query_checker.rs` become generic over `FI: FieldIndexRead` (and `R: AsRef<Vec<FI>>`). The bodies only call `special_check_condition` which is on `FieldIndexRead`, so the generalization is free.

3. **`variable_retriever`** in `read_view/value_retriever/helpers.rs` gains an `F` generic; the body already only uses `FieldIndexRead` methods.

4. **`with_view`** and **`SegmentReadViewFor`** instantiate `F = FieldIndex`. No external consumer breaks.

5. Tests construct the view with an inferred `F`.

## Note

This commit was briefly pushed directly to `dev` as `3ef647991` and then reverted via `d914c0eda` before being moved here for proper PR review. No functional difference — same diff, same green tests.

## Test plan

- [x] `cargo build --workspace --tests` (clean)
- [x] `cargo nextest run -p segment` — 786/786 pass
- [x] `cargo +nightly fmt --all -- --check`

## Stats

`+61 / -26` across 11 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)