### PR TITLE
read only map index

### DIFF
--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,8 +1,10 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::{MmapFile, UniversalRead};
 
 use super::bool_index::BoolIndex;
 use super::map_index::MapIndex;
+use super::map_index::read_only::ReadOnlyMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::types::{IntPayloadType, UuidIntType};
@@ -69,14 +71,30 @@ pub trait FacetIndex {
     }
 }
 
-pub enum FacetIndexEnum<'a> {
+/// Borrowed view over any concrete index that can produce facet counts.
+///
+/// The `S: UniversalRead` parameter is consumed only by the `*ReadOnly`
+/// variants, which carry a `ReadOnlyMapIndex<N, S>`; appendable / in-memory
+/// variants (`Keyword`, `Int`, `Uuid`, `Bool`) ignore it. The default
+/// `S = MmapFile` keeps the common construction path
+/// (`FieldIndex::as_facet_index`) free of turbofish.
+pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
     Bool(&'a BoolIndex),
+    // Constructed only by `ReadOnlyFieldIndex::as_facet_index`, which is
+    // itself dead-code-allowed (`ReadOnlyFieldIndex` isn't wired into the
+    // read path yet).
+    #[allow(dead_code)]
+    KeywordReadOnly(&'a ReadOnlyMapIndex<str, S>),
+    #[allow(dead_code)]
+    IntReadOnly(&'a ReadOnlyMapIndex<IntPayloadType, S>),
+    #[allow(dead_code)]
+    UuidReadOnly(&'a ReadOnlyMapIndex<UuidIntType, S>),
 }
 
-impl<'a> FacetIndex for FacetIndexEnum<'a> {
+impl<'a, S: UniversalRead> FacetIndex for FacetIndexEnum<'a, S> {
     fn for_points_values(
         &self,
         points: impl Iterator<Item = PointOffsetType>,
@@ -96,6 +114,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Bool(index) => {
                 FacetIndex::for_points_values(*index, points, hw_counter, f)
             }
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
         }
     }
 
@@ -108,6 +135,9 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Int(index) => FacetIndex::for_each_value(*index, f),
             FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value(*index, f),
             FacetIndexEnum::Bool(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::KeywordReadOnly(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::IntReadOnly(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::UuidReadOnly(index) => FacetIndex::for_each_value(*index, f),
         }
     }
 
@@ -124,6 +154,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Int(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
             FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
             FacetIndexEnum::Bool(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
         }
     }
 
@@ -143,6 +182,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
                 FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
             }
             FacetIndexEnum::Bool(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
                 FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
             }
         }

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -256,11 +256,15 @@ impl FieldIndexRead for FieldIndex {
     }
 
     fn as_facet_index(&self) -> Option<impl FacetIndex + '_> {
+        // None of these variants carry the `S` storage parameter; pin the
+        // returned `FacetIndexEnum`'s `S` to `MmapFile` (the default) so
+        // inference doesn't choke on the unconstrained generic.
+        use common::universal_io::MmapFile;
         match self {
-            FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::Keyword(index)),
-            FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::Int(index)),
-            FieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::Uuid(index)),
-            FieldIndex::BoolIndex(index) => Some(FacetIndexEnum::Bool(index)),
+            FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::<MmapFile>::Keyword(index)),
+            FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::<MmapFile>::Int(index)),
+            FieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::<MmapFile>::Uuid(index)),
+            FieldIndex::BoolIndex(index) => Some(FacetIndexEnum::<MmapFile>::Bool(index)),
             FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)
             | FieldIndex::DatetimeIndex(_)

--- a/lib/segment/src/index/field_index/field_index_base/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/mod.rs
@@ -3,6 +3,7 @@ mod field_index;
 mod field_index_read;
 mod field_index_read_impl;
 mod payload_field_index;
+mod read_only;
 mod value_indexer;
 
 pub use builder::{FieldIndexBuilder, FieldIndexBuilderTrait};

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -1,0 +1,25 @@
+mod read_ops;
+
+use common::universal_io::UniversalRead;
+
+use crate::index::field_index::map_index::read_only::ReadOnlyMapIndex;
+use crate::index::field_index::null_index::ReadOnlyNullIndex;
+use crate::types::{IntPayloadType, UuidIntType};
+
+// Not yet wired into the broader read-path; lifecycle and constructors land
+// in a follow-up. Variants intentionally share the `*Index` postfix to mirror
+// `FieldIndex`.
+#[allow(dead_code, clippy::enum_variant_names)]
+pub enum ReadOnlyFieldIndex<S: UniversalRead> {
+    // IntIndex(NumericIndex<IntPayloadType, IntPayloadType>),
+    // DatetimeIndex(NumericIndex<IntPayloadType, DateTimePayloadType>),
+    IntMapIndex(ReadOnlyMapIndex<IntPayloadType, S>),
+    KeywordIndex(ReadOnlyMapIndex<str, S>),
+    // FloatIndex(NumericIndex<FloatPayloadType, FloatPayloadType>),
+    // GeoIndex(GeoMapIndex),
+    // FullTextIndex(FullTextIndex),
+    // BoolIndex(BoolIndex),
+    // UuidIndex(NumericIndex<UuidIntType, UuidPayloadType>),
+    UuidMapIndex(ReadOnlyMapIndex<UuidIntType, S>),
+    NullIndex(ReadOnlyNullIndex<S>),
+}

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -1,0 +1,184 @@
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use serde_json::Value;
+
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::field_index_base::read_only::ReadOnlyFieldIndex;
+use crate::index::field_index::map_index::read_ops::MapIndexRead;
+use crate::index::field_index::null_index::NullIndexRead;
+use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
+use crate::index::field_index::{
+    CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition, PayloadFieldIndexRead,
+};
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
+use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, PayloadKeyType};
+
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
+    fn count_indexed_points(&self) -> usize {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.count_indexed_points(),
+        }
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.filter(condition, hw_counter),
+        }
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                idx.estimate_cardinality(condition, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                idx.estimate_cardinality(condition, hw_counter)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
+        }
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+        }
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.condition_checker(condition, hw_acc),
+        }
+    }
+
+    fn special_check_condition(
+        &self,
+        condition: &FieldCondition,
+        payload_value: &Value,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> FieldIndexRead for ReadOnlyFieldIndex<S> {
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.get_telemetry_data(),
+        }
+    }
+
+    fn values_count(&self, point_id: PointOffsetType) -> usize {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_count(idx, point_id),
+        }
+    }
+
+    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_is_empty(idx, point_id),
+        }
+    }
+
+    fn value_retriever<'a, 'q>(
+        &'a self,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> Option<VariableRetrieverFn<'q>>
+    where
+        'a: 'q,
+    {
+        // Mirrors `FieldIndex::value_retriever`: NullIndex has no underlying
+        // values to return; the map variants build their per-K closure via
+        // an inherent `value_retriever` method.
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::NullIndex(_) => None,
+        }
+    }
+
+    fn as_numeric(&self) -> Option<impl NumericFieldIndexRead + '_> {
+        // No numeric variants in `ReadOnlyFieldIndex` yet (numeric reads
+        // land in a follow-up). Concrete `None` type keeps the
+        // return-position `impl Trait` inferable.
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(_)
+            | ReadOnlyFieldIndex::KeywordIndex(_)
+            | ReadOnlyFieldIndex::UuidMapIndex(_)
+            | ReadOnlyFieldIndex::NullIndex(_) => None::<NumericFieldIndex<'_>>,
+        }
+    }
+
+    fn as_facet_index(&self) -> Option<impl FacetIndex + '_> {
+        use crate::index::field_index::facet_index::FacetIndexEnum;
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::IntReadOnly(index)),
+            ReadOnlyFieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::KeywordReadOnly(index)),
+            ReadOnlyFieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::UuidReadOnly(index)),
+            // NullIndex doesn't carry facet-able values.
+            ReadOnlyFieldIndex::NullIndex(_) => None,
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/builders.rs
+++ b/lib/segment/src/index/field_index/map_index/builders.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use super::MapIndex;
 use super::key::MapIndexKey;
-use super::mmap_map_index::MmapMapIndex;
+use super::universal_map_index::UniversalMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex, ValueIndexer};
 
