### PR TITLE
Authorize request before we accept snapshot file upload

### DIFF
--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -41,7 +41,7 @@ use super::{
     CollectionPath, CollectionShardPath, CollectionShardSnapshotPath, CollectionSnapshotPath,
     StrictCollectionPath,
 };
-use crate::actix::auth::ActixAuth;
+use crate::actix::auth::{ActixAccessManage, ActixAuth, ManageAction};
 use crate::actix::helpers::{self, HttpError};
 use crate::common;
 use crate::common::auth::Auth;
@@ -69,6 +69,25 @@ pub struct SnapshottingParam {
 #[derive(MultipartForm)]
 pub struct SnapshottingForm {
     snapshot: TempFile,
+}
+
+/// Audit-action markers for the snapshot upload endpoints. Each names the
+/// `Auth::check_global_access(manage())` call that runs *before* the
+/// multipart body is extracted, so unauthorized callers cannot force the
+/// server to spool an upload to disk (GHSA-3v92-w72v-j994).
+pub struct UploadSnapshotAction;
+impl ManageAction for UploadSnapshotAction {
+    const ACTION_NAME: &'static str = "upload_snapshot";
+}
+
+pub struct UploadShardSnapshotAction;
+impl ManageAction for UploadShardSnapshotAction {
+    const ACTION_NAME: &'static str = "upload_shard_snapshot";
+}
+
+pub struct RecoverPartialSnapshotAction;
+impl ManageAction for RecoverPartialSnapshotAction {
+    const ACTION_NAME: &'static str = "recover_partial_snapshot";
 }
 
 // Actix specific code
@@ -192,13 +211,17 @@ async fn create_snapshot(
 
 #[post("/collections/{collection_name}/snapshots/upload")]
 async fn upload_snapshot(
+    // NOTE: this extractor must come *before* `MultipartForm` so that
+    // unauthorized requests are rejected before the body is spooled to disk
+    // (GHSA-3v92-w72v-j994).
+    early_auth: ActixAccessManage<UploadSnapshotAction>,
     dispatcher: web::Data<Dispatcher>,
     http_client: web::Data<HttpClient>,
     collection: valid::Path<StrictCollectionPath>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
     params: valid::Query<SnapshotUploadingParam>,
-    ActixAuth(auth): ActixAuth,
 ) -> impl Responder {
+    let auth = early_auth.auth;
     let wait = params.wait;
 
     // Nothing to verify.
@@ -206,8 +229,6 @@ async fn upload_snapshot(
 
     let future = async move {
         let snapshot = form.snapshot;
-
-        auth.check_global_access(AccessRequirements::new().manage(), "upload_snapshot")?;
 
         if let Some(checksum) = &params.checksum {
             let snapshot_checksum = sha_256::hash_file(snapshot.file.path()).await?;
@@ -499,12 +520,18 @@ async fn recover_shard_snapshot(
 // TODO: `POST` (same as `upload_snapshot`) or `PUT`!?
 #[post("/collections/{collection_name}/shards/{shard}/snapshots/upload")]
 async fn upload_shard_snapshot(
+    // NOTE: this extractor must come *before* `MultipartForm` so that
+    // unauthorized requests are rejected before the body is spooled to disk
+    // (GHSA-3v92-w72v-j994).
+    early_auth: ActixAccessManage<UploadShardSnapshotAction>,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
     query: web::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
-    ActixAuth(auth): ActixAuth,
 ) -> impl Responder {
+    let ActixAccessManage {
+        auth, multipass, ..
+    } = early_auth;
     // nothing to verify.
     let pass = new_unchecked_verification_pass();
 
@@ -522,10 +549,7 @@ async fn upload_shard_snapshot(
     //   - but the task is *spawned* on the runtime and won't be cancelled, if request is cancelled
 
     let future = cancel::future::spawn_cancel_on_drop(async move |cancel| {
-        // TODO: Run this check before the multipart blob is uploaded
-        let collection_pass = auth
-            .check_global_access(AccessRequirements::new().manage(), "upload_shard_snapshot")?
-            .issue_pass(&collection);
+        let collection_pass = multipass.issue_pass(&collection);
 
         let cancel_safe = async {
             if let Some(checksum) = checksum {
@@ -664,12 +688,18 @@ async fn create_partial_snapshot(
 
 #[post("/collections/{collection_name}/shards/{shard}/snapshot/partial/recover")]
 async fn recover_partial_snapshot(
+    // NOTE: this extractor must come *before* `MultipartForm` so that
+    // unauthorized requests are rejected before the body is spooled to disk
+    // (GHSA-3v92-w72v-j994).
+    early_auth: ActixAccessManage<RecoverPartialSnapshotAction>,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
     query: web::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
-    ActixAuth(auth): ActixAuth,
 ) -> impl Responder {
+    let ActixAccessManage {
+        auth, multipass, ..
+    } = early_auth;
     let CollectionShardPath {
         collection_name: collection,
         shard,
@@ -702,13 +732,7 @@ async fn recover_partial_snapshot(
     let future = cancel::future::spawn_cancel_on_drop(async move |cancel| {
         let _recovery_lock = recovery_lock;
 
-        // TODO: Run this check before the multipart blob is uploaded
-        let collection_pass = auth
-            .check_global_access(
-                AccessRequirements::new().manage(),
-                "recover_partial_snapshot",
-            )?
-            .issue_pass(&collection);
+        let collection_pass = multipass.issue_pass(&collection);
 
         let cancel_safe = async {
             if let Some(checksum) = checksum {

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -41,7 +41,7 @@ use super::{
     CollectionPath, CollectionShardPath, CollectionShardSnapshotPath, CollectionSnapshotPath,
     StrictCollectionPath,
 };
-use crate::actix::auth::{ActixAccessManage, ActixAuth, ManageAction};
+use crate::actix::auth::{ActixAccessManage, ActixAuth};
 use crate::actix::helpers::{self, HttpError};
 use crate::common;
 use crate::common::auth::Auth;
@@ -69,25 +69,6 @@ pub struct SnapshottingParam {
 #[derive(MultipartForm)]
 pub struct SnapshottingForm {
     snapshot: TempFile,
-}
-
-/// Audit-action markers for the snapshot upload endpoints. Each names the
-/// `Auth::check_global_access(manage())` call that runs *before* the
-/// multipart body is extracted, so unauthorized callers cannot force the
-/// server to spool an upload to disk (GHSA-3v92-w72v-j994).
-pub struct UploadSnapshotAction;
-impl ManageAction for UploadSnapshotAction {
-    const ACTION_NAME: &'static str = "upload_snapshot";
-}
-
-pub struct UploadShardSnapshotAction;
-impl ManageAction for UploadShardSnapshotAction {
-    const ACTION_NAME: &'static str = "upload_shard_snapshot";
-}
-
-pub struct RecoverPartialSnapshotAction;
-impl ManageAction for RecoverPartialSnapshotAction {
-    const ACTION_NAME: &'static str = "recover_partial_snapshot";
 }
 
 // Actix specific code
@@ -214,7 +195,7 @@ async fn upload_snapshot(
     // NOTE: this extractor must come *before* `MultipartForm` so that
     // unauthorized requests are rejected before the body is spooled to disk
     // (GHSA-3v92-w72v-j994).
-    early_auth: ActixAccessManage<UploadSnapshotAction>,
+    early_auth: ActixAccessManage,
     dispatcher: web::Data<Dispatcher>,
     http_client: web::Data<HttpClient>,
     collection: valid::Path<StrictCollectionPath>,
@@ -523,15 +504,13 @@ async fn upload_shard_snapshot(
     // NOTE: this extractor must come *before* `MultipartForm` so that
     // unauthorized requests are rejected before the body is spooled to disk
     // (GHSA-3v92-w72v-j994).
-    early_auth: ActixAccessManage<UploadShardSnapshotAction>,
+    early_auth: ActixAccessManage,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
     query: web::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
 ) -> impl Responder {
-    let ActixAccessManage {
-        auth, multipass, ..
-    } = early_auth;
+    let ActixAccessManage { auth, multipass } = early_auth;
     // nothing to verify.
     let pass = new_unchecked_verification_pass();
 
@@ -691,15 +670,13 @@ async fn recover_partial_snapshot(
     // NOTE: this extractor must come *before* `MultipartForm` so that
     // unauthorized requests are rejected before the body is spooled to disk
     // (GHSA-3v92-w72v-j994).
-    early_auth: ActixAccessManage<RecoverPartialSnapshotAction>,
+    early_auth: ActixAccessManage,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
     query: web::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
 ) -> impl Responder {
-    let ActixAccessManage {
-        auth, multipass, ..
-    } = early_auth;
+    let ActixAccessManage { auth, multipass } = early_auth;
     let CollectionShardPath {
         collection_name: collection,
         shard,

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 use std::future::{Ready, ready};
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use actix_web::body::EitherBody;
@@ -7,7 +8,7 @@ use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forwar
 use actix_web::{Error, FromRequest, HttpMessage, HttpResponse, ResponseError};
 use futures_util::future::LocalBoxFuture;
 use storage::audit::{audit_trust_forwarded_headers, extract_tracing_id};
-use storage::rbac::Access;
+use storage::rbac::{Access, AccessRequirements, CollectionMultipass};
 
 use super::forwarded;
 use super::helpers::HttpError;
@@ -165,6 +166,32 @@ where
     }
 }
 
+/// Retrieve the per-request [`Auth`] from request extensions, falling back to
+/// a default full-access [`Auth`] when no auth middleware is configured.
+fn take_request_auth(req: &actix_web::HttpRequest) -> Auth {
+    req.extensions_mut().remove::<Auth>().unwrap_or_else(|| {
+        let remote = if audit_trust_forwarded_headers() {
+            forwarded::forwarded_for_http(req)
+        } else {
+            None
+        }
+        .or_else(|| req.peer_addr().map(|a| a.ip().to_string()));
+        let tracing_id = extract_tracing_id(|h| {
+            req.headers()
+                .get(h)
+                .and_then(|val| val.to_str().ok())
+                .map(str::to_string)
+        });
+        Auth::new(
+            Access::full("All requests have full by default access when API key is not configured"),
+            None,
+            remote,
+            AuthType::None,
+            tracing_id,
+        )
+    })
+}
+
 /// Actix extractor that retrieves the per-request [`Auth`] context from
 /// request extensions.  When no authentication middleware is configured,
 /// a default [`Auth`] with full access is created.
@@ -178,29 +205,53 @@ impl FromRequest for ActixAuth {
         req: &actix_web::HttpRequest,
         _payload: &mut actix_web::dev::Payload,
     ) -> Self::Future {
-        let auth = req.extensions_mut().remove::<Auth>().unwrap_or_else(|| {
-            let remote = if audit_trust_forwarded_headers() {
-                forwarded::forwarded_for_http(req)
-            } else {
-                None
-            }
-            .or_else(|| req.peer_addr().map(|a| a.ip().to_string()));
-            let tracing_id = extract_tracing_id(|h| {
-                req.headers()
-                    .get(h)
-                    .and_then(|val| val.to_str().ok())
-                    .map(str::to_string)
-            });
-            Auth::new(
-                Access::full(
-                    "All requests have full by default access when API key is not configured",
-                ),
-                None,
-                remote,
-                AuthType::None,
-                tracing_id,
-            )
-        });
-        ready(Ok(ActixAuth(auth)))
+        ready(Ok(ActixAuth(take_request_auth(req))))
+    }
+}
+
+/// Marker trait that names the audit action for an [`ActixAccessManage`]
+/// extractor instance.
+pub trait ManageAction {
+    /// String passed to `Auth::check_global_access` for audit logging.
+    const ACTION_NAME: &'static str;
+}
+
+/// Actix extractor that enforces global `manage` access *before* any other
+/// extractors run.
+///
+/// Place this as the **first** parameter in a handler signature, ahead of
+/// body-consuming extractors such as `MultipartForm`. Actix-web polls tuple
+/// extractors in declaration order and short-circuits on the first
+/// `Ready(Err)` (see actix-web `extract.rs` `tuple_from_req!`). Because
+/// [`Self::from_request`] returns a synchronously-ready result, an
+/// unauthorized request is rejected with `403 Forbidden` before any
+/// subsequent extractor's future is polled — meaning the request body is
+/// never read from the socket and no temp file is created.
+///
+/// This is the fix for the read-only-key snapshot-upload disk-exhaustion
+/// issue described in GHSA-3v92-w72v-j994.
+pub struct ActixAccessManage<A> {
+    pub auth: Auth,
+    pub multipass: CollectionMultipass,
+    _action: PhantomData<fn() -> A>,
+}
+
+impl<A: ManageAction + 'static> FromRequest for ActixAccessManage<A> {
+    type Error = HttpError;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(
+        req: &actix_web::HttpRequest,
+        _payload: &mut actix_web::dev::Payload,
+    ) -> Self::Future {
+        let auth = take_request_auth(req);
+        match auth.check_global_access(AccessRequirements::new().manage(), A::ACTION_NAME) {
+            Ok(multipass) => ready(Ok(Self {
+                auth,
+                multipass,
+                _action: PhantomData,
+            })),
+            Err(err) => ready(Err(HttpError::from(err))),
+        }
     }
 }

--- a/src/actix/auth.rs
+++ b/src/actix/auth.rs
@@ -1,6 +1,5 @@
 use std::convert::Infallible;
 use std::future::{Ready, ready};
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use actix_web::body::EitherBody;
@@ -209,13 +208,6 @@ impl FromRequest for ActixAuth {
     }
 }
 
-/// Marker trait that names the audit action for an [`ActixAccessManage`]
-/// extractor instance.
-pub trait ManageAction {
-    /// String passed to `Auth::check_global_access` for audit logging.
-    const ACTION_NAME: &'static str;
-}
-
 /// Actix extractor that enforces global `manage` access *before* any other
 /// extractors run.
 ///
@@ -230,13 +222,12 @@ pub trait ManageAction {
 ///
 /// This is the fix for the read-only-key snapshot-upload disk-exhaustion
 /// issue described in GHSA-3v92-w72v-j994.
-pub struct ActixAccessManage<A> {
+pub struct ActixAccessManage {
     pub auth: Auth,
     pub multipass: CollectionMultipass,
-    _action: PhantomData<fn() -> A>,
 }
 
-impl<A: ManageAction + 'static> FromRequest for ActixAccessManage<A> {
+impl FromRequest for ActixAccessManage {
     type Error = HttpError;
     type Future = Ready<Result<Self, Self::Error>>;
 
@@ -245,12 +236,14 @@ impl<A: ManageAction + 'static> FromRequest for ActixAccessManage<A> {
         _payload: &mut actix_web::dev::Payload,
     ) -> Self::Future {
         let auth = take_request_auth(req);
-        match auth.check_global_access(AccessRequirements::new().manage(), A::ACTION_NAME) {
-            Ok(multipass) => ready(Ok(Self {
-                auth,
-                multipass,
-                _action: PhantomData,
-            })),
+        // Use the matched route pattern (e.g.
+        // `/collections/{collection_name}/snapshots/upload`) as the audit
+        // action name, falling back to the raw path for unmatched requests.
+        let action = req
+            .match_pattern()
+            .unwrap_or_else(|| req.path().to_string());
+        match auth.check_global_access(AccessRequirements::new().manage(), &action) {
+            Ok(multipass) => ready(Ok(Self { auth, multipass })),
             Err(err) => ready(Err(HttpError::from(err))),
         }
     }

--- a/tests/consensus_tests/auth_tests/test_snapshot_upload_authorization.py
+++ b/tests/consensus_tests/auth_tests/test_snapshot_upload_authorization.py
@@ -1,0 +1,247 @@
+"""
+Regression tests for GHSA-3v92-w72v-j994.
+
+The snapshot upload endpoints parse the multipart body (writing the snapshot to
+a temp file on disk) before the manage-access check runs. A caller holding only
+a read-only API key can therefore force the server to allocate disk I/O for an
+arbitrarily large upload that ultimately gets rejected with 403 Forbidden.
+
+These tests stream a multipart upload using the read-only API key while a
+background thread polls the snapshot upload temp directory. After the request
+finishes, they assert:
+
+  1. the response was 403 Forbidden (the auth boundary holds at the end), and
+  2. no bytes were observed in the upload temp directory during the request
+     (the auth boundary holds *before* any disk I/O).
+
+On a vulnerable build, condition (2) fails: the watcher observes the multipart
+temp file growing while the upload is in flight. On a fixed build the request
+is rejected before the body is consumed, so the watcher sees nothing.
+
+See: https://github.com/qdrant/qdrant/security/advisories/GHSA-3v92-w72v-j994
+"""
+
+import secrets
+import threading
+import time
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+import requests
+from consensus_tests import fixtures
+
+from .utils import API_KEY_HEADERS, READ_ONLY_API_KEY, REST_URI, random_str
+
+# Streamed body is ~3 MB delivered in ~50 ms chunks (~2.4 s upload). Large
+# enough that a 10 ms-interval poller will reliably see the temp file on a
+# vulnerable build, small enough not to noticeably slow the test suite.
+_PAYLOAD_SIZE_BYTES = 3 * 1024 * 1024
+_CHUNK_SIZE_BYTES = 64 * 1024
+_CHUNK_DELAY_SECS = 0.05
+_WATCH_POLL_INTERVAL_SECS = 0.01
+_REQUEST_TIMEOUT_SECS = 30
+
+
+class _UploadDirWatcher:
+    """Polls a directory in a background thread, recording the largest total
+    byte count observed across all files at any single poll."""
+
+    def __init__(self, upload_dir: Path, poll_interval: float = _WATCH_POLL_INTERVAL_SECS):
+        self._upload_dir = upload_dir
+        self._poll_interval = poll_interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._max_total_bytes = 0
+        self._files_seen: set[str] = set()
+
+    def __enter__(self) -> "_UploadDirWatcher":
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._poll_once()
+            time.sleep(self._poll_interval)
+        # Final sweep in case the request finished mid-sleep.
+        self._poll_once()
+
+    def _poll_once(self) -> None:
+        if not self._upload_dir.exists():
+            return
+        try:
+            entries = list(self._upload_dir.iterdir())
+        except (FileNotFoundError, OSError):
+            return
+
+        total = 0
+        for entry in entries:
+            try:
+                size = entry.stat().st_size
+            except (FileNotFoundError, OSError):
+                # File was deleted between iterdir() and stat() — normal race
+                # with actix-multipart's TempFile cleanup.
+                continue
+            total += size
+            with self._lock:
+                self._files_seen.add(entry.name)
+
+        with self._lock:
+            if total > self._max_total_bytes:
+                self._max_total_bytes = total
+
+    @property
+    def max_total_bytes(self) -> int:
+        with self._lock:
+            return self._max_total_bytes
+
+    @property
+    def files_seen(self) -> set[str]:
+        with self._lock:
+            return set(self._files_seen)
+
+
+def _slow_multipart_body(
+    field_name: str,
+    filename: str,
+    payload: bytes,
+    boundary: str,
+) -> Iterator[bytes]:
+    """Yield a multipart/form-data body in slow chunks, so that a vulnerable
+    server has time to start writing the temp file while we are still uploading."""
+    header = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="{field_name}"; '
+        f'filename="{filename}"\r\n'
+        f"Content-Type: application/octet-stream\r\n\r\n"
+    ).encode()
+    footer = f"\r\n--{boundary}--\r\n".encode()
+
+    yield header
+    for i in range(0, len(payload), _CHUNK_SIZE_BYTES):
+        yield payload[i : i + _CHUNK_SIZE_BYTES]
+        time.sleep(_CHUNK_DELAY_SECS)
+    yield footer
+
+
+def _send_slow_upload_with_readonly_key(url: str) -> requests.Response:
+    boundary = f"----qdrantghsapoc{secrets.token_hex(8)}"
+    payload = b"\x00" * _PAYLOAD_SIZE_BYTES
+    body_iter = _slow_multipart_body(
+        field_name="snapshot",
+        filename="ghsa-3v92-w72v-j994.snapshot",
+        payload=payload,
+        boundary=boundary,
+    )
+    return requests.post(
+        url,
+        data=body_iter,
+        headers={
+            "api-key": READ_ONLY_API_KEY,
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+        timeout=_REQUEST_TIMEOUT_SECS,
+    )
+
+
+def _watch_and_upload(upload_dir: Path, url: str) -> Tuple[requests.Response, int, set]:
+    with _UploadDirWatcher(upload_dir) as watcher:
+        response = _send_slow_upload_with_readonly_key(url)
+    return response, watcher.max_total_bytes, watcher.files_seen
+
+
+def _assert_no_unauthorized_disk_writes(
+    response: requests.Response,
+    bytes_observed: int,
+    files_seen: set,
+    upload_dir: Path,
+    endpoint_label: str,
+) -> None:
+    assert response.status_code == 403, (
+        f"{endpoint_label}: expected 403 Forbidden for read-only credentials "
+        f"but got HTTP {response.status_code}: {response.text!r}"
+    )
+    assert bytes_observed == 0, (
+        f"GHSA-3v92-w72v-j994 ({endpoint_label}): read-only credentials caused "
+        f"at least {bytes_observed} bytes to be persisted into {upload_dir} "
+        f"(files seen: {sorted(files_seen)}) before the 403 was returned. "
+        f"The manage-access check must run before the multipart body is accepted."
+    )
+
+
+@pytest.fixture(scope="module")
+def upload_auth_collection(jwt_cluster):
+    """A dedicated collection (with a shard) for the upload-auth regression
+    tests, so we don't perturb the shared jwt_test_collection."""
+    collection_name = f"upload_auth_{random_str()}"
+    fixtures.create_collection(
+        REST_URI,
+        collection=collection_name,
+        headers=API_KEY_HEADERS,
+    )
+    try:
+        yield collection_name
+    finally:
+        fixtures.drop_collection(REST_URI, collection_name, headers=API_KEY_HEADERS)
+
+
+@pytest.fixture(scope="module")
+def snapshot_upload_dir(jwt_cluster) -> Path:
+    """The directory actix-multipart uses for snapshot upload temp files.
+
+    Matches `TableOfContent::upload_dir()` from
+    `lib/storage/src/content_manager/toc/temp_directories.rs`."""
+    _peer_api_uris, peer_dirs, _bootstrap_uri = jwt_cluster
+    return Path(peer_dirs[0]) / "snapshots" / "tmp" / "upload"
+
+
+def test_upload_collection_snapshot_does_not_persist_for_readonly_key(
+    snapshot_upload_dir: Path, upload_auth_collection: str
+):
+    url = f"{REST_URI}/collections/{upload_auth_collection}/snapshots/upload"
+    response, bytes_observed, files_seen = _watch_and_upload(snapshot_upload_dir, url)
+    _assert_no_unauthorized_disk_writes(
+        response,
+        bytes_observed,
+        files_seen,
+        snapshot_upload_dir,
+        endpoint_label="POST /collections/{collection}/snapshots/upload",
+    )
+
+
+def test_upload_shard_snapshot_does_not_persist_for_readonly_key(
+    snapshot_upload_dir: Path, upload_auth_collection: str
+):
+    url = f"{REST_URI}/collections/{upload_auth_collection}/shards/0/snapshots/upload"
+    response, bytes_observed, files_seen = _watch_and_upload(snapshot_upload_dir, url)
+    _assert_no_unauthorized_disk_writes(
+        response,
+        bytes_observed,
+        files_seen,
+        snapshot_upload_dir,
+        endpoint_label="POST /collections/{collection}/shards/{shard}/snapshots/upload",
+    )
+
+
+def test_recover_partial_snapshot_does_not_persist_for_readonly_key(
+    snapshot_upload_dir: Path, upload_auth_collection: str
+):
+    url = (
+        f"{REST_URI}/collections/{upload_auth_collection}"
+        f"/shards/0/snapshot/partial/recover"
+    )
+    response, bytes_observed, files_seen = _watch_and_upload(snapshot_upload_dir, url)
+    _assert_no_unauthorized_disk_writes(
+        response,
+        bytes_observed,
+        files_seen,
+        snapshot_upload_dir,
+        endpoint_label="POST /collections/{collection}/shards/{shard}/snapshot/partial/recover",
+    )


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/security/advisories/GHSA-3v92-w72v-j994>

A read-only API key may be used to submit a snapshot upload request. The request will be rejected if you don't have enough permissions, but, the file gets uploaded first. This allows you to cause a DoS by making the server go out of disk.

This PR fixes the problem by authorizing before processing the upload.

A test is included that asserts behavior. The test fails on the existing code base, and becomes green when the fix is included.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
