### PR TITLE
Reorganize `universal_io` modules

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -5,8 +5,9 @@ use super::{BucketOffset, Key, MaybeIncompleteEntry, MaybeIncompleteEntryKind, U
 use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Random;
 use crate::persisted_hashmap::uio::parse_bucket_offset;
-use crate::universal_io::read::UniversalReadPipeline;
-use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalRead, UserData};
+use crate::universal_io::{
+    ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadPipeline, UserData,
+};
 
 pub(super) enum Request<'a, K: Key + ?Sized> {
     /// Request an entry by the given offset with unknown key.

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -137,7 +137,6 @@ impl CachedSlice {
         Ok(cow)
     }
 
-    #[expect(clippy::len_without_is_empty)] // Doesn't make sense to cache 0-length files
     pub fn len<T>(&self) -> usize {
         self.len_bytes / size_of::<T>()
     }

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -4,19 +4,21 @@ use std::path::{Path, PathBuf};
 
 use fs_err as fs;
 
-use crate::generic_consts::{AccessPattern, Random};
+use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     OpenOptions, ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
-    UniversalReadPipeline, UserData, local_file_ops,
+    UserData, local_file_ops,
 };
 
 mod cached_slice;
 mod controller;
+mod pipeline;
 #[cfg(test)]
 mod tests;
 
 pub use cached_slice::CachedSlice;
 use controller::{CacheController, CacheRead};
+use pipeline::DiskCacheReadPipeline;
 
 use super::UniversalKind;
 
@@ -120,50 +122,5 @@ impl UniversalRead for CachedSlice {
 
     fn kind() -> UniversalKind {
         UniversalKind::DiskCache
-    }
-}
-
-pub struct DiskCacheReadPipeline<'file, T, U>
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    result: Option<(U, Cow<'file, [T]>)>,
-}
-
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for DiskCacheReadPipeline<'file, T, U>
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    type File = CachedSlice;
-
-    fn new() -> Result<Self> {
-        Ok(Self { result: None })
-    }
-
-    fn can_schedule(&mut self) -> bool {
-        self.result.is_none()
-    }
-
-    fn schedule<P>(
-        &mut self,
-        user_data: U,
-        file: &'file CachedSlice,
-        range: ReadRange,
-    ) -> Result<()>
-    where
-        P: AccessPattern,
-    {
-        if self.result.is_some() {
-            return Err(UniversalIoError::QueueIsFull);
-        }
-
-        self.result = Some((user_data, file.read::<Random, T>(range)?));
-        Ok(())
-    }
-
-    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
-        Ok(self.result.take())
     }
 }

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use fs_err as fs;
 
 use crate::generic_consts::{AccessPattern, Random};
-use crate::universal_io::read::UniversalReadPipeline;
 use crate::universal_io::{
     OpenOptions, ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
-    UserData, local_file_ops,
+    UniversalReadPipeline, UserData, local_file_ops,
 };
 
 mod cached_slice;

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -1,0 +1,52 @@
+use std::borrow::Cow;
+
+use super::CachedSlice;
+use crate::generic_consts::{AccessPattern, Random};
+use crate::universal_io::{
+    ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadPipeline, UserData,
+};
+
+pub struct DiskCacheReadPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    result: Option<(U, Cow<'file, [T]>)>,
+}
+
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for DiskCacheReadPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = CachedSlice;
+
+    fn new() -> Result<Self> {
+        Ok(Self { result: None })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.result.is_none()
+    }
+
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file CachedSlice,
+        range: ReadRange,
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        if self.result.is_some() {
+            return Err(UniversalIoError::QueueIsFull);
+        }
+
+        self.result = Some((user_data, file.read::<Random, T>(range)?));
+        Ok(())
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
+        Ok(self.result.take())
+    }
+}

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -1,4 +1,5 @@
 mod error;
+mod pipeline;
 mod pool;
 mod runtime;
 
@@ -8,7 +9,7 @@ mod tests;
 use std::borrow::Cow;
 use std::io::{self, Read as _, Seek as _};
 use std::os::fd::AsRawFd as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ::io_uring::types::Fd;
@@ -16,8 +17,10 @@ use fs_err as fs;
 use fs_err::os::unix::fs::{FileExt as _, OpenOptionsExt as _};
 
 use self::error::*;
+use self::pipeline::IoUringPipeline;
 use self::pool::*;
 use self::runtime::*;