@@ -109,7 +109,7 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(MapIndex::Mmap(Box::new(MmapMapIndex::build(
+        Ok(MapIndex::Mmap(Box::new(UniversalMapIndex::build(
             &self.path,
             self.point_to_values,
             self.values_to_points,

--- a/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
@@ -6,6 +6,7 @@ use gridstore::Blob;
 
 use super::MapIndex;
 use super::key::MapIndexKey;
+use super::read_ops::MapIndexRead;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::field_index::facet_index::FacetIndex;
@@ -40,7 +41,10 @@ where
         &self,
         mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_value(|v| f(v.into()))
+        // Disambiguate from `FacetIndex::for_each_value` (the trait we're
+        // implementing): the inner call is `MapIndexRead::for_each_value`,
+        // which iterates raw `&N` values rather than `FacetValueRef`.
+        MapIndexRead::for_each_value(self, |v| f(v.into()))
     }
 
     fn for_each_value_map(
@@ -51,7 +55,7 @@ where
             &mut dyn Iterator<Item = PointOffsetType>,
         ) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_value_map(hw_counter, |value, iter| f(value.into(), iter))
+        MapIndexRead::for_each_value_map(self, hw_counter, |value, iter| f(value.into(), iter))
     }
 
     fn for_each_count_per_value(
@@ -59,7 +63,7 @@ where
         deferred_internal_id: Option<PointOffsetType>,
         mut f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_count_per_value(deferred_internal_id, |value, count| {
+        MapIndexRead::for_each_count_per_value(self, deferred_internal_id, |value, count| {
             f(FacetHit {
                 value: value.into(),
                 count,

--- a/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
@@ -2,10 +2,12 @@ use std::borrow::{Borrow, Cow};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::MapIndex;
 use super::key::MapIndexKey;
+use super::read_only::ReadOnlyMapIndex;
 use super::read_ops::MapIndexRead;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
@@ -44,6 +46,70 @@ where
         // Disambiguate from `FacetIndex::for_each_value` (the trait we're
         // implementing): the inner call is `MapIndexRead::for_each_value`,
         // which iterates raw `&N` values rather than `FacetValueRef`.
+        MapIndexRead::for_each_value(self, |v| f(v.into()))
+    }
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(
+            FacetValueRef<'_>,
+            &mut dyn Iterator<Item = PointOffsetType>,
+        ) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        MapIndexRead::for_each_value_map(self, hw_counter, |value, iter| f(value.into(), iter))
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        mut f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        MapIndexRead::for_each_count_per_value(self, deferred_internal_id, |value, count| {
+            f(FacetHit {
+                value: value.into(),
+                count,
+            })
+        })
+    }
+}
+
+/// Faceting over the read-only enum mirrors [`FacetIndex for MapIndex<N>`]:
+/// the three iteration methods come from the shared [`MapIndexRead`] surface,
+/// and `for_points_values` dispatches to the inner variant's inherent method
+/// (the two variants differ in whether they need a `HardwareCounterCell`).
+impl<N: MapIndexKey + common::persisted_hashmap::Key + ?Sized, S: UniversalRead> FacetIndex
+    for ReadOnlyMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    for<'a> Cow<'a, N>: Into<FacetValueRef<'a>>,
+    for<'a> &'a N: Into<FacetValueRef<'a>>,
+{
+    fn for_points_values(
+        &self,
+        points: impl Iterator<Item = PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.for_points_values(points, |idx, slice| {
+                    f(idx, &mut slice.iter().map(|v| v.borrow().into()));
+                });
+                Ok(())
+            }
+            ReadOnlyMapIndex::Immutable(index) => {
+                index.for_points_values(points, hw_counter, |idx, vals| {
+                    f(idx, &mut vals.map(|v| v.into()));
+                })
+            }
+        }
+    }
+
+    fn for_each_value(
+        &self,
+        mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         MapIndexRead::for_each_value(self, |v| f(v.into()))
     }
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -8,8 +8,8 @@ use common::types::PointOffsetType;
 use gridstore::Blob;
 
 use super::super::MapIndexKey;
-use super::super::universal_map_index::UniversalMapIndex;
 use super::super::read_ops::MapIndexRead;
+use super::super::universal_map_index::UniversalMapIndex;
 use super::{ContainerSegment, ImmutableMapIndex, Storage};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 use gridstore::Blob;
 
 use super::super::MapIndexKey;
-use super::super::mmap_map_index::MmapMapIndex;
+use super::super::universal_map_index::UniversalMapIndex;
 use super::super::read_ops::MapIndexRead;
 use super::{ContainerSegment, ImmutableMapIndex, Storage};
 use crate::common::Flusher;
@@ -20,7 +20,7 @@ where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
     /// Open and load immutable map index from mmap storage
-    pub(in super::super) fn open_mmap(index: MmapMapIndex<N>) -> OperationResult<Self> {
+    pub(in super::super) fn open_mmap(index: UniversalMapIndex<N>) -> OperationResult<Self> {
         let hw_counter = HardwareCounterCell::disposable(); // Internal operation
 
         let mut indexed_points = 0;
@@ -32,7 +32,7 @@ where
         // Create flattened values-to-points mapping. Skip values whose live
         // points are all deleted in the backing mmap (e.g., points the
         // id-tracker has deleted at runtime, applied at open time by
-        // `MmapMapIndex::open`). This mirrors the runtime invariant in
+        // `UniversalMapIndex::open`). This mirrors the runtime invariant in
         // `remove_idx_from_value_list`: `value_to_points` only ever contains
         // entries with `count > 0`.
         let mut value_to_points_container = Vec::with_capacity(index.get_values_count());

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
@@ -6,7 +6,7 @@ use common::persisted_hashmap::Key;
 use common::types::PointOffsetType;
 
 use super::MapIndexKey;
-use super::mmap_map_index::MmapMapIndex;
+use super::universal_map_index::UniversalMapIndex;
 use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues;
 
 mod lifecycle;
@@ -30,7 +30,7 @@ pub struct ImmutableMapIndex<N: MapIndexKey + Key + ?Sized> {
 }
 
 pub(super) enum Storage<N: MapIndexKey + Key + ?Sized> {
-    Mmap(Box<MmapMapIndex<N>>),
+    Mmap(Box<UniversalMapIndex<N>>),
 }
 
 pub(super) struct ContainerSegment {

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
@@ -110,6 +110,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.cached_ram_usage_bytes
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "immutable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N>

--- a/lib/segment/src/index/field_index/map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/lifecycle.rs
@@ -8,8 +8,8 @@ use super::MapIndex;
 use super::builders::MapIndexMmapBuilder;
 use super::immutable_map_index::ImmutableMapIndex;
 use super::key::MapIndexKey;
-use super::mmap_map_index::MmapMapIndex;
 use super::mutable_map_index::MutableMapIndex;
+use super::universal_map_index::UniversalMapIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 
@@ -30,16 +30,17 @@ where
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) = MmapMapIndex::open(path, effective_is_on_disk, deleted_points)?
+        let Some(universal_index) =
+            UniversalMapIndex::open(path, effective_is_on_disk, deleted_points)?
         else {
             return Ok(None);
         };
 
         let index = if effective_is_on_disk {
-            MapIndex::Mmap(Box::new(mmap_index))
+            MapIndex::Mmap(Box::new(universal_index))
         } else {
             // Load into RAM, use mmap as backing storage
-            MapIndex::Immutable(ImmutableMapIndex::open_mmap(mmap_index)?)
+            MapIndex::Immutable(ImmutableMapIndex::open_mmap(universal_index)?)
         };
         Ok(Some(index))
     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -14,14 +14,13 @@ pub mod key;
 mod lifecycle;
 pub mod mutable_map_index;
 mod payload_index_impl;
-mod read_ops;
+pub mod read_ops;
 #[cfg(test)]
 mod tests;
 pub mod universal_map_index;
 mod value_indexer_impl;
 
-#[allow(dead_code)]
-mod read_only;
+pub mod read_only;
 
 /// Block size in Gridstore for keyword map index.
 /// Keyword(s) are stored as cbor vector.

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -4,21 +4,24 @@ use gridstore::Blob;
 pub use self::builders::{MapIndexBuilder, MapIndexGridstoreBuilder, MapIndexMmapBuilder};
 use self::immutable_map_index::ImmutableMapIndex;
 pub use self::key::MapIndexKey;
-use self::mmap_map_index::MmapMapIndex;
 use self::mutable_map_index::MutableMapIndex;
+use self::universal_map_index::UniversalMapIndex;
 
 mod builders;
 mod facet_index_impl;
 pub mod immutable_map_index;
 pub mod key;
 mod lifecycle;
-pub mod mmap_map_index;
 pub mod mutable_map_index;
 mod payload_index_impl;
 mod read_ops;
 #[cfg(test)]
 mod tests;
+pub mod universal_map_index;
 mod value_indexer_impl;
+
+#[allow(dead_code)]
+mod read_only;
 
 /// Block size in Gridstore for keyword map index.
 /// Keyword(s) are stored as cbor vector.
@@ -33,7 +36,10 @@ pub enum MapIndex<N: MapIndexKey + ?Sized>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
+    /// Loaded in RAM, use mutable storage format
     Mutable(MutableMapIndex<N>),
+    /// Loaded in RAM, use immutable storage format
     Immutable(ImmutableMapIndex<N>),
-    Mmap(Box<MmapMapIndex<N>>),
+    /// Served directly from storage (via mmap), use immutable format
+    Mmap(Box<UniversalMapIndex<N>>),
 }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
@@ -176,6 +176,13 @@ where
         StorageType::Gridstore
     }
 
+    /// Placeholder telemetry tag — like [`Self::storage_type`], the inner is
+    /// never queried directly; wrappers override this on their own
+    /// [`MapIndexRead`] impls.
+    fn telemetry_index_type(&self) -> &'static str {
+        "mutable_map"
+    }
+
     /// Approximate RAM usage in bytes for in-memory index structures.
     fn ram_usage_bytes(&self) -> usize {
         let Self {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
@@ -88,6 +88,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.inner.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "read_only_appendable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized, S: UniversalRead> ReadOnlyAppendableMapIndex<N, S>

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
@@ -85,6 +85,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.inner.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "mutable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized> MutableMapIndex<N>

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
@@ -4,9 +4,14 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
 use itertools::Itertools;
 
 use super::super::MapIndex;
+use super::super::key::MapIndexKey;
+use super::super::read_only::ReadOnlyMapIndex;
+use super::super::read_ops::MapIndexRead;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
@@ -41,7 +46,7 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
 
 impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
     fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
+        MapIndexRead::get_indexed_points(self)
     }
 
     fn filter<'a>(
@@ -49,44 +54,7 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> =
-            match &condition.r#match {
-                Some(Match::Value(MatchValue { value })) => match value {
-                    ValueVariants::String(_) => None,
-                    ValueVariants::Integer(integer) => {
-                        Some(Box::new(self.get_iterator(integer, hw_counter)))
-                    }
-                    ValueVariants::Bool(_) => None,
-                },
-                Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                    AnyVariants::Strings(keywords) => {
-                        if keywords.is_empty() {
-                            Some(Box::new(std::iter::empty()))
-                        } else {
-                            None
-                        }
-                    }
-                    AnyVariants::Integers(integers) => Some(Box::new(
-                        integers
-                            .iter()
-                            .flat_map(move |integer| self.get_iterator(integer, hw_counter))
-                            .unique(),
-                    )),
-                },
-                Some(Match::Except(MatchExcept { except })) => match except {
-                    AnyVariants::Strings(other) => {
-                        if other.is_empty() {
-                            Some(Box::new(iter::empty()))
-                        } else {
-                            None
-                        }
-                    }
-                    AnyVariants::Integers(integers) => Some(self.except_set(integers, hw_counter)?),
-                },
-                _ => None,
-            };
-
-        Ok(result)
+        filter_impl(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -94,61 +62,7 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(match &condition.r#match {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(_) => None,
-                ValueVariants::Integer(integer) => {
-                    let mut estimation = self.match_cardinality(integer, hw_counter);
-                    estimation
-                        .primary_clauses
-                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
-                    Some(estimation)
-                }
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variants })) => match any_variants {
-                AnyVariants::Strings(keywords) => {
-                    if keywords.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-                AnyVariants::Integers(integers) => {
-                    let estimations = integers
-                        .iter()
-                        .map(|integer| self.match_cardinality(integer, hw_counter))
-                        .collect::<Vec<_>>();
-                    let estimation = if estimations.is_empty() {
-                        CardinalityEstimation::exact(0)
-                    } else {
-                        combine_should_estimations(&estimations, self.get_indexed_points())
-                    };
-                    Some(
-                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
-                            condition.clone(),
-                        ))),
-                    )
-                }
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(others) => {
-                    if others.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-                AnyVariants::Integers(integers) => {
-                    Some(self.except_cardinality(integers.iter(), hw_counter))
-                }
-            },
-            _ => None,
-        })
+        Ok(estimate_cardinality_impl(self, condition, hw_counter))
     }
 
     fn for_each_payload_block(
@@ -157,18 +71,7 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         key: PayloadKeyType,
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_value(|value| {
-            let count = self
-                .get_count_for_value(value, &HardwareCounterCell::disposable()) // Only used in HNSW building so no measurement needed here.
-                .unwrap_or(0);
-            if count >= threshold {
-                f(PayloadBlockCondition {
-                    condition: FieldCondition::new_match(key.clone(), (*value).into()),
-                    cardinality: count,
-                })?;
-            }
-            Ok(())
-        })
+        for_each_payload_block_impl(self, threshold, key, f)
     }
 
     fn condition_checker<'a>(
@@ -176,76 +79,256 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
-        // Destructure explicitly (no `..`) so a new field added to
-        // `FieldCondition` forces this method to be revisited.
-        let FieldCondition {
-            key: _,
-            r#match,
-            range: _,
-            geo_radius: _,
-            geo_bounding_box: _,
-            geo_polygon: _,
-            values_count: _,
-            is_empty: _,
-            is_null: _,
-        } = condition;
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
 
-        let cond_match = r#match.as_ref()?;
-        let hw_counter = hw_acc.get_counter_cell();
-        match cond_match {
-            Match::Value(MatchValue {
-                value: ValueVariants::Integer(value),
-            }) => {
-                let value = *value;
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<IntPayloadType, S>
+where
+    Vec<<IntPayloadType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn count_indexed_points(&self) -> usize {
+        MapIndexRead::get_indexed_points(self)
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        filter_impl(self, condition, hw_counter)
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        Ok(estimate_cardinality_impl(self, condition, hw_counter))
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        for_each_payload_block_impl(self, threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
+
+// Shared bodies for `MapIndex<IntPayloadType>` and
+// `ReadOnlyMapIndex<IntPayloadType, S>`.
+
+fn filter_impl<'a, T: MapIndexRead<IntPayloadType>>(
+    index: &'a T,
+    condition: &'a FieldCondition,
+    hw_counter: &'a HardwareCounterCell,
+) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+    let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> = match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(_) => None,
+            ValueVariants::Integer(integer) => {
+                Some(Box::new(index.get_iterator(integer, hw_counter)))
+            }
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+            AnyVariants::Strings(keywords) => {
+                if keywords.is_empty() {
+                    Some(Box::new(std::iter::empty()))
+                } else {
+                    None
+                }
+            }
+            AnyVariants::Integers(integers) => Some(Box::new(
+                integers
+                    .iter()
+                    .flat_map(move |integer| index.get_iterator(integer, hw_counter))
+                    .unique(),
+            )),
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(other) => {
+                if other.is_empty() {
+                    Some(Box::new(iter::empty()))
+                } else {
+                    None
+                }
+            }
+            AnyVariants::Integers(integers) => Some(index.except_set(integers, hw_counter)?),
+        },
+        _ => None,
+    };
+
+    Ok(result)
+}
+
+fn estimate_cardinality_impl<T: MapIndexRead<IntPayloadType>>(
+    index: &T,
+    condition: &FieldCondition,
+    hw_counter: &HardwareCounterCell,
+) -> Option<CardinalityEstimation> {
+    match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(_) => None,
+            ValueVariants::Integer(integer) => {
+                let mut estimation = index.match_cardinality(integer, hw_counter);
+                estimation
+                    .primary_clauses
+                    .push(PrimaryCondition::Condition(Box::new(condition.clone())));
+                Some(estimation)
+            }
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variants })) => match any_variants {
+            AnyVariants::Strings(keywords) => {
+                if keywords.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+            AnyVariants::Integers(integers) => {
+                let estimations = integers
+                    .iter()
+                    .map(|integer| index.match_cardinality(integer, hw_counter))
+                    .collect::<Vec<_>>();
+                let estimation = if estimations.is_empty() {
+                    CardinalityEstimation::exact(0)
+                } else {
+                    combine_should_estimations(&estimations, index.get_indexed_points())
+                };
+                Some(
+                    estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                        condition.clone(),
+                    ))),
+                )
+            }
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(others) => {
+                if others.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+            AnyVariants::Integers(integers) => {
+                Some(index.except_cardinality(integers.iter(), hw_counter))
+            }
+        },
+        _ => None,
+    }
+}
+
+fn for_each_payload_block_impl<T: MapIndexRead<IntPayloadType>>(
+    index: &T,
+    threshold: usize,
+    key: PayloadKeyType,
+    f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+) -> OperationResult<()> {
+    index.for_each_value(|value| {
+        let count = index
+            // Only used in HNSW building so no measurement needed here.
+            .get_count_for_value(value, &HardwareCounterCell::disposable())
+            .unwrap_or(0);
+        if count >= threshold {
+            f(PayloadBlockCondition {
+                condition: FieldCondition::new_match(key.clone(), (*value).into()),
+                cardinality: count,
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn condition_checker_impl<'a, T: MapIndexRead<IntPayloadType> + 'a>(
+    index: &'a T,
+    condition: &FieldCondition,
+    hw_acc: HwMeasurementAcc,
+) -> Option<ConditionCheckerFn<'a>> {
+    // Destructure explicitly (no `..`) so a new field added to
+    // `FieldCondition` forces this method to be revisited.
+    let FieldCondition {
+        key: _,
+        r#match,
+        range: _,
+        geo_radius: _,
+        geo_bounding_box: _,
+        geo_polygon: _,
+        values_count: _,
+        is_empty: _,
+        is_null: _,
+    } = condition;
+
+    let cond_match = r#match.as_ref()?;
+    let hw_counter = hw_acc.get_counter_cell();
+    match cond_match {
+        Match::Value(MatchValue {
+            value: ValueVariants::Integer(value),
+        }) => {
+            let value = *value;
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, &hw_counter, |i| *i == value)
+            }))
+        }
+        Match::Any(MatchAny {
+            any: AnyVariants::Integers(list),
+        }) => {
+            let list = list.clone();
+            if list.len() < INDEXSET_ITER_THRESHOLD {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    self.check_values_any(point_id, &hw_counter, |i| *i == value)
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        list.iter().any(|i| i == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| list.contains(value))
                 }))
             }
-            Match::Any(MatchAny {
-                any: AnyVariants::Integers(list),
-            }) => {
-                let list = list.clone();
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            list.iter().any(|i| i == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| list.contains(value))
-                    }))
-                }
-            }
-            Match::Except(MatchExcept {
-                except: AnyVariants::Integers(list),
-            }) => {
-                let list = list.clone();
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            !list.iter().any(|i| i == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
-                    }))
-                }
-            }
-            // Conditions this index can't serve.
-            Match::Value(MatchValue {
-                value: ValueVariants::String(_) | ValueVariants::Bool(_),
-            })
-            | Match::Any(MatchAny {
-                any: AnyVariants::Strings(_),
-            })
-            | Match::Except(MatchExcept {
-                except: AnyVariants::Strings(_),
-            })
-            | Match::Text(_)
-            | Match::TextAny(_)
-            | Match::Phrase(_) => None,
         }
