### PR TITLE
refactor: make `get_quantized_vector_size` methods static

### DIFF
--- a/lib/quantization/benches/binary.rs
+++ b/lib/quantization/benches/binary.rs
@@ -4,10 +4,10 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
 use permutation_iterator::Permutor;
-use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 use quantization::encoded_vectors_binary::{
-    EncodedQueryBQ, EncodedVectorsBin, Encoding, QueryEncoding,
+    self, EncodedQueryBQ, EncodedVectorsBin, Encoding, QueryEncoding,
 };
 use rand::{RngExt, SeedableRng};
 
@@ -34,11 +34,10 @@ fn binary_bench(c: &mut Criterion) {
         vectors.push(vector);
     }
 
-    let quantized_vector_size =
-        EncodedVectorsBin::<u128, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+    let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+        vector_dim,
+        Encoding::OneBit,
+    );
     let encoded_u128 = EncodedVectorsBin::<u128, _>::encode(
         vectors.iter(),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -81,11 +80,10 @@ fn binary_bench(c: &mut Criterion) {
         });
     });
 
-    let quantized_vector_size =
-        EncodedVectorsBin::<u8, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+    let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
+        vector_dim,
+        Encoding::OneBit,
+    );
     let encoded_u8 = EncodedVectorsBin::<u8, _>::encode(
         vectors.iter(),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -141,11 +139,10 @@ fn binary_scalar_query_bench_impl(c: &mut Criterion) {
         vectors.push(vector);
     }
 
-    let quantized_vector_size =
-        EncodedVectorsBin::<u128, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+    let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+        vector_dim,
+        Encoding::OneBit,
+    );
     let encoded_u128 = EncodedVectorsBin::<u128, _>::encode(
         vectors.iter(),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -204,11 +201,10 @@ fn binary_scalar_query_bench_impl(c: &mut Criterion) {
         });
     });
 
