### PR TITLE
fix correct ReadConsistency factor minimum to 1

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14958,7 +14958,7 @@
           {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 1
           },
           {
             "$ref": "#/components/schemas/ReadConsistencyType"

--- a/lib/collection/src/operations/consistency_params.rs
+++ b/lib/collection/src/operations/consistency_params.rs
@@ -25,7 +25,11 @@ use validator::{Validate, ValidationError as ValidatorError, ValidationErrors};
 #[serde(untagged)]
 pub enum ReadConsistency {
     // send N random request and return points, which present on all of them
-    Factor(#[serde(deserialize_with = "deserialize_factor")] usize),
+    Factor(
+        #[serde(deserialize_with = "deserialize_factor")]
+        #[schemars(range(min = 1))]
+        usize,
+    ),
     Type(ReadConsistencyType),
 }
 

--- a/lib/collection/src/operations/consistency_params.rs
+++ b/lib/collection/src/operations/consistency_params.rs
@@ -95,6 +95,10 @@ impl TryFrom<ReadConsistencyGrpc> for ReadConsistency {
             read_consistency::Value::Type(consistency) => Self::Type(consistency.try_into()?),
         };
 
+        consistency
+            .validate()
+            .map_err(|err| tonic::Status::invalid_argument(err.to_string()))?;
+
         Ok(consistency)
     }
 }


### PR DESCRIPTION
`ReadConsistency::Factor(usize)` is rejected at runtime when factor == 0, but the invariant wasn't surfaced consistently:

- OpenAPI schema advertised minimum: 0.
- The native Validate impl was never invoked on the gRPC path: the conversion from ReadConsistencyGrpc happily produced `Factor(0)`.

REST behavior unchanged (serde deserializer already rejected 0).