+        Match::Except(MatchExcept {
+            except: AnyVariants::Integers(list),
+        }) => {
+            let list = list.clone();
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        !list.iter().any(|i| i == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
+                }))
+            }
+        }
+        // Conditions this index can't serve.
+        Match::Value(MatchValue {
+            value: ValueVariants::String(_) | ValueVariants::Bool(_),
+        })
+        | Match::Any(MatchAny {
+            any: AnyVariants::Strings(_),
+        })
+        | Match::Except(MatchExcept {
+            except: AnyVariants::Strings(_),
+        })
+        | Match::Text(_)
+        | Match::TextAny(_)
+        | Match::Phrase(_) => None,
     }
 }

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -4,9 +4,14 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
 use itertools::Itertools;
 
 use super::super::MapIndex;
+use super::super::key::MapIndexKey;
+use super::super::read_only::ReadOnlyMapIndex;
+use super::super::read_ops::MapIndexRead;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
@@ -41,7 +46,7 @@ impl PayloadFieldIndex for MapIndex<str> {
 
 impl PayloadFieldIndexRead for MapIndex<str> {
     fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
+        MapIndexRead::get_indexed_points(self)
     }
 
     fn filter<'a>(
@@ -49,45 +54,7 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> = match &condition
-            .r#match
-        {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(keyword) => {
-                    Some(Box::new(self.get_iterator(keyword.as_str(), hw_counter)))
-                }
-                ValueVariants::Integer(_) => None,
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                AnyVariants::Strings(keywords) => Some(Box::new(
-                    keywords
-                        .iter()
-                        .flat_map(move |keyword| self.get_iterator(keyword.as_str(), hw_counter))
-                        .unique(),
-                )),
-                AnyVariants::Integers(integers) => {
-                    if integers.is_empty() {
-                        Some(Box::new(iter::empty()))
-                    } else {
-                        None
-                    }
-                }
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(keywords) => Some(self.except_set(keywords, hw_counter)?),
-                AnyVariants::Integers(other) => {
-                    if other.is_empty() {
-                        Some(Box::new(iter::empty()))
-                    } else {
-                        None
-                    }
-                }
-            },
-            _ => None,
-        };
-
-        Ok(result)
+        filter_impl(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -95,61 +62,7 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(match &condition.r#match {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(keyword) => {
-                    let mut estimation = self.match_cardinality(keyword.as_str(), hw_counter);
-                    estimation
-                        .primary_clauses
-                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
-                    Some(estimation)
-                }
-                ValueVariants::Integer(_) => None,
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                AnyVariants::Strings(keywords) => {
-                    let estimations = keywords
-                        .iter()
-                        .map(|keyword| self.match_cardinality(keyword.as_str(), hw_counter))
-                        .collect::<Vec<_>>();
-                    let estimation = if estimations.is_empty() {
-                        CardinalityEstimation::exact(0)
-                    } else {
-                        combine_should_estimations(&estimations, self.get_indexed_points())
-                    };
-                    Some(
-                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
-                            condition.clone(),
-                        ))),
-                    )
-                }
-                AnyVariants::Integers(integers) => {
-                    if integers.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(keywords) => {
-                    Some(self.except_cardinality(keywords.iter().map(|k| k.as_str()), hw_counter))
-                }
-                AnyVariants::Integers(others) => {
-                    if others.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            },
-            _ => None,
-        })
+        Ok(estimate_cardinality_impl(self, condition, hw_counter))
     }
 
     fn for_each_payload_block(
@@ -158,18 +71,7 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         key: PayloadKeyType,
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_value(|value| {
-            let count = self
-                .get_count_for_value(value, &HardwareCounterCell::disposable()) // Payload_blocks only used in HNSW building, which is unmeasured.
-                .unwrap_or(0);
-            if count > threshold {
-                f(PayloadBlockCondition {
-                    condition: FieldCondition::new_match(key.clone(), value.to_string().into()),
-                    cardinality: count,
-                })?;
-            }
-            Ok(())
-        })
+        for_each_payload_block_impl(self, threshold, key, f)
     }
 
     fn condition_checker<'a>(
@@ -177,78 +79,260 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
-        // Destructure explicitly (no `..`) so a new field added to
-        // `FieldCondition` forces this method to be revisited.
-        let FieldCondition {
-            key: _,
-            r#match,
-            range: _,
-            geo_radius: _,
-            geo_bounding_box: _,
-            geo_polygon: _,
-            values_count: _,
-            is_empty: _,
-            is_null: _,
-        } = condition;
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
 
