### PR TITLE
[UIO] Generic quantized storage

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -54,10 +54,11 @@ pub trait EncodedStorage {
 
 pub trait EncodedStorageBuilder {
     type Storage: EncodedStorage;
+    type Error: std::fmt::Display;
 
-    fn build(self) -> std::io::Result<Self::Storage>;
+    fn build(self) -> Result<Self::Storage, Self::Error>;
 
-    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()>;
+    fn push_vector_data(&mut self, other: &[u8]) -> Result<(), Self::Error>;
 }
 
 #[cfg(feature = "testing")]
@@ -197,6 +198,7 @@ impl TestEncodedStorageBuilder {
 #[cfg(feature = "testing")]
 impl EncodedStorageBuilder for TestEncodedStorageBuilder {
     type Storage = TestEncodedStorage;
+    type Error = std::io::Error;
 
     fn build(self) -> std::io::Result<Self::Storage> {
         if let Some(path) = &self.path {

--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -1,10 +1,10 @@
 mod quantized_chunked_mmap_storage;
 mod quantized_custom_query_scorer;
-mod quantized_mmap_storage;
 mod quantized_multi_custom_query_scorer;
 mod quantized_multi_query_scorer;
 pub mod quantized_multivector_storage;
 pub mod quantized_query_scorer;
 mod quantized_ram_storage;
 mod quantized_scorer_builder;
+mod quantized_storage;
 pub mod quantized_vectors;

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -124,6 +124,7 @@ impl QuantizedChunkedMmapStorageBuilder {
 
 impl quantization::EncodedStorageBuilder for QuantizedChunkedMmapStorageBuilder {
     type Storage = QuantizedChunkedMmapStorage;
+    type Error = std::io::Error;
 
     fn build(self) -> std::io::Result<QuantizedChunkedMmapStorage> {
         let Self {

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -8,19 +8,18 @@ use common::mmap::{MmapFlusher, advice};
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
 use fs_err as fs;
-
 use memmap2::MmapMut;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 
 #[derive(Debug)]
-pub struct QuantizedMmapStorage<S: UniversalRead = MmapFile> {
+pub struct QuantizedStorage<S: UniversalRead = MmapFile> {
     storage: ReadOnly<S>,
     quantized_vector_size: NonZeroUsize,
     path: PathBuf,
 }
 
-impl QuantizedMmapStorage {
+impl QuantizedStorage {
     pub fn populate(&self) {
         if let Err(err) = self.storage.populate() {
             log::warn!("Failed to populate quantized storage: {err}")
@@ -46,7 +45,7 @@ pub struct QuantizedMmapStorageBuilder {
     path: PathBuf,
 }
 
-impl<S: UniversalRead> QuantizedMmapStorage<S> {
+impl<S: UniversalRead> QuantizedStorage<S> {
     fn open_options() -> OpenOptions {
         OpenOptions {
             writeable: false,
@@ -61,7 +60,7 @@ impl<S: UniversalRead> QuantizedMmapStorage<S> {
     pub fn from_file(
         path: &Path,
         quantized_vector_size: usize,
-    ) -> OperationResult<QuantizedMmapStorage<S>> {
+    ) -> OperationResult<QuantizedStorage<S>> {
         let storage = ReadOnly::open(path, Self::open_options())?;
 
         let quantized_vector_size = NonZeroUsize::new(quantized_vector_size).ok_or_else(|| {
@@ -84,7 +83,7 @@ impl<S: UniversalRead> QuantizedMmapStorage<S> {
     }
 }
 
-impl quantization::EncodedStorage for QuantizedMmapStorage {
+impl quantization::EncodedStorage for QuantizedStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]> {
         let start = (self.quantized_vector_size.get() * index as usize) as u64;
         let length = self.quantized_vector_size.get() as u64;
@@ -141,15 +140,15 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
 }
 
 impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
-    type Storage = QuantizedMmapStorage;
+    type Storage = QuantizedStorage;
 
-    fn build(self) -> std::io::Result<QuantizedMmapStorage> {
+    fn build(self) -> std::io::Result<QuantizedStorage> {
         self.mmap.flush()?;
 
         let storage = ReadOnly::open(&self.path, Self::Storage::open_options())
             .expect("todo: switch to UniversalIoError");
 
-        Ok(QuantizedMmapStorage {
+        Ok(QuantizedStorage {
             storage,
             quantized_vector_size: self.quantized_vector_size,
             path: self.path,

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -39,7 +39,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     }
 }
 
-pub struct QuantizedMmapStorageBuilder<S> {
+pub struct QuantizedStorageBuilder<S> {
     mmap: MmapMut,
     cursor_pos: usize,
     quantized_vector_size: NonZeroUsize,
@@ -141,14 +141,14 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
     }
 }
 
-impl<S: UniversalRead> quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder<S> {
+impl<S: UniversalRead> quantization::EncodedStorageBuilder for QuantizedStorageBuilder<S> {
     type Storage = QuantizedStorage<S>;
+    type Error = OperationError;
 
-    fn build(self) -> std::io::Result<QuantizedStorage<S>> {
+    fn build(self) -> OperationResult<QuantizedStorage<S>> {
         self.mmap.flush()?;
 
-        let storage = ReadOnly::open(&self.path, Self::Storage::open_options())
-            .expect("todo: switch to UniversalIoError");
+        let storage = ReadOnly::open(&self.path, Self::Storage::open_options())?;
 
         Ok(QuantizedStorage {
             storage,
@@ -157,7 +157,7 @@ impl<S: UniversalRead> quantization::EncodedStorageBuilder for QuantizedMmapStor
         })
     }
 
-    fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
+    fn push_vector_data(&mut self, other: &[u8]) -> OperationResult<()> {
         debug_assert_eq!(
             self.quantized_vector_size.get(),
             other.len(),
@@ -176,7 +176,7 @@ impl<S: UniversalRead> quantization::EncodedStorageBuilder for QuantizedMmapStor
     }
 }
 
-impl<S> QuantizedMmapStorageBuilder<S> {
+impl<S> QuantizedStorageBuilder<S> {
     pub fn new(
         path: &Path,
         vectors_count: usize,

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
@@ -13,13 +14,13 @@ use memmap2::MmapMut;
 use crate::common::operation_error::{OperationError, OperationResult};
 
 #[derive(Debug)]
-pub struct QuantizedStorage<S: UniversalRead = MmapFile> {
+pub struct QuantizedStorage<S: UniversalRead> {
     storage: ReadOnly<S>,
     quantized_vector_size: NonZeroUsize,
     path: PathBuf,
 }
 
-impl QuantizedStorage {
+impl<S: UniversalRead> QuantizedStorage<S> {
     pub fn populate(&self) {
         if let Err(err) = self.storage.populate() {
             log::warn!("Failed to populate quantized storage: {err}")
@@ -38,11 +39,12 @@ impl QuantizedStorage {
     }
 }
 
-pub struct QuantizedMmapStorageBuilder {
+pub struct QuantizedMmapStorageBuilder<S> {
     mmap: MmapMut,
     cursor_pos: usize,
     quantized_vector_size: NonZeroUsize,
     path: PathBuf,
+    output_storage: PhantomData<S>,
 }
 
 impl<S: UniversalRead> QuantizedStorage<S> {
@@ -83,7 +85,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     }
 }
 
-impl quantization::EncodedStorage for QuantizedStorage {
+impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
     fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]> {
         let start = (self.quantized_vector_size.get() * index as usize) as u64;
         let length = self.quantized_vector_size.get() as u64;
@@ -139,10 +141,10 @@ impl quantization::EncodedStorage for QuantizedStorage {
     }
 }
 
-impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
-    type Storage = QuantizedStorage;
+impl<S: UniversalRead> quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder<S> {
+    type Storage = QuantizedStorage<S>;
 
-    fn build(self) -> std::io::Result<QuantizedStorage> {
+    fn build(self) -> std::io::Result<QuantizedStorage<S>> {
         self.mmap.flush()?;
 
         let storage = ReadOnly::open(&self.path, Self::Storage::open_options())
@@ -174,7 +176,7 @@ impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
     }
 }
 
-impl QuantizedMmapStorageBuilder {
+impl<S> QuantizedMmapStorageBuilder<S> {
     pub fn new(
         path: &Path,
         vectors_count: usize,
@@ -217,6 +219,7 @@ impl QuantizedMmapStorageBuilder {
                 )
             })?,
             path: path.to_path_buf(),
+            output_storage: PhantomData,
         })
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_mmap_storage.rs
@@ -3,31 +3,39 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::mmap::{Madviseable, MmapFlusher, advice};
+use common::generic_consts::Random;
+use common::mmap::{MmapFlusher, advice};
 use common::types::PointOffsetType;
+use common::universal_io::{MmapFile, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
 use fs_err as fs;
-use fs_err::OpenOptions;
-use memmap2::{Mmap, MmapMut};
+
+use memmap2::MmapMut;
+
+use crate::common::operation_error::{OperationError, OperationResult};
 
 #[derive(Debug)]
-pub struct QuantizedMmapStorage {
-    mmap: Mmap,
+pub struct QuantizedMmapStorage<S: UniversalRead = MmapFile> {
+    storage: ReadOnly<S>,
     quantized_vector_size: NonZeroUsize,
     path: PathBuf,
 }
 
 impl QuantizedMmapStorage {
     pub fn populate(&self) {
-        self.mmap.populate();
+        if let Err(err) = self.storage.populate() {
+            log::warn!("Failed to populate quantized storage: {err}")
+        };
     }
 
     pub fn clear_cache(&self) {
         let Self {
-            mmap,
+            storage: mmap,
             quantized_vector_size: _,
             path: _,
         } = self;
-        mmap.clear_cache();
+        if let Err(err) = mmap.clear_ram_cache() {
+            log::warn!("Failed to clear quantized storage RAM cache: {err}")
+        }
     }
 }
 
@@ -38,14 +46,23 @@ pub struct QuantizedMmapStorageBuilder {
     path: PathBuf,
 }
 
-impl QuantizedMmapStorage {
+impl<S: UniversalRead> QuantizedMmapStorage<S> {
+    fn open_options() -> OpenOptions {
+        OpenOptions {
+            writeable: false,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::No,
+            advice: None,
+            prevent_caching: None,
+        }
+    }
+
     pub fn from_file(
         path: &Path,
         quantized_vector_size: usize,
-    ) -> std::io::Result<QuantizedMmapStorage> {
-        let file = OpenOptions::new().read(true).open(path)?;
-        let mmap = unsafe { Mmap::map(&file)? };
-        advice::madvise(&mmap, advice::get_global())?;
+    ) -> OperationResult<QuantizedMmapStorage<S>> {
+        let storage = ReadOnly::open(path, Self::open_options())?;
 
         let quantized_vector_size = NonZeroUsize::new(quantized_vector_size).ok_or_else(|| {
             std::io::Error::new(
@@ -53,18 +70,14 @@ impl QuantizedMmapStorage {
                 "`quantized_vector_size` must be non-zero",
             )
         })?;
-        if !mmap.len().is_multiple_of(quantized_vector_size.get()) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "Encoded file size ({}) is not a multiple of quantized_vector_size ({})",
-                    mmap.len(),
-                    quantized_vector_size
-                ),
-            ));
+        let len = storage.len::<u8>()? as usize;
+        if !len.is_multiple_of(quantized_vector_size.get()) {
+            return Err(OperationError::inconsistent_storage(format!(
+                "Encoded file size ({len}) is not a multiple of quantized_vector_size ({quantized_vector_size})",
+            )));
         }
         Ok(Self {
-            mmap,
+            storage,
             quantized_vector_size,
             path: path.to_path_buf(),
         })
@@ -73,9 +86,14 @@ impl QuantizedMmapStorage {
 
 impl quantization::EncodedStorage for QuantizedMmapStorage {
     fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]> {
-        let start = self.quantized_vector_size.get() * index as usize;
-        let end = self.quantized_vector_size.get() * (index + 1) as usize;
-        Cow::Borrowed(self.mmap.get(start..end).unwrap_or(&[]))
+        let start = (self.quantized_vector_size.get() * index as usize) as u64;
+        let length = self.quantized_vector_size.get() as u64;
+        self.storage
+            .read::<Random, u8>(ReadRange {
+                byte_offset: start,
+                length,
+            })
+            .expect("vector exists")
     }
 
     fn upsert_vector(
@@ -95,7 +113,7 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
     }
 
     fn vectors_count(&self) -> usize {
-        self.mmap.len() / self.quantized_vector_size.get()
+        self.storage.len::<u8>().unwrap_or(0) as usize / self.quantized_vector_size.get()
     }
 
     fn flusher(&self) -> MmapFlusher {
@@ -113,7 +131,7 @@ impl quantization::EncodedStorage for QuantizedMmapStorage {
 
     fn heap_size_bytes(&self) -> usize {
         let Self {
-            mmap: _,
+            storage: _,
             quantized_vector_size: _,
             path: _,
         } = self;
@@ -127,9 +145,12 @@ impl quantization::EncodedStorageBuilder for QuantizedMmapStorageBuilder {
 
     fn build(self) -> std::io::Result<QuantizedMmapStorage> {
         self.mmap.flush()?;
-        let mmap = self.mmap.make_read_only()?;
+
+        let storage = ReadOnly::open(&self.path, Self::Storage::open_options())
+            .expect("todo: switch to UniversalIoError");
+
         Ok(QuantizedMmapStorage {
-            mmap,
+            storage,
             quantized_vector_size: self.quantized_vector_size,
             path: self.path,
         })
@@ -176,7 +197,7 @@ impl QuantizedMmapStorageBuilder {
             })
             .and_then(fs::create_dir_all)?;
 
-        let file = OpenOptions::new()
+        let file = fs_err::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -105,6 +105,7 @@ impl QuantizedRamStorageBuilder {
 
 impl quantization::EncodedStorageBuilder for QuantizedRamStorageBuilder {
     type Storage = QuantizedRamStorage;
+    type Error = std::io::Error;
 
     fn build(self) -> std::io::Result<QuantizedRamStorage> {
         if let Some(dir) = self.path.parent() {

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -7,7 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{MmapFlusher, advice};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
+use common::universal_io::{OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
 use fs_err as fs;
 use memmap2::MmapMut;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -35,7 +35,7 @@ use crate::vector_storage::quantized::quantized_chunked_mmap_storage::{
     QuantizedChunkedMmapStorage, QuantizedChunkedMmapStorageBuilder,
 };
 use crate::vector_storage::quantized::quantized_mmap_storage::{
-    QuantizedMmapStorage, QuantizedMmapStorageBuilder,
+    QuantizedMmapStorageBuilder, QuantizedStorage,
 };
 use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
@@ -93,10 +93,8 @@ type ScalarRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsU8<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type ScalarMmapMulti = QuantizedMultivectorStorage<
-    EncodedVectorsU8<QuantizedMmapStorage>,
-    MultivectorOffsetsStorageMmap,
->;
+type ScalarMmapMulti =
+    QuantizedMultivectorStorage<EncodedVectorsU8<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
 
 type ScalarChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsU8<QuantizedChunkedMmapStorage>,
@@ -107,10 +105,8 @@ type PQRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsPQ<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type PQMmapMulti = QuantizedMultivectorStorage<
-    EncodedVectorsPQ<QuantizedMmapStorage>,
-    MultivectorOffsetsStorageMmap,
->;
+type PQMmapMulti =
+    QuantizedMultivectorStorage<EncodedVectorsPQ<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
 
 type PQChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsPQ<QuantizedChunkedMmapStorage>,
@@ -122,7 +118,7 @@ type BinaryRamMulti = QuantizedMultivectorStorage<
     MultivectorOffsetsStorageRam,
 >;
 type BinaryMmapMulti = QuantizedMultivectorStorage<
-    EncodedVectorsBin<u8, QuantizedMmapStorage>,
+    EncodedVectorsBin<u8, QuantizedStorage>,
     MultivectorOffsetsStorageMmap,
 >;
 
@@ -135,10 +131,8 @@ type TQRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsTQ<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type TQMmapMulti = QuantizedMultivectorStorage<
-    EncodedVectorsTQ<QuantizedMmapStorage>,
-    MultivectorOffsetsStorageMmap,
->;
+type TQMmapMulti =
+    QuantizedMultivectorStorage<EncodedVectorsTQ<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
 
 type TQChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsTQ<QuantizedChunkedMmapStorage>,
@@ -147,16 +141,16 @@ type TQChunkedMmapMulti = QuantizedMultivectorStorage<
 
 pub enum QuantizedVectorStorage {
     ScalarRam(EncodedVectorsU8<QuantizedRamStorage>),
-    ScalarMmap(EncodedVectorsU8<QuantizedMmapStorage>),
+    ScalarMmap(EncodedVectorsU8<QuantizedStorage>),
     ScalarChunkedMmap(EncodedVectorsU8<QuantizedChunkedMmapStorage>),
     PQRam(EncodedVectorsPQ<QuantizedRamStorage>),
-    PQMmap(EncodedVectorsPQ<QuantizedMmapStorage>),
+    PQMmap(EncodedVectorsPQ<QuantizedStorage>),
     PQChunkedMmap(EncodedVectorsPQ<QuantizedChunkedMmapStorage>),
     BinaryRam(EncodedVectorsBin<u128, QuantizedRamStorage>),
-    BinaryMmap(EncodedVectorsBin<u128, QuantizedMmapStorage>),
+    BinaryMmap(EncodedVectorsBin<u128, QuantizedStorage>),
     BinaryChunkedMmap(EncodedVectorsBin<u128, QuantizedChunkedMmapStorage>),
     TQRam(EncodedVectorsTQ<QuantizedRamStorage>),
-    TQMmap(EncodedVectorsTQ<QuantizedMmapStorage>),
+    TQMmap(EncodedVectorsTQ<QuantizedStorage>),
     TQChunkedMmap(EncodedVectorsTQ<QuantizedChunkedMmapStorage>),
     ScalarRamMulti(ScalarRamMulti),
     ScalarMmapMulti(ScalarMmapMulti),
@@ -1103,7 +1097,7 @@ impl QuantizedVectors {
             let quantized_vector_size =
                 encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let quantized_vectors_storage =
-                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::ScalarMmap(EncodedVectorsU8::load(
                 quantized_vectors_storage,
                 &meta_path,
@@ -1147,7 +1141,7 @@ impl QuantizedVectors {
             let quantized_vector_size =
                 encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let inner_vectors_storage =
-                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
             let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
             Ok(QuantizedVectorStorage::ScalarMmapMulti(
@@ -1195,7 +1189,7 @@ impl QuantizedVectors {
                 bucket_size,
             );
             let quantized_vectors_storage =
-                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::PQMmap(EncodedVectorsPQ::load(
                 quantized_vectors_storage,
                 &meta_path,
@@ -1245,7 +1239,7 @@ impl QuantizedVectors {
                 bucket_size,
             );
             let inner_vectors_storage =
-                QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
             let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
             Ok(QuantizedVectorStorage::PQMmapMulti(
@@ -1306,7 +1300,7 @@ impl QuantizedVectors {
                         Self::convert_binary_encoding(binary_config.encoding),
                     );
                 let quantized_vectors_storage =
-                    QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                    QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::BinaryMmap(EncodedVectorsBin::load(
                     quantized_vectors_storage,
                     &meta_path,
@@ -1381,7 +1375,7 @@ impl QuantizedVectors {
                         Self::convert_binary_encoding(binary_config.encoding),
                     );
                 let inner_vectors_storage =
-                    QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                    QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
                     EncodedVectorsBin::load(inner_vectors_storage, &meta_path)?;
                 let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;
@@ -1447,7 +1441,7 @@ impl QuantizedVectors {
                     mode,
                 );
                 let quantized_vectors_storage =
-                    QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                    QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::TQMmap(EncodedVectorsTQ::load(
                     quantized_vectors_storage,
                     &meta_path,
@@ -1525,7 +1519,7 @@ impl QuantizedVectors {
                     mode,
                 );
                 let inner_vectors_storage =
-                    QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
+                    QuantizedStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
                     EncodedVectorsTQ::load(inner_vectors_storage, &meta_path)?;
                 let offsets = MultivectorOffsetsStorageMmap::load(&offsets_path)?;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -93,8 +93,10 @@ type ScalarRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsU8<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type ScalarMmapMulti =
-    QuantizedMultivectorStorage<EncodedVectorsU8<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
+type ScalarMmapMulti = QuantizedMultivectorStorage<
+    EncodedVectorsU8<QuantizedStorage<MmapFile>>,
+    MultivectorOffsetsStorageMmap,
+>;
 
 type ScalarChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsU8<QuantizedChunkedMmapStorage>,
@@ -105,8 +107,10 @@ type PQRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsPQ<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type PQMmapMulti =
-    QuantizedMultivectorStorage<EncodedVectorsPQ<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
+type PQMmapMulti = QuantizedMultivectorStorage<
+    EncodedVectorsPQ<QuantizedStorage<MmapFile>>,
+    MultivectorOffsetsStorageMmap,
+>;
 
 type PQChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsPQ<QuantizedChunkedMmapStorage>,
@@ -118,7 +122,7 @@ type BinaryRamMulti = QuantizedMultivectorStorage<
     MultivectorOffsetsStorageRam,
 >;
 type BinaryMmapMulti = QuantizedMultivectorStorage<
-    EncodedVectorsBin<u8, QuantizedStorage>,
+    EncodedVectorsBin<u8, QuantizedStorage<MmapFile>>,
     MultivectorOffsetsStorageMmap,
 >;
 
@@ -131,8 +135,10 @@ type TQRamMulti = QuantizedMultivectorStorage<
     EncodedVectorsTQ<QuantizedRamStorage>,
     MultivectorOffsetsStorageRam,
 >;
-type TQMmapMulti =
-    QuantizedMultivectorStorage<EncodedVectorsTQ<QuantizedStorage>, MultivectorOffsetsStorageMmap>;
+type TQMmapMulti = QuantizedMultivectorStorage<
+    EncodedVectorsTQ<QuantizedStorage<MmapFile>>,
+    MultivectorOffsetsStorageMmap,
+>;
 
 type TQChunkedMmapMulti = QuantizedMultivectorStorage<
     EncodedVectorsTQ<QuantizedChunkedMmapStorage>,
@@ -141,16 +147,16 @@ type TQChunkedMmapMulti = QuantizedMultivectorStorage<
 
 pub enum QuantizedVectorStorage {
     ScalarRam(EncodedVectorsU8<QuantizedRamStorage>),
-    ScalarMmap(EncodedVectorsU8<QuantizedStorage>),
+    ScalarMmap(EncodedVectorsU8<QuantizedStorage<MmapFile>>),
     ScalarChunkedMmap(EncodedVectorsU8<QuantizedChunkedMmapStorage>),
     PQRam(EncodedVectorsPQ<QuantizedRamStorage>),
-    PQMmap(EncodedVectorsPQ<QuantizedStorage>),
+    PQMmap(EncodedVectorsPQ<QuantizedStorage<MmapFile>>),
     PQChunkedMmap(EncodedVectorsPQ<QuantizedChunkedMmapStorage>),
     BinaryRam(EncodedVectorsBin<u128, QuantizedRamStorage>),
-    BinaryMmap(EncodedVectorsBin<u128, QuantizedStorage>),
+    BinaryMmap(EncodedVectorsBin<u128, QuantizedStorage<MmapFile>>),
     BinaryChunkedMmap(EncodedVectorsBin<u128, QuantizedChunkedMmapStorage>),
     TQRam(EncodedVectorsTQ<QuantizedRamStorage>),
-    TQMmap(EncodedVectorsTQ<QuantizedStorage>),
+    TQMmap(EncodedVectorsTQ<QuantizedStorage<MmapFile>>),
     TQChunkedMmap(EncodedVectorsTQ<QuantizedChunkedMmapStorage>),
     ScalarRamMulti(ScalarRamMulti),
     ScalarMmapMulti(ScalarMmapMulti),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -35,7 +35,7 @@ use crate::vector_storage::quantized::quantized_chunked_mmap_storage::{
     QuantizedChunkedMmapStorage, QuantizedChunkedMmapStorageBuilder,
 };
 use crate::vector_storage::quantized::quantized_mmap_storage::{
-    QuantizedMmapStorageBuilder, QuantizedStorage,
+    QuantizedStorageBuilder, QuantizedStorage,
 };
 use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
@@ -1581,7 +1581,7 @@ impl QuantizedVectors {
                 stopped,
             )?))
         } else {
-            let storage_builder = QuantizedMmapStorageBuilder::new(
+            let storage_builder = QuantizedStorageBuilder::new(
                 data_path.as_path(),
                 vectors_count,
                 quantized_vector_size,
@@ -1654,7 +1654,7 @@ impl QuantizedVectors {
                 ),
             ))
         } else {
-            let storage_builder = QuantizedMmapStorageBuilder::new(
+            let storage_builder = QuantizedStorageBuilder::new(
                 data_path.as_path(),
                 inner_vectors_count,
                 quantized_vector_size,
@@ -1723,7 +1723,7 @@ impl QuantizedVectors {
                 stopped,
             )?))
         } else {
-            let storage_builder = QuantizedMmapStorageBuilder::new(
+            let storage_builder = QuantizedStorageBuilder::new(
                 data_path.as_path(),
                 vectors_count,
                 quantized_vector_size,
@@ -1795,7 +1795,7 @@ impl QuantizedVectors {
                 ),
             ))
         } else {
-            let storage_builder = QuantizedMmapStorageBuilder::new(
+            let storage_builder = QuantizedStorageBuilder::new(
                 data_path.as_path(),
                 inner_vectors_count,
                 quantized_vector_size,
@@ -1881,7 +1881,7 @@ impl QuantizedVectors {
                 ))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let storage_builder = QuantizedMmapStorageBuilder::new(
+                let storage_builder = QuantizedStorageBuilder::new(
                     data_path.as_path(),
                     vectors_count,
                     quantized_vector_size,
@@ -1978,7 +1978,7 @@ impl QuantizedVectors {
                 ))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let storage_builder = QuantizedMmapStorageBuilder::new(
+                let storage_builder = QuantizedStorageBuilder::new(
                     data_path.as_path(),
                     inner_vectors_count,
                     quantized_vector_size,
@@ -2066,7 +2066,7 @@ impl QuantizedVectors {
                 )?))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let storage_builder = QuantizedMmapStorageBuilder::new(
+                let storage_builder = QuantizedStorageBuilder::new(
                     data_path.as_path(),
                     vectors_count,
                     quantized_vector_size,
@@ -2167,7 +2167,7 @@ impl QuantizedVectors {
                 ))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let storage_builder = QuantizedMmapStorageBuilder::new(
+                let storage_builder = QuantizedStorageBuilder::new(
                     data_path.as_path(),
                     inner_vectors_count,
                     quantized_vector_size,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -9,6 +9,7 @@ use common::fs::{atomic_save_json, read_json};
 use common::generic_consts::{Random, Sequential};
 use common::low_memory::low_memory_mode;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use quantization::encoded_vectors_binary::{self, EncodedVectorsBin};
 use quantization::encoded_vectors_u8::{self, ScalarQuantizationMethod};
 use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
@@ -34,9 +35,6 @@ use crate::types::{
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::{
     QuantizedChunkedMmapStorage, QuantizedChunkedMmapStorageBuilder,
 };
-use crate::vector_storage::quantized::quantized_mmap_storage::{
-    QuantizedStorageBuilder, QuantizedStorage,
-};
 use crate::vector_storage::quantized::quantized_multi_query_scorer::QuantizedMultiQueryScorer;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
     MultivectorOffsetsStorageChunkedMmap, MultivectorOffsetsStorageRam,
@@ -46,6 +44,9 @@ use crate::vector_storage::quantized::quantized_query_scorer::{
 };
 use crate::vector_storage::quantized::quantized_ram_storage::{
     QuantizedRamStorage, QuantizedRamStorageBuilder,
+};
+use crate::vector_storage::quantized::quantized_storage::{
+    QuantizedStorage, QuantizedStorageBuilder,
 };
 use crate::vector_storage::{
     DenseVectorStorage, MultiVectorStorage, RawScorer, RawScorerImpl, VectorStorageEnum,


### PR DESCRIPTION
Builds on top of #9060 

Changes `QuantizedMmapStorage` into `QuantizedStorage<S>`, where `S` is the generic backend.

It still builds the storage using mmap, but reading it is generic.