+use super::traits::UniversalReadFileOps;
 use super::*;
 use crate::generic_consts::AccessPattern;
 
@@ -29,11 +32,11 @@ pub struct IoUringFile {
     ///
     /// This is because `O_DIRECT` can only read in aligned blocks of data, so reads at EOF might not
     /// be aligned with O_DIRECT alignment, but it is not possible to request less than one block.
-    direct_io: bool,
+    pub(super) direct_io: bool,
 }
 
 impl IoUringFile {
-    fn fd(&self) -> Fd {
+    pub(super) fn fd(&self) -> Fd {
         Fd(self.file.as_raw_fd())
     }
 }
@@ -139,79 +142,6 @@ impl UniversalRead for IoUringFile {
 
     fn kind() -> UniversalKind {
         UniversalKind::IoUring
-    }
-}
-
-pub struct IoUringPipeline<'file, T, U>
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    runtime: IoUringRuntime<'file, T, U>,
-}
-
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for IoUringPipeline<'file, T, U>
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    type File = IoUringFile;
-
-    fn new() -> Result<Self> {
-        Ok(Self {
-            runtime: IoUringRuntime::new()?,
-        })
-    }
-
-    fn can_schedule(&mut self) -> bool {
-        let squeue = self.runtime.io_uring.submission();
-        self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
-    }
-
-    fn schedule<P>(
-        &mut self,
-        user_data: U,
-        file: &'file IoUringFile,
-        range: ReadRange,
-    ) -> Result<()>
-    where
-        P: AccessPattern,
-    {
-        let mut squeue = self.runtime.io_uring.submission();
-
-        if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
-            return Err(UniversalIoError::QueueIsFull);
-        }
-
-        let entry = self
-            .runtime
-            .state
-            .read(user_data, file.fd(), range, file.direct_io);
-
-        unsafe {
-            squeue.push(&entry).expect("submission queue is not full");
-        }
-
-        Ok(())
-    }
-
-    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
-        let next = self.runtime.completed().next();
-
-        let enqueued = self.runtime.enqueued();
-
-        if next.is_some() && enqueued > 0 {
-            self.runtime.submit_and_wait(0)?;
-        } else if next.is_none() && enqueued + self.runtime.in_progress > 0 {
-            self.runtime.submit_and_wait(1)?;
-        }
-
-        let Some(result) = next.or_else(|| self.runtime.completed().next()) else {
-            return Ok(None);
-        };
-
-        let (user_data, resp) = result?;
-        Ok(Some((user_data, Cow::Owned(resp.expect_read()))))
     }
 }
 

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,0 +1,79 @@
+use std::borrow::Cow;
+
+use super::pool::IO_URING_QUEUE_LENGTH;
+use super::{IoUringFile, IoUringRuntime};
+use crate::generic_consts::AccessPattern;
+use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalReadPipeline, UserData};
+
+pub struct IoUringPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    runtime: IoUringRuntime<'file, T, U>,
+}
+
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for IoUringPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = IoUringFile;
+
+    fn new() -> Result<Self> {
+        Ok(Self {
+            runtime: IoUringRuntime::new()?,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        let squeue = self.runtime.io_uring.submission();
+        self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
+    }
+
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file IoUringFile,
+        range: ReadRange,
+    ) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        let mut squeue = self.runtime.io_uring.submission();
+
+        if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
+            return Err(UniversalIoError::QueueIsFull);
+        }
+
+        let entry = self
+            .runtime
+            .state
+            .read(user_data, file.fd(), range, file.direct_io);
+
+        unsafe {
+            squeue.push(&entry).expect("submission queue is not full");
+        }
+
+        Ok(())
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
+        let next = self.runtime.completed().next();
+
+        let enqueued = self.runtime.enqueued();
+
+        if next.is_some() && enqueued > 0 {
+            self.runtime.submit_and_wait(0)?;
+        } else if next.is_none() && enqueued + self.runtime.in_progress > 0 {
+            self.runtime.submit_and_wait(1)?;
+        }
+
+        let Some(result) = next.or_else(|| self.runtime.completed().next()) else {
+            return Ok(None);
+        };
+
+        let (user_data, resp) = result?;
+        Ok(Some((user_data, Cow::Owned(resp.expect_read()))))
+    }
+}

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -7,7 +7,6 @@ use slab::Slab;
 
 use super::*;
 use crate::maybe_uninit;
