### PR TITLE
refactor(map_index): extract inner state; add ReadOnlyAppendableMapIndex skeleton

### DIFF
--- a/lib/segment/src/index/field_index/map_index/mmap_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mmap_map_index/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use common::bitvec::BitVec;
 use common::persisted_hashmap::{Key, UniversalHashMap};
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
+use common::universal_io::{MmapFile, UniversalRead};
 use serde::{Deserialize, Serialize};
 
 use super::MapIndexKey;
@@ -28,17 +28,17 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 /// only updates the in-memory bitvec. Callers must re-supply the authoritative
 /// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
 /// `deleted_points` argument to [`Self::open`] on reload.
-pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized> {
+pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
     pub(super) path: PathBuf,
-    pub(super) storage: Storage<N>,
+    pub(super) storage: Storage<N, S>,
     pub(super) deleted_count: usize,
     pub(super) total_key_value_pairs: usize,
     pub(super) is_on_disk: bool,
 }
 
-pub(super) struct Storage<N: MapIndexKey + Key + ?Sized> {
-    pub(super) value_to_points: UniversalHashMap<N, PointOffsetType, MmapFile>,
-    pub(super) point_to_values: StoredPointToValues<N, MmapFile>,
+pub(super) struct Storage<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
+    pub(super) value_to_points: UniversalHashMap<N, PointOffsetType, S>,
+    pub(super) point_to_values: StoredPointToValues<N, S>,
     /// In-memory deletion bitmap. Reconstructed at load time as the union of
     /// the build-time empty-payload bits read from `deleted.bin` and the
     /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
@@ -1,0 +1,205 @@
+use std::borrow::{Borrow, Cow};
+use std::collections::HashMap;
+use std::iter;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use gridstore::Blob;
+use roaring::RoaringBitmap;
+
+use super::super::read_ops::MapIndexRead;
+use super::super::{IdIter, MapIndexKey};
+use crate::common::operation_error::OperationResult;
+use crate::index::payload_config::StorageType;
+
+/// In-memory state shared by `MutableMapIndex` and `ReadOnlyAppendableMapIndex`.
+///
+/// Both wrappers add a different backing storage (`Gridstore` vs
+/// `GridstoreReader`); the in-memory layout that serves every
+/// [`MapIndexRead`] method is the same, so it lives here once.
+pub(in crate::index::field_index::map_index) struct MutableMapIndexInner<N: MapIndexKey + ?Sized>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub(in crate::index::field_index::map_index) map:
+        HashMap<<N as MapIndexKey>::Owned, RoaringBitmap>,
+    pub(in crate::index::field_index::map_index) point_to_values:
+        Vec<Vec<<N as MapIndexKey>::Owned>>,
+    /// Amount of point which have at least one indexed payload value
+    pub(in crate::index::field_index::map_index) indexed_points: usize,
+    pub(in crate::index::field_index::map_index) values_count: usize,
+}
+
+impl<N: MapIndexKey + ?Sized> MutableMapIndexInner<N>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub(in crate::index::field_index::map_index) fn empty() -> Self {
+        Self {
+            map: HashMap::new(),
+            point_to_values: Vec::new(),
+            indexed_points: 0,
+            values_count: 0,
+        }
+    }
+
+    /// Apply one `(point_id, value)` pair from a backing store iteration.
+    ///
+    /// Used by `MutableMapIndex::open_gridstore` to populate the in-memory
+    /// state from on-disk data; the matching loader for
+    /// [`super::read_only::ReadOnlyAppendableMapIndex`] will reuse this helper
+    /// once its lifecycle layer lands.
+    pub(in crate::index::field_index::map_index) fn ingest(
+        &mut self,
+        idx: PointOffsetType,
+        value: <N as MapIndexKey>::Owned,
+    ) {
+        if self.point_to_values.len() <= idx as usize {
+            self.point_to_values.resize_with(idx as usize + 1, Vec::new);
+        }
+        let point_values = &mut self.point_to_values[idx as usize];
+
+        if point_values.is_empty() {
+            self.indexed_points += 1;
+        }
+        self.values_count += 1;
+
+        point_values.push(value.clone());
+        self.map.entry(value).or_default().insert(idx);
+    }
+
+    pub(in crate::index::field_index::map_index) fn for_points_values(
+        &self,
+        points: impl Iterator<Item = PointOffsetType>,
+        mut f: impl FnMut(PointOffsetType, &[<N as MapIndexKey>::Owned]),
+    ) {
+        points.for_each(|idx| {
+            if let Some(values) = self.point_to_values.get(idx as usize) {
+                f(idx, values);
+            }
+        });
+    }
+}
+
+impl<N: MapIndexKey + ?Sized> MapIndexRead<N> for MutableMapIndexInner<N>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn check_values_any(
+        &self,
+        idx: PointOffsetType,
+        _hw_counter: &HardwareCounterCell,
+        check_fn: impl Fn(&N) -> bool,
+    ) -> bool {
+        self.point_to_values
+            .get(idx as usize)
+            .map(|values| values.iter().any(|v| check_fn(v.borrow())))
+            .unwrap_or(false)
+    }
+
+    fn get_values<'a>(
+        &'a self,
+        idx: PointOffsetType,
+        _hw_counter: &HardwareCounterCell,
+    ) -> Option<impl Iterator<Item = Cow<'a, N>> + 'a>
+    where
+        N: 'a,
+    {
+        Some(
+            self.point_to_values
+                .get(idx as usize)?
+                .iter()
+                .map(|v| Cow::Borrowed(v.borrow())),
+        )
+    }
+
+    fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        self.point_to_values.get(idx as usize).map(Vec::len)
+    }
+
+    fn get_indexed_points(&self) -> usize {
+        self.indexed_points
+    }
+
+    fn get_values_count(&self) -> usize {
+        self.values_count
+    }
+
+    fn get_unique_values_count(&self) -> usize {
+        self.map.len()
+    }
+
+    fn get_count_for_value(&self, value: &N, _hw_counter: &HardwareCounterCell) -> Option<usize> {
+        self.map.get(value).map(|p| p.len() as usize)
+    }
+
+    fn get_iterator(&self, value: &N, _hw_counter: &HardwareCounterCell) -> IdIter<'_> {
+        self.map
+            .get(value)
+            .map(|ids| Box::new(ids.iter()) as IdIter)
+            .unwrap_or_else(|| Box::new(iter::empty::<PointOffsetType>()))
+    }
+
+    fn for_each_value(&self, mut f: impl FnMut(&N) -> OperationResult<()>) -> OperationResult<()> {
+        self.map.keys().try_for_each(|v| f(v.borrow()))
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        mut f: impl FnMut(&N, usize) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.map.iter().try_for_each(|(k, v)| {
+            let count = match deferred_internal_id {
+                Some(deferred_internal_id) => v.range_cardinality(..deferred_internal_id) as usize,
+                None => v.len() as usize,
+            };
+            f(k.borrow(), count)
+        })
+    }
+
+    fn for_each_value_map(
+        &self,
+        _hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(&N, &mut dyn Iterator<Item = PointOffsetType>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.map
+            .iter()
+            .try_for_each(|(k, v)| f(k.borrow(), &mut v.iter()))
+    }
+
+    /// Placeholder — neither wrapper exposes the inner directly; both override
+    /// `storage_type()` in their own `MapIndexRead` impls to report the
+    /// concrete storage. The inner is never consumed as a bare
+    /// `&dyn MapIndexRead`, so this value is unobservable in practice.
+    fn storage_type(&self) -> StorageType {
+        StorageType::Gridstore
+    }
+
+    /// Approximate RAM usage in bytes for in-memory index structures.
+    fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            map,
+            point_to_values,
+            indexed_points: _,
+            values_count: _,
+        } = self;
+
+        let hashmap_entry_overhead = std::mem::size_of::<u64>() + std::mem::size_of::<usize>();
+        let map_base_bytes = map.capacity()
+            * (std::mem::size_of::<<N as MapIndexKey>::Owned>()
+                + std::mem::size_of::<RoaringBitmap>()
+                + hashmap_entry_overhead);
+        // Account for heap-allocated key data (e.g., long strings)
+        let map_key_heap_bytes: usize = map.keys().map(|k| N::owned_heap_bytes(k)).sum();
+        let map_bitmap_bytes: usize = map.values().map(|bitmap| bitmap.serialized_size()).sum();
+        let map_bytes = map_base_bytes + map_key_heap_bytes + map_bitmap_bytes;
+        let ptv_bytes: usize = point_to_values.capacity()
+            * std::mem::size_of::<Vec<<N as MapIndexKey>::Owned>>()
+            + point_to_values
+                .iter()
+                .map(|v| v.capacity() * std::mem::size_of::<<N as MapIndexKey>::Owned>())
+                .sum::<usize>();
+        map_bytes + ptv_bytes
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -7,10 +6,10 @@ use common::types::PointOffsetType;
 use gridstore::config::StorageOptions;
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, Gridstore};
-use roaring::RoaringBitmap;
 
 use super::super::MapIndexKey;
 use super::MutableMapIndex;
