### PR TITLE
Replace `Meta` with `U: UserData`

### DIFF
--- a/lib/common/common/src/persisted_hashmap/tests.rs
+++ b/lib/common/common/src/persisted_hashmap/tests.rs
@@ -182,7 +182,7 @@ fn run_uio_checks<K: ?Sized + TestKey, V: TestValue, S: UniversalRead>(
         struct Entry<KO, V> {
             key: KO,
             values: Option<Vec<V>>,
-            meta: u16,
+            user_data: u16,
         }
 
         let mut rng2 = rng.fork();
@@ -190,12 +190,12 @@ fn run_uio_checks<K: ?Sized + TestKey, V: TestValue, S: UniversalRead>(
             orig.iter().map(|(k, v)| Entry {
                 key: k.clone(),
                 values: Some(v.clone()),
-                meta: rng.random::<u16>(),
+                user_data: rng.random::<u16>(),
             }),
             non_existing_keys.iter().map(|k| Entry {
                 key: k.clone(),
                 values: None,
-                meta: rng2.random::<u16>(),
+                user_data: rng2.random::<u16>(),
             }),
         )
         .collect_vec();
@@ -207,17 +207,17 @@ fn run_uio_checks<K: ?Sized + TestKey, V: TestValue, S: UniversalRead>(
                 let Entry {
                     key,
                     values: _,
-                    meta,
+                    user_data,
                 } = entry;
-                ((*meta, key.clone()), K::as_ref(key))
+                ((*user_data, key.clone()), K::as_ref(key))
             }),
-            |(meta, key), vals| {
+            |(user_data, key), vals| {
                 push_val(
                     &mut collected,
                     Entry {
                         key,
                         values: vals.map(|v| v.to_vec()),
-                        meta,
+                        user_data,
                     },
                 )
             },

--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -11,7 +11,7 @@ use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Sequential;
 use crate::iterator_ext::ordering_iterator::OrderingIterator;
 use crate::universal_io::{
-    OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead,
+    OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead, UserData,
 };
 
 mod random_reader;
@@ -196,20 +196,21 @@ where
     }
 
     /// Read all keys and call the provided closure on each of them.
-    pub fn for_each_entry_in_iter<Meta, I, F, E>(&self, keys: I, mut f: F) -> Result<(), E>
+    pub fn for_each_entry_in_iter<U, I, F, E>(&self, keys: I, mut f: F) -> Result<(), E>
     where
-        I: IntoIterator<Item = (Meta, &'key K)>,
-        F: FnMut(Meta, Option<&[V]>) -> Result<(), E>,
+        U: UserData,
+        I: IntoIterator<Item = (U, &'key K)>,
+        F: FnMut(U, Option<&[V]>) -> Result<(), E>,
         E: From<UniversalIoError>,
     {
         self.for_each_sparse(
             MaybeIncompleteEntryKind::KeyAndValues,
             keys.into_iter()
-                .map(|(meta, key)| (meta, Request::Key(key))),
-            |meta, entry| {
+                .map(|(user_data, key)| (user_data, Request::Key(key))),
+            |user_data, entry| {
                 let values =
                     entry.map(|e| e.values().expect("KeyAndValues entry should have values"));
-                f(meta, values)
+                f(user_data, values)
             },
         )
     }

--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -6,7 +6,7 @@ use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Random;
 use crate::persisted_hashmap::uio::parse_bucket_offset;
 use crate::universal_io::read::UniversalReadPipeline;
-use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalRead};
+use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalRead, UserData};
 
 pub(super) enum Request<'a, K: Key + ?Sized> {
     /// Request an entry by the given offset with unknown key.
@@ -16,21 +16,22 @@ pub(super) enum Request<'a, K: Key + ?Sized> {
 }
 
 /// State machine driver for [`UniversalHashMap::for_each_sparse`].
-struct PipelineDriver<'map, 'key, Meta, K, V, S>
+struct PipelineDriver<'map, 'key, U, K, V, S>
 where
+    U: UserData,
     K: Key + ?Sized + 'key,
     V: Sized + Copy + FromBytes + Immutable + IntoBytes + KnownLayout,
     S: UniversalRead,
 {
     map: &'map UniversalHashMap<K, V, S>,
     entry_kind: MaybeIncompleteEntryKind,
-    queue: Vec<Entry<'key, Meta, K>>,
+    queue: Vec<Entry<'key, U, K>>,
     entry_read_size_est: u64,
     file_len: u64,
 }
 
-struct Entry<'a, Meta, K: Key + ?Sized> {
-    meta: Meta,
+struct Entry<'a, U: UserData, K: Key + ?Sized> {
+    user_data: U,
     state: State<'a, K>,
 }
 
@@ -64,15 +65,16 @@ where
     ///
     /// Implementation detail: unlike [`UniversalHashMap::for_each_entry`], it
     /// will try to read only the requested entries.