-        let cond_match = r#match.as_ref()?;
-        let hw_counter = hw_acc.get_counter_cell();
-        match cond_match {
-            Match::Value(MatchValue {
-                value: ValueVariants::String(keyword),
-            }) => {
-                let keyword = keyword.clone();
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<str, S>
+where
+    Vec<<str as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn count_indexed_points(&self) -> usize {
+        MapIndexRead::get_indexed_points(self)
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        filter_impl(self, condition, hw_counter)
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        Ok(estimate_cardinality_impl(self, condition, hw_counter))
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        for_each_payload_block_impl(self, threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
+
+// Shared bodies for `MapIndex<str>` and `ReadOnlyMapIndex<str, S>`. Parameterized
+// over `T: MapIndexRead<str>` so a single body serves both `PayloadFieldIndexRead`
+// impls above.
+
+fn filter_impl<'a, T: MapIndexRead<str>>(
+    index: &'a T,
+    condition: &'a FieldCondition,
+    hw_counter: &'a HardwareCounterCell,
+) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+    let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> = match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(keyword) => {
+                Some(Box::new(index.get_iterator(keyword.as_str(), hw_counter)))
+            }
+            ValueVariants::Integer(_) => None,
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+            AnyVariants::Strings(keywords) => Some(Box::new(
+                keywords
+                    .iter()
+                    .flat_map(move |keyword| index.get_iterator(keyword.as_str(), hw_counter))
+                    .unique(),
+            )),
+            AnyVariants::Integers(integers) => {
+                if integers.is_empty() {
+                    Some(Box::new(iter::empty()))
+                } else {
+                    None
+                }
+            }
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(keywords) => Some(index.except_set(keywords, hw_counter)?),
+            AnyVariants::Integers(other) => {
+                if other.is_empty() {
+                    Some(Box::new(iter::empty()))
+                } else {
+                    None
+                }
+            }
+        },
+        _ => None,
+    };
+
+    Ok(result)
+}
+
+fn estimate_cardinality_impl<T: MapIndexRead<str>>(
+    index: &T,
+    condition: &FieldCondition,
+    hw_counter: &HardwareCounterCell,
+) -> Option<CardinalityEstimation> {
+    match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(keyword) => {
+                let mut estimation = index.match_cardinality(keyword.as_str(), hw_counter);
+                estimation
+                    .primary_clauses
+                    .push(PrimaryCondition::Condition(Box::new(condition.clone())));
+                Some(estimation)
+            }
+            ValueVariants::Integer(_) => None,
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+            AnyVariants::Strings(keywords) => {
+                let estimations = keywords
+                    .iter()
+                    .map(|keyword| index.match_cardinality(keyword.as_str(), hw_counter))
+                    .collect::<Vec<_>>();
+                let estimation = if estimations.is_empty() {
+                    CardinalityEstimation::exact(0)
+                } else {
+                    combine_should_estimations(&estimations, index.get_indexed_points())
+                };
+                Some(
+                    estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                        condition.clone(),
+                    ))),
+                )
+            }
+            AnyVariants::Integers(integers) => {
+                if integers.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(keywords) => {
+                Some(index.except_cardinality(keywords.iter().map(|k| k.as_str()), hw_counter))
+            }
+            AnyVariants::Integers(others) => {
+                if others.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+        },
+        _ => None,
+    }
+}
+
+fn for_each_payload_block_impl<T: MapIndexRead<str>>(
+    index: &T,
+    threshold: usize,
+    key: PayloadKeyType,
+    f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+) -> OperationResult<()> {
+    index.for_each_value(|value| {
+        let count = index
+            // `for_each_payload_block` is only used while building HNSW, which
+            // intentionally bypasses hardware measurement.
+            .get_count_for_value(value, &HardwareCounterCell::disposable())
+            .unwrap_or(0);
+        if count > threshold {
+            f(PayloadBlockCondition {
+                condition: FieldCondition::new_match(key.clone(), value.to_string().into()),
+                cardinality: count,
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn condition_checker_impl<'a, T: MapIndexRead<str> + 'a>(
+    index: &'a T,
+    condition: &FieldCondition,
+    hw_acc: HwMeasurementAcc,
+) -> Option<ConditionCheckerFn<'a>> {
+    // Destructure explicitly (no `..`) so a new field added to
+    // `FieldCondition` forces this method to be revisited.
+    let FieldCondition {
+        key: _,
+        r#match,
+        range: _,
+        geo_radius: _,
+        geo_bounding_box: _,
+        geo_polygon: _,
+        values_count: _,
+        is_empty: _,
+        is_null: _,
+    } = condition;
+
+    let cond_match = r#match.as_ref()?;
+    let hw_counter = hw_acc.get_counter_cell();
+    match cond_match {
+        Match::Value(MatchValue {
+            value: ValueVariants::String(keyword),
+        }) => {
+            let keyword = keyword.clone();
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, &hw_counter, |value| value == keyword.as_str())
+            }))
+        }
+        Match::Any(MatchAny {
+            any: AnyVariants::Strings(list),
+        }) => {
+            let list = list.clone();
+            if list.len() < INDEXSET_ITER_THRESHOLD {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    self.check_values_any(point_id, &hw_counter, |value| value == keyword.as_str())
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        list.iter().any(|s| s.as_str() == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| list.contains(value))
                 }))
             }
-            Match::Any(MatchAny {
-                any: AnyVariants::Strings(list),
-            }) => {
-                let list = list.clone();
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            list.iter().any(|s| s.as_str() == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| list.contains(value))
-                    }))
-                }
-            }
-            Match::Except(MatchExcept {
-                except: AnyVariants::Strings(list),
-            }) => {
-                let list = list.clone();
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            !list.iter().any(|s| s.as_str() == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
-                    }))
-                }
-            }
-            // Conditions this index can't serve: Match::Text/TextAny/Phrase
-            // (handled by FullTextIndex) and value-type mismatches (e.g.
-            // Match::Value(Integer) against a string-keyed map).
-            Match::Value(MatchValue {
-                value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
-            })
-            | Match::Any(MatchAny {
-                any: AnyVariants::Integers(_),
-            })
-            | Match::Except(MatchExcept {
-                except: AnyVariants::Integers(_),
-            })
-            | Match::Text(_)
-            | Match::TextAny(_)
-            | Match::Phrase(_) => None,
         }
+        Match::Except(MatchExcept {
+            except: AnyVariants::Strings(list),
+        }) => {
+            let list = list.clone();
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        !list.iter().any(|s| s.as_str() == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
+                }))
+            }
+        }
+        // Conditions this index can't serve: Match::Text/TextAny/Phrase
+        // (handled by FullTextIndex) and value-type mismatches (e.g.
+        // Match::Value(Integer) against a string-keyed map).
+        Match::Value(MatchValue {
+            value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
+        })
+        | Match::Any(MatchAny {
+            any: AnyVariants::Integers(_),
+        })
+        | Match::Except(MatchExcept {
+            except: AnyVariants::Integers(_),
+        })
+        | Match::Text(_)
+        | Match::TextAny(_)
+        | Match::Phrase(_) => None,
     }
 }

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -5,11 +5,16 @@ use std::str::FromStr;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use uuid::Uuid;
 
 use super::super::MapIndex;
+use super::super::key::MapIndexKey;
+use super::super::read_only::ReadOnlyMapIndex;
+use super::super::read_ops::MapIndexRead;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
@@ -44,7 +49,7 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
 
 impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
     fn count_indexed_points(&self) -> usize {
-        self.get_indexed_points()
+        MapIndexRead::get_indexed_points(self)
     }
 
     fn filter<'a>(
@@ -52,75 +57,7 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> =
-            match &condition.r#match {
-                Some(Match::Value(MatchValue { value })) => match value {
-                    ValueVariants::String(uuid_string) => {
-                        let Ok(uuid) = Uuid::from_str(uuid_string) else {
-                            return Ok(None);
-                        };
-                        Some(Box::new(self.get_iterator(&uuid.as_u128(), hw_counter)))
-                    }
-                    ValueVariants::Integer(_) => None,
-                    ValueVariants::Bool(_) => None,
-                },
-                Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                    AnyVariants::Strings(uuids_string) => {
-                        let Ok(uuids) = uuids_string
-                            .iter()
-                            .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                            .collect::<Result<IndexSet<u128>, _>>()
-                        else {
-                            return Ok(None);
-                        };
-
-                        Some(Box::new(
-                            uuids
-                                .into_iter()
-                                .flat_map(move |uuid| self.get_iterator(&uuid, hw_counter))
-                                .unique(),
-                        ))
-                    }
-                    AnyVariants::Integers(integers) => {
-                        if integers.is_empty() {
-                            Some(Box::new(iter::empty()))
-                        } else {
-                            None
-                        }
-                    }
-                },
-                Some(Match::Except(MatchExcept { except })) => match except {
-                    AnyVariants::Strings(uuids_string) => {
-                        let Ok(excluded_uuids) = uuids_string
-                            .iter()
-                            .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                            .collect::<Result<IndexSet<u128>, _>>()
-                        else {
-                            return Ok(None);
-                        };
-                        let mut points = IndexSet::new();
-                        self.for_each_value(|key| {
-                            if !excluded_uuids.contains(key) {
-                                self.get_iterator(key, hw_counter).for_each(|p| {
-                                    points.insert(p);
-                                });
-                            }
-                            Ok(())
-                        })?;
-                        Some(Box::new(points.into_iter()))
-                    }
-                    AnyVariants::Integers(other) => {
-                        if other.is_empty() {
-                            Some(Box::new(iter::empty()))
-                        } else {
-                            None
-                        }
-                    }
-                },
-                _ => None,
-            };
-
-        Ok(result)
+        filter_impl(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -128,82 +65,7 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(match &condition.r#match {
-            Some(Match::Value(MatchValue { value })) => match value {
-                ValueVariants::String(uuid_string) => {
-                    let Some(uuid) = Uuid::from_str(uuid_string).ok() else {
-                        return Ok(None);
-                    };
-                    let mut estimation = self.match_cardinality(&uuid.as_u128(), hw_counter);
-                    estimation
-                        .primary_clauses
-                        .push(PrimaryCondition::Condition(Box::new(condition.clone())));
-                    Some(estimation)
-                }
-                ValueVariants::Integer(_) => None,
-                ValueVariants::Bool(_) => None,
-            },
-            Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
-                AnyVariants::Strings(uuids_string) => {
-                    let uuids: Result<IndexSet<u128>, _> = uuids_string
-                        .iter()
-                        .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                        .collect();
-
-                    let Some(uuids) = uuids.ok() else {
-                        return Ok(None);
-                    };
-
-                    let estimations = uuids
-                        .into_iter()
-                        .map(|uuid| self.match_cardinality(&uuid, hw_counter))
-                        .collect::<Vec<_>>();
-                    let estimation = if estimations.is_empty() {
-                        CardinalityEstimation::exact(0)
-                    } else {
-                        combine_should_estimations(&estimations, self.get_indexed_points())
-                    };
-                    Some(
-                        estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
-                            condition.clone(),
-                        ))),
-                    )
-                }
-                AnyVariants::Integers(integers) => {
-                    if integers.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            },
-            Some(Match::Except(MatchExcept { except })) => match except {
-                AnyVariants::Strings(uuids_string) => {
-                    let uuids: Result<IndexSet<u128>, _> = uuids_string
-                        .iter()
-                        .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
-                        .collect();
-
-                    let Some(excluded_uuids) = uuids.ok() else {
-                        return Ok(None);
-                    };
-
-                    Some(self.except_cardinality(excluded_uuids.iter(), hw_counter))
-                }
-                AnyVariants::Integers(other) => {
-                    if other.is_empty() {
-                        Some(CardinalityEstimation::exact(0).with_primary_clause(
-                            PrimaryCondition::Condition(Box::new(condition.clone())),
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            },
-            _ => None,
-        })
+        estimate_cardinality_impl(self, condition, hw_counter)
     }
 
     fn for_each_payload_block(
@@ -212,21 +74,7 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         key: PayloadKeyType,
         f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        self.for_each_value(|value| {
-            let count = self
-                .get_count_for_value(value, &HardwareCounterCell::disposable()) // payload_blocks only used in HNSW building, which is unmeasured.
-                .unwrap_or(0);
-            if count >= threshold {
-                f(PayloadBlockCondition {
-                    condition: FieldCondition::new_match(
-                        key.clone(),
-                        Uuid::from_u128(*value).to_string().into(),
-                    ),
-                    cardinality: count,
-                })?;
-            }
-            Ok(())
-        })
+        for_each_payload_block_impl(self, threshold, key, f)
     }
 
     fn condition_checker<'a>(
@@ -234,82 +82,317 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
     ) -> Option<ConditionCheckerFn<'a>> {
-        // Destructure explicitly (no `..`) so a new field added to
-        // `FieldCondition` forces this method to be revisited.
-        let FieldCondition {
-            key: _,
-            r#match,
-            range: _,
-            geo_radius: _,
-            geo_bounding_box: _,
-            geo_polygon: _,
-            values_count: _,
-            is_empty: _,
-            is_null: _,
-        } = condition;
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
 
