### PR TITLE
Introduce Collection model testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 /.devcontainer
 /storage
+/storage-model
 /snapshots
 /consensus_test_logs
 /tests/consensus_test_logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2029,18 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -4636,6 +4668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,6 +4684,12 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-io-kit"
@@ -5741,6 +5788,8 @@ dependencies = [
  "config",
  "console-subscriber",
  "constant_time_eq 0.4.2",
+ "ctrlc",
+ "env_logger",
  "fs-err",
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 
 [features]
 default = []
-service_debug = ["parking_lot/deadlock_detection"]
+service_debug = ["parking_lot/deadlock_detection", "collection/testing"]
 tracing = [
     "api/tracing",
     "collection/tracing",
@@ -67,6 +67,8 @@ anyhow = "1.0.98"
 futures = { workspace = true }
 futures-util = { workspace = true }
 clap = { workspace = true }
+ctrlc = "3.5.2"
+env_logger = { workspace = true }
 serde_cbor = { workspace = true }
 uuid = { workspace = true }
 sys-info = "0.9.1"
@@ -339,6 +341,13 @@ required-features = ["service_debug"]
 [[bin]]
 name = "segment_inspector"
 path = "src/segment_inspector.rs"
+test = false
+bench = false
+required-features = ["service_debug"]
+
+[[bin]]
+name = "model_testing"
+path = "src/model_testing.rs"
 test = false
 bench = false
 required-features = ["service_debug"]

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 workspace = true
 
 [features]
-testing = []
+testing = ["common/testing", "segment/testing", "shard/testing"]
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 data-consistency-check = []
 staging = ["shard/staging"]

--- a/lib/collection/src/lib.rs
+++ b/lib/collection/src/lib.rs
@@ -17,6 +17,8 @@ mod update_handler;
 pub mod wal_delta;
 
 pub mod events;
+#[cfg(feature = "testing")]
+pub mod model_testing;
 #[cfg(test)]
 mod tests;
 

--- a/lib/collection/src/model_testing/apply/mod.rs
+++ b/lib/collection/src/model_testing/apply/mod.rs
@@ -1,0 +1,164 @@
+mod reads;
+mod writes;
+
+use std::collections::{BTreeSet, HashMap};
+
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::types::VectorNameBuf;
+
+use super::op::{NamedVectors, Op};
+use super::{Model, VectorValue};
+use crate::collection::Collection;
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::point_ops::{VectorPersisted, VectorStructPersisted, WriteOrdering};
+
+pub(super) async fn apply(
+    collection: &Collection,
+    model: &mut Model,
+    active: &mut BTreeSet<VectorNameBuf>,
+    op: &Op,
+) {
+    match op {
+        Op::Upsert(id, vecs, payload) => {
+            writes::apply_upsert(collection, model, *id, vecs, payload).await
+        }
+        Op::UpsertBatch(points) => writes::apply_upsert_batch(collection, model, points).await,
+        Op::Delete(ids) => writes::apply_delete(collection, model, ids).await,
+        Op::DeleteByFilter(num) => writes::apply_delete_by_filter(collection, model, *num).await,
+        Op::SetPayload(ids, payload) => {
+            writes::apply_set_payload(collection, model, ids, payload).await
+        }
+        Op::OverwritePayload(ids, payload) => {
+            writes::apply_overwrite_payload(collection, model, ids, payload).await
+        }
+        Op::DeletePayload(ids, keys) => {
+            writes::apply_delete_payload(collection, model, ids, keys).await
+        }
+        Op::ClearPayload(ids) => writes::apply_clear_payload(collection, model, ids).await,
+        Op::CreateIndex(field, schema) => {
+            writes::apply_create_index(collection, field, schema).await
+        }
+        Op::DropIndex(field) => writes::apply_drop_index(collection, field).await,
+        Op::RetrieveRandom(ids) => {
+            reads::apply_retrieve(collection, model, ids, "RetrieveRandom").await
+        }
+        Op::RetrieveExisting(ids) => {
+            reads::apply_retrieve(collection, model, ids, "RetrieveExisting").await
+        }
+        Op::Search {
+            vector_name,
+            query,
+            limit,
+            exact,
+            filter_num,
+        } => {
+            reads::apply_search(
+                collection,
+                model,
+                vector_name,
+                query,
+                *limit,
+                *exact,
+                *filter_num,
+            )
+            .await
+        }
+        Op::CountByNum(num) => reads::apply_count_by_num(collection, model, *num).await,
+        Op::UpsertConditional {
+            points,
+            condition_num,
+            mode,
+        } => {
+            writes::apply_upsert_conditional(collection, model, points, *condition_num, *mode).await
+        }
+        Op::UpdateVectors {
+            points,
+            condition_num,
+        } => writes::apply_update_vectors(collection, model, points, *condition_num).await,
+        Op::DeleteVectors { ids, names } => {
+            writes::apply_delete_vectors(collection, model, ids, names).await
+        }
+        Op::DeleteVectorsByFilter { num, names } => {
+            writes::apply_delete_vectors_by_filter(collection, model, *num, names).await
+        }
+        Op::ScrollFilteredByNum(num) => {
+            reads::apply_scroll_filtered_by_num(collection, model, *num).await
+        }
+        Op::CountByTag(tag) => reads::apply_count_by_tag(collection, model, tag).await,
+        Op::ScrollFilteredByTag(tag) => {
+            reads::apply_scroll_filtered_by_tag(collection, model, tag).await
+        }
+        Op::ScrollOrdered(direction) => {
+            reads::apply_scroll_ordered(collection, model, *direction).await
+        }
+        Op::Recommend {
+            positive,
+            negative,
+            limit,
+            strategy,
+            vector_name,
+        } => {
+            reads::apply_recommend(
+                collection,
+                model,
+                positive,
+                negative,
+                *limit,
+                *strategy,
+                vector_name,
+            )
+            .await
+        }
+        Op::CreateVectorName { name, config } => {
+            writes::apply_create_vector_name(collection, active, name, config).await
+        }
+        Op::DeleteVectorName(name) => {
+            writes::apply_delete_vector_name(collection, model, active, name).await
+        }
+        Op::SetPayloadByFilter { num, payload } => {
+            writes::apply_set_payload_by_filter(collection, model, *num, payload).await
+        }
+        Op::OverwritePayloadByFilter { num, payload } => {
+            writes::apply_overwrite_payload_by_filter(collection, model, *num, payload).await
+        }
+        Op::DeletePayloadByFilter { num, keys } => {
+            writes::apply_delete_payload_by_filter(collection, model, *num, keys).await
+        }
+        Op::ClearPayloadByFilter(num) => {
+            writes::apply_clear_payload_by_filter(collection, model, *num).await
+        }
+        Op::Facet { key, filter_num } => {
+            reads::apply_facet(collection, model, key, *filter_num).await
+        }
+    }
+}
+
+// ───── shared utilities ─────────────────────────────────────────────────────
+
+/// Submit a write op through the standard path and panic with the engine error on failure.
+async fn apply_update(collection: &Collection, op: CollectionUpdateOperations, ctx: &str) {
+    collection
+        .update_from_client_simple(
+            op,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("{ctx} failed: {e:?}"));
+}
+
+/// Convert the test-side `NamedVectors` into the on-the-wire `VectorStructPersisted::Named`.
+fn to_named_persisted(vecs: &NamedVectors) -> VectorStructPersisted {
+    let mut map: HashMap<VectorNameBuf, VectorPersisted> = HashMap::new();
+    for (name, value) in vecs {
+        let persisted = match value {
+            VectorValue::Dense(v) => VectorPersisted::Dense(v.clone()),
+            VectorValue::Sparse(s) => VectorPersisted::Sparse(s.clone()),
+            VectorValue::MultiDense(matrix) => VectorPersisted::MultiDense(matrix.clone()),
+        };
+        map.insert(name.clone(), persisted);
+    }
+    VectorStructPersisted::Named(map)
+}

--- a/lib/collection/src/model_testing/apply/reads.rs
+++ b/lib/collection/src/model_testing/apply/reads.rs
@@ -1,0 +1,724 @@
+use std::collections::HashMap;
+
+use ahash::AHashSet;
+use api::rest::RecommendStrategy;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::data_types::facets::{FacetParams, FacetValue};
+use segment::data_types::order_by::{Direction, OrderBy, OrderByInterface, OrderValue};
+use segment::data_types::vectors::{
+    MultiDenseVectorInternal, NamedQuery, VectorInternal, VectorStructInternal,
+};
+use segment::types::{PointIdType, SearchParams, VectorNameBuf, WithPayloadInterface, WithVector};
+use shard::query::query_enum::QueryEnum;
+use shard::scroll::ScrollRequestInternal;
+
+use super::super::op::{
+    NamedVectors, canonical_sparse, has_num, match_num_filter, match_tag_filter, num_matches,
+    tag_matches,
+};
+use super::super::{Model, VectorValue};
+use crate::collection::Collection;
+use crate::operations::shard_selector_internal::ShardSelectorInternal;
+use crate::operations::types::{
+    CoreSearchRequest, CountRequestInternal, PointRequestInternal, RecommendExample,
+    RecommendRequestInternal, UsingVector,
+};
+use crate::recommendations::recommend_by;
+
+/// Assert two id sets are equal; on failure, panic with only the symmetric difference
+/// instead of dumping both full sets (much friendlier when sets have hundreds of entries).
+fn assert_id_sets_eq(
+    returned: &AHashSet<PointIdType>,
+    expected: &AHashSet<PointIdType>,
+    ctx: &str,
+) {
+    if returned == expected {
+        return;
+    }
+    let missing: Vec<_> = expected.difference(returned).copied().collect();
+    let extra: Vec<_> = returned.difference(expected).copied().collect();
+    panic!(
+        "{ctx}: id-set mismatch (returned {} ids, expected {}); \
+         missing from returned: {missing:?}; \
+         extra in returned: {extra:?}",
+        returned.len(),
+        expected.len(),
+    );
+}
+
+/// Compare a returned `HashMap<VectorName, VectorInternal>` against the model's `NamedVectors`.
+/// `ctx` is the originating op name (e.g. "RetrieveRandom" / "RetrieveExisting"), prefixed
+/// into every assertion message so failures point at the exact op variant.
+fn assert_named_vectors_match(
+    returned: &HashMap<VectorNameBuf, VectorInternal>,
+    expected: &NamedVectors,
+    id: PointIdType,
+    ctx: &str,
+) {
+    // Returned names should be a subset of expected (vectors may have been deleted from a point;
+    // the engine returns whatever is currently present).
+    for (name, ret_vec) in returned {
+        let exp = expected.get(name).unwrap_or_else(|| {
+            panic!("{ctx} for {id:?} returned vector `{name}` that the model doesn't have")
+        });
+        match (ret_vec, exp) {
+            (VectorInternal::Dense(a), VectorValue::Dense(b)) => {
+                assert_eq!(a, b, "{ctx}: dense vector `{name}` mismatch for id {id:?}");
+            }
+            (VectorInternal::Sparse(a), VectorValue::Sparse(b)) => {
+                assert_eq!(
+                    &canonical_sparse(a),
+                    b,
+                    "{ctx}: sparse vector `{name}` mismatch for id {id:?}",
+                );
+            }
+            (VectorInternal::MultiDense(a), VectorValue::MultiDense(b)) => {
+                // Internal stores `{ flattened_vectors, dim }`; un-flatten into rows for
+                // direct comparison against the model's `Vec<Vec<f32>>`.
+                assert!(
+                    a.dim > 0 && a.flattened_vectors.len() % a.dim == 0,
+                    "{ctx}: multi-dense vector `{name}` has malformed internal shape for id {id:?}",
+                );
+                let returned_rows: Vec<Vec<f32>> = a
+                    .flattened_vectors
+                    .chunks(a.dim)
+                    .map(<[f32]>::to_vec)
+                    .collect();
+                assert_eq!(
+                    &returned_rows, b,
+                    "{ctx}: multi-dense vector `{name}` mismatch for id {id:?}",
+                );
+            }
+            (other_a, other_b) => panic!(
+                "{ctx}: vector type mismatch for `{name}` id {id:?}: engine returned {other_a:?}, \
+                 model has {other_b:?}",
+            ),
+        }
+    }
+    // Each model-side vector should also appear in the returned map.
+    for name in expected.keys() {
+        assert!(
+            returned.contains_key(name),
+            "{ctx} for {id:?} is missing vector `{name}` that the model has",
+        );
+    }
+}
+
+pub(super) async fn apply_retrieve(
+    collection: &Collection,
+    model: &Model,
+    ids: &[PointIdType],
+    ctx: &str,
+) {
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: ids.to_vec(),
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("{ctx} failed: {e:?}"));
+    let returned: AHashSet<PointIdType> = records.iter().map(|r| r.id).collect();
+    for id in ids {
+        let in_model = model.contains_key(id);
+        let in_returned = returned.contains(id);
+        assert!(
+            in_model == in_returned,
+            "{ctx} membership mismatch for id {id:?}: model={in_model}, returned={in_returned}",
+        );
+    }
+    for record in &records {
+        let entry = model
+            .get(&record.id)
+            .unwrap_or_else(|| panic!("{ctx} returned unknown id {:?}", record.id));
+        let named = match record.vector.as_ref().expect("retrieve vector missing") {
+            VectorStructInternal::Named(m) => m,
+            other @ (VectorStructInternal::Single(_) | VectorStructInternal::MultiDense(_)) => {
+                panic!("{ctx}: expected Named vector struct, got {other:?}")
+            }
+        };
+        assert_named_vectors_match(named, &entry.vectors, record.id, ctx);
+        let actual_payload = record.payload.clone().unwrap_or_default();
+        assert_eq!(
+            &actual_payload, &entry.payload,
+            "{ctx} payload mismatch for id {:?}",
+            record.id,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn apply_search(
+    collection: &Collection,
+    model: &Model,
+    vector_name: &str,
+    query: &VectorValue,
+    limit: usize,
+    exact: bool,
+    filter_num: Option<i64>,
+) {
+    let internal_query = match query {
+        VectorValue::Dense(v) => VectorInternal::Dense(v.clone()),
+        VectorValue::Sparse(s) => VectorInternal::Sparse(s.clone()),
+        VectorValue::MultiDense(matrix) => VectorInternal::MultiDense(
+            MultiDenseVectorInternal::try_from_matrix(matrix.clone()).expect("non-empty matrix"),
+        ),
+    };
+    let named_query = NamedQuery::new(internal_query, vector_name);
+    let results = collection
+        .search(
+            CoreSearchRequest {
+                query: QueryEnum::Nearest(named_query),
+                filter: filter_num.map(match_num_filter),
+                params: Some(SearchParams {
+                    exact,
+                    ..Default::default()
+                }),
+                limit,
+                offset: 0,
+                with_payload: None,
+                with_vector: None,
+                score_threshold: None,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("search failed");
+    // Candidates = points that (a) have the queried vector populated and (b) pass the optional
+    // filter. Points missing the vector aren't searchable.
+    let candidates: AHashSet<PointIdType> = model
+        .iter()
+        .filter(|(_, entry)| entry.vectors.contains_key(vector_name))
+        .filter(|(_, entry)| filter_num.is_none_or(|n| num_matches(&entry.payload, n)))
+        .map(|(id, _)| *id)
+        .collect();
+    let expected_len = limit.min(candidates.len());
+    // For dense exact=true we have an exact scan so the result is exactly the top-k.
+    // For dense exact=false (HNSW), the engine may legally return fewer than expected when the
+    // filter is restrictive or recall is below 1.0.
+    // For sparse search, the effective candidate set is "points with non-zero overlap with the
+    // query" rather than "all points with the vector populated", which is data-dependent and
+    // smaller than `candidate_count`. So sparse search is always an upper bound.
+    // Multi-dense (MaxSim) over an exact scan should also return every candidate, so it
+    // can use the strict equality path alongside plain dense exact.
+    let strict = exact && matches!(query, VectorValue::Dense(_) | VectorValue::MultiDense(_));
+    if strict {
+        if results.len() != expected_len {
+            let returned_ids: AHashSet<PointIdType> = results.iter().map(|r| r.id).collect();
+            let mut missing: Vec<_> = candidates.difference(&returned_ids).copied().collect();
+            let mut extra: Vec<_> = returned_ids.difference(&candidates).copied().collect();
+            missing.sort();
+            extra.sort();
+
+            // Follow-up probes before panicking — classify the bug.
+            //   1. Does Retrieve see the missing point(s)?
+            //   2. Does CountByFilter see the right count?
+            //   3. Does re-running the same search give the same wrong answer (consistent
+            //      vs flapping)?
+            let probe_retrieve = collection
+                .retrieve(
+                    PointRequestInternal {
+                        ids: missing.clone(),
+                        with_payload: Some(WithPayloadInterface::Bool(true)),
+                        with_vector: WithVector::Bool(true),
+                    },
+                    None,
+                    &ShardSelectorInternal::All,
+                    None,
+                    HwMeasurementAcc::new(),
+                )
+                .await;
+            let retrieved_summary = match probe_retrieve {
+                Ok(records) => records
+                    .iter()
+                    .map(|r| {
+                        let has_vec = r
+                            .vector
+                            .as_ref()
+                            .and_then(|v| match v {
+                                VectorStructInternal::Named(m) => Some(m.contains_key(vector_name)),
+                                VectorStructInternal::Single(_)
+                                | VectorStructInternal::MultiDense(_) => None,
+                            })
+                            .unwrap_or(false);
+                        let has_num = r
+                            .payload
+                            .as_ref()
+                            .and_then(|p| p.0.get("num").and_then(|v| v.as_i64()))
+                            == filter_num;
+                        format!("{:?}{{vec:{has_vec}, num_match:{has_num}}}", r.id)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                Err(e) => format!("retrieve failed: {e:?}"),
+            };
+
+            let probe_count = collection
+                .count(
+                    CountRequestInternal {
+                        filter: filter_num.map(match_num_filter),
+                        exact: true,
+                    },
+                    None,
+                    &ShardSelectorInternal::All,
+                    None,
+                    HwMeasurementAcc::new(),
+                )
+                .await;
+            let count_summary = match probe_count {
+                Ok(c) => format!("{}", c.count),
+                Err(e) => format!("err: {e:?}"),
+            };
+
+            // Scroll by the same filter — gives us the exact id list the engine thinks matches.
+            // If this set differs from the model's `candidates`, the payload index is out of sync.
+            let probe_scroll = collection
+                .scroll_by(
+                    ScrollRequestInternal {
+                        offset: None,
+                        limit: Some(usize::MAX),
+                        filter: filter_num.map(match_num_filter),
+                        with_payload: Some(WithPayloadInterface::Bool(false)),
+                        with_vector: WithVector::Bool(false),
+                        order_by: None,
+                    },
+                    None,
+                    &ShardSelectorInternal::All,
+                    None,
+                    HwMeasurementAcc::new(),
+                )
+                .await;
+            let scroll_summary = match probe_scroll {
+                Ok(s) => {
+                    let mut engine_ids: Vec<PointIdType> = s.points.iter().map(|r| r.id).collect();
+                    engine_ids.sort();
+                    let engine_set: AHashSet<_> = engine_ids.iter().copied().collect();
+                    let mut ghost: Vec<_> = engine_set.difference(&candidates).copied().collect();
+                    let mut missing_from_engine: Vec<_> =
+                        candidates.difference(&engine_set).copied().collect();
+                    ghost.sort();
+                    missing_from_engine.sort();
+                    format!(
+                        "engine has {} ids matching filter; ghost (engine but not model): {ghost:?}; \
+                         missing from engine (in model but not engine scroll): {missing_from_engine:?}",
+                        engine_ids.len(),
+                    )
+                }
+                Err(e) => format!("err: {e:?}"),
+            };
+
+            // Re-run the same search to see if it's deterministic or flapping.
+            let retry_internal_query = match query {
+                VectorValue::Dense(v) => VectorInternal::Dense(v.clone()),
+                VectorValue::Sparse(s) => VectorInternal::Sparse(s.clone()),
+                VectorValue::MultiDense(matrix) => VectorInternal::MultiDense(
+                    MultiDenseVectorInternal::try_from_matrix(matrix.clone())
+                        .expect("non-empty matrix"),
+                ),
+            };
+            let retry_named = NamedQuery::new(retry_internal_query, vector_name);
+            let retry_results = collection
+                .search(
+                    CoreSearchRequest {
+                        query: QueryEnum::Nearest(retry_named),
+                        filter: filter_num.map(match_num_filter),
+                        params: Some(SearchParams {
+                            exact,
+                            ..Default::default()
+                        }),
+                        limit,
+                        offset: 0,
+                        with_payload: None,
+                        with_vector: None,
+                        score_threshold: None,
+                    },
+                    None,
+                    &ShardSelectorInternal::All,
+                    None,
+                    HwMeasurementAcc::new(),
+                )
+                .await;
+            let retry_summary = match retry_results {
+                Ok(r) => {
+                    let retry_ids: AHashSet<PointIdType> = r.iter().map(|x| x.id).collect();
+                    let still_missing: Vec<_> = missing
+                        .iter()
+                        .filter(|id| !retry_ids.contains(id))
+                        .copied()
+                        .collect();
+                    format!(
+                        "retry returned {} points, still missing: {still_missing:?}",
+                        r.len(),
+                    )
+                }
+                Err(e) => format!("retry err: {e:?}"),
+            };
+
+            panic!(
+                "search(exact, name={vector_name}, filter={filter_num:?}, limit={limit}) returned \
+                 {} points, expected {expected_len} (candidates: {}); \
+                 missing from result: {missing:?}; extra in result: {extra:?}\n\
+                 PROBE: retrieve(missing) = [{retrieved_summary}]\n\
+                 PROBE: count(filter) = {count_summary} (model says {})\n\
+                 PROBE: scroll(filter) — {scroll_summary}\n\
+                 PROBE: {retry_summary}",
+                results.len(),
+                candidates.len(),
+                candidates.len(),
+            );
+        }
+    } else {
+        assert!(
+            results.len() <= expected_len,
+            "search(approx, name={vector_name}, filter={filter_num:?}) returned {} points, expected at most {}",
+            results.len(),
+            expected_len,
+        );
+    }
+    for record in &results {
+        let entry = model
+            .get(&record.id)
+            .unwrap_or_else(|| panic!("search returned unknown id {:?}", record.id));
+        assert!(
+            entry.vectors.contains_key(vector_name),
+            "search returned id {:?} that doesn't have vector `{vector_name}`",
+            record.id,
+        );
+        if let Some(n) = filter_num {
+            assert!(
+                num_matches(&entry.payload, n),
+                "search(filter num=={n}) returned id {:?} that does not match",
+                record.id,
+            );
+        }
+    }
+}
+
+pub(super) async fn apply_count_by_num(collection: &Collection, model: &Model, num: i64) {
+    let actual = collection
+        .count(
+            CountRequestInternal {
+                filter: Some(match_num_filter(num)),
+                exact: true,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("count by filter failed")
+        .count;
+    let expected = model
+        .values()
+        .filter(|entry| num_matches(&entry.payload, num))
+        .count();
+    assert_eq!(actual, expected, "count(num=={num}) mismatch");
+}
+
+/// Map a model payload value to its facet representation. Only the facetable JSON kinds the
+/// soak produces for `num`/`b` are handled (integer, bool).
+fn facet_value_of(value: &serde_json::Value) -> Option<FacetValue> {
+    match value {
+        serde_json::Value::Bool(b) => Some(FacetValue::Bool(*b)),
+        serde_json::Value::Number(n) => n.as_i64().map(FacetValue::Int),
+        serde_json::Value::Null
+        | serde_json::Value::String(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => None,
+    }
+}
+
+pub(super) async fn apply_facet(
+    collection: &Collection,
+    model: &Model,
+    key: &str,
+    filter_num: Option<i64>,
+) {
+    // `limit` is set well above any field's cardinality (`num` is 0..100, `b` is 2) so `exact`
+    // facet returns every value with a nonzero count and nothing is truncated — letting us
+    // compare the full per-value count map to the model.
+    const FACET_LIMIT: usize = 1024;
+
+    let response = collection
+        .facet(
+            FacetParams {
+                key: key.parse().unwrap(),
+                limit: FACET_LIMIT,
+                filter: filter_num.map(match_num_filter),
+                exact: true,
+            },
+            ShardSelectorInternal::All,
+            None,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("facet failed");
+
+    // Drop zero-count buckets: with the optimizer off (no vacuum), facet still emits a value
+    // whose points have all been deleted, with count 0 — the model can't predict those. Keeping
+    // only count > 0 still catches a real count error (a value the engine wrongly drops to 0
+    // would then be absent here but present in the model).
+    let actual: HashMap<FacetValue, usize> = response
+        .hits
+        .into_iter()
+        .filter(|hit| hit.count > 0)
+        .map(|hit| (hit.value, hit.count))
+        .collect();
+
+    let mut expected: HashMap<FacetValue, usize> = HashMap::new();
+    for entry in model.values() {
+        if filter_num.is_some_and(|n| !num_matches(&entry.payload, n)) {
+            continue;
+        }
+        if let Some(value) = entry.payload.0.get(key).and_then(facet_value_of) {
+            *expected.entry(value).or_insert(0) += 1;
+        }
+    }
+
+    assert_eq!(
+        actual, expected,
+        "facet(key={key}, filter_num={filter_num:?}) mismatch",
+    );
+}
+
+pub(super) async fn apply_scroll_filtered_by_num(collection: &Collection, model: &Model, num: i64) {
+    let scroll = collection
+        .scroll_by(
+            ScrollRequestInternal {
+                offset: None,
+                limit: Some(usize::MAX),
+                filter: Some(match_num_filter(num)),
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(false),
+                order_by: None,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("scroll(filtered) failed");
+    let returned: AHashSet<PointIdType> = scroll.points.iter().map(|r| r.id).collect();
+    let expected: AHashSet<PointIdType> = model
+        .iter()
+        .filter(|(_, entry)| num_matches(&entry.payload, num))
+        .map(|(id, _)| *id)
+        .collect();
+    assert_id_sets_eq(&returned, &expected, &format!("scroll(num=={num})"));
+}
+
+pub(super) async fn apply_count_by_tag(collection: &Collection, model: &Model, tag: &str) {
+    let actual = collection
+        .count(
+            CountRequestInternal {
+                filter: Some(match_tag_filter(tag)),
+                exact: true,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("count by tag failed")
+        .count;
+    let expected = model
+        .values()
+        .filter(|entry| tag_matches(&entry.payload, tag))
+        .count();
+    assert_eq!(actual, expected, "count(tag=={tag:?}) mismatch");
+}
+
+pub(super) async fn apply_scroll_filtered_by_tag(
+    collection: &Collection,
+    model: &Model,
+    tag: &str,
+) {
+    let scroll = collection
+        .scroll_by(
+            ScrollRequestInternal {
+                offset: None,
+                limit: Some(usize::MAX),
+                filter: Some(match_tag_filter(tag)),
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(false),
+                order_by: None,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("scroll(filtered by tag) failed");
+    let returned: AHashSet<PointIdType> = scroll.points.iter().map(|r| r.id).collect();
+    let expected: AHashSet<PointIdType> = model
+        .iter()
+        .filter(|(_, entry)| tag_matches(&entry.payload, tag))
+        .map(|(id, _)| *id)
+        .collect();
+    assert_id_sets_eq(&returned, &expected, &format!("scroll(tag=={tag:?})"));
+}
+
+pub(super) async fn apply_scroll_ordered(
+    collection: &Collection,
+    model: &Model,
+    direction: Direction,
+) {
+    let scroll = collection
+        .scroll_by(
+            ScrollRequestInternal {
+                offset: None,
+                limit: Some(usize::MAX),
+                filter: None,
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(false),
+                order_by: Some(OrderByInterface::Struct(OrderBy {
+                    key: "num".parse().unwrap(),
+                    direction: Some(direction),
+                    start_from: None,
+                })),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("scroll(ordered) failed");
+
+    // Pull (id, num) pairs from order_value on each record.
+    let returned: Vec<(PointIdType, i64)> = scroll
+        .points
+        .iter()
+        .map(|r| {
+            let n = match r.order_value.as_ref().expect("order_value missing") {
+                OrderValue::Int(i) => *i,
+                other @ OrderValue::Float(_) => {
+                    panic!("unexpected order_value variant: {other:?}")
+                }
+            };
+            (r.id, n)
+        })
+        .collect();
+
+    // 1. order_value must match the model's `num` for each returned id.
+    for (id, n) in &returned {
+        let entry = model.get(id).expect("ordered scroll returned unknown id");
+        let model_num = entry
+            .payload
+            .0
+            .get("num")
+            .and_then(|v| v.as_i64())
+            .expect("ordered scroll returned id without `num`");
+        assert_eq!(
+            *n, model_num,
+            "ordered scroll order_value disagrees with model for id {id:?}",
+        );
+    }
+
+    // 2. Returned order_values must be monotonic.
+    for w in returned.windows(2) {
+        let ok = match direction {
+            Direction::Asc => w[0].1 <= w[1].1,
+            Direction::Desc => w[0].1 >= w[1].1,
+        };
+        assert!(
+            ok,
+            "ordered scroll not monotonic ({direction:?}): {} then {}",
+            w[0].1, w[1].1,
+        );
+    }
+
+    // 3. Every model point with a `num` must appear in the result.
+    let returned_ids: AHashSet<PointIdType> = returned.iter().map(|(id, _)| *id).collect();
+    let expected_ids: AHashSet<PointIdType> = model
+        .iter()
+        .filter(|(_, entry)| has_num(&entry.payload))
+        .map(|(id, _)| *id)
+        .collect();
+    assert_id_sets_eq(&returned_ids, &expected_ids, "ordered scroll");
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn apply_recommend(
+    collection: &Collection,
+    model: &Model,
+    positive: &[PointIdType],
+    negative: &[PointIdType],
+    limit: usize,
+    strategy: RecommendStrategy,
+    vector_name: &str,
+) {
+    let results = recommend_by(
+        RecommendRequestInternal {
+            positive: positive
+                .iter()
+                .map(|id| RecommendExample::PointId(*id))
+                .collect(),
+            negative: negative
+                .iter()
+                .map(|id| RecommendExample::PointId(*id))
+                .collect(),
+            limit,
+            strategy: Some(strategy),
+            using: Some(UsingVector::Name(vector_name.to_string())),
+            ..Default::default()
+        },
+        collection,
+        |_name| async { unreachable!("no cross-collection lookup in this test") },
+        None,
+        ShardSelectorInternal::All,
+        None,
+        HwMeasurementAcc::new(),
+    )
+    .await
+    .expect("recommend failed");
+
+    let excluded: AHashSet<PointIdType> = positive.iter().chain(negative.iter()).copied().collect();
+    // Candidate points must (a) not be excluded and (b) have the requested vector populated.
+    let candidate_count = model
+        .iter()
+        .filter(|(id, _)| !excluded.contains(id))
+        .filter(|(_, entry)| entry.vectors.contains_key(vector_name))
+        .count();
+    let expected_len = limit.min(candidate_count);
+    // `recommend_by` defaults to `params: None` which lowers to an approximate search; we only
+    // assert an upper bound.
+    assert!(
+        results.len() <= expected_len,
+        "recommend(name={vector_name}, {strategy:?}) returned {} points, expected at most {}",
+        results.len(),
+        expected_len,
+    );
+    for record in &results {
+        let entry = model.get(&record.id).unwrap_or_else(|| {
+            panic!(
+                "recommend({strategy:?}) returned unknown id {:?}",
+                record.id
+            )
+        });
+        assert!(
+            entry.vectors.contains_key(vector_name),
+            "recommend returned id {:?} that doesn't have vector `{vector_name}`",
+            record.id,
+        );
+        assert!(
+            !excluded.contains(&record.id),
+            "recommend({strategy:?}) returned excluded id {:?}",
+            record.id,
+        );
+    }
+}

--- a/lib/collection/src/model_testing/apply/writes.rs
+++ b/lib/collection/src/model_testing/apply/writes.rs
@@ -1,0 +1,412 @@
+use std::collections::BTreeSet;
+
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::data_types::vector_name_config::VectorNameConfig;
+use segment::json_path::JsonPath;
+use segment::types::{Payload, PayloadFieldSchema, PointIdType, VectorNameBuf};
+
+use super::super::Model;
+use super::super::op::{NamedVectors, match_num_filter, model_entry_from, num_matches};
+use super::{apply_update, to_named_persisted};
+use crate::collection::Collection;
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
+use crate::operations::point_ops::{
+    ConditionalInsertOperationInternal, PointIdsList, PointInsertOperationsInternal,
+    PointOperations, PointStructPersisted, UpdateMode,
+};
+use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, VectorOperations};
+
+pub(super) async fn apply_upsert(
+    collection: &Collection,
+    model: &mut Model,
+    id: PointIdType,
+    vecs: &NamedVectors,
+    payload: &Payload,
+) {
+    let point = PointStructPersisted {
+        id,
+        vector: to_named_persisted(vecs),
+        payload: Some(payload.clone()),
+    };
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(vec![point]),
+    ));
+    apply_update(collection, upsert, "upsert").await;
+    model.insert(id, model_entry_from(vecs, payload));
+}
+
+pub(super) async fn apply_upsert_batch(
+    collection: &Collection,
+    model: &mut Model,
+    points: &[(PointIdType, NamedVectors, Payload)],
+) {
+    let persisted: Vec<_> = points
+        .iter()
+        .map(|(id, vecs, payload)| PointStructPersisted {
+            id: *id,
+            vector: to_named_persisted(vecs),
+            payload: Some(payload.clone()),
+        })
+        .collect();
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(persisted),
+    ));
+    apply_update(collection, upsert, "batch upsert").await;
+    for (id, vecs, payload) in points {
+        model.insert(*id, model_entry_from(vecs, payload));
+    }
+}
+
+pub(super) async fn apply_delete(collection: &Collection, model: &mut Model, ids: &[PointIdType]) {
+    let delete = CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+        ids: ids.to_vec(),
+    });
+    apply_update(collection, delete, "delete").await;
+    for id in ids {
+        model.remove(id);
+    }
+}
+
+pub(super) async fn apply_delete_by_filter(collection: &Collection, model: &mut Model, num: i64) {
+    let delete = CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
+        match_num_filter(num),
+    ));
+    apply_update(collection, delete, "delete by filter").await;
+    model.retain(|_, entry| !num_matches(&entry.payload, num));
+}
+
+pub(super) async fn apply_set_payload(
+    collection: &Collection,
+    model: &mut Model,
+    ids: &[PointIdType],
+    payload: &Payload,
+) {
+    let op = CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+        payload: payload.clone(),
+        points: Some(ids.to_vec()),
+        filter: None,
+        key: None,
+    }));
+    apply_update(collection, op, "set payload").await;
+    for id in ids {
+        if let Some(entry) = model.get_mut(id) {
+            for (k, v) in &payload.0 {
+                entry.payload.0.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_overwrite_payload(
+    collection: &Collection,
+    model: &mut Model,
+    ids: &[PointIdType],
+    payload: &Payload,
+) {
+    let op =
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::OverwritePayload(SetPayloadOp {
+            payload: payload.clone(),
+            points: Some(ids.to_vec()),
+            filter: None,
+            key: None,
+        }));
+    apply_update(collection, op, "overwrite payload").await;
+    for id in ids {
+        if let Some(entry) = model.get_mut(id) {
+            entry.payload = payload.clone();
+        }
+    }
+}
+
+pub(super) async fn apply_delete_payload(
+    collection: &Collection,
+    model: &mut Model,
+    ids: &[PointIdType],
+    keys: &[JsonPath],
+) {
+    let op =
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::DeletePayload(DeletePayloadOp {
+            keys: keys.to_vec(),
+            points: Some(ids.to_vec()),
+            filter: None,
+        }));
+    apply_update(collection, op, "delete payload").await;
+    for id in ids {
+        if let Some(entry) = model.get_mut(id) {
+            for k in keys {
+                entry.payload.0.remove(&k.to_string());
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_clear_payload(
+    collection: &Collection,
+    model: &mut Model,
+    ids: &[PointIdType],
+) {
+    let op = CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
+        points: ids.to_vec(),
+    });
+    apply_update(collection, op, "clear payload").await;
+    for id in ids {
+        if let Some(entry) = model.get_mut(id) {
+            entry.payload = Payload::default();
+        }
+    }
+}
+
+pub(super) async fn apply_set_payload_by_filter(
+    collection: &Collection,
+    model: &mut Model,
+    num: i64,
+    payload: &Payload,
+) {
+    let op = CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+        payload: payload.clone(),
+        points: None,
+        filter: Some(match_num_filter(num)),
+        key: None,
+    }));
+    apply_update(collection, op, "set payload by filter").await;
+    for entry in model.values_mut() {
+        if num_matches(&entry.payload, num) {
+            for (k, v) in &payload.0 {
+                entry.payload.0.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_overwrite_payload_by_filter(
+    collection: &Collection,
+    model: &mut Model,
+    num: i64,
+    payload: &Payload,
+) {
+    let op =
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::OverwritePayload(SetPayloadOp {
+            payload: payload.clone(),
+            points: None,
+            filter: Some(match_num_filter(num)),
+            key: None,
+        }));
+    apply_update(collection, op, "overwrite payload by filter").await;
+    for entry in model.values_mut() {
+        if num_matches(&entry.payload, num) {
+            entry.payload = payload.clone();
+        }
+    }
+}
+
+pub(super) async fn apply_delete_payload_by_filter(
+    collection: &Collection,
+    model: &mut Model,
+    num: i64,
+    keys: &[JsonPath],
+) {
+    let op =
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::DeletePayload(DeletePayloadOp {
+            keys: keys.to_vec(),
+            points: None,
+            filter: Some(match_num_filter(num)),
+        }));
+    apply_update(collection, op, "delete payload by filter").await;
+    // Snapshot which points match BEFORE mutating, since deleting `num` would change matches.
+    for entry in model.values_mut() {
+        if num_matches(&entry.payload, num) {
+            for k in keys {
+                entry.payload.0.remove(&k.to_string());
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_clear_payload_by_filter(
+    collection: &Collection,
+    model: &mut Model,
+    num: i64,
+) {
+    let op = CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayloadByFilter(
+        match_num_filter(num),
+    ));
+    apply_update(collection, op, "clear payload by filter").await;
+    for entry in model.values_mut() {
+        if num_matches(&entry.payload, num) {
+            entry.payload = Payload::default();
+        }
+    }
+}
+
+pub(super) async fn apply_create_index(
+    collection: &Collection,
+    field: &JsonPath,
+    schema: &PayloadFieldSchema,
+) {
+    collection
+        .create_payload_index_with_wait(
+            field.clone(),
+            schema.clone(),
+            true,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("create index failed");
+}
+
+pub(super) async fn apply_drop_index(collection: &Collection, field: &JsonPath) {
+    collection
+        .drop_payload_index(field.clone())
+        .await
+        .expect("drop index failed");
+}
+
+pub(super) async fn apply_upsert_conditional(
+    collection: &Collection,
+    model: &mut Model,
+    points: &[(PointIdType, NamedVectors, Payload)],
+    condition_num: i64,
+    mode: UpdateMode,
+) {
+    let persisted: Vec<_> = points
+        .iter()
+        .map(|(id, vecs, payload)| PointStructPersisted {
+            id: *id,
+            vector: to_named_persisted(vecs),
+            payload: Some(payload.clone()),
+        })
+        .collect();
+    let conditional = CollectionUpdateOperations::PointOperation(
+        PointOperations::UpsertPointsConditional(ConditionalInsertOperationInternal {
+            points_op: PointInsertOperationsInternal::PointsList(persisted),
+            condition: match_num_filter(condition_num),
+            update_mode: Some(mode),
+        }),
+    );
+    apply_update(collection, conditional, "conditional upsert").await;
+    for (id, vecs, payload) in points {
+        let existing = model.get(id);
+        let should_apply = match (mode, existing) {
+            (UpdateMode::Upsert, None) => true,
+            (UpdateMode::Upsert, Some(entry)) => num_matches(&entry.payload, condition_num),
+            (UpdateMode::InsertOnly, None) => true,
+            (UpdateMode::InsertOnly, Some(_)) => false,
+            (UpdateMode::UpdateOnly, None) => false,
+            (UpdateMode::UpdateOnly, Some(entry)) => num_matches(&entry.payload, condition_num),
+        };
+        if should_apply {
+            model.insert(*id, model_entry_from(vecs, payload));
+        }
+    }
+}
+
+pub(super) async fn apply_update_vectors(
+    collection: &Collection,
+    model: &mut Model,
+    points: &[(PointIdType, NamedVectors)],
+    condition_num: Option<i64>,
+) {
+    let persisted: Vec<_> = points
+        .iter()
+        .map(|(id, vecs)| PointVectorsPersisted {
+            id: *id,
+            vector: to_named_persisted(vecs),
+        })
+        .collect();
+    let op = CollectionUpdateOperations::VectorOperation(VectorOperations::UpdateVectors(
+        UpdateVectorsOp {
+            points: persisted,
+            update_filter: condition_num.map(match_num_filter),
+        },
+    ));
+    apply_update(collection, op, "update vectors").await;
+    for (id, partial) in points {
+        if let Some(entry) = model.get_mut(id) {
+            let passes = condition_num.is_none_or(|n| num_matches(&entry.payload, n));
+            if passes {
+                for (name, value) in partial {
+                    entry.vectors.insert(name.clone(), value.clone());
+                }
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_delete_vectors(
+    collection: &Collection,
+    model: &mut Model,
+    ids: &[PointIdType],
+    names: &[VectorNameBuf],
+) {
+    let op = CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
+        PointIdsList {
+            points: ids.to_vec(),
+            shard_key: None,
+        },
+        names.to_vec(),
+    ));
+    apply_update(collection, op, "delete vectors").await;
+    for id in ids {
+        if let Some(entry) = model.get_mut(id) {
+            for name in names {
+                entry.vectors.remove(name);
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_delete_vectors_by_filter(
+    collection: &Collection,
+    model: &mut Model,
+    num: i64,
+    names: &[VectorNameBuf],
+) {
+    let op = CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectorsByFilter(
+        match_num_filter(num),
+        names.to_vec(),
+    ));
+    apply_update(collection, op, "delete vectors by filter").await;
+    for entry in model.values_mut() {
+        if num_matches(&entry.payload, num) {
+            for name in names {
+                entry.vectors.remove(name);
+            }
+        }
+    }
+}
+
+pub(super) async fn apply_create_vector_name(
+    collection: &Collection,
+    active: &mut BTreeSet<VectorNameBuf>,
+    name: &str,
+    config: &VectorNameConfig,
+) {
+    // Use the Collection-level helper rather than `update_from_client_simple` directly —
+    // the helper updates the persisted CollectionParams (so Search sees the new name) and
+    // then emits the per-shard `CreateVectorName` WAL op. A raw WAL op alone would leave
+    // the Collection config stale and Search would error with "Vector with name X is not
+    // configured in this collection".
+    collection
+        .create_named_vector(name.to_string(), config.clone(), HwMeasurementAcc::new())
+        .await
+        .unwrap_or_else(|e| panic!("create_named_vector({name:?}) failed: {e:?}"));
+    active.insert(name.to_string());
+}
+
+pub(super) async fn apply_delete_vector_name(
+    collection: &Collection,
+    model: &mut Model,
+    active: &mut BTreeSet<VectorNameBuf>,
+    name: &str,
+) {
+    collection
+        .delete_named_vector(name.to_string())
+        .await
+        .unwrap_or_else(|e| panic!("delete_named_vector({name:?}) failed: {e:?}"));
+    active.remove(name);
+    // Drop the name from every model entry — the engine has dropped all data for it.
+    for entry in model.values_mut() {
+        entry.vectors.remove(name);
+    }
+}

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -1,0 +1,218 @@
+use std::collections::{BTreeMap, HashSet};
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::types::{Distance, MultiVectorConfig, PayloadFieldSchema, PayloadSchemaType};
+
+use super::{COLLECTION_NAME, INITIAL_ACTIVE, PEER_ID, VectorKind, kind_of};
+use crate::collection::{Collection, RequestShardTransfer};
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+use crate::operations::shared_storage_config::SharedStorageConfig;
+use crate::operations::types::{SparseVectorParams, VectorsConfig};
+use crate::operations::vector_params_builder::VectorParamsBuilder;
+use crate::optimizers_builder::OptimizersConfig;
+use crate::shards::channel_service::ChannelService;
+use crate::shards::collection_shard_distribution::CollectionShardDistribution;
+use crate::shards::replica_set::replica_set_state::ReplicaState;
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+use crate::shards::shard::{PeerId, ShardId};
+
+/// Build a fresh soak collection rooted at `storage_path`. Creates `collection/` and
+/// `snapshots/` subdirs, wiping any pre-existing contents — each soak run starts from a
+/// clean slate. If you need to preserve a crashed run's state for post-mortem, copy the
+/// directory out before re-running.
+pub(super) async fn fixture(
+    shard_count: u32,
+    storage_path: &Path,
+    disable_optimizer: bool,
+    max_segment_size_kb: usize,
+    indexing_threshold_kb: usize,
+    flush_interval_sec: u64,
+    on_disk: bool,
+) -> (PathBuf, PathBuf, Collection) {
+    let collection_dir = storage_path.join("collection");
+    let snapshots_dir = storage_path.join("snapshots");
+    for dir in [&collection_dir, &snapshots_dir] {
+        if dir.exists() {
+            fs_err::remove_dir_all(dir)
+                .unwrap_or_else(|e| panic!("failed to wipe {}: {e:?}", dir.display()));
+        }
+        fs_err::create_dir_all(dir)
+            .unwrap_or_else(|e| panic!("failed to create {}: {e:?}", dir.display()));
+    }
+
+    let wal_config = WalConfig::default();
+
+    // Build the initial vector schema from the candidate pool. The remaining (initially
+    // inactive) candidates are reachable through `Op::CreateVectorName` later in the run.
+    let mut dense_vectors = BTreeMap::new();
+    let mut sparse_vectors = BTreeMap::new();
+    for name in INITIAL_ACTIVE {
+        match kind_of(name) {
+            VectorKind::Dense(dim) => {
+                let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
+                // Only override when enabled. Leaving `on_disk` unset (None) preserves the
+                // engine's default resolution, so no-flag runs stay byte-identical to before
+                // this flag existed (`None` and `Some(false)` aren't equivalent everywhere —
+                // e.g. the config-mismatch optimizer only acts on `Some`).
+                if on_disk {
+                    builder = builder.with_on_disk(true);
+                }
+                dense_vectors.insert(name.to_string(), builder.build());
+            }
+            VectorKind::Sparse => {
+                sparse_vectors.insert(
+                    name.to_string(),
+                    SparseVectorParams {
+                        index: None,
+                        modifier: None,
+                    },
+                );
+            }
+            VectorKind::MultiDense(dim) => {
+                // The builder has no `with_multivector_config`; set the field on the built
+                // `VectorParams` directly to mark this dense slot as a ColBERT-style multi-vec.
+                let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
+                if on_disk {
+                    builder = builder.with_on_disk(true);
+                }
+                let mut params = builder.build();
+                params.multivector_config = Some(MultiVectorConfig::default());
+                dense_vectors.insert(name.to_string(), params);
+            }
+        }
+    }
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Multi(dense_vectors),
+        sparse_vectors: Some(sparse_vectors),
+        shard_number: NonZeroU32::new(shard_count).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        sharding_method: None,
+        read_fan_out_factor: None,
+        read_fan_out_delay_ms: None,
+        on_disk_payload: false,
+    };
+
+    // Optimizer config — `max_segment_size_kb` / `indexing_threshold_kb` are caller-supplied
+    // so the binary can experiment with race surfaces under different cadences. Defaults
+    // are scaled down from production (~200 MB / ~20 MB) because the soak collection holds
+    // only a few MB and would never trip the optimizer at those thresholds.
+    let optimizer_config = OptimizersConfig {
+        deleted_threshold: 0.1,
+        vacuum_min_vector_number: 100,
+        default_segment_number: 2,
+        max_segment_size: Some(max_segment_size_kb),
+        #[expect(deprecated)]
+        memmap_threshold: None,
+        indexing_threshold: Some(indexing_threshold_kb),
+        flush_interval_sec,
+        // `Some(0)` disables the optimizer worker entirely (per `OptimizersConfig::fixture`'s
+        // comment); `None` lets it use its default thread count.
+        max_optimization_threads: if disable_optimizer { Some(0) } else { Some(1) },
+        prevent_unoptimized: Some(false),
+    };
+
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config,
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+
+    let shards: AHashMap<ShardId, HashSet<PeerId>> = (0..shard_count)
+        .map(|i| (i, HashSet::from([PEER_ID])))
+        .collect();
+
+    let collection = Collection::new(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        &collection_dir,
+        &snapshots_dir,
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution { shards },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    for shard_id in 0..shard_count {
+        collection
+            .set_shard_replica_state(shard_id, PEER_ID, ReplicaState::Active, None)
+            .await
+            .expect("failed to activate shard");
+    }
+
+    // Eagerly index all "always-on" payload fields so filter ops run through the index path.
+    // `tag` is left out — the test toggles it via Op::CreateIndex / Op::DropIndex.
+    let eager_indices: &[(&str, PayloadSchemaType)] = &[
+        ("num", PayloadSchemaType::Integer),
+        ("f", PayloadSchemaType::Float),
+        ("b", PayloadSchemaType::Bool),
+        ("d", PayloadSchemaType::Datetime),
+        ("g", PayloadSchemaType::Geo),
+        ("t", PayloadSchemaType::Text),
+    ];
+    for (field, schema) in eager_indices {
+        collection
+            .create_payload_index_with_wait(
+                field.parse().unwrap(),
+                PayloadFieldSchema::FieldType(*schema),
+                true,
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("failed to create eager `{field}` index: {e:?}"));
+    }
+
+    (collection_dir, snapshots_dir, collection)
+}
+
+pub(super) async fn reopen_collection(collection_dir: &Path, snapshots_dir: &Path) -> Collection {
+    Collection::load(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir,
+        snapshots_dir,
+        Arc::new(SharedStorageConfig::default()),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+}
+
+fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(move |_peer_id, _shard_id, _from_state| {})
+}
+
+fn dummy_request_shard_transfer() -> RequestShardTransfer {
+    Arc::new(move |_transfer| {})
+}
+
+fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_transfer, _reason| {})
+}

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -332,3 +332,40 @@ pub async fn run(
     );
     verify::assert_matches_model(&reloaded, &model, "reloaded");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end smoke run: 10k seeded ops against a single-shard collection, including
+    /// the per-op verification ops, the end-of-run live check, and the final close+reopen
+    /// reload check. Catches harness rot (op/model drift, fixture breakage) on every
+    /// `cargo test` run.
+    ///
+    /// Single shard, optimizer disabled, no mid-run restarts: keeps the run fast and
+    /// deterministic (no background segment churn) and steers clear of the known-unfixed
+    /// multi-shard reload bug class, so this stays green as a regression gate for the
+    /// harness itself rather than a bug-finder (that's the binary's job).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn harness_no_optimizer() {
+        let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
+        run(
+            42,     // seed
+            10_000, // op_num
+            1,      // shard_count
+            500,    // id_pool
+            storage_dir.path(),
+            true,  // disable_optimizer
+            10,    // max_segment_size_kb
+            5,     // indexing_threshold_kb
+            5,     // flush_interval_sec
+            0.0,   // restart_probability
+            2500,  // swarm_interval: a few redraws within the run
+            false, // on_disk
+            false, // pre_restart_check
+            false, // enable_force_off
+            Arc::new(AtomicBool::new(false)),
+        )
+        .await;
+    }
+}

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -337,6 +337,10 @@ pub async fn run(
 mod tests {
     use super::*;
 
+    // Windows CI is significantly slower; keep the smoke run short there.
+    #[cfg(target_os = "windows")]
+    const OP_NUM: usize = 1_000;
+    #[cfg(not(target_os = "windows"))]
     const OP_NUM: usize = 10_000;
     const ID_POOL: u64 = 500;
 

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -337,7 +337,10 @@ pub async fn run(
 mod tests {
     use super::*;
 
-    /// End-to-end smoke run: 10k seeded ops against a single-shard collection, including
+    const OP_NUM: usize = 10_000;
+    const ID_POOL: u64 = 500;
+
+    /// End-to-end smoke run: [`OP_NUM`] seeded ops against a single-shard collection, including
     /// the per-op verification ops, the end-of-run live check, and the final close+reopen
     /// reload check. Catches harness rot (op/model drift, fixture breakage) on every
     /// `cargo test` run.
@@ -347,19 +350,51 @@ mod tests {
     /// multi-shard reload bug class, so this stays green as a regression gate for the
     /// harness itself rather than a bug-finder (that's the binary's job).
     #[tokio::test(flavor = "multi_thread")]
-    async fn harness_no_optimizer() {
+    async fn harness_no_optimizer_no_restarts() {
         let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let seed = rand::rng().random();
         run(
-            42,     // seed
-            10_000, // op_num
-            1,      // shard_count
-            500,    // id_pool
+            seed,    // fresh seed each run
+            OP_NUM,  // op_num
+            1,       // shard_count
+            ID_POOL, // id_pool
             storage_dir.path(),
             true,  // disable_optimizer
             10,    // max_segment_size_kb
             5,     // indexing_threshold_kb
             5,     // flush_interval_sec
             0.0,   // restart_probability
+            2500,  // swarm_interval: a few redraws within the run
+            false, // on_disk
+            false, // pre_restart_check
+            false, // enable_force_off
+            Arc::new(AtomicBool::new(false)),
+        )
+        .await;
+    }
+
+    /// Same configuration as [`harness_no_optimizer_no_restarts`], plus seeded mid-run
+    /// restarts (~20 expected at p=0.002 over 10k ops): each one is a cold close+reopen+full
+    /// model verification, so the WAL-replay path is exercised throughout the run
+    /// instead of only at the final reload check.
+    ///
+    /// Note: the restart roll consumes one rng draw per iteration, so even for the same
+    /// seed the op stream differs from a no-restart run.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn harness_no_optimizer_restarts() {
+        let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let seed = rand::rng().random();
+        run(
+            seed,    // fresh seed each run
+            OP_NUM,  // op_num
+            1,       // shard_count
+            ID_POOL, // id_pool
+            storage_dir.path(),
+            true,  // disable_optimizer
+            10,    // max_segment_size_kb
+            5,     // indexing_threshold_kb
+            5,     // flush_interval_sec
+            0.002, // restart_probability
             2500,  // swarm_interval: a few redraws within the run
             false, // on_disk
             false, // pre_restart_check

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -1,0 +1,334 @@
+mod apply;
+mod fixture;
+mod op;
+mod trace;
+mod verify;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+use segment::types::{Payload, PointIdType, VectorNameBuf};
+use sparse::common::sparse_vector::SparseVector;
+
+use crate::shards::shard::PeerId;
+
+const PEER_ID: PeerId = 1;
+const COLLECTION_NAME: &str = "test";
+
+/// Static metadata for every vector name the test might ever activate. Four names start
+/// active in the fixture; the remaining two are exclusively reachable through
+/// `Op::CreateVectorName`.
+pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
+    VectorCandidate {
+        name: "a",
+        kind: VectorKind::Dense(4),
+    },
+    VectorCandidate {
+        name: "b",
+        kind: VectorKind::Dense(6),
+    },
+    VectorCandidate {
+        name: "c",
+        kind: VectorKind::Dense(5),
+    },
+    VectorCandidate {
+        name: "s",
+        kind: VectorKind::Sparse,
+    },
+    VectorCandidate {
+        name: "u",
+        kind: VectorKind::Sparse,
+    },
+    VectorCandidate {
+        name: "m",
+        kind: VectorKind::MultiDense(4),
+    },
+];
+
+/// Names present in the collection schema at fixture time.
+// "m" (multivector) is temporarily disabled while its reload divergence is unresolved.
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "s"];
+
+pub(super) struct VectorCandidate {
+    pub(super) name: &'static str,
+    pub(super) kind: VectorKind,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(super) enum VectorKind {
+    Dense(u64),
+    Sparse,
+    /// ColBERT-style multi-vector: each point stores a matrix of `dim`-wide rows. Scoring
+    /// uses MaxSim across query rows × stored rows.
+    MultiDense(u64),
+}
+
+pub(super) fn kind_of(name: &str) -> VectorKind {
+    ALL_CANDIDATES
+        .iter()
+        .find(|c| c.name == name)
+        .map(|c| c.kind)
+        .unwrap_or_else(|| panic!("unknown vector name: {name}"))
+}
+
+// BTreeMap for deterministic iteration order — several op generators sample from `model.keys()`
+// with a seeded RNG, and reservoir sampling order is iteration-order-dependent. AHashMap's
+// `RandomState` seeds with per-process entropy, which breaks workload determinism even for a
+// fixed `--seed`. BTreeMap's natural ordering by `PointIdType` is stable across runs.
+type Model = BTreeMap<PointIdType, ModelEntry>;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct ModelEntry {
+    pub(super) vectors: BTreeMap<VectorNameBuf, VectorValue>,
+    pub(super) payload: Payload,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum VectorValue {
+    Dense(Vec<f32>),
+    /// Stored canonicalized: sorted by index, zero-valued entries dropped. The engine returns
+    /// sparse vectors in this form, so storing them canonically makes round-trip equality work.
+    Sparse(SparseVector),
+    /// ColBERT-style multi-vector: a matrix of rows, each of the configured dim.
+    MultiDense(Vec<Vec<f32>>),
+}
+
+/// Soak entrypoint — drives `op_num` randomized operations against a fresh collection,
+/// continuously verifying it against an in-memory model. Reproducible for a given `seed`.
+///
+/// Storage is rooted at `storage_path`. Any pre-existing `collection/` and `snapshots/`
+/// subdirectories are wiped at the start of each run; copy them out beforehand if you
+/// need to preserve a previous run for post-mortem inspection.
+///
+/// `shutdown` lets the caller request an early stop (e.g. on Ctrl-C). The op loop
+/// checks it before each iteration and exits cleanly when set; post-run verification
+/// + summary + reload still run with whatever ops were applied.
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    seed: u64,
+    op_num: usize,
+    shard_count: u32,
+    id_pool: u64,
+    storage_path: &Path,
+    disable_optimizer: bool,
+    max_segment_size_kb: usize,
+    indexing_threshold_kb: usize,
+    flush_interval_sec: u64,
+    restart_probability: f64,
+    swarm_interval: usize,
+    on_disk: bool,
+    pre_restart_check: bool,
+    enable_force_off: bool,
+    shutdown: Arc<AtomicBool>,
+) {
+    let (collection_dir, snapshots_dir, mut collection) = fixture::fixture(
+        shard_count,
+        storage_path,
+        disable_optimizer,
+        max_segment_size_kb,
+        indexing_threshold_kb,
+        flush_interval_sec,
+        on_disk,
+    )
+    .await;
+
+    // Trace lives at the storage-path root (next to `collection/` and `snapshots/`) so the
+    // fixture's per-run wipe of those subdirs leaves it alone; `File::create` truncates so each
+    // run starts fresh. Schema is documented in `trace.rs`.
+    let trace_path = storage_path.join("trace.log");
+    let mut trace = trace::Trace::create(&trace_path)
+        .unwrap_or_else(|e| panic!("failed to create trace at {}: {e}", trace_path.display()));
+    trace.header(
+        seed,
+        op_num,
+        shard_count,
+        id_pool,
+        disable_optimizer,
+        max_segment_size_kb,
+        indexing_threshold_kb,
+        flush_interval_sec,
+        restart_probability,
+        swarm_interval,
+        enable_force_off,
+    );
+
+    let mut model: Model = Model::new();
+    let mut active_names: BTreeSet<VectorNameBuf> =
+        INITIAL_ACTIVE.iter().map(|s| s.to_string()).collect();
+    let rng = &mut SmallRng::seed_from_u64(seed);
+
+    // Swarm-testing config (Groce et al., ISSTA 2012): disable a random subset of ops. Recomputed
+    // every `swarm_interval` ops so one long run becomes a sequence of swarm sub-tests (broader
+    // feature-interaction coverage than a single fixed config). Drawn from the seeded rng so it's
+    // reproducible; each redraw is logged with its op tick so a failure is attributable to the
+    // config that was live. (This consumes rng draws, so the op stream differs from a non-swarm
+    // build for the same seed.)
+    let mut swarm = op::Swarm::random(rng, enable_force_off);
+    let initial_enabled = swarm.enabled_ops();
+    trace.swarm(0, &initial_enabled);
+    println!("model_testing: op:0 swarm -> {initial_enabled:?}");
+
+    let bar = ProgressBar::new(op_num as u64);
+    bar.set_style(
+        ProgressStyle::default_bar()
+            // Single line with a fixed-width bar: a multi-line (`{msg}\n…`) template plus a
+            // full-width `{wide_bar}` can't be repainted in place — the bar line hits the
+            // terminal-width auto-wrap boundary and occupies one more physical row than indicatif
+            // clears, so stale `{msg}` lines stick and smear together. A fixed-width `{bar}` never
+            // reaches that boundary; `{msg:24}` is width-padded so a changing op kind (longest is
+            // "OverwritePayloadByFilter", 24 chars) doesn't shift the bar left/right each frame.
+            .template("{msg:24} [{elapsed_precise}] {bar:40} {pos}/{len} ({per_sec}, eta:{eta})")
+            .expect("Failed to create progress style"),
+    );
+
+    let mut applied = 0usize;
+    for i in 0..op_num {
+        if shutdown.load(Ordering::Relaxed) {
+            log::info!("shutdown received at op:{i}, exiting loop");
+            break;
+        }
+        // Recompute the swarm config at each interval boundary (op 0 was drawn before the loop).
+        if i > 0 && i % swarm_interval == 0 {
+            let prev = swarm.enabled_ops();
+            swarm = op::Swarm::random(rng, enable_force_off);
+            let next = swarm.enabled_ops();
+            // Trace keeps the full enabled set (for reproducibility); the console shows only the
+            // delta vs. the previous config — that's what changed.
+            trace.swarm(i, &next);
+            let enabled: Vec<&str> = next.iter().copied().filter(|n| !prev.contains(n)).collect();
+            let disabled: Vec<&str> = prev.iter().copied().filter(|n| !next.contains(n)).collect();
+            let kept: Vec<&str> = next.iter().copied().filter(|n| prev.contains(n)).collect();
+            // `suspend` clears the bar, runs the closure, then redraws — without it the bar's next
+            // repaint overwrites the last printed line (the `=kept` one). Plain `println!`
+            // (stdout) inside keeps it visible when piped, unlike `bar.println` which routes
+            // through the bar's stderr draw target and is swallowed on a non-TTY.
+            bar.suspend(|| {
+                println!("model_testing: op:{i} regen swarm Δ\n  +{enabled:?}\n  -{disabled:?}\n  ={kept:?}");
+            });
+        }
+        // Roll for a mid-run restart BEFORE generating an op so an iteration is either
+        // a restart OR an apply (not both). The `> 0.0` short-circuits the rng draw at
+        // the default value, so workload determinism is preserved for `--restart-probability 0`
+        // (which matches the previous no-restart default exactly).
+        let do_restart = restart_probability > 0.0 && rng.random::<f64>() < restart_probability;
+        if do_restart {
+            log::debug!("op:{i} Restart");
+            bar.set_message("Restart");
+            let (pre_segments, _) = verify::run_summary(&collection).await;
+            trace.restart(i, model.len(), pre_segments);
+            // Verify the LIVE collection against the model *before* closing. This splits a
+            // restart failure into its two possible causes: if this assert fires, the engine
+            // diverged from the model while serving (an apply-path bug); if it passes but the
+            // post-reload assert below fires, the divergence was introduced by close+reopen (a
+            // durability / WAL-replay bug). Without this split, a "restart at op:N" panic can't
+            // distinguish the two.
+            //
+            // Opt-in (`--pre-restart-check`, off by default): the full pre-close scroll is slow,
+            // and reading the whole collection warms caches / forces lazy loads that can mask a
+            // reload divergence — so the default cold close+reopen surfaces more bugs. Enable the
+            // check when you need to attribute a failure to the apply path vs. the reload path.
+            if pre_restart_check {
+                let live_pre = verify::collect_model_from_collection(&collection).await;
+                verify::assert_matches_model(
+                    &live_pre,
+                    &model,
+                    &format!("pre-restart (live) at op:{i}"),
+                );
+            }
+            // Close + reopen + full model verification. Does NOT force a flush — mirrors
+            // what a real user gets from `stop_gracefully`, which is the path that exposes
+            // the WAL-replay bug class.
+            //
+            // `Collection::load` (inside `reopen_collection`) draws its own
+            // "Recovering collection" progress bar to stderr. Two independent indicatif bars on
+            // the same stream fight over the cursor — our op bar keeps overwriting the recovery
+            // bar, so it never visibly advances. Hide our bar for the duration of the reopen so
+            // the recovery bar owns the terminal, then restore it. The leading newline drops the
+            // recovery bar onto a fresh line (a fresh indicatif bar's first draw lands at the
+            // cursor without clearing, so it would otherwise share our bar's last frame's line);
+            // the trailing newline preserves the recovery bar's final frame in scrollback instead
+            // of letting the op loop's next tick `\r`-overwrite it.
+            bar.set_draw_target(ProgressDrawTarget::hidden());
+            eprintln!();
+            collection.stop_gracefully().await;
+            drop(collection);
+            collection = fixture::reopen_collection(&collection_dir, &snapshots_dir).await;
+            // `Collection::load` returns before tail-of-WAL ops queued to the
+            // update worker have been applied — that's an intentional fast-start
+            // feature. Wait for the queue to drain so the scroll below observes
+            // all WAL-replayed state.
+            verify::wait_for_pending_updates(&collection).await;
+            let live = verify::collect_model_from_collection(&collection).await;
+            verify::assert_matches_model(&live, &model, &format!("restart at op:{i}"));
+            eprintln!();
+            bar.set_draw_target(ProgressDrawTarget::stderr());
+        } else {
+            let op = op::Op::random(rng, &model, &active_names, id_pool, &swarm);
+            log::debug!("op:{i} {op:?}");
+            bar.set_message(op.kind());
+            // Log BEFORE apply so a panic preserves the offending op in the trace.
+            trace.op(i, &op);
+            apply::apply(&collection, &mut model, &mut active_names, &op).await;
+        }
+        bar.inc(1);
+        applied += 1;
+    }
+    bar.finish();
+
+    let interrupted = shutdown.load(Ordering::Relaxed);
+    if interrupted {
+        eprintln!("model_testing: verifying live state...");
+    }
+    log::debug!("all ops applied, verifying live collection against model");
+    let live = verify::collect_model_from_collection(&collection).await;
+    let (live_extra, live_missing) = verify::id_diff(&live, &model);
+    let (segments, optimized) = verify::run_summary(&collection).await;
+    trace.live_verify(
+        applied,
+        model.len(),
+        live.len(),
+        segments,
+        optimized,
+        &live_extra,
+        &live_missing,
+    );
+    verify::assert_matches_model(&live, &model, "live");
+
+    // Confirm the segment optimizer actually fired — but skip on shutdown (short run may
+    // not have triggered) or when the optimizer is intentionally disabled.
+    if !interrupted && !disable_optimizer {
+        verify::wait_for_optimizer(&collection).await;
+    }
+
+    println!(
+        "model_testing: {applied} ops applied, {} live points, {segments} segments, {optimized} \
+         optimized points",
+        model.len(),
+    );
+
+    if interrupted {
+        eprintln!("model_testing: reopening to verify reload...");
+    }
+    // Close and reopen, then re-verify — mirrors gridstore tests.rs:488-516.
+    collection.stop_gracefully().await;
+    drop(collection);
+    let collection = fixture::reopen_collection(&collection_dir, &snapshots_dir).await;
+    // Same reason as the mid-run restart above — drain deferred WAL ops before scrolling.
+    verify::wait_for_pending_updates(&collection).await;
+
+    let reloaded = verify::collect_model_from_collection(&collection).await;
+    let (reload_extra, reload_missing) = verify::id_diff(&reloaded, &model);
+    trace.reload_verify(
+        applied,
+        model.len(),
+        reloaded.len(),
+        &reload_extra,
+        &reload_missing,
+    );
+    verify::assert_matches_model(&reloaded, &model, "reloaded");
+}

--- a/lib/collection/src/model_testing/op/generators.rs
+++ b/lib/collection/src/model_testing/op/generators.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeSet;
+
+use ahash::AHashSet;
+use api::rest::RecommendStrategy;
+use rand::seq::{IndexedRandom, IteratorRandom};
+use rand::{Rng, RngExt};
+use segment::data_types::order_by::Direction;
+use segment::json_path::JsonPath;
+use segment::types::{ExtendedPointId, Payload, PointIdType, VectorNameBuf};
+use serde_json::{Map, Value};
+use sparse::common::sparse_vector::SparseVector;
+
+use super::super::{Model, VectorKind, VectorValue, kind_of};
+use super::{NamedVectors, Op, canonical_sparse};
+use crate::operations::point_ops::UpdateMode;
+
+// ───── payload value pools ────────────────────────────────────────────────
+//
+// Each non-numeric field is sampled from a small discrete pool. Pools are kept small enough
+// that filter ranges have plenty of "clearly in" and "clearly out" points to avoid floating-
+// point boundary flakes between the engine and the model.
+
+const TAGS: [&str; 3] = ["a", "b", "c"];
+const FLOATS: [f64; 5] = [0.0, 0.25, 0.5, 0.75, 1.0];
+const DATETIMES: [&str; 5] = [
+    "2023-01-15T00:00:00Z",
+    "2023-04-15T00:00:00Z",
+    "2023-07-15T00:00:00Z",
+    "2023-10-15T00:00:00Z",
+    "2023-12-31T00:00:00Z",
+];
+const TEXTS: [&str; 4] = [
+    "alpha beta gamma",
+    "alpha delta",
+    "beta epsilon",
+    "gamma delta zeta",
+];
+// Geo coords live in a small EU-shaped rectangle, snapped to 0.1 degree.
+const GEO_LAT_LO: f64 = 40.0;
+const GEO_LAT_HI: f64 = 50.0;
+const GEO_LON_LO: f64 = -10.0;
+const GEO_LON_HI: f64 = 10.0;
+
+// Sparse vector generation parameters.
+const SPARSE_DIM_SPACE: u32 = 32; // indices are drawn from 0..SPARSE_DIM_SPACE
+const SPARSE_NNZ_MIN: usize = 1; // at least one nonzero so the engine has something to index
+const SPARSE_NNZ_MAX: usize = 6;
+
+pub(super) fn random_tag(rng: &mut impl Rng) -> &'static str {
+    TAGS.choose(rng).unwrap()
+}
+
+fn random_id(rng: &mut impl Rng, id_pool: u64) -> PointIdType {
+    ExtendedPointId::NumId(rng.random_range(0..id_pool))
+}
+
+pub(super) fn random_num(rng: &mut impl Rng) -> i64 {
+    rng.random_range(0..100i64)
+}
+
+pub(super) fn random_distinct_ids(
+    rng: &mut impl Rng,
+    range: std::ops::RangeInclusive<usize>,
+    id_pool: u64,
+) -> Vec<PointIdType> {
+    let n = rng.random_range(range);
+    let mut seen = AHashSet::new();
+    let mut ids = Vec::with_capacity(n);
+    while ids.len() < n {
+        let id = random_id(rng, id_pool);
+        if seen.insert(id) {
+            ids.push(id);
+        }
+    }
+    ids
+}
+
+/// Sample up to `max` ids from the model. Returns `None` if the model is empty so the caller
+/// can fall back to an Upsert (see `upsert_fallback`).
+pub(super) fn random_existing_ids(
+    rng: &mut impl Rng,
+    model: &Model,
+    max: usize,
+) -> Option<Vec<PointIdType>> {
+    if model.is_empty() {
+        return None;
+    }
+    let n = rng.random_range(1..=max).min(model.len());
+    Some(model.keys().copied().sample(rng, n))
+}
+
+/// When an op needs existing ids but the model is empty, replace it with a simple Upsert so
+/// the workload still makes progress.
+pub(super) fn upsert_fallback(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+    id_pool: u64,
+) -> Op {
+    let (id, vecs, payload) = random_point(rng, active, id_pool);
+    Op::Upsert(id, vecs, payload)
+}
+
+pub(super) fn random_payload_keys(rng: &mut impl Rng) -> Vec<JsonPath> {
+    let all_keys = ["num", "tag", "f", "b", "d", "g", "t"];
+    let mut keys: Vec<JsonPath> = all_keys
+        .iter()
+        .filter(|_| rng.random_bool(0.4))
+        .map(|k| k.parse().unwrap())
+        .collect();
+    // Guarantee at least one key so DeletePayload always has work to do.
+    if keys.is_empty() {
+        let pick = all_keys.choose(rng).unwrap();
+        keys.push(pick.parse().unwrap());
+    }
+    keys
+}
+
+// ───── vector generators ────────────────────────────────────────────────────
+
+fn random_dense_vec(rng: &mut impl Rng, dim: u64) -> Vec<f32> {
+    (0..dim).map(|_| rng.random_range(0.0..1.0)).collect()
+}
+
+fn random_sparse_vector(rng: &mut impl Rng) -> SparseVector {
+    let nnz = rng.random_range(SPARSE_NNZ_MIN..=SPARSE_NNZ_MAX);
+    let mut indices: Vec<u32> = (0..SPARSE_DIM_SPACE).sample(rng, nnz);
+    indices.sort_unstable();
+    // Use a small discrete value pool so values round-trip exactly (no FP equality risk).
+    let values: Vec<f32> = (0..nnz)
+        .map(|_| *[0.25_f32, 0.5, 0.75, 1.0].choose(rng).unwrap())
+        .collect();
+    canonical_sparse(&SparseVector { indices, values })
+}
+
+/// All currently-active named vectors populated — used by initial Upsert/Batch/Conditional.
+fn random_named_vectors(rng: &mut impl Rng, active: &BTreeSet<VectorNameBuf>) -> NamedVectors {
+    let mut map = NamedVectors::default();
+    for name in active {
+        map.insert(name.clone(), random_vector_for_name(rng, name));
+    }
+    map
+}
+
+/// A partial named-vector map (1-2 of the currently-active names) — used by UpdateVectors.
+pub(super) fn random_partial_named_vectors(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+) -> NamedVectors {
+    let names = random_vector_name_subset(rng, active);
+    let mut map = NamedVectors::default();
+    for name in names {
+        let value = random_vector_for_name(rng, &name);
+        map.insert(name, value);
+    }
+    map
+}
+
+/// Build a random vector matching the kind metadata associated with `name`.
+fn random_vector_for_name(rng: &mut impl Rng, name: &str) -> VectorValue {
+    match kind_of(name) {
+        VectorKind::Dense(dim) => VectorValue::Dense(random_dense_vec(rng, dim)),
+        VectorKind::Sparse => VectorValue::Sparse(random_sparse_vector(rng)),
+        VectorKind::MultiDense(dim) => VectorValue::MultiDense(random_multi_dense(rng, dim)),
+    }
+}
+
+/// 2-4 rows of `dim`-wide dense vectors. Row count varies per point — exercises the
+/// engine's variable-length matrix storage.
+fn random_multi_dense(rng: &mut impl Rng, dim: u64) -> Vec<Vec<f32>> {
+    let rows = rng.random_range(2..=4);
+    (0..rows).map(|_| random_dense_vec(rng, dim)).collect()
+}
+
+/// Random 1-2 distinct names from the active set (callers gate on `active` being non-empty).
+pub(super) fn random_vector_name_subset(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+) -> Vec<VectorNameBuf> {
+    let n = rng.random_range(1..=2).min(active.len());
+    active.iter().cloned().sample(rng, n)
+}
+
+pub(super) fn random_vector_name(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+) -> VectorNameBuf {
+    active.iter().choose(rng).cloned().expect("active is empty")
+}
+
+/// Build a search query appropriate for the chosen vector name.
+pub(super) fn random_query_for_name(rng: &mut impl Rng, name: &str) -> VectorValue {
+    random_vector_for_name(rng, name)
+}
+
+pub(super) fn random_payload(rng: &mut impl Rng) -> Payload {
+    let mut map = Map::new();
+    map.insert("num".to_string(), Value::from(rng.random_range(0..100i64)));
+    if rng.random_bool(0.5) {
+        map.insert("tag".to_string(), Value::from(random_tag(rng)));
+    }
+    // Always-on fields — payload mutation ops (Set/Overwrite/Delete/Clear) can still drop them.
+    map.insert("f".to_string(), Value::from(*FLOATS.choose(rng).unwrap()));
+    map.insert("b".to_string(), Value::from(rng.random_bool(0.5)));
+    map.insert(
+        "d".to_string(),
+        Value::from(*DATETIMES.choose(rng).unwrap()),
+    );
+    let (lat, lon) = random_geo_coords(rng);
+    let mut geo = Map::new();
+    geo.insert("lat".to_string(), Value::from(lat));
+    geo.insert("lon".to_string(), Value::from(lon));
+    map.insert("g".to_string(), Value::Object(geo));
+    map.insert("t".to_string(), Value::from(*TEXTS.choose(rng).unwrap()));
+    Payload(map)
+}
+
+fn random_geo_coords(rng: &mut impl Rng) -> (f64, f64) {
+    // 0.1-degree snapping: ≈11km separation between adjacent positions, well above any
+    // Haversine FP imprecision a radius filter could land on.
+    let lat = (rng.random_range(GEO_LAT_LO..GEO_LAT_HI) * 10.0).round() / 10.0;
+    let lon = (rng.random_range(GEO_LON_LO..GEO_LON_HI) * 10.0).round() / 10.0;
+    (lat, lon)
+}
+
+pub(super) fn random_point(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+    id_pool: u64,
+) -> (PointIdType, NamedVectors, Payload) {
+    (
+        random_id(rng, id_pool),
+        random_named_vectors(rng, active),
+        random_payload(rng),
+    )
+}
+
+pub(super) fn random_distinct_points(
+    rng: &mut impl Rng,
+    active: &BTreeSet<VectorNameBuf>,
+    range: std::ops::RangeInclusive<usize>,
+    id_pool: u64,
+) -> Vec<(PointIdType, NamedVectors, Payload)> {
+    let n = rng.random_range(range);
+    let mut seen = AHashSet::new();
+    let mut points = Vec::with_capacity(n);
+    while points.len() < n {
+        let (id, vecs, payload) = random_point(rng, active, id_pool);
+        if seen.insert(id) {
+            points.push((id, vecs, payload));
+        }
+    }
+    points
+}
+
+pub(super) fn random_direction(rng: &mut impl Rng) -> Direction {
+    if rng.random_bool(0.5) {
+        Direction::Asc
+    } else {
+        Direction::Desc
+    }
+}
+
+pub(super) fn random_recommend_strategy(rng: &mut impl Rng) -> RecommendStrategy {
+    match rng.random_range(0..3) {
+        0 => RecommendStrategy::AverageVector,
+        1 => RecommendStrategy::BestScore,
+        2 => RecommendStrategy::SumScores,
+        _ => unreachable!(),
+    }
+}
+
+pub(super) fn random_update_mode(rng: &mut impl Rng) -> UpdateMode {
+    match rng.random_range(0..3) {
+        0 => UpdateMode::Upsert,
+        1 => UpdateMode::InsertOnly,
+        2 => UpdateMode::UpdateOnly,
+        _ => unreachable!(),
+    }
+}

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -428,9 +428,12 @@ impl Op {
             22 => {
                 // CreateVectorName: pick a candidate currently absent from the active set.
                 // If all candidates are active, fall back to a regular upsert.
+                // Multivector (`MultiDense`) candidates are excluded while their reload
+                // divergence is unresolved — see the note on `INITIAL_ACTIVE`.
                 let inactive: Vec<&'static super::VectorCandidate> = ALL_CANDIDATES
                     .iter()
                     .filter(|c| !active.contains(c.name))
+                    .filter(|c| !matches!(c.kind, VectorKind::MultiDense(_)))
                     .collect();
                 if inactive.is_empty() {
                     return upsert_fallback(rng, active, id_pool);

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -1,0 +1,595 @@
+mod generators;
+
+use std::collections::BTreeSet;
+
+use ahash::AHashSet;
+use api::rest::RecommendStrategy;
+use generators::{
+    random_direction, random_distinct_ids, random_distinct_points, random_existing_ids, random_num,
+    random_partial_named_vectors, random_payload, random_payload_keys, random_point,
+    random_query_for_name, random_recommend_strategy, random_tag, random_update_mode,
+    random_vector_name, random_vector_name_subset, upsert_fallback,
+};
+use rand::distr::weighted::WeightedIndex;
+use rand::prelude::Distribution;
+use rand::seq::{IndexedRandom, IteratorRandom};
+use rand::{Rng, RngExt};
+use segment::data_types::order_by::Direction;
+use segment::data_types::vector_name_config::{
+    DenseVectorConfig, SparseVectorConfig, VectorNameConfig,
+};
+use segment::json_path::JsonPath;
+use segment::types::{
+    Condition, Distance, FieldCondition, Filter, Match, MultiVectorConfig, Payload,
+    PayloadFieldSchema, PayloadSchemaType, PointIdType, VectorNameBuf,
+};
+use sparse::common::sparse_vector::SparseVector;
+
+use super::{ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue};
+use crate::operations::point_ops::UpdateMode;
+
+/// Operations driven against both the live `Collection` and the model.
+#[derive(Debug, Clone)]
+pub(super) enum Op {
+    Upsert(PointIdType, NamedVectors, Payload),
+    UpsertBatch(Vec<(PointIdType, NamedVectors, Payload)>),
+    Delete(Vec<PointIdType>),
+    DeleteByFilter(i64),
+    SetPayload(Vec<PointIdType>, Payload),
+    OverwritePayload(Vec<PointIdType>, Payload),
+    DeletePayload(Vec<PointIdType>, Vec<JsonPath>),
+    ClearPayload(Vec<PointIdType>),
+    CreateIndex(JsonPath, PayloadFieldSchema),
+    DropIndex(JsonPath),
+    /// Retrieve verification: IDs sampled uniformly from `0..id_pool`. Most IDs won't be in
+    /// the model — the assertion exercises engine⇄model agreement on missing IDs plus the
+    /// occasional full per-id check on a hit.
+    RetrieveRandom(Vec<PointIdType>),
+    /// Retrieve verification: IDs sampled from the model so every requested ID exercises
+    /// the full per-id vectors+payload equality check.
+    RetrieveExisting(Vec<PointIdType>),
+    CountByNum(i64),
+    /// Verification op: nearest-neighbor search. `exact=true` does a brute-force scan;
+    /// `exact=false` goes through the HNSW (dense) or sparse-index path.
+    /// We don't compare scores (float-flaky), only result size and id membership in the model.
+    Search {
+        vector_name: VectorNameBuf,
+        query: VectorValue,
+        limit: usize,
+        exact: bool,
+        filter_num: Option<i64>,
+    },
+    /// Upsert that only applies to a point if the existing payload matches the filter
+    /// (semantics depend on `mode`).
+    UpsertConditional {
+        points: Vec<(PointIdType, NamedVectors, Payload)>,
+        condition_num: i64,
+        mode: UpdateMode,
+    },
+    /// Replace a subset of named vectors on existing points; the rest stay untouched.
+    /// `condition_num=None` updates blindly; `Some(n)` only updates points where `num == n`.
+    /// Ids are sampled from the model so the no-filter path doesn't hit `PointIdError`.
+    UpdateVectors {
+        /// Each entry's map contains only the names being replaced on that point.
+        points: Vec<(PointIdType, NamedVectors)>,
+        condition_num: Option<i64>,
+    },
+    /// Drop specific named vectors from existing points. The point keeps payload + the
+    /// remaining vectors. Ids are sampled from the model.
+    DeleteVectors {
+        ids: Vec<PointIdType>,
+        names: Vec<VectorNameBuf>,
+    },
+    /// Same as `DeleteVectors` but driven by a `num == X` filter instead of an id list.
+    ///
+    /// NOTE: this is structurally similar to `DeleteByFilter` (which is currently disabled
+    /// due to a proxy-installation race — see that variant's comment). If post-reload count
+    /// mismatches appear here, the same engine-side race is the prime suspect.
+    DeleteVectorsByFilter {
+        num: i64,
+        names: Vec<VectorNameBuf>,
+    },
+    /// Verification op: scroll all points matching `num == X`, compare id set to model.
+    ScrollFilteredByNum(i64),
+    /// Verification op: count points matching `tag == X`, compare to model count.
+    CountByTag(String),
+    /// Verification op: scroll all points matching `tag == X`, compare id set to model.
+    ScrollFilteredByTag(String),
+    /// Verification op: scroll ordered by `num` (requires the eager `num` index).
+    /// Asserts monotonic ordering and that the returned set covers every point with a `num`.
+    ScrollOrdered(Direction),
+    /// Verification op: recommend by point IDs. Positives and negatives are sampled from the
+    /// model so they exist in the collection AND have the chosen `vector_name` populated
+    /// (otherwise the engine errors with e.g. "Positive vectors should not be empty").
+    Recommend {
+        positive: Vec<PointIdType>,
+        negative: Vec<PointIdType>,
+        limit: usize,
+        strategy: RecommendStrategy,
+        vector_name: VectorNameBuf,
+    },
+    /// Add a new named vector to the collection schema. Existing points have no value for the
+    /// new name until a later `UpdateVectors` fills it in. The name is drawn from the static
+    /// pool (see `ALL_CANDIDATES`) and must currently be inactive.
+    CreateVectorName {
+        name: VectorNameBuf,
+        config: VectorNameConfig,
+    },
+    /// Remove a named vector from the collection schema. All points lose any value for that
+    /// name. At least one name must remain active; the random selector skips this op when
+    /// the active set has only one entry.
+    DeleteVectorName(VectorNameBuf),
+    /// Merge `payload` into every point matching `num == X` (filter-driven `SetPayload`).
+    SetPayloadByFilter {
+        num: i64,
+        payload: Payload,
+    },
+    /// Replace the whole payload of every point matching `num == X` (filter-driven
+    /// `OverwritePayload`).
+    OverwritePayloadByFilter {
+        num: i64,
+        payload: Payload,
+    },
+    /// Delete `keys` from the payload of every point matching `num == X` (filter-driven
+    /// `DeletePayload`).
+    DeletePayloadByFilter {
+        num: i64,
+        keys: Vec<JsonPath>,
+    },
+    /// Clear all payload from every point matching `num == X` (filter-driven `ClearPayload`).
+    ClearPayloadByFilter(i64),
+    /// Verification op: facet (count points per distinct value) on an always-indexed, facetable
+    /// field (`num` or `b`), optionally restricted to `num == X`. Run with `exact=true` and a
+    /// limit above the field's cardinality, so the full per-value count map is compared to the
+    /// model exactly.
+    Facet {
+        key: &'static str,
+        filter_num: Option<i64>,
+    },
+}
+
+/// Per-point named-vector payload — used by Upsert/UpsertBatch/UpdateVectors/UpsertConditional.
+pub(super) type NamedVectors = std::collections::BTreeMap<VectorNameBuf, VectorValue>;
+
+/// Per-run workload selection in the sense of Groce et al., "Swarm Testing" (ISSTA 2012):
+/// rather than enabling every op in every run under one fixed distribution, each run draws a
+/// random *subset* of ops to enable (omitted ops get weight 0). Omitting features for a whole
+/// run surfaces bugs the uniform mix suppresses — e.g. a run that never deletes lets segments
+/// grow and stresses reload, while a delete-heavy run stresses tombstones and `deleted_mask`.
+///
+/// The config is drawn from the seeded rng once before the op loop, so a seed reproduces both
+/// the swarm config and the op stream. The enabled set is logged to the trace as a `Swarm` line.
+pub(super) struct Swarm {
+    weights: [u32; Self::N],
+}
+
+impl Swarm {
+    const N: usize = 30;
+
+    /// Op names, aligned 1:1 with `BASE` and the `match` arms in `Op::random`.
+    const NAMES: [&'static str; Self::N] = [
+        "Upsert",
+        "UpsertBatch",
+        "Delete",
+        "DeleteByFilter",
+        "SetPayload",
+        "OverwritePayload",
+        "DeletePayload",
+        "ClearPayload",
+        "CreateIndex",
+        "DropIndex",
+        "RetrieveRandom",
+        "CountByNum",
+        "Search",
+        "UpsertConditional",
+        "UpdateVectors",
+        "DeleteVectors",
+        "DeleteVectorsByFilter",
+        "ScrollFilteredByNum",
+        "CountByTag",
+        "ScrollFilteredByTag",
+        "ScrollOrdered",
+        "Recommend",
+        "CreateVectorName",
+        "DeleteVectorName",
+        "RetrieveExisting",
+        "SetPayloadByFilter",
+        "OverwritePayloadByFilter",
+        "DeletePayloadByFilter",
+        "ClearPayloadByFilter",
+        "Facet",
+    ];
+
+    /// Each op's *natural* relative weight — the default distribution before swarm masking.
+    /// Whether an op actually fires is decided by `random()` with `FORCE_ON`/`FORCE_OFF`; a
+    /// `FORCE_OFF` op keeps its natural weight here (never read while disabled), so re-enabling
+    /// is just removing it from `FORCE_OFF`.
+    //
+    // Currently in `FORCE_OFF` (known-broken):
+    // - DeleteByFilter (3): post-reload count mismatch — a live-time deletion doesn't survive
+    //   reload and the point is resurrected. #9116 fixed only the live filtered-search drop, NOT
+    //   reload durability; needs a forward-port of "durable proxy deletes" before re-enabling.
+    // - CreateVectorName / DeleteVectorName (22, 23): (1) proxy-segment schema race (optimizer-on)
+    //   → "missing / Not existing vector name"; (2) DeleteVectorName vs. storage incoherence
+    //   (fires without the optimizer too) — `delete_named_vector` updates `CollectionParams` but
+    //   doesn't reconcile on-disk segment storage or the WAL, so reload drops WAL-replayed points
+    //   or re-exposes purged vector data. Re-enable once both are fixed.
+    const BASE: [u32; Self::N] = [
+        35, // Upsert
+        15, // UpsertBatch
+        12, // Delete
+        3,  // DeleteByFilter
+        8,  // SetPayload
+        5,  // OverwritePayload
+        5,  // DeletePayload
+        4,  // ClearPayload
+        3,  // CreateIndex
+        2,  // DropIndex
+        4,  // RetrieveRandom
+        4,  // CountByNum
+        6,  // Search
+        5,  // UpsertConditional
+        5,  // UpdateVectors
+        4,  // DeleteVectors
+        3,  // DeleteVectorsByFilter
+        5,  // ScrollFilteredByNum
+        4,  // CountByTag
+        4,  // ScrollFilteredByTag
+        4,  // ScrollOrdered
+        4,  // Recommend
+        1,  // CreateVectorName
+        1,  // DeleteVectorName
+        8,  // RetrieveExisting
+        4,  // SetPayloadByFilter
+        3,  // OverwritePayloadByFilter
+        3,  // DeletePayloadByFilter
+        3,  // ClearPayloadByFilter
+        4,  // Facet
+    ];
+
+    /// Indices kept enabled in every swarm config: without a way to insert points the run can't
+    /// make progress and most ops degrade to no-ops.
+    const FORCE_ON: [usize; 1] = [0]; // Upsert
+
+    /// Indices kept disabled in every swarm config: known-broken ops (see `BASE`).
+    const FORCE_OFF: [usize; 3] = [3, 22, 23]; // DeleteByFilter, CreateVectorName, DeleteVectorName
+
+    /// Draw a per-run config: each non-forced op is included with probability 0.5 (keeping its
+    /// base weight); omitted ops get weight 0.
+    ///
+    /// With `enable_force_off`, the known-broken `FORCE_OFF` ops are promoted to forced-on instead
+    /// (enabled in every config) so a run can deliberately exercise them — see the CLI flag of the
+    /// same name. They never draw `random_bool` either way (forced-off or forced-on), so the
+    /// rng-draw count is identical regardless of the flag and a given seed reproduces the same op
+    /// stream for the non-broken ops.
+    pub(super) fn random(rng: &mut impl Rng, enable_force_off: bool) -> Self {
+        let mut weights = Self::BASE;
+        for (i, w) in weights.iter_mut().enumerate() {
+            let forced_off = Self::FORCE_OFF.contains(&i);
+            let forced_on = Self::FORCE_ON.contains(&i) || (enable_force_off && forced_off);
+            // Short-circuit order matters: `random_bool` is only drawn for non-forced ops, so
+            // the rng-draw count stays fixed (one per swarmable op) regardless of the forced
+            // sets — keeping a given seed reproducible.
+            let disable =
+                (forced_off && !enable_force_off) || (!forced_on && !rng.random_bool(0.5));
+            if disable {
+                *w = 0;
+            }
+        }
+        Self { weights }
+    }
+
+    /// Names of the ops enabled (nonzero weight) in this config, for the trace `Swarm` line.
+    pub(super) fn enabled_ops(&self) -> Vec<&'static str> {
+        Self::NAMES
+            .iter()
+            .zip(self.weights)
+            .filter(|(_, w)| *w > 0)
+            .map(|(name, _)| *name)
+            .collect()
+    }
+
+    fn distribution(&self) -> WeightedIndex<u32> {
+        // FORCE_ON guarantees a nonzero total weight.
+        WeightedIndex::new(self.weights).expect("swarm config has at least one enabled op")
+    }
+}
+
+impl Op {
+    pub(super) fn random(
+        rng: &mut impl Rng,
+        model: &Model,
+        active: &BTreeSet<VectorNameBuf>,
+        id_pool: u64,
+        swarm: &Swarm,
+    ) -> Self {
+        // The op at index N below MUST line up with `Swarm::BASE`/`Swarm::NAMES` at the same
+        // index. Adding a new op? Append at the END of all three — never insert in the middle,
+        // or every arm after the insertion silently fires the wrong handler.
+        let workload = swarm.distribution();
+
+        match workload.sample(rng) {
+            0 => {
+                let (id, vecs, payload) = random_point(rng, active, id_pool);
+                Op::Upsert(id, vecs, payload)
+            }
+            1 => Op::UpsertBatch(random_distinct_points(rng, active, 2..=5, id_pool)),
+            2 => Op::Delete(random_distinct_ids(rng, 1..=3, id_pool)),
+            3 => Op::DeleteByFilter(random_num(rng)),
+            4 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::SetPayload(ids, random_payload(rng))
+            }
+            5 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::OverwritePayload(ids, random_payload(rng))
+            }
+            6 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::DeletePayload(ids, random_payload_keys(rng))
+            }
+            7 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::ClearPayload(ids)
+            }
+            8 => Op::CreateIndex(
+                // Only toggle `tag`; the fixture eagerly indexes `num` and the test relies on it
+                // staying indexed (e.g. for ordered scroll).
+                "tag".parse().unwrap(),
+                PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+            ),
+            9 => Op::DropIndex("tag".parse().unwrap()),
+            10 => Op::RetrieveRandom(random_distinct_ids(rng, 3..=10, id_pool)),
+            11 => Op::CountByNum(random_num(rng)),
+            12 => {
+                let vector_name = random_vector_name(rng, active);
+                let query = random_query_for_name(rng, &vector_name);
+                Op::Search {
+                    vector_name,
+                    query,
+                    limit: rng.random_range(1..=10),
+                    exact: rng.random_bool(0.5),
+                    filter_num: rng.random_bool(0.5).then(|| random_num(rng)),
+                }
+            }
+            13 => Op::UpsertConditional {
+                points: random_distinct_points(rng, active, 1..=3, id_pool),
+                condition_num: random_num(rng),
+                mode: random_update_mode(rng),
+            },
+            14 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                let mut points = Vec::with_capacity(ids.len());
+                for id in ids {
+                    points.push((id, random_partial_named_vectors(rng, active)));
+                }
+                let condition_num = rng.random_bool(0.5).then(|| random_num(rng));
+                Op::UpdateVectors {
+                    points,
+                    condition_num,
+                }
+            }
+            15 => {
+                let Some(ids) = random_existing_ids(rng, model, 3) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::DeleteVectors {
+                    ids,
+                    names: random_vector_name_subset(rng, active),
+                }
+            }
+            16 => Op::DeleteVectorsByFilter {
+                num: random_num(rng),
+                names: random_vector_name_subset(rng, active),
+            },
+            17 => Op::ScrollFilteredByNum(random_num(rng)),
+            18 => Op::CountByTag(random_tag(rng).to_string()),
+            19 => Op::ScrollFilteredByTag(random_tag(rng).to_string()),
+            20 => Op::ScrollOrdered(random_direction(rng)),
+            21 => {
+                // Positives + negatives must both have the chosen vector populated, else the
+                // engine errors (e.g. "Positive vectors should not be empty with `average`").
+                let vector_name = random_vector_name(rng, active);
+                let eligible: Vec<PointIdType> = model
+                    .iter()
+                    .filter(|(_, entry)| entry.vectors.contains_key(&vector_name))
+                    .map(|(id, _)| *id)
+                    .collect();
+                if eligible.is_empty() {
+                    return upsert_fallback(rng, active, id_pool);
+                }
+                let n_pos = rng.random_range(1..=3).min(eligible.len());
+                let positive: Vec<PointIdType> = eligible.iter().copied().sample(rng, n_pos);
+                let pos_set: AHashSet<PointIdType> = positive.iter().copied().collect();
+                let n_neg = rng.random_range(0..=2);
+                let negative: Vec<PointIdType> = eligible
+                    .iter()
+                    .copied()
+                    .filter(|id| !pos_set.contains(id))
+                    .sample(rng, n_neg);
+                Op::Recommend {
+                    positive,
+                    negative,
+                    limit: rng.random_range(1..=5),
+                    strategy: random_recommend_strategy(rng),
+                    vector_name,
+                }
+            }
+            22 => {
+                // CreateVectorName: pick a candidate currently absent from the active set.
+                // If all candidates are active, fall back to a regular upsert.
+                let inactive: Vec<&'static super::VectorCandidate> = ALL_CANDIDATES
+                    .iter()
+                    .filter(|c| !active.contains(c.name))
+                    .collect();
+                if inactive.is_empty() {
+                    return upsert_fallback(rng, active, id_pool);
+                }
+                let pick = inactive.choose(rng).unwrap();
+                let config = match pick.kind {
+                    VectorKind::Dense(dim) => VectorNameConfig::dense(DenseVectorConfig {
+                        size: dim as usize,
+                        distance: Distance::Dot,
+                        multivector_config: None,
+                        datatype: None,
+                    }),
+                    VectorKind::Sparse => VectorNameConfig::sparse(SparseVectorConfig {
+                        modifier: None,
+                        datatype: None,
+                    }),
+                    VectorKind::MultiDense(dim) => VectorNameConfig::dense(DenseVectorConfig {
+                        size: dim as usize,
+                        distance: Distance::Dot,
+                        multivector_config: Some(MultiVectorConfig::default()),
+                        datatype: None,
+                    }),
+                };
+                Op::CreateVectorName {
+                    name: pick.name.to_string(),
+                    config,
+                }
+            }
+            23 => {
+                // DeleteVectorName: at least one name must remain active.
+                if active.len() < 2 {
+                    return upsert_fallback(rng, active, id_pool);
+                }
+                let name = active.iter().choose(rng).unwrap().clone();
+                Op::DeleteVectorName(name)
+            }
+            24 => {
+                let Some(ids) = random_existing_ids(rng, model, 10) else {
+                    return upsert_fallback(rng, active, id_pool);
+                };
+                Op::RetrieveExisting(ids)
+            }
+            25 => Op::SetPayloadByFilter {
+                num: random_num(rng),
+                payload: random_payload(rng),
+            },
+            26 => Op::OverwritePayloadByFilter {
+                num: random_num(rng),
+                payload: random_payload(rng),
+            },
+            27 => Op::DeletePayloadByFilter {
+                num: random_num(rng),
+                keys: random_payload_keys(rng),
+            },
+            28 => Op::ClearPayloadByFilter(random_num(rng)),
+            29 => Op::Facet {
+                // Always-indexed, facetable fields (`num`: Integer, `b`: Bool).
+                key: ["num", "b"].choose(rng).copied().unwrap(),
+                filter_num: rng.random_bool(0.5).then(|| random_num(rng)),
+            },
+            n => panic!("unexpected op index {n}"),
+        }
+    }
+
+    /// Variant name only, no payload — suitable for the progress bar message
+    /// (the full `{:?}` is hundreds of characters per op).
+    pub(super) fn kind(&self) -> &'static str {
+        match self {
+            Op::Upsert(..) => "Upsert",
+            Op::UpsertBatch(_) => "UpsertBatch",
+            Op::Delete(_) => "Delete",
+            Op::DeleteByFilter(_) => "DeleteByFilter",
+            Op::SetPayload(..) => "SetPayload",
+            Op::OverwritePayload(..) => "OverwritePayload",
+            Op::DeletePayload(..) => "DeletePayload",
+            Op::ClearPayload(_) => "ClearPayload",
+            Op::CreateIndex(..) => "CreateIndex",
+            Op::DropIndex(_) => "DropIndex",
+            Op::RetrieveRandom(_) => "RetrieveRandom",
+            Op::RetrieveExisting(_) => "RetrieveExisting",
+            Op::CountByNum(_) => "CountByNum",
+            Op::Search { .. } => "Search",
+            Op::UpsertConditional { .. } => "UpsertConditional",
+            Op::UpdateVectors { .. } => "UpdateVectors",
+            Op::DeleteVectors { .. } => "DeleteVectors",
+            Op::DeleteVectorsByFilter { .. } => "DeleteVectorsByFilter",
+            Op::ScrollFilteredByNum(_) => "ScrollFilteredByNum",
+            Op::CountByTag(_) => "CountByTag",
+            Op::ScrollFilteredByTag(_) => "ScrollFilteredByTag",
+            Op::ScrollOrdered(_) => "ScrollOrdered",
+            Op::Recommend { .. } => "Recommend",
+            Op::CreateVectorName { .. } => "CreateVectorName",
+            Op::DeleteVectorName(_) => "DeleteVectorName",
+            Op::SetPayloadByFilter { .. } => "SetPayloadByFilter",
+            Op::OverwritePayloadByFilter { .. } => "OverwritePayloadByFilter",
+            Op::DeletePayloadByFilter { .. } => "DeletePayloadByFilter",
+            Op::ClearPayloadByFilter(_) => "ClearPayloadByFilter",
+            Op::Facet { .. } => "Facet",
+        }
+    }
+}
+
+// ───── shared filter constructors + predicates ─────────────────────────────
+
+pub(super) fn match_num_filter(num: i64) -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_match(
+        "num".parse().unwrap(),
+        Match::from(num),
+    )))
+}
+
+pub(super) fn match_tag_filter(tag: &str) -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_match(
+        "tag".parse().unwrap(),
+        Match::from(tag.to_string()),
+    )))
+}
+
+pub(super) fn num_matches(payload: &Payload, target: i64) -> bool {
+    payload
+        .0
+        .get("num")
+        .and_then(|v| v.as_i64())
+        .is_some_and(|n| n == target)
+}
+
+pub(super) fn tag_matches(payload: &Payload, target: &str) -> bool {
+    payload
+        .0
+        .get("tag")
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t == target)
+}
+
+pub(super) fn has_num(payload: &Payload) -> bool {
+    payload.0.get("num").and_then(|v| v.as_i64()).is_some()
+}
+
+/// Build a new `ModelEntry` from a fresh upsert.
+pub(super) fn model_entry_from(vecs: &NamedVectors, payload: &Payload) -> ModelEntry {
+    ModelEntry {
+        vectors: vecs.clone(),
+        payload: payload.clone(),
+    }
+}
+
+/// Sort sparse indices ascending and drop entries with zero value (mirrors the engine's
+/// canonicalization on read — see `lib/sparse/src/common/sparse_vector.rs`).
+pub(super) fn canonical_sparse(sv: &SparseVector) -> SparseVector {
+    let mut pairs: Vec<(u32, f32)> = sv
+        .indices
+        .iter()
+        .zip(sv.values.iter())
+        .filter(|(_, v)| **v != 0.0)
+        .map(|(i, v)| (*i, *v))
+        .collect();
+    pairs.sort_by_key(|&(i, _)| i);
+    SparseVector {
+        indices: pairs.iter().map(|(i, _)| *i).collect(),
+        values: pairs.iter().map(|(_, v)| *v).collect(),
+    }
+}

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -1,0 +1,280 @@
+//! JSON Lines trace writer for the soak run, designed for **post-mortem debugging
+//! and run-to-run diffing** — both by humans and by AI agents reading the file.
+//!
+//! # Where
+//!
+//! `<storage_path>/trace.log`. Overwritten on every run (`File::create` truncates).
+//!
+//! # Format
+//!
+//! One JSON object per line. Compact (`serde_json::to_string`), so a plain
+//! `grep '"id":157'` or `grep '"ids":\[.*157' trace.log` reconstructs every op
+//! that touched a misbehaving point.
+//!
+//! The writer flushes after every line, so a panic preserves the trace up to
+//! and including the failing op.
+//!
+//! # Event kinds
+//!
+//! Every event has a `kind` field. Lifecycle events also have an `op` field
+//! (the iteration counter from `run`'s main loop, NOT a globally unique op_num);
+//! op events have `op` plus per-op fields.
+//!
+//! | `kind`         | When                                            | Extra fields |
+//! |----------------|-------------------------------------------------|---|
+//! | `Header`       | First line — run configuration                  | `seed`, `op_num`, `shard_count`, `id_pool`, `disable_optimizer`, `max_segment_size_kb`, `indexing_threshold_kb`, `flush_interval_sec`, `restart_probability` |
+//! | *(op variant)* | Each `Op` from the workload generator           | See `op_payload` below — `id`/`ids`/etc. depending on variant |
+//! | `Restart`      | Mid-run close+reopen+verify                     | `pre_points`, `pre_segments` |
+//! | `LiveVerify`   | End-of-run scroll vs model, before reload       | `model_points`, `engine_points`, `segments`, `optimized_points`, `extra`, `missing` |
+//! | `ReloadVerify` | End-of-run scroll vs model, after final reload  | `model_points`, `engine_points`, `extra`, `missing` |
+//!
+//! `extra` = ids the engine has that the model doesn't.
+//! `missing` = ids the model has that the engine doesn't.
+//! When the run is clean both arrays are empty.
+//!
+//! # Reading the file (agent workflow)
+//!
+//! 1. Read the first line → run config (seed, optimizer mode, etc.).
+//! 2. Read the last 1–2 lines → outcome. `ReloadVerify` with empty `extra`/`missing`
+//!    means the run finished clean. Non-empty arrays = the bug surface.
+//! 3. For each id in `extra`/`missing`, grep the file for that id to reconstruct
+//!    its operation history. The last op for an id in `missing` should tell you
+//!    why the model expected it to exist; the last op for an id in `extra`
+//!    should tell you why the model expected it gone.
+//! 4. If the file ends with no `ReloadVerify` line, the panic happened during
+//!    live verification or earlier — the trailing op events are the suspects.
+//!
+//! # Run-to-run comparison
+//!
+//! Two runs with the same seed and same args should produce byte-identical op
+//! lines. Differences in `LiveVerify`/`ReloadVerify`/`Restart` fields (segment
+//! counts, optimizer counters) point at engine-side non-determinism. Use
+//! `diff -u trace.log other.log` and ignore the verify lines if you only care
+//! about workload determinism.
+
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use fs_err::File;
+use segment::types::PointIdType;
+use serde_json::{Value, json};
+
+use super::op::{NamedVectors, Op};
+
+pub(super) struct Trace {
+    writer: BufWriter<File>,
+}
+
+impl Trace {
+    pub(super) fn create(path: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            writer: BufWriter::new(File::create(path)?),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn header(
+        &mut self,
+        seed: u64,
+        op_num: usize,
+        shard_count: u32,
+        id_pool: u64,
+        disable_optimizer: bool,
+        max_segment_size_kb: usize,
+        indexing_threshold_kb: usize,
+        flush_interval_sec: u64,
+        restart_probability: f64,
+        swarm_interval: usize,
+        enable_force_off: bool,
+    ) {
+        self.write(&json!({
+            "kind": "Header",
+            "seed": seed,
+            "op_num": op_num,
+            "shard_count": shard_count,
+            "id_pool": id_pool,
+            "disable_optimizer": disable_optimizer,
+            "max_segment_size_kb": max_segment_size_kb,
+            "indexing_threshold_kb": indexing_threshold_kb,
+            "flush_interval_sec": flush_interval_sec,
+            "restart_probability": restart_probability,
+            "swarm_interval": swarm_interval,
+            "enable_force_off": enable_force_off,
+        }));
+    }
+
+    /// Records a swarm-testing config (the random subset of enabled ops) effective from op
+    /// `tick` until the next redraw. Logged with its tick so a failure is attributable to the
+    /// config that was live when it happened.
+    pub(super) fn swarm(&mut self, tick: usize, enabled_ops: &[&str]) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "Swarm",
+            "enabled_ops": enabled_ops,
+        }));
+    }
+
+    pub(super) fn op(&mut self, tick: usize, op: &Op) {
+        // Insert `op` and `kind` first so they lead every line — agents and humans
+        // scanning the trace identify the event from the leftmost fields.
+        let mut map = serde_json::Map::new();
+        map.insert("op".to_string(), json!(tick));
+        map.insert("kind".to_string(), json!(op.kind()));
+        if let Value::Object(payload) = op_payload(op) {
+            for (k, v) in payload {
+                map.insert(k, v);
+            }
+        }
+        self.write(&Value::Object(map));
+    }
+
+    pub(super) fn restart(&mut self, tick: usize, pre_points: usize, pre_segments: usize) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "Restart",
+            "pre_points": pre_points,
+            "pre_segments": pre_segments,
+        }));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn live_verify(
+        &mut self,
+        tick: usize,
+        model_points: usize,
+        engine_points: usize,
+        segments: usize,
+        optimized_points: usize,
+        extra: &[PointIdType],
+        missing: &[PointIdType],
+    ) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "LiveVerify",
+            "model_points": model_points,
+            "engine_points": engine_points,
+            "segments": segments,
+            "optimized_points": optimized_points,
+            "extra": extra,
+            "missing": missing,
+        }));
+    }
+
+    pub(super) fn reload_verify(
+        &mut self,
+        tick: usize,
+        model_points: usize,
+        engine_points: usize,
+        extra: &[PointIdType],
+        missing: &[PointIdType],
+    ) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "ReloadVerify",
+            "model_points": model_points,
+            "engine_points": engine_points,
+            "extra": extra,
+            "missing": missing,
+        }));
+    }
+
+    fn write(&mut self, value: &Value) {
+        if let Ok(line) = serde_json::to_string(value) {
+            let _ = writeln!(self.writer, "{line}");
+            let _ = self.writer.flush();
+        }
+    }
+}
+
+fn op_payload(op: &Op) -> Value {
+    match op {
+        Op::Upsert(id, vecs, _payload) => json!({
+            "id": id,
+            "vectors": vector_names(vecs),
+        }),
+        Op::UpsertBatch(points) => json!({
+            "ids": points.iter().map(|(id, _, _)| id).collect::<Vec<_>>(),
+        }),
+        Op::Delete(ids) => json!({ "ids": ids }),
+        Op::DeleteByFilter(num) => json!({ "num": num }),
+        Op::SetPayload(ids, _payload) => json!({ "ids": ids }),
+        Op::OverwritePayload(ids, _payload) => json!({ "ids": ids }),
+        Op::DeletePayload(ids, keys) => json!({
+            "ids": ids,
+            "keys": keys.iter().map(|k| k.to_string()).collect::<Vec<_>>(),
+        }),
+        Op::ClearPayload(ids) => json!({ "ids": ids }),
+        Op::CreateIndex(field, _) => json!({ "field": field.to_string() }),
+        Op::DropIndex(field) => json!({ "field": field.to_string() }),
+        Op::RetrieveRandom(ids) => json!({ "ids": ids }),
+        Op::RetrieveExisting(ids) => json!({ "ids": ids }),
+        Op::CountByNum(num) => json!({ "num": num }),
+        Op::Search {
+            vector_name,
+            limit,
+            exact,
+            filter_num,
+            ..
+        } => json!({
+            "vector_name": vector_name,
+            "limit": limit,
+            "exact": exact,
+            "filter_num": filter_num,
+        }),
+        Op::UpsertConditional {
+            points,
+            condition_num,
+            mode,
+        } => json!({
+            "ids": points.iter().map(|(id, _, _)| id).collect::<Vec<_>>(),
+            "condition_num": condition_num,
+            "mode": mode,
+        }),
+        Op::UpdateVectors {
+            points,
+            condition_num,
+        } => json!({
+            "ids": points.iter().map(|(id, _)| id).collect::<Vec<_>>(),
+            "condition_num": condition_num,
+        }),
+        Op::DeleteVectors { ids, names } => json!({
+            "ids": ids,
+            "names": names,
+        }),
+        Op::DeleteVectorsByFilter { num, names } => json!({
+            "num": num,
+            "names": names,
+        }),
+        Op::ScrollFilteredByNum(num) => json!({ "num": num }),
+        Op::CountByTag(tag) => json!({ "tag": tag }),
+        Op::ScrollFilteredByTag(tag) => json!({ "tag": tag }),
+        Op::ScrollOrdered(dir) => json!({ "direction": dir }),
+        Op::Recommend {
+            positive,
+            negative,
+            limit,
+            strategy,
+            vector_name,
+        } => json!({
+            "positive": positive,
+            "negative": negative,
+            "limit": limit,
+            "strategy": strategy,
+            "vector_name": vector_name,
+        }),
+        Op::CreateVectorName { name, .. } => json!({ "name": name }),
+        Op::DeleteVectorName(name) => json!({ "name": name }),
+        Op::SetPayloadByFilter { num, .. } => json!({ "num": num }),
+        Op::OverwritePayloadByFilter { num, .. } => json!({ "num": num }),
+        Op::DeletePayloadByFilter { num, keys } => json!({
+            "num": num,
+            "keys": keys.iter().map(|k| k.to_string()).collect::<Vec<_>>(),
+        }),
+        Op::ClearPayloadByFilter(num) => json!({ "num": num }),
+        Op::Facet { key, filter_num } => json!({ "key": key, "filter_num": filter_num }),
+    }
+}
+
+fn vector_names(vecs: &NamedVectors) -> Vec<&str> {
+    vecs.keys().map(String::as_str).collect()
+}

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -1,0 +1,196 @@
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant};
+
+use api::rest::{VectorOutput, VectorStructOutput};
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::types::{DetailsLevel, TelemetryDetail};
+use segment::types::{PointIdType, VectorNameBuf, WithPayloadInterface, WithVector};
+use shard::scroll::ScrollRequestInternal;
+
+use super::op::canonical_sparse;
+use super::{Model, ModelEntry, VectorValue};
+use crate::collection::Collection;
+use crate::operations::shard_selector_internal::ShardSelectorInternal;
+
+pub(super) async fn collect_model_from_collection(collection: &Collection) -> Model {
+    let scroll = collection
+        .scroll_by(
+            ScrollRequestInternal {
+                offset: None,
+                limit: Some(usize::MAX),
+                filter: None,
+                with_payload: Some(WithPayloadInterface::Bool(true)),
+                with_vector: WithVector::Bool(true),
+                order_by: None,
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("scroll failed");
+
+    let mut out = Model::new();
+    for record in scroll.points {
+        let named = match record.vector.expect("vector missing in scroll result") {
+            VectorStructOutput::Named(m) => m,
+            other @ (VectorStructOutput::Single(_) | VectorStructOutput::MultiDense(_)) => {
+                panic!("expected Named vector struct, got {other:?}")
+            }
+        };
+        let vectors = named_output_to_model(named);
+        let payload = record.payload.unwrap_or_default();
+        out.insert(record.id, ModelEntry { vectors, payload });
+    }
+    out
+}
+
+fn named_output_to_model(
+    named: HashMap<VectorNameBuf, VectorOutput>,
+) -> BTreeMap<VectorNameBuf, VectorValue> {
+    let mut out = BTreeMap::new();
+    for (name, value) in named {
+        let v = match value {
+            VectorOutput::Dense(v) => VectorValue::Dense(v),
+            VectorOutput::Sparse(sv) => VectorValue::Sparse(canonical_sparse(&sv)),
+            VectorOutput::MultiDense(matrix) => VectorValue::MultiDense(matrix),
+        };
+        out.insert(name, v);
+    }
+    out
+}
+
+/// Returns `(extra, missing)` — the ids in `actual` but not in `expected`, and vice versa.
+/// Both lists are sorted for deterministic output (used by the trace writer and by the
+/// size-mismatch panic in `assert_matches_model`).
+pub(super) fn id_diff(actual: &Model, expected: &Model) -> (Vec<PointIdType>, Vec<PointIdType>) {
+    let actual_ids: ahash::AHashSet<_> = actual.keys().copied().collect();
+    let expected_ids: ahash::AHashSet<_> = expected.keys().copied().collect();
+    let mut extra: Vec<_> = actual_ids.difference(&expected_ids).copied().collect();
+    let mut missing: Vec<_> = expected_ids.difference(&actual_ids).copied().collect();
+    extra.sort();
+    missing.sort();
+    (extra, missing)
+}
+
+pub(super) fn assert_matches_model(actual: &Model, expected: &Model, ctx: &str) {
+    if actual.len() != expected.len() {
+        let (extra, missing) = id_diff(actual, expected);
+        panic!(
+            "{ctx}: collection has {} points, model has {}; \
+             extra in collection (not in model): {extra:?}; \
+             missing from collection (in model): {missing:?}",
+            actual.len(),
+            expected.len(),
+        );
+    }
+    for (id, expected_entry) in expected {
+        let actual_entry = actual
+            .get(id)
+            .unwrap_or_else(|| panic!("{ctx}: missing id {id:?}"));
+        assert_eq!(
+            actual_entry.vectors, expected_entry.vectors,
+            "{ctx}: vectors mismatch for id {id:?}",
+        );
+        assert_eq!(
+            actual_entry.payload, expected_entry.payload,
+            "{ctx}: payload mismatch for id {id:?}",
+        );
+    }
+}
+
+/// Returns `(segment_count, total_optimized_points)` summed across every local shard.
+pub(super) async fn run_summary(collection: &Collection) -> (usize, usize) {
+    // Level4 is needed for the per-segment telemetry to be populated; lower levels return
+    // an empty `segments` Vec (see `local_shard/telemetry.rs:24`).
+    let detail = TelemetryDetail {
+        level: DetailsLevel::Level4,
+        histograms: false,
+        per_collection: false,
+    };
+    let telemetry = collection
+        .get_telemetry_data(detail, Duration::from_secs(5))
+        .await
+        .expect("telemetry failed");
+    let mut segments = 0;
+    let mut optimized = 0;
+    for local in telemetry
+        .shards
+        .iter()
+        .flatten()
+        .filter_map(|rs| rs.local.as_ref())
+    {
+        segments += local.segments.as_ref().map(Vec::len).unwrap_or(0);
+        optimized += local.total_optimized_points;
+    }
+    (segments, optimized)
+}
+
+/// Drain every local shard's update worker queue.
+///
+/// After `Collection::load`, `load_from_wal` queues WAL entries past
+/// `applied_seq + APPLIED_SEQ_SAVE_INTERVAL` to the update worker without a
+/// callback (`local_shard/mod.rs:867-877`). This is **intentional**: in
+/// production it makes `Collection::load` return quickly, with the tail of
+/// the WAL applied in the background as the service warms up.
+///
+/// The soak's verification path scrolls immediately after reopen and asserts
+/// against the model, so it has to explicitly wait for that background queue
+/// to drain — otherwise the scroll sees segment state from before those
+/// deferred ops have been applied (recent upserts appear missing, recent
+/// deletes appear un-applied).
+///
+/// Send a `Plunger` to each local shard's update worker and wait for the
+/// ack. The update queue is FIFO, so an ack means every op queued before the
+/// plunger has been applied to in-memory segment state.
+pub(super) async fn wait_for_pending_updates(collection: &Collection) {
+    let receivers = {
+        let holder = collection.shards_holder.read().await;
+        let mut receivers = Vec::with_capacity(holder.all_shards().count());
+        for replica_set in holder.all_shards() {
+            if let Some(rx) = replica_set
+                .plunge_local_async()
+                .await
+                .expect("plunge_local_async failed")
+            {
+                receivers.push(rx);
+            }
+        }
+        receivers
+    };
+    for rx in receivers {
+        rx.await.expect("plunger callback dropped");
+    }
+}
+
+pub(super) async fn wait_for_optimizer(collection: &Collection) {
+    let detail = TelemetryDetail {
+        level: DetailsLevel::Level3,
+        histograms: false,
+        per_collection: false,
+    };
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let telemetry = collection
+            .get_telemetry_data(detail, Duration::from_secs(5))
+            .await
+            .expect("telemetry failed");
+        let optimized: usize = telemetry
+            .shards
+            .iter()
+            .flatten()
+            .filter_map(|rs| rs.local.as_ref())
+            .map(|local| local.total_optimized_points)
+            .sum();
+        if optimized > 0 {
+            log::debug!("optimizer ran: {optimized} points optimized");
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "optimizer did not run within 30s",
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/lib/collection/src/shards/channel_service.rs
+++ b/lib/collection/src/shards/channel_service.rs
@@ -263,7 +263,7 @@ impl ChannelService {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl Default for ChannelService {
     fn default() -> Self {
         Self {

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -7,6 +7,18 @@ use clap::Parser;
 use collection::profiling::interface::init_requests_profile_collector;
 use common::flags::{FeatureFlags, init_feature_flags};
 use common::mmap::MULTI_MMAP_SUPPORT_CHECK_RESULT;
+#[cfg(all(
+    not(target_env = "msvc"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(all(
+    not(target_env = "msvc"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Parser, Debug)]
 #[command(

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -1,0 +1,189 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use clap::Parser;
+use collection::profiling::interface::init_requests_profile_collector;
+use common::flags::{FeatureFlags, init_feature_flags};
+use common::mmap::MULTI_MMAP_SUPPORT_CHECK_RESULT;
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about = "Long-running soak test: random ops against a Collection, verified live against an in-memory model"
+)]
+struct Args {
+    /// RNG seed — same seed reproduces the exact op sequence.
+    #[clap(long, default_value_t = 0)]
+    seed: u64,
+
+    /// Number of randomized operations to apply.
+    #[clap(long, default_value_t = 10_000, value_parser = clap::value_parser!(u64).range(1..))]
+    op_num: u64,
+
+    /// Number of shards in the test collection.
+    #[clap(long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(1..))]
+    shard_count: u32,
+
+    /// Size of the point ID space (ids are drawn uniformly from 0..id_pool).
+    #[clap(long, default_value_t = 500, value_parser = clap::value_parser!(u64).range(1..))]
+    id_pool: u64,
+
+    /// Where to write the collection + snapshots data. Wiped at the start of each run;
+    /// copy the directory out beforehand to preserve a previous run for post-mortem.
+    #[clap(long, default_value = "./storage-model")]
+    storage_path: PathBuf,
+
+    /// Disable the segment optimizer entirely (sets `max_optimization_threads=0` in the
+    /// fixture). Useful for isolating optimizer-race bugs: if a failure stops reproducing
+    /// with this flag on, the bug depends on concurrent optimization.
+    #[clap(long, default_value_t = false)]
+    disable_optimizer: bool,
+
+    /// Optimizer `max_segment_size` in KB. Smaller values produce more segments and more
+    /// optimizer churn (more chances to trip races); larger values mimic production
+    /// cadence. The fixture's default (10 KB) is well below production thresholds because
+    /// the soak collection only holds a few MB total — at production defaults
+    /// (~200 MB) the optimizer would never fire on this workload.
+    #[clap(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
+    max_segment_size_kb: u64,
+
+    /// Optimizer `indexing_threshold` in KB. Same rationale as `max_segment_size_kb`:
+    /// scaled down from production (~20 MB) to fire on the soak's small workload.
+    #[clap(long, default_value_t = 5, value_parser = clap::value_parser!(u64).range(1..))]
+    indexing_threshold_kb: u64,
+
+    /// Periodic flush worker interval in seconds. Lower values mean smaller unflushed-WAL
+    /// windows (more production-realistic given the soak's high op rate); larger values
+    /// stress the unflushed-WAL path and surface bugs like the `DeleteVectorName` replay
+    /// issue where historical Upserts referencing a since-deleted vector name fail.
+    #[clap(long, default_value_t = 5, value_parser = clap::value_parser!(u64).range(1..))]
+    flush_interval_sec: u64,
+
+    /// Per-iteration probability (0.0..=1.0) of restarting the collection mid-run:
+    /// close + reopen + full model verification. Surfaces reload/WAL-replay bugs at the
+    /// op where they're introduced rather than only at end-of-run. 0.0 (default) skips
+    /// restarts entirely; small positive values (e.g. 0.005) are enough to expose the
+    /// known engine bugs without dominating the run with restart overhead.
+    #[clap(long, default_value_t = 0.0)]
+    restart_probability: f64,
+
+    /// Recompute the swarm config (the random subset of enabled ops) every N ops, turning one
+    /// long run into a sequence of swarm sub-tests for broader feature-interaction coverage
+    /// (Groce et al., "Swarm Testing"). Each redraw is logged to the trace. Set
+    /// `>= op_num` for a single config for the whole run. Default 10000 — long enough for a
+    /// config to build up meaningful state (e.g. a no-delete epoch grows segments) before the
+    /// next redraw; smaller values trade that depth for more config breadth.
+    #[clap(long, default_value_t = 10_000, value_parser = clap::value_parser!(u64).range(1..))]
+    swarm_interval: u64,
+
+    /// Set `on_disk` on the dense vector params. Vectors are persisted to disk either way; this
+    /// chooses mmap-on-demand storage (`VectorStorageType::Mmap`, reads hit the page cache/disk)
+    /// over a RAM-resident copy (`InRamMmap`, mmap populated into memory). Required for
+    /// `--async-scorer` to actually exercise io_uring: with an in-RAM copy, reads are served from
+    /// memory and the async read path is bypassed even though the io_uring storage is opened.
+    #[clap(long, default_value_t = false)]
+    on_disk: bool,
+
+    /// Enable the io_uring async scorer for mmap dense vector storage (Linux only). Falls back to
+    /// plain mmap with a logged `failed to open io_uring based vector storage` error if io_uring is
+    /// unavailable — check the log to confirm it actually engaged. Pair with `--on-disk` (otherwise
+    /// reads come from the RAM-resident copy); has no effect on sparse or multivector storage.
+    #[clap(long, default_value_t = false)]
+    async_scorer: bool,
+
+    /// Run the live pre-close verification on a mid-run restart (the full model check before
+    /// `stop_gracefully`). Off by default: it's slow, and scrolling the whole collection first
+    /// warms caches / forces lazy loads that can mask a reload divergence, so the default cold
+    /// close+reopen surfaces more bugs. Enable it to attribute a `restart at op:N` failure to the
+    /// apply path vs. the reload path.
+    #[clap(long, default_value_t = false)]
+    pre_restart_check: bool,
+
+    /// Promote the always-disabled (`FORCE_OFF`) ops — DeleteByFilter, CreateVectorName,
+    /// DeleteVectorName — to forced-on, so they're enabled in every swarm config and guaranteed
+    /// to fire. These ops are masked off by default because they trip known engine bugs (see the
+    /// `FORCE_OFF` comment in `op/mod.rs`); enable this to deliberately reproduce them. The rng-draw
+    /// count is unchanged vs. the default, so the non-broken op stream stays reproducible per seed.
+    #[clap(long, default_value_t = false)]
+    enable_force_off: bool,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    env_logger::init();
+    init_feature_flags(FeatureFlags::default());
+    let _ = MULTI_MMAP_SUPPORT_CHECK_RESULT.set(true);
+    init_requests_profile_collector(tokio::runtime::Handle::current());
+    let args = Args::parse();
+
+    // Ctrl-C handler: first signal flags shutdown so the run loop exits cleanly between
+    // ops; a second Ctrl-C falls through to the default handler and terminates. Wired
+    // BEFORE the run starts so an early signal still gets caught.
+    let shutdown = Arc::new(AtomicBool::new(false));
+    {
+        let s = shutdown.clone();
+        ctrlc::set_handler(move || {
+            if s.swap(true, Ordering::Relaxed) {
+                eprintln!("\nmodel_testing: second Ctrl-C, terminating");
+                std::process::exit(130);
+            } else {
+                eprintln!("\nmodel_testing: shutdown requested, draining current op...");
+            }
+        })
+        .expect("failed to install ctrl-c handler");
+    }
+
+    if !(0.0..=1.0).contains(&args.restart_probability) {
+        eprintln!(
+            "model_testing: --restart-probability must be in [0.0, 1.0], got {}",
+            args.restart_probability,
+        );
+        std::process::exit(2);
+    }
+    // Process-global flag, read when each on-disk dense vector storage is opened — set it before
+    // the fixture builds any segments.
+    segment::vector_storage::common::set_async_scorer(args.async_scorer);
+    println!(
+        "model_testing: seed={} op_num={} shard_count={} id_pool={} storage_path={} \
+         disable_optimizer={} max_segment_size_kb={} indexing_threshold_kb={} \
+         flush_interval_sec={} restart_probability={} swarm_interval={} on_disk={} \
+         async_scorer={} pre_restart_check={} enable_force_off={}",
+        args.seed,
+        args.op_num,
+        args.shard_count,
+        args.id_pool,
+        args.storage_path.display(),
+        args.disable_optimizer,
+        args.max_segment_size_kb,
+        args.indexing_threshold_kb,
+        args.flush_interval_sec,
+        args.restart_probability,
+        args.swarm_interval,
+        args.on_disk,
+        args.async_scorer,
+        args.pre_restart_check,
+        args.enable_force_off,
+    );
+    let start = Instant::now();
+    collection::model_testing::run(
+        args.seed,
+        args.op_num as usize,
+        args.shard_count,
+        args.id_pool,
+        &args.storage_path,
+        args.disable_optimizer,
+        args.max_segment_size_kb as usize,
+        args.indexing_threshold_kb as usize,
+        args.flush_interval_sec,
+        args.restart_probability,
+        args.swarm_interval as usize,
+        args.on_disk,
+        args.pre_restart_check,
+        args.enable_force_off,
+        shutdown,
+    )
+    .await;
+    println!("model_testing: ok in {:.1?}", start.elapsed());
+}


### PR DESCRIPTION
A new `model_testing` harness that drives randomized operations against a live `Collection`, continuously verifying engine state against an in-memory model.

## What it does

The harness maintains an in-memory `Model` that mirrors the engine's expected state and applies one of 24 randomized op variants per iteration (Upsert/Delete batches, payload mutations, filter-driven
  mutations, conditional ops, schema mutations, plus read verifications via Retrieve/Search/Count/Scroll/Recommend).

After each op, read variants assert the engine's response matches the model.

At end of run, the harness scrolls the full collection, compares to the model, then closes, reopens, and re-verifies.

Workload is **deterministic given `--seed`** 

The same seed reproduces the same op stream byte-for-byte, so failures are bisectable.

## How to use

Built as a binary gated on the `service_debug` feature:

  ```bash
  # CI smoke (clean correctness check, ~75 s, no race noise)
   cargo run --bin model_testing --features service_debug --profile perf -- \
    --seed 42 --op-num 100000 --shard-count 2 --id-pool 1000 --disable-optimizer

  # Bug-hunting (default — exposes the optimizer-vs-write races)
   cargo run --bin model_testing --features service_debug --profile perf -- \
    --seed 42 --op-num 100000 --shard-count 2 --id-pool 1000

  # Eager bug surfacing (catches reload-time bugs mid-run instead of at end)
   cargo run --bin model_testing --features service_debug --profile perf -- \
    --seed 42 --op-num 100000 --shard-count 2 --id-pool 1000 \
    --restart-probability 0.005
  ```

  Flags: `--seed`, `--op-num`, `--shard-count`, `--id-pool`, `--storage-path`, `--disable-optimizer`, `--max-segment-size-kb`, `--indexing-threshold-kb`, `--flush-interval-sec`, `--restart-probability`. Ctrl-C
  drains the current op then runs verification; second Ctrl-C hard-exits.

  The unit tests run via `cargo test -p collection --lib delete_vector_name_replay`.

## Bugs allegedly found so far

  | # | Class | Bug | Optimizer needed? |
  |---|---|---|:-:|
  | 1 | proxy-segment race | `DeleteByFilter` — post-reload count mismatch + `debug_assert!` panic at `search.rs:145` | yes |
  | 2 | proxy-segment race | `CreateVectorName`/`DeleteVectorName` — background optimizer "Cannot update from other segment because it is missing vector name X" | yes |
  | 3 | proxy-segment race | Exact dense search + payload filter drops a candidate; other paths (retrieve, scroll, count) see the point | yes |
  | 4 | WAL/config incoherence | `DeleteVectorName` updates `CollectionParams` but doesn't reconcile the WAL — historical Upserts referencing a since-deleted vector name fail at replay with `"Not existing vector name error: X"` and drop their target points | **no** |

Bugs 1-3 share a single fix surface (proxy-construction → holder-installation window in `optimize.rs:727-779` / `proxy_segment/mod.rs:48-77`). Bug 5 has its own fix (replay-tolerance for unknown vector names)
  and ships with three unit-test reproducers in `delete_vector_name_replay.rs`.

Default mode in this PR keeps bug 5 visible (DeleteVectorName at weight 1). The `--disable-optimizer` mode plus disabling DeleteVectorName is the only configuration that passes cleanly today — useful as a
  baseline CI smoke target.