### PR TITLE
Better `io_uring` support in quantized multi-vector scorers

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -20,14 +20,14 @@ use fs_err::File;
 pub trait EncodedStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]>;
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], mut callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let vector = self.get_vector_data(offset);
-            callback(idx, &vector);
-        }
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        offsets
+            .iter()
+            .map(move |&offset| self.get_vector_data(offset))
+            .enumerate()
     }
 
     fn is_on_disk(&self) -> bool;

--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -30,6 +30,7 @@ pub trait EncodedStorage {
             .enumerate()
     }
 
+    fn is_in_ram_or_mmap() -> bool;
     fn is_on_disk(&self) -> bool;
 
     fn upsert_vector(
@@ -138,6 +139,10 @@ impl EncodedStorage for TestEncodedStorage {
         }
         self.data[offset..offset + self.quantized_vector_size.get()].copy_from_slice(vector);
         Ok(())
+    }
+
+    fn is_in_ram_or_mmap() -> bool {
+        true
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -45,15 +45,6 @@ pub trait EncodedVectors: Sized {
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], mut callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        for (idx, vector) in self.iter_batch(offsets) {
-            callback(idx, &vector);
-        }
-    }
-
     fn iter_batch(
         &self,
         offsets: &[PointOffsetType],

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -44,9 +45,19 @@ pub trait EncodedVectors: Sized {
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
+    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], mut callback: F)
     where
-        F: FnMut(usize, &[u8]);
+        F: FnMut(usize, &[u8]),
+    {
+        for (idx, vector) in self.iter_batch(offsets) {
+            callback(idx, &vector);
+        }
+    }
+
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)>;
 
     fn score(
         &self,

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -41,6 +41,7 @@ pub struct VectorParameters {
 pub trait EncodedVectors: Sized {
     type EncodedQuery;
 
+    fn is_in_ram_or_mmap() -> bool;
     fn is_on_disk(&self) -> bool;
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -46,6 +46,9 @@ pub trait EncodedVectors: Sized {
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;
 
+    /// This function is expected to:
+    /// - be implemented by non-multivector storages
+    /// - be used by multivector storages
     fn iter_batch(
         &self,
         offsets: &[PointOffsetType],

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -842,11 +842,11 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
         )
     }
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        self.encoded_vectors.iter_batch(offsets)
     }
 
     fn score(

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -828,6 +828,10 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors
 {
     type EncodedQuery = EncodedQueryBQ<TBitsStoreType>;
 
+    fn is_in_ram_or_mmap() -> bool {
+        TStorage::is_in_ram_or_mmap()
+    }
+
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()
     }

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -526,11 +526,11 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
         EncodedQueryPQ { lut }
     }
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        self.encoded_vectors.iter_batch(offsets)
     }
 
     fn score(

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -498,6 +498,10 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
     type EncodedQuery = EncodedQueryPQ;
 
+    fn is_in_ram_or_mmap() -> bool {
+        TStorage::is_in_ram_or_mmap()
+    }
+
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()
     }

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -602,11 +602,11 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
         }
     }
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        self.encoded_vectors.iter_batch(offsets)
     }
 
     fn score(

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -592,6 +592,10 @@ pub fn get_quantized_vector_size(vector_parameters: &VectorParameters) -> usize 
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
     type EncodedQuery = EncodedQueryU8;
 
+    fn is_in_ram_or_mmap() -> bool {
+        TStorage::is_in_ram_or_mmap()
+    }
+
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()
     }

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -408,11 +408,11 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         self.quantizer.precompute_query(query)
     }
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        self.encoded_vectors.for_each_in_batch(offsets, callback);
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        self.encoded_vectors.iter_batch(offsets)
     }
 
     fn score(

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -400,6 +400,10 @@ pub fn get_quantized_vector_size(
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
     type EncodedQuery = EncodedQueryTQ;
 
+    fn is_in_ram_or_mmap() -> bool {
+        TStorage::is_in_ram_or_mmap()
+    }
+
     fn is_on_disk(&self) -> bool {
         self.encoded_vectors.is_on_disk()
     }

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::atomic_save_json;
 use common::mmap::AdviceSetting;
-use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalWrite};
+use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalKind, UniversalWrite};
 use fs_err as fs;
 use num_traits::AsPrimitive;
 