-        let cond_match = r#match.as_ref()?;
-        let hw_counter = hw_acc.get_counter_cell();
-        match cond_match {
-            Match::Value(MatchValue {
-                value: ValueVariants::String(keyword),
-            }) => {
-                let uuid = Uuid::parse_str(keyword).map(|u| u.as_u128()).ok()?;
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<UuidIntType, S>
+where
+    Vec<<UuidIntType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn count_indexed_points(&self) -> usize {
+        MapIndexRead::get_indexed_points(self)
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        filter_impl(self, condition, hw_counter)
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        estimate_cardinality_impl(self, condition, hw_counter)
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        for_each_payload_block_impl(self, threshold, key, f)
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        condition_checker_impl(self, condition, hw_acc)
+    }
+}
+
+// Shared bodies for `MapIndex<UuidIntType>` and
+// `ReadOnlyMapIndex<UuidIntType, S>`.
+
+fn filter_impl<'a, T: MapIndexRead<UuidIntType>>(
+    index: &'a T,
+    condition: &'a FieldCondition,
+    hw_counter: &'a HardwareCounterCell,
+) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+    let result: Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> = match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(uuid_string) => {
+                let Ok(uuid) = Uuid::from_str(uuid_string) else {
+                    return Ok(None);
+                };
+                Some(Box::new(index.get_iterator(&uuid.as_u128(), hw_counter)))
+            }
+            ValueVariants::Integer(_) => None,
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+            AnyVariants::Strings(uuids_string) => {
+                let Ok(uuids) = uuids_string
+                    .iter()
+                    .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                    .collect::<Result<IndexSet<u128>, _>>()
+                else {
+                    return Ok(None);
+                };
+
+                Some(Box::new(
+                    uuids
+                        .into_iter()
+                        .flat_map(move |uuid| index.get_iterator(&uuid, hw_counter))
+                        .unique(),
+                ))
+            }
+            AnyVariants::Integers(integers) => {
+                if integers.is_empty() {
+                    Some(Box::new(iter::empty()))
+                } else {
+                    None
+                }
+            }
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(uuids_string) => {
+                let Ok(excluded_uuids) = uuids_string
+                    .iter()
+                    .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                    .collect::<Result<IndexSet<u128>, _>>()
+                else {
+                    return Ok(None);
+                };
+                let mut points = IndexSet::new();
+                index.for_each_value(|key| {
+                    if !excluded_uuids.contains(key) {
+                        index.get_iterator(key, hw_counter).for_each(|p| {
+                            points.insert(p);
+                        });
+                    }
+                    Ok(())
+                })?;
+                Some(Box::new(points.into_iter()))
+            }
+            AnyVariants::Integers(other) => {
+                if other.is_empty() {
+                    Some(Box::new(iter::empty()))
+                } else {
+                    None
+                }
+            }
+        },
+        _ => None,
+    };
+
+    Ok(result)
+}
+
+fn estimate_cardinality_impl<T: MapIndexRead<UuidIntType>>(
+    index: &T,
+    condition: &FieldCondition,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<Option<CardinalityEstimation>> {
+    Ok(match &condition.r#match {
+        Some(Match::Value(MatchValue { value })) => match value {
+            ValueVariants::String(uuid_string) => {
+                let Some(uuid) = Uuid::from_str(uuid_string).ok() else {
+                    return Ok(None);
+                };
+                let mut estimation = index.match_cardinality(&uuid.as_u128(), hw_counter);
+                estimation
+                    .primary_clauses
+                    .push(PrimaryCondition::Condition(Box::new(condition.clone())));
+                Some(estimation)
+            }
+            ValueVariants::Integer(_) => None,
+            ValueVariants::Bool(_) => None,
+        },
+        Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
+            AnyVariants::Strings(uuids_string) => {
+                let uuids: Result<IndexSet<u128>, _> = uuids_string
+                    .iter()
+                    .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                    .collect();
+
+                let Some(uuids) = uuids.ok() else {
+                    return Ok(None);
+                };
+
+                let estimations = uuids
+                    .into_iter()
+                    .map(|uuid| index.match_cardinality(&uuid, hw_counter))
+                    .collect::<Vec<_>>();
+                let estimation = if estimations.is_empty() {
+                    CardinalityEstimation::exact(0)
+                } else {
+                    combine_should_estimations(&estimations, index.get_indexed_points())
+                };
+                Some(
+                    estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(
+                        condition.clone(),
+                    ))),
+                )
+            }
+            AnyVariants::Integers(integers) => {
+                if integers.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+        },
+        Some(Match::Except(MatchExcept { except })) => match except {
+            AnyVariants::Strings(uuids_string) => {
+                let uuids: Result<IndexSet<u128>, _> = uuids_string
+                    .iter()
+                    .map(|uuid_string| Uuid::from_str(uuid_string).map(|x| x.as_u128()))
+                    .collect();
+
+                let Some(excluded_uuids) = uuids.ok() else {
+                    return Ok(None);
+                };
+
+                Some(index.except_cardinality(excluded_uuids.iter(), hw_counter))
+            }
+            AnyVariants::Integers(other) => {
+                if other.is_empty() {
+                    Some(CardinalityEstimation::exact(0).with_primary_clause(
+                        PrimaryCondition::Condition(Box::new(condition.clone())),
+                    ))
+                } else {
+                    None
+                }
+            }
+        },
+        _ => None,
+    })
+}
+
+fn for_each_payload_block_impl<T: MapIndexRead<UuidIntType>>(
+    index: &T,
+    threshold: usize,
+    key: PayloadKeyType,
+    f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+) -> OperationResult<()> {
+    index.for_each_value(|value| {
+        let count = index
+            // payload_blocks only used in HNSW building, which is unmeasured.
+            .get_count_for_value(value, &HardwareCounterCell::disposable())
+            .unwrap_or(0);
+        if count >= threshold {
+            f(PayloadBlockCondition {
+                condition: FieldCondition::new_match(
+                    key.clone(),
+                    Uuid::from_u128(*value).to_string().into(),
+                ),
+                cardinality: count,
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn condition_checker_impl<'a, T: MapIndexRead<UuidIntType> + 'a>(
+    index: &'a T,
+    condition: &FieldCondition,
+    hw_acc: HwMeasurementAcc,
+) -> Option<ConditionCheckerFn<'a>> {
+    // Destructure explicitly (no `..`) so a new field added to
+    // `FieldCondition` forces this method to be revisited.
+    let FieldCondition {
+        key: _,
+        r#match,
+        range: _,
+        geo_radius: _,
+        geo_bounding_box: _,
+        geo_polygon: _,
+        values_count: _,
+        is_empty: _,
+        is_null: _,
+    } = condition;
+
+    let cond_match = r#match.as_ref()?;
+    let hw_counter = hw_acc.get_counter_cell();
+    match cond_match {
+        Match::Value(MatchValue {
+            value: ValueVariants::String(keyword),
+        }) => {
+            let uuid = Uuid::parse_str(keyword).map(|u| u.as_u128()).ok()?;
+            Some(Box::new(move |point_id: PointOffsetType| {
+                index.check_values_any(point_id, &hw_counter, |value| value == &uuid)
+            }))
+        }
+        Match::Any(MatchAny {
+            any: AnyVariants::Strings(list),
+        }) => {
+            let list = list
+                .iter()
+                .map(|s| Uuid::parse_str(s).map(|u| u.as_u128()).ok())
+                .collect::<Option<IndexSet<_>>>()?;
+            if list.len() < INDEXSET_ITER_THRESHOLD {
                 Some(Box::new(move |point_id: PointOffsetType| {
-                    self.check_values_any(point_id, &hw_counter, |value| value == &uuid)
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        list.iter().any(|i| i == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| list.contains(value))
                 }))
             }
-            Match::Any(MatchAny {
-                any: AnyVariants::Strings(list),
-            }) => {
-                let list = list
-                    .iter()
-                    .map(|s| Uuid::parse_str(s).map(|u| u.as_u128()).ok())
-                    .collect::<Option<IndexSet<_>>>()?;
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            list.iter().any(|i| i == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| list.contains(value))
-                    }))
-                }
-            }
-            Match::Except(MatchExcept {
-                except: AnyVariants::Strings(list),
-            }) => {
-                let list = list
-                    .iter()
-                    .map(|s| Uuid::parse_str(s).map(|u| u.as_u128()).ok())
-                    .collect::<Option<IndexSet<_>>>()?;
-                if list.len() < INDEXSET_ITER_THRESHOLD {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| {
-                            !list.iter().any(|i| i == value)
-                        })
-                    }))
-                } else {
-                    Some(Box::new(move |point_id: PointOffsetType| {
-                        self.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
-                    }))
-                }
-            }
-            // Conditions this index can't serve.
-            Match::Value(MatchValue {
-                value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
-            })
-            | Match::Any(MatchAny {
-                any: AnyVariants::Integers(_),
-            })
-            | Match::Except(MatchExcept {
-                except: AnyVariants::Integers(_),
-            })
-            | Match::Text(_)
-            | Match::TextAny(_)
-            | Match::Phrase(_) => None,
         }
+        Match::Except(MatchExcept {
+            except: AnyVariants::Strings(list),
+        }) => {
+            let list = list
+                .iter()
+                .map(|s| Uuid::parse_str(s).map(|u| u.as_u128()).ok())
+                .collect::<Option<IndexSet<_>>>()?;
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        !list.iter().any(|i| i == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
+                }))
+            }
+        }
+        // Conditions this index can't serve.
+        Match::Value(MatchValue {
+            value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
+        })
+        | Match::Any(MatchAny {
+            any: AnyVariants::Integers(_),
+        })
+        | Match::Except(MatchExcept {
+            except: AnyVariants::Integers(_),
+        })
+        | Match::Text(_)
+        | Match::TextAny(_)
+        | Match::Phrase(_) => None,
     }
 }

--- a/lib/segment/src/index/field_index/map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/mod.rs
@@ -5,6 +5,8 @@ use crate::index::field_index::map_index::MapIndexKey;
 use crate::index::field_index::map_index::mutable_map_index::read_only::ReadOnlyAppendableMapIndex;
 use crate::index::field_index::map_index::universal_map_index::UniversalMapIndex;
 
+mod read_ops;
+
 pub enum ReadOnlyMapIndex<N: MapIndexKey + ?Sized, S: UniversalRead>
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,

--- a/lib/segment/src/index/field_index/map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/mod.rs
@@ -1,0 +1,16 @@
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use crate::index::field_index::map_index::MapIndexKey;
+use crate::index::field_index::map_index::mutable_map_index::read_only::ReadOnlyAppendableMapIndex;
+use crate::index::field_index::map_index::universal_map_index::UniversalMapIndex;
+
+pub enum ReadOnlyMapIndex<N: MapIndexKey + ?Sized, S: UniversalRead>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    /// Loads into RAM from appendable storage format
+    Appendable(ReadOnlyAppendableMapIndex<N, S>),
+    /// Directly reads from storage in immutable format
+    Immutable(UniversalMapIndex<N, S>),
+}