+use super::inner::MutableMapIndexInner;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 
@@ -54,10 +53,7 @@ where
         };
 
         // Load in-memory index from Gridstore
-        let mut map = HashMap::<_, RoaringBitmap>::new();
-        let mut point_to_values = Vec::new();
-        let mut indexed_points = 0;
-        let mut values_count = 0;
+        let mut inner = MutableMapIndexInner::<N>::empty();
 
         let hw_counter = HardwareCounterCell::disposable();
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
@@ -65,20 +61,8 @@ where
             .iter::<_, GridstoreError>(
                 |idx, values: Vec<_>| {
                     for value in values {
-                        if point_to_values.len() <= idx as usize {
-                            point_to_values.resize_with(idx as usize + 1, Vec::new)
-                        }
-                        let point_values = &mut point_to_values[idx as usize];
-
-                        if point_values.is_empty() {
-                            indexed_points += 1;
-                        }
-                        values_count += 1;
-
-                        point_values.push(value.clone());
-                        map.entry(value).or_default().insert(idx);
+                        inner.ingest(idx, value);
                     }
-
                     Ok(true)
                 },
                 hw_counter_ref,
@@ -87,10 +71,7 @@ where
             .unwrap();
 
         Ok(Some(Self {
-            map,
-            point_to_values,
-            indexed_points,
-            values_count,
+            inner,
             storage: store,
         }))
     }
