### PR TITLE
Fix indexed integer range filter with float values

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -47,7 +47,7 @@ where
     }
 
     let range = match range {
-        RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
         RangeInterface::DateTime(datetime_range) => {
             datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
         }
@@ -158,7 +158,7 @@ where
     };
 
     let (start_bound, end_bound) = match range_cond {
-        RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
         RangeInterface::DateTime(datetime_range) => {
             datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
         }
@@ -325,11 +325,13 @@ where
 
     let range = range.as_ref()?;
     // Convert the range bounds into the index's storage type `T`.
-    // `T::from_f64` / `T::from_u128` are total functions provided by
+    // `T::from_f64_range` / `T::from_u128` are total functions provided by
     // `Numericable`, so every numeric variant (Int / Float / Datetime /
-    // Uuid) can serve any `RangeInterface` shape.
+    // Uuid) can serve any `RangeInterface` shape. For integer `T`, the
+    // float-range conversion rounds each bound *away* from the matching
+    // set so fractional bounds keep their `f64`-comparison semantics.
     let typed_range = match range {
-        RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
         RangeInterface::DateTime(datetime_range) => {
             datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
         }
@@ -358,7 +360,7 @@ where
     I: NumericIndexRead<T>,
 {
     let range = match range {
-        RangeInterface::Float(float_range) => float_range.map(|float| T::from_f64(float.0)),
+        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
         RangeInterface::DateTime(datetime_range) => {
             datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
         }

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -917,3 +917,78 @@ fn test_remove_reopen() {
     assert_eq!(index.values_count(2), 1);
     assert_eq!(index.values_count(3), 0);
 }
+
+/// Regression test for #9049: fractional `f64` range bounds were truncated
+/// toward zero when converted to the integer index's storage type, so a
+/// `gte: 1.5` predicate (meaning `>= 1.5`) wrongly matched the integer
+/// value `1`. The indexed path must agree with the documented
+/// `f64`-comparison semantics for every fractional bound.
+#[test]
+fn test_integer_index_fractional_range_bounds() {
+    use crate::types::IntPayloadType;
+
+    let temp_dir = Builder::new()
+        .prefix("test_integer_index_fractional_range_bounds")
+        .tempdir()
+        .unwrap();
+
+    let mut builder = NumericIndex::<IntPayloadType, IntPayloadType>::builder_gridstore(
+        temp_dir.path().to_path_buf(),
+    );
+    builder.init().unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    let v1 = Value::from(1_i64);
+    let v2 = Value::from(2_i64);
+    builder.add_point(0, &[&v1], &hw_counter).unwrap();
+    builder.add_point(1, &[&v2], &hw_counter).unwrap();
+    let index = builder.finalize().unwrap();
+
+    let run = |range: Range<FloatPayloadType>| -> Vec<PointOffsetType> {
+        let cond = FieldCondition::new_range(JsonPath::new("price"), range.map(OrderedFloat::from));
+        let hw = HardwareCounterCell::new();
+        let mut ids: Vec<_> = index.inner().filter(&cond, &hw).unwrap().unwrap().collect();
+        ids.sort();
+        ids
+    };
+
+    // `gte: 1.5` ⇒ `>= 1.5` ⇒ integer 1 must NOT match, integer 2 must match.
+    assert_eq!(
+        run(Range {
+            gte: Some(1.5),
+            ..Default::default()
+        }),
+        vec![1],
+        "gte: 1.5 must exclude integer 1",
+    );
+
+    // `gt: 1.5` ⇒ `> 1.5` ⇒ integer 1 must NOT match, integer 2 must match.
+    assert_eq!(
+        run(Range {
+            gt: Some(1.5),
+            ..Default::default()
+        }),
+        vec![1],
+        "gt: 1.5 must exclude integer 1",
+    );
+
+    // `lt: 1.5` ⇒ `< 1.5` ⇒ integer 1 must match, integer 2 must NOT.
+    assert_eq!(
+        run(Range {
+            lt: Some(1.5),
+            ..Default::default()
+        }),
+        vec![0],
+        "lt: 1.5 must include integer 1 and exclude 2",
+    );
+
+    // `lte: 1.5` ⇒ `<= 1.5` ⇒ integer 1 must match, integer 2 must NOT.
+    assert_eq!(
+        run(Range {
+            lte: Some(1.5),
+            ..Default::default()
+        }),
+        vec![0],
+        "lte: 1.5 must include integer 1 and exclude 2",
+    );
+}

--- a/lib/segment/src/index/field_index/numeric_point.rs
+++ b/lib/segment/src/index/field_index/numeric_point.rs
@@ -2,9 +2,11 @@ use std::fmt::Debug;
 
 use common::types::PointOffsetType;
 use num_traits::Num;
+use ordered_float::OrderedFloat;
 use serde::Serialize;
 
 pub use self::point::Point;
+use crate::types::{FloatPayloadType, Range};
 
 // bytemuck macros expand to code that triggers this clippy lint
 // The only reason this is its own module is so that we scope the lint suppression
@@ -100,6 +102,18 @@ pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod {
     fn abs_diff(self, b: Self) -> Self {
         if self > b { self - b } else { b - self }
     }
+
+    /// Convert a fractional `f64` range into an equivalent `Self`-typed range
+    /// that preserves the original predicate for every value of `Self`.
+    ///
+    /// The default impl uses [`Self::from_f64`] per bound and is correct
+    /// for floating-point `Self`. Integer types must override to round
+    /// each bound *away* from the matching set — ceil for `lt`/`gte`,
+    /// floor for `gt`/`lte` — so that fractional predicates like
+    /// `gte: 1.5` do not slip the integer `1` into the result set (#9049).
+    fn from_f64_range(range: Range<OrderedFloat<FloatPayloadType>>) -> Range<Self> {
+        range.map(|x| Self::from_f64(x.0))
+    }
 }
 
 impl Numericable for i64 {
@@ -122,6 +136,15 @@ impl Numericable for i64 {
     }
     fn abs_diff(self, b: Self) -> Self {
         i64::abs_diff(self, b) as i64
+    }
+
+    fn from_f64_range(range: Range<OrderedFloat<FloatPayloadType>>) -> Range<Self> {
+        Range {
+            lt: range.lt.map(|f| f.0.ceil() as Self),
+            gt: range.gt.map(|f| f.0.floor() as Self),
+            gte: range.gte.map(|f| f.0.ceil() as Self),
+            lte: range.lte.map(|f| f.0.floor() as Self),
+        }
     }
 }
 
@@ -170,5 +193,14 @@ impl Numericable for u128 {
 
     fn abs_diff(self, b: Self) -> Self {
         u128::abs_diff(self, b)
+    }
+
+    fn from_f64_range(range: Range<OrderedFloat<FloatPayloadType>>) -> Range<Self> {
+        Range {
+            lt: range.lt.map(|f| f.0.ceil() as Self),
+            gt: range.gt.map(|f| f.0.floor() as Self),
+            gte: range.gte.map(|f| f.0.ceil() as Self),
+            lte: range.lte.map(|f| f.0.floor() as Self),
+        }
     }
 }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/9049>

A numeric range filter with float values behaves inconsistent when having an integer index. A range filter with `gte: 1.5` would still match a value of `1`.

Note this only affects filters when an integer index is created. If having a float index, or having no index at all, behavior is sound.

This adds a test to assert behavior. I've added a function for converting a float range into an integer range respecting integer bounds.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
