### PR TITLE
fix: handle keyword except with mixed payload types

### DIFF
--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -289,21 +289,26 @@ fn condition_checker_impl<'a, T: MapIndexRead<str> + 'a>(
                 }))
             }
         }
-        // When a keyword index exists for this field, points with non-string
-        // payload values (e.g. bool, number) have no entries in the index.
-        // `check_values_any` returns false for such points, but `except`
-        // semantics require returning true: a non-string value is never equal
-        // to any string in the except list.  We can't distinguish "no keyword
-        // values because the payload is a bool" from "no payload at all" using
-        // only the keyword index, so fall back to the payload condition checker
-        // which correctly handles all value types.
         Match::Except(MatchExcept {
-            except: AnyVariants::Strings(_),
-        })
+            except: AnyVariants::Strings(list),
+        }) => {
+            let list = list.clone();
+            if list.len() < INDEXSET_ITER_THRESHOLD {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| {
+                        !list.iter().any(|s| s.as_str() == value)
+                    })
+                }))
+            } else {
+                Some(Box::new(move |point_id: PointOffsetType| {
+                    index.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
+                }))
+            }
+        }
         // Conditions this index can't serve: Match::Text/TextAny/Phrase
         // (handled by FullTextIndex) and value-type mismatches (e.g.
         // Match::Value(Integer) against a string-keyed map).
-        | Match::Value(MatchValue {
+        Match::Value(MatchValue {
             value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
         })
         | Match::Any(MatchAny {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -289,26 +289,21 @@ fn condition_checker_impl<'a, T: MapIndexRead<str> + 'a>(
                 }))
             }
         }
+        // When a keyword index exists for this field, points with non-string
+        // payload values (e.g. bool, number) have no entries in the index.
+        // `check_values_any` returns false for such points, but `except`
+        // semantics require returning true: a non-string value is never equal
+        // to any string in the except list.  We can't distinguish "no keyword
+        // values because the payload is a bool" from "no payload at all" using
+        // only the keyword index, so fall back to the payload condition checker
+        // which correctly handles all value types.
         Match::Except(MatchExcept {
-            except: AnyVariants::Strings(list),
-        }) => {
-            let list = list.clone();
-            if list.len() < INDEXSET_ITER_THRESHOLD {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index.check_values_any(point_id, &hw_counter, |value| {
-                        !list.iter().any(|s| s.as_str() == value)
-                    })
-                }))
-            } else {
-                Some(Box::new(move |point_id: PointOffsetType| {
-                    index.check_values_any(point_id, &hw_counter, |value| !list.contains(value))
-                }))
-            }
-        }
+            except: AnyVariants::Strings(_),
+        })
         // Conditions this index can't serve: Match::Text/TextAny/Phrase
         // (handled by FullTextIndex) and value-type mismatches (e.g.
         // Match::Value(Integer) against a string-keyed map).
-        Match::Value(MatchValue {
+        | Match::Value(MatchValue {
             value: ValueVariants::Integer(_) | ValueVariants::Bool(_),
         })
         | Match::Any(MatchAny {

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -4,7 +4,7 @@ use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use serde_json::Value;
 
-use super::StructPayloadIndexReadView;
+use super::{StructPayloadIndexReadView, is_match_except_strings};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
@@ -14,9 +14,7 @@ use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
 };
-use crate::types::{
-    AnyVariants, Condition, FieldCondition, Match, MatchExcept, OwnedPayloadRef, PayloadContainer,
-};
+use crate::types::{Condition, FieldCondition, OwnedPayloadRef, PayloadContainer};
 use crate::vector_storage::VectorStorageRead;
 
 impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
@@ -239,13 +237,4 @@ where
             Condition::Filter(_) => unreachable!(),
         }
     }
-}
-
-fn is_match_except_strings(condition: &FieldCondition) -> bool {
-    matches!(
-        &condition.r#match,
-        Some(Match::Except(MatchExcept {
-            except: AnyVariants::Strings(_)
-        }))
-    )
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -14,7 +14,9 @@ use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
 };
-use crate::types::{Condition, FieldCondition, OwnedPayloadRef, PayloadContainer};
+use crate::types::{
+    AnyVariants, Condition, FieldCondition, Match, MatchExcept, OwnedPayloadRef, PayloadContainer,
+};
 use crate::vector_storage::VectorStorageRead;
 
 impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
