### PR TITLE
[ai] test: wait for cluster readiness in flaky e2e test

### DIFF
--- a/tests/e2e_tests/client_utils.py
+++ b/tests/e2e_tests/client_utils.py
@@ -38,6 +38,25 @@ class ClientUtils:
             time.sleep(1)
         return False
 
+    def wait_for_cluster_ready(self, expected_peers: int, timeout: int = 60) -> bool:
+        """Wait until consensus has elected a leader, all expected peers are visible, and pending operations have drained."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                status = self.client.cluster_status()
+                if (getattr(status, "status", None) == "enabled"
+                        and len(status.peers) >= expected_peers
+                        and status.raft_info.leader is not None
+                        and status.raft_info.pending_operations == 0):
+                    print(f"Cluster ready with {len(status.peers)} peers, leader={status.raft_info.leader}")
+                    return True
+            except Exception:
+                pass
+
+            print(f"Waiting for cluster to form ({expected_peers} peers expected)...")
+            time.sleep(0.5)
+        return False
+
     def wait_for_collection_loaded(self, collection_name: str, timeout: int = 10) -> bool:
         """Wait for a specific collection to be loaded."""
         for _ in range(timeout):

--- a/tests/e2e_tests/test_bugs.py
+++ b/tests/e2e_tests/test_bugs.py
@@ -11,7 +11,7 @@ class TestSnapshotsInterferenceWithConsensus:
         """Test that creating snapshots does not block other operations - https://github.com/qdrant/qdrant/issues/7489."""
         client = ClientUtils(host=qdrant_compose[0].host, port=qdrant_compose[0].http_port, timeout=10)
         client.wait_for_server()
-        client.wait_for_cluster_ready(expected_peers=3)
+        assert client.wait_for_cluster_ready(expected_peers=3), "Cluster did not become ready within timeout"
 
         # Create collection and insert points
         collection_config = {"vectors": {"size": 512, "distance": "Dot"}, "shard_number": 3, "replication_factor": 1, "optimization_config": {"indexing_threshold": 0}}

--- a/tests/e2e_tests/test_bugs.py
+++ b/tests/e2e_tests/test_bugs.py
@@ -11,6 +11,7 @@ class TestSnapshotsInterferenceWithConsensus:
         """Test that creating snapshots does not block other operations - https://github.com/qdrant/qdrant/issues/7489."""
         client = ClientUtils(host=qdrant_compose[0].host, port=qdrant_compose[0].http_port, timeout=10)
         client.wait_for_server()
+        client.wait_for_cluster_ready(expected_peers=3)
 
         # Create collection and insert points
         collection_config = {"vectors": {"size": 512, "distance": "Dot"}, "shard_number": 3, "replication_factor": 1, "optimization_config": {"indexing_threshold": 0}}


### PR DESCRIPTION
Utilize more intelligent wait condition.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [X] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [X] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?