--- a/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
@@ -138,4 +138,11 @@ where
             ReadOnlyMapIndex::Immutable(index) => index.ram_usage_bytes(),
         }
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.telemetry_index_type(),
+            ReadOnlyMapIndex::Immutable(index) => index.telemetry_index_type(),
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
@@ -1,0 +1,141 @@
+use std::borrow::Cow;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::persisted_hashmap::Key;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::super::read_ops::MapIndexRead;
+use super::super::{IdIter, MapIndexKey};
+use super::ReadOnlyMapIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::payload_config::StorageType;
+
+/// Dispatcher impl: forwards every [`MapIndexRead`] method to the active
+/// variant. Helper methods (`match_cardinality`, `except_cardinality`,
+/// `except_set`, `values_is_empty`) are picked up from the trait's default
+/// impls — they only depend on the required methods, so no per-variant
+/// dispatch is needed for them.
+impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for ReadOnlyMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn check_values_any(
+        &self,
+        idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+        check_fn: impl Fn(&N) -> bool,
+    ) -> bool {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.check_values_any(idx, hw_counter, check_fn)
+            }
+            ReadOnlyMapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),
+        }
+    }
+
+    fn get_values<'a>(
+        &'a self,
+        idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> Option<impl Iterator<Item = Cow<'a, N>> + 'a>
+    where
+        N: 'a,
+    {
+        let boxed: Box<dyn Iterator<Item = Cow<'a, N>> + 'a> = match self {
+            ReadOnlyMapIndex::Appendable(index) => Box::new(index.get_values(idx, hw_counter)?),
+            ReadOnlyMapIndex::Immutable(index) => Box::new(index.get_values(idx, hw_counter)?),
+        };
+        Some(boxed)
+    }
+
+    fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.values_count(idx),
+            ReadOnlyMapIndex::Immutable(index) => index.values_count(idx),
+        }
+    }
+
+    fn get_indexed_points(&self) -> usize {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.get_indexed_points(),
+            ReadOnlyMapIndex::Immutable(index) => index.get_indexed_points(),
+        }
+    }
+
+    fn get_values_count(&self) -> usize {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.get_values_count(),
+            ReadOnlyMapIndex::Immutable(index) => index.get_values_count(),
+        }
+    }
+
+    fn get_unique_values_count(&self) -> usize {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.get_unique_values_count(),
+            ReadOnlyMapIndex::Immutable(index) => index.get_unique_values_count(),
+        }
+    }
+
+    fn get_count_for_value(&self, value: &N, hw_counter: &HardwareCounterCell) -> Option<usize> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.get_count_for_value(value, hw_counter),
+            ReadOnlyMapIndex::Immutable(index) => index.get_count_for_value(value, hw_counter),
+        }
+    }
+
+    fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdIter<'_> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.get_iterator(value, hw_counter),
+            ReadOnlyMapIndex::Immutable(index) => index.get_iterator(value, hw_counter),
+        }
+    }
+
+    fn for_each_value(&self, f: impl FnMut(&N) -> OperationResult<()>) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.for_each_value(f),
+            ReadOnlyMapIndex::Immutable(index) => index.for_each_value(f),
+        }
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(&N, usize) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.for_each_count_per_value(deferred_internal_id, f)
+            }
+            ReadOnlyMapIndex::Immutable(index) => {
+                index.for_each_count_per_value(deferred_internal_id, f)
+            }
+        }
+    }
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(&N, &mut dyn Iterator<Item = PointOffsetType>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.for_each_value_map(hw_counter, f),
+            ReadOnlyMapIndex::Immutable(index) => index.for_each_value_map(hw_counter, f),
+        }
+    }
+
+    fn storage_type(&self) -> StorageType {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.storage_type(),
+            ReadOnlyMapIndex::Immutable(index) => index.storage_type(),
+        }
+    }
+
+    fn ram_usage_bytes(&self) -> usize {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.ram_usage_bytes(),
+            ReadOnlyMapIndex::Immutable(index) => index.ram_usage_bytes(),
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -17,12 +17,12 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// Read-only operations supported by every map-index storage variant
 /// ([`super::mutable_map_index::MutableMapIndex`],
 /// [`super::immutable_map_index::ImmutableMapIndex`],
-/// [`super::mmap_map_index::MmapMapIndex`]).
+/// [`super::universal_map_index::UniversalMapIndex`]).
 ///
 /// Signatures are unified across variants so the enum-level dispatcher in
 /// [`MapIndex`] can call them generically. Variants that don't need
-/// `hw_counter` (`Mutable` / `Immutable`) accept and ignore it; the mmap
-/// variant uses it to track payload-index IO.
+/// `hw_counter` (`Mutable` / `Immutable`) accept and ignore it; the
+/// storage-backed `Universal` variant uses it to track payload-index IO.
 pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
     fn check_values_any(
         &self,

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -23,7 +23,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// [`MapIndex`] can call them generically. Variants that don't need
 /// `hw_counter` (`Mutable` / `Immutable`) accept and ignore it; the
 /// storage-backed `Universal` variant uses it to track payload-index IO.
-pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
+pub trait MapIndexRead<N: MapIndexKey + ?Sized> {
     fn check_values_any(
         &self,
         idx: PointOffsetType,
@@ -74,11 +74,29 @@ pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
 
     fn ram_usage_bytes(&self) -> usize;
 
+    /// Per-variant telemetry tag (e.g. `"mutable_map"`, `"mmap_map"`,
+    /// `"read_only_map"`). Used by the default [`Self::get_telemetry_data`]
+    /// to fill the `index_type` field. Mirrors
+    /// [`NullIndexRead::telemetry_index_type`][1].
+    ///
+    /// [1]: crate::index::field_index::null_index::NullIndexRead::telemetry_index_type
+    fn telemetry_index_type(&self) -> &'static str;
+
     // Default-method helpers derived from the required methods above.
     //
     // Kept here (rather than as inherent methods on a single concrete type) so
     // that every `MapIndexRead<N>` impl — `MapIndex<N>`, `ReadOnlyMapIndex<N, S>`,
     // and the leaf variants — exposes them via the same call syntax.
+
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        PayloadIndexTelemetry {
+            field_name: None,
+            points_count: self.get_indexed_points(),
+            points_values_count: self.get_values_count(),
+            histogram_bucket_size: None,
+            index_type: self.telemetry_index_type(),
+        }
+    }
 
     fn values_is_empty(&self, idx: PointOffsetType) -> bool {
         self.values_count(idx).unwrap_or(0) == 0
@@ -310,6 +328,14 @@ where
             MapIndex::Mutable(index) => index.ram_usage_bytes(),
             MapIndex::Immutable(index) => index.ram_usage_bytes(),
             MapIndex::Mmap(index) => index.ram_usage_bytes(),
+        }
+    }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        match self {
+            MapIndex::Mutable(_) => "mutable_map",
+            MapIndex::Immutable(_) => "immutable_map",
+            MapIndex::Mmap(_) => "mmap_map",
         }
     }
 }

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -73,153 +73,24 @@ pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
     fn storage_type(&self) -> StorageType;
 
     fn ram_usage_bytes(&self) -> usize;
-}
 
-impl<N: MapIndexKey + ?Sized> MapIndex<N>
-where
-    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
-{
-    pub fn check_values_any(
-        &self,
-        idx: PointOffsetType,
-        hw_counter: &HardwareCounterCell,
-        check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
-        match self {
-            MapIndex::Mutable(index) => index.check_values_any(idx, hw_counter, check_fn),
-            MapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),
-            MapIndex::Mmap(index) => index.check_values_any(idx, hw_counter, check_fn),
-        }
+    // Default-method helpers derived from the required methods above.
+    //
+    // Kept here (rather than as inherent methods on a single concrete type) so
+    // that every `MapIndexRead<N>` impl — `MapIndex<N>`, `ReadOnlyMapIndex<N, S>`,
+    // and the leaf variants — exposes them via the same call syntax.
+
+    fn values_is_empty(&self, idx: PointOffsetType) -> bool {
+        self.values_count(idx).unwrap_or(0) == 0
     }
 
-    pub fn get_values(
-        &self,
-        idx: PointOffsetType,
-        hw_counter: &HardwareCounterCell,
-    ) -> Option<Box<dyn Iterator<Item = Cow<'_, N>> + '_>> {
-        match self {
-            MapIndex::Mutable(index) => Some(Box::new(index.get_values(idx, hw_counter)?)),
-            MapIndex::Immutable(index) => Some(Box::new(index.get_values(idx, hw_counter)?)),
-            MapIndex::Mmap(index) => Some(Box::new(index.get_values(idx, hw_counter)?)),
-        }
-    }
-
-    pub fn values_count(&self, idx: PointOffsetType) -> usize {
-        match self {
-            MapIndex::Mutable(index) => index.values_count(idx).unwrap_or_default(),
-            MapIndex::Immutable(index) => index.values_count(idx).unwrap_or_default(),
-            MapIndex::Mmap(index) => index.values_count(idx).unwrap_or_default(),
-        }
-    }
-
-    pub(crate) fn get_indexed_points(&self) -> usize {
-        match self {
-            MapIndex::Mutable(index) => index.get_indexed_points(),
-            MapIndex::Immutable(index) => index.get_indexed_points(),
-            MapIndex::Mmap(index) => index.get_indexed_points(),
-        }
-    }
-
-    fn get_values_count(&self) -> usize {
-        match self {
-            MapIndex::Mutable(index) => index.get_values_count(),
-            MapIndex::Immutable(index) => index.get_values_count(),
-            MapIndex::Mmap(index) => index.get_values_count(),
-        }
-    }
-
-    pub fn get_unique_values_count(&self) -> usize {
-        match self {
-            MapIndex::Mutable(index) => index.get_unique_values_count(),
-            MapIndex::Immutable(index) => index.get_unique_values_count(),
-            MapIndex::Mmap(index) => index.get_unique_values_count(),
-        }
-    }
-
-    pub(crate) fn get_count_for_value(
-        &self,
-        value: &N,
-        hw_counter: &HardwareCounterCell,
-    ) -> Option<usize> {
-        match self {
-            MapIndex::Mutable(index) => index.get_count_for_value(value, hw_counter),
-            MapIndex::Immutable(index) => index.get_count_for_value(value, hw_counter),
-            MapIndex::Mmap(index) => index.get_count_for_value(value, hw_counter),
-        }
-    }
-
-    pub(crate) fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdIter<'_> {
-        match self {
-            MapIndex::Mutable(index) => index.get_iterator(value, hw_counter),
-            MapIndex::Immutable(index) => index.get_iterator(value, hw_counter),
-            MapIndex::Mmap(index) => index.get_iterator(value, hw_counter),
-        }
-    }
-
-    pub fn for_each_value(&self, f: impl FnMut(&N) -> OperationResult<()>) -> OperationResult<()> {
-        match self {
-            MapIndex::Mutable(index) => index.for_each_value(f),
-            MapIndex::Immutable(index) => index.for_each_value(f),
-            MapIndex::Mmap(index) => index.for_each_value(f),
-        }
-    }
-
-    pub fn for_each_count_per_value(
-        &self,
-        deferred_internal_id: Option<PointOffsetType>,
-        f: impl FnMut(&N, usize) -> OperationResult<()>,
-    ) -> OperationResult<()> {
-        // The immutable variant does not support deferred filtering — it
-        // asserts the argument is `None`. Two reasons we don't implement it:
-        //  - We don't have both deferred points and an immutable index.
-        //  - It is not trivial (nor performant) to implement correct filtering
-        //    for this index variant as it doesn't work well in combination
-        //    with the way it handles deletions.
-        match self {
-            MapIndex::Mutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
-            MapIndex::Immutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
-            MapIndex::Mmap(index) => index.for_each_count_per_value(deferred_internal_id, f),
-        }
-    }
-
-    pub fn for_each_value_map(
-        &self,
-        hw_cell: &HardwareCounterCell,
-        f: impl FnMut(&N, &mut dyn Iterator<Item = PointOffsetType>) -> OperationResult<()>,
-    ) -> OperationResult<()> {
-        match self {
-            MapIndex::Mutable(index) => index.for_each_value_map(hw_cell, f),
-            MapIndex::Immutable(index) => index.for_each_value_map(hw_cell, f),
-            MapIndex::Mmap(index) => index.for_each_value_map(hw_cell, f),
-        }
-    }
-
-    pub(crate) fn match_cardinality(
+    fn match_cardinality(
         &self,
         value: &N,
         hw_counter: &HardwareCounterCell,
     ) -> CardinalityEstimation {
         let values_count = self.get_count_for_value(value, hw_counter).unwrap_or(0);
-
         CardinalityEstimation::exact(values_count)
-    }
-
-    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
-        PayloadIndexTelemetry {
-            field_name: None,
-            points_count: self.get_indexed_points(),
-            points_values_count: self.get_values_count(),
-            histogram_bucket_size: None,
-            index_type: match self {
-                MapIndex::Mutable(_) => "mutable_map",
-                MapIndex::Immutable(_) => "immutable_map",
-                MapIndex::Mmap(_) => "mmap_map",
-            },
-        }
-    }
-
-    pub fn values_is_empty(&self, idx: PointOffsetType) -> bool {
-        self.values_count(idx) == 0
     }
 
     /// Estimates cardinality for `except` clause
