### PR TITLE
[UIO] Propagate `S` to `ImmutableIdTracker`

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 
 use super::point_mappings_ref::PointMappingsRefEnum;
 use super::trait_def::{IdTracker, IdTrackerRead};
@@ -16,7 +17,7 @@ use crate::types::{PointIdType, SeqNumberType};
 #[allow(clippy::large_enum_variant)]
 pub enum IdTrackerEnum {
     MutableIdTracker(MutableIdTracker),
-    ImmutableIdTracker(ImmutableIdTracker),
+    ImmutableIdTracker(ImmutableIdTracker<MmapFile>),
     InMemoryIdTracker(InMemoryIdTracker),
 }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mappings_storage.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mappings_storage.rs
@@ -15,7 +15,7 @@ use crate::types::{ExtendedPointId, PointIdType};
 
 pub const MAPPINGS_FILE_NAME: &str = "id_tracker.mappings";
 
-pub(crate) fn mappings_path(base: &Path) -> PathBuf {
+pub fn mappings_path(base: &Path) -> PathBuf {
     base.join(MAPPINGS_FILE_NAME)
 }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -8,23 +8,24 @@ pub(super) mod tests;
 #[allow(dead_code)]
 pub mod read_only;
 
+use std::fmt::Debug;
 use std::io::{BufReader, BufWriter, Write};
 use std::mem::{size_of, size_of_val};
 use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitVec};
 use common::mmap::create_and_ensure_length;
-use common::stored_bitslice::MmapBitSlice;
+use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage,
+    OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage, UniversalWrite,
 };
 use fs_err::File;
 
 pub use self::deleted_storage::DELETED_FILE_NAME;
 use self::deleted_storage::deleted_path;
-pub use self::mappings_storage::MAPPINGS_FILE_NAME;
-use self::mappings_storage::{load_mapping, mappings_path, store_mapping};
+pub use self::mappings_storage::{MAPPINGS_FILE_NAME, mappings_path};
+use self::mappings_storage::{load_mapping, store_mapping};
 pub use self::versions_storage::VERSION_MAPPING_FILE_NAME;
 use self::versions_storage::{mmap_size, version_mapping_path};
 use crate::common::Flusher;
@@ -37,18 +38,21 @@ use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMa
 use crate::types::{PointIdType, SeqNumberType};
 
 #[derive(Debug)]