-use crate::universal_io::read::UserData;
 
 const KERNEL_PAGE_SIZE: u64 = 4096; // 4 kB
 

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -7,7 +7,6 @@ use rstest::rstest;
 use super::super::*;
 use super::*;
 use crate::generic_consts::Sequential;
-use crate::universal_io::read::UniversalRead;
 
 #[rstest]
 #[case(false)]

--- a/lib/common/common/src/universal_io/mmap.rs
+++ b/lib/common/common/src/universal_io/mmap.rs
@@ -8,7 +8,6 @@ use memmap2::MmapRaw;
 use super::*;
 use crate::generic_consts::AccessPattern;
 use crate::mmap::{MULTI_MMAP_IS_SUPPORTED, Madviseable as _};
-use crate::universal_io::read::UniversalReadPipeline;
 
 #[derive(Debug)]
 pub struct MmapFile {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -1,13 +1,17 @@
+mod pipeline;
+
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, slice};
 
 use memmap2::MmapRaw;
 
+use self::pipeline::MmapReadPipeline;
+use super::traits::UniversalReadFileOps;
 use super::*;
 use crate::generic_consts::AccessPattern;
-use crate::mmap::{MULTI_MMAP_IS_SUPPORTED, Madviseable as _};
+use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as _};
 
 #[derive(Debug)]
 pub struct MmapFile {
@@ -135,43 +139,6 @@ impl UniversalRead for MmapFile {
     }
 }
 
-pub struct MmapReadPipeline<'file, T, U> {
-    result: Option<(U, &'file [T])>,
-}
-
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for MmapReadPipeline<'file, T, U>
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    type File = MmapFile;
-
-    fn new() -> Result<Self> {
-        Ok(Self { result: None })
-    }
-
-    fn can_schedule(&mut self) -> bool {
-        self.result.is_none()
-    }
-
-    fn schedule<P>(&mut self, user_data: U, file: &'file MmapFile, range: ReadRange) -> Result<()>
-    where
-        P: AccessPattern,
-    {
-        if self.result.is_some() {
-            return Err(UniversalIoError::QueueIsFull);
-        }
-
-        self.result = Some((user_data, read(file.as_bytes::<P>(), range)?));
-        Ok(())
-    }
-
-    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
-        let result = self.result.take();
-        Ok(result.map(|(user_data, items)| (user_data, Cow::Borrowed(items))))
-    }
-}
-
 impl UniversalWrite for MmapFile {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
         let mmap = self.as_bytes_mut();
@@ -294,7 +261,7 @@ impl MmapFile {
         Ok((disk_bytes, resident_bytes))
     }
 
-    fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
+    pub(super) fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
         let ptr = if P::IS_SEQUENTIAL {
             self.ptr_seq
         } else {
@@ -309,7 +276,7 @@ impl MmapFile {
 }
 
 #[inline]
-fn read<T>(bytes: &[u8], range: ReadRange) -> Result<&[T]>
+pub(super) fn read<T>(bytes: &[u8], range: ReadRange) -> Result<&[T]>
 where
     T: bytemuck::Pod,
 {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -1,0 +1,42 @@
+use std::borrow::Cow;
+
+use super::{MmapFile, read};
+use crate::generic_consts::AccessPattern;
+use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalReadPipeline, UserData};
+
+pub struct MmapReadPipeline<'file, T, U> {
+    result: Option<(U, &'file [T])>,
+}
+
+impl<'file, T, U> UniversalReadPipeline<'file, T, U> for MmapReadPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = MmapFile;
+
+    fn new() -> Result<Self> {
+        Ok(Self { result: None })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.result.is_none()
+    }
+
+    fn schedule<P>(&mut self, user_data: U, file: &'file MmapFile, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        if self.result.is_some() {
+            return Err(UniversalIoError::QueueIsFull);
+        }
+
+        self.result = Some((user_data, read(file.as_bytes::<P>(), range)?));
+        Ok(())
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
+        let result = self.result.take();
+        Ok(result.map(|(user_data, items)| (user_data, Cow::Borrowed(items))))
+    }
+}

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -2,166 +2,23 @@
 #[expect(dead_code, reason = "Not yet used")]
 mod disk_cache;
 mod error;
-mod file_ops;
 #[cfg(target_os = "linux")]
 mod io_uring;
 mod local_file_ops;
 mod mmap;
