### PR TITLE
[AI] Implement read-only PayloadFieldIndexRead / FieldIndexRead

### DIFF
--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,8 +1,10 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::{MmapFile, UniversalRead};
 
 use super::bool_index::BoolIndex;
 use super::map_index::MapIndex;
+use super::map_index::read_only::ReadOnlyMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::types::{IntPayloadType, UuidIntType};
@@ -69,14 +71,30 @@ pub trait FacetIndex {
     }
 }
 
-pub enum FacetIndexEnum<'a> {
+/// Borrowed view over any concrete index that can produce facet counts.
+///
+/// The `S: UniversalRead` parameter is consumed only by the `*ReadOnly`
+/// variants, which carry a `ReadOnlyMapIndex<N, S>`; appendable / in-memory
+/// variants (`Keyword`, `Int`, `Uuid`, `Bool`) ignore it. The default
+/// `S = MmapFile` keeps the common construction path
+/// (`FieldIndex::as_facet_index`) free of turbofish.
+pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
     Bool(&'a BoolIndex),
+    // Constructed only by `ReadOnlyFieldIndex::as_facet_index`, which is
+    // itself dead-code-allowed (`ReadOnlyFieldIndex` isn't wired into the
+    // read path yet).
+    #[allow(dead_code)]
+    KeywordReadOnly(&'a ReadOnlyMapIndex<str, S>),
+    #[allow(dead_code)]
+    IntReadOnly(&'a ReadOnlyMapIndex<IntPayloadType, S>),
+    #[allow(dead_code)]
+    UuidReadOnly(&'a ReadOnlyMapIndex<UuidIntType, S>),
 }
 
-impl<'a> FacetIndex for FacetIndexEnum<'a> {
+impl<'a, S: UniversalRead> FacetIndex for FacetIndexEnum<'a, S> {
     fn for_points_values(
         &self,
         points: impl Iterator<Item = PointOffsetType>,
@@ -96,6 +114,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Bool(index) => {
                 FacetIndex::for_points_values(*index, points, hw_counter, f)
             }
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
+                FacetIndex::for_points_values(*index, points, hw_counter, f)
+            }
         }
     }
 
@@ -108,6 +135,9 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Int(index) => FacetIndex::for_each_value(*index, f),
             FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value(*index, f),
             FacetIndexEnum::Bool(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::KeywordReadOnly(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::IntReadOnly(index) => FacetIndex::for_each_value(*index, f),
+            FacetIndexEnum::UuidReadOnly(index) => FacetIndex::for_each_value(*index, f),
         }
     }
 
@@ -124,6 +154,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
             FacetIndexEnum::Int(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
             FacetIndexEnum::Uuid(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
             FacetIndexEnum::Bool(index) => FacetIndex::for_each_value_map(*index, hw_counter, f),
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
+                FacetIndex::for_each_value_map(*index, hw_counter, f)
+            }
         }
     }
 
@@ -143,6 +182,15 @@ impl<'a> FacetIndex for FacetIndexEnum<'a> {
                 FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
             }
             FacetIndexEnum::Bool(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::KeywordReadOnly(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::IntReadOnly(index) => {
+                FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
+            }
+            FacetIndexEnum::UuidReadOnly(index) => {
                 FacetIndex::for_each_count_per_value(*index, deferred_internal_id, f)
             }
         }

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -256,11 +256,15 @@ impl FieldIndexRead for FieldIndex {
     }
 
     fn as_facet_index(&self) -> Option<impl FacetIndex + '_> {
+        // None of these variants carry the `S` storage parameter; pin the
+        // returned `FacetIndexEnum`'s `S` to `MmapFile` (the default) so
+        // inference doesn't choke on the unconstrained generic.
+        use common::universal_io::MmapFile;
         match self {
-            FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::Keyword(index)),
-            FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::Int(index)),
-            FieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::Uuid(index)),
-            FieldIndex::BoolIndex(index) => Some(FacetIndexEnum::Bool(index)),
+            FieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::<MmapFile>::Keyword(index)),
+            FieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::<MmapFile>::Int(index)),
+            FieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::<MmapFile>::Uuid(index)),
+            FieldIndex::BoolIndex(index) => Some(FacetIndexEnum::<MmapFile>::Bool(index)),
             FieldIndex::UuidIndex(_)
             | FieldIndex::IntIndex(_)
             | FieldIndex::DatetimeIndex(_)

--- a/lib/segment/src/index/field_index/field_index_base/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/mod.rs
@@ -3,6 +3,7 @@ mod field_index;
 mod field_index_read;
 mod field_index_read_impl;
 mod payload_field_index;
