### PR TITLE
fix(openapi-tests): inject QDRANT_HOST_HEADERS

### DIFF
--- a/tests/openapi/test_named_vector_crud.py
+++ b/tests/openapi/test_named_vector_crud.py
@@ -2,7 +2,7 @@ import pytest
 import time
 import requests
 
-from .helpers.helpers import request_with_validation
+from .helpers.helpers import qdrant_host_headers, request_with_validation
 from .helpers.settings import QDRANT_HOST
 
 
@@ -117,6 +117,7 @@ def test_create_vector_rejects_zero_size(collection_name):
     response = requests.put(
         f"{QDRANT_HOST}/collections/{collection_name}/vectors/vec_zero",
         params={'wait': 'true'},
+        headers=qdrant_host_headers(),
         json={"dense": {"size": 0, "distance": "Cosine"}},
     )
     assert response.status_code == 422, response.text
@@ -128,6 +129,7 @@ def test_create_vector_rejects_oversize(collection_name):
     response = requests.put(
         f"{QDRANT_HOST}/collections/{collection_name}/vectors/vec_huge",
         params={'wait': 'true'},
+        headers=qdrant_host_headers(),
         json={"dense": {"size": 65537, "distance": "Cosine"}},
     )
     assert response.status_code == 422, response.text

--- a/tests/openapi/test_shard_snapshot.py
+++ b/tests/openapi/test_shard_snapshot.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
-from .helpers.helpers import request_with_validation
+from .helpers.helpers import qdrant_host_headers, request_with_validation
 from .helpers.settings import QDRANT_HOST
 
 
@@ -212,7 +212,7 @@ def test_shard_snapshot_security(collection_name):
     snapshot_name = "/etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404
@@ -220,7 +220,7 @@ def test_shard_snapshot_security(collection_name):
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
-from .helpers.helpers import request_with_validation
+from .helpers.helpers import qdrant_host_headers, request_with_validation
 from .helpers.settings import QDRANT_HOST
 
 
@@ -370,7 +370,7 @@ def test_full_snapshot_security():
     snapshot_name = "/etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404
@@ -378,7 +378,7 @@ def test_full_snapshot_security():
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404
@@ -398,7 +398,7 @@ def test_collection_snapshot_security(collection_name):
     snapshot_name = "/etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404
@@ -406,7 +406,7 @@ def test_collection_snapshot_security(collection_name):
     snapshot_name = "../../../../../../../etc/passwd"
     response = requests.get(
         f"{QDRANT_HOST}/collections/{collection_name}/snapshots/{snapshot_name}",
-        headers={"Content-Type": "application/json"},
+        headers={**qdrant_host_headers(), "Content-Type": "application/json"},
     )
     assert not response.ok
     assert response.status_code == 404

--- a/tests/openapi/test_stopwords.py
+++ b/tests/openapi/test_stopwords.py
@@ -21,14 +21,31 @@ from qdrant_client.http.models import (
     VectorParams,
 )
 
+from .helpers.helpers import qdrant_host_headers
+from .helpers.settings import QDRANT_HOST
+
 
 def _build_client(prefer_grpc: bool) -> QdrantClient:
+    host_headers = qdrant_host_headers()
+    grpc_host = host_headers.get("host") or host_headers.get("Host") or "127.0.0.1"
+
+    # NOTE: The test setup is different compared to other pure HTTP or gRPC tests.
+    # It intentionally compares REST and gRPC through QdrantClient instead of request_with_validation.
+    # Both clients must still use the shared host-routing config for proxy-backed runs.
+    if prefer_grpc:
+        return QdrantClient(
+            host=grpc_host,
+            port=6333,
+            grpc_port=6334,
+            prefer_grpc=True,
+            timeout=30,
+        )
+
     return QdrantClient(
-        host="127.0.0.1",
-        port=6333,
-        grpc_port=6334,
-        prefer_grpc=prefer_grpc,
+        url=QDRANT_HOST,
+        prefer_grpc=False,
         timeout=30,
+        headers=host_headers,
     )
 
 
@@ -82,7 +99,10 @@ def _run(prefer_grpc: bool):
             ),
             wait=True,
         )
-        return {term: _scroll_ids(client, collection, term) for term in ("lazy", "The", "LAZY")}
+        return {
+            term: _scroll_ids(client, collection, term)
+            for term in ("lazy", "The", "LAZY")
+        }
     finally:
         if client.collection_exists(collection):
             client.delete_collection(collection)

--- a/tests/openapi/test_update_queue.py
+++ b/tests/openapi/test_update_queue.py
@@ -4,6 +4,7 @@ import requests
 from openapi.helpers.helpers import (
     skip_if_no_feature,
     get_api_string,
+    qdrant_host_headers,
     request_with_validation,
 )
 from openapi.helpers.settings import QDRANT_HOST
@@ -133,6 +134,7 @@ def test_queue_length(collection_name):
     # apply update delay
     response = requests.post(
         url=get_api_string(QDRANT_HOST, '/collections/{collection_name}/debug', {"collection_name": collection_name}),
+        headers=qdrant_host_headers(),
         json={"delay": {"duration_sec": 3.0}}
     )
     assert response.ok


### PR DESCRIPTION
Raw requests in OpenAPI tests already use `QDRANT_HOST`, but bypass
`request_with_validation` and missed `QDRANT_HOST_HEADERS`.

Without these headers, tests cannot run behind host-based reverse proxies
or mocks. In those setups, requests may hit the proxy with the default
`Host` header and receive proxy-level responses instead of hitting the Qdrant cluster.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