@@ -231,57 +102,17 @@ where
     /// # Returns
     ///
     /// * `CardinalityEstimation` - estimation of cardinality
-    pub(crate) fn except_cardinality<'a>(
+    fn except_cardinality<'a>(
         &'a self,
         excluded: impl Iterator<Item = &'a N>,
         hw_counter: &HardwareCounterCell,
-    ) -> CardinalityEstimation {
+    ) -> CardinalityEstimation
+    where
+        N: 'a,
+    {
         // Minimal case: we exclude as many points as possible.
-        // In this case, excluded points do not have any other values except excluded ones.
-        // So the first step - we estimate how many other points is needed to fit unused values.
-
-        // Example:
-        // Values: 20, 20
-        // Unique values: 5
-        // Total points: 100
-        // Total values: 110
-        // total_excluded_value_count = 40
-        // non_excluded_values_count = 110 - 40 = 70
-        // max_values_per_point = 5 - 2 = 3
-        // min_not_excluded_by_values = 70 / 3 = 24
-        // min = max(24, 100 - 40) = 60
-        // exp = ...
-        // max = min(20, 70) = 20
-
-        // Values: 60, 60
-        // Unique values: 5
-        // Total points: 100
-        // Total values: 200
-        // total_excluded_value_count = 120
-        // non_excluded_values_count = 200 - 120 = 80
-        // max_values_per_point = 5 - 2 = 3
-        // min_not_excluded_by_values = 80 / 3 = 27
-        // min = max(27, 100 - 120) = 27
-        // exp = ...
-        // max = min(60, 80) = 60
-
-        // Values: 60, 60, 60
-        // Unique values: 5
-        // Total points: 100
-        // Total values: 200
-        // total_excluded_value_count = 180
-        // non_excluded_values_count = 200 - 180 = 20
-        // max_values_per_point = 5 - 3 = 2
-        // min_not_excluded_by_values = 20 / 2 = 10
-        // min = max(10, 100 - 180) = 10
-        // exp = ...
-        // max = min(60, 20) = 20
-
         let excluded_value_counts: Vec<_> = excluded
-            .map(|val| {
-                self.get_count_for_value(val.borrow(), hw_counter)
-                    .unwrap_or(0)
-            })
+            .map(|val| self.get_count_for_value(val, hw_counter).unwrap_or(0))
             .collect();
         let total_excluded_value_count: usize = excluded_value_counts.iter().sum();
 
@@ -325,7 +156,7 @@ where
         }
     }
 
-    pub(crate) fn except_set<'a, K, A>(
+    fn except_set<'a, K, A>(
         &'a self,
         excluded: &'a IndexSet<K, A>,
         hw_counter: &'a HardwareCounterCell,
@@ -334,7 +165,7 @@ where
         A: BuildHasher,
         K: Borrow<N> + Hash + Eq,
     {
-        let mut points = IndexSet::new();
+        let mut points = IndexSet::<PointOffsetType>::new();
         self.for_each_value(|key| {
             if !excluded.contains(key.borrow()) {
                 self.get_iterator(key.borrow(), hw_counter).for_each(|p| {
@@ -345,14 +176,191 @@ where
         })?;
         Ok(Box::new(points.into_iter()))
     }
+}
 
-    /// Approximate RAM usage in bytes for in-memory structures.
-    pub fn ram_usage_bytes(&self) -> usize {
+impl<N: MapIndexKey + ?Sized> MapIndexRead<N> for MapIndex<N>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    fn check_values_any(
+        &self,
+        idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+        check_fn: impl Fn(&N) -> bool,
+    ) -> bool {
+        match self {
+            MapIndex::Mutable(index) => index.check_values_any(idx, hw_counter, check_fn),
+            MapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),
+            MapIndex::Mmap(index) => index.check_values_any(idx, hw_counter, check_fn),
+        }
+    }
+
+    fn get_values<'a>(
+        &'a self,
+        idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> Option<impl Iterator<Item = Cow<'a, N>> + 'a>
+    where
+        N: 'a,
+    {
+        let boxed: Box<dyn Iterator<Item = Cow<'a, N>> + 'a> = match self {
+            MapIndex::Mutable(index) => Box::new(index.get_values(idx, hw_counter)?),
+            MapIndex::Immutable(index) => Box::new(index.get_values(idx, hw_counter)?),
+            MapIndex::Mmap(index) => Box::new(index.get_values(idx, hw_counter)?),
+        };
+        Some(boxed)
+    }
+
+    fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
+        match self {
+            MapIndex::Mutable(index) => index.values_count(idx),
+            MapIndex::Immutable(index) => index.values_count(idx),
+            MapIndex::Mmap(index) => index.values_count(idx),
+        }
+    }
+
+    fn get_indexed_points(&self) -> usize {
+        match self {
+            MapIndex::Mutable(index) => index.get_indexed_points(),
+            MapIndex::Immutable(index) => index.get_indexed_points(),
+            MapIndex::Mmap(index) => index.get_indexed_points(),
+        }
+    }
+
+    fn get_values_count(&self) -> usize {
+        match self {
+            MapIndex::Mutable(index) => index.get_values_count(),
+            MapIndex::Immutable(index) => index.get_values_count(),
+            MapIndex::Mmap(index) => index.get_values_count(),
+        }
+    }
+
+    fn get_unique_values_count(&self) -> usize {
+        match self {
+            MapIndex::Mutable(index) => index.get_unique_values_count(),
+            MapIndex::Immutable(index) => index.get_unique_values_count(),
+            MapIndex::Mmap(index) => index.get_unique_values_count(),
+        }
+    }
+
+    fn get_count_for_value(&self, value: &N, hw_counter: &HardwareCounterCell) -> Option<usize> {
+        match self {
+            MapIndex::Mutable(index) => index.get_count_for_value(value, hw_counter),
+            MapIndex::Immutable(index) => index.get_count_for_value(value, hw_counter),
+            MapIndex::Mmap(index) => index.get_count_for_value(value, hw_counter),
+        }
+    }
+
+    fn get_iterator(&self, value: &N, hw_counter: &HardwareCounterCell) -> IdIter<'_> {
+        match self {
+            MapIndex::Mutable(index) => index.get_iterator(value, hw_counter),
+            MapIndex::Immutable(index) => index.get_iterator(value, hw_counter),
+            MapIndex::Mmap(index) => index.get_iterator(value, hw_counter),
+        }
+    }
+
+    fn for_each_value(&self, f: impl FnMut(&N) -> OperationResult<()>) -> OperationResult<()> {
+        match self {
+            MapIndex::Mutable(index) => index.for_each_value(f),
+            MapIndex::Immutable(index) => index.for_each_value(f),
+            MapIndex::Mmap(index) => index.for_each_value(f),
+        }
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        f: impl FnMut(&N, usize) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        // The immutable variant does not support deferred filtering — it
+        // asserts the argument is `None`. Two reasons we don't implement it:
+        //  - We don't have both deferred points and an immutable index.
+        //  - It is not trivial (nor performant) to implement correct filtering
+        //    for this index variant as it doesn't work well in combination
+        //    with the way it handles deletions.
+        match self {
+            MapIndex::Mutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
+            MapIndex::Immutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
+            MapIndex::Mmap(index) => index.for_each_count_per_value(deferred_internal_id, f),
+        }
+    }
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        f: impl FnMut(&N, &mut dyn Iterator<Item = PointOffsetType>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match self {
+            MapIndex::Mutable(index) => index.for_each_value_map(hw_counter, f),
+            MapIndex::Immutable(index) => index.for_each_value_map(hw_counter, f),
+            MapIndex::Mmap(index) => index.for_each_value_map(hw_counter, f),
+        }
+    }
+
+    fn storage_type(&self) -> StorageType {
+        match self {
+            MapIndex::Mutable(index) => index.storage_type(),
+            MapIndex::Immutable(index) => index.storage_type(),
+            MapIndex::Mmap(index) => index.storage_type(),
+        }
+    }
+
+    fn ram_usage_bytes(&self) -> usize {
         match self {
             MapIndex::Mutable(index) => index.ram_usage_bytes(),
             MapIndex::Immutable(index) => index.ram_usage_bytes(),
             MapIndex::Mmap(index) => index.ram_usage_bytes(),
         }
+    }
+}
+
+impl<N: MapIndexKey + ?Sized> MapIndex<N>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        PayloadIndexTelemetry {
+            field_name: None,
+            points_count: <Self as MapIndexRead<N>>::get_indexed_points(self),
+            points_values_count: <Self as MapIndexRead<N>>::get_values_count(self),
+            histogram_bucket_size: None,
+            index_type: match self {
+                MapIndex::Mutable(_) => "mutable_map",
+                MapIndex::Immutable(_) => "immutable_map",
+                MapIndex::Mmap(_) => "mmap_map",
+            },
+        }
+    }
+
+    /// `usize`-returning convenience wrapper around
+    /// [`MapIndexRead::values_count`] for callers outside this module who
+    /// don't have the (`pub(super)`) trait in scope.
+    pub fn values_count(&self, idx: PointOffsetType) -> usize {
+        <Self as MapIndexRead<N>>::values_count(self, idx).unwrap_or(0)
+    }
+
+    /// `bool`-returning convenience wrapper around
+    /// [`MapIndexRead::values_is_empty`]; see [`Self::values_count`] for why.
+    pub fn values_is_empty(&self, idx: PointOffsetType) -> bool {
+        <Self as MapIndexRead<N>>::values_is_empty(self, idx)
+    }
+
+    /// Convenience wrapper around [`MapIndexRead::get_values`] that boxes the
+    /// returned iterator into `dyn Iterator`. See [`Self::values_count`] for
+    /// why the wrapper exists.
+    pub fn get_values(
+        &self,
+        idx: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> Option<Box<dyn Iterator<Item = Cow<'_, N>> + '_>> {
+        let iter = <Self as MapIndexRead<N>>::get_values(self, idx, hw_counter)?;
+        Some(Box::new(iter))
+    }
+
+    /// Convenience wrapper around [`MapIndexRead::ram_usage_bytes`]; see
+    /// [`Self::values_count`] for why.
+    pub fn ram_usage_bytes(&self) -> usize {
+        <Self as MapIndexRead<N>>::ram_usage_bytes(self)
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/field_index/map_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/tests.rs
@@ -14,6 +14,7 @@ use tempfile::Builder;
 
 use super::MapIndex;
 use super::key::MapIndexKey;
+use super::read_ops::MapIndexRead;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -13,7 +13,9 @@ use common::universal_io::{MmapFile, OpenOptions};
 use fs_err as fs;
 
 use super::super::MapIndexKey;
-use super::{CONFIG_PATH, DELETED_PATH, HASHMAP_PATH, UniversalMapIndex, UniversalMapIndexConfig, Storage};
+use super::{
+    CONFIG_PATH, DELETED_PATH, HASHMAP_PATH, Storage, UniversalMapIndex, UniversalMapIndexConfig,
+};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::stored_point_to_values::StoredPointToValues;

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -13,12 +13,12 @@ use common::universal_io::{MmapFile, OpenOptions};
 use fs_err as fs;
 
 use super::super::MapIndexKey;
-use super::{CONFIG_PATH, DELETED_PATH, HASHMAP_PATH, MmapMapIndex, MmapMapIndexConfig, Storage};
+use super::{CONFIG_PATH, DELETED_PATH, HASHMAP_PATH, UniversalMapIndex, UniversalMapIndexConfig, Storage};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::stored_point_to_values::StoredPointToValues;
 
-impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
+impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
     /// Open and load mmap map index from the given path
     pub fn open(
         path: &Path,
@@ -34,7 +34,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
             return Ok(None);
         }
 
-        let config: MmapMapIndexConfig = read_json(&config_path)?;
+        let config: UniversalMapIndexConfig = read_json(&config_path)?;
 
         let do_populate = !is_on_disk;
 
@@ -91,7 +91,7 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
 
         atomic_save_json(
             &config_path,
-            &MmapMapIndexConfig {
+            &UniversalMapIndexConfig {
                 total_key_value_pairs: point_to_values.iter().map(|v| v.len()).sum(),
             },
         )?;
@@ -134,12 +134,12 @@ impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
         }
 
         Self::open(path, is_on_disk, deleted_points)?.ok_or_else(|| {
-            OperationError::service_error("Failed to open MmapMapIndex after building it")
+            OperationError::service_error("Failed to open UniversalMapIndex after building it")
         })
     }
 
     /// No-op flusher: the on-disk state is build-time only. See the type-level
-    /// docs on [`MmapMapIndex`] for the deletion durability contract.
+    /// docs on [`UniversalMapIndex`] for the deletion durability contract.
     pub fn flusher(&self) -> Flusher {
         Box::new(|| Ok(()))
     }

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/mod.rs
@@ -48,7 +48,7 @@ pub(super) struct Storage<N: MapIndexKey + Key + ?Sized, S: UniversalRead = Mmap
     pub(super) deleted: BitVec,
 }
 
