### PR TITLE
Validate TurboQuant internal scoring

### DIFF
--- a/lib/quantization/src/turboquant/lloyd_max.rs
+++ b/lib/quantization/src/turboquant/lloyd_max.rs
@@ -57,27 +57,13 @@ impl TQBits {
 
 #[cfg(test)]
 mod tests {
+    use crate::turboquant::math::std_normal_cdf;
+
     use super::*;
 
     /// Standard normal PDF: φ(x) = exp(-x²/2) / √(2π).
     fn std_normal_pdf(x: f64) -> f64 {
         (-0.5 * x * x).exp() / (2.0 * std::f64::consts::PI).sqrt()
-    }
-
-    /// Approximate error function (Abramowitz & Stegun 7.1.26, max error 1.5e-7).
-    fn erf_approx(x: f64) -> f64 {
-        let a = x.abs();
-        let t = 1.0 / (1.0 + 0.3275911 * a);
-        let poly = t
-            * (0.254829592
-                + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
-        let result = 1.0 - poly * (-a * a).exp();
-        if x >= 0.0 { result } else { -result }
-    }
-
-    /// Standard normal CDF: Φ(x) = (1 + erf(x/√2)) / 2.
-    fn std_normal_cdf(x: f64) -> f64 {
-        0.5 * (1.0 + erf_approx(x / std::f64::consts::SQRT_2))
     }
 
     /// Approximate inverse of the standard normal CDF (Abramowitz & Stegun 26.2.23).

--- a/lib/quantization/src/turboquant/lloyd_max.rs
+++ b/lib/quantization/src/turboquant/lloyd_max.rs
@@ -57,9 +57,8 @@ impl TQBits {
 
 #[cfg(test)]
 mod tests {
-    use crate::turboquant::math::std_normal_cdf;
-
     use super::*;
+    use crate::turboquant::math::std_normal_cdf;
 
     /// Standard normal PDF: φ(x) = exp(-x²/2) / √(2π).
     fn std_normal_pdf(x: f64) -> f64 {

--- a/lib/quantization/src/turboquant/math.rs
+++ b/lib/quantization/src/turboquant/math.rs
@@ -1,0 +1,15 @@
+/// Standard normal CDF Φ(x) = (1 + erf(x/√2)) / 2 via the Abramowitz & Stegun
+/// 7.1.26 rational approximation (max error ≈ 1.5e-7).
+pub(crate) fn std_normal_cdf(x: f64) -> f64 {
+    0.5 * (1.0 + erf_approx(x / std::f64::consts::SQRT_2))
+}
+
+fn erf_approx(x: f64) -> f64 {
+    let a = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * a);
+    let poly = t
+        * (0.254829592
+            + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+    let result = 1.0 - poly * (-a * a).exp();
+    if x >= 0.0 { result } else { -result }
+}

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod encoding;
 pub mod lloyd_max;
+mod math;
 mod permutation;
 pub mod quantization;
 pub mod rotation;
@@ -22,6 +23,7 @@ use crate::EncodingError;
 use crate::encoded_storage::{EncodedStorage, EncodedStorageBuilder};
 use crate::encoded_vectors::{EncodedVectors, VectorParameters, validate_vector_parameters};
 use crate::quantile::find_quantile_interval_per_coordinate_with_preprocess;
+use crate::turboquant::math::std_normal_cdf;
 use crate::turboquant::quantization::{ErrorCorrection, TurboQuantizer};
 use crate::turboquant::simd::{Query1bitSimd, Query2bitSimd, Query4bitSimd};
 
@@ -157,21 +159,6 @@ pub struct ErrorCorrectionMetadata {
     pub scale: Vec<f32>,
 }
 
-/// Standard normal CDF Φ(x) = (1 + erf(x/√2)) / 2 via the Abramowitz & Stegun
-/// 7.1.26 rational approximation (max error ≈ 1.5e-7). Used once per encode to
-/// turn `c_outer` into the symmetric quantile probability for the TQ+ pre-pass.
-fn phi(x: f64) -> f64 {
-    let z = x / std::f64::consts::SQRT_2;
-    let a = z.abs();
-    let t = 1.0 / (1.0 + 0.3275911 * a);
-    let poly = t
-        * (0.254829592
-            + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
-    let erf = 1.0 - poly * (-a * a).exp();
-    let erf = if z >= 0.0 { erf } else { -erf };
-    0.5 * (1.0 + erf)
-}
-
 impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
     pub fn storage(&self) -> &TStorage {
         &self.encoded_vectors
@@ -237,7 +224,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
                     .iter()
                     .copied()
                     .fold(0.0_f32, |acc, c| acc.max(c.abs()));
-                let p_outer = phi(f64::from(c_outer));
+                let p_outer = std_normal_cdf(f64::from(c_outer));
                 // `find_interval_per_coordinate` interprets `quantile` as the
                 // symmetric interval `[(1-q)/2, 1-(1-q)/2]`, so 2·p_outer − 1
                 // gives us the `[1-p_outer, p_outer]` pair we want.

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -5,6 +5,9 @@ mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
     use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
+    use quantization::turboquant::simd::{
+        score_1bit_internal_scalar, score_2bit_internal_scalar, score_4bit_internal_scalar,
+    };
     use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
     use rand::{RngExt, SeedableRng};
 
@@ -94,6 +97,97 @@ mod tests {
 
     fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         dot_similarity(a, b) / (l2_norm(a) * l2_norm(b))
+    }
+
+    fn read_f32(src: &[u8], offset: usize) -> f32 {
+        f32::from_le_bytes(src[offset..offset + size_of::<f32>()].try_into().unwrap())
+    }
+
+    fn score_scalar_reference(v1: &[u8], v2: &[u8], bits: TQBits, distance: DistanceType) -> f32 {
+        let extra_len = match distance {
+            DistanceType::Dot | DistanceType::Cosine => size_of::<f32>(),
+            DistanceType::L2 => 2 * size_of::<f32>(),
+            DistanceType::L1 => unreachable!("L1 reference needs inverse rotation"),
+        };
+        let (data_v1, extra_v1) = v1.split_at(v1.len() - extra_len);
+        let (data_v2, extra_v2) = v2.split_at(v2.len() - extra_len);
+        let raw_dot = match bits {
+            TQBits::Bits1 | TQBits::Bits1_5 => score_1bit_internal_scalar(data_v1, data_v2),
+            TQBits::Bits2 => score_2bit_internal_scalar(data_v1, data_v2),
+            TQBits::Bits4 => score_4bit_internal_scalar(data_v1, data_v2),
+        };
+        let v1_scale = read_f32(extra_v1, 0);
+        let v2_scale = read_f32(extra_v2, 0);
+        match distance {
+            DistanceType::Dot | DistanceType::Cosine => raw_dot * v1_scale * v2_scale,
+            DistanceType::L2 => {
+                let l2_a = read_f32(extra_v1, size_of::<f32>());
+                let l2_b = read_f32(extra_v2, size_of::<f32>());
+                l2_a * l2_a + l2_b * l2_b - 2.0 * v1_scale * v2_scale * raw_dot
+            }
+            DistanceType::L1 => unreachable!("L1 reference needs inverse rotation"),
+        }
+    }
+
+    #[test]
+    fn test_tq_internal_score_matches_reference() {
+        let dim = 128;
+        let vectors_count = 32;
+        let counter = HardwareCounterCell::new();
+
+        for &bits in BITS {
+            for &distance in &[DistanceType::Dot, DistanceType::Cosine, DistanceType::L2] {
+                let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                let vector_data: Vec<Vec<f32>> = (0..vectors_count)
+                    .map(|_| {
+                        let vector: Vec<f32> =
+                            (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                        match distance {
+                            DistanceType::Cosine => normalize(&vector),
+                            _ => vector,
+                        }
+                    })
+                    .collect();
+
+                let vector_parameters = VectorParameters {
+                    dim,
+                    deprecated_count: None,
+                    distance_type: distance,
+                    invert: false,
+                };
+                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                    &vector_parameters,
+                    bits,
+                    TQMode::Normal,
+                );
+                let encoded = EncodedVectorsTQ::encode(
+                    vector_data.iter(),
+                    TestEncodedStorageBuilder::new(None, quantized_vector_size),
+                    &vector_parameters,
+                    vectors_count,
+                    bits,
+                    TQMode::Normal,
+                    1,
+                    None,
+                    &AtomicBool::new(false),
+                )
+                .unwrap();
+
+                for i in 1..vectors_count {
+                    let v1 = encoded.get_quantized_vector(0);
+                    let v2 = encoded.get_quantized_vector(i as u32);
+                    let optimized = encoded.score_internal(0, i as u32, &counter);
+                    let reference = score_scalar_reference(&v1, &v2, bits, distance);
+                    let tolerance = 1e-5 * reference.abs().max(1.0);
+
+                    assert!(
+                        (optimized - reference).abs() <= tolerance,
+                        "bits={bits:?}, distance={distance:?}, i={i}: \
+                         optimized={optimized}, reference={reference}, tolerance={tolerance}"
+                    );
+                }
+            }
+        }
     }
 
     #[rstest::rstest]

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -6,9 +6,13 @@ mod tests {
     use quantization::encoded_storage::TestEncodedStorageBuilder;
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
     use quantization::turboquant::simd::{
-        score_1bit_internal_scalar, score_2bit_internal_scalar, score_4bit_internal_scalar,
+        CODEBOOK_SCALE_SQ_2BIT, CODEBOOK_SCALE_SQ_4BIT, score_1bit_internal_scalar,
+        score_2bit_internal_scalar, score_2bit_internal_weighted_scalar,
+        score_4bit_internal_scalar, score_4bit_internal_weighted_scalar,
     };
-    use quantization::turboquant::{self as encoded_vectors_tq, EncodedVectorsTQ, TQBits, TQMode};
+    use quantization::turboquant::{
+        self as encoded_vectors_tq, EncodedVectorsTQ, ErrorCorrectionMetadata, TQBits, TQMode,
+    };
     use rand::{RngExt, SeedableRng};
 
     use crate::metrics::{dot_similarity, l1_similarity, l2_similarity};
@@ -103,18 +107,82 @@ mod tests {
         f32::from_le_bytes(src[offset..offset + size_of::<f32>()].try_into().unwrap())
     }
 
-    fn score_scalar_reference(v1: &[u8], v2: &[u8], bits: TQBits, distance: DistanceType) -> f32 {
-        let extra_len = match distance {
+    fn extra_len(distance: DistanceType, mode: TQMode) -> usize {
+        let distance_extra_len = match distance {
             DistanceType::Dot | DistanceType::Cosine => size_of::<f32>(),
             DistanceType::L2 => 2 * size_of::<f32>(),
             DistanceType::L1 => unreachable!("L1 reference needs inverse rotation"),
         };
+        let mode_extra_len = match mode {
+            TQMode::Normal => 0,
+            TQMode::Plus => size_of::<f32>(),
+        };
+        distance_extra_len + mode_extra_len
+    }
+
+    fn ec_correction(extra: &[u8]) -> f32 {
+        read_f32(extra, extra.len() - size_of::<f32>())
+    }
+
+    fn tq_plus_weight_scale(ec: &ErrorCorrectionMetadata) -> (Vec<i16>, f32) {
+        let d_prime_sq_f32: Vec<f32> = ec
+            .scale
+            .iter()
+            .map(|&s| {
+                if s.abs() > f32::EPSILON {
+                    (s * s).recip()
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let max_d_prime_sq = d_prime_sq_f32.iter().copied().fold(0.0f32, f32::max);
+        const QUANT_CAP: i16 = i16::MAX - 1;
+        let weight_scale = if max_d_prime_sq > f32::EPSILON {
+            f32::from(QUANT_CAP) / max_d_prime_sq
+        } else {
+            1.0
+        };
+        let weights: Vec<i16> = d_prime_sq_f32
+            .iter()
+            .map(|&x| (x * weight_scale).round().clamp(0.0, f32::from(QUANT_CAP)) as i16)
+            .collect();
+        (weights, weight_scale)
+    }
+
+    fn score_scalar_reference(
+        v1: &[u8],
+        v2: &[u8],
+        bits: TQBits,
+        distance: DistanceType,
+        mode: TQMode,
+        ec: Option<&ErrorCorrectionMetadata>,
+    ) -> f32 {
+        let extra_len = extra_len(distance, mode);
         let (data_v1, extra_v1) = v1.split_at(v1.len() - extra_len);
         let (data_v2, extra_v2) = v2.split_at(v2.len() - extra_len);
-        let raw_dot = match bits {
-            TQBits::Bits1 | TQBits::Bits1_5 => score_1bit_internal_scalar(data_v1, data_v2),
-            TQBits::Bits2 => score_2bit_internal_scalar(data_v1, data_v2),
-            TQBits::Bits4 => score_4bit_internal_scalar(data_v1, data_v2),
+        let raw_dot = match (mode, bits) {
+            (TQMode::Plus, TQBits::Bits2) => {
+                let ec = ec.expect("TQ+ reference requires error correction metadata");
+                let (weights, weight_scale) = tq_plus_weight_scale(ec);
+                let raw_int = score_2bit_internal_weighted_scalar(data_v1, data_v2, &weights);
+                let xm_a = ec_correction(extra_v1);
+                let xm_b = ec_correction(extra_v2);
+                let mm: f32 = ec.shift.iter().map(|&s| s * s).sum();
+                raw_int as f32 / (weight_scale * CODEBOOK_SCALE_SQ_2BIT) + xm_a + xm_b - mm
+            }
+            (TQMode::Plus, TQBits::Bits4) => {
+                let ec = ec.expect("TQ+ reference requires error correction metadata");
+                let (weights, weight_scale) = tq_plus_weight_scale(ec);
+                let raw_int = score_4bit_internal_weighted_scalar(data_v1, data_v2, &weights);
+                let xm_a = ec_correction(extra_v1);
+                let xm_b = ec_correction(extra_v2);
+                let mm: f32 = ec.shift.iter().map(|&s| s * s).sum();
+                raw_int as f32 / (weight_scale * CODEBOOK_SCALE_SQ_4BIT) + xm_a + xm_b - mm
+            }
+            (_, TQBits::Bits1 | TQBits::Bits1_5) => score_1bit_internal_scalar(data_v1, data_v2),
+            (_, TQBits::Bits2) => score_2bit_internal_scalar(data_v1, data_v2),
+            (_, TQBits::Bits4) => score_4bit_internal_scalar(data_v1, data_v2),
         };
         let v1_scale = read_f32(extra_v1, 0);
         let v2_scale = read_f32(extra_v2, 0);
@@ -155,36 +223,39 @@ mod tests {
                     distance_type: distance,
                     invert: false,
                 };
-                let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
-                    &vector_parameters,
-                    bits,
-                    TQMode::Normal,
-                );
-                let encoded = EncodedVectorsTQ::encode(
-                    vector_data.iter(),
-                    TestEncodedStorageBuilder::new(None, quantized_vector_size),
-                    &vector_parameters,
-                    vectors_count,
-                    bits,
-                    TQMode::Normal,
-                    1,
-                    None,
-                    &AtomicBool::new(false),
-                )
-                .unwrap();
-
-                for i in 1..vectors_count {
-                    let v1 = encoded.get_quantized_vector(0);
-                    let v2 = encoded.get_quantized_vector(i as u32);
-                    let optimized = encoded.score_internal(0, i as u32, &counter);
-                    let reference = score_scalar_reference(&v1, &v2, bits, distance);
-                    let tolerance = 1e-5 * reference.abs().max(1.0);
-
-                    assert!(
-                        (optimized - reference).abs() <= tolerance,
-                        "bits={bits:?}, distance={distance:?}, i={i}: \
-                         optimized={optimized}, reference={reference}, tolerance={tolerance}"
+                for &mode in &[TQMode::Normal, TQMode::Plus] {
+                    let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                        &vector_parameters,
+                        bits,
+                        mode,
                     );
+                    let encoded = EncodedVectorsTQ::encode(
+                        vector_data.iter(),
+                        TestEncodedStorageBuilder::new(None, quantized_vector_size),
+                        &vector_parameters,
+                        vectors_count,
+                        bits,
+                        mode,
+                        1,
+                        None,
+                        &AtomicBool::new(false),
+                    )
+                    .unwrap();
+                    let ec = encoded.get_metadata().error_correction.as_ref();
+
+                    for i in 1..vectors_count {
+                        let v1 = encoded.get_quantized_vector(0);
+                        let v2 = encoded.get_quantized_vector(i as u32);
+                        let optimized = encoded.score_internal(0, i as u32, &counter);
+                        let reference = score_scalar_reference(&v1, &v2, bits, distance, mode, ec);
+                        let tolerance = 1e-5 * reference.abs().max(1.0);
+
+                        assert!(
+                            (optimized - reference).abs() <= tolerance,
+                            "bits={bits:?}, mode={mode:?}, distance={distance:?}, i={i}: \
+                             optimized={optimized}, reference={reference}, tolerance={tolerance}"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds reference coverage for TurboQuant internal scoring and deduplicates the shared standard-normal CDF approximation used by TurboQuant code/tests.

## Changes

- Move the Abramowitz & Stegun normal CDF approximation into `turboquant::math`.
- Reuse the shared CDF helper from:
  - TQ+ quantile selection in `mod.rs`
  - Lloyd-Max validation tests in `lloyd_max.rs`
- Add an integration test that compares `EncodedVectorsTQ::score_internal` against scalar reference scoring for:
  - `Bits1`
  - `Bits1_5`
  - `Bits2`
  - `Bits4`
  - Dot, Cosine, and L2 distances

## Tests

Passed locally:

```bash
cargo test -p quantization --test integration test_tq::tests::test_tq_internal_score_matches_reference
cargo test -p quantization turboquant::lloyd_max::tests
cargo test -p quantization --test integration test_tq::tests
cargo test -p quantization turboquant::quantization::tests
cargo clippy -p quantization --all-features
```

## Checklist

### All Submissions:

- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