+mod read_only;
 mod value_indexer;
 
 pub use builder::{FieldIndexBuilder, FieldIndexBuilderTrait};

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -1,0 +1,25 @@
+mod read_ops;
+
+use common::universal_io::UniversalRead;
+
+use crate::index::field_index::map_index::read_only::ReadOnlyMapIndex;
+use crate::index::field_index::null_index::ReadOnlyNullIndex;
+use crate::types::{IntPayloadType, UuidIntType};
+
+// Not yet wired into the broader read-path; lifecycle and constructors land
+// in a follow-up. Variants intentionally share the `*Index` postfix to mirror
+// `FieldIndex`.
+#[allow(dead_code, clippy::enum_variant_names)]
+pub enum ReadOnlyFieldIndex<S: UniversalRead> {
+    // IntIndex(NumericIndex<IntPayloadType, IntPayloadType>),
+    // DatetimeIndex(NumericIndex<IntPayloadType, DateTimePayloadType>),
+    IntMapIndex(ReadOnlyMapIndex<IntPayloadType, S>),
+    KeywordIndex(ReadOnlyMapIndex<str, S>),
+    // FloatIndex(NumericIndex<FloatPayloadType, FloatPayloadType>),
+    // GeoIndex(GeoMapIndex),
+    // FullTextIndex(FullTextIndex),
+    // BoolIndex(BoolIndex),
+    // UuidIndex(NumericIndex<UuidIntType, UuidPayloadType>),
+    UuidMapIndex(ReadOnlyMapIndex<UuidIntType, S>),
+    NullIndex(ReadOnlyNullIndex<S>),
+}

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -1,0 +1,184 @@
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use serde_json::Value;
+
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::field_index_base::read_only::ReadOnlyFieldIndex;
+use crate::index::field_index::map_index::read_ops::MapIndexRead;
+use crate::index::field_index::null_index::NullIndexRead;
+use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
+use crate::index::field_index::{
+    CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition, PayloadFieldIndexRead,
+};
+use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
+use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::{FieldCondition, PayloadKeyType};
+
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
+    fn count_indexed_points(&self) -> usize {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.count_indexed_points(),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.count_indexed_points(),
+        }
+    }
+
+    fn filter<'a>(
+        &'a self,
+        condition: &'a FieldCondition,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.filter(condition, hw_counter),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.filter(condition, hw_counter),
+        }
+    }
+
+    fn estimate_cardinality(
+        &self,
+        condition: &FieldCondition,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<CardinalityEstimation>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                idx.estimate_cardinality(condition, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                idx.estimate_cardinality(condition, hw_counter)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.estimate_cardinality(condition, hw_counter),
+        }
+    }
+
+    fn for_each_payload_block(
+        &self,
+        threshold: usize,
+        key: PayloadKeyType,
+        f: &mut dyn FnMut(PayloadBlockCondition) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.for_each_payload_block(threshold, key, f),
+        }
+    }
+
+    fn condition_checker<'a>(
+        &'a self,
+        condition: &FieldCondition,
+        hw_acc: HwMeasurementAcc,
+    ) -> Option<ConditionCheckerFn<'a>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.condition_checker(condition, hw_acc),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.condition_checker(condition, hw_acc),
+        }
+    }
+
+    fn special_check_condition(
+        &self,
+        condition: &FieldCondition,
+        payload_value: &Value,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Option<bool>> {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => {
+                idx.special_check_condition(condition, payload_value, hw_counter)
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> FieldIndexRead for ReadOnlyFieldIndex<S> {
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::NullIndex(idx) => idx.get_telemetry_data(),
+        }
+    }
+
+    fn values_count(&self, point_id: PointOffsetType) -> usize {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::KeywordIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => {
+                MapIndexRead::values_count(idx, point_id).unwrap_or(0)
+            }
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_count(idx, point_id),
+        }
+    }
+
+    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_is_empty(idx, point_id),
+        }
+    }
+
+    fn value_retriever<'a, 'q>(
+        &'a self,
+        hw_counter: &'q HardwareCounterCell,
+    ) -> Option<VariableRetrieverFn<'q>>
+    where
+        'a: 'q,
+    {
+        // Mirrors `FieldIndex::value_retriever`: NullIndex has no underlying
+        // values to return; the map variants build their per-K closure via
+        // an inherent `value_retriever` method.
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::KeywordIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::UuidMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::NullIndex(_) => None,
+        }
+    }
+
+    fn as_numeric(&self) -> Option<impl NumericFieldIndexRead + '_> {
+        // No numeric variants in `ReadOnlyFieldIndex` yet (numeric reads
+        // land in a follow-up). Concrete `None` type keeps the
+        // return-position `impl Trait` inferable.
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(_)
+            | ReadOnlyFieldIndex::KeywordIndex(_)
+            | ReadOnlyFieldIndex::UuidMapIndex(_)
+            | ReadOnlyFieldIndex::NullIndex(_) => None::<NumericFieldIndex<'_>>,
+        }
+    }
+
+    fn as_facet_index(&self) -> Option<impl FacetIndex + '_> {
+        use crate::index::field_index::facet_index::FacetIndexEnum;
+        match self {
+            ReadOnlyFieldIndex::IntMapIndex(index) => Some(FacetIndexEnum::IntReadOnly(index)),
+            ReadOnlyFieldIndex::KeywordIndex(index) => Some(FacetIndexEnum::KeywordReadOnly(index)),
+            ReadOnlyFieldIndex::UuidMapIndex(index) => Some(FacetIndexEnum::UuidReadOnly(index)),
+            // NullIndex doesn't carry facet-able values.
+            ReadOnlyFieldIndex::NullIndex(_) => None,
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
@@ -2,10 +2,12 @@ use std::borrow::{Borrow, Cow};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::MapIndex;
 use super::key::MapIndexKey;
+use super::read_only::ReadOnlyMapIndex;
 use super::read_ops::MapIndexRead;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValueRef};