@@ -108,18 +89,20 @@ where
             return Ok(());
         }
 
-        self.values_count += values.len();
-        if self.point_to_values.len() <= idx as usize {
-            self.point_to_values.resize_with(idx as usize + 1, Vec::new)
+        self.inner.values_count += values.len();
+        if self.inner.point_to_values.len() <= idx as usize {
+            self.inner
+                .point_to_values
+                .resize_with(idx as usize + 1, Vec::new)
         }
 
-        self.point_to_values[idx as usize] = Vec::with_capacity(values.len());
+        self.inner.point_to_values[idx as usize] = Vec::with_capacity(values.len());
 
         let hw_counter_ref = hw_counter.ref_payload_index_io_write_counter();
 
         for value in values.clone() {
-            let entry = self.map.entry(value.into());
-            self.point_to_values[idx as usize].push(entry.key().clone());
+            let entry = self.inner.map.entry(value.into());
+            self.inner.point_to_values[idx as usize].push(entry.key().clone());
             entry.or_default().insert(idx);
         }
 
@@ -132,24 +115,24 @@ where
                 ))
             })?;
 
-        self.indexed_points += 1;
+        self.inner.indexed_points += 1;
         Ok(())
     }
 
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
-        if self.point_to_values.len() <= idx as usize {
+        if self.inner.point_to_values.len() <= idx as usize {
             return Ok(());
         }
 
-        let removed_values = std::mem::take(&mut self.point_to_values[idx as usize]);
+        let removed_values = std::mem::take(&mut self.inner.point_to_values[idx as usize]);
 
         if !removed_values.is_empty() {
-            self.indexed_points -= 1;
+            self.inner.indexed_points -= 1;
         }
-        self.values_count -= removed_values.len();
+        self.inner.values_count -= removed_values.len();
 
         for value in &removed_values {
-            if let Some(vals) = self.map.get_mut(value.borrow()) {
+            if let Some(vals) = self.inner.map.get_mut(value.borrow()) {
                 vals.remove(idx);
             }
         }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/mod.rs
@@ -1,21 +1,17 @@
-use std::collections::HashMap;
-
 use gridstore::{Blob, Gridstore};
-use roaring::RoaringBitmap;
 
+use self::inner::MutableMapIndexInner;
 use super::MapIndexKey;
 
+pub(super) mod inner;
 mod lifecycle;
+pub mod read_only;
 mod read_ops;
 
 pub struct MutableMapIndex<N: MapIndexKey + ?Sized>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    pub(super) map: HashMap<<N as MapIndexKey>::Owned, RoaringBitmap>,
-    pub(super) point_to_values: Vec<Vec<<N as MapIndexKey>::Owned>>,
-    /// Amount of point which have at least one indexed payload value
-    pub(super) indexed_points: usize,
-    pub(super) values_count: usize,
+    pub(super) inner: MutableMapIndexInner<N>,
     pub(super) storage: Gridstore<Vec<<N as MapIndexKey>::Owned>>,
 }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/mod.rs
@@ -1,0 +1,28 @@
+use common::universal_io::MmapFile;
+use gridstore::{Blob, GridstoreReader};
+
+use super::super::MapIndexKey;
+use super::inner::MutableMapIndexInner;
+
+mod read_ops;
+
+/// Read-only counterpart to [`super::MutableMapIndex`].
+///
+/// Owns the same in-memory state ([`MutableMapIndexInner`]) but is backed by
+/// [`GridstoreReader`] over [`MmapFile`] instead of a writable
+/// [`gridstore::Gridstore`]. Implements
+/// [`super::super::read_ops::MapIndexRead`] by forwarding to the inner;
+/// provides no mutation surface.
+///
+/// Loading / lifecycle (constructor, `files`, `populate`, `clear_cache`, …)
+/// will be added in a follow-up.
+pub struct ReadOnlyAppendableMapIndex<N: MapIndexKey + ?Sized>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub(super) inner: MutableMapIndexInner<N>,
+    // Read once the lifecycle layer lands; until then the field is held to
+    // pin the on-disk layout of the type.
+    #[allow(dead_code)]
+    pub(super) storage: GridstoreReader<Vec<<N as MapIndexKey>::Owned>, MmapFile>,
+}

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/mod.rs
@@ -1,4 +1,4 @@
-use common::universal_io::MmapFile;
+use common::universal_io::UniversalRead;
 use gridstore::{Blob, GridstoreReader};
 
 use super::super::MapIndexKey;
