### PR TITLE
refactor: add missing return type to load_new_shard

### DIFF
--- a/lib/edge/python/examples/common.py
+++ b/lib/edge/python/examples/common.py
@@ -19,7 +19,7 @@ DATA_DIR = Path(__file__).parent.parent.parent / "data"
 TMP_DIR = DATA_DIR / "tmp"
 
 
-def load_new_shard():
+def load_new_shard() -> EdgeShard:
     """Create a new edge shard (clears DATA_DIRECTORY first)."""
     print("---- Load shard ----")
 


### PR DESCRIPTION
### Summary

Adds the missing return type annotation to `load_new_shard` in the Python edge example.

### Changes

- Updated `load_new_shard()` to explicitly return `EdgeShard`.

### Testing

- Not run locally; this is a type annotation-only change.

### Checklist

- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in the Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?