### PR TITLE
fix: duplicated words in metrics.rs and validation.rs comments

### DIFF
--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -133,7 +133,7 @@ pub fn validate_vector_name(value: &str) -> Result<(), ValidationError> {
 ///
 /// This does not check the length of the name.
 pub fn validate_collection_name_legacy(value: &str) -> Result<(), ValidationError> {
-    // Disallowed characters on on both Linux/Windows, sourced from: <https://stackoverflow.com/a/31976060/1000145>
+    // Disallowed characters on both Linux/Windows, sourced from: <https://stackoverflow.com/a/31976060/1000145>
     const INVALID_CHARS: [char; 2] = ['/', '\0'];
 
     match INVALID_CHARS.into_iter().find(|c| value.contains(*c)) {

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -274,7 +274,7 @@ impl CollectionsTelemetry {
                 // - in stage 2 (migrate points) of resharding up we don't rely on the replica
                 //   to be available yet. In this stage, these replicas will have the `Resharding`
                 //   state.
-                // - in stage 3 (replicate) of resharding up we activate the the replica and
+                // - in stage 3 (replicate) of resharding up we activate the replica and
                 //   replicate to match the configuration replication factor. From this point on we
                 //   do rely on the replica to be available. Now one replica will be `Active`, and
                 //   the other replicas will be in a transfer state. No replica will have `Resharding`


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in comments:
- `src/common/metrics.rs` — "// - in stage 3 (replicate) of resharding up we activate the the replica and" → "...activate the replica and"
- `lib/common/common/src/validation.rs` — "// Disallowed characters on on both Linux/Windows, sourced from: <...>" → "// Disallowed characters on both Linux/Windows, sourced from: <...>"

No code/behavior change.