### PR TITLE
[WIP] fix: durable proxy deletes (eager forward to wrapped)

### DIFF
--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -37,7 +37,6 @@ pub struct ProxySegment {
     /// May contain points which are not in wrapped_segment,
     /// because the set is shared among all proxy segments
     deleted_points: DeletedPoints,
-    deleted_deferred_count: usize,
     wrapped_config: SegmentConfig,
 
     /// Version of the last change in this proxy, considering point deletes and payload index
@@ -70,7 +69,6 @@ impl ProxySegment {
             changed_indexes: ProxyIndexChanges::default(),
             changed_vector_names: ProxyVectorNameChanges::default(),
             deleted_points: AHashMap::new(),
-            deleted_deferred_count: 0,
             wrapped_config,
             version,
         }
@@ -173,13 +171,26 @@ impl ProxySegment {
     /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
     /// required.
     pub fn propagate_to_wrapped(&mut self) -> OperationResult<()> {
-        // Important: we must not keep a write lock on the wrapped segment for the duration of this
+        let target = self.wrapped_segment.clone();
+        self.propagate_to(&target)
+    }
+
+    /// Propagate accumulated changes to an arbitrary target segment, instead of
+    /// the wrapped segment. Used during `SegmentHolder::swap_new` to redirect a
+    /// concurrent snapshot's pending changes onto the newly-committed optimized
+    /// segment, before the proxy's wrapped reference becomes orphaned.
+    ///
+    /// On success the proxy's pending state (changed indexes, changed vector
+    /// names, deleted points) is drained, so a subsequent
+    /// `propagate_to_wrapped` becomes a no-op for already-drained categories.
+    pub fn propagate_to(&mut self, target: &LockedSegment) -> OperationResult<()> {
+        // Important: we must not keep a write lock on the target segment for the duration of this
         // function to prevent a deadlock. The search functions conflict with it trying to take a
-        // read lock on the wrapped segment as well while already holding the deleted points lock
+        // read lock on the target segment as well while already holding the deleted points lock
         // (or others). Careful locking management is very important here. Instead we just take an
         // upgradable read lock, upgrading to a write lock on demand.
         // See: <https://github.com/qdrant/qdrant/pull/4206>
-        let wrapped_segment = self.wrapped_segment.get();
+        let wrapped_segment = target.get();
         let mut wrapped_segment = wrapped_segment.upgradable_read();
 
         // Propagate index changes before point deletions
@@ -259,11 +270,17 @@ impl ProxySegment {
             if !self.deleted_points.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (point_id, versions) in self.deleted_points.iter() {
-                        // Note:
-                        // Queued deletes may have an older version than what is currently in the
-                        // wrapped segment. Such deletes are ignored because the point in the
-                        // wrapped segment is considered to be newer. This is possible because
-                        // different proxy segments can share state through a common write segment.
+                        // Note: This is a best-effort re-apply. The wrapped's
+                        // `delete_point` may return `Ok(false)` because either:
+                        //  - The point has already been removed (e.g. the
+                        //    eager-forward in `ProxySegment::delete_point`
+                        //    already applied this delete, or a sibling proxy
+                        //    sharing the same write segment did so).
+                        //  - The queued delete's `operation_version` is older
+                        //    than what's currently in the wrapped segment.
+                        // Both are harmless — the canonical state is in the
+                        // wrapped's `id_tracker`, and we just need to make sure
+                        // every recorded delete *eventually* reaches there.
                         // See: <https://github.com/qdrant/qdrant/pull/7208>
                         wrapped_segment.delete_point(
                             versions.operation_version,
@@ -274,7 +291,6 @@ impl ProxySegment {
                     OperationResult::Ok(())
                 })?;
                 self.deleted_points.clear();
-                self.deleted_deferred_count = 0;
 
                 // Note: We do not clear the deleted mask here, as it provides
                 // no performance advantage and does not affect the correctness of search.

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -459,29 +459,26 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn available_point_count(&self) -> usize {
-        let deleted_points_count = self.deleted_points.len();
-        let wrapped_segment_count = self.wrapped_segment.get().read().available_point_count();
-        wrapped_segment_count.saturating_sub(deleted_points_count)
+        // `ProxySegment::delete_point` applies the delete to the wrapped
+        // segment's id_tracker eagerly, so the wrapped's `available_point_count`
+        // already excludes everything in `self.deleted_points`. Don't subtract
+        // it again.
+        self.wrapped_segment.get().read().available_point_count()
     }
 
     fn available_point_count_without_deferred(&self) -> usize {
-        let wrapped_segment_visible_count = self
-            .wrapped_segment
+        // Same as `available_point_count`: the wrapped already reflects every
+        // delete recorded in `self.deleted_points`.
+        self.wrapped_segment
             .get()
             .read()
-            .available_point_count_without_deferred();
-
-        // Amount of visible points that are deleted in this proxy.
-        let deleted_visible = self
-            .deleted_points
-            .len()
-            .saturating_sub(self.deleted_deferred_count);
-
-        wrapped_segment_visible_count.saturating_sub(deleted_visible)
+            .available_point_count_without_deferred()
     }
 
     fn deleted_point_count(&self) -> usize {
-        self.wrapped_segment.get().read().deleted_point_count() + self.deleted_points.len()
+        // Same as above: the wrapped's `deleted_point_count` already counts
+        // everything we recorded in `self.deleted_points`.
+        self.wrapped_segment.get().read().deleted_point_count()
     }
 
     fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize> {
@@ -497,18 +494,17 @@ impl ReadSegmentEntry for ProxySegment {
         let wrapped_segment = self.wrapped_segment.get();
         let wrapped_segment_guard = wrapped_segment.read();
         let wrapped_size = wrapped_segment_guard.available_vectors_size_in_bytes(vector_name)?;
+        // `available_vectors_size_in_bytes` is derived from `vector_storage`,
+        // which `Segment::delete_point` does NOT touch (only `id_tracker` is
+        // updated). The wrapped's available point count from `id_tracker`
+        // already reflects the eager-forward, but the size hasn't been
+        // adjusted, so we scale by the live-point ratio.
         let wrapped_count = wrapped_segment_guard.available_point_count();
         drop(wrapped_segment_guard);
 
-        let stored_points = wrapped_count;
-        // because we don't know the exact size of deleted vectors, we assume that they are the same avg size as the wrapped ones
+        let stored_points = wrapped_count + self.deleted_points.len();
         if stored_points > 0 {
-            let deleted_points_count = self.deleted_points.len();
-            let available_points = stored_points.saturating_sub(deleted_points_count);
-            Ok(
-                ((wrapped_size as u128) * available_points as u128 / stored_points as u128)
-                    as usize,
-            )
+            Ok(((wrapped_size as u128) * wrapped_count as u128 / stored_points as u128) as usize)
         } else {
             Ok(0)
         }
@@ -521,40 +517,13 @@ impl ReadSegmentEntry for ProxySegment {
     ) -> OperationResult<CardinalityEstimation> {
         let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
 
-        let deleted_point_count = self
-            .deleted_points
-            .len()
-            .saturating_sub(self.deleted_deferred_count);
-
-        let (wrapped_segment_est, total_wrapped_size) = {
-            let wrapped_segment = self.wrapped_segment.get();
-            let wrapped_segment_guard = wrapped_segment.read();
-            (
-                wrapped_segment_guard.estimate_point_count(filter.as_deref(), hw_counter)?,
-                wrapped_segment_guard.available_point_count_without_deferred(),
-            )
-        };
-
-        let expected_deleted_count = if total_wrapped_size > 0 {
-            (wrapped_segment_est.exp as f64
-                * (deleted_point_count as f64 / total_wrapped_size as f64)) as usize
-        } else {
-            0
-        };
-
-        let CardinalityEstimation {
-            primary_clauses,
-            min,
-            exp,
-            max,
-        } = wrapped_segment_est;
-
-        Ok(CardinalityEstimation {
-            primary_clauses,
-            min: min.saturating_sub(deleted_point_count),
-            exp: exp.saturating_sub(expected_deleted_count),
-            max,
-        })
+        // Eager-forward delete keeps the wrapped's id_tracker in sync with
+        // `self.deleted_points`, so the wrapped's estimate already excludes
+        // anything the proxy deleted; no extra subtraction needed.
+        self.wrapped_segment
+            .get()
+            .read()
+            .estimate_point_count(filter.as_deref(), hw_counter)
     }
 
     fn segment_uuid(&self) -> Uuid {
@@ -591,12 +560,14 @@ impl ReadSegmentEntry for ProxySegment {
             }
         });
 
+        // `num_vectors` / `num_indexed_vectors` come from `vector_storage`,
+        // which `Segment::delete_point` does NOT touch (only `id_tracker` and
+        // the payload index are updated). So the proxy still has to subtract
+        // its per-point deletions × remaining vector names to surface the
+        // user-visible "available vectors" count.
         let vector_name_count = vector_data.len();
         let deleted_points_count = self.deleted_points.len();
 
-        // Best estimate: start from wrapped aggregate, subtract what we just
-        // removed (stale vectors) and what the proxy deleted (per-point
-        // deletions × remaining vector names).
         let num_vectors = wrapped_info
             .num_vectors
             .saturating_sub(removed_num_vectors)
@@ -611,10 +582,12 @@ impl ReadSegmentEntry for ProxySegment {
             0
         };
 
+        // `num_deleted_vectors` already reflects the eager-forward delete via
+        // `id_tracker.deleted_point_count()`; just strip the stale-vector
+        // adjustment.
         let num_deleted_vectors = wrapped_info
             .num_deleted_vectors
-            .saturating_sub(removed_num_deleted)
-            + deleted_points_count * vector_name_count;
+            .saturating_sub(removed_num_deleted);
 
         SegmentInfo {
             uuid: wrapped_info.uuid,
@@ -623,11 +596,7 @@ impl ReadSegmentEntry for ProxySegment {
             num_indexed_vectors,
             num_points: self.available_point_count(),
             num_deferred_points: Some(self.deferred_point_count()),
-            num_deleted_deferred_points: wrapped_info.num_deleted_deferred_points.map(
-                |num_deleted_deferred_points| {
-                    num_deleted_deferred_points.saturating_add(self.deleted_deferred_count)
-                },
-            ),
+            num_deleted_deferred_points: wrapped_info.num_deleted_deferred_points,
             num_deleted_vectors,
             vectors_size_bytes: wrapped_info.vectors_size_bytes,
             payloads_size_bytes: wrapped_info.payloads_size_bytes,
@@ -698,11 +667,9 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn deferred_point_ids(&self) -> Vec<PointIdType> {
-        let mut ids = self.wrapped_segment.get().read().deferred_point_ids();
-        if self.deleted_deferred_count > 0 {
-            ids.retain(|point_id| !self.deleted_points.contains_key(point_id));
-        }
-        ids
+        // Eager-forward delete drops deleted points from the wrapped's
+        // id_tracker, so wrapped's `deferred_point_ids` already excludes them.
+        self.wrapped_segment.get().read().deferred_point_ids()
     }
 
     fn has_deferred_points(&self) -> bool {
@@ -710,11 +677,9 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn deferred_point_count(&self) -> usize {
-        self.wrapped_segment
-            .get()
-            .read()
-            .deferred_point_count()
-            .saturating_sub(self.deleted_deferred_count)
+        // Same as `deferred_point_ids`: wrapped's count already reflects every
+        // delete this proxy has issued.
+        self.wrapped_segment.get().read().deferred_point_count()
     }
 }
 
@@ -833,78 +798,66 @@ impl NonAppendableSegmentEntry for ProxySegment {
         &mut self,
         op_num: SeqNumberType,
         point_id: PointIdType,
-        _hw_counter: &HardwareCounterCell,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        let mut was_deleted = false;
-        let was_deferred_point;
+        // Apply the delete to the wrapped segment IMMEDIATELY (in addition to
+        // recording it in `self.deleted_points` for `propagate_to_wrapped` to
+        // re-apply later). This makes the delete durable regardless of whether
+        // this proxy's `propagate_to_wrapped` ever runs — important because the
+        // proxy can be dropped without a final propagate when an in-flight
+        // `apply_points` captured this proxy's Arc and lands a `delete_point`
+        // *after* the snapshot's first propagate (e.g. between propagate and
+        // slot replacement in `try_unproxy_segment`, or after the proxy has
+        // already been removed from the holder via `swap_new`).
+        //
+        // Without an immediate forward, the late delete sits in
+        // `deleted_points` on a proxy that nobody will drain again — surfaced
+        // as duplicate-point inflation by the `crasher` chaos test, since the
+        // COW source-delete is lost.
+        //
+        // The `propagate_to_wrapped` path still iterates `self.deleted_points`
+        // and calls `wrapped.delete_point` again; on that second call the
+        // wrapped's `id_tracker` no longer has the mapping, so it returns
+        // `Ok(false)`. Harmless — the canonical state lives in the wrapped
+        // segment's `id_tracker`, and `deleted_points` remains as an in-memory
+        // cache used by other read paths on the proxy.
+        //
+        // Read the internal_id BEFORE the eager forward, because the forward
+        // calls `drop_internal` which removes the mapping. Only the
+        // single-proxy-over-Original case has an internal_id we can put in
+        // the deleted_mask fast-path; an inner Proxy hides its mapping.
+        let point_offset = match &self.wrapped_segment {
+            LockedSegment::Original(raw_segment) => raw_segment.read().get_internal_id(point_id),
+            LockedSegment::Proxy(_) => None,
+        };
+
+        let was_deleted_in_wrapped = self
+            .wrapped_segment
+            .get()
+            .write()
+            .delete_point(op_num, point_id, hw_counter)?;
 
         self.version = cmp::max(self.version, op_num);
 
-        let point_offset = match &self.wrapped_segment {
-            LockedSegment::Original(raw_segment) => {
-                let (point_offset, is_deferred) = {
-                    let read_segment = raw_segment.read();
-                    (
-                        read_segment.get_internal_id(point_id),
-                        read_segment.point_is_deferred(point_id),
-                    )
-                };
-                was_deferred_point = is_deferred;
-
-                if point_offset.is_some() {
-                    let prev = self.deleted_points.insert(
-                        point_id,
-                        ProxyDeletedPoint {
-                            local_version: op_num,
-                            operation_version: op_num,
-                        },
-                    );
-                    was_deleted = prev.is_none();
-                    if let Some(prev) = prev {
-                        debug_assert!(
-                            prev.operation_version < op_num,
-                            "Overriding deleted flag {prev:?} with older op_num:{op_num}",
-                        )
-                    }
-                }
-                point_offset
+        let mut was_deleted = false;
+        if was_deleted_in_wrapped {
+            let prev = self.deleted_points.insert(
+                point_id,
+                ProxyDeletedPoint {
+                    local_version: op_num,
+                    operation_version: op_num,
+                },
+            );
+            was_deleted = prev.is_none();
+            if let Some(prev) = prev {
+                debug_assert!(
+                    prev.operation_version < op_num,
+                    "Overriding deleted flag {prev:?} with older op_num:{op_num}",
+                )
             }
-            LockedSegment::Proxy(proxy) => {
-                let (has_point, is_deferred) = {
-                    let read_proxy = proxy.read();
-                    (
-                        read_proxy.has_point(point_id),
-                        read_proxy.point_is_deferred(point_id),
-                    )
-                };
-                was_deferred_point = is_deferred;
-
-                if has_point {
-                    let prev = self.deleted_points.insert(
-                        point_id,
-                        ProxyDeletedPoint {
-                            local_version: op_num,
-                            operation_version: op_num,
-                        },
-                    );
-                    was_deleted = prev.is_none();
-                    if let Some(prev) = prev {
-                        debug_assert!(
-                            prev.operation_version < op_num,
-                            "Overriding deleted flag {prev:?} with older op_num:{op_num}",
-                        )
-                    }
-                }
-                None
-            }
-        };
+        }
 
         self.set_deleted_offset(point_offset);
-
-        // Increase delete counter for deferred point.
-        if was_deleted && was_deferred_point {
-            self.deleted_deferred_count += 1;
-        }
 
         Ok(was_deleted)
     }

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -527,13 +527,19 @@ fn test_proxy_segment_flush() {
 
     let flushed_version_2 = proxy_segment.flush(false).unwrap();
 
-    assert_eq!(flushed_version_2, flushed_version_1);
+    // `ProxySegment::delete_point` eagerly applies to the wrapped segment, so
+    // the delete IS persisted by flushing the wrapped. The flushed version
+    // advances to the delete's op_num (100).
+    assert!(
+        flushed_version_2 > flushed_version_1,
+        "delete should advance the flushed version (was {flushed_version_1}, now {flushed_version_2})",
+    );
 
     let version_after_delete = proxy_segment.version();
 
-    // We can never fully persist proxy segment, as list of deleted points is always in-memory only.
-    // So we have to keep WAL for deleted points.
-    assert!(version_after_delete > flushed_version_2);
+    // Proxy's reported version mirrors the wrapped's after the eager forward,
+    // so it equals what we just flushed.
+    assert_eq!(version_after_delete, flushed_version_2);
 }
 
 #[test]

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -195,6 +195,16 @@ impl SegmentHolder {
     /// Pair of (id of newly inserted segment, Vector of replaced segments)
     ///
     /// The inserted segment gets assigned a new unique ID.
+    ///
+    /// If any of the `remove_ids` slots is currently occupied by an outer
+    /// proxy (e.g. a snapshot proxy wrapping an optimization's inner proxy),
+    /// the outer proxy's accumulated pending changes — deleted points, payload
+    /// index changes, named-vector changes — are drained into the new segment
+    /// *before* the proxy is removed. Without this, the outer proxy's later
+    /// `propagate_to_wrapped` lands on a segment that is no longer in the
+    /// holder, silently losing the data. Surfaced as duplicate-point inflation
+    /// by the `crasher` chaos-test tool when snapshotting overlaps with an
+    /// optimization commit.
     pub fn swap_new<T>(
         &mut self,
         segment: T,
@@ -203,7 +213,20 @@ impl SegmentHolder {
     where
         T: Into<LockedSegment>,
     {
-        let new_id = self.add_new(segment);
+        let new_segment: LockedSegment = segment.into();
+
+        for &remove_id in remove_ids {
+            if let Some(LockedSegment::Proxy(outer_proxy)) = self.get(remove_id).cloned()
+                && let Err(err) = outer_proxy.write().propagate_to(&new_segment)
+            {
+                log::warn!(
+                    "swap_new: failed to drain outer-proxy state for segment \
+                     {remove_id} into new segment, ignoring: {err}",
+                );
+            }
+        }
+
+        let new_id = self.add_new_locked(new_segment);
         (new_id, self.remove(remove_ids))
     }
 

--- a/tools/codespell.toml
+++ b/tools/codespell.toml
@@ -20,4 +20,5 @@ ignore-words-list = [
     "inout",               # Rust inline-asm operand keyword
     "mmapped",             # Memory mapped
     "ser",                 # Serde package
+    "crasher"              # Internal tool for testing
 ]


### PR DESCRIPTION
`count(filter)` over-reports by N points after a window of concurrent snapshotting and COW writes (set_payload over a populated collection). 

The same N points appear live in two segments at once, the COW destination AND the COW source that the proxy was supposed to delete from.

## Cause

`ProxySegment::delete_point` recorded the delete into `self.deleted_points` and relied on a later `propagate_to_wrapped` to apply it to the wrapped segment's id_tracker. 

Two races leak deletes onto proxies that get dropped without that final propagate:

1. Snapshot teardown: an in-flight `apply_points` holds the proxy's Arc, lands delete_point after try_unproxy_segment's first propagate but before slot replacement. The proxy then gets removed via
  proxies.retain, taking the delete with it.
2. Optimization commit with snapshot overlap: swap_new removes the outer snapshot proxy's slot; the proxy stays alive on the snapshot's local vec but its deleted_points never reach the new merged segment.

##  Fix

 - `ProxySegment::delete_point`: eagerly apply to the wrapped segment's id_tracker in addition to recording in `deleted_points`. The delete is now durable regardless of proxy lifecycle. The later propagate_to_wrapped harmlessly returns Ok(false) (mapping is already gone).
- `propagate_to_wrapped` factored into propagate_to(target) so swap_new can drain into the new merged segment.
- `SegmentHolder::swap_new drains` the outer proxy's changed_indexes / changed_vector_names into the new merged segment before the slot is removed (eager forward only covers point deletes; index/vector-name changes still need this).

### Cascade fixes (same file)

Wrapped's id_tracker is now updated by every delete_point, so 7 accounting methods that previously added self.deleted_points.len() on top of the wrapped's count double-counted.

 Fixed:

  - available_point_count, available_point_count_without_deferred, deleted_point_count
  - deferred_point_count, deferred_point_ids
  - estimate_point_count
  - num_deleted_deferred_points in info()

### Removed now-dead deleted_deferred_count field.

num_vectors / num_indexed_vectors / available_vectors_size_in_bytes still discount per-point — those derive from vector_storage, which Segment::delete_point doesn't touch.