### PR TITLE
fix: segment merge tolerates source missing a named vector

### DIFF
--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -73,10 +73,15 @@ impl<'a> BatchedVectorReader<'a> {
     /// Reading of a single point looks like this:
     ///
     /// ```text
-    ///  let source_vector_storage = &source_vector_storages[point_data.segment_index.get() as usize];
-    ///  let vec = source_vector_storage.get_vector(point_data.internal_id);
-    ///  let vector_deleted = source_vector_storage.is_deleted_vector(point_data.internal_id);
-    ///  (vec, vector_deleted)
+    ///  match &source_vector_storages[point_data.segment_index.get() as usize] {
+    ///      Some(storage) => (
+    ///          storage.get_vector(point_data.internal_id),
+    ///          storage.is_deleted_vector(point_data.internal_id),
+    ///      ),
+    ///      // Source segment lacks this named vector — emit a typed placeholder
+    ///      // marked deleted (see `missing_vector_placeholder`).
+    ///      None => (missing_vector_placeholder.clone(), true),
+    ///  }
     /// ```
     fn refill_buffer(&mut self) {
         let start_pos = self.position;

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -29,7 +29,17 @@ pub struct PointData {
 /// and then iterate over them.
 pub struct BatchedVectorReader<'a> {
     points_to_insert: &'a [PointData],
-    source_vector_storages: &'a [AtomicRef<'a, VectorStorageEnum>],
+    /// `None` for source segments that do not have this named vector
+    /// (e.g. segments persisted before `create_vector_name` was called).
+    /// Points coming from such segments yield `missing_vector_placeholder`
+    /// with `deleted = true`.
+    source_vector_storages: &'a [Option<AtomicRef<'a, VectorStorageEnum>>],
+    /// Correctly-typed, correctly-sized stand-in for points whose source
+    /// segment lacks the target vector. Always paired with `deleted = true`,
+    /// so the data itself is never read — it only exists to keep the
+    /// receiving storage layout consistent (some `update_from` impls write
+    /// raw bytes regardless of the deleted flag).
+    missing_vector_placeholder: CowVector<'a>,
     buffer: Vec<(CowVector<'a>, bool)>,
     seg_to_points_buffer: AHashMap<U24, Vec<(&'a PointData, usize)>>,
     /// Global position of the iterator.
@@ -40,7 +50,8 @@ pub struct BatchedVectorReader<'a> {
 impl<'a> BatchedVectorReader<'a> {
     pub fn new(
         points_to_insert: &'a [PointData],
-        source_vector_storages: &'a [AtomicRef<'a, VectorStorageEnum>],
+        source_vector_storages: &'a [Option<AtomicRef<'a, VectorStorageEnum>>],
+        missing_vector_placeholder: CowVector<'a>,
     ) -> BatchedVectorReader<'a> {
         // We need to allocate the buffer with the size of the batch,
         // but we don't know the size of the vectors.
@@ -50,6 +61,7 @@ impl<'a> BatchedVectorReader<'a> {
         BatchedVectorReader {
             points_to_insert,
             source_vector_storages,
+            missing_vector_placeholder,
             buffer,
             seg_to_points_buffer: AHashMap::default(),
             position: 0,
@@ -82,12 +94,26 @@ impl<'a> BatchedVectorReader<'a> {
         }
 
         for (segment_index, points) in self.seg_to_points_buffer.drain() {
-            let source_vector_storage = &self.source_vector_storages[segment_index.get() as usize];
-            for (point_data, offset_in_batch) in points {
-                let vec = source_vector_storage.get_vector::<Sequential>(point_data.internal_id);
-                let vector_deleted =
-                    source_vector_storage.is_deleted_vector(point_data.internal_id);
-                self.buffer[offset_in_batch] = (vec, vector_deleted);
+            match &self.source_vector_storages[segment_index.get() as usize] {
+                Some(source_vector_storage) => {
+                    for (point_data, offset_in_batch) in points {
+                        let vec =
+                            source_vector_storage.get_vector::<Sequential>(point_data.internal_id);
+                        let vector_deleted =
+                            source_vector_storage.is_deleted_vector(point_data.internal_id);
+                        self.buffer[offset_in_batch] = (vec, vector_deleted);
+                    }
+                }
+                None => {
+                    // Source segment was persisted before the target named vector
+                    // existed; emit a typed placeholder marked as deleted so the
+                    // merged segment records "no data for this vector" on these
+                    // points without corrupting storage layout.
+                    for (_point_data, offset_in_batch) in points {
+                        self.buffer[offset_in_batch] =
+                            (self.missing_vector_placeholder.clone(), true);
+                    }
+                }
             }
         }
     }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -31,6 +31,7 @@ use super::{
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
+use crate::data_types::vectors::VectorRef;
 use crate::entry::ReadSegmentEntry;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
@@ -349,13 +350,17 @@ impl SegmentBuilder {
                 })
                 .collect::<Vec<_>>();
 
-            // Owned, correctly-typed placeholder for points whose source
-            // segment is `None` for this vector. Paired with `deleted = true`
-            // inside the reader so the data is never read; it only keeps the
-            // storage layout intact for impls that write raw bytes regardless
-            // of the deleted flag.
-            let missing_vector_placeholder =
-                CowVector::from(vector_data.vector_storage.default_vector());
+            // Correctly-typed placeholder for points whose source segment is
+            // `None` for this vector. Paired with `deleted = true` inside the
+            // reader so the data is never read; it only keeps the storage
+            // layout intact for impls that write raw bytes regardless of the
+            // deleted flag.
+            //
+            // Held as an owned `VectorInternal` and handed to the reader as a
+            // `CowVector::Borrowed` so per-point `clone()` inside the reader
+            // copies a slice reference rather than allocating a new vector.
+            let placeholder_backing = vector_data.vector_storage.default_vector();
+            let missing_vector_placeholder = CowVector::from(VectorRef::from(&placeholder_backing));
 
             let mut vectors_iter: BatchedVectorReader = BatchedVectorReader::new(
                 &points_to_insert,

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -30,6 +30,7 @@ use super::{
 };
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
+use crate::data_types::named_vectors::CowVector;
 use crate::entry::ReadSegmentEntry;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
@@ -329,26 +330,38 @@ impl SegmentBuilder {
         for (vector_name, vector_data) in &mut self.vector_data {
             check_process_stopped(stopped)?;
 
+            // Build per-source storage references. Source segments that lack
+            // this named vector contribute `None` — their points will be
+            // recorded in the merged segment as having no data for the vector
+            // (the same state `create_vector_name` leaves on a freshly added
+            // vector). Skip pushing to `old_indices` for those: HNSW reuse is
+            // an optimization keyed on present indices only.
             let other_vector_storages = vector_storages
                 .iter()
-                .map(|i| {
-                    let other_vector_data = i.get(vector_name).ok_or_else(|| {
-                        OperationError::service_error(format!(
-                            "Cannot update from other segment because it is \
-                             missing vector name {vector_name}"
-                        ))
-                    })?;
-
-                    vector_data
-                        .old_indices
-                        .push(Arc::clone(&other_vector_data.vector_index));
-
-                    Ok(other_vector_data.vector_storage.borrow())
+                .map(|i| match i.get(vector_name) {
+                    Some(other_vector_data) => {
+                        vector_data
+                            .old_indices
+                            .push(Arc::clone(&other_vector_data.vector_index));
+                        Some(other_vector_data.vector_storage.borrow())
+                    }
+                    None => None,
                 })
-                .collect::<Result<Vec<_>, OperationError>>()?;
+                .collect::<Vec<_>>();
 
-            let mut vectors_iter: BatchedVectorReader =
-                BatchedVectorReader::new(&points_to_insert, &other_vector_storages);
+            // Owned, correctly-typed placeholder for points whose source
+            // segment is `None` for this vector. Paired with `deleted = true`
+            // inside the reader so the data is never read; it only keeps the
+            // storage layout intact for impls that write raw bytes regardless
+            // of the deleted flag.
+            let missing_vector_placeholder =
+                CowVector::from(vector_data.vector_storage.default_vector());
+
+            let mut vectors_iter: BatchedVectorReader = BatchedVectorReader::new(
+                &points_to_insert,
+                &other_vector_storages,
+                missing_vector_placeholder,
+            );
 
             let internal_range = vector_data
                 .vector_storage
@@ -753,6 +766,17 @@ impl SegmentBuilder {
             if let Some(quantization_config) = config.quantization_config(vector_name) {
                 // Don't build quantization for appendable vectors if quantization method does not support it
                 if is_appendable && !quantization_config.supports_appendable() {
+                    continue;
+                }
+
+                // Skip quantization training when there is no live data for this
+                // vector yet. Happens right after `create_vector_name` on a
+                // collection that already has data: every merged point is marked
+                // deleted for this vector. Training on all-deleted (placeholder)
+                // data would feed k-means/scale-fit with zero/garbage samples
+                // and either panic or produce a useless quantization. The next
+                // optimization pass after points get backfilled will build it.
+                if vector_info.vector_storage.available_vector_count() == 0 {
                     continue;
                 }
 

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -17,6 +17,7 @@ use segment::id_tracker::IdTrackerRead;
 use segment::index::hnsw_index::get_num_indexing_threads;
 use segment::json_path::JsonPath;
 use segment::segment::Segment;
+use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment_with_payload_storage;
 use segment::types::{
@@ -668,6 +669,102 @@ fn test_building_segment_with_added_quantized_vector_name() {
         merged_segment.available_point_count(),
         segment1.iter_points().count(),
     );
+
+    // The actual guard under test: training was skipped because every point
+    // for this vector is a deleted placeholder. Without the skip, this would
+    // be `Some(_)` built over zero live samples.
+    assert!(
+        merged_segment.vector_data[added_vector_name]
+            .quantized_vectors
+            .borrow()
+            .is_none(),
+        "quantization must not be trained for an all-deleted added vector",
+    );
+}
+
+/// Mixed-source merge: one source segment has the added named vector with
+/// real data, the other doesn't. Exercises the per-source `Option` branching
+/// in `BatchedVectorReader` — points from the source with data must come
+/// through as live, points from the source without it must come through as
+/// the placeholder marked deleted.
+#[test]
+fn test_building_segment_mixed_sources_added_vector() {
+    let dir_a = Builder::new().prefix("segment_a").tempdir().unwrap();
+    let dir_b = Builder::new().prefix("segment_b").tempdir().unwrap();
+    let dir_target = Builder::new().prefix("segment_target").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+
+    let added_vector_name = "added_vec";
+
+    // Source A: only the default vector — five points (1..=5).
+    let segment_a = build_segment_1(dir_a.path());
+
+    // Source B: built directly with both vectors so we can populate real data
+    // for the added vector. Uses point IDs disjoint from segment_a.
+    let mut config_b = segment_a.segment_config.clone();
+    config_b.vector_data.insert(
+        added_vector_name.to_owned(),
+        VectorDataConfig {
+            size: 4,
+            distance: Distance::Dot,
+            storage_type: VectorStorageType::default(),
+            index: Indexes::Plain {},
+            quantization_config: None,
+            multivector_config: None,
+            datatype: None,
+        },
+    );
+    let mut segment_b = build_segment(dir_b.path(), &config_b, None, true).unwrap();
+    for i in 0..5u64 {
+        let vectors = NamedVectors::from_pairs([
+            (DEFAULT_VECTOR_NAME.to_owned(), vec![0.5, 0.5, 0.5, 0.5]),
+            (added_vector_name.to_owned(), vec![1.0, 1.0, 1.0, 1.0]),
+        ]);
+        segment_b
+            .upsert_point(10 + i, (100 + i).into(), vectors, &hw_counter)
+            .unwrap();
+    }
+
+    let target_config = config_b.clone();
+
+    let mut builder = SegmentBuilder::new(
+        temp_dir.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    builder
+        .update(&[&segment_a, &segment_b], &stopped, &hw_counter)
+        .expect("merge must succeed when sources disagree on whether a vector is present");
+
+    let merged_segment: Segment = builder.build_for_test(dir_target.path());
+
+    // Both sources contribute their points.
+    assert_eq!(merged_segment.available_point_count(), 10);
+
+    let added_storage = merged_segment.vector_data[added_vector_name]
+        .vector_storage
+        .borrow();
+    assert_eq!(
+        added_storage.total_vector_count(),
+        10,
+        "one slot per merged point regardless of source coverage",
+    );
+    assert_eq!(
+        added_storage.available_vector_count(),
+        5,
+        "only segment_b's points carry live data for the added vector",
+    );
+
+    // The default vector is unaffected — both sources contribute live data.
+    let default_storage = merged_segment.vector_data[DEFAULT_VECTOR_NAME]
+        .vector_storage
+        .borrow();
+    assert_eq!(default_storage.available_vector_count(), 10);
 }
 
 #[test]

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -540,8 +540,7 @@ fn test_building_cancellation() {
 ///
 ///   `Cannot update from other segment because it is missing vector name X`
 ///
-/// Surfaced by the `crasher` chaos-test harness with no crash needed —
-/// triggered by the steady-state interaction between dynamic vector creation
+/// Triggered by the steady-state interaction between dynamic vector creation
 /// and concurrent segment work that provokes an optimization pass.
 #[test]
 fn test_building_segment_with_added_vector_name() {

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -23,6 +23,7 @@ use segment::types::{
     Distance, HnswGlobalConfig, Indexes, PayloadContainer, PayloadFieldSchema, PayloadKeyType,
     PayloadSchemaType, PayloadStorageType, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
+use segment::vector_storage::VectorStorageRead;
 use serde_json::Value;
 use sparse::common::sparse_vector::SparseVector;
 use tempfile::Builder;
@@ -526,6 +527,147 @@ fn test_building_cancellation() {
     assert!(
         time_fast < time_long,
         "time_early: {time_fast}, time_later: {time_long}, was_cancelled_later: {was_cancelled_later}",
+    );
+}
+
+/// Regression test: adding a named vector to a collection with pre-existing
+/// segments must not break segment merge.
+///
+/// When `create_vector_name` is called on a live collection, segments that
+/// were persisted earlier do not carry the new named vector. The merge code
+/// iterates the *target* segment's `vector_data` and fetches each name from
+/// every source segment, failing with:
+///
+///   `Cannot update from other segment because it is missing vector name X`
+///
+/// Surfaced by the `crasher` chaos-test harness with no crash needed —
+/// triggered by the steady-state interaction between dynamic vector creation
+/// and concurrent segment work that provokes an optimization pass.
+#[test]
+fn test_building_segment_with_added_vector_name() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+
+    let segment1 = build_segment_1(dir.path());
+
+    // Target schema after `create_vector_name` added a vector that the source
+    // segment was persisted without.
+    let added_vector_name = "added_vec";
+    let mut target_config = segment1.segment_config.clone();
+    target_config.vector_data.insert(
+        added_vector_name.to_owned(),
+        VectorDataConfig {
+            size: 4,
+            distance: Distance::Dot,
+            storage_type: VectorStorageType::default(),
+            index: Indexes::Plain {},
+            quantization_config: None,
+            multivector_config: None,
+            datatype: None,
+        },
+    );
+
+    let mut builder = SegmentBuilder::new(
+        temp_dir.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    builder.update(&[&segment1], &stopped, &hw_counter).expect(
+        "segment merge must tolerate a target schema that adds a named vector \
+             not present in the source segments",
+    );
+
+    let merged_segment: Segment = builder.build_for_test(dir.path());
+
+    // All source points are present in the merged segment.
+    assert_eq!(
+        merged_segment.available_point_count(),
+        segment1.iter_points().count(),
+    );
+
+    // For points coming from a segment that lacked the added vector, the
+    // merged segment must mark every slot as having no data — same state
+    // `create_vector_name` leaves on the collection. The legacy default
+    // vector is still present and complete.
+    let added_storage = merged_segment.vector_data[added_vector_name]
+        .vector_storage
+        .borrow();
+    let default_storage = merged_segment.vector_data[DEFAULT_VECTOR_NAME]
+        .vector_storage
+        .borrow();
+    assert_eq!(
+        added_storage.available_vector_count(),
+        0,
+        "added named vector must have no live data after merge",
+    );
+    assert_eq!(
+        added_storage.total_vector_count(),
+        default_storage.total_vector_count(),
+        "added named vector storage must have one slot per merged point",
+    );
+}
+
+/// Same scenario as [`test_building_segment_with_added_vector_name`], but the
+/// added named vector has a quantization config set. Without the live-count
+/// guard in `update_quantization`, training would run over all-deleted
+/// placeholder data and either panic (PQ k-means) or produce a degenerate
+/// scale (SQ).
+#[test]
+fn test_building_segment_with_added_quantized_vector_name() {
+    use segment::types::{
+        QuantizationConfig, ScalarQuantization, ScalarQuantizationConfig, ScalarType,
+    };
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+
+    let segment1 = build_segment_1(dir.path());
+
+    let added_vector_name = "added_quantized_vec";
+    let mut target_config = segment1.segment_config.clone();
+    target_config.vector_data.insert(
+        added_vector_name.to_owned(),
+        VectorDataConfig {
+            size: 4,
+            distance: Distance::Dot,
+            storage_type: VectorStorageType::default(),
+            index: Indexes::Plain {},
+            quantization_config: Some(QuantizationConfig::Scalar(ScalarQuantization {
+                scalar: ScalarQuantizationConfig {
+                    r#type: ScalarType::Int8,
+                    quantile: None,
+                    always_ram: None,
+                },
+            })),
+            multivector_config: None,
+            datatype: None,
+        },
+    );
+
+    let mut builder = SegmentBuilder::new(
+        temp_dir.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    builder
+        .update(&[&segment1], &stopped, &hw_counter)
+        .expect("segment merge must succeed with a quantized added vector");
+
+    let merged_segment: Segment = builder.build_for_test(dir.path());
+
+    assert_eq!(
+        merged_segment.available_point_count(),
+        segment1.iter_points().count(),
     );
 }
 


### PR DESCRIPTION
Optimization fails with `Cannot update from other segment because it is missing vector name X` when the optimizer merges a segment whose schema lags the collection's.

  ## Cause

  `create_vector_name` propagates V to every segment alive at dispatch time, but
  nothing stops a concurrent optimizer job from outliving the schema change:

  1. Optimizer job J starts. Captures `target_config` from the pre-change schema.
  2. `create_vector_name(V)` runs. Every loaded segment receives V.
     `recreate_optimizers_blocking()` refreshes the cached config for *future*
     jobs but does not cancel J.
  3. J finishes with the old `target_config` and installs a merged segment C
     with no V. C inherits `max(source versions)` — too high for the older
     `CreateVectorName` op_num to retroactively apply (`handle_segment_version`).
  4. The next optimizer job uses the refreshed `target_config = {…, V}`, picks
     C as a source, and fails: `C.vector_data` has no entry for V.

  ## Fix

  Make `SegmentBuilder::update` tolerate sources missing a target named vector,
  matching the "no data for V" state `create_vector_name` records on existing
  points:

  - `BatchedVectorReader::source_vector_storages` → `&[Option<AtomicRef>]`;
    missing sources emit a typed placeholder with `deleted = true`.
  - Skip `old_indices` push for missing sources (HNSW reuse only cares about
    present indices).
  - Skip quantization training when `available_vector_count() == 0` — otherwise
    PQ k-means / SQ scale-fit hits all-deleted data.

  Patches the merge boundary; the underlying race with in-flight optimization is
  unchanged.