### PR TITLE
Fix TurboQuant heap memory under-reporting

### DIFF
--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -93,9 +93,11 @@ pub trait EncodedVectors: Sized {
 
     /// Additional heap memory used by this encoded vectors instance
     /// beyond what's tracked in files (storage heap + metadata).
-    fn heap_size_bytes(&self) -> usize {
-        0
-    }
+    ///
+    /// Required (no default) so every quantizer must account for its own
+    /// heap explicitly — at minimum delegating to the storage backend's
+    /// [`EncodedStorage::heap_size_bytes`].
+    fn heap_size_bytes(&self) -> usize;
 
     type SupportsBytes: TBool;
     fn score_bytes(

--- a/lib/quantization/src/turboquant/mod.rs
+++ b/lib/quantization/src/turboquant/mod.rs
@@ -475,6 +475,22 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         )
     }
 
+    fn heap_size_bytes(&self) -> usize {
+        let Self {
+            encoded_vectors,
+            metadata: _,
+            metadata_path: _,
+            quantizer,
+            encoding_buffer,
+        } = self;
+        // Storage backend (the quantized vectors themselves; non-zero for the
+        // RAM-backed variants), plus the always-resident quantizer tables and
+        // the per-instance encoding scratch buffer.
+        encoded_vectors.heap_size_bytes()
+            + quantizer.heap_size_bytes()
+            + encoding_buffer.capacity() * size_of::<f64>()
+    }
+
     fn encode_internal_vector(&self, _id: PointOffsetType) -> Option<EncodedQueryTQ> {
         // Turbo quant is asymmetric, so we cannot encode internal vectors, only queries.
         // This method is used for symmetric quantization,

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -117,6 +117,33 @@ impl ErrorCorrection {
 }
 
 impl TurboQuantizer {
+    /// Heap memory owned by the quantizer: the rotation tables and, in TQ+
+    /// mode, the per-coordinate error-correction vectors. Resident in RAM
+    /// regardless of whether the encoded vectors are stored in RAM or mmap.
+    pub(super) fn heap_size_bytes(&self) -> usize {
+        let Self {
+            rotation,
+            bits: _,
+            mode: _,
+            distance: _,
+            padded_dim: _,
+            error_correction,
+        } = self;
+        rotation.heap_size_bytes()
+            + error_correction.as_ref().map_or(0, |ec| {
+                let ErrorCorrection {
+                    shift,
+                    scale,
+                    d_prime_sq_i16,
+                    weight_scale: _,
+                    mm_const: _,
+                } = ec;
+                shift.capacity() * size_of::<f32>()
+                    + scale.capacity() * size_of::<f32>()
+                    + d_prime_sq_i16.capacity() * size_of::<i16>()
+            })
+    }
+
     /// Initialize a new TurboQuantizer.
     pub fn new(
         dim: usize,

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -45,6 +45,18 @@ impl HadamardRotation {
         }
     }
 
+    /// Heap memory owned by the rotation tables. The permutations are stored
+    /// inline (no heap), so only the chunk metadata vectors are counted.
+    pub(super) fn heap_size_bytes(&self) -> usize {
+        let Self {
+            permutations: _,
+            dim: _,
+            chunk_sizes,
+            chunk_norms,
+        } = self;
+        chunk_sizes.capacity() * size_of::<usize>() + chunk_norms.capacity() * size_of::<f64>()
+    }
+
     pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
 


### PR DESCRIPTION
## Problem

`EncodedVectorsTQ` was the **only** quantizer that did not override `EncodedVectors::heap_size_bytes()`, so it fell back to the trait default of `0`.

Impact:
- For the RAM-backed variants (`TQRam`/`TQRamMulti`), the underlying storage backend computes the resident quantized-vector size correctly — but `EncodedVectorsTQ` never delegated to it. The entire RAM-resident quantized dataset was reported as **0 bytes** and misclassified as fully on-disk by `MemoryReporter for QuantizedVectors`.
- The always-resident quantizer tables (Hadamard rotation + TQ+ error-correction `shift`/`scale`/`d_prime_sq_i16` vectors) and the per-instance encoding buffer were uncounted for **every** variant, including mmap.

## Fix

- Make `heap_size_bytes()` a **required** trait method (remove the `{ 0 }` default) so every quantizer must account for its own heap explicitly. U8/PQ/Binary already implemented it — only TurboQuant broke, surfacing the gap as a compile error.
- Add the missing `EncodedVectorsTQ` impl: storage backend + quantizer tables + encoding buffer.
- Add `TurboQuantizer::heap_size_bytes()` (rotation tables + TQ+ error-correction vectors) and `HadamardRotation::heap_size_bytes()` (chunk metadata; permutations are inline).

All four impls destructure `Self` so future field additions force a compile-time decision about whether they count toward heap.

## Verification

`cargo check -p quantization`, `cargo check -p segment`, and `cargo clippy -p quantization` all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)