@@ -44,6 +46,70 @@ where
         // Disambiguate from `FacetIndex::for_each_value` (the trait we're
         // implementing): the inner call is `MapIndexRead::for_each_value`,
         // which iterates raw `&N` values rather than `FacetValueRef`.
+        MapIndexRead::for_each_value(self, |v| f(v.into()))
+    }
+
+    fn for_each_value_map(
+        &self,
+        hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(
+            FacetValueRef<'_>,
+            &mut dyn Iterator<Item = PointOffsetType>,
+        ) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        MapIndexRead::for_each_value_map(self, hw_counter, |value, iter| f(value.into(), iter))
+    }
+
+    fn for_each_count_per_value(
+        &self,
+        deferred_internal_id: Option<PointOffsetType>,
+        mut f: impl FnMut(FacetHit<FacetValueRef<'_>>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        MapIndexRead::for_each_count_per_value(self, deferred_internal_id, |value, count| {
+            f(FacetHit {
+                value: value.into(),
+                count,
+            })
+        })
+    }
+}
+
+/// Faceting over the read-only enum mirrors [`FacetIndex for MapIndex<N>`]:
+/// the three iteration methods come from the shared [`MapIndexRead`] surface,
+/// and `for_points_values` dispatches to the inner variant's inherent method
+/// (the two variants differ in whether they need a `HardwareCounterCell`).
+impl<N: MapIndexKey + common::persisted_hashmap::Key + ?Sized, S: UniversalRead> FacetIndex
+    for ReadOnlyMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    for<'a> Cow<'a, N>: Into<FacetValueRef<'a>>,
+    for<'a> &'a N: Into<FacetValueRef<'a>>,
+{
+    fn for_points_values(
+        &self,
+        points: impl Iterator<Item = PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+        mut f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.for_points_values(points, |idx, slice| {
+                    f(idx, &mut slice.iter().map(|v| v.borrow().into()));
+                });
+                Ok(())
+            }
+            ReadOnlyMapIndex::Immutable(index) => {
+                index.for_points_values(points, hw_counter, |idx, vals| {
+                    f(idx, &mut vals.map(|v| v.into()));
+                })
+            }
+        }
+    }
+
+    fn for_each_value(
+        &self,
+        mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
         MapIndexRead::for_each_value(self, |v| f(v.into()))
     }
 

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
@@ -110,6 +110,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.cached_ram_usage_bytes
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "immutable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized> ImmutableMapIndex<N>

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -14,14 +14,13 @@ pub mod key;
 mod lifecycle;
 pub mod mutable_map_index;
 mod payload_index_impl;
-mod read_ops;
+pub mod read_ops;
 #[cfg(test)]
 mod tests;
 pub mod universal_map_index;
 mod value_indexer_impl;
 
-#[allow(dead_code)]
-mod read_only;
+pub mod read_only;
 
 /// Block size in Gridstore for keyword map index.
 /// Keyword(s) are stored as cbor vector.

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/inner.rs
@@ -176,6 +176,13 @@ where
         StorageType::Gridstore
     }
 