@@ -9,14 +9,14 @@ mod read_ops;
 /// Read-only counterpart to [`super::MutableMapIndex`].
 ///
 /// Owns the same in-memory state ([`MutableMapIndexInner`]) but is backed by
-/// [`GridstoreReader`] over [`MmapFile`] instead of a writable
+/// [`GridstoreReader`] over generic [`UniversalRead`] instead of a writable
 /// [`gridstore::Gridstore`]. Implements
 /// [`super::super::read_ops::MapIndexRead`] by forwarding to the inner;
 /// provides no mutation surface.
 ///
 /// Loading / lifecycle (constructor, `files`, `populate`, `clear_cache`, …)
 /// will be added in a follow-up.
-pub struct ReadOnlyAppendableMapIndex<N: MapIndexKey + ?Sized>
+pub struct ReadOnlyAppendableMapIndex<N: MapIndexKey + ?Sized, S: UniversalRead>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -24,5 +24,5 @@ where
     // Read once the lifecycle layer lands; until then the field is held to
     // pin the on-disk layout of the type.
     #[allow(dead_code)]
-    pub(super) storage: GridstoreReader<Vec<<N as MapIndexKey>::Owned>, MmapFile>,
+    pub(super) storage: GridstoreReader<Vec<<N as MapIndexKey>::Owned>, S>,
 }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