-    let quantized_vector_size =
-        EncodedVectorsBin::<u8, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+    let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
+        vector_dim,
+        Encoding::OneBit,
+    );
     let encoded_u8 = EncodedVectorsBin::<u8, _>::encode(
         vectors.iter(),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -2,9 +2,9 @@ use std::sync::atomic::AtomicBool;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use permutation_iterator::Permutor;
-use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
 use rand::RngExt;
 
 fn encode_dot_bench(c: &mut Criterion) {
@@ -25,8 +25,7 @@ fn encode_dot_bench(c: &mut Criterion) {
         distance_type: DistanceType::Dot,
         invert: false,
     };
-    let quantized_vector_size =
-        EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+    let quantized_vector_size = encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
     let i8_encoded = EncodedVectorsU8::encode(
         (0..vectors_count).map(|i| &list[i * vector_dim..(i + 1) * vector_dim]),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -130,8 +129,7 @@ fn encode_l1_bench(c: &mut Criterion) {
         distance_type: DistanceType::L1,
         invert: true,
     };
-    let quantized_vector_size =
-        EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+    let quantized_vector_size = encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
     let i8_encoded = EncodedVectorsU8::encode(
         (0..vectors_count).map(|i| &list[i * vector_dim..(i + 1) * vector_dim]),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/benches/pq.rs
+++ b/lib/quantization/benches/pq.rs
@@ -2,9 +2,9 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
-use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-use quantization::encoded_vectors_pq::EncodedVectorsPQ;
+use quantization::encoded_vectors_pq::{self, EncodedVectorsPQ};
 use rand::RngExt;
 
 fn encode_bench(c: &mut Criterion) {
@@ -26,7 +26,7 @@ fn encode_bench(c: &mut Criterion) {
         invert: false,
     };
     let quantized_vector_size =
-        EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters, 2);
+        encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 2);
     let pq_encoded = EncodedVectorsPQ::encode(
         (0..vectors_count).map(|i| &list[i * vector_dim..(i + 1) * vector_dim]),
         TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -523,7 +523,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         encoding: Encoding,
     ) -> EncodedBinVector<TBitsStoreType> {
         let encoded_vector_size =
-            Self::get_quantized_vector_size_from_params(vector.len(), encoding)
+            get_quantized_vector_size_from_params::<TBitsStoreType>(vector.len(), encoding)
                 / std::mem::size_of::<TBitsStoreType>();
         let mut encoded_vector = vec![Default::default(); encoded_vector_size];
 
@@ -741,18 +741,8 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         }
     }
 
-    pub fn get_quantized_vector_size_from_params(dim: usize, encoding: Encoding) -> usize {
-        let extended_dim = match encoding {
-            Encoding::OneBit => dim,
-            Encoding::TwoBits => dim * 2,
-            Encoding::OneAndHalfBits => (dim * 3).div_ceil(2), // ceil(dim * 1.5)
-        };
-        TBitsStoreType::get_storage_size(extended_dim.max(1))
-            * std::mem::size_of::<TBitsStoreType>()
-    }
-
     fn get_quantized_vector_size(&self) -> usize {
-        Self::get_quantized_vector_size_from_params(
+        get_quantized_vector_size_from_params::<TBitsStoreType>(
             self.metadata.vector_parameters.dim,
             self.metadata.encoding,
         )
@@ -819,6 +809,18 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
     pub fn get_vector_parameters(&self) -> &VectorParameters {
         &self.metadata.vector_parameters
     }
+}
+
+pub fn get_quantized_vector_size_from_params<TBitsStoreType: BitsStoreType>(
+    dim: usize,
+    encoding: Encoding,
+) -> usize {
+    let extended_dim = match encoding {
+        Encoding::OneBit => dim,
+        Encoding::TwoBits => dim * 2,
+        Encoding::OneAndHalfBits => (dim * 3).div_ceil(2), // ceil(dim * 1.5)
+    };
+    TBitsStoreType::get_storage_size(extended_dim.max(1)) * std::mem::size_of::<TBitsStoreType>()
 }
 
 impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> EncodedVectors

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -151,13 +151,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         Ok(result)
     }
 
-    pub fn get_quantized_vector_size(
-        vector_parameters: &VectorParameters,
-        chunk_size: usize,
-    ) -> usize {
-        (0..vector_parameters.dim).step_by(chunk_size).count()
-    }
-
     fn get_vector_division(dim: usize, chunk_size: usize) -> Vec<Range<usize>> {
         (0..dim)
             .step_by(chunk_size)
@@ -697,4 +690,8 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsPQ<TStorage> {
 
         self.score_point_simple(query, bytes)
     }
+}
+
+pub fn get_quantized_vector_size(vector_parameters: &VectorParameters, chunk_size: usize) -> usize {
+    (0..vector_parameters.dim).step_by(chunk_size).count()
 }

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -148,7 +148,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         stopped: &AtomicBool,
     ) -> Result<Self, EncodingError> {
         assert_eq!(method, ScalarQuantizationMethod::Int8);
-        let actual_dim = Self::get_actual_dim(vector_parameters);
+        let actual_dim = get_actual_dim(vector_parameters);
 
         if count == 0 {
             let metadata = Metadata::Int8(MetadataInt8 {
@@ -529,11 +529,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         (offset, code)
     }
 
-    pub fn get_quantized_vector_size(vector_parameters: &VectorParameters) -> usize {
-        let actual_dim = Self::get_actual_dim(vector_parameters);
-        actual_dim + ADDITIONAL_CONSTANT_SIZE
-    }
-
     pub fn get_multiplier(&self) -> f32 {
         match &self.metadata {
             Metadata::Int8(meta) => meta.multiplier,
@@ -544,10 +539,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         match &self.metadata {
             Metadata::Int8(metadata) => metadata.get_shift(),
         }
-    }
-
-    pub fn get_actual_dim(vector_parameters: &VectorParameters) -> usize {
-        vector_parameters.dim + (ALIGNMENT - vector_parameters.dim % ALIGNMENT) % ALIGNMENT
     }
 
     fn encode_int8_query(metadata: &MetadataInt8, query: &[f32]) -> EncodedQueryU8 {
@@ -587,6 +578,15 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
             encoded_query: query,
         }
     }
+}
+
+pub fn get_actual_dim(vector_parameters: &VectorParameters) -> usize {
+    vector_parameters.dim + (ALIGNMENT - vector_parameters.dim % ALIGNMENT) % ALIGNMENT
+}
+
+pub fn get_quantized_vector_size(vector_parameters: &VectorParameters) -> usize {
+    let actual_dim = get_actual_dim(vector_parameters);
+    actual_dim + ADDITIONAL_CONSTANT_SIZE
 }
 
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -375,20 +375,6 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         Ok(result)
     }
 
-    // Get quantized vector size in bytes
-    pub fn get_quantized_vector_size(
-        vector_parameters: &VectorParameters,
-        bits: TQBits,
-        mode: TQMode,
-    ) -> usize {
-        TurboQuantizer::quantized_size_for(
-            vector_parameters.dim,
-            bits,
-            vector_parameters.distance_type,
-            mode,
-        )
-    }
-
     fn encode_vector(
         vector_data: &[f32],
         turbo_quantizer: &TurboQuantizer,
@@ -408,6 +394,20 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
     pub fn get_metadata(&self) -> &Metadata {
         &self.metadata
     }
+}
+
+/// Get quantized vector size in bytes
+pub fn get_quantized_vector_size(
+    vector_parameters: &VectorParameters,
+    bits: TQBits,
+    mode: TQMode,
+) -> usize {
+    TurboQuantizer::quantized_size_for(
+        vector_parameters.dim,
+        bits,
+        vector_parameters.distance_type,
+        mode,
+    )
 }
 
 impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
@@ -468,7 +468,7 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
     }
 
     fn quantized_vector_size(&self) -> usize {
-        Self::get_quantized_vector_size(
+        get_quantized_vector_size(
             &self.metadata.vector_parameters,
             self.metadata.bits,
             self.metadata.mode,

--- a/lib/quantization/tests/integration/empty_storage.rs
+++ b/lib/quantization/tests/integration/empty_storage.rs
@@ -2,11 +2,13 @@
 mod tests {
     use std::sync::atomic::AtomicBool;
 
-    use quantization::EncodedVectorsPQ;
     use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
     use quantization::encoded_vectors::{DistanceType, VectorParameters};
     use quantization::encoded_vectors_binary::{EncodedVectorsBin, QueryEncoding};
     use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+    use quantization::{
+        EncodedVectorsPQ, encoded_vectors_binary, encoded_vectors_pq, encoded_vectors_u8,
+    };
     use tempfile::Builder;
 
     #[test]
@@ -26,7 +28,7 @@ mod tests {
         let data_path = dir.path().join("data.bin");
         let meta_path = dir.path().join("meta.json");
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let _encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(Some(data_path.as_path()), quantized_vector_size),
@@ -63,10 +65,7 @@ mod tests {
         let data_path = dir.path().join("data.bin");
         let meta_path = dir.path().join("meta.json");
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                2,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 2);
         let _encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(Some(data_path.as_path()), quantized_vector_size),
@@ -102,7 +101,7 @@ mod tests {
         let data_path = dir.path().join("data.bin");
         let meta_path = dir.path().join("meta.json");
         let quantized_vector_size =
-            EncodedVectorsBin::<u8, TestEncodedStorage>::get_quantized_vector_size_from_params(
+            encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
                 vector_dim,
                 quantization::encoded_vectors_binary::Encoding::OneBit,
             );

--- a/lib/quantization/tests/integration/stop_condition.rs
+++ b/lib/quantization/tests/integration/stop_condition.rs
@@ -3,10 +3,10 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, VectorParameters};
-    use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
-    use quantization::{EncodedVectorsPQ, EncodingError};
+    use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
+    use quantization::{EncodedVectorsPQ, EncodingError, encoded_vectors_pq};
 
     #[test]
     fn stop_condition_u8() {
@@ -30,7 +30,7 @@ mod tests {
         let zero_vector = vec![0.0; vector_dim];
 
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         assert_eq!(
             EncodedVectorsU8::encode(
                 (0..vectors_count).map(|_| &zero_vector),
@@ -71,10 +71,7 @@ mod tests {
         let zero_vector = vec![0.0; vector_dim];
 
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                2,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 2);
         assert_eq!(
             EncodedVectorsPQ::encode(
                 (0..vectors_count).map(|_| &zero_vector),

--- a/lib/quantization/tests/integration/test_avx2.rs
+++ b/lib/quantization/tests/integration/test_avx2.rs
@@ -3,9 +3,9 @@
 mod tests {
     use std::sync::atomic::AtomicBool;
 
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+    use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
     use rand::{RngExt, SeedableRng};
     use rstest::rstest;
 
@@ -33,7 +33,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -77,7 +77,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -125,7 +125,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/tests/integration/test_binary.rs
+++ b/lib/quantization/tests/integration/test_binary.rs
@@ -3,10 +3,10 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
     use quantization::encoded_vectors_binary::{
-        BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
+        self, BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
     };
     use rand::{RngExt, SeedableRng};
 
@@ -43,10 +43,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -96,10 +95,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -149,10 +147,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -199,10 +196,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -248,10 +244,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -316,10 +311,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -384,10 +378,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -449,10 +442,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -514,10 +506,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -582,10 +573,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -650,10 +640,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -715,10 +704,9 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let quantized_vector_size = EncodedVectorsBin::<TBitsStoreType, TestEncodedStorage>::get_quantized_vector_size_from_params(
-            vector_dim,
-            Encoding::OneBit,
-        );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            TBitsStoreType,
+        >(vector_dim, Encoding::OneBit);
         let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/tests/integration/test_binary_encodings.rs
+++ b/lib/quantization/tests/integration/test_binary_encodings.rs
@@ -3,10 +3,10 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
     use quantization::encoded_vectors_binary::{
-        BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
+        self, BitsStoreType, EncodedVectorsBin, Encoding, QueryEncoding,
     };
     use rand::{RngExt, SeedableRng};
     use strum::IntoEnumIterator;
@@ -68,11 +68,9 @@ mod tests {
         let encoded: Vec<_> = encodings
             .iter()
             .map(|&encoding| {
-                let quantized_vector_size = EncodedVectorsBin::<
-                        TBitsStoreType,
-                        TestEncodedStorage,
-                    >::get_quantized_vector_size_from_params(
-                        vector_dim, encoding
+                let quantized_vector_size =
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<TBitsStoreType>(
+                        vector_dim, encoding,
                     );
 
                 EncodedVectorsBin::<TBitsStoreType, _>::encode(
@@ -172,11 +170,9 @@ mod tests {
 
         let encoded: Vec<_> = QueryEncoding::iter()
             .map(|query_encoding| {
-                let quantized_vector_size = EncodedVectorsBin::<
-                        TBitsStoreType,
-                        TestEncodedStorage,
-                    >::get_quantized_vector_size_from_params(
-                        vector_dim, encoding
+                let quantized_vector_size =
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<TBitsStoreType>(
+                        vector_dim, encoding,
                     );
 
                 EncodedVectorsBin::<TBitsStoreType, _>::encode(

--- a/lib/quantization/tests/integration/test_neon.rs
+++ b/lib/quantization/tests/integration/test_neon.rs
@@ -3,9 +3,9 @@
 mod tests {
     use std::sync::atomic::AtomicBool;
 
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+    use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
     use rand::{RngExt, SeedableRng};
     use rstest::rstest;
 
@@ -33,7 +33,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -77,7 +77,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -121,7 +121,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/tests/integration/test_pq.rs
+++ b/lib/quantization/tests/integration/test_pq.rs
@@ -4,9 +4,9 @@ mod tests {
     use std::time::Duration;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_pq::EncodedVectorsPQ;
+    use quantization::encoded_vectors_pq::{self, EncodedVectorsPQ};
     use rand::{RngExt, SeedableRng};
 
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
@@ -31,10 +31,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -72,10 +69,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -113,10 +107,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -154,10 +145,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -195,10 +183,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -236,10 +221,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -276,10 +258,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -315,10 +294,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                &vector_parameters,
-                1,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
         let encoded = EncodedVectorsPQ::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -365,10 +341,7 @@ mod tests {
                 invert: false,
             };
             let quantized_vector_size =
-                EncodedVectorsPQ::<TestEncodedStorage>::get_quantized_vector_size(
-                    &vector_parameters,
-                    1,
-                );
+                encoded_vectors_pq::get_quantized_vector_size(&vector_parameters, 1);
 
             let result = std::thread::spawn(move || {
                 EncodedVectorsPQ::encode(

--- a/lib/quantization/tests/integration/test_simple.rs
+++ b/lib/quantization/tests/integration/test_simple.rs
@@ -3,8 +3,9 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
+    use quantization::encoded_vectors_u8;
     use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
     use rand::{RngExt, SeedableRng};
     use rstest::rstest;
@@ -33,7 +34,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -77,7 +78,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -125,7 +126,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -169,7 +170,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -213,7 +214,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -261,7 +262,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -304,7 +305,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -346,7 +347,7 @@ mod tests {
             invert: true,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -389,7 +390,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -436,9 +437,7 @@ mod tests {
                 invert,
             };
             let quantized_vector_size =
-                EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(
-                    &vector_parameters,
-                );
+                encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
 
             let encoded = EncodedVectorsU8::encode(
                 vector_data.iter(),

--- a/lib/quantization/tests/integration/test_sse.rs
+++ b/lib/quantization/tests/integration/test_sse.rs
@@ -3,9 +3,9 @@
 mod tests {
     use std::sync::atomic::AtomicBool;
 
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+    use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
     use rand::{RngExt, SeedableRng};
     use rstest::rstest;
 
@@ -33,7 +33,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -77,7 +77,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -121,7 +121,7 @@ mod tests {
             invert: false,
         };
         let quantized_vector_size =
-            EncodedVectorsU8::<TestEncodedStorage>::get_quantized_vector_size(&vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
         let encoded = EncodedVectorsU8::encode(
             vector_data.iter(),
             TestEncodedStorageBuilder::new(None, quantized_vector_size),

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -3,9 +3,9 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::{TestEncodedStorage, TestEncodedStorageBuilder};
+    use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::turboquant::{EncodedVectorsTQ, TQBits, TQMode};
+    use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
     use rand::{RngExt, SeedableRng};
 
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
@@ -124,11 +124,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -182,11 +178,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -237,11 +229,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -292,11 +280,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -352,11 +336,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -407,11 +387,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -471,11 +447,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -528,11 +500,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -582,11 +550,7 @@ mod tests {
                 invert: false,
             };
             let quantized_vector_size =
-                EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                    &vector_parameters,
-                    bits,
-                    mode,
-                );
+                encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
             let encoded = EncodedVectorsTQ::encode(
                 vector_data.iter(),
                 TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -640,11 +604,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -695,11 +655,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -750,11 +706,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -805,11 +757,7 @@ mod tests {
                     invert: false,
                 };
                 let quantized_vector_size =
-                    EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(
-                        &vector_parameters,
-                        bits,
-                        mode,
-                    );
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
                 let encoded = EncodedVectorsTQ::encode(
                     vector_data.iter(),
                     TestEncodedStorageBuilder::new(None, quantized_vector_size),
@@ -875,8 +823,7 @@ mod tests {
                 invert: false,
                 deprecated_count: None,
             };
-            let qsize =
-                EncodedVectorsTQ::<TestEncodedStorage>::get_quantized_vector_size(&vp, bits, mode);
+            let qsize = encoded_vectors_tq::get_quantized_vector_size(&vp, bits, mode);
             let encoded = EncodedVectorsTQ::encode(
                 vectors.iter(),
                 TestEncodedStorageBuilder::new(None, qsize),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -9,10 +9,10 @@ use common::fs::{atomic_save_json, read_json};
 use common::generic_consts::{Random, Sequential};
 use common::low_memory::low_memory_mode;
 use common::types::PointOffsetType;
-use quantization::encoded_vectors_binary::EncodedVectorsBin;
-use quantization::encoded_vectors_u8::ScalarQuantizationMethod;
-use quantization::turboquant::{EncodedVectorsTQ, TQBits, TQMode};
-use quantization::{EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8};
+use quantization::encoded_vectors_binary::{self, EncodedVectorsBin};
+use quantization::encoded_vectors_u8::{self, ScalarQuantizationMethod};
+use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
+use quantization::{EncodedVectors, EncodedVectorsPQ, EncodedVectorsU8, encoded_vectors_pq};
 use serde::{Deserialize, Serialize};
 
 use super::quantized_multivector_storage::{
@@ -1119,9 +1119,7 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         if Self::is_ram(scalar_config.always_ram, on_disk_vector_storage) {
             let quantized_vector_size =
-                EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                );
+                encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let quantized_vectors_storage =
                 QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::ScalarRam(EncodedVectorsU8::load(
@@ -1130,9 +1128,7 @@ impl QuantizedVectors {
             )?))
         } else {
             let quantized_vector_size =
-                EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                );
+                encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let quantized_vectors_storage =
                 QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::ScalarMmap(EncodedVectorsU8::load(
@@ -1161,9 +1157,7 @@ impl QuantizedVectors {
         let offsets_path = Self::get_offsets_path(path, config.storage_type);
         if Self::is_ram(scalar_config.always_ram, on_disk_vector_storage) {
             let quantized_vector_size =
-                EncodedVectorsU8::<QuantizedRamStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                );
+                encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let inner_vectors_storage =
                 QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
@@ -1178,9 +1172,7 @@ impl QuantizedVectors {
             ))
         } else {
             let quantized_vector_size =
-                EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                );
+                encoded_vectors_u8::get_quantized_vector_size(&config.vector_parameters);
             let inner_vectors_storage =
                 QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsU8::load(inner_vectors_storage, &meta_path)?;
@@ -1213,11 +1205,10 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         if Self::is_ram(pq_config.always_ram, on_disk_vector_storage) {
             let bucket_size = Self::get_bucket_size(pq_config.compression);
-            let quantized_vector_size =
-                EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                    bucket_size,
-                );
+            let quantized_vector_size = encoded_vectors_pq::get_quantized_vector_size(
+                &config.vector_parameters,
+                bucket_size,
+            );
             let quantized_vectors_storage =
                 QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::PQRam(EncodedVectorsPQ::load(
@@ -1226,11 +1217,10 @@ impl QuantizedVectors {
             )?))
         } else {
             let bucket_size = Self::get_bucket_size(pq_config.compression);
-            let quantized_vector_size =
-                EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                    bucket_size,
-                );
+            let quantized_vector_size = encoded_vectors_pq::get_quantized_vector_size(
+                &config.vector_parameters,
+                bucket_size,
+            );
             let quantized_vectors_storage =
                 QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             Ok(QuantizedVectorStorage::PQMmap(EncodedVectorsPQ::load(
@@ -1259,11 +1249,10 @@ impl QuantizedVectors {
         let offsets_path = Self::get_offsets_path(path, config.storage_type);
         if Self::is_ram(pq_config.always_ram, on_disk_vector_storage) {
             let bucket_size = Self::get_bucket_size(pq_config.compression);
-            let quantized_vector_size =
-                EncodedVectorsPQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                    bucket_size,
-                );
+            let quantized_vector_size = encoded_vectors_pq::get_quantized_vector_size(
+                &config.vector_parameters,
+                bucket_size,
+            );
             let inner_vectors_storage =
                 QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
@@ -1278,11 +1267,10 @@ impl QuantizedVectors {
             ))
         } else {
             let bucket_size = Self::get_bucket_size(pq_config.compression);
-            let quantized_vector_size =
-                EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                    &config.vector_parameters,
-                    bucket_size,
-                );
+            let quantized_vector_size = encoded_vectors_pq::get_quantized_vector_size(
+                &config.vector_parameters,
+                bucket_size,
+            );
             let inner_vectors_storage =
                 QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
             let inner_vectors_storage = EncodedVectorsPQ::load(inner_vectors_storage, &meta_path)?;
@@ -1312,10 +1300,10 @@ impl QuantizedVectors {
         match (in_ram, config.storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u128, QuantizedChunkedMmapStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let quantization_storage = QuantizedChunkedMmapStorage::new(
                     data_path.as_path(),
                     quantized_vector_size,
@@ -1327,10 +1315,10 @@ impl QuantizedVectors {
             }
             (true, QuantizedVectorsStorageType::Immutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u128, QuantizedRamStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let quantized_vectors_storage =
                     QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::BinaryRam(EncodedVectorsBin::load(
@@ -1340,10 +1328,10 @@ impl QuantizedVectors {
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u128, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let quantized_vectors_storage =
                     QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::BinaryMmap(EncodedVectorsBin::load(
@@ -1370,10 +1358,10 @@ impl QuantizedVectors {
         match (in_ram, config.storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u8, QuantizedChunkedMmapStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let quantization_storage = QuantizedChunkedMmapStorage::new(
                     data_path.as_path(),
                     quantized_vector_size,
@@ -1395,10 +1383,10 @@ impl QuantizedVectors {
             }
             (true, QuantizedVectorsStorageType::Immutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u8, QuantizedRamStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let inner_vectors_storage =
                     QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
@@ -1415,10 +1403,10 @@ impl QuantizedVectors {
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
                 let quantized_vector_size =
-                EncodedVectorsBin::<u8, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                    config.vector_parameters.dim,
-                    Self::convert_binary_encoding(binary_config.encoding),
-                );
+                    encoded_vectors_binary::get_quantized_vector_size_from_params::<u8>(
+                        config.vector_parameters.dim,
+                        Self::convert_binary_encoding(binary_config.encoding),
+                    );
                 let inner_vectors_storage =
                     QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
@@ -1452,12 +1440,11 @@ impl QuantizedVectors {
 
         match (in_ram, config.storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedChunkedMmapStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let quantization_storage = QuantizedChunkedMmapStorage::new(
                     data_path.as_path(),
                     quantized_vector_size,
@@ -1468,12 +1455,11 @@ impl QuantizedVectors {
                 ))
             }
             (true, QuantizedVectorsStorageType::Immutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let quantized_vectors_storage =
                     QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::TQRam(EncodedVectorsTQ::load(
@@ -1482,12 +1468,11 @@ impl QuantizedVectors {
                 )?))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let quantized_vectors_storage =
                     QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 Ok(QuantizedVectorStorage::TQMmap(EncodedVectorsTQ::load(
@@ -1516,12 +1501,11 @@ impl QuantizedVectors {
 
         match (in_ram, config.storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedChunkedMmapStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let quantization_storage = QuantizedChunkedMmapStorage::new(
                     data_path.as_path(),
                     quantized_vector_size,
@@ -1542,12 +1526,11 @@ impl QuantizedVectors {
                 ))
             }
             (true, QuantizedVectorsStorageType::Immutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedRamStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let inner_vectors_storage =
                     QuantizedRamStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
@@ -1563,12 +1546,11 @@ impl QuantizedVectors {
                 ))
             }
             (false, QuantizedVectorsStorageType::Immutable) => {
-                let quantized_vector_size =
-                    EncodedVectorsTQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                        &config.vector_parameters,
-                        bits,
-                        mode,
-                    );
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &config.vector_parameters,
+                    bits,
+                    mode,
+                );
                 let inner_vectors_storage =
                     QuantizedMmapStorage::from_file(data_path.as_path(), quantized_vector_size)?;
                 let inner_vectors_storage =
@@ -1605,7 +1587,7 @@ impl QuantizedVectors {
 
         let encoding = Self::convert_scalar_encoding(scalar_config.r#type);
         let quantized_vector_size =
-            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(vector_parameters);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
@@ -1668,7 +1650,7 @@ impl QuantizedVectors {
 
         let encoding = Self::convert_scalar_encoding(scalar_config.r#type);
         let quantized_vector_size =
-            EncodedVectorsU8::<QuantizedMmapStorage>::get_quantized_vector_size(vector_parameters);
+            encoded_vectors_u8::get_quantized_vector_size(vector_parameters);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
@@ -1747,10 +1729,7 @@ impl QuantizedVectors {
 
         let bucket_size = Self::get_bucket_size(pq_config.compression);
         let quantized_vector_size =
-            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                vector_parameters,
-                bucket_size,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(vector_parameters, bucket_size);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
@@ -1812,10 +1791,7 @@ impl QuantizedVectors {
 
         let bucket_size = Self::get_bucket_size(pq_config.compression);
         let quantized_vector_size =
-            EncodedVectorsPQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                vector_parameters,
-                bucket_size,
-            );
+            encoded_vectors_pq::get_quantized_vector_size(vector_parameters, bucket_size);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
@@ -1887,11 +1863,9 @@ impl QuantizedVectors {
     ) -> OperationResult<QuantizedVectorStorage> {
         let encoding = Self::convert_binary_encoding(binary_config.encoding);
         let query_encoding = Self::convert_binary_query_encoding(binary_config.query_encoding);
-        let quantized_vector_size =
-            EncodedVectorsBin::<u128, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                vector_parameters.dim,
-                encoding,
-            );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            u128,
+        >(vector_parameters.dim, encoding);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let in_ram = Self::is_ram(binary_config.always_ram, on_disk_vector_storage);
@@ -1970,11 +1944,9 @@ impl QuantizedVectors {
     ) -> OperationResult<QuantizedVectorStorage> {
         let encoding = Self::convert_binary_encoding(binary_config.encoding);
         let query_encoding = Self::convert_binary_query_encoding(binary_config.query_encoding);
-        let quantized_vector_size =
-            EncodedVectorsBin::<u8, QuantizedMmapStorage>::get_quantized_vector_size_from_params(
-                vector_parameters.dim,
-                encoding,
-            );
+        let quantized_vector_size = encoded_vectors_binary::get_quantized_vector_size_from_params::<
+            u8,
+        >(vector_parameters.dim, encoding);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
@@ -2076,11 +2048,7 @@ impl QuantizedVectors {
         let bits = Self::convert_tq_bits(turbo_config.bits.unwrap_or_default());
         let mode = TQMode::Plus;
         let quantized_vector_size =
-            EncodedVectorsTQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                vector_parameters,
-                bits,
-                mode,
-            );
+            encoded_vectors_tq::get_quantized_vector_size(vector_parameters, bits, mode);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let in_ram = Self::is_ram(turbo_config.always_ram, on_disk_vector_storage);
@@ -2163,11 +2131,7 @@ impl QuantizedVectors {
         let bits = Self::convert_tq_bits(turbo_config.bits.unwrap_or_default());
         let mode = TQMode::Plus;
         let quantized_vector_size =
-            EncodedVectorsTQ::<QuantizedMmapStorage>::get_quantized_vector_size(
-                vector_parameters,
-                bits,
-                mode,
-            );
+            encoded_vectors_tq::get_quantized_vector_size(vector_parameters, bits, mode);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);


### PR DESCRIPTION
In order to clean up #9059, I separated this refactor so that it is easier to review.

This PR makes `get_quantized_vector_size` a fully static function so that we don't need to do `EncodedVectorsU8::<QuantizedStorage::<Mmap>>::get_quantized_vector_size(...)`, since the function has nothing to do with the type of storage. Instead, we now call it as `encoded_vectors_u8::get_quantized_vector_size(...)`.
