### PR TITLE
refactor(field_index): push PayloadFieldIndexRead per-variant; move special_check_condition

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
@@ -1,14 +1,11 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use serde_json::Value;
 
 use super::payload_field_index::PayloadFieldIndexRead;
-use crate::common::operation_error::OperationResult;
 use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::numeric_index::NumericFieldIndexRead;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::FieldCondition;
 
 /// Read-only access surface of [`FieldIndex`](super::FieldIndex).
 ///
@@ -40,19 +37,6 @@ pub trait FieldIndexRead: PayloadFieldIndexRead {
 
     /// True if `point_id` has zero values in this index.
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool;
-
-    /// Index-aware check for conditions that need parameters held by
-    /// the index (today: full-text tokenizers).
-    ///
-    /// Returns `Ok(None)` for index types that don't have such
-    /// conditions, `Ok(Some(true))` if the condition is satisfied,
-    /// `Ok(Some(false))` if it is not.
-    fn special_check_condition(
-        &self,
-        condition: &FieldCondition,
-        payload_value: &Value,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Option<bool>>;
 
     /// Build a closure that extracts this index's values for a given
     /// point as a [`MultiValue<Value>`](crate::common::utils::MultiValue).

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -8,26 +8,25 @@ use super::field_index_read::FieldIndexRead;
 use super::payload_field_index::PayloadFieldIndexRead;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::facet_index::{FacetIndex, FacetIndexEnum};
-use crate::index::field_index::full_text_index::text_index::PayloadMatchQueryType;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{FieldCondition, Match, MatchPhrase, MatchText, MatchTextAny, PayloadKeyType};
+use crate::types::{FieldCondition, PayloadKeyType};
 
 impl PayloadFieldIndexRead for FieldIndex {
     fn count_indexed_points(&self) -> usize {
         match self {
-            FieldIndex::IntIndex(idx) => idx.inner().count_indexed_points(),
-            FieldIndex::DatetimeIndex(idx) => idx.inner().count_indexed_points(),
+            FieldIndex::IntIndex(idx) => idx.count_indexed_points(),
+            FieldIndex::DatetimeIndex(idx) => idx.count_indexed_points(),
             FieldIndex::IntMapIndex(idx) => idx.count_indexed_points(),
             FieldIndex::KeywordIndex(idx) => idx.count_indexed_points(),
-            FieldIndex::FloatIndex(idx) => idx.inner().count_indexed_points(),
+            FieldIndex::FloatIndex(idx) => idx.count_indexed_points(),
             FieldIndex::GeoIndex(idx) => idx.count_indexed_points(),
             FieldIndex::BoolIndex(idx) => idx.count_indexed_points(),
             FieldIndex::FullTextIndex(idx) => idx.count_indexed_points(),
-            FieldIndex::UuidIndex(idx) => idx.inner().count_indexed_points(),
+            FieldIndex::UuidIndex(idx) => idx.count_indexed_points(),
             FieldIndex::UuidMapIndex(idx) => idx.count_indexed_points(),
             FieldIndex::NullIndex(idx) => idx.count_indexed_points(),
         }
@@ -39,15 +38,15 @@ impl PayloadFieldIndexRead for FieldIndex {
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
         match self {
-            FieldIndex::IntIndex(idx) => idx.inner().filter(condition, hw_counter),
-            FieldIndex::DatetimeIndex(idx) => idx.inner().filter(condition, hw_counter),
+            FieldIndex::IntIndex(idx) => idx.filter(condition, hw_counter),
+            FieldIndex::DatetimeIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::IntMapIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::KeywordIndex(idx) => idx.filter(condition, hw_counter),
-            FieldIndex::FloatIndex(idx) => idx.inner().filter(condition, hw_counter),
+            FieldIndex::FloatIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::GeoIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::BoolIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::FullTextIndex(idx) => idx.filter(condition, hw_counter),
-            FieldIndex::UuidIndex(idx) => idx.inner().filter(condition, hw_counter),
+            FieldIndex::UuidIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::UuidMapIndex(idx) => idx.filter(condition, hw_counter),
             FieldIndex::NullIndex(idx) => idx.filter(condition, hw_counter),
         }
@@ -59,17 +58,15 @@ impl PayloadFieldIndexRead for FieldIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
         match self {
-            FieldIndex::IntIndex(idx) => idx.inner().estimate_cardinality(condition, hw_counter),
-            FieldIndex::DatetimeIndex(idx) => {
-                idx.inner().estimate_cardinality(condition, hw_counter)
-            }
+            FieldIndex::IntIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
+            FieldIndex::DatetimeIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::IntMapIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::KeywordIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
-            FieldIndex::FloatIndex(idx) => idx.inner().estimate_cardinality(condition, hw_counter),
+            FieldIndex::FloatIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::GeoIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::BoolIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::FullTextIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
-            FieldIndex::UuidIndex(idx) => idx.inner().estimate_cardinality(condition, hw_counter),
+            FieldIndex::UuidIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::UuidMapIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
             FieldIndex::NullIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
         }
@@ -82,15 +79,15 @@ impl PayloadFieldIndexRead for FieldIndex {
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
         match self {
-            FieldIndex::IntIndex(idx) => idx.inner().for_each_payload_block(threshold, key, f),
-            FieldIndex::DatetimeIndex(idx) => idx.inner().for_each_payload_block(threshold, key, f),
+            FieldIndex::IntIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            FieldIndex::DatetimeIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::IntMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::KeywordIndex(idx) => idx.for_each_payload_block(threshold, key, f),
-            FieldIndex::FloatIndex(idx) => idx.inner().for_each_payload_block(threshold, key, f),
+            FieldIndex::FloatIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::GeoIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::BoolIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::FullTextIndex(idx) => idx.for_each_payload_block(threshold, key, f),
-            FieldIndex::UuidIndex(idx) => idx.inner().for_each_payload_block(threshold, key, f),
+            FieldIndex::UuidIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::UuidMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
             FieldIndex::NullIndex(idx) => idx.for_each_payload_block(threshold, key, f),
         }
@@ -102,72 +99,65 @@ impl PayloadFieldIndexRead for FieldIndex {
         hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
         match self {
-            FieldIndex::IntIndex(idx) => idx.inner().condition_checker(condition, hw_acc),
-            FieldIndex::DatetimeIndex(idx) => idx.inner().condition_checker(condition, hw_acc),
+            FieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
+            FieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::IntMapIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::KeywordIndex(idx) => idx.condition_checker(condition, hw_acc),
-            FieldIndex::FloatIndex(idx) => idx.inner().condition_checker(condition, hw_acc),
+            FieldIndex::FloatIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::GeoIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::BoolIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::FullTextIndex(idx) => idx.condition_checker(condition, hw_acc),
-            FieldIndex::UuidIndex(idx) => idx.inner().condition_checker(condition, hw_acc),
+            FieldIndex::UuidIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::UuidMapIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::NullIndex(idx) => idx.condition_checker(condition, hw_acc),
         }
     }
-}
 
-impl FieldIndexRead for FieldIndex {
-    /// Try to check condition for a payload given a field index.
-    /// Required because some index parameters may influence the condition checking logic.
-    /// For example, full text index may have different tokenizers.
-    ///
-    /// Returns `None` if there is no special logic for the given index
-    /// returns `Some(true)` if condition is satisfied
-    /// returns `Some(false)` if condition is not satisfied
     fn special_check_condition(
         &self,
         condition: &FieldCondition,
         payload_value: &Value,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<bool>> {
-        Ok(match self {
-            FieldIndex::IntIndex(_) => None,
-            FieldIndex::DatetimeIndex(_) => None,
-            FieldIndex::IntMapIndex(_) => None,
-            FieldIndex::KeywordIndex(_) => None,
-            FieldIndex::FloatIndex(_) => None,
-            FieldIndex::GeoIndex(_) => None,
-            FieldIndex::BoolIndex(_) => None,
-            FieldIndex::FullTextIndex(index) => match &condition.r#match {
-                Some(Match::Text(MatchText { text })) => Some(index.check_payload_match(
-                    payload_value,
-                    text,
-                    PayloadMatchQueryType::Text,
-                    hw_counter,
-                )?),
-                Some(Match::Phrase(MatchPhrase { phrase })) => Some(index.check_payload_match(
-                    payload_value,
-                    phrase,
-                    PayloadMatchQueryType::Phrase,
-                    hw_counter,
-                )?),
-                Some(Match::TextAny(MatchTextAny { text_any })) => {
-                    Some(index.check_payload_match(
-                        payload_value,
-                        text_any,
-                        PayloadMatchQueryType::TextAny,
-                        hw_counter,
-                    )?)
-                }
-                Some(Match::Value(_) | Match::Any(_) | Match::Except(_)) | None => None,
-            },
-            FieldIndex::UuidIndex(_) => None,
-            FieldIndex::UuidMapIndex(_) => None,
-            FieldIndex::NullIndex(_) => None,
-        })
+        match self {
+            FieldIndex::IntIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::DatetimeIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::IntMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::KeywordIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::FloatIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::GeoIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::BoolIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::FullTextIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::UuidIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::UuidMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            FieldIndex::NullIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+        }
     }
+}
 
+impl FieldIndexRead for FieldIndex {
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
         match self {
             FieldIndex::IntIndex(index) => index.get_telemetry_data(),

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use serde_json::Value;
 
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
@@ -56,6 +57,21 @@ pub trait PayloadFieldIndexRead {
         _condition: &FieldCondition,
         _hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>>;
+
+    /// Index-aware check for conditions that need parameters held by
+    /// the index (today: full-text tokenizers).
+    ///
+    /// Returns `Ok(None)` for index types that don't have such
+    /// conditions, `Ok(Some(true))` if the condition is satisfied,
+    /// `Ok(Some(false))` if it is not.
+    fn special_check_condition(
+        &self,
+        _condition: &FieldCondition,
+        _payload_value: &Value,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>> {
+        Ok(None)
+    }
 }
 
 /// Storage-lifecycle operations on top of [`PayloadFieldIndexRead`].

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -8,7 +8,7 @@ use tempfile::Builder;
 use crate::data_types::index::{TextIndexParams, TextIndexType, TokenizerType};
 use crate::index::field_index::full_text_index::text_index::FullTextIndex;
 use crate::index::field_index::{
-    FieldIndex, FieldIndexBuilderTrait as _, FieldIndexRead, ValueIndexer,
+    FieldIndex, FieldIndexBuilderTrait as _, PayloadFieldIndexRead, ValueIndexer,
 };
 
 fn movie_titles() -> Vec<String> {

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -659,6 +659,35 @@ impl PayloadFieldIndexRead for FullTextIndex {
             self.check_match(&parsed_query, point_id).unwrap_or(false)
         }))
     }
+
+    fn special_check_condition(
+        &self,
+        condition: &FieldCondition,
+        payload_value: &Value,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>> {
+        Ok(match &condition.r#match {
+            Some(Match::Text(MatchText { text })) => Some(self.check_payload_match(
+                payload_value,
+                text,
+                PayloadMatchQueryType::Text,
+                hw_counter,
+            )?),
+            Some(Match::Phrase(MatchPhrase { phrase })) => Some(self.check_payload_match(
+                payload_value,
+                phrase,
+                PayloadMatchQueryType::Phrase,
+                hw_counter,
+            )?),
+            Some(Match::TextAny(MatchTextAny { text_any })) => Some(self.check_payload_match(
+                payload_value,
+                text_any,
+                PayloadMatchQueryType::TextAny,
+                hw_counter,
+            )?),
+            Some(Match::Value(_) | Match::Any(_) | Match::Except(_)) | None => None,
+        })
+    }
 }
 
 pub struct FullTextGridstoreIndexBuilder {

--- a/lib/segment/src/index/field_index/numeric_index/index.rs
+++ b/lib/segment/src/index/field_index/numeric_index/index.rs
@@ -2,18 +2,25 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use gridstore::Blob;
+use serde_json::Value;
 
 use super::storage::NumericIndexInner;
 use super::{Encodable, NumericIndexGridstoreBuilder, NumericIndexMmapBuilder};
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::stored_point_to_values::StoredValue;
-use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
+use crate::index::field_index::{
+    CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
+    ValueIndexer,
+};
 use crate::index::payload_config::{IndexMutability, StorageType};
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, PayloadKeyType};
 
 pub struct NumericIndex<T: Encodable + Numericable + StoredValue + Send + Sync + Default, P>
 where
@@ -137,5 +144,58 @@ where
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.inner.clear_cache()
+    }
+}
+
+impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, P> PayloadFieldIndexRead
+    for NumericIndex<T, P>
+where
+    Vec<T>: Blob,
+{
+    fn count_indexed_points(&self) -> usize {
+        self.inner.count_indexed_points()
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        self.inner.filter(condition, hw_counter)
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        self.inner.estimate_cardinality(condition, hw_counter)
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.inner.for_each_payload_block(threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        self.inner.condition_checker(condition, hw_acc)
+    }
+
+    fn special_check_condition(
+        &self,
+        condition: &FieldCondition,
+        payload_value: &Value,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>> {
+        self.inner
+            .special_check_condition(condition, payload_value, hw_counter)
     }
 }


### PR DESCRIPTION
## Summary

Stacks on #8997. Two related cleanups, both pushing read-trait logic from the `FieldIndex` enum down to per-variant trait impls.

### 1. `impl PayloadFieldIndexRead for NumericIndex<T, P>`

`NumericIndex<T, P>` now implements `PayloadFieldIndexRead` directly, forwarding all five methods to its inner storage enum. The four numeric arms (`IntIndex`, `DatetimeIndex`, `FloatIndex`, `UuidIndex`) in `FieldIndex`'s `impl PayloadFieldIndexRead` drop their `.inner()` calls. All eleven variants now use a uniform `idx.<method>(...)` form.

### 2. `special_check_condition` moves to `PayloadFieldIndexRead`

Previously \`special_check_condition\` lived on \`FieldIndexRead\` and the \`FieldIndex\` enum carried the entire dispatch logic (including the FullTextIndex-specific match body) inline.

- Added \`special_check_condition\` to \`PayloadFieldIndexRead\` with a default \`Ok(None)\` body — the right default for every non-text index.
- \`FullTextIndex\` overrides it with the match logic that previously lived in \`field_index_read_impl.rs\`.
- \`NumericIndex<T, P>\` forwards to its inner enum (so any future numeric override on the inner side propagates).
- \`FieldIndex\`'s match dispatch moves out of \`FieldIndexRead\` into \`PayloadFieldIndexRead\` for consistency with the other five trait methods.
- Removed the now-redundant declaration from \`FieldIndexRead\` — it's inherited via the supertrait introduced in #8996.

\`FullTextIndex\`'s logic is now where it belongs (next to the index that owns it), and the \`FieldIndex\` enum's read-trait impls are uniform: every method is a one-line per-variant forward.

## Test plan

- [x] \`cargo check -p segment --tests\`
- [x] \`cargo clippy -p segment --all-targets -- -D warnings\`
- [x] \`cargo test -p segment --lib\` — 666 passed
- [x] \`cargo +nightly fmt --all -- --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)