@@ -44,6 +44,10 @@ where
     T: bytemuck::Pod,
     S: UniversalWrite + Send + 'static,
 {
+    pub fn storage_kind() -> UniversalKind {
+        S::kind()
+    }
+
     pub fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {
         let status_file = ChunkedVectorsRead::<T, S>::status_file(directory);
         if !S::exists(&status_file)? {

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -48,11 +48,11 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
             .unwrap_or_default()
     }
 
-    fn for_each_in_batch<F>(&self, offsets: &[PointOffsetType], callback: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        self.data.for_each_in_batch(offsets, callback);
+    fn iter_batch(
+        &self,
+        offsets: &[PointOffsetType],
+    ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        self.data.iter(offsets)
     }
 
     fn upsert_vector(

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -5,7 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
+use common::universal_io::{MmapFile, UniversalKind};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -64,6 +64,22 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
         self.data
             .insert(id as VectorOffsetType, vector, hw_counter)
             .map_err(std::io::Error::other)
+    }
+
+    fn is_in_ram_or_mmap() -> bool {
+        type StorageType = ChunkedVectors<u8, MmapFile>;
+
+        // This should produce compilation error, if `QuantizedChunkedMmapStorage::data` type is changed,
+        // to ensure that we always use correct type for this check
+        fn _static_assert_storage_type(storage: QuantizedChunkedMmapStorage) {
+            let _: StorageType = storage.data;
+        }
+
+        match StorageType::storage_kind() {
+            UniversalKind::Mmap => true,
+            UniversalKind::IoUring => false,
+            UniversalKind::DiskCache => false,
+        }
     }
 
     fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -99,11 +99,11 @@ where
             .vector_io_read()
             .incr_delta(ids.len() * storage.quantized_vector_size());
 
-        storage.for_each_in_batch(ids, |idx, vector| {
+        for (idx, vector) in storage.iter_batch(ids) {
             scores[idx] = self.query.score_by(|query| {
-                storage.score(query, vector, &self.hardware_counter) // inhibit `rustfmt`
+                storage.score(query, &vector, &self.hardware_counter) // inhibit `rustfmt`
             });
-        });
+        }
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -109,18 +109,10 @@ where
             .vector_io_read()
             .incr_delta(size_of::<MultivectorOffset>() * ids.len());
 
-        let score_multi_vector = |idx, multi_vector: &[Cow<'_, _>]| {
-            scores[idx] = self.query.score_by(|query| {
-                // `score_point_max_similarity` handles CPU hardware counter
-                self.quantized_multivector_storage
-                    .score_vector_max_similarity(query, multi_vector, &self.hardware_counter)
-            });
-        };
-
-        // `for_each_in_multi_batch` handles multi-vector I/O hardware counter
-        self.quantized_multivector_storage.for_each_in_multi_batch(
+        self.quantized_multivector_storage.score_points_batch(
             ids,
-            score_multi_vector,
+            |score_fn| self.query.score_by(score_fn),
+            scores,
             &self.hardware_counter,
         );
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -109,20 +109,20 @@ where
             .vector_io_read()
             .incr_delta(size_of::<MultivectorOffset>() * ids.len());
 
-        for (idx, offset) in self.quantized_multivector_storage.iter_offsets(ids) {
-            self.hardware_counter.vector_io_read().incr_delta(
-                self.quantized_multivector_storage.quantized_vector_size() * offset.count as usize,
-            );
-
+        let score_multi_vector = |idx, multi_vector: &[Cow<'_, _>]| {
             scores[idx] = self.query.score_by(|query| {
-                // quantized multivector storage handles CPU hardware counter
-                self.quantized_multivector_storage.score_multi(
-                    query,
-                    offset,
-                    &self.hardware_counter,
-                )
+                // `score_point_max_similarity` handles CPU hardware counter
+                self.quantized_multivector_storage
+                    .score_vector_max_similarity(query, multi_vector, &self.hardware_counter)
             });
-        }
+        };
+
+        // `for_each_in_multi_batch` handles multi-vector I/O hardware counter
+        self.quantized_multivector_storage.for_each_in_multi_batch(
+            ids,
+            score_multi_vector,
+            &self.hardware_counter,
+        );
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -106,19 +106,12 @@ where
             .vector_io_read()
             .incr_delta(size_of::<MultivectorOffset>() * ids.len());
 
-        let score_multi_vector = |idx, multi_vector: &[Cow<'_, _>]| {
-            // `score_point_max_similarity` handles CPU hardware counter
-            scores[idx] = self
-                .quantized_multivector_storage
-                .score_vector_max_similarity(&self.query, multi_vector, &self.hardware_counter);
-        };
-
-        // `for_each_in_multi_batch` handles multi-vector I/O hardware counter
-        self.quantized_multivector_storage.for_each_in_multi_batch(
+        self.quantized_multivector_storage.score_points_batch(
             ids,
-            score_multi_vector,
+            |score_fn| score_fn(&self.query),
+            scores,
             &self.hardware_counter,
-        );
+        )
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -106,18 +106,19 @@ where
             .vector_io_read()
             .incr_delta(size_of::<MultivectorOffset>() * ids.len());
 
-        for (idx, offset) in self.quantized_multivector_storage.iter_offsets(ids) {
-            self.hardware_counter.vector_io_read().incr_delta(
-                self.quantized_multivector_storage.quantized_vector_size() * offset.count as usize,
-            );
+        let score_multi_vector = |idx, multi_vector: &[Cow<'_, _>]| {
+            // `score_point_max_similarity` handles CPU hardware counter
+            scores[idx] = self
+                .quantized_multivector_storage
+                .score_vector_max_similarity(&self.query, multi_vector, &self.hardware_counter);
+        };
 
-            // quantized multivector storage handles CPU hardware counter
-            scores[idx] = self.quantized_multivector_storage.score_multi(
-                &self.query,
-                offset,
-                &self.hardware_counter,
-            );
-        }
+        // `for_each_in_multi_batch` handles multi-vector I/O hardware counter
+        self.quantized_multivector_storage.for_each_in_multi_batch(
+            ids,
+            score_multi_vector,
+            &self.hardware_counter,
+        );
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -434,15 +434,11 @@ where
     {
         debug_assert_eq!(point_ids.len(), scores.len());
 
-        if self.is_in_ram_or_mmap() {
+        if QuantizedStorage::is_in_ram_or_mmap() {
             self.score_points_batch_mmap(point_ids, scorer, scores, hw_counter);
         } else {
             self.score_points_batch_uring(point_ids, scorer, scores, hw_counter);
         }
-    }
-
-    fn is_in_ram_or_mmap(&self) -> bool {
-        true // TODO
     }
 
     #[inline]
@@ -656,6 +652,10 @@ where
 {
     // TODO(colbert): refactor `EncodedVectors` to support multi vector storage after quantization migration
     type EncodedQuery = Vec<QuantizedStorage::EncodedQuery>;
+
+    fn is_in_ram_or_mmap() -> bool {
+        QuantizedStorage::is_in_ram_or_mmap()
+    }
 
     fn is_on_disk(&self) -> bool {
         self.quantized_storage.is_on_disk()

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -507,26 +507,14 @@ where
         sum
     }
 
-    pub fn score_multi(
-        &self,
-        query: &[QuantizedStorage::EncodedQuery],
-        offset: MultivectorOffset,
-        hw_counter: &HardwareCounterCell,
-    ) -> ScoreType {
-        match self.multi_vector_config.comparator {
-            MultiVectorComparator::MaxSim => {
-                self.score_point_max_similarity(query, offset, hw_counter)
-            }
-        }
-    }
-
     /// Custom `score_max_similarity` implementation for quantized vectors
     fn score_point_max_similarity(
         &self,
         query: &[QuantizedStorage::EncodedQuery],
-        offset: MultivectorOffset,
+        point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
+        let offset = self.offsets.get_offset(point_id);
         let offsets: SmallVec<[_; 8]> = (offset.start..offset.start + offset.count).collect();
 
         let mut max_sim: SmallVec<[_; 8]> = SmallVec::new();
@@ -628,8 +616,9 @@ where
         i: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
-        let offset = self.offsets.get_offset(i);
-        self.score_multi(query, offset, hw_counter)
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => self.score_point_max_similarity(query, i, hw_counter),
+        }
     }
 
     fn score_internal(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -435,14 +435,18 @@ where
         debug_assert_eq!(point_ids.len(), scores.len());
 
         if QuantizedStorage::is_in_ram_or_mmap() {
-            self.score_points_batch_mmap(point_ids, scorer, scores, hw_counter);
+            // This function is optimized of in-ram access
+            // it doesn't do extra mem copies and assume reference access
+            self.score_points_batch_in_mem_like(point_ids, scorer, scores, hw_counter);
         } else {
-            self.score_points_batch_uring(point_ids, scorer, scores, hw_counter);
+            // Optimized for remote access from external storage,
+            // does memory copy, but minimizes assessed to external storage
+            self.score_points_batch_uring_like(point_ids, scorer, scores, hw_counter);
         }
     }
 
     #[inline]
-    fn score_points_batch_mmap<F>(
+    fn score_points_batch_in_mem_like<F>(
         &self,
         point_ids: &[PointOffsetType],
         scorer: F,
@@ -463,7 +467,7 @@ where
     }
 
     #[inline]
-    fn score_points_batch_uring<F>(
+    fn score_points_batch_uring_like<F>(
         &self,
         point_ids: &[PointOffsetType],
         scorer: F,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -1,4 +1,6 @@
-use std::ops::DerefMut;
+use std::borrow::Cow;
+use std::iter;
+use std::ops::DerefMut as _;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -442,16 +444,15 @@ where
         let mut max_sim: SmallVec<[_; 8]> = SmallVec::new();
         max_sim.resize(query.len(), ScoreType::NEG_INFINITY);
 
-        self.quantized_storage
-            .for_each_in_batch(&offsets, |_, vector| {
-                for (query_idx, query) in query.iter().enumerate() {
-                    let sim = self.quantized_storage.score(query, vector, hw_counter);
+        for (_, vector) in self.quantized_storage.iter_batch(&offsets) {
+            for (query_idx, query) in query.iter().enumerate() {
+                let sim = self.quantized_storage.score(query, &vector, hw_counter);
 
-                    if max_sim[query_idx] < sim {
-                        max_sim[query_idx] = sim;
-                    }
+                if max_sim[query_idx] < sim {
+                    max_sim[query_idx] = sim;
                 }
-            });
+            }
+        }
 
         max_sim.into_iter().sum()
     }
@@ -522,11 +523,11 @@ where
             .collect()
     }
 
-    fn for_each_in_batch<F>(&self, _: &[PointOffsetType], _: F)
-    where
-        F: FnMut(usize, &[u8]),
-    {
-        unimplemented!("quantized multi-vector storage does not support `for_each_in_batch`")
+    fn iter_batch(&self, _: &[PointOffsetType]) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
+        unimplemented!("quantized multi-vector storage does not support `iter_batch`");
+
+        #[allow(unreachable_code)]
+        iter::empty()
     }
 
     fn score(&self, _: &Self::EncodedQuery, _: &[u8], _: &HardwareCounterCell) -> f32 {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
-use std::iter;
 use std::ops::DerefMut as _;
 use std::path::{Path, PathBuf};
+use std::{iter, slice};
 
+use ahash::HashMapExt as _;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
@@ -417,6 +418,93 @@ where
             dim,
             multi_vector_config,
         }
+    }
+
+    pub fn for_each_in_multi_batch(
+        &self,
+        point_ids: &[PointOffsetType],
+        mut callback: impl FnMut(usize, &[Cow<'_, [u8]>]),
+        hw_counter: &HardwareCounterCell,
+    ) {
+        debug_assert!(point_ids.len() <= u32::MAX as usize);
+
+        #[derive(Copy, Clone)]
+        struct State {
+            index: u32,
+            count: u32,
+        }
+
+        let mut state = Vec::with_capacity(point_ids.len());
+        let mut chunks = Vec::with_capacity(point_ids.len());
+
+        for (index, offset) in self.offsets.iter_offsets(point_ids) {
+            for _ in 0..offset.count {
+                state.push(State {
+                    index: index as u32,
+                    count: offset.count,
+                });
+            }
+
+            chunks.extend(offset.start..offset.start + offset.count);
+        }
+
+        hw_counter
+            .vector_io_read()
+            .incr_delta(chunks.len() * self.quantized_vector_size());
+
+        let mut multi_vectors = ahash::HashMap::new();
+
+        for (chunk_index, vector) in self.quantized_storage.iter_batch(&chunks) {
+            let State { index, count } = state[chunk_index];
+
+            if count == 1 {
+                callback(index as _, slice::from_ref(&vector));
+                continue;
+            }
+
+            let multi_vector = multi_vectors
+                .entry(index)
+                .or_insert_with(SmallVec::<[_; 4]>::new);
+
+            multi_vector.push(vector);
+
+            if multi_vector.len() == count as usize {
+                let multi_vector = multi_vectors.remove(&index).expect("multi-vector exists");
+                callback(index as _, &multi_vector);
+            }
+        }
+
+        debug_assert!(multi_vectors.is_empty());
+    }
+
+    /// Custom `score_max_similarity` implementation for quantized vectors
+    pub fn score_vector_max_similarity(
+        &self,
+        query: &[QuantizedStorage::EncodedQuery],
+        multi_vector: &[Cow<'_, [u8]>],
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        let mut sum = 0.0;
+
+        for inner_query in query {
+            let mut max_sim = ScoreType::NEG_INFINITY;
+
+            // manual `max_by` for performance
+            for vector in multi_vector {
+                let sim = self
+                    .quantized_storage
+                    .score(inner_query, vector, hw_counter);
+
+                if max_sim < sim {
+                    max_sim = sim;
+                }
+            }
+
+            // sum of max similarity
+            sum += max_sim;
+        }
+
+        sum
     }
 
     pub fn score_multi(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -392,6 +392,8 @@ where
     multi_vector_config: MultiVectorConfig,
 }
 
+pub type DynScore<'a, Query> = dyn Fn(&Vec<Query>) -> ScoreType + 'a;
+
 impl<QuantizedStorage, TMultivectorOffsetsStorage>
     QuantizedMultivectorStorage<QuantizedStorage, TMultivectorOffsetsStorage>
 where
@@ -420,7 +422,76 @@ where
         }
     }
 
-    pub fn for_each_in_multi_batch(
+    #[inline]
+    pub fn score_points_batch<F>(
+        &self,
+        point_ids: &[PointOffsetType],
+        scorer: F,
+        scores: &mut [ScoreType],
+        hw_counter: &HardwareCounterCell,
+    ) where
+        F: Fn(&DynScore<QuantizedStorage::EncodedQuery>) -> ScoreType,
+    {
+        debug_assert_eq!(point_ids.len(), scores.len());
+
+        if self.is_in_ram_or_mmap() {
+            self.score_points_batch_mmap(point_ids, scorer, scores, hw_counter);
+        } else {
+            self.score_points_batch_uring(point_ids, scorer, scores, hw_counter);
+        }
+    }
+
+    fn is_in_ram_or_mmap(&self) -> bool {
+        true // TODO
+    }
+
+    #[inline]
+    fn score_points_batch_mmap<F>(
+        &self,
+        point_ids: &[PointOffsetType],
+        scorer: F,
+        scores: &mut [ScoreType],
+        hw_counter: &HardwareCounterCell,
+    ) where
+        F: Fn(&DynScore<QuantizedStorage::EncodedQuery>) -> ScoreType,
+    {
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => (),
+        }
+
+        for (index, &point_id) in point_ids.iter().enumerate() {
+            scores[index] = scorer(&|query| {
+                self.score_point_max_similarity(query, point_id, hw_counter) // inhibit rustfmt
+            });
+        }
+    }
+
+    #[inline]
+    fn score_points_batch_uring<F>(
+        &self,
+        point_ids: &[PointOffsetType],
+        scorer: F,
+        scores: &mut [ScoreType],
+        hw_counter: &HardwareCounterCell,
+    ) where
+        F: Fn(&DynScore<QuantizedStorage::EncodedQuery>) -> ScoreType,
+    {
+        match self.multi_vector_config.comparator {
+            MultiVectorComparator::MaxSim => (),
+        }
+
+        self.for_each_in_multi_batch(
+            point_ids,
+            |index, multi_vector| {
+                scores[index] = scorer(&|query| {
+                    self.score_vector_max_similarity(query, multi_vector, hw_counter)
+                });
+            },
+            hw_counter,
+        );
+    }
+
+    fn for_each_in_multi_batch(
         &self,
         point_ids: &[PointOffsetType],
         mut callback: impl FnMut(usize, &[Cow<'_, [u8]>]),
@@ -477,8 +548,9 @@ where
         debug_assert!(multi_vectors.is_empty());
     }
 
-    /// Custom `score_max_similarity` implementation for quantized vectors
-    pub fn score_vector_max_similarity(
+    /// Custom `score_max_similarity` implementation for quantized vectors.
+    /// Efficient for io_uring storage implementation.
+    fn score_vector_max_similarity(
         &self,
         query: &[QuantizedStorage::EncodedQuery],
         multi_vector: &[Cow<'_, [u8]>],
@@ -507,7 +579,8 @@ where
         sum
     }
 
-    /// Custom `score_max_similarity` implementation for quantized vectors
+    /// Custom `score_max_similarity` implementation for quantized vectors.
+    /// Efficient for in-RAM and mmap storage implementations.
     fn score_point_max_similarity(
         &self,
         query: &[QuantizedStorage::EncodedQuery],

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -87,11 +87,11 @@ where
             .vector_io_read()
             .incr_delta(ids.len() * self.quantized_data.quantized_vector_size());
 
-        self.quantized_data.for_each_in_batch(ids, |idx, vector| {
+        for (idx, vector) in self.quantized_data.iter_batch(ids) {
             scores[idx] = self
                 .quantized_data
-                .score(&self.query, vector, &self.hardware_counter);
-        });
+                .score(&self.query, &vector, &self.hardware_counter);
+        }
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -61,6 +61,10 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         Ok(())
     }
 
+    fn is_in_ram_or_mmap() -> bool {
+        true
+    }
+
     fn is_on_disk(&self) -> bool {
         false
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -108,6 +108,10 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
         ))
     }
 
+    fn is_in_ram_or_mmap() -> bool {
+        true
+    }
+
     fn is_on_disk(&self) -> bool {
         true
     }


### PR DESCRIPTION
If we look at how `score_stored_batch` is implemented (especially for custom queries/custom scorer), the flow is:

```rust
for point_id in point_ids {
    // custom queries have multiple positive/negative/etc queries
    for inner_query in custom_query {
        // vectors are only read in the inner-most loop!
        let multi_vector = storage.read_vector(point_id);
        storage.score_vector(inner_query, multi_vector);
    }
}
```

So, each vector is potentially read multiple times. And to make this worse, it's practically impossible to "flatten" scoring functions into single `io_uring.read_batch(point_ids, scoring_callback)`, so that vector reads are parallelized most efficiently.

This PR restructures `score_stored_batch` to be like this:

```rust
// read vectors once
for multi_vector in storage.read_vectors(point_ids) {
	// and then score vectors in-memory
    for inner_query in custom_query {
        storage.score_vector(inner_query, multi_vector);
    }
}
```

There are two caveats:
- this is a lot less efficient for in-RAM/mmap storage
  - so, there are two code paths: one for in-RAM/mmap, one for io_uring
- `storage.read_vectors` implementations is moderately complex

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