@@ -4,13 +4,13 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use gridstore::Blob;
 
-use super::super::read_ops::MapIndexRead;
-use super::super::{IdIter, MapIndexKey};
-use super::MutableMapIndex;
+use super::super::super::read_ops::MapIndexRead;
+use super::super::super::{IdIter, MapIndexKey};
+use super::ReadOnlyAppendableMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::payload_config::StorageType;
 
-impl<N: MapIndexKey + ?Sized> MapIndexRead<N> for MutableMapIndex<N>
+impl<N: MapIndexKey + ?Sized> MapIndexRead<N> for ReadOnlyAppendableMapIndex<N>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -79,6 +79,8 @@ where
     }
 
     fn storage_type(&self) -> StorageType {
+        // The on-disk format is Gridstore; the read-only-vs-mutable
+        // distinction is not yet reflected in [`StorageType`].
         StorageType::Gridstore
     }
 
@@ -87,7 +89,7 @@ where
     }
 }
 
-impl<N: MapIndexKey + ?Sized> MutableMapIndex<N>
+impl<N: MapIndexKey + ?Sized> ReadOnlyAppendableMapIndex<N>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::super::read_ops::MapIndexRead;
@@ -10,7 +11,7 @@ use super::ReadOnlyAppendableMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::payload_config::StorageType;
 
-impl<N: MapIndexKey + ?Sized> MapIndexRead<N> for ReadOnlyAppendableMapIndex<N>
+impl<N: MapIndexKey + ?Sized, S: UniversalRead> MapIndexRead<N> for ReadOnlyAppendableMapIndex<N, S>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -89,7 +90,7 @@ where
     }
 }
 
-impl<N: MapIndexKey + ?Sized> ReadOnlyAppendableMapIndex<N>
+impl<N: MapIndexKey + ?Sized, S: UniversalRead> ReadOnlyAppendableMapIndex<N, S>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {


### PR DESCRIPTION
## Summary
- Extract `MutableMapIndex<N>`'s four in-memory fields (`map`, `point_to_values`, `indexed_points`, `values_count`) into a shared inner struct `MutableMapIndexInner<N>` in `mutable_map_index/inner.rs`. The `MapIndexRead<N>` impl moves wholesale onto the inner.
- `MutableMapIndex<N>` becomes a thin wrapper `{ inner, storage: Gridstore<...> }`. Its `MapIndexRead<N>` impl forwards to the inner. The Gridstore load loop in `open_gridstore` collapses to `MutableMapIndexInner::empty()` + `inner.ingest(idx, value)` per row.
- Add `mutable_map_index/read_only/` containing `ReadOnlyAppendableMapIndex<N>` — same inner + `GridstoreReader<Vec<...>, MmapFile>` instead of `Gridstore`. Its `MapIndexRead<N>` impl forwards to the same inner, so the read-method bodies are shared across the two storage variants.
- No constructor / loader yet — the read-only variant's lifecycle (`open`, `files`, `populate`, …) will land in a follow-up. The `storage` field carries an `#[allow(dead_code)]` until then.

Pure refactor — no behavioural change.

## Test plan
- [x] `cargo check -p segment --tests` — clean
- [x] `cargo test -p segment --lib index::field_index::map_index::` — all 17 existing tests pass unchanged
- [ ] Follow-up PR will add the `ReadOnlyAppendableMapIndex::open(path)` constructor and a cross-load test that writes via `MutableMapIndex`, reopens via `ReadOnlyAppendableMapIndex`, and asserts read parity through the shared inner.