-    pub(super) fn for_each_sparse<Meta, I, F, E>(
+    pub(super) fn for_each_sparse<U, I, F, E>(
         &self,
         entry_kind: MaybeIncompleteEntryKind,
         requests: I,
         mut f: F,
     ) -> Result<(), E>
     where
-        I: Iterator<Item = (Meta, Request<'key, K>)>,
-        F: FnMut(Meta, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
+        U: UserData,
+        I: Iterator<Item = (U, Request<'key, K>)>,
+        F: FnMut(U, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
         E: From<UniversalIoError>,
     {
         let mut sparse = PipelineDriver::new(self, entry_kind)?;
@@ -95,10 +97,11 @@ where
     }
 }
 
-type ScheduledEntry<'key, Meta, K> = (Entry<'key, Meta, K>, ReadRange);
+type ScheduledEntry<'key, U, K> = (Entry<'key, U, K>, ReadRange);
 
-impl<'map, 'key, Meta, K, V, S> PipelineDriver<'map, 'key, Meta, K, V, S>
+impl<'map, 'key, U, K, V, S> PipelineDriver<'map, 'key, U, K, V, S>
 where
+    U: UserData,
     K: Key + ?Sized + 'key,
     V: Copy + FromBytes + Immutable + IntoBytes + KnownLayout,
     S: UniversalRead,
@@ -119,12 +122,12 @@ where
     /// Produce the next entry to schedule.
     fn schedule_next_entry<E, F>(
         &mut self,
-        requests: &mut impl Iterator<Item = (Meta, Request<'key, K>)>,
+        requests: &mut impl Iterator<Item = (U, Request<'key, K>)>,
         f: &mut F,
-    ) -> Result<Option<ScheduledEntry<'key, Meta, K>>, E>
+    ) -> Result<Option<ScheduledEntry<'key, U, K>>, E>
     where
         E: From<UniversalIoError>,
-        F: FnMut(Meta, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
+        F: FnMut(U, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
     {
         if let Some(entry) = self.queue.pop() {
             match &entry.state {
@@ -148,7 +151,7 @@ where
             };
         }
 
-        for (meta, request) in requests.by_ref() {
+        for (user_data, request) in requests.by_ref() {
             let (state, range);
             match request {
                 Request::Offset(offset) => {
@@ -167,7 +170,7 @@ where
                 Request::Key(requested_key) => {
                     // PHF miss: no stored entry; report immediately and continue.
                     let Some(hash) = self.map.phf.get(requested_key) else {
-                        f(meta, None)?;
+                        f(user_data, None)?;
                         continue;
                     };
                     // PHF hit: schedule the bucket-offset read; transitions to
@@ -181,7 +184,7 @@ where
                     };
                 }
             }
-            let entry = Entry { meta, state };
+            let entry = Entry { user_data, state };
             return Ok(Some((entry, range.clamp::<u8>(self.file_len))));
         }
 
@@ -189,21 +192,16 @@ where
     }
 
     /// Process a completed read result.
-    fn process<E, F>(
-        &mut self,
-        entry: Entry<'key, Meta, K>,
-        data: &[u8],
-        f: &mut F,
-    ) -> Result<(), E>
+    fn process<E, F>(&mut self, entry: Entry<'key, U, K>, data: &[u8], f: &mut F) -> Result<(), E>
     where
         E: From<UniversalIoError>,
-        F: FnMut(Meta, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
+        F: FnMut(U, Option<MaybeIncompleteEntry<'_, K, V>>) -> Result<(), E>,
     {
         match entry.state {
             State::ReadingOffset { requested_key } => {
                 let byte_offset = self.map.entries_start + parse_bucket_offset(data)?;
                 self.queue.push(Entry {
-                    meta: entry.meta,
+                    user_data: entry.user_data,
                     state: State::ReadingEntry {
                         byte_offset,
                         buf: AlignedBuf::new_for_offset(byte_offset),
@@ -227,17 +225,17 @@ where
                     && let Some(stored_key) = parsed.key()
                 {
                     if key != stored_key {
-                        f(entry.meta, None)?;
+                        f(entry.user_data, None)?;
                         return Ok(());
                     }
                     requested_key = None;
                 }
 
                 if parsed.satisfies_kind(self.entry_kind) {
-                    f(entry.meta, Some(parsed))?;
+                    f(entry.user_data, Some(parsed))?;
                 } else {
                     self.queue.push(Entry {
-                        meta: entry.meta,
+                        user_data: entry.user_data,
                         state: State::ReadingEntry {
                             byte_offset,
                             // `+ 1` so the size strictly grows when `buf.len()` is already a

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -8,7 +8,7 @@ use crate::generic_consts::{AccessPattern, Random};
 use crate::universal_io::read::UniversalReadPipeline;
 use crate::universal_io::{
     OpenOptions, ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
-    local_file_ops,
+    UserData, local_file_ops,
 };
 
 mod cached_slice;
@@ -67,11 +67,12 @@ impl UniversalReadFileOps for CachedSlice {
 }
 
 impl UniversalRead for CachedSlice {
-    type ReadPipeline<'a, T, Meta>
-        = DiskCacheReadPipeline<'a, T, Meta>
+    type ReadPipeline<'a, T, U>
+        = DiskCacheReadPipeline<'a, T, U>
     where
         Self: 'a,
-        T: bytemuck::Pod;
+        T: bytemuck::Pod,
+        U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let Some(controller) = CacheController::global() else {
@@ -123,16 +124,18 @@ impl UniversalRead for CachedSlice {
     }
 }
 
-pub struct DiskCacheReadPipeline<'file, T, Meta>
+pub struct DiskCacheReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
-    result: Option<(Meta, Cow<'file, [T]>)>,
+    result: Option<(U, Cow<'file, [T]>)>,
 }
 
-impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for DiskCacheReadPipeline<'file, T, Meta>
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for DiskCacheReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     type File = CachedSlice;
 
@@ -144,7 +147,12 @@ where
         self.result.is_none()
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'file CachedSlice, range: ReadRange) -> Result<()>
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file CachedSlice,
+        range: ReadRange,
+    ) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -152,11 +160,11 @@ where
             return Err(UniversalIoError::QueueIsFull);
         }
 
-        self.result = Some((meta, file.read::<Random, T>(range)?));
+        self.result = Some((user_data, file.read::<Random, T>(range)?));
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
         Ok(self.result.take())
     }
 }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -49,10 +49,11 @@ impl UniversalReadFileOps for IoUringFile {
 }
 
 impl UniversalRead for IoUringFile {
-    type ReadPipeline<'a, T, Meta>
-        = IoUringPipeline<'a, T, Meta>
+    type ReadPipeline<'a, T, U>
+        = IoUringPipeline<'a, T, U>
     where
-        T: bytemuck::Pod;
+        T: bytemuck::Pod,
+        U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         // Check that io_uring is supported on this system.
@@ -141,16 +142,18 @@ impl UniversalRead for IoUringFile {
     }
 }
 
-pub struct IoUringPipeline<'file, T, Meta>
+pub struct IoUringPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
-    runtime: IoUringRuntime<'file, T, Meta>,
+    runtime: IoUringRuntime<'file, T, U>,
 }
 
-impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for IoUringPipeline<'file, T, Meta>
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for IoUringPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     type File = IoUringFile;
 
@@ -165,7 +168,12 @@ where
         self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'file IoUringFile, range: ReadRange) -> Result<()>
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file IoUringFile,
+        range: ReadRange,
+    ) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -178,7 +186,7 @@ where
         let entry = self
             .runtime
             .state
-            .read(meta, file.fd(), range, file.direct_io);
+            .read(user_data, file.fd(), range, file.direct_io);
 
         unsafe {
             squeue.push(&entry).expect("submission queue is not full");
@@ -187,7 +195,7 @@ where
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
         let next = self.runtime.completed().next();
 
         let enqueued = self.runtime.enqueued();
@@ -202,8 +210,8 @@ where
             return Ok(None);
         };
 
-        let (meta, resp) = result?;
-        Ok(Some((meta, Cow::Owned(resp.expect_read()))))
+        let (user_data, resp) = result?;
+        Ok(Some((user_data, Cow::Owned(resp.expect_read()))))
     }
 }
 

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -7,6 +7,7 @@ use slab::Slab;
 
 use super::*;
 use crate::maybe_uninit;
+use crate::universal_io::read::UserData;
 
 const KERNEL_PAGE_SIZE: u64 = 4096; // 4 kB
 
@@ -29,15 +30,16 @@ impl PageAlignedBytes {
     }
 }
 
-pub struct IoUringRuntime<'data, T: bytemuck::Pod, Meta = u64> {
+pub struct IoUringRuntime<'data, T: bytemuck::Pod, U: UserData = u64> {
     pub io_uring: IoUringGuard,
-    pub state: IoUringState<'data, T, Meta>,
+    pub state: IoUringState<'data, T, U>,
     pub in_progress: usize,
 }
 
-impl<'data, T, Meta> IoUringRuntime<'data, T, Meta>
+impl<'data, T, U> IoUringRuntime<'data, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     pub fn new() -> Result<Self> {
         let mut io_uring = pool::get_io_uring()?;
@@ -55,7 +57,7 @@ where
     /// or the queue is full.
     pub fn enqueue_while<F>(&mut self, mut entries: F) -> Result<()>
     where
-        F: FnMut(&mut IoUringState<'data, T, Meta>) -> Result<Option<squeue::Entry>>,
+        F: FnMut(&mut IoUringState<'data, T, U>) -> Result<Option<squeue::Entry>>,
     {
         let mut squeue = self.io_uring.submission();
 
@@ -121,7 +123,7 @@ where
         Ok(())
     }
 
-    pub fn completed(&mut self) -> impl Iterator<Item = io::Result<(Meta, IoUringResponse<T>)>> {
+    pub fn completed(&mut self) -> impl Iterator<Item = io::Result<(U, IoUringResponse<T>)>> {
         self.io_uring.completion().map(|entry| {
             self.in_progress -= 1;
 
@@ -138,15 +140,16 @@ where
             }
 
             let length = result as _;
-            let (meta, resp) = self.state.finalize(slot, length)?;
-            Ok((meta, resp))
+            let (user_data, resp) = self.state.finalize(slot, length)?;
+            Ok((user_data, resp))
         })
     }
 }
 
-impl<'data, T, Meta> Drop for IoUringRuntime<'data, T, Meta>
+impl<'data, T, U> Drop for IoUringRuntime<'data, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     fn drop(&mut self) {
         while self.in_progress > 0 || !self.io_uring.submission().is_empty() {
@@ -167,13 +170,14 @@ where
 }
 
 #[derive(Debug)]
-pub struct IoUringState<'data, T, Meta> {
-    requests: Slab<(Meta, IoUringRequest<'data, T>)>,
+pub struct IoUringState<'data, T, U> {
+    requests: Slab<(U, IoUringRequest<'data, T>)>,
 }
 
-impl<'data, T, Meta> IoUringState<'data, T, Meta>
+impl<'data, T, U> IoUringState<'data, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -182,17 +186,23 @@ where
     }
 
     /// Prepare the buffer for storing the read with correct alignment, and returns the queue entry.
-    pub fn read(&mut self, meta: Meta, fd: Fd, range: ReadRange, o_direct: bool) -> squeue::Entry {
+    pub fn read(
+        &mut self,
+        user_data: U,
+        fd: Fd,
+        range: ReadRange,
+        o_direct: bool,
+    ) -> squeue::Entry {
         if o_direct {
-            self.read_o_direct(meta, fd, range)
+            self.read_o_direct(user_data, fd, range)
         } else {
-            self.read_exact(meta, fd, range)
+            self.read_exact(user_data, fd, range)
         }
     }
 
     /// Allocates `Vec<MaybeUninit<T>>`, reinterprets it as `Vec<MaybeUninit<u8>>`, and stores the byte buffer
     /// so the kernel writes into correctly aligned memory for `T`.
-    fn read_exact(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
+    fn read_exact(&mut self, user_data: U, fd: Fd, range: ReadRange) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,
@@ -200,7 +210,7 @@ where
 
         // Size the buffer exactly to the number of items to read
         let items: Vec<MaybeUninit<T>> = vec![MaybeUninit::uninit(); length as _];
-        let (slot, req) = self.init(meta, IoUringRequest::Read { items });
+        let (slot, req) = self.init(user_data, IoUringRequest::Read { items });
         let items = req.expect_read();
 
         let bytes_ptr = items.as_mut_ptr().cast();
@@ -214,7 +224,7 @@ where
     }
 
     /// Allocates a `Vec<MaybeUninit<u8>>` aligned to 4kB.
-    fn read_o_direct(&mut self, meta: Meta, fd: Fd, range: ReadRange) -> squeue::Entry {
+    fn read_o_direct(&mut self, user_data: U, fd: Fd, range: ReadRange) -> squeue::Entry {
         let ReadRange {
             byte_offset,
             length,
@@ -232,7 +242,7 @@ where
         let buffer: Vec<PageAlignedBytes> = vec![PageAlignedBytes::uninit(); num_pages as _];
 
         let (slot, req) = self.init(
-            meta,
+            user_data,
             IoUringRequest::ODirectRead {
                 buffer,
                 inner_byte_offset: inner_byte_offset as usize,
@@ -252,12 +262,12 @@ where
 
     pub fn write(
         &mut self,
-        meta: Meta,
+        user_data: U,
         fd: Fd,
         byte_offset: u64,
         items: &'data [T],
     ) -> squeue::Entry {
-        let (slot, req) = self.init(meta, IoUringRequest::Write(items));
+        let (slot, req) = self.init(user_data, IoUringRequest::Write(items));
         let items = req.expect_write();
 
         let bytes: &[u8] = bytemuck::cast_slice(items);
@@ -270,12 +280,12 @@ where
 
     fn init(
         &mut self,
-        meta: Meta,
+        user_data: U,
         req: IoUringRequest<'data, T>,
     ) -> (usize, &mut IoUringRequest<'data, T>) {
         let entry = self.requests.vacant_entry();
         let slot = entry.key();
-        let (_, req) = entry.insert((meta, req));
+        let (_, req) = entry.insert((user_data, req));
         (slot, req)
     }
 
@@ -283,8 +293,8 @@ where
         &mut self,
         slot: usize,
         byte_length: u32,
-    ) -> io::Result<(Meta, IoUringResponse<T>)> {
-        let (meta, req) = self
+    ) -> io::Result<(U, IoUringResponse<T>)> {
+        let (user_data, req) = self
             .requests
             .try_remove(slot)
             .ok_or_else(|| io::Error::other(format!("request in slot {slot} does not exist")))?;
@@ -345,7 +355,7 @@ where
             }
         };
 
-        Ok((meta, resp))
+        Ok((user_data, resp))
     }
 
     pub fn abort(&mut self, slot: usize) {
@@ -353,7 +363,7 @@ where
     }
 }
 
-impl<'data, T, Meta> Drop for IoUringState<'data, T, Meta> {
+impl<'data, T, U> Drop for IoUringState<'data, T, U> {
     fn drop(&mut self) {
         debug_assert!(self.requests.is_empty());
     }

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -44,10 +44,11 @@ impl UniversalReadFileOps for MmapFile {
 }
 
 impl UniversalRead for MmapFile {
-    type ReadPipeline<'a, T, Meta>
-        = MmapReadPipeline<'a, T, Meta>
+    type ReadPipeline<'a, T, U>
+        = MmapReadPipeline<'a, T, U>
     where
-        T: bytemuck::Pod;
+        T: bytemuck::Pod,
+        U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let OpenOptions {
@@ -129,13 +130,14 @@ impl UniversalRead for MmapFile {
     }
 }
 
-pub struct MmapReadPipeline<'file, T, Meta> {
-    result: Option<(Meta, &'file [T])>,
+pub struct MmapReadPipeline<'file, T, U> {
+    result: Option<(U, &'file [T])>,
 }
 
-impl<'file, T, Meta> UniversalReadPipeline<'file, T, Meta> for MmapReadPipeline<'file, T, Meta>
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for MmapReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     type File = MmapFile;
 
@@ -147,7 +149,7 @@ where
         self.result.is_none()
     }
 
-    fn schedule<P>(&mut self, meta: Meta, file: &'file MmapFile, range: ReadRange) -> Result<()>
+    fn schedule<P>(&mut self, user_data: U, file: &'file MmapFile, range: ReadRange) -> Result<()>
     where
         P: AccessPattern,
     {
@@ -155,13 +157,13 @@ where
             return Err(UniversalIoError::QueueIsFull);
         }
 
-        self.result = Some((meta, read(file.as_bytes::<P>(), range)?));
+        self.result = Some((user_data, read(file.as_bytes::<P>(), range)?));
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
         let result = self.result.take();
-        Ok(result.map(|(meta, items)| (meta, Cow::Borrowed(items))))
+        Ok(result.map(|(user_data, items)| (user_data, Cow::Borrowed(items))))
     }
 }
 

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -9,10 +9,11 @@ use crate::universal_io::file_ops::UniversalReadFileOps;
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
 #[expect(clippy::len_without_is_empty)]
 pub trait UniversalRead: UniversalReadFileOps {
-    type ReadPipeline<'file, T, Meta>: UniversalReadPipeline<'file, T, Meta, File = Self>
+    type ReadPipeline<'file, T, U>: UniversalReadPipeline<'file, T, U, File = Self>
     where
         Self: 'file,
-        T: bytemuck::Pod;
+        T: bytemuck::Pod,
+        U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>;
 
@@ -32,18 +33,19 @@ pub trait UniversalRead: UniversalReadFileOps {
         self.read::<Sequential, T>(range)
     }
 
-    fn read_batch<P, T, Meta>(
+    fn read_batch<P, T, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-        mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        mut callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
     {
-        for record in self.read_iter::<P, T, Meta>(ranges)? {
-            let (meta, data) = record?;
-            callback(meta, &data)?;
+        for record in self.read_iter::<P, T, U>(ranges)? {
+            let (user_data, data) = record?;
+            callback(user_data, &data)?;
         }
 
         Ok(())
@@ -51,19 +53,20 @@ pub trait UniversalRead: UniversalReadFileOps {
 
     /// Like [`read_batch`](Self::read_batch), but returns a fallible iterator instead of
     /// accepting a callback.
-    fn read_iter<P, T, Meta>(
+    fn read_iter<P, T, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
     {
         let reads = ranges
             .into_iter()
-            .map(move |(meta, range)| (meta, self, range));
+            .map(move |(user_data, range)| (user_data, self, range));
 
-        Self::read_multi_iter::<P, T, Meta>(reads)
+        Self::read_multi_iter::<P, T, U>(reads)
     }
 
     fn len<T>(&self) -> Result<u64>;
@@ -79,18 +82,19 @@ pub trait UniversalRead: UniversalReadFileOps {
     fn clear_ram_cache(&self) -> Result<()>;
 
     /// Read from multiple files in a single operation.
-    fn read_multi<'a, P, T, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-        mut callback: impl FnMut(Meta, &[T]) -> Result<()>,
+    fn read_multi<'a, P, T, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+        mut callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
         Self: 'a,
     {
-        for record in Self::read_multi_iter::<P, T, Meta>(reads)? {
-            let (meta, items) = record?;
-            callback(meta, &items)?;
+        for record in Self::read_multi_iter::<P, T, U>(reads)? {
+            let (user_data, items) = record?;
+            callback(user_data, &items)?;
         }
 
         Ok(())
@@ -98,24 +102,25 @@ pub trait UniversalRead: UniversalReadFileOps {
 
     /// Like [`read_multi`](Self::read_multi), but returns a fallible iterator instead of
     /// accepting a callback.
-    fn read_multi_iter<'a, P, T, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
+    fn read_multi_iter<'a, P, T, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'a, [T]>)>>>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
         Self: 'a,
     {
-        let mut pipeline = Self::ReadPipeline::<'a, T, Meta>::new()?;
+        let mut pipeline = Self::ReadPipeline::<'a, T, U>::new()?;
         let mut reads = reads.into_iter();
 
         let iter = std::iter::from_fn(move || {
             while pipeline.can_schedule()
                 && let Some(read) = reads.next()
             {
-                let (meta, file, range) = read;
+                let (user_data, file, range) = read;
 
-                if let Err(err) = pipeline.schedule::<P>(meta, file, range) {
+                if let Err(err) = pipeline.schedule::<P>(user_data, file, range) {
                     return Some(Err(err));
                 }
             }
@@ -131,9 +136,10 @@ pub trait UniversalRead: UniversalReadFileOps {
     // When adding provided methods, don't forget to update impls in crate::universal_io::wrappers::*.
 }
 
-pub trait UniversalReadPipeline<'file, T, Meta>: Sized
+pub trait UniversalReadPipeline<'file, T, U>: Sized
 where
     T: bytemuck::Pod,
+    U: UserData,
 {
     type File: 'file;
 
@@ -148,11 +154,29 @@ where
     ///
     /// Should be called only when [`UniversalReadPipeline::can_schedule()`] is
     /// `true`. Returns [`UniversalIoError::QueueIsFull`] otherwise.
-    fn schedule<P>(&mut self, meta: Meta, file: &'file Self::File, range: ReadRange) -> Result<()>
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        range: ReadRange,
+    ) -> Result<()>
     where
         P: AccessPattern;
 
     /// Block until any of the scheduled operations is completed and consume its
     /// result.
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'file, [T]>)>>;
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>>;
 }
+
+/// An arbitrary value to distinguish requests.
+///
+/// Batched universal I/O methods let callers to add an arbitrary user-provided
+/// value to each request. This value will be passed back to the caller/callback
+/// when the request completes.
+///
+/// Similar to `user_data` in `io_uring`, but allows arbitrary type, not just
+/// `u64`.
+///
+/// This trait exists for documentation/code navigation purposes only.
+pub trait UserData {}
+impl<T> UserData for T {}

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use bytemuck::TransparentWrapper;
 
 use super::super::{
-    OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps,
+    OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps, UserData,
 };
 use super::WrappedReadPipeline;
 use crate::generic_consts::AccessPattern;
@@ -32,11 +32,12 @@ impl<S> UniversalRead for ReadOnly<S>
 where
     S: UniversalRead,
 {
-    type ReadPipeline<'file, T, Meta>
-        = WrappedReadPipeline<'file, Self, S::ReadPipeline<'file, T, Meta>>
+    type ReadPipeline<'file, T, U>
+        = WrappedReadPipeline<'file, Self, S::ReadPipeline<'file, T, U>>
     where
         Self: 'file,
-        T: bytemuck::Pod;
+        T: bytemuck::Pod,
+        U: UserData;
 
     #[inline]
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -56,28 +57,30 @@ where
     }
 
     #[inline]
-    fn read_batch<P, T, Meta>(
+    fn read_batch<P, T, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-        callback: impl FnMut(Meta, &[T]) -> Result<()>,
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
     {
-        self.0.read_batch::<P, T, Meta>(ranges, callback)
+        self.0.read_batch::<P, T, U>(ranges, callback)
     }
 
     #[inline]
-    fn read_iter<P, T, Meta>(
+    fn read_iter<P, T, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
     {
-        self.0.read_iter::<P, T, Meta>(ranges)
+        self.0.read_iter::<P, T, U>(ranges)
     }
 
     #[inline]
@@ -96,34 +99,36 @@ where
     }
 
     #[inline]
-    fn read_multi<'a, P, T, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-        callback: impl FnMut(Meta, &[T]) -> Result<()>,
+    fn read_multi<'a, P, T, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+        callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
         Self: 'a,
     {
         let reads = reads
             .into_iter()
-            .map(|(meta, file, range)| (meta, &file.0, range));
+            .map(|(user_data, file, range)| (user_data, &file.0, range));
 
         S::read_multi::<P, T, _>(reads, callback)
     }
 
     #[inline]
-    fn read_multi_iter<'a, P, T, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
+    fn read_multi_iter<'a, P, T, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'a, [T]>)>>>
     where
         P: AccessPattern,
         T: bytemuck::Pod,
+        U: UserData,
         Self: 'a,
     {
         let it = reads
             .into_iter()
-            .map(|(meta, file, range)| (meta, &file.0, range));
+            .map(|(user_data, file, range)| (user_data, &file.0, range));
 
         S::read_multi_iter::<P, T, _>(it)
     }

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -6,7 +6,7 @@ use bytemuck::TransparentWrapper;
 
 use super::super::{
     ByteOffset, FileIndex, Flusher, OpenOptions, ReadRange, Result, UniversalKind, UniversalRead,
-    UniversalReadFileOps, UniversalWrite,
+    UniversalReadFileOps, UniversalWrite, UserData,
 };
 use crate::generic_consts::AccessPattern;
 
@@ -72,26 +72,28 @@ where
     }
 
     #[inline]
-    pub fn read_batch<P, Meta>(
+    pub fn read_batch<P, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-        callback: impl FnMut(Meta, &[T]) -> Result<()>,
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
+        U: UserData,
     {
-        self.inner.read_batch::<P, T, Meta>(ranges, callback)
+        self.inner.read_batch::<P, T, U>(ranges, callback)
     }
 
     #[inline]
-    pub fn read_iter<P, Meta>(
+    pub fn read_iter<P, U>(
         &self,
-        ranges: impl IntoIterator<Item = (Meta, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'_, [T]>)>>>
+        ranges: impl IntoIterator<Item = (U, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
+        U: UserData,
     {
-        self.inner.read_iter::<P, T, Meta>(ranges)
+        self.inner.read_iter::<P, T, U>(ranges)
     }
 
     #[inline]
@@ -110,31 +112,33 @@ where
     }
 
     #[inline]
-    pub fn read_multi<'a, P, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-        callback: impl FnMut(Meta, &[T]) -> Result<()>,
+    pub fn read_multi<'a, P, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+        callback: impl FnMut(U, &[T]) -> Result<()>,
     ) -> Result<()>
     where
         P: AccessPattern,
+        U: UserData,
         Self: 'a,
     {
         let reads = reads
             .into_iter()
-            .map(|(meta, file, range)| (meta, &file.inner, range));
-        S::read_multi::<P, T, Meta>(reads, callback)
+            .map(|(user_data, file, range)| (user_data, &file.inner, range));
+        S::read_multi::<P, T, U>(reads, callback)
     }
 
     #[inline]
-    pub fn read_multi_iter<'a, P, Meta>(
-        reads: impl IntoIterator<Item = (Meta, &'a Self, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(Meta, Cow<'a, [T]>)>>>
+    pub fn read_multi_iter<'a, P, U>(
+        reads: impl IntoIterator<Item = (U, &'a Self, ReadRange)>,
+    ) -> Result<impl Iterator<Item = Result<(U, Cow<'a, [T]>)>>>
     where
         P: AccessPattern,
+        U: UserData,
         Self: 'a,
     {
         let reads = reads
             .into_iter()
-            .map(|(meta, file, range)| (meta, &file.inner, range));
+            .map(|(user_data, file, range)| (user_data, &file.inner, range));
         S::read_multi_iter::<P, T, _>(reads)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::read::UniversalReadPipeline;
+use crate::universal_io::read::{UniversalReadPipeline, UserData};
 use crate::universal_io::{ReadRange, Result};
 
 /// Default implementation of [`UniversalReadPipeline`] for wrappers.
@@ -13,12 +13,12 @@ pub struct WrappedReadPipeline<'a, File, Inner> {
     _phantom: PhantomData<&'a File>,
 }
 
-impl<'a, File, Inner, T, Meta> UniversalReadPipeline<'a, T, Meta>
-    for WrappedReadPipeline<'a, File, Inner>
+impl<'a, File, Inner, T, U> UniversalReadPipeline<'a, T, U> for WrappedReadPipeline<'a, File, Inner>
 where
     File: TransparentWrapper<Inner::File>,
-    Inner: UniversalReadPipeline<'a, T, Meta>,
+    Inner: UniversalReadPipeline<'a, T, U>,
     T: bytemuck::Pod,
+    U: UserData,
 {
     type File = File;
 
@@ -38,15 +38,16 @@ where
     }
 
     #[inline]
-    fn schedule<P>(&mut self, meta: Meta, file: &'a File, range: ReadRange) -> Result<()>
+    fn schedule<P>(&mut self, user_data: U, file: &'a File, range: ReadRange) -> Result<()>
     where
         P: AccessPattern,
     {
-        self.inner.schedule::<P>(meta, File::peel_ref(file), range)
+        self.inner
+            .schedule::<P>(user_data, File::peel_ref(file), range)
     }
 
     #[inline]
-    fn wait(&mut self) -> Result<Option<(Meta, Cow<'a, [T]>)>> {
+    fn wait(&mut self) -> Result<Option<(U, Cow<'a, [T]>)>> {
         self.inner.wait()
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -5,6 +5,7 @@ use ahash::AHashMap;
 use common::bitvec::BitSliceExt;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use itertools::Either;
 use posting_list::{PostingBuilder, PostingList, PostingListView, PostingValue};
 
@@ -349,13 +350,13 @@ impl InvertedIndex for ImmutableInvertedIndex {
         self.points_count
     }
 
-    fn for_each_token_id<'a, Meta>(
+    fn for_each_token_id<'a, U: UserData>(
         &self,
-        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        tokens: impl Iterator<Item = (U, &'a str)>,
         _: &HardwareCounterCell,
-        mut f: impl FnMut(Meta, Option<TokenId>),
+        mut f: impl FnMut(U, Option<TokenId>),
     ) -> OperationResult<()> {
-        tokens.for_each(|(meta, token)| f(meta, self.vocab.get(token).copied()));
+        tokens.for_each(|(user_data, token)| f(user_data, self.vocab.get(token).copied()));
         Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -9,7 +9,7 @@ use common::mmap::{self, Advice, AdviceSetting, MmapSlice, create_and_ensure_len
 use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions};
+use common::universal_io::{MmapFile, OpenOptions, UserData};
 use types::ZerocopyPostingValue;
 use uio_postings::UniversalPostings;
 
@@ -620,21 +620,21 @@ impl InvertedIndex for MmapInvertedIndex {
         self.active_points_count
     }
 
-    fn for_each_token_id<'a, Meta>(
+    fn for_each_token_id<'a, U: UserData>(
         &self,
-        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        tokens: impl Iterator<Item = (U, &'a str)>,
         hw_counter: &HardwareCounterCell,
-        mut f: impl FnMut(Meta, Option<TokenId>),
+        mut f: impl FnMut(U, Option<TokenId>),
     ) -> OperationResult<()> {
         self.storage
             .vocab
-            .for_each_entry_in_iter(tokens, |meta, token_ids| {
+            .for_each_entry_in_iter(tokens, |user_data, token_ids| {
                 if self.is_on_disk {
                     hw_counter.payload_index_io_read_counter().incr_delta(
                         READ_ENTRY_OVERHEAD + size_of::<TokenId>(), // Avoid check overhead and assume token is always read
                     );
                 }
-                f(meta, token_ids.map(unwrap_token));
+                f(user_data, token_ids.map(unwrap_token));
                 Ok(())
             })
     }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use itertools::Itertools;
 
 use crate::common::operation_error::OperationResult;
@@ -400,11 +401,11 @@ pub trait InvertedIndex {
     fn points_count(&self) -> usize;
 
     /// Resolve token -> token_id and call the closure for each token_id.
-    fn for_each_token_id<'a, Meta>(
+    fn for_each_token_id<'a, U: UserData>(
         &self,
-        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        tokens: impl Iterator<Item = (U, &'a str)>,
         hw_counter: &HardwareCounterCell,
-        f: impl FnMut(Meta, Option<TokenId>),
+        f: impl FnMut(U, Option<TokenId>),
     ) -> OperationResult<()>;
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use itertools::Either;
 
 use super::posting_list::PostingList;
@@ -289,13 +290,13 @@ impl InvertedIndex for MutableInvertedIndex {
         self.points_count
     }
 
-    fn for_each_token_id<'a, Meta>(
+    fn for_each_token_id<'a, U: UserData>(
         &self,
-        tokens: impl Iterator<Item = (Meta, &'a str)>,
+        tokens: impl Iterator<Item = (U, &'a str)>,
         _: &HardwareCounterCell,
-        mut f: impl FnMut(Meta, Option<TokenId>),
+        mut f: impl FnMut(U, Option<TokenId>),
     ) -> OperationResult<()> {
-        tokens.for_each(|(meta, token)| f(meta, self.vocab.get(token).copied()));
+        tokens.for_each(|(user_data, token)| f(user_data, self.vocab.get(token).copied()));
         Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/text_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/text_index.rs
@@ -7,6 +7,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -127,11 +128,11 @@ impl FullTextIndex {
         }
     }
 
-    pub(super) fn for_each_token_id<'a, Meta>(
+    pub(super) fn for_each_token_id<'a, U: UserData>(
         &self,
-        iter: impl Iterator<Item = (Meta, &'a str)>,
+        iter: impl Iterator<Item = (U, &'a str)>,
         hw_counter: &HardwareCounterCell,
-        f: impl FnMut(Meta, Option<TokenId>),
+        f: impl FnMut(U, Option<TokenId>),
     ) -> OperationResult<()> {
         match self {
             Self::Mutable(index) => index.inverted_index.for_each_token_id(iter, hw_counter, f),


### PR DESCRIPTION
@generall said that `Meta` (added in #8601) looks confusing for those who are not familiar with universal_io traits.
Especially when it's used in methods outside `universal_io` module, e.g., in the example below.
This PR is an attempt to make it less confusing.

```rust
// Before this PR
fn for_each_token_id<'a, Meta>(
    &self,
    mut f: impl FnMut(Meta, Option<TokenId>),
) -> OperationResult<()> {
```

```rust
// After this PR
fn for_each_token_id<'a, U: UserData>(
    &self,
    mut f: impl FnMut(U, Option<TokenId>),
) -> OperationResult<()> {
```

- Why `UserData` instead of `Meta`:
  Familiarity -- `user_data` is used in `io_uring` and other similar APIs.

- Why it's a trait bound (`U: UserData`):
  Make it clickable/hoverable in IDEs. This trait has a doc comment.

Fixes [\#1447](https://xkcd.com/1447/).