-mod read;
+mod traits;
+mod types;
 mod wrappers;
-mod write;
-
-use std::path::Path;
-
-use serde::de::DeserializeOwned;
 
 pub use self::error::UniversalIoError;
-pub use self::file_ops::UniversalReadFileOps;
 #[cfg(target_os = "linux")]
-pub use self::io_uring::*;
-pub use self::mmap::*;
-pub use self::read::*;
-pub use self::wrappers::*;
-pub use self::write::UniversalWrite;
-use crate::mmap::{Advice, AdviceSetting};
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum UniversalKind {
-    Mmap,
-    IoUring,
-    DiskCache,
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub enum Populate {
-    /// Let backend choose
-    #[default]
-    Auto,
-    /// Do not populate
-    No,
-    /// Populate on foreground
-    Blocking,
-    /// Populate, but prefer to do it in the background
-    PreferBackground,
-}
-
-impl From<bool> for Populate {
-    fn from(populate: bool) -> Self {
-        if populate {
-            Populate::Blocking
-        } else {
-            Populate::No
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct OpenOptions {
-    pub writeable: bool,
-    pub need_sequential: bool,
-    /// How many parallel requests to the disk we can do.
-    /// If `None`, then use implementation-specific default.
-    pub disk_parallel: Option<usize>,
-    /// Populate RAM cache on open, if applicable for this implementation.
-    pub populate: Populate,
-    /// Use specific mmap advice.
-    pub advice: Option<AdviceSetting>,
-    /// Whether to try to prevent caching for reads.
-    pub prevent_caching: Option<bool>,
-}
-
-impl Default for OpenOptions {
-    fn default() -> Self {
-        Self {
-            writeable: true,
-            need_sequential: true,
-            disk_parallel: None,
-            populate: Populate::Auto,
-            advice: None,
-            prevent_caching: None,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct ReadRange {
-    /// Start position in bytes from the beginning of the file/storage.
-    pub byte_offset: u64,
-    /// Number of elements to read.
-    pub length: u64,
-}
-
-impl ReadRange {
-    pub fn new(byte_offset: u64, length: u64) -> ReadRange {
-        ReadRange {
-            byte_offset,
-            length,
-        }
-    }
-
-    pub fn one(byte_offset: u64) -> ReadRange {
-        ReadRange {
-            byte_offset,
-            length: 1,
-        }
-    }
-
-    /// Split the range into a consecutive sequence of smaller ranges of
-    /// reasonable size. Takes `T` as a hint for element size in bytes.
-    pub fn iter_autochunks<T>(self) -> impl Iterator<Item = ReadRange> {
-        // TODO: align chunks. Perhaps this method and `blocks_for_range_in_file`
-        // can be unified.
-        const MAX_CHUNK_BYTES: u64 = 16 * 1024;
-        let chunk_len = (MAX_CHUNK_BYTES / size_of::<T>() as u64).max(1);
-        let Self {
-            byte_offset,
-            length,
-        } = self;
-        (0..)
-            .map(move |i| i * chunk_len)
-            .take_while(move |&start| start < length)
-            .map(move |start| ReadRange {
-                byte_offset: byte_offset + start * size_of::<T>() as u64,
-                length: std::cmp::min(chunk_len, length - start),
-            })
-    }
-
-    /// If the last element is beyond `max_end_offset`, then shorten the length
-    /// to fit into the `0..max_end_offset` range.
-    pub fn clamp<T>(mut self, max_end_offset: u64) -> ReadRange {
-        self.byte_offset = self.byte_offset.min(max_end_offset);
-        let max_len = max_end_offset.saturating_sub(self.byte_offset) / size_of::<T>() as u64;
-        self.length = self.length.min(max_len);
-        self
-    }
-}
-
-pub type ByteOffset = u64;
-
-pub type FileIndex = usize;
-
-pub type Flusher = Box<dyn FnOnce() -> Result<()> + Send>;
-
-pub type Result<T, E = UniversalIoError> = std::result::Result<T, E>;
-
-/// Open a file via universal io, read it as a whole, and deserialize as JSON.
-///
-/// Uses a single logical read when the backend overrides [`UniversalRead::read_whole`].
-pub fn read_json_via<S, T>(path: impl AsRef<Path>) -> Result<T>
-where
-    S: UniversalRead,
-    T: DeserializeOwned,
-{
-    let options = OpenOptions {
-        writeable: false,
-        need_sequential: false,
-        disk_parallel: None,
-        populate: Populate::No,
-        advice: Some(AdviceSetting::Advice(Advice::Sequential)),
-        prevent_caching: Some(false),
-    };
-
-    let storage = S::open(path, options)?;
-    let bytes = storage.read_whole::<u8>()?;
-    serde_json::from_slice(&bytes).map_err(UniversalIoError::from)
-}
+pub use self::io_uring::IoUringFile;
+pub use self::mmap::MmapFile;
+pub use self::traits::{
+    UniversalRead, UniversalReadFileOps, UniversalReadPipeline, UniversalWrite, UserData,
+};
+pub use self::types::{
+    ByteOffset, FileIndex, Flusher, OpenOptions, Populate, ReadRange, Result, UniversalKind,
+    read_json_via,
+};
+pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,14 +1,15 @@
 #[cfg(not(target_os = "windows"))]
-pub mod disk_cache;
-pub mod error;
-pub mod file_ops;
+#[expect(dead_code, reason = "Not yet used")]
+mod disk_cache;
+mod error;
+mod file_ops;
 #[cfg(target_os = "linux")]
-pub mod io_uring;
-pub mod local_file_ops;
-pub mod mmap;
-pub mod read;
-pub mod wrappers;
-pub mod write;
+mod io_uring;
+mod local_file_ops;
+mod mmap;
+mod read;
+mod wrappers;
+mod write;
 
 use std::path::Path;
 

--- a/lib/common/common/src/universal_io/read.rs
+++ b/lib/common/common/src/universal_io/read.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use super::*;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::file_ops::UniversalReadFileOps;
 
 /// Interface for accessing files in a universal way, abstracting away possible
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
-use super::*;
+use crate::universal_io::Result;
 
 pub trait UniversalReadFileOps: Sized + Debug {
     /// List files in the storage with the given prefix.

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -1,0 +1,22 @@
+mod file_ops;
+mod pipeline;
+mod read;
+mod write;
+
+pub use file_ops::UniversalReadFileOps;
+pub use pipeline::UniversalReadPipeline;
+pub use read::UniversalRead;
+pub use write::UniversalWrite;
+
+/// An arbitrary value to distinguish requests.
+///
+/// Batched universal I/O methods let callers to add an arbitrary user-provided
+/// value to each request. This value will be passed back to the caller/callback
+/// when the request completes.
+///
+/// Similar to `user_data` in `io_uring`, but allows arbitrary type, not just
+/// `u64`.
+///
+/// This trait exists for documentation/code navigation purposes only.
+pub trait UserData {}
+impl<T> UserData for T {}

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -1,0 +1,38 @@
+use std::borrow::Cow;
+
+use crate::generic_consts::AccessPattern;
+use crate::universal_io::{ReadRange, Result, UserData};
+
+pub trait UniversalReadPipeline<'file, T, U>: Sized
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File: 'file;
+
+    fn new() -> Result<Self>;
+
+    fn can_schedule(&mut self) -> bool;
+
+    /// Schedule read operation.
+    ///
+    /// Note: an implementation might add it to internal queue, but not actually
+    /// execute it until [`UniversalReadPipeline::wait()`] is called.
+    ///
+    /// Should be called only when [`UniversalReadPipeline::can_schedule()`] is
+    /// `true`. Returns [`UniversalIoError::QueueIsFull`] otherwise.
+    ///
+    /// [`UniversalIoError::QueueIsFull`]: crate::universal_io::UniversalIoError::QueueIsFull
+    fn schedule<P>(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        range: ReadRange,
+    ) -> Result<()>
+    where
+        P: AccessPattern;
+
+    /// Block until any of the scheduled operations is completed and consume its
+    /// result.
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>>;
+}

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-use super::*;
+use super::{UniversalReadFileOps, UniversalReadPipeline, UserData};
 use crate::generic_consts::{AccessPattern, Sequential};
+use crate::universal_io::{OpenOptions, ReadRange, Result, UniversalKind};
 
 /// Interface for accessing files in a universal way, abstracting away possible
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
@@ -134,48 +135,3 @@ pub trait UniversalRead: UniversalReadFileOps {
 
     // When adding provided methods, don't forget to update impls in crate::universal_io::wrappers::*.
 }
-
-pub trait UniversalReadPipeline<'file, T, U>: Sized
-where
-    T: bytemuck::Pod,
-    U: UserData,
-{
-    type File: 'file;
-
-    fn new() -> Result<Self>;
-
-    fn can_schedule(&mut self) -> bool;
-
-    /// Schedule read operation.
-    ///
-    /// Note: an implementation might add it to internal queue, but not actually
-    /// execute it until [`UniversalReadPipeline::wait()`] is called.
-    ///
-    /// Should be called only when [`UniversalReadPipeline::can_schedule()`] is
-    /// `true`. Returns [`UniversalIoError::QueueIsFull`] otherwise.
-    fn schedule<P>(
-        &mut self,
-        user_data: U,
-        file: &'file Self::File,
-        range: ReadRange,
-    ) -> Result<()>
-    where
-        P: AccessPattern;
-
-    /// Block until any of the scheduled operations is completed and consume its
-    /// result.
-    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>>;
-}
-
-/// An arbitrary value to distinguish requests.
-///
-/// Batched universal I/O methods let callers to add an arbitrary user-provided
-/// value to each request. This value will be passed back to the caller/callback
-/// when the request completes.
-///
-/// Similar to `user_data` in `io_uring`, but allows arbitrary type, not just
-/// `u64`.
-///
-/// This trait exists for documentation/code navigation purposes only.
-pub trait UserData {}
-impl<T> UserData for T {}

--- a/lib/common/common/src/universal_io/traits/write.rs
+++ b/lib/common/common/src/universal_io/traits/write.rs
@@ -1,5 +1,5 @@
-use super::read::UniversalRead;
-use super::*;
+use super::UniversalRead;
+use crate::universal_io::{ByteOffset, FileIndex, Flusher, Result, UniversalIoError};
 
 pub trait UniversalWrite: UniversalRead {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()>;

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -1,0 +1,148 @@
+use std::path::Path;
+
+use serde::de::DeserializeOwned;
+
+use super::UniversalIoError;
+use super::traits::UniversalRead;
+use crate::mmap::{Advice, AdviceSetting};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum UniversalKind {
+    Mmap,
+    IoUring,
+    DiskCache,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub enum Populate {
+    /// Let backend choose
+    #[default]
+    Auto,
+    /// Do not populate
+    No,
+    /// Populate on foreground
+    Blocking,
+    /// Populate, but prefer to do it in the background
+    PreferBackground,
+}
+
+impl From<bool> for Populate {
+    fn from(populate: bool) -> Self {
+        if populate {
+            Populate::Blocking
+        } else {
+            Populate::No
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct OpenOptions {
+    pub writeable: bool,
+    pub need_sequential: bool,
+    /// How many parallel requests to the disk we can do.
+    /// If `None`, then use implementation-specific default.
+    pub disk_parallel: Option<usize>,
+    /// Populate RAM cache on open, if applicable for this implementation.
+    pub populate: Populate,
+    /// Use specific mmap advice.
+    pub advice: Option<AdviceSetting>,
+    /// Whether to try to prevent caching for reads.
+    pub prevent_caching: Option<bool>,
+}
+
+impl Default for OpenOptions {
+    fn default() -> Self {
+        Self {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ReadRange {
+    /// Start position in bytes from the beginning of the file/storage.
+    pub byte_offset: u64,
+    /// Number of elements to read.
+    pub length: u64,
+}
+
+impl ReadRange {
+    pub fn new(byte_offset: u64, length: u64) -> ReadRange {
+        ReadRange {
+            byte_offset,
+            length,
+        }
+    }
+
+    pub fn one(byte_offset: u64) -> ReadRange {
+        ReadRange {
+            byte_offset,
+            length: 1,
+        }
+    }
+
+    /// Split the range into a consecutive sequence of smaller ranges of
+    /// reasonable size. Takes `T` as a hint for element size in bytes.
+    pub fn iter_autochunks<T>(self) -> impl Iterator<Item = ReadRange> {
+        // TODO: align chunks. Perhaps this method and `blocks_for_range_in_file`
+        // can be unified.
+        const MAX_CHUNK_BYTES: u64 = 16 * 1024;
+        let chunk_len = (MAX_CHUNK_BYTES / size_of::<T>() as u64).max(1);
+        let Self {
+            byte_offset,
+            length,
+        } = self;
+        (0..)
+            .map(move |i| i * chunk_len)
+            .take_while(move |&start| start < length)
+            .map(move |start| ReadRange {
+                byte_offset: byte_offset + start * size_of::<T>() as u64,
+                length: std::cmp::min(chunk_len, length - start),
+            })
+    }
+
+    /// If the last element is beyond `max_end_offset`, then shorten the length
+    /// to fit into the `0..max_end_offset` range.
+    pub fn clamp<T>(mut self, max_end_offset: u64) -> ReadRange {
+        self.byte_offset = self.byte_offset.min(max_end_offset);
+        let max_len = max_end_offset.saturating_sub(self.byte_offset) / size_of::<T>() as u64;
+        self.length = self.length.min(max_len);
+        self
+    }
+}
+
+pub type ByteOffset = u64;
+
+pub type FileIndex = usize;
+
+pub type Flusher = Box<dyn FnOnce() -> Result<()> + Send>;
+
+pub type Result<T, E = UniversalIoError> = std::result::Result<T, E>;
+
+/// Open a file via universal io, read it as a whole, and deserialize as JSON.
+///
+/// Uses a single logical read when the backend overrides [`UniversalRead::read_whole`].
+pub fn read_json_via<S, T>(path: impl AsRef<Path>) -> Result<T>
+where
+    S: UniversalRead,
+    T: DeserializeOwned,
+{
+    let options = OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        disk_parallel: None,
+        populate: Populate::No,
+        advice: Some(AdviceSetting::Advice(Advice::Sequential)),
+        prevent_caching: Some(false),
+    };
+
+    let storage = S::open(path, options)?;
+    let bytes = storage.read_whole::<u8>()?;
+    serde_json::from_slice(&bytes).map_err(UniversalIoError::from)
+}

--- a/lib/common/common/src/universal_io/wrappers/mod.rs
+++ b/lib/common/common/src/universal_io/wrappers/mod.rs
@@ -8,4 +8,4 @@ pub use buffered_update::SliceBufferedUpdateWrapper;
 pub use read_only::ReadOnly;
 pub use stored_struct::StoredStruct;
 pub use typed::TypedStorage;
-pub use wrapped_pipeline::WrappedReadPipeline;
+use wrapped_pipeline::WrappedReadPipeline;

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -3,11 +3,11 @@ use std::path::{Path, PathBuf};
 
 use bytemuck::TransparentWrapper;
 
-use super::super::{
-    OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps, UserData,
-};
 use super::WrappedReadPipeline;
 use crate::generic_consts::AccessPattern;
+use crate::universal_io::{
+    OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps, UserData,
+};
 
 #[derive(Debug, TransparentWrapper)]
 #[repr(transparent)]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 
 use bytemuck::TransparentWrapper;
 
-use super::super::{
+use crate::generic_consts::AccessPattern;
+use crate::universal_io::{
     ByteOffset, FileIndex, Flusher, OpenOptions, ReadRange, Result, UniversalKind, UniversalRead,
     UniversalReadFileOps, UniversalWrite, UserData,
 };
-use crate::generic_consts::AccessPattern;
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
 /// type to a specific `T`.

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -4,8 +4,7 @@ use std::marker::PhantomData;
 use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::read::{UniversalReadPipeline, UserData};
-use crate::universal_io::{ReadRange, Result};
+use crate::universal_io::{ReadRange, Result, UniversalReadPipeline, UserData};
 
 /// Default implementation of [`UniversalReadPipeline`] for wrappers.
 pub struct WrappedReadPipeline<'a, File, Inner> {

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -12,8 +12,9 @@ use api::grpc::qdrant::{
     ReadWholeRequest, ReadWholeResponse,
 };
 use common::generic_consts::Random;
-use common::universal_io::mmap::MmapFile;
-use common::universal_io::{FileIndex, OpenOptions, ReadRange, UniversalIoError, UniversalRead};
+use common::universal_io::{
+    FileIndex, MmapFile, OpenOptions, ReadRange, UniversalIoError, UniversalRead,
+};
 use futures::Stream;
 use storage::dispatcher::Dispatcher;
 use tonic::{Request, Response, Status, async_trait};

--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -57,9 +57,9 @@ use crate::tonic::api::telemetry_wrapper::{
 // Compile-time storage backend selection for StorageRead gRPC service.
 // On Linux, uses io_uring for optimal async I/O; falls back to mmap elsewhere.
 #[cfg(target_os = "linux")]
-type StorageBackend = common::universal_io::io_uring::IoUringFile;
+type StorageBackend = common::universal_io::IoUringFile;
 #[cfg(not(target_os = "linux"))]
-type StorageBackend = common::universal_io::mmap::MmapFile;
+type StorageBackend = common::universal_io::MmapFile;
 
 #[derive(Default)]
 pub struct QdrantService {}


### PR DESCRIPTION
This PR rearranges `universal_io` modules.
- Extract pipeline implementation/traits into `pipeline.rs` (4 times). Preparation before adding another pipeline trait.
- Move traits into a separate directory.

No changes beyond moving and pub visibility.

If this PR cause merge conflicts, I can rebase affected open PRs after merging this. (if any)

# `tree lib/common/common/src/universal_io`

New module structure: (updates are marked with `❗`)

```
lib/common/common/src/universal_io
├── disk_cache
│   ├── cached_slice.rs
│   ├── controller.rs
│   ├── mod.rs
│   ├── ❗pipeline.rs (extracted from mod.rs)
│   └── tests.rs
├── error.rs
├── io_uring
│   ├── error.rs
│   ├── mod.rs
│   ├── ❗pipeline.rs (extracted from mod.rs)
│   ├── pool.rs
│   ├── runtime.rs
│   └── tests.rs
├── local_file_ops.rs
├── ❗mmap (mmap.rs split into two files)
│   ├── ❗mod.rs
│   └── ❗pipeline.rs
├── ❗mod.rs (now just re-exports; definitions moved to types.rs)
├── ❗traits (traits are moved into separate dir)
│   ├── ❗file_ops.rs
│   ├── ❗mod.rs
│   ├── ❗pipeline.rs (extracted from read.rs)
│   ├── ❗read.rs
│   └── ❗write.rs
├── ❗types.rs (extracted from mod.rs)
└── wrappers
    ├── buffered_update.rs
    ├── mod.rs
    ├── read_only.rs
    ├── stored_struct.rs
    ├── typed.rs
    └── wrapped_pipeline.rs
```

Old module structure:
```
lib/common/common/src/universal_io
├── disk_cache
│   ├── cached_slice.rs
│   ├── controller.rs
│   ├── mod.rs
│   └── tests.rs
├── error.rs
├── file_ops.rs
├── io_uring
│   ├── error.rs
│   ├── mod.rs
│   ├── pool.rs
│   ├── runtime.rs
│   └── tests.rs
├── local_file_ops.rs
├── mmap.rs
├── mod.rs
├── read.rs
├── wrappers
│   ├── buffered_update.rs
│   ├── mod.rs
│   ├── read_only.rs
│   ├── stored_struct.rs
│   ├── typed.rs
│   └── wrapped_pipeline.rs
└── write.rs
```

# `ls -R lib/common/common/src/universal_io`

Old:
```
lib/common/common/src/universal_io:
disk_cache  error.rs  file_ops.rs  io_uring  local_file_ops.rs  mmap.rs  mod.rs  read.rs  wrappers  write.rs

lib/common/common/src/universal_io/disk_cache:
cached_slice.rs  controller.rs  mod.rs  tests.rs

lib/common/common/src/universal_io/io_uring:
error.rs  mod.rs  pool.rs  runtime.rs  tests.rs

lib/common/common/src/universal_io/wrappers:
buffered_update.rs  mod.rs  read_only.rs  stored_struct.rs  typed.rs  wrapped_pipeline.rs
```

New:
```
lib/common/common/src/universal_io:
disk_cache  error.rs  io_uring  local_file_ops.rs  mmap  mod.rs  traits  types.rs  wrappers

lib/common/common/src/universal_io/disk_cache:
cached_slice.rs  controller.rs  mod.rs  pipeline.rs  tests.rs

lib/common/common/src/universal_io/io_uring:
error.rs  mod.rs  pipeline.rs  pool.rs  runtime.rs  tests.rs

lib/common/common/src/universal_io/mmap:
mod.rs  pipeline.rs

lib/common/common/src/universal_io/traits:
file_ops.rs  mod.rs  pipeline.rs  read.rs  write.rs

lib/common/common/src/universal_io/wrappers:
buffered_update.rs  mod.rs  read_only.rs  stored_struct.rs  typed.rs  wrapped_pipeline.rs
```