### PR TITLE
BorrowedReadPipeline/OwnedReadPipeline

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -6,7 +6,7 @@ use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Random;
 use crate::persisted_hashmap::uio::parse_bucket_offset;
 use crate::universal_io::{
-    ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadPipeline, UserData,
+    BorrowedReadPipeline, ReadRange, Result, UniversalIoError, UniversalRead, UserData,
 };
 
 pub(super) enum Request<'a, K: Key + ?Sized> {
@@ -79,7 +79,7 @@ where
         E: From<UniversalIoError>,
     {
         let mut sparse = PipelineDriver::new(self, entry_kind)?;
-        let mut pipeline = S::ReadPipeline::new()?;
+        let mut pipeline = S::BorrowedReadPipeline::new()?;
         let mut requests = requests.into_iter();
         loop {
             while pipeline.can_schedule() {

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -12,7 +12,7 @@ use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, Cac
 /// through the [`CacheController`]. Blocks that are already cached are returned
 /// as zero-copy borrows from the mmap; multi-block reads allocate a `Vec<T>`
 /// (not `Vec<u8>`) so alignment is always correct.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CachedSlice {
     /// The id assigned by the controller for this file.
     file_id: FileId,

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -12,7 +12,7 @@ use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, Cac
 /// through the [`CacheController`]. Blocks that are already cached are returned
 /// as zero-copy borrows from the mmap; multi-block reads allocate a `Vec<T>`
 /// (not `Vec<u8>`) so alignment is always correct.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CachedSlice {
     /// The id assigned by the controller for this file.
     file_id: FileId,

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -18,7 +18,7 @@ mod tests;
 
 pub use cached_slice::CachedSlice;
 use controller::{CacheController, CacheRead};
-use pipeline::DiskCacheReadPipeline;
+use pipeline::{BorrowedDiskCacheReadPipeline, OwnedDiskCacheReadPipeline};
 
 use super::UniversalKind;
 
@@ -68,10 +68,16 @@ impl UniversalReadFileOps for CachedSlice {
 }
 
 impl UniversalRead for CachedSlice {
-    type ReadPipeline<'a, T, U>
-        = DiskCacheReadPipeline<'a, T, U>
+    type BorrowedReadPipeline<'a, T, U>
+        = BorrowedDiskCacheReadPipeline<'a, T, U>
     where
         Self: 'a,
+        T: bytemuck::Pod,
+        U: UserData;
+
+    type OwnedReadPipeline<T, U>
+        = OwnedDiskCacheReadPipeline<T, U>
+    where
         T: bytemuck::Pod,
         U: UserData;
 

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -3,10 +3,11 @@ use std::borrow::Cow;
 use super::CachedSlice;
 use crate::generic_consts::{AccessPattern, Random};
 use crate::universal_io::{
-    ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadPipeline, UserData,
+    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UniversalRead,
+    UserData,
 };
 
-pub struct DiskCacheReadPipeline<'file, T, U>
+pub struct BorrowedDiskCacheReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
     U: UserData,
@@ -14,7 +15,7 @@ where
     result: Option<(U, Cow<'file, [T]>)>,
 }
 
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for DiskCacheReadPipeline<'file, T, U>
+impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedDiskCacheReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
     U: UserData,
@@ -42,11 +43,59 @@ where
             return Err(UniversalIoError::QueueIsFull);
         }
 
+        // FIXME: This is a temporary stub implementation.
         self.result = Some((user_data, file.read::<Random, T>(range)?));
         Ok(())
     }
 
     fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
         Ok(self.result.take())
+    }
+}
+
+pub struct OwnedDiskCacheReadPipeline<T, U> {
+    file: CachedSlice,
+    pending: Option<(U, ReadRange)>,
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, U> OwnedReadPipeline<T, U> for OwnedDiskCacheReadPipeline<T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = CachedSlice;
+
+    fn new(file: &CachedSlice) -> Result<Self> {
+        Ok(Self {
+            file: file.clone(),
+            pending: None,
+            phantom: std::marker::PhantomData,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.pending.is_none()
+    }
+
+    fn schedule<P>(&mut self, user_data: U, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        if self.pending.is_some() {
+            return Err(UniversalIoError::QueueIsFull);
+        }
+
+        // FIXME: This is a temporary stub implementation.
+        self.pending = Some((user_data, range));
+        Ok(())
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
+        let Some((user_data, range)) = self.pending.take() else {
+            return Ok(None);
+        };
+        let items = self.file.read::<Random, T>(range)?;
+        Ok(Some((user_data, items)))
     }
 }

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -66,9 +66,9 @@ where
 {
     type File = CachedSlice;
 
-    fn new(file: &CachedSlice) -> Result<Self> {
+    fn new(file: CachedSlice) -> Result<Self> {
         Ok(Self {
-            file: file.clone(),
+            file,
             pending: None,
             phantom: std::marker::PhantomData,
         })

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -17,7 +17,7 @@ use fs_err as fs;
 use fs_err::os::unix::fs::{FileExt as _, OpenOptionsExt as _};
 
 use self::error::*;
-use self::pipeline::IoUringPipeline;
+use self::pipeline::{BorrowedIoUringPipeline, OwnedIoUringPipeline};
 use self::pool::*;
 use self::runtime::*;
 use super::traits::UniversalReadFileOps;
@@ -52,8 +52,14 @@ impl UniversalReadFileOps for IoUringFile {
 }
 
 impl UniversalRead for IoUringFile {
-    type ReadPipeline<'a, T, U>
-        = IoUringPipeline<'a, T, U>
+    type BorrowedReadPipeline<'a, T, U>
+        = BorrowedIoUringPipeline<'a, T, U>
+    where
+        T: bytemuck::Pod,
+        U: UserData;
+
+    type OwnedReadPipeline<T, U>
+        = OwnedIoUringPipeline<T, U>
     where
         T: bytemuck::Pod,
         U: UserData;

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
 
 use ::io_uring::types::Fd;
 
@@ -71,11 +70,7 @@ where
 {
     type File = IoUringFile;
 
-    fn new(file: &IoUringFile) -> Result<Self> {
-        let file = IoUringFile {
-            file: Arc::clone(&file.file),
-            direct_io: file.direct_io,
-        };
+    fn new(file: IoUringFile) -> Result<Self> {
         let inner = IoUringPipelineInner::new()?;
         Ok(Self {
             file: ManuallyDrop::new(file),

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,11 +1,125 @@
 use std::borrow::Cow;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+
+use ::io_uring::types::Fd;
 
 use super::pool::IO_URING_QUEUE_LENGTH;
 use super::{IoUringFile, IoUringRuntime};
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalReadPipeline, UserData};
+use crate::universal_io::{
+    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+};
 
-pub struct IoUringPipeline<'file, T, U>
+pub struct BorrowedIoUringPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    inner: IoUringPipelineInner<'file, T, U>,
+}
+
+impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedIoUringPipeline<'file, T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = IoUringFile;
+
+    fn new() -> Result<Self> {
+        Ok(Self {
+            inner: IoUringPipelineInner::new()?,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.inner.can_schedule()
+    }
+
+    fn schedule<P: AccessPattern>(
+        &mut self,
+        user_data: U,
+        file: &'file IoUringFile,
+        range: ReadRange,
+    ) -> Result<()> {
+        // Safety: `file.fd()` doesn't outlive the inner pipeline because of
+        // `'file` lifetime.
+        unsafe {
+            self.inner
+                .schedule(user_data, file.fd(), file.direct_io, range)
+        }
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
+        self.inner.wait()
+    }
+}
+
+pub struct OwnedIoUringPipeline<T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    file: ManuallyDrop<IoUringFile>,
+    inner: ManuallyDrop<IoUringPipelineInner<'static, T, U>>,
+}
+
+impl<T, U> OwnedReadPipeline<T, U> for OwnedIoUringPipeline<T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = IoUringFile;
+
+    fn new(file: &IoUringFile) -> Result<Self> {
+        let file = IoUringFile {
+            file: Arc::clone(&file.file),
+            direct_io: file.direct_io,
+        };
+        let inner = IoUringPipelineInner::new()?;
+        Ok(Self {
+            file: ManuallyDrop::new(file),
+            inner: ManuallyDrop::new(inner),
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.inner.can_schedule()
+    }
+
+    fn schedule<P>(&mut self, user_data: U, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        // Safety: `self.file.fd()` doesn't outlive the inner pipeline because
+        // of explicit drop order in `impl Drop`.
+        unsafe {
+            self.inner
+                .schedule(user_data, self.file.fd(), self.file.direct_io, range)
+        }
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
+        self.inner.wait()
+    }
+}
+
+impl<T, U> Drop for OwnedIoUringPipeline<T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    fn drop(&mut self) {
+        // Drop `inner` before `file`.
+        let Self { file, inner } = self;
+        let file: IoUringFile = unsafe { ManuallyDrop::take(file) };
+        let inner: IoUringPipelineInner<_, _> = unsafe { ManuallyDrop::take(inner) };
+        drop(inner);
+        drop(file);
+    }
+}
+
+struct IoUringPipelineInner<'file, T, U>
 where
     T: bytemuck::Pod,
     U: UserData,
@@ -13,13 +127,11 @@ where
     runtime: IoUringRuntime<'file, T, U>,
 }
 
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for IoUringPipeline<'file, T, U>
+impl<'file, T, U> IoUringPipelineInner<'file, T, U>
 where
     T: bytemuck::Pod,
     U: UserData,
 {
-    type File = IoUringFile;
-
     fn new() -> Result<Self> {
         Ok(Self {
             runtime: IoUringRuntime::new()?,
@@ -31,25 +143,23 @@ where
         self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
     }
 
-    fn schedule<P>(
+    /// # Safety
+    ///
+    /// The caller must ensure that the `fd` will not outlive the pipeline.
+    unsafe fn schedule(
         &mut self,
         user_data: U,
-        file: &'file IoUringFile,
+        fd: Fd,
+        direct_io: bool,
         range: ReadRange,
-    ) -> Result<()>
-    where
-        P: AccessPattern,
-    {
+    ) -> Result<()> {
         let mut squeue = self.runtime.io_uring.submission();
 
         if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
             return Err(UniversalIoError::QueueIsFull);
         }
 
-        let entry = self
-            .runtime
-            .state
-            .read(user_data, file.fd(), range, file.direct_io);
+        let entry = self.runtime.state.read(user_data, fd, range, direct_io);
 
         unsafe {
             squeue.push(&entry).expect("submission queue is not full");

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -170,7 +170,13 @@ where
 
 #[derive(Debug)]
 pub struct IoUringState<'data, T, U> {
-    requests: Slab<(U, IoUringRequest<'data, T>)>,
+    requests: Slab<PendingRequest<'data, T, U>>,
+}
+
+#[derive(Debug)]
+struct PendingRequest<'data, T, U> {
+    user_data: U,
+    request: IoUringRequest<'data, T>,
 }
 
 impl<'data, T, U> IoUringState<'data, T, U>
@@ -280,12 +286,12 @@ where
     fn init(
         &mut self,
         user_data: U,
-        req: IoUringRequest<'data, T>,
+        request: IoUringRequest<'data, T>,
     ) -> (usize, &mut IoUringRequest<'data, T>) {
         let entry = self.requests.vacant_entry();
         let slot = entry.key();
-        let (_, req) = entry.insert((user_data, req));
-        (slot, req)
+        let pending = entry.insert(PendingRequest { user_data, request });
+        (slot, &mut pending.request)
     }
 
     pub fn finalize(
@@ -293,14 +299,14 @@ where
         slot: usize,
         byte_length: u32,
     ) -> io::Result<(U, IoUringResponse<T>)> {
-        let (user_data, req) = self
+        let PendingRequest { user_data, request } = self
             .requests
             .try_remove(slot)
             .ok_or_else(|| io::Error::other(format!("request in slot {slot} does not exist")))?;
 
         let byte_length = byte_length as usize;
 
-        let resp = match req {
+        let resp = match request {
             IoUringRequest::Read { items } => {
                 assert_eq!(size_of_val(items.as_slice()), byte_length);
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -16,14 +16,10 @@ use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as
 #[derive(Debug)]
 pub struct MmapFile {
     path: PathBuf,
-    inner: MmapFileInner,
-}
 
-#[derive(Debug, Clone)]
-struct MmapFileInner {
     // `mmap` and `mmap_seq` own the mmaps.
     mmap: Arc<MmapRaw>,
-    mmap_seq: Option<Arc<MmapRaw>>,
+    mmap_seq: Option<MmapRaw>,
 
     // `len`, `ptr`, `ptr_seq` contain the same values as `mmap`, `mmap_seq`,
     // but duplicated here to avoid `Arc`/`Option` overhead in hot loops.
@@ -101,7 +97,7 @@ impl UniversalRead for MmapFile {
 
             len = std::cmp::min(mmap.len(), mmap_seq_.len());
             ptr_seq = SendSyncPtr(mmap_seq_.as_mut_ptr());
-            mmap_seq = Some(Arc::new(mmap_seq_));
+            mmap_seq = Some(mmap_seq_);
         } else {
             len = mmap.len();
             ptr_seq = ptr;
@@ -110,37 +106,35 @@ impl UniversalRead for MmapFile {
 
         let mmap = Self {
             path: path.as_ref().into(),
-            inner: MmapFileInner {
-                mmap: Arc::new(mmap),
-                mmap_seq,
-                len,
-                ptr,
-                ptr_seq,
-            },
+            mmap: Arc::new(mmap),
+            mmap_seq,
+            len,
+            ptr,
+            ptr_seq,
         };
 
         Ok(mmap)
     }
 
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        let mmap = self.inner.as_bytes::<P>();
+        let mmap = self.as_bytes::<P>();
         let items = read(mmap, range)?;
         Ok(Cow::Borrowed(items))
     }
 
     fn len<T>(&self) -> Result<u64> {
-        let len = self.inner.len / size_of::<T>();
+        let len = self.len / size_of::<T>();
         Ok(len as u64)
     }
 
     fn populate(&self) -> Result<()> {
-        self.inner.mmap.populate();
+        self.mmap.populate();
         Ok(())
     }
 
     fn clear_ram_cache(&self) -> Result<()> {
-        self.inner.mmap.clear_cache();
-        if let Some(mmap_seq) = &self.inner.mmap_seq {
+        self.mmap.clear_cache();
+        if let Some(mmap_seq) = &self.mmap_seq {
             mmap_seq.clear_cache();
         }
         Ok(())
@@ -153,7 +147,7 @@ impl UniversalRead for MmapFile {
 
 impl UniversalWrite for MmapFile {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
-        let mmap = self.inner.as_bytes_mut();
+        let mmap = self.as_bytes_mut();
         write(mmap, byte_offset, items)?;
         Ok(())
     }
@@ -162,7 +156,7 @@ impl UniversalWrite for MmapFile {
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        let mmap = self.inner.as_bytes_mut();
+        let mmap = self.as_bytes_mut();
 
         for (byte_offset, items) in offset_data {
             write(mmap, byte_offset, items)?;
@@ -172,7 +166,7 @@ impl UniversalWrite for MmapFile {
     }
 
     fn flusher(&self) -> Flusher {
-        let mmap = self.inner.mmap.clone();
+        let mmap = self.mmap.clone();
         let flusher = move || {
             // flushing empty mmap returns error on some platforms
             if mmap.len() > 0 {
@@ -225,7 +219,7 @@ impl MmapFile {
     /// measured via `mincore`. This is a point-in-time approximation.
     #[cfg(unix)]
     pub fn resident_bytes(&self) -> std::io::Result<u64> {
-        let len = self.inner.len;
+        let len = self.len;
         if len == 0 {
             return Ok(0);
         }
@@ -235,10 +229,9 @@ impl MmapFile {
         let num_pages = len.div_ceil(page_size);
         let mut vec = vec![0u8; num_pages];
 
-        // SAFETY: `self.inner.ptr.as_ptr()` is a valid page-aligned pointer for `len` bytes
+        // SAFETY: `self.ptr.as_ptr()` is a valid page-aligned pointer for `len` bytes
         // (guaranteed by memmap2). `vec` is correctly sized for `num_pages` entries.
-        let ret =
-            unsafe { nix::libc::mincore(self.inner.ptr.0.cast(), len, vec.as_mut_ptr().cast()) };
+        let ret = unsafe { nix::libc::mincore(self.ptr.0.cast(), len, vec.as_mut_ptr().cast()) };
         if ret != 0 {
             return Err(std::io::Error::last_os_error());
         }
@@ -275,8 +268,8 @@ impl MmapFile {
     }
 }
 
-impl MmapFileInner {
-    pub fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
+impl MmapFile {
+    pub(super) fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
         let ptr = if P::IS_SEQUENTIAL {
             self.ptr_seq
         } else {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -7,7 +7,7 @@ use std::{fs, slice};
 
 use memmap2::MmapRaw;
 
-use self::pipeline::MmapReadPipeline;
+use self::pipeline::{BorrowedMmapReadPipeline, OwnedMmapReadPipeline};
 use super::traits::UniversalReadFileOps;
 use super::*;
 use crate::generic_consts::AccessPattern;
@@ -16,10 +16,14 @@ use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as
 #[derive(Debug)]
 pub struct MmapFile {
     path: PathBuf,
+    inner: MmapFileInner,
+}
 
+#[derive(Debug, Clone)]
+struct MmapFileInner {
     // `mmap` and `mmap_seq` own the mmaps.
     mmap: Arc<MmapRaw>,
-    mmap_seq: Option<MmapRaw>,
+    mmap_seq: Option<Arc<MmapRaw>>,
 
     // `len`, `ptr`, `ptr_seq` contain the same values as `mmap`, `mmap_seq`,
     // but duplicated here to avoid `Arc`/`Option` overhead in hot loops.
@@ -47,8 +51,14 @@ impl UniversalReadFileOps for MmapFile {
 }
 
 impl UniversalRead for MmapFile {
-    type ReadPipeline<'a, T, U>
-        = MmapReadPipeline<'a, T, U>
+    type BorrowedReadPipeline<'a, T, U>
+        = BorrowedMmapReadPipeline<'a, T, U>
+    where
+        T: bytemuck::Pod,
+        U: UserData;
+
+    type OwnedReadPipeline<T, U>
+        = OwnedMmapReadPipeline<T, U>
     where
         T: bytemuck::Pod,
         U: UserData;
@@ -91,7 +101,7 @@ impl UniversalRead for MmapFile {
 
             len = std::cmp::min(mmap.len(), mmap_seq_.len());
             ptr_seq = SendSyncPtr(mmap_seq_.as_mut_ptr());
-            mmap_seq = Some(mmap_seq_);
+            mmap_seq = Some(Arc::new(mmap_seq_));
         } else {
             len = mmap.len();
             ptr_seq = ptr;
@@ -100,35 +110,37 @@ impl UniversalRead for MmapFile {
 
         let mmap = Self {
             path: path.as_ref().into(),
-            mmap: Arc::new(mmap),
-            mmap_seq,
-            len,
-            ptr,
-            ptr_seq,
+            inner: MmapFileInner {
+                mmap: Arc::new(mmap),
+                mmap_seq,
+                len,
+                ptr,
+                ptr_seq,
+            },
         };
 
         Ok(mmap)
     }
 
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        let mmap = self.as_bytes::<P>();
+        let mmap = self.inner.as_bytes::<P>();
         let items = read(mmap, range)?;
         Ok(Cow::Borrowed(items))
     }
 
     fn len<T>(&self) -> Result<u64> {
-        let len = self.len / size_of::<T>();
+        let len = self.inner.len / size_of::<T>();
         Ok(len as u64)
     }
 
     fn populate(&self) -> Result<()> {
-        self.mmap.populate();
+        self.inner.mmap.populate();
         Ok(())
     }
 
     fn clear_ram_cache(&self) -> Result<()> {
-        self.mmap.clear_cache();
-        if let Some(mmap_seq) = &self.mmap_seq {
+        self.inner.mmap.clear_cache();
+        if let Some(mmap_seq) = &self.inner.mmap_seq {
             mmap_seq.clear_cache();
         }
         Ok(())
@@ -141,7 +153,7 @@ impl UniversalRead for MmapFile {
 
 impl UniversalWrite for MmapFile {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
-        let mmap = self.as_bytes_mut();
+        let mmap = self.inner.as_bytes_mut();
         write(mmap, byte_offset, items)?;
         Ok(())
     }
@@ -150,7 +162,7 @@ impl UniversalWrite for MmapFile {
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        let mmap = self.as_bytes_mut();
+        let mmap = self.inner.as_bytes_mut();
 
         for (byte_offset, items) in offset_data {
             write(mmap, byte_offset, items)?;
@@ -160,7 +172,7 @@ impl UniversalWrite for MmapFile {
     }
 
     fn flusher(&self) -> Flusher {
-        let mmap = self.mmap.clone();
+        let mmap = self.inner.mmap.clone();
         let flusher = move || {
             // flushing empty mmap returns error on some platforms
             if mmap.len() > 0 {
@@ -213,7 +225,7 @@ impl MmapFile {
     /// measured via `mincore`. This is a point-in-time approximation.
     #[cfg(unix)]
     pub fn resident_bytes(&self) -> std::io::Result<u64> {
-        let len = self.len;
+        let len = self.inner.len;
         if len == 0 {
             return Ok(0);
         }
@@ -223,9 +235,10 @@ impl MmapFile {
         let num_pages = len.div_ceil(page_size);
         let mut vec = vec![0u8; num_pages];
 
-        // SAFETY: `self.ptr.as_ptr()` is a valid page-aligned pointer for `len` bytes
+        // SAFETY: `self.inner.ptr.as_ptr()` is a valid page-aligned pointer for `len` bytes
         // (guaranteed by memmap2). `vec` is correctly sized for `num_pages` entries.
-        let ret = unsafe { nix::libc::mincore(self.ptr.0.cast(), len, vec.as_mut_ptr().cast()) };
+        let ret =
+            unsafe { nix::libc::mincore(self.inner.ptr.0.cast(), len, vec.as_mut_ptr().cast()) };
         if ret != 0 {
             return Err(std::io::Error::last_os_error());
         }
@@ -260,8 +273,10 @@ impl MmapFile {
         let resident_bytes = file.resident_bytes()?;
         Ok((disk_bytes, resident_bytes))
     }
+}
 
-    pub(super) fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
+impl MmapFileInner {
+    pub fn as_bytes<P: AccessPattern>(&self) -> &[u8] {
         let ptr = if P::IS_SEQUENTIAL {
             self.ptr_seq
         } else {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::{MmapFile, MmapFileInner, read};
+use super::{MmapFile, read};
 use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::{
     BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
@@ -33,7 +33,7 @@ where
             return Err(UniversalIoError::QueueIsFull);
         }
 
-        self.result = Some((user_data, read(file.inner.as_bytes::<P>(), range)?));
+        self.result = Some((user_data, read(file.as_bytes::<P>(), range)?));
         Ok(())
     }
 
@@ -44,7 +44,7 @@ where
 }
 
 pub struct OwnedMmapReadPipeline<T, U> {
-    inner: MmapFileInner,
+    file: MmapFile,
     pending: Option<(U, ReadRange, bool)>,
     _phantom: std::marker::PhantomData<T>,
 }
@@ -56,9 +56,9 @@ where
 {
     type File = MmapFile;
 
-    fn new(file: &MmapFile) -> Result<Self> {
+    fn new(file: MmapFile) -> Result<Self> {
         Ok(Self {
-            inner: file.inner.clone(),
+            file,
             pending: None,
             _phantom: std::marker::PhantomData,
         })
@@ -84,9 +84,9 @@ where
             return Ok(None);
         };
         let bytes = if is_sequential {
-            self.inner.as_bytes::<Sequential>()
+            self.file.as_bytes::<Sequential>()
         } else {
-            self.inner.as_bytes::<Random>()
+            self.file.as_bytes::<Random>()
         };
         Ok(Some((user_data, Cow::Borrowed(read::<T>(bytes, range)?))))
     }

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -1,14 +1,16 @@
 use std::borrow::Cow;
 
-use super::{MmapFile, read};
-use crate::generic_consts::AccessPattern;
-use crate::universal_io::{ReadRange, Result, UniversalIoError, UniversalReadPipeline, UserData};
+use super::{MmapFile, MmapFileInner, read};
+use crate::generic_consts::{AccessPattern, Random, Sequential};
+use crate::universal_io::{
+    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+};
 
-pub struct MmapReadPipeline<'file, T, U> {
+pub struct BorrowedMmapReadPipeline<'file, T, U> {
     result: Option<(U, &'file [T])>,
 }
 
-impl<'file, T, U> UniversalReadPipeline<'file, T, U> for MmapReadPipeline<'file, T, U>
+impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedMmapReadPipeline<'file, T, U>
 where
     T: bytemuck::Pod,
     U: UserData,
@@ -31,12 +33,61 @@ where
             return Err(UniversalIoError::QueueIsFull);
         }
 
-        self.result = Some((user_data, read(file.as_bytes::<P>(), range)?));
+        self.result = Some((user_data, read(file.inner.as_bytes::<P>(), range)?));
         Ok(())
     }
 
     fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
         let result = self.result.take();
         Ok(result.map(|(user_data, items)| (user_data, Cow::Borrowed(items))))
+    }
+}
+
+pub struct OwnedMmapReadPipeline<T, U> {
+    inner: MmapFileInner,
+    pending: Option<(U, ReadRange, bool)>,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, U> OwnedReadPipeline<T, U> for OwnedMmapReadPipeline<T, U>
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = MmapFile;
+
+    fn new(file: &MmapFile) -> Result<Self> {
+        Ok(Self {
+            inner: file.inner.clone(),
+            pending: None,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.pending.is_none()
+    }
+
+    fn schedule<P>(&mut self, user_data: U, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        if self.pending.is_some() {
+            return Err(UniversalIoError::QueueIsFull);
+        }
+        self.pending = Some((user_data, range, P::IS_SEQUENTIAL));
+        Ok(())
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
+        let Some((user_data, range, is_sequential)) = self.pending.take() else {
+            return Ok(None);
+        };
+        let bytes = if is_sequential {
+            self.inner.as_bytes::<Sequential>()
+        } else {
+            self.inner.as_bytes::<Random>()
+        };
+        Ok(Some((user_data, Cow::Borrowed(read::<T>(bytes, range)?))))
     }
 }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -15,7 +15,8 @@ pub use self::error::UniversalIoError;
 pub use self::io_uring::IoUringFile;
 pub use self::mmap::MmapFile;
 pub use self::traits::{
-    UniversalRead, UniversalReadFileOps, UniversalReadPipeline, UniversalWrite, UserData,
+    BorrowedReadPipeline, OwnedReadPipeline, UniversalRead, UniversalReadFileOps, UniversalWrite,
+    UserData,
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, OpenOptions, Populate, ReadRange, Result, UniversalKind,

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -4,7 +4,7 @@ mod read;
 mod write;
 
 pub use file_ops::UniversalReadFileOps;
-pub use pipeline::UniversalReadPipeline;
+pub use pipeline::{BorrowedReadPipeline, OwnedReadPipeline};
 pub use read::UniversalRead;
 pub use write::UniversalWrite;
 

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -1,9 +1,29 @@
+//! Read pipelines.
+//!
+//! Workflow:
+//! 1. Push read operations using `schedule()`.
+//! 2. Pull the completed results using `wait()`.
+//! 3. Interleave steps 1 and 2 as needed.
+//!
+//! There are two variants of the pipeline traits.
+//! The reason to have two traits is in the lifetime of the `wait()` result:
+//! - [`BorrowedReadPipeline::wait()`]: `Cow<'file, [T]>`.
+//!   I.e. the result might outlive the pipeline itself, but not the file.
+//!   Thus, suitable for implementing an [`Iterator`] or other short-living
+//!   structures over long-living files.
+//! - [`OwnedReadPipeline::wait()`]:    `Cow<'_,    [T]>`.
+//!   I.e. the result might outlive the file, but not the pipeline.
+//!   Suitable for holding the pipeline in long-living structures.
+//!
+//! Other differences (e.g. single-file vs multi-file) are not fundamental and
+//! can be adjusted later if needed.
+
 use std::borrow::Cow;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{ReadRange, Result, UserData};
 
-pub trait UniversalReadPipeline<'file, T, U>: Sized
+pub trait BorrowedReadPipeline<'file, T, U>: Sized
 where
     T: bytemuck::Pod,
     U: UserData,
@@ -35,4 +55,24 @@ where
     /// Block until any of the scheduled operations is completed and consume its
     /// result.
     fn wait(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>>;
+}
+
+pub trait OwnedReadPipeline<T, U>: Sized
+where
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File;
+
+    fn new(file: &Self::File) -> Result<Self>;
+
+    fn can_schedule(&mut self) -> bool;
+
+    /// See [`BorrowedReadPipeline::schedule()`].
+    fn schedule<P>(&mut self, user_data: U, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern;
+
+    /// See [`BorrowedReadPipeline::wait()`].
+    fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>>;
 }

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -64,7 +64,7 @@ where
 {
     type File;
 
-    fn new(file: &Self::File) -> Result<Self>;
+    fn new(file: Self::File) -> Result<Self>;
 
     fn can_schedule(&mut self) -> bool;
 

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-use super::{UniversalReadFileOps, UniversalReadPipeline, UserData};
+use super::{BorrowedReadPipeline, OwnedReadPipeline, UniversalReadFileOps, UserData};
 use crate::generic_consts::{AccessPattern, Sequential};
 use crate::universal_io::{OpenOptions, ReadRange, Result, UniversalKind};
 
@@ -9,9 +9,14 @@ use crate::universal_io::{OpenOptions, ReadRange, Result, UniversalKind};
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
 #[expect(clippy::len_without_is_empty)]
 pub trait UniversalRead: UniversalReadFileOps {
-    type ReadPipeline<'file, T, U>: UniversalReadPipeline<'file, T, U, File = Self>
+    type BorrowedReadPipeline<'file, T, U>: BorrowedReadPipeline<'file, T, U, File = Self>
     where
         Self: 'file,
+        T: bytemuck::Pod,
+        U: UserData;
+
+    type OwnedReadPipeline<T, U>: OwnedReadPipeline<T, U, File = Self>
+    where
         T: bytemuck::Pod,
         U: UserData;
 
@@ -111,7 +116,7 @@ pub trait UniversalRead: UniversalReadFileOps {
         U: UserData,
         Self: 'a,
     {
-        let mut pipeline = Self::ReadPipeline::<'a, T, U>::new()?;
+        let mut pipeline = Self::BorrowedReadPipeline::<'a, T, U>::new()?;
         let mut reads = reads.into_iter();
 
         let iter = std::iter::from_fn(move || {

--- a/lib/common/common/src/universal_io/wrappers/mod.rs
+++ b/lib/common/common/src/universal_io/wrappers/mod.rs
@@ -8,4 +8,4 @@ pub use buffered_update::SliceBufferedUpdateWrapper;
 pub use read_only::ReadOnly;
 pub use stored_struct::StoredStruct;
 pub use typed::TypedStorage;
-use wrapped_pipeline::WrappedReadPipeline;
+use wrapped_pipeline::{BorrowedWrappedReadPipeline, OwnedWrappedReadPipeline};

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use bytemuck::TransparentWrapper;
 
-use super::WrappedReadPipeline;
+use super::{BorrowedWrappedReadPipeline, OwnedWrappedReadPipeline};
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps, UserData,
@@ -32,10 +32,16 @@ impl<S> UniversalRead for ReadOnly<S>
 where
     S: UniversalRead,
 {
-    type ReadPipeline<'file, T, U>
-        = WrappedReadPipeline<'file, Self, S::ReadPipeline<'file, T, U>>
+    type BorrowedReadPipeline<'file, T, U>
+        = BorrowedWrappedReadPipeline<'file, Self, S::BorrowedReadPipeline<'file, T, U>>
     where
         Self: 'file,
+        T: bytemuck::Pod,
+        U: UserData;
+
+    type OwnedReadPipeline<T, U>
+        = OwnedWrappedReadPipeline<Self, S::OwnedReadPipeline<T, U>>
+    where
         T: bytemuck::Pod,
         U: UserData;
 

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -4,18 +4,19 @@ use std::marker::PhantomData;
 use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::{ReadRange, Result, UniversalReadPipeline, UserData};
+use crate::universal_io::{BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UserData};
 
-/// Default implementation of [`UniversalReadPipeline`] for wrappers.
-pub struct WrappedReadPipeline<'a, File, Inner> {
+/// Default implementation of [`BorrowedReadPipeline`] for wrappers.
+pub struct BorrowedWrappedReadPipeline<'a, File, Inner> {
     inner: Inner,
     _phantom: PhantomData<&'a File>,
 }
 
-impl<'a, File, Inner, T, U> UniversalReadPipeline<'a, T, U> for WrappedReadPipeline<'a, File, Inner>
+impl<'a, File, Inner, T, U> BorrowedReadPipeline<'a, T, U>
+    for BorrowedWrappedReadPipeline<'a, File, Inner>
 where
     File: TransparentWrapper<Inner::File>,
-    Inner: UniversalReadPipeline<'a, T, U>,
+    Inner: BorrowedReadPipeline<'a, T, U>,
     T: bytemuck::Pod,
     U: UserData,
 {
@@ -24,7 +25,7 @@ where
     #[inline]
     fn new() -> Result<Self> {
         let wrapper = Self {
-            inner: UniversalReadPipeline::new()?,
+            inner: BorrowedReadPipeline::new()?,
             _phantom: PhantomData,
         };
 
@@ -47,6 +48,50 @@ where
 
     #[inline]
     fn wait(&mut self) -> Result<Option<(U, Cow<'a, [T]>)>> {
+        self.inner.wait()
+    }
+}
+
+/// Default implementation of [`OwnedReadPipeline`] for wrappers.
+pub struct OwnedWrappedReadPipeline<File, Inner> {
+    inner: Inner,
+    _phantom: PhantomData<File>,
+}
+
+impl<File, Inner, T, U> OwnedReadPipeline<T, U> for OwnedWrappedReadPipeline<File, Inner>
+where
+    File: TransparentWrapper<Inner::File>,
+    Inner: OwnedReadPipeline<T, U>,
+    T: bytemuck::Pod,
+    U: UserData,
+{
+    type File = File;
+
+    #[inline]
+    fn new(file: &File) -> Result<Self> {
+        let wrapper = Self {
+            inner: OwnedReadPipeline::new(File::peel_ref(file))?,
+            _phantom: PhantomData,
+        };
+
+        Ok(wrapper)
+    }
+
+    #[inline]
+    fn can_schedule(&mut self) -> bool {
+        self.inner.can_schedule()
+    }
+
+    #[inline]
+    fn schedule<P>(&mut self, user_data: U, range: ReadRange) -> Result<()>
+    where
+        P: AccessPattern,
+    {
+        self.inner.schedule::<P>(user_data, range)
+    }
+
+    #[inline]
+    fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
         self.inner.wait()
     }
 }

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -68,9 +68,9 @@ where
     type File = File;
 
     #[inline]
-    fn new(file: &File) -> Result<Self> {
+    fn new(file: File) -> Result<Self> {
         let wrapper = Self {
-            inner: OwnedReadPipeline::new(File::peel_ref(file))?,
+            inner: OwnedReadPipeline::new(File::peel(file))?,
             _phantom: PhantomData,
         };
 


### PR DESCRIPTION
Depends on #9078.

In this PR:
- `UniversalReadPipeline` renamed to `BorrowedReadPipeline`.
- Added `OwnedReadPipeline`.

Why: avoid jumping through hoops like thos:
https://github.com/qdrant/qdrant/blob/6066a75215c23c994b45eea1c4ccb600b61147af/lib/common/common/src/universal_io/simple_disk_cache/prefill.rs#L54-L73

Explanation:
https://github.com/qdrant/qdrant/blob/d9d643f3abfb4ee448f07a23f27b9df7b9e1b82e/lib/common/common/src/universal_io/traits/pipeline.rs#L1-L19