### PR TITLE
UniversalReadFileOps: require Debug

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -12,6 +12,7 @@ use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, Cac
 /// through the [`CacheController`]. Blocks that are already cached are returned
 /// as zero-copy borrows from the mmap; multi-block reads allocate a `Vec<T>`
 /// (not `Vec<u8>`) so alignment is always correct.
+#[derive(Debug)]
 pub struct CachedSlice {
     /// The id assigned by the controller for this file.
     file_id: FileId,

--- a/lib/common/common/src/universal_io/file_ops.rs
+++ b/lib/common/common/src/universal_io/file_ops.rs
@@ -1,8 +1,9 @@
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use super::*;
 
-pub trait UniversalReadFileOps: Sized {
+pub trait UniversalReadFileOps: Sized + Debug {
     /// List files in the storage with the given prefix.
     /// The prefix is used to filter files, e.g. by directory or filename pattern.
     ///

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
@@ -16,12 +17,20 @@ use crate::generic_consts::AccessPattern;
 /// The underlying read/write methods are generic over `T` per call. This
 /// wrapper forwards them with `T` fixed, acting as a fail-safe against
 /// accidentally reading or writing the wrong type from a generic storage.
-#[derive(Debug, TransparentWrapper)]
+#[derive(TransparentWrapper)]
 #[repr(transparent)]
 #[transparent(S)]
 pub struct TypedStorage<S, T> {
     pub inner: S,
     _phantom: PhantomData<T>,
+}
+
+impl<S: fmt::Debug, T> fmt::Debug for TypedStorage<S, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TypedStorage")
+            .field("inner", &self.inner)
+            .finish()
+    }
 }
 
 impl<S, T> TypedStorage<S, T> {


### PR DESCRIPTION
Tiny change. Needed for sparse index migration in subsequent PRs.

```diff
-pub trait UniversalReadFileOps: Sized {
+pub trait UniversalReadFileOps: Sized + Debug {
```