-pub struct ImmutableIdTracker {
+pub struct ImmutableIdTracker<S: UniversalWrite> {
     path: PathBuf,
 
-    deleted_wrapper: BufferedUpdateBitSlice<MmapFile>,
+    deleted_wrapper: BufferedUpdateBitSlice<S>,
 
     pub(super) internal_to_version: CompressedVersions,
-    internal_to_version_wrapper: SliceBufferedUpdateWrapper<MmapFile, SeqNumberType>,
+    internal_to_version_wrapper: SliceBufferedUpdateWrapper<S, SeqNumberType>,
 
     pub(super) mappings: CompressedPointMappings,
 }
 
-impl ImmutableIdTracker {
+impl<S> ImmutableIdTracker<S>
+where
+    S: UniversalWrite + Send + Sync + 'static,
+{
     /// Approximate RAM usage in bytes for in-memory data structures.
     ///
     /// ImmutableIdTracker loads all mappings and versions into compressed
@@ -78,7 +82,7 @@ impl ImmutableIdTracker {
     }
 
     pub fn open(segment_path: &Path) -> OperationResult<Self> {
-        let deleted_storage = MmapBitSlice::open(
+        let deleted_storage = StoredBitSlice::open(
             deleted_path(segment_path),
             OpenOptions {
                 populate: Populate::Blocking,
@@ -91,7 +95,7 @@ impl ImmutableIdTracker {
 
         let deleted_wrapper = BufferedUpdateBitSlice::new(deleted_storage);
 
-        let internal_to_version_file = TypedStorage::<MmapFile, SeqNumberType>::open(
+        let internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
             version_mapping_path(segment_path),
             OpenOptions {
                 writeable: true,
@@ -139,7 +143,7 @@ impl ImmutableIdTracker {
                 .next_multiple_of(size_of::<u64>()),
         )?;
 
-        let mut deleted_storage = MmapBitSlice::open(&deleted_filepath, OpenOptions::default())?;
+        let mut deleted_storage = StoredBitSlice::open(&deleted_filepath, OpenOptions::default())?;
 
         // Set bits for deleted points from the mappings,
         deleted_storage.write_bitslice(mappings.deleted())?;
@@ -168,7 +172,7 @@ impl ImmutableIdTracker {
             create_and_ensure_length(&version_filepath, version_size)?;
         }
 
-        let mut internal_to_version_file = TypedStorage::<MmapFile, SeqNumberType>::open(
+        let mut internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
             &version_filepath,
             OpenOptions {
                 writeable: true,
@@ -210,13 +214,9 @@ impl ImmutableIdTracker {
             mappings,
         })
     }
-
-    pub(crate) fn mappings_file_path(base: &Path) -> PathBuf {
-        mappings_path(base)
-    }
 }
 
-impl IdTrackerRead for ImmutableIdTracker {
+impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for ImmutableIdTracker<S> {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id)
     }
@@ -264,7 +264,7 @@ impl IdTrackerRead for ImmutableIdTracker {
     }
 }
 
-impl IdTracker for ImmutableIdTracker {
+impl<S: UniversalWrite + Debug + Send + Sync + 'static> IdTracker for ImmutableIdTracker<S> {
     fn set_internal_version(
         &mut self,
         internal_id: PointOffsetType,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use itertools::Itertools;
 use rand::prelude::*;
 use tempfile::Builder;
@@ -33,7 +34,8 @@ fn test_iterator() {
     id_tracker.set_link(177.into(), 8).unwrap();
     id_tracker.set_link(118.into(), 9).unwrap();
 
-    let id_tracker = ImmutableIdTracker::from_in_memory_tracker(id_tracker, dir.path()).unwrap();
+    let id_tracker =
+        ImmutableIdTracker::<MmapFile>::from_in_memory_tracker(id_tracker, dir.path()).unwrap();
 
     let first_four = id_tracker
         .point_mappings()
@@ -92,7 +94,7 @@ fn test_load_store() {
         (id_tracker.mappings, id_tracker.internal_to_version)
     };
 
-    let mut loaded_id_tracker = ImmutableIdTracker::open(dir.path()).unwrap();
+    let mut loaded_id_tracker = ImmutableIdTracker::<MmapFile>::open(dir.path()).unwrap();
 
     // We may extend the length of deleted bitvec as memory maps need to be aligned to
     // a multiple of `usize-width`.
@@ -152,7 +154,7 @@ fn test_store_load_mutated() {
         (dropped_points, custom_version)
     };
 
-    let id_tracker = ImmutableIdTracker::open(dir.path()).unwrap();
+    let id_tracker = ImmutableIdTracker::<MmapFile>::open(dir.path()).unwrap();
     for (index, point) in TEST_POINTS.iter().enumerate() {
         let internal_id = index as PointOffsetType;
 
@@ -248,7 +250,7 @@ fn test_point_deletion_persists_reload() {
     };
 
     // Point should still be gone
-    let id_tracker = ImmutableIdTracker::open(dir.path()).unwrap();
+    let id_tracker = ImmutableIdTracker::<MmapFile>::open(dir.path()).unwrap();
     assert_eq!(id_tracker.internal_id(point_to_delete), None);
 
     old_mappings
@@ -351,7 +353,7 @@ fn make_in_memory_tracker_from_memory() -> InMemoryIdTracker {
     id_tracker
 }
 
-fn make_immutable_tracker(path: &Path) -> ImmutableIdTracker {
+fn make_immutable_tracker(path: &Path) -> ImmutableIdTracker<MmapFile> {
     let id_tracker = make_in_memory_tracker_from_memory();
     ImmutableIdTracker::from_in_memory_tracker(id_tracker, path).unwrap()
 }

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::vectors::DEFAULT_VECTOR_NAME;
-use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
+use crate::id_tracker::immutable_id_tracker::{self, ImmutableIdTracker};
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::VectorIndexEnum;
@@ -227,12 +227,6 @@ pub(crate) fn create_mutable_id_tracker(segment_path: &Path) -> OperationResult<
     MutableIdTracker::open(segment_path)
 }
 
-pub(crate) fn create_immutable_id_tracker(
-    segment_path: &Path,
-) -> OperationResult<ImmutableIdTracker> {
-    ImmutableIdTracker::open(segment_path)
-}
-
 pub(crate) fn get_payload_index_path(segment_path: &Path) -> PathBuf {
     segment_path.join(PAYLOAD_INDEX_PATH)
 }
@@ -429,7 +423,7 @@ fn create_segment(
     let deferred_internal_id = deferred_internal_id.filter(|_| appendable_flag);
 
     let use_mutable_id_tracker =
-        appendable_flag || !ImmutableIdTracker::mappings_file_path(segment_path).is_file();
+        appendable_flag || !immutable_id_tracker::mappings_path(segment_path).is_file();
     let started = Instant::now();
     let id_tracker = create_segment_id_tracker(use_mutable_id_tracker, segment_path)?;
     log_load_timing(segment_path, "id_tracker", started);
@@ -637,7 +631,7 @@ fn create_segment_id_tracker(
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
     if !mutable_id_tracker {
         return Ok(sp(IdTrackerEnum::ImmutableIdTracker(
-            create_immutable_id_tracker(segment_path)?,
+            ImmutableIdTracker::open(segment_path)?,
         )));
     }
 


### PR DESCRIPTION
Completes the generalization of `ImmutableIdTracker<S>` by wiring up the `S` generic