-impl<N: MapIndexKey + Key + ?Sized> Storage<N> {
+impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> Storage<N, S> {
     pub(super) fn ram_usage_bytes(&self) -> usize {
         let Self {
             value_to_points: _,

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/mod.rs
@@ -16,7 +16,10 @@ pub(super) const DELETED_PATH: &str = "deleted.bin";
 pub(super) const HASHMAP_PATH: &str = "values_to_points.bin";
 pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
-/// Mmap-backed immutable map index.
+/// Immutable map index served directly from a [`UniversalRead`] storage backend.
+///
+/// The storage parameter `S` defaults to [`MmapFile`], but any `UniversalRead`
+/// implementation works — e.g. io_uring or disk-cache wrappers.
 ///
 /// On-disk state (`values_to_points.bin`, `deleted.bin`, `point_to_values.*`,
 /// `mmap_field_index_config.json`) is written once during [`Self::build`] and
@@ -28,7 +31,7 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 /// only updates the in-memory bitvec. Callers must re-supply the authoritative
 /// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
 /// `deleted_points` argument to [`Self::open`] on reload.
-pub struct MmapMapIndex<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
+pub struct UniversalMapIndex<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
     pub(super) path: PathBuf,
     pub(super) storage: Storage<N, S>,
     pub(super) deleted_count: usize,
@@ -53,12 +56,12 @@ impl<N: MapIndexKey + Key + ?Sized> Storage<N> {
             deleted,
         } = self;
 
-        // `value_to_points` is a mmap-backed hashmap with no in-memory state.
+        // `value_to_points` is a storage-backed hashmap with no in-memory state.
         point_to_values.ram_usage_bytes() + deleted.capacity().div_ceil(u8::BITS as usize)
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct MmapMapIndexConfig {
+pub(super) struct UniversalMapIndexConfig {
     pub(super) total_key_value_pairs: usize,
 }

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
@@ -219,6 +219,10 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for Univer
     fn ram_usage_bytes(&self) -> usize {
         self.storage.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "mmap_map"
+    }
 }
 
 impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> UniversalMapIndex<N, S> {

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
@@ -11,12 +11,12 @@ use itertools::Itertools;
 
 use super::super::read_ops::MapIndexRead;
 use super::super::{IdIter, MapIndexKey};
-use super::MmapMapIndex;
+use super::UniversalMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::stored_point_to_values::ValuesIter;
 use crate::index::payload_config::StorageType;
 
-impl<N: MapIndexKey + Key + ?Sized> MapIndexRead<N> for MmapMapIndex<N> {
+impl<N: MapIndexKey + Key + ?Sized> MapIndexRead<N> for UniversalMapIndex<N> {
     fn check_values_any(
         &self,
         idx: PointOffsetType,
@@ -220,7 +220,7 @@ impl<N: MapIndexKey + Key + ?Sized> MapIndexRead<N> for MmapMapIndex<N> {
     }
 }
 
-impl<N: MapIndexKey + Key + ?Sized> MmapMapIndex<N> {
+impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
     pub fn for_points_values(
         &self,
         mut points: impl Iterator<Item = PointOffsetType>,

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
@@ -7,6 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::persisted_hashmap::{Key, READ_ENTRY_OVERHEAD};
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use itertools::Itertools;
 
 use super::super::read_ops::MapIndexRead;
@@ -16,7 +17,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::stored_point_to_values::ValuesIter;
 use crate::index::payload_config::StorageType;
 
-impl<N: MapIndexKey + Key + ?Sized> MapIndexRead<N> for UniversalMapIndex<N> {
+impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for UniversalMapIndex<N, S> {
     fn check_values_any(
         &self,
         idx: PointOffsetType,
@@ -220,7 +221,7 @@ impl<N: MapIndexKey + Key + ?Sized> MapIndexRead<N> for UniversalMapIndex<N> {
     }
 }
 
-impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
+impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> UniversalMapIndex<N, S> {
     pub fn for_points_values(
         &self,
         mut points: impl Iterator<Item = PointOffsetType>,

--- a/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
@@ -1,9 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
 use serde_json::{Number, Value};
 use uuid::Uuid;
 
 use super::MapIndex;
+use super::key::MapIndexKey;
+use super::read_only::ReadOnlyMapIndex;
+use super::read_ops::MapIndexRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::MultiValue;
 use crate::index::field_index::ValueIndexer;
@@ -101,23 +106,19 @@ impl ValueIndexer for MapIndex<UuidIntType> {
     }
 }
 
-// Per-K value retrievers — produce a closure that maps a point id to
-// its indexed keyword/int/uuid values as JSON `Value`s. The conversion
-// is K-specific, so each MapIndex variant has its own inherent impl.
-// `FieldIndex::value_retriever` dispatches here per variant.
+// Per-K value retrievers — produce a closure that maps a point id to its
+// indexed keyword/int/uuid values as JSON `Value`s. The conversion is
+// K-specific, so each `MapIndex` and `ReadOnlyMapIndex` specialization has
+// its own inherent `value_retriever` method that delegates to one of the
+// per-K free functions below. `FieldIndex::value_retriever` /
+// `ReadOnlyFieldIndex::value_retriever` dispatch here per variant.
 
 impl MapIndex<str> {
     pub fn value_retriever<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .filter_map(|v| serde_json::to_value(v).ok())
-                .collect()
-        })
+        value_retriever_str(self, hw_counter)
     }
 }
 
@@ -126,13 +127,7 @@ impl MapIndex<IntPayloadType> {
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .map(|v| Value::Number(Number::from(*v)))
-                .collect()
-        })
+        value_retriever_int(self, hw_counter)
     }
 }
 
@@ -141,12 +136,87 @@ impl MapIndex<UuidIntType> {
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
-                .collect()
-        })
+        value_retriever_uuid(self, hw_counter)
     }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<str, S>
+where
+    Vec<<str as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_str(self, hw_counter)
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<IntPayloadType, S>
+where
+    Vec<<IntPayloadType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_int(self, hw_counter)
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<UuidIntType, S>
+where
+    Vec<<UuidIntType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_uuid(self, hw_counter)
+    }
+}
+
+// Shared per-K bodies, parameterized over `T: MapIndexRead<N>` so a single
+// implementation serves both `MapIndex<N>` and `ReadOnlyMapIndex<N, S>`.
+
+fn value_retriever_str<'a, T: MapIndexRead<str> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .filter_map(|v| serde_json::to_value(v).ok())
+            .collect()
+    })
+}
+
+fn value_retriever_int<'a, T: MapIndexRead<IntPayloadType> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .map(|v| Value::Number(Number::from(*v)))
+            .collect()
+    })
+}
+
+fn value_retriever_uuid<'a, T: MapIndexRead<UuidIntType> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
+            .collect()
+    })
 }

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -66,7 +66,7 @@ impl StoredValue for str {
 /// Flattened memmapped points-to-values map
 /// It's an analogue of `Vec<Vec<N>>` but in memmapped file.
 /// This structure is immutable.
-/// It's used in mmap field indices like `MmapMapIndex`, `MmapNumericIndex`, etc to store points-to-values map.
+/// It's used in mmap field indices like `UniversalMapIndex`, `MmapNumericIndex`, etc to store points-to-values map.
 /// This structure is not generic to avoid boxing lifetimes for `&str` values.
 pub struct StoredPointToValues<T: StoredValue + ?Sized, S: UniversalRead> {
     file_name: PathBuf,


### PR DESCRIPTION
Implement 

```
pub enum ReadOnlyMapIndex<N: MapIndexKey + ?Sized, S: UniversalRead>
where
    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
{
    /// Loads into RAM from appendable storage format
    Appendable(ReadOnlyAppendableMapIndex<N, S>),
    /// Directly reads from storage in immutable format
    Immutable(UniversalMapIndex<N, S>),
}
```

Which mirrors

```
pub enum MapIndex<N: MapIndexKey + ?Sized>
where
    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
{
    /// Loaded in RAM, use mutable storage format
    Mutable(MutableMapIndex<N>),
    /// Loaded in RAM, use immutable storage format
    Immutable(ImmutableMapIndex<N>),
    /// Served directly from storage (via mmap), use immutable format
    Mmap(Box<UniversalMapIndex<N>>),
}
```

They also share implementations of the read methods, so no code duplication