### PR TITLE
fix: values_count lte 0 matches missing payload keys

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -134,11 +134,14 @@ impl ValueChecker for FieldCondition {
             geo_radius: _,
             geo_bounding_box: _,
             geo_polygon: _,
-            values_count: _,
+            values_count,
             key: _,
             is_empty,
             is_null,
         } = self;
+        if let Some(values_count) = values_count {
+            return values_count.check_count(0);
+        }
         if let Some(is_empty) = is_empty {
             return *is_empty;
         }
@@ -377,6 +380,40 @@ mod tests {
             lte: None,
         };
         assert!(gte_two_countries_query.check(&countries));
+    }
+
+    #[test]
+    fn test_values_count_missing_key_matches_lte_zero() {
+        let lte_zero = ValuesCount {
+            lt: None,
+            gt: None,
+            gte: None,
+            lte: Some(0),
+        };
+        assert!(lte_zero.check_empty());
+
+        let eq_zero = ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(0),
+            lte: Some(0),
+        };
+        assert!(eq_zero.check_empty());
+
+        let lte_zero_field = FieldCondition {
+            r#match: None,
+            range: None,
+            geo_radius: None,
+            geo_bounding_box: None,
+            geo_polygon: None,
+            values_count: Some(lte_zero),
+            key: JsonPath::new("comments"),
+            is_empty: None,
+            is_null: None,
+        };
+        assert!(lte_zero_field.check_empty());
+        assert!(!lte_zero_field.check(&json!(["one"])));
+        assert!(lte_zero_field.check(&json!([])));
     }
 
     #[test]

--- a/tests/openapi/test_filter_values_count.py
+++ b/tests/openapi/test_filter_values_count.py
@@ -89,3 +89,61 @@ def test_filter_values_count(collection_name):
     json = response.json()
     assert len(json['result']) == 3
     assert json['result'][0]['id'] == 1
+
+
+def test_values_count_lte_zero_matches_missing_key():
+    collection_name = "test_values_count_missing_key"
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 2,
+                "distance": "Cosine",
+            },
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {"id": 1, "vector": [1.0, 0.0], "payload": {"comments": ["one"]}},
+                {"id": 2, "vector": [1.0, 0.0], "payload": {"comments": []}},
+                {"id": 3, "vector": [1.0, 0.0], "payload": {}},
+            ]
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "comments",
+                        "values_count": {
+                            "lte": 0
+                        }
+                    }
+                ]
+            },
+            "limit": 10,
+            "with_payload": True,
+        }
+    )
+    assert response.ok
+    ids = sorted(p['id'] for p in response.json()['result']['points'])
+    assert ids == [2, 3]
+
+    drop_collection(collection_name)


### PR DESCRIPTION
## Summary

- Treat a missing payload field as zero values when evaluating `values_count` filters, so `lte: 0` and `eq: 0` match both empty arrays and absent keys.
- Update `FieldCondition::check_empty` to delegate to `ValuesCount::check_count(0)` when `values_count` is set.

Fixes #9065

## Test plan

- [x] Unit test `test_values_count_missing_key_matches_lte_zero`
- [x] OpenAPI test `test_values_count_lte_zero_matches_missing_key`