### PR TITLE
Fix incorrect oversampling assertion in HNSW quantization tests

### DIFF
--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -289,7 +289,7 @@ fn check_oversampling(
         let oversampling_2_result = hnsw_index
             .search(
                 &[query],
-                None,
+                filter,
                 top,
                 Some(&SearchParams {
                     hnsw_ef: Some(ef_oversampling),


### PR DESCRIPTION
The `check_oversampling` test helper asserts that enabling 'oversampling' doesn't cause a drop in accuracy.
Under the hood we do 2 runs: one **without** oversampling and one **with** oversampling. Then we assert that the run **with** oversampling [has equal or better accuracy](https://github.com/qdrant/qdrant/blob/b500fa5d70bfa62c7b59f8808d319b811edabace/lib/segment/tests/integration/hnsw_quantized_search_test.rs#L314).

<br>

However, currently we have **2** variables that change between our first and second run: 
1. Oversampling (the one we want to test)
2. Filter (<- This is not expected)

The second run that enables oversampling currently [never applies the filter](https://github.com/qdrant/qdrant/blob/master/lib/segment/tests/integration/hnsw_quantized_search_test.rs#L292), which seems like a bug to me.

This appears to be the main source of **frequent flakes** as shown by the measurements below.


## Measurements

Failure rate for 3 non-TQ tests across 150 runs compared between dev and this PR.
| branch | Pass | Fail | Rate |
  |---|---|---|---|
  | dev | 146 | 4 | 2.7% |
  | PR  | 150 | 0 | 0% |

Failure rate for _all_ TQ tests across 150 runs (again between dev and this PR)
 | branch | Pass | Fail | Rate |
  |---|---|---|---|
  | dev | 139 | 11 | 7.3% |
  | PR  | 149 | 1*  | 0.7% |

\* The one failure in case of TQ is caused by the `acc > 40.0.` assertion [here](https://github.com/qdrant/qdrant/blob/b500fa5d70bfa62c7b59f8808d319b811edabace/lib/segment/tests/integration/hnsw_quantized_search_test.rs#L257), not the `check_oversampling` function. 
I'll address this in the next PR.