@@ -33,15 +35,55 @@ where
         let id_tracker = self.id_tracker;
         let field_indexes = self.field_indexes;
         match condition {
-            Condition::Field(field_condition) => field_indexes
-                .get(&field_condition.key)
-                .and_then(|indexes| {
+            Condition::Field(field_condition) => {
+                let indexed_checker = field_indexes.get(&field_condition.key).and_then(|indexes| {
                     indexes.iter().find_map(move |index| {
                         let hw_acc = hw_counter.new_accumulator();
                         index.condition_checker(field_condition, hw_acc)
                     })
-                })
-                .unwrap_or_else(|| {
+                });
+
+                if let Some(indexed_checker) = indexed_checker {
+                    if is_match_except_strings(field_condition) {
+                        let has_values_condition =
+                            FieldCondition::new_is_empty(field_condition.key.clone(), false);
+                        let has_values_checker =
+                            field_indexes.get(&field_condition.key).and_then(|indexes| {
+                                indexes.iter().find_map(|index| {
+                                    let hw_acc = hw_counter.new_accumulator();
+                                    index.condition_checker(&has_values_condition, hw_acc)
+                                })
+                            });
+
+                        let hw = hw_counter.fork();
+                        Box::new(move |point_id| {
+                            if indexed_checker(point_id) {
+                                return true;
+                            }
+                            if has_values_checker
+                                .as_ref()
+                                .is_some_and(|has_values| !has_values(point_id))
+                            {
+                                return false;
+                            }
+                            payload_provider.with_payload(
+                                point_id,
+                                |payload| {
+                                    check_field_condition(
+                                        field_condition,
+                                        &payload,
+                                        field_indexes,
+                                        &hw,
+                                    )
+                                    .unwrap(/* TODO(uio): handle errors */)
+                                },
+                                &hw,
+                            )
+                        })
+                    } else {
+                        indexed_checker
+                    }
+                } else {
                     let hw = hw_counter.fork();
                     Box::new(move |point_id| {
                         payload_provider.with_payload(
@@ -53,7 +95,8 @@ where
                             &hw,
                         )
                     })
-                }),
+                }
+            }
             // is_empty / is_null are served by NullIndex via
             // `condition_checker`. NullIndex is built alongside every
             // index from #6088 (released in v1.13.5) onwards, so the
@@ -196,4 +239,13 @@ where
             Condition::Filter(_) => unreachable!(),
         }
     }
+}
+
+fn is_match_except_strings(condition: &FieldCondition) -> bool {
+    matches!(
+        &condition.r#match,
+        Some(Match::Except(MatchExcept {
+            except: AnyVariants::Strings(_)
+        }))
+    )
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
-use super::StructPayloadIndexReadView;
+use super::{StructPayloadIndexReadView, is_match_except_strings};
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
@@ -12,10 +12,7 @@ use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::{
-    AnyVariants, Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, Match,
-    MatchExcept,
-};
+use crate::types::{Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition};
 use crate::vector_storage::VectorStorageRead;
 
 impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
@@ -160,13 +157,4 @@ where
             }
         })
     }
-}
-
-fn is_match_except_strings(condition: &FieldCondition) -> bool {
-    matches!(
-        &condition.r#match,
-        Some(Match::Except(MatchExcept {
-            except: AnyVariants::Strings(_)
-        }))
-    )
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -12,7 +12,10 @@ use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::{Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition};
+use crate::types::{
+    AnyVariants, Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, Match,
+    MatchExcept,
+};
 use crate::vector_storage::VectorStorageRead;
 
 impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
@@ -37,11 +40,16 @@ where
             key: full_path,
             ..condition.clone()
         };
+        let primary_condition = if is_match_except_strings(&full_path_condition) {
+            FieldCondition::new_is_empty(full_path_condition.key.clone(), false)
+        } else {
+            full_path_condition
+        };
         indexes
             .iter()
             .find_map(|index| {
                 index
-                    .estimate_cardinality(&full_path_condition, hw_counter)
+                    .estimate_cardinality(&primary_condition, hw_counter)
                     .transpose()
             })
             .transpose()
@@ -152,4 +160,13 @@ where
             }
         })
     }
+}
+
+fn is_match_except_strings(condition: &FieldCondition) -> bool {
+    matches!(
+        &condition.r#match,
+        Some(Match::Except(MatchExcept {
+            except: AnyVariants::Strings(_)
+        }))
+    )
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -18,7 +18,9 @@ use crate::index::field_index::FieldIndexRead;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::{PayloadKeyType, VectorNameBuf};
+use crate::types::{
+    AnyVariants, FieldCondition, Match, MatchExcept, PayloadKeyType, VectorNameBuf,
+};
 use crate::vector_storage::VectorStorageRead;
 
 /// Read-only view over a [`StructPayloadIndex`].
@@ -69,4 +71,13 @@ where
     pub fn available_point_count(&self) -> usize {
         self.id_tracker.available_point_count()
     }
+}
+
+fn is_match_except_strings(condition: &FieldCondition) -> bool {
+    matches!(
+        &condition.r#match,
+        Some(Match::Except(MatchExcept {
+            except: AnyVariants::Strings(_)
+        }))
+    )
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1398,6 +1398,75 @@ fn test_null_index_appendable_reopen_loads_and_accepts_updates() {
     );
 }
 
