### PR TITLE
test: fix race in test_corrupted_snapshot_recovery

### DIFF
--- a/tests/consensus_tests/test_failed_snapshot_recovery.py
+++ b/tests/consensus_tests/test_failed_snapshot_recovery.py
@@ -201,9 +201,11 @@ def test_corrupted_snapshot_recovery(tmp_path: pathlib.Path):
         # Sometimes restart is fast and flag is deleted immediately because we initiate a transfer
         assert flag_exists
 
-    # Initiate transfer from another peer to recover the shard.
-    # This part checks that dummy shard can be recovered with shard transfer.
-    recover_shard(peer_api_uris[-1], collection_name=COLLECTION_NAME)
+        # Initiate transfer from another peer to recover the shard.
+        # This part checks that dummy shard can be recovered with shard transfer.
+        # If a transfer was already auto-initiated by the cluster recovery loop,
+        # skip the manual call — it would fail with 400 "already involved in transfer".
+        recover_shard(peer_api_uris[-1], collection_name=COLLECTION_NAME)
 
     # Assert storage does not contain initialized flag when transfer is started
     print("Checking that the shard initializing flag was removed after recovery")


### PR DESCRIPTION

Fix for https://github.com/qdrant/qdrant/actions/runs/25706195257/job/75476715323?pr=8999

---

## Summary

- Fixes a race in `tests/consensus_tests/test_failed_snapshot_recovery.py::test_corrupted_snapshot_recovery` where the manual `recover_shard()` call returns **400 \"Shard 0 is already involved in transfer\"** if the cluster's auto-recovery loop initiates the transfer first.
- After the restarted peer loads its dummy shard, `Collection::recover_dirty_shards` (see `lib/collection/src/collection/mod.rs:826`) auto-proposes a `ShardTransfer` from another replica. The test was then unconditionally calling `recover_shard()`, racing with that proposal.
- The test already conditionally skips the `flag_exists` assertion when a transfer is in flight; now it also skips the manual `recover_shard()` call in the same branch. The subsequent `wait_for(flag removed)`, `wait_for_collection_shard_transfers_count`, and replica/scroll assertions still verify recovery completes either way.

## Timeline from failing run

From `peer_3_restarted.log`:

- `01:01:13.735` peer 3 auto-proposes recovery transfer (WalDelta, 7575… → 2573…)
- `01:01:13.880` transfer applied; shard `Dead` → `Recovery`
- `01:01:14.832` test polls `/cluster` (transfer visible)
- `01:01:14.949` test's manual `POST /cluster` → **400** \"Shard 0 is already involved in transfer\"

## Test plan

- [ ] CI green on `test_corrupted_snapshot_recovery` (consensus tests)
- [ ] Local reruns with concurrent xdist load do not reproduce the 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)