### PR TITLE
Fix empty vector panic

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -18,9 +18,25 @@ use segment::types::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sparse::common::sparse_vector::SparseVector;
-use validator::{Validate, ValidationErrors};
+use validator::{Validate, ValidationError, ValidationErrors};
 
 use crate::rest::validate::validate_relevance_feedback_input;
+
+/// Reject zero-length dense vectors at the API boundary.
+///
+/// Without this check, `wait=false` upserts silently enqueue empty vectors that
+/// later get discarded by the segment dimension check, and can also reach code
+/// that asserts on non-zero length and panics (see qdrant/qdrant#9045, #7967).
+pub(crate) fn validate_non_empty_dense(vector: &[f32]) -> Result<(), ValidationErrors> {
+    if vector.is_empty() {
+        let mut err = ValidationError::new("empty_vector");
+        err.message = Some(Cow::Borrowed("dense vector must not be empty"));
+        let mut errors = ValidationErrors::new();
+        errors.add("vector", err);
+        return Err(errors);
+    }
+    Ok(())
+}
 
 /// Vector Data
 /// Vectors can be described directly with values
@@ -48,7 +64,7 @@ pub enum VectorOutput {
 impl Validate for Vector {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            Vector::Dense(_) => Ok(()),
+            Vector::Dense(v) => validate_non_empty_dense(v),
             Vector::Sparse(v) => v.validate(),
             Vector::MultiDense(m) => validate_multi_vector(m),
             Vector::Document(_) => Ok(()),
@@ -130,7 +146,7 @@ impl VectorStruct {
 impl Validate for VectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
-            VectorStruct::Single(_) => Ok(()),
+            VectorStruct::Single(v) => validate_non_empty_dense(v),
             VectorStruct::MultiDense(v) => validate_multi_vector(v),
             VectorStruct::Named(v) => common::validation::validate_iter(v.values()),
             VectorStruct::Document(_) => Ok(()),

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -4,6 +4,7 @@ use common::validation::validate_multi_vector;
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use validator::{Validate, ValidationError, ValidationErrors};
 
+use super::schema::validate_non_empty_dense;
 use super::{
     Batch, BatchVectorStruct, ContextInput, Expression, FormulaQuery, Fusion, NamedVectorStruct,
     PointVectors, Query, QueryInterface, RecommendInput, RelevanceFeedbackInput, Sample,
@@ -155,7 +156,12 @@ impl Validate for Sample {
 impl Validate for BatchVectorStruct {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
-            BatchVectorStruct::Single(_) => Ok(()),
+            BatchVectorStruct::Single(vectors) => {
+                for vector in vectors {
+                    validate_non_empty_dense(vector)?;
+                }
+                Ok(())
+            }
             BatchVectorStruct::MultiDense(vectors) => {
                 for vector in vectors {
                     validate_multi_vector(vector)?;

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -322,6 +322,13 @@ pub async fn do_upsert_points(
     use point_ops::UpdateMode;
     use segment::types::Filter;
 
+    // The REST handler already runs this via `actix_web_validator::Json`, but the
+    // gRPC handler does not — without this, empty vectors entering through gRPC
+    // would only be rejected on the synchronous (wait=true) apply path.
+    operation
+        .validate()
+        .map_err(|err| StorageError::bad_input(err.to_string()))?;
+
     let toc = toc_provider
         .check_strict_mode(
             &operation,

--- a/tests/openapi/test_multi_vector.py
+++ b/tests/openapi/test_multi_vector.py
@@ -154,7 +154,10 @@ def test_multi_vector_validation(collection_name):
         }
     )
     assert not response.ok
-    assert 'Wrong input: Vector dimension error: expected dim: 4, got 0' in response.json()["status"]["error"]
+    # `Vector` is an untagged enum with `Dense` listed before `MultiDense`, so
+    # `[]` deserializes as an empty dense vector and is rejected at the
+    # validation boundary rather than by the dimension check during apply.
+    assert 'dense vector must not be empty' in response.json()["status"]["error"]
 
     # fails because it uses an empty inner vector
     response = request_with_validation(

--- a/tests/openapi/test_multi_vector_unnamed.py
+++ b/tests/openapi/test_multi_vector_unnamed.py
@@ -148,7 +148,11 @@ def test_multi_vector_validation(collection_name):
         }
     )
     assert not response.ok
-    assert 'Wrong input' in response.json()["status"]["error"]
+    # `VectorStruct` is an untagged enum with `Single` listed before
+    # `MultiDense`, so `[]` deserializes as an empty single dense vector and is
+    # rejected at the validation boundary rather than by the dimension check
+    # during apply.
+    assert 'Validation error' in response.json()["status"]["error"]
 
     # fails because it uses an empty inner vector
     response = request_with_validation(

--- a/tests/openapi/test_validation.py
+++ b/tests/openapi/test_validation.py
@@ -123,3 +123,43 @@ def test_validation_iter_batch_named_vectors(collection_name):
     )
     assert not response.ok
     assert 'Validation error' in response.json()["status"]["error"]
+
+
+# Regression for https://github.com/qdrant/qdrant/issues/9045
+#
+# Upserting an empty vector `[]` is rejected on the synchronous (`wait=true`)
+# path but silently accepted on the asynchronous path: the response is HTTP 200
+# `acknowledged`, the point is later discarded, and the zero-length vector can
+# reach internal code paths that assert on non-zero length (see #7967).
+@pytest.mark.parametrize("wait", ["true", "false"])
+def test_validation_empty_vector_upsert(collection_name, wait):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': wait},
+        body={"points": [{"id": 1000, "vector": []}]},
+    )
+    assert not response.ok, (
+        f"empty vector accepted with wait={wait}: "
+        f"status={response.status_code}, body={response.text}"
+    )
+
+
+@pytest.mark.parametrize("wait", ["true", "false"])
+def test_validation_empty_vector_batch_upsert(collection_name, wait):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/batch',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': wait},
+        body={
+            "operations": [
+                {"upsert": {"points": [{"id": 1001, "vector": []}]}},
+            ],
+        },
+    )
+    assert not response.ok, (
+        f"empty vector accepted in batch upsert with wait={wait}: "
+        f"status={response.status_code}, body={response.text}"
+    )


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/9045>

Upserting an empty vector with wait=false can cause a panic. This fixes the problem by adding a validation rule and adds a test to assert behavior.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