+    /// Placeholder telemetry tag — like [`Self::storage_type`], the inner is
+    /// never queried directly; wrappers override this on their own
+    /// [`MapIndexRead`] impls.
+    fn telemetry_index_type(&self) -> &'static str {
+        "mutable_map"
+    }
+
     /// Approximate RAM usage in bytes for in-memory index structures.
     fn ram_usage_bytes(&self) -> usize {
         let Self {

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
@@ -88,6 +88,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.inner.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "read_only_appendable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized, S: UniversalRead> ReadOnlyAppendableMapIndex<N, S>

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
@@ -85,6 +85,10 @@ where
     fn ram_usage_bytes(&self) -> usize {
         self.inner.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "mutable_map"
+    }
 }
 
 impl<N: MapIndexKey + ?Sized> MutableMapIndex<N>

--- a/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
@@ -138,4 +138,11 @@ where
             ReadOnlyMapIndex::Immutable(index) => index.ram_usage_bytes(),
         }
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => index.telemetry_index_type(),
+            ReadOnlyMapIndex::Immutable(index) => index.telemetry_index_type(),
+        }
+    }
 }

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -23,7 +23,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// [`MapIndex`] can call them generically. Variants that don't need
 /// `hw_counter` (`Mutable` / `Immutable`) accept and ignore it; the
 /// storage-backed `Universal` variant uses it to track payload-index IO.
-pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
+pub trait MapIndexRead<N: MapIndexKey + ?Sized> {
     fn check_values_any(
         &self,
         idx: PointOffsetType,
@@ -74,11 +74,29 @@ pub(super) trait MapIndexRead<N: MapIndexKey + ?Sized> {
 
     fn ram_usage_bytes(&self) -> usize;
 
+    /// Per-variant telemetry tag (e.g. `"mutable_map"`, `"mmap_map"`,
+    /// `"read_only_map"`). Used by the default [`Self::get_telemetry_data`]
+    /// to fill the `index_type` field. Mirrors
+    /// [`NullIndexRead::telemetry_index_type`][1].
+    ///
+    /// [1]: crate::index::field_index::null_index::NullIndexRead::telemetry_index_type
+    fn telemetry_index_type(&self) -> &'static str;
+
     // Default-method helpers derived from the required methods above.
     //
     // Kept here (rather than as inherent methods on a single concrete type) so
     // that every `MapIndexRead<N>` impl — `MapIndex<N>`, `ReadOnlyMapIndex<N, S>`,
     // and the leaf variants — exposes them via the same call syntax.
+
+    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        PayloadIndexTelemetry {
+            field_name: None,
+            points_count: self.get_indexed_points(),
+            points_values_count: self.get_values_count(),
+            histogram_bucket_size: None,
+            index_type: self.telemetry_index_type(),
+        }
+    }
 
     fn values_is_empty(&self, idx: PointOffsetType) -> bool {
         self.values_count(idx).unwrap_or(0) == 0
@@ -310,6 +328,14 @@ where
             MapIndex::Mutable(index) => index.ram_usage_bytes(),
             MapIndex::Immutable(index) => index.ram_usage_bytes(),
             MapIndex::Mmap(index) => index.ram_usage_bytes(),
+        }
+    }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        match self {
+            MapIndex::Mutable(_) => "mutable_map",
+            MapIndex::Immutable(_) => "immutable_map",
+            MapIndex::Mmap(_) => "mmap_map",
         }
     }
 }

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/read_ops.rs
@@ -219,6 +219,10 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for Univer
     fn ram_usage_bytes(&self) -> usize {
         self.storage.ram_usage_bytes()
     }
+
+    fn telemetry_index_type(&self) -> &'static str {
+        "mmap_map"
+    }
 }
 
 impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> UniversalMapIndex<N, S> {

--- a/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
@@ -1,9 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
 use serde_json::{Number, Value};
 use uuid::Uuid;
 
 use super::MapIndex;
+use super::key::MapIndexKey;
+use super::read_only::ReadOnlyMapIndex;
+use super::read_ops::MapIndexRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::MultiValue;
 use crate::index::field_index::ValueIndexer;
@@ -101,23 +106,19 @@ impl ValueIndexer for MapIndex<UuidIntType> {
     }
 }
 
-// Per-K value retrievers — produce a closure that maps a point id to
-// its indexed keyword/int/uuid values as JSON `Value`s. The conversion
-// is K-specific, so each MapIndex variant has its own inherent impl.
-// `FieldIndex::value_retriever` dispatches here per variant.
+// Per-K value retrievers — produce a closure that maps a point id to its
+// indexed keyword/int/uuid values as JSON `Value`s. The conversion is
+// K-specific, so each `MapIndex` and `ReadOnlyMapIndex` specialization has
+// its own inherent `value_retriever` method that delegates to one of the
+// per-K free functions below. `FieldIndex::value_retriever` /
+// `ReadOnlyFieldIndex::value_retriever` dispatch here per variant.
 
 impl MapIndex<str> {
     pub fn value_retriever<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .filter_map(|v| serde_json::to_value(v).ok())
-                .collect()
-        })
+        value_retriever_str(self, hw_counter)
     }
 }
 