+#[test]
+fn test_keyword_except_matches_non_string_payloads() {
+    let dir = Builder::new().prefix("keyword_except").tempdir().unwrap();
+    let mut segment = build_simple_segment(dir.path(), DIM, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key = JsonPath::new("mixed");
+
+    let payloads = [
+        Some(payload_json! {"mixed": "keep"}),
+        Some(payload_json! {"mixed": "drop"}),
+        Some(payload_json! {"mixed": true}),
+        Some(payload_json! {"mixed": 42}),
+        Some(payload_json! {"mixed": null}),
+        None,
+    ];
+    let payload_count = payloads.len();
+
+    for (idx, payload) in payloads.into_iter().enumerate() {
+        let idx = idx as PointOffsetType;
+        let point_id = u64::from(idx);
+        segment
+            .upsert_point(
+                point_id,
+                point_id.into(),
+                only_default_vector(&vec![idx as f32; DIM]),
+                &hw_counter,
+            )
+            .unwrap();
+        if let Some(payload) = payload {
+            segment
+                .set_full_payload(point_id, point_id.into(), &payload, &hw_counter)
+                .unwrap();
+        }
+    }
+
+    segment
+        .create_field_index(10, &key, Some(&Keyword.into()), &hw_counter)
+        .unwrap();
+
+    let excluded: IndexSet<String, FnvBuildHasher> = ["drop".to_owned()].into_iter().collect();
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        key,
+        Match::new_except(AnyVariants::Strings(excluded)),
+    )));
+    let is_stopped = AtomicBool::new(false);
+
+    let mut queried = segment
+        .payload_index
+        .borrow()
+        .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped))
+        .unwrap();
+    queried.sort_unstable();
+    assert_eq!(queried, vec![0, 2, 3]);
+
+    let checked = segment
+        .payload_index
+        .borrow()
+        .with_view(|v| {
+            v.filter_context(&filter, &hw_counter)
+                .map(|filter_context| {
+                    (0..payload_count as PointOffsetType)
+                        .filter(|point_id| filter_context.check(*point_id))
+                        .collect_vec()
+                })
+        })
+        .unwrap();
+    assert_eq!(checked, vec![0, 2, 3]);
+}
+
 fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Result<()> {
     let keywords: IndexSet<String, FnvBuildHasher> = ["value1", "value2"]
         .iter()

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1439,10 +1439,23 @@ fn test_keyword_except_matches_non_string_payloads() {
 
     let excluded: IndexSet<String, FnvBuildHasher> = ["drop".to_owned()].into_iter().collect();
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
-        key,
+        key.clone(),
         Match::new_except(AnyVariants::Strings(excluded)),
     )));
     let is_stopped = AtomicBool::new(false);
+
+    let estimation = segment
+        .payload_index
+        .borrow()
+        .with_view(|v| v.estimate_cardinality(&filter, &hw_counter))
+        .unwrap();
+    assert_eq!(estimation.primary_clauses.len(), 1);
+    match estimation.primary_clauses.first().unwrap() {
+        PrimaryCondition::Condition(field_condition) => {
+            assert_eq!(**field_condition, FieldCondition::new_is_empty(key, false));
+        }
+        clause => panic!("unexpected primary clause: {clause:?}"),
+    }
 
     let mut queried = segment
         .payload_index


### PR DESCRIPTION
## Summary
Fixed `match.except` with a keyword payload index dropping points whose payload value is present but not a string, such as bool or number values.

Fixes #9068.

## Root cause
The keyword index only stores string values. For a point like `{ "tag": true }`, `check_values_any` returns `false` because there are no keyword entries for that point. For `match.except` against a string list, that is not enough information: a bool or number should match because it is not equal to any excluded string, while a missing/null field should not match.

## Fix
This keeps the keyword-index checker for the normal fast path and adds a bounded fallback for the ambiguous case:

- Keyword values not in the excluded set still return directly from the keyword index.
- Optimized point selection uses the NullIndex-backed `is_empty(false)` primary clause, so candidates stay limited to points that actually have the field.
- When the keyword checker returns false, the checker first excludes empty/null field values and only then reads payload to distinguish excluded strings from non-string values.

This avoids the previous full payload fallback for every keyword `except` query while preserving correct mixed-type semantics.

## Test plan
- [x] `cargo test -p segment --test integration test_keyword_except_matches_non_string_payloads -- --nocapture`
- [x] Regression covers `query_points` and `filter_context`
- [x] Regression covers string keep/drop, bool, number, null, and missing field values