### PR TITLE
[UIO] Accept `Cow` in `quantization_preprocess`

### DIFF
--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -25,7 +25,7 @@ where
     fn quantization_preprocess<'a>(
         quantization_config: &QuantizationConfig,
         distance: Distance,
-        vector: &'a [Self],
+        vector: Cow<'a, [Self]>,
     ) -> Cow<'a, [f32]>;
 
     fn datatype() -> VectorStorageDatatype;
@@ -51,9 +51,9 @@ impl PrimitiveVectorElement for VectorElementType {
     fn quantization_preprocess<'a>(
         _quantization_config: &QuantizationConfig,
         _distance: Distance,
-        vector: &'a [Self],
+        vector: Cow<'a, [Self]>,
     ) -> Cow<'a, [f32]> {
-        Cow::Borrowed(vector)
+        vector
     }
 
     fn datatype() -> VectorStorageDatatype {
@@ -85,7 +85,7 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
     fn quantization_preprocess<'a>(
         _quantization_config: &QuantizationConfig,
         _distance: Distance,
-        vector: &'a [Self],
+        vector: Cow<'a, [Self]>,
     ) -> Cow<'a, [f32]> {
         Cow::Owned(vector.iter().map(|&x| f16::to_f32(x)).collect_vec())
     }
@@ -140,10 +140,10 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     fn quantization_preprocess<'a>(
         quantization_config: &QuantizationConfig,
         distance: Distance,
-        vector: &'a [Self],
+        vector: Cow<'a, [Self]>,
     ) -> Cow<'a, [f32]> {
         if let QuantizationConfig::Binary(_) = quantization_config {
-            Cow::from(
+            Cow::Owned(
                 vector
                     .iter()
                     .map(|&x| VectorElementType::from(x) - 127.0)
@@ -154,7 +154,7 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
                 .iter()
                 .map(|&x| VectorElementType::from(x))
                 .collect_vec();
-            Cow::from(distance.preprocess_vector::<VectorElementType>(vector))
+            Cow::Owned(distance.preprocess_vector::<VectorElementType>(vector))
         }
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -60,7 +60,7 @@ where
                 let original_vector_prequantized = TElement::quantization_preprocess(
                     quantization_config,
                     TMetric::distance(),
-                    &original_vector,
+                    Cow::Borrowed(&original_vector),
                 );
                 Ok(quantized_storage.encode_query(&original_vector_prequantized))
             })

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
@@ -72,7 +74,7 @@ where
                 let original_vector_prequantized = TElement::quantization_preprocess(
                     quantization_config,
                     TMetric::distance(),
-                    &original_vector.flattened_vectors,
+                    Cow::Borrowed(&original_vector.flattened_vectors),
                 );
                 Ok(quantized_multivector_storage.encode_query(&original_vector_prequantized))
             })

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -51,7 +51,7 @@ where
             let inner_prequantized = TElement::quantization_preprocess(
                 quantization_config,
                 TMetric::distance(),
-                inner_converted.as_ref(),
+                inner_converted,
             );
             query.extend_from_slice(&inner_prequantized);
         }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -41,7 +41,7 @@ where
         let original_query_prequantized = TElement::quantization_preprocess(
             quantization_config,
             TMetric::distance(),
-            original_query.as_ref(),
+            original_query,
         );
         let query = quantized_data.encode_query(&original_query_prequantized);
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -754,22 +754,8 @@ impl QuantizedVectors {
         let distance = vector_storage.distance();
         let datatype = vector_storage.datatype();
         let vectors = (0..count as PointOffsetType).map(|i| {
-            match vector_storage.get_dense::<Sequential>(i) {
-                Cow::Borrowed(slice) => PrimitiveVectorElement::quantization_preprocess(
-                    quantization_config,
-                    distance,
-                    slice,
-                ),
-                Cow::Owned(vec) => Cow::Owned(
-                    // TODO: Preprocess without reallocating
-                    PrimitiveVectorElement::quantization_preprocess(
-                        quantization_config,
-                        distance,
-                        &vec,
-                    )
-                    .into_owned(),
-                ),
-            }
+            let vector = vector_storage.get_dense::<Sequential>(i);
+            PrimitiveVectorElement::quantization_preprocess(quantization_config, distance, vector)
         });
         let on_disk_vector_storage = vector_storage.is_on_disk();
 
@@ -867,21 +853,8 @@ impl QuantizedVectors {
         let distance = vector_storage.distance();
         let datatype = vector_storage.datatype();
         let multi_vector_config = *vector_storage.multi_vector_config();
-        let vectors = vector_storage.iterate_inner_vectors().map(|v| match v {
-            Cow::Borrowed(slice) => PrimitiveVectorElement::quantization_preprocess(
-                quantization_config,
-                distance,
-                slice,
-            ),
-            // TODO: avoid reallocation by accepting Cow in quantization_preprocess
-            Cow::Owned(vec) => Cow::Owned(
-                PrimitiveVectorElement::quantization_preprocess(
-                    quantization_config,
-                    distance,
-                    &vec,
-                )
-                .into_owned(),
-            ),
+        let vectors = vector_storage.iterate_inner_vectors().map(|vector| {
+            PrimitiveVectorElement::quantization_preprocess(quantization_config, distance, vector)
         });
         let inner_vectors_count = vectors.clone().count();
         let vectors_count = vector_storage.total_vector_count();


### PR DESCRIPTION
Handles a [pending TODO](https://github.com/qdrant/qdrant/compare/dev...accept-cow-in-preprocess?expand=1#diff-0f7857c1ec04477ac0a6d207f0cb745cbeadfcbe1addf2eece1fcdcf11681fd9L876) so that we don't do `to_owned` twice, and instead, lets `quantization_preprocess` be aware of whether it is already owned or not.