### PR TITLE
Refactor `MultivectorsOffsetsStorageMmap` to use `UniversalRead`

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -186,14 +186,12 @@ impl MultivectorOffsetsStorageMmap {
         })
     }
 
-    pub fn populate(&self) -> std::io::Result<()> {
-        self.offsets.populate().map_err(std::io::Error::other)
+    pub fn populate(&self) -> OperationResult<()> {
+        Ok(self.offsets.populate()?)
     }
 
-    pub fn clear_cache(&self) -> std::io::Result<()> {
-        self.offsets
-            .clear_ram_cache()
-            .map_err(std::io::Error::other)
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        Ok(self.offsets.clear_ram_cache()?)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -6,7 +6,7 @@ use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::MmapFile;
+use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, TypedStorage};
 use fs_err as fs;
 use memmap2::MmapMut;
 use quantization::EncodedVectors;
@@ -153,7 +153,7 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageRam {
 
 #[derive(Debug)]
 pub struct MultivectorOffsetsStorageMmap {
-    offsets: MmapSlice<MultivectorOffset>,
+    offsets: TypedStorage<MmapFile, MultivectorOffset>,
     path: PathBuf,
 }
 
@@ -168,9 +168,18 @@ impl MultivectorOffsetsStorageMmap {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        let offsets_file = fs::OpenOptions::new().read(true).write(true).open(path)?;
-        let offsets_mmap = unsafe { MmapMut::map_mut(&offsets_file) }?;
-        let offsets = unsafe { MmapSlice::<MultivectorOffset>::try_from(offsets_mmap)? };
+        let offsets = TypedStorage::<MmapFile, MultivectorOffset>::open(
+            path,
+            OpenOptions {
+                writeable: false,
+                need_sequential: false,
+                disk_parallel: None,
+                populate: Populate::No,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
+
         Ok(Self {
             offsets,
             path: path.to_path_buf(),
@@ -178,29 +187,59 @@ impl MultivectorOffsetsStorageMmap {
     }
 
     pub fn populate(&self) -> std::io::Result<()> {
-        self.offsets.populate()
+        self.offsets.populate().map_err(std::io::Error::other)
     }
 
     pub fn clear_cache(&self) -> std::io::Result<()> {
-        let Self { offsets, path: _ } = self;
-        offsets.clear_cache()
+        self.offsets
+            .clear_ram_cache()
+            .map_err(std::io::Error::other)
     }
 }
 
 impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
-        self.offsets[idx as usize]
+        let offset = self
+            .offsets
+            .read::<Random>(ReadRange::one(
+                u64::from(idx) * size_of::<MultivectorOffset>() as u64,
+            ))
+            .expect("multi-vector offset read");
+
+        let [offset] = offset.as_ref() else {
+            unreachable!("multi-vector offsets are stored as a single-element slice");
+        };
+
+        *offset
     }
 
     fn iter_offsets(
         &self,
         ids: &[PointOffsetType],
     ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
-        ids.iter().map(|&id| self.get_offset(id)).enumerate()
+        let ranges = ids.iter().copied().enumerate().map(|(idx, id)| {
+            let offset = u64::from(id) * size_of::<MultivectorOffset>() as u64;
+            let range = ReadRange::one(offset);
+            (idx, range)
+        });
+
+        self.offsets
+            .read_iter::<Random, _>(ranges)
+            .expect("multi-vector offsets iterator initialized")
+            .map(|result| {
+                let (idx, offset) = result.expect("multi-vector offset read");
+                let [offset] = offset.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as a single-element slice");
+                };
+
+                (idx, *offset)
+            })
     }
 
     fn len(&self) -> usize {
-        self.offsets.len()
+        self.offsets
+            .len()
+            .expect("multi-vector offsets length read") as _
     }
 
     fn upsert_offset(
@@ -233,6 +272,7 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageMmap {
             offsets: _,
             path: _,
         } = self;
+
         0
     }
 }


### PR DESCRIPTION
Does not expose `MultivectorsOffsetsStorageMmap<S>` yet, but replaces `MmapSlice` with `TypedStorage<MmapFile>`. Trivial to expose when we need this, but better code navigation while we don't.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
