### PR TITLE
Add TurboQuant metadata versioning

### DIFF
--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -4,7 +4,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use quantization::DistanceType;
 use quantization::encoded_vectors::VectorParameters;
 use quantization::turboquant::quantization::TurboQuantizer;
-use quantization::turboquant::{Metadata, TQBits, TQMode};
+use quantization::turboquant::{CURRENT_TQ_VERSION, Metadata, TQBits, TQMode};
 use rand::prelude::StdRng;
 use rand::{RngExt, SeedableRng};
 
@@ -12,6 +12,7 @@ const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];
 
 fn make_tq(dim: usize, bits: TQBits) -> TurboQuantizer {
     let metadata = Metadata {
+        version: CURRENT_TQ_VERSION,
         vector_parameters: VectorParameters {
             dim,
             distance_type: DistanceType::Dot,

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -140,8 +140,26 @@ pub enum EncodedQueryTQData {
     Bits4(Query4bitSimd),
 }
 
+/// Current version of the TurboQuant persisted format.
+/// Increment when the on-disk representation changes in a way
+/// that is not backward-compatible. Load rejects versions
+/// newer than this constant.
+pub const CURRENT_TQ_VERSION: u32 = 1;
+
+const FIRST_TQ_VERSION: u32 = 1;
+
+fn default_tq_version() -> u32 {
+    FIRST_TQ_VERSION
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Metadata {
+    /// Persisted-format version. Collections written before this field existed
+    /// default to version 1. Load rejects any version greater than
+    /// [`CURRENT_TQ_VERSION`] to guard against downgrading to a binary that
+    /// predates a format change.
+    #[serde(default = "default_tq_version")]
+    pub version: u32,
     pub vector_parameters: VectorParameters,
     pub bits: TQBits,
     pub mode: TQMode,
@@ -155,6 +173,29 @@ pub struct Metadata {
 pub struct ErrorCorrectionMetadata {
     pub shift: Vec<f32>,
     pub scale: Vec<f32>,
+}
+
+fn validate_metadata_version(version: u32) -> std::io::Result<()> {
+    if version < FIRST_TQ_VERSION {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "TurboQuant metadata version {version} is older than the minimum supported version {FIRST_TQ_VERSION}",
+            ),
+        ));
+    }
+
+    if version > CURRENT_TQ_VERSION {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "TurboQuant metadata version {version} is newer than the maximum supported version {CURRENT_TQ_VERSION} \
+                 (this binary is too old to read this collection; upgrade Qdrant first)",
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Standard normal CDF Φ(x) = (1 + erf(x/√2)) / 2 via the Abramowitz & Stegun
@@ -217,6 +258,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
             TQMode::Normal => None,
             TQMode::Plus => {
                 let pre_quantizer = TurboQuantizer::new_from_metadata(&Metadata {
+                    version: CURRENT_TQ_VERSION,
                     vector_parameters: *vector_parameters,
                     bits,
                     mode,
@@ -294,6 +336,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         };
 
         let metadata = Metadata {
+            version: CURRENT_TQ_VERSION,
             vector_parameters: *vector_parameters,
             bits,
             mode,
@@ -361,6 +404,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
     pub fn load(encoded_vectors: TStorage, meta_path: &Path) -> std::io::Result<Self> {
         let contents = fs::read_to_string(meta_path)?;
         let metadata: Metadata = serde_json::from_str(&contents)?;
+
+        validate_metadata_version(metadata.version)?;
 
         let quantizer = TurboQuantizer::new_from_metadata(&metadata)?;
 

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -175,7 +175,7 @@ pub struct ErrorCorrectionMetadata {
     pub scale: Vec<f32>,
 }
 
-fn validate_metadata_version(version: u32) -> std::io::Result<()> {
+pub(crate) fn validate_metadata_version(version: u32) -> std::io::Result<()> {
     if version < FIRST_TQ_VERSION {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -8,6 +8,7 @@ use crate::turboquant::simd::{
 };
 use crate::turboquant::{
     EncodedQueryTQ, EncodedQueryTQData, ErrorCorrectionMetadata, Metadata, TQBits, TQMode,
+    validate_metadata_version,
 };
 
 /// Quantize vectors using TurboQuant.
@@ -141,6 +142,8 @@ impl TurboQuantizer {
     /// persisted `ErrorCorrection` shift/scale lengths don't match the
     /// expected `padded_dim`.
     pub fn new_from_metadata(metadata: &Metadata) -> std::io::Result<Self> {
+        validate_metadata_version(metadata.version)?;
+
         let padded_dim = Self::padded_dim(metadata.vector_parameters.dim, metadata.bits);
         let error_correction = metadata
             .error_correction

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -1,12 +1,16 @@
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_counter::HardwareCounterCell;
-    use quantization::encoded_storage::TestEncodedStorageBuilder;
+    use quantization::encoded_storage::{EncodedStorageBuilder, TestEncodedStorageBuilder};
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
-    use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
+    use quantization::turboquant::{
+        self as encoded_vectors_tq, CURRENT_TQ_VERSION, EncodedVectorsTQ, Metadata, TQBits, TQMode,
+    };
     use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
 
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
 
@@ -81,6 +85,68 @@ mod tests {
             TQBits::Bits4 => 8,
         };
         dim >= min_dim
+    }
+
+    fn metadata_for_version_tests(version: u32) -> Metadata {
+        Metadata {
+            version,
+            vector_parameters: VectorParameters {
+                dim: 16,
+                deprecated_count: None,
+                distance_type: DistanceType::Dot,
+                invert: false,
+            },
+            bits: TQBits::Bits4,
+            mode: TQMode::Normal,
+            error_correction: None,
+        }
+    }
+
+    fn assert_tq_load_rejects_version(version: u32, expected_message: &str) {
+        let dir = Builder::new()
+            .prefix("tq_metadata_version")
+            .tempdir()
+            .unwrap();
+        let meta_path = dir.path().join("meta.json");
+        let metadata = metadata_for_version_tests(version);
+        fs::write(&meta_path, serde_json::to_string(&metadata).unwrap()).unwrap();
+
+        let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+            &metadata.vector_parameters,
+            metadata.bits,
+            metadata.mode,
+        );
+        let storage = TestEncodedStorageBuilder::new(None, quantized_vector_size)
+            .build()
+            .unwrap();
+        let err = match EncodedVectorsTQ::load(storage, meta_path.as_path()) {
+            Ok(_) => panic!("load should reject TurboQuant metadata version {version}"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains(expected_message));
+    }
+
+    #[test]
+    fn metadata_without_version_deserializes_as_v1() {
+        let mut value =
+            serde_json::to_value(metadata_for_version_tests(CURRENT_TQ_VERSION)).unwrap();
+        value.as_object_mut().unwrap().remove("version");
+
+        let metadata: Metadata = serde_json::from_value(value).unwrap();
+
+        assert_eq!(metadata.version, 1);
+    }
+
+    #[test]
+    fn load_rejects_too_old_metadata_version() {
+        assert_tq_load_rejects_version(0, "minimum supported version");
+    }
+
+    #[test]
+    fn load_rejects_newer_metadata_version() {
+        assert_tq_load_rejects_version(CURRENT_TQ_VERSION + 1, "upgrade Qdrant");
     }
 
     fn l2_norm(v: &[f32]) -> f32 {


### PR DESCRIPTION
## Summary
Adds an explicit persisted-format version to TurboQuant metadata.

This makes future TurboQuant format changes safer by allowing older binaries to reject metadata written by newer versions instead of attempting to load incompatible data.

## Changes

- Add `CURRENT_TQ_VERSION` for the current TurboQuant metadata format.
- Add `version` to `Metadata`.
- Default missing version fields to v1 so existing TurboQuant metadata remains backward-compatible.
- Reject metadata with versions outside the supported range during load/reconstruction:
  - versions below `FIRST_TQ_VERSION`
  - versions above `CURRENT_TQ_VERSION`
- Validate metadata version in `TurboQuantizer::new_from_metadata`, so direct metadata reconstruction cannot bypass the version guard.
- Update benchmark-side hand-constructed `Metadata`.
- Add tests for:
  - old metadata without a version field loading as v1
  - rejecting too-old metadata versions
  - rejecting newer metadata versions

## Tests

Passed:

- `cargo +nightly fmt --all`
- `cargo test -p quantization metadata_ --test integration`
- `cargo bench -p quantization --bench turboquant --no-run`

## Checklist

All Submissions:

- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

New Feature Submissions:

- [x] Does your submission pass tests?
- [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
- [x] Have you checked your code using cargo clippy --workspace --all-features command?

Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?