@@ -126,13 +127,7 @@ impl MapIndex<IntPayloadType> {
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .map(|v| Value::Number(Number::from(*v)))
-                .collect()
-        })
+        value_retriever_int(self, hw_counter)
     }
 }
 
@@ -141,12 +136,87 @@ impl MapIndex<UuidIntType> {
         &'a self,
         hw_counter: &'a HardwareCounterCell,
     ) -> VariableRetrieverFn<'a> {
-        Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-            self.get_values(point_id, hw_counter)
-                .into_iter()
-                .flatten()
-                .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
-                .collect()
-        })
+        value_retriever_uuid(self, hw_counter)
     }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<str, S>
+where
+    Vec<<str as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_str(self, hw_counter)
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<IntPayloadType, S>
+where
+    Vec<<IntPayloadType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_int(self, hw_counter)
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyMapIndex<UuidIntType, S>
+where
+    Vec<<UuidIntType as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    pub fn value_retriever<'a>(
+        &'a self,
+        hw_counter: &'a HardwareCounterCell,
+    ) -> VariableRetrieverFn<'a> {
+        value_retriever_uuid(self, hw_counter)
+    }
+}
+
+// Shared per-K bodies, parameterized over `T: MapIndexRead<N>` so a single
+// implementation serves both `MapIndex<N>` and `ReadOnlyMapIndex<N, S>`.
+
+fn value_retriever_str<'a, T: MapIndexRead<str> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .filter_map(|v| serde_json::to_value(v).ok())
+            .collect()
+    })
+}
+
+fn value_retriever_int<'a, T: MapIndexRead<IntPayloadType> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .map(|v| Value::Number(Number::from(*v)))
+            .collect()
+    })
+}
+
+fn value_retriever_uuid<'a, T: MapIndexRead<UuidIntType> + 'a>(
+    index: &'a T,
+    hw_counter: &'a HardwareCounterCell,
+) -> VariableRetrieverFn<'a> {
+    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
+        index
+            .get_values(point_id, hw_counter)
+            .into_iter()
+            .flatten()
+            .map(|value| Value::String(UuidPayloadType::from_u128(*value).to_string()))
+            .collect()
+    })
 }


### PR DESCRIPTION
## Summary

Wires `ReadOnlyFieldIndex` into the read-only field-index surface that `ReadOnlyMapIndex` and `ReadOnlyNullIndex` already provide, sharing the non-trivial bodies with the existing `MapIndex` impls — zero body duplication between the writable and read-only paths.

- **Per-`N` `PayloadFieldIndexRead` bodies extracted** in `payload_index_impl/{str,int,uuid}.rs` to free functions over `T: MapIndexRead<N>` (`filter_impl`, `estimate_cardinality_impl`, `for_each_payload_block_impl`, `condition_checker_impl`). Both `MapIndex<N>` and `ReadOnlyMapIndex<N, S>` impl `PayloadFieldIndexRead` via thin delegation to those bodies.
- **`value_retriever` lifted** in `value_indexer_impl.rs` the same way (`value_retriever_str/int/uuid`); `ReadOnlyMapIndex<N, S>` gets the per-K closure for free.
- **Telemetry on `MapIndexRead`**: added `telemetry_index_type` (required) + `get_telemetry_data` (default), mirroring the `NullIndexRead` pattern. Every map-index variant now reports telemetry without an inherent method on the enum.
- **`FacetIndex for ReadOnlyMapIndex<N, S>`** added; `FacetIndexEnum` extended with `S: UniversalRead = MmapFile` plus three new variants (`KeywordReadOnly`, `IntReadOnly`, `UuidReadOnly`). `FieldIndex::as_facet_index` pins `S = MmapFile` via turbofish since the unused-by-this-variant generic is otherwise ambiguous.
- **`ReadOnlyFieldIndex::as_numeric`** returns `None` — no concrete read-only numeric type exists yet (the existing `NumericFieldIndexRead` doc already notes this is intended for a future `ReadOnlySegment`).
- **`MapIndexRead` + its module promoted to `pub`** so `field_index_base/read_only/` can name them.

## Test plan

- [x] `cargo check -p segment --lib --tests`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p segment --lib field_index::` — 252/252 pass