### PR TITLE
Make OpenOptions explicit

### DIFF
--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -55,7 +55,7 @@ fn bench_mmap_hashmap(c: &mut Criterion) {
         &path,
         OpenOptions {
             writeable: false,
-            ..Default::default()
+            ..OpenOptions::new_for_test()
         },
     )
     .unwrap();

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use common::generic_consts::{Random, Sequential};
+use common::mmap::AdviceSetting;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
 use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, UniversalRead};
@@ -71,7 +72,7 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
         writeable: false,
         need_sequential: true,
         populate: Populate::No,
-        advice: None,
+        advice: AdviceSetting::Global,
         prevent_caching: Some(false),
     };
     let storage = C::open(path, options).unwrap();

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -73,7 +73,7 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
         need_sequential: true,
         populate: Populate::No,
         advice: AdviceSetting::Global,
-        prevent_caching: Some(false),
+        extra: Default::default(),
     };
     let storage = C::open(path, options).unwrap();
     let len = FILE_SIZE_BYTES / size_of::<T>() as u64;

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -70,7 +70,6 @@ fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
     let options = OpenOptions {
         writeable: false,
         need_sequential: true,
-        disk_parallel: None,
         populate: Populate::No,
         advice: None,
         prevent_caching: Some(false),

--- a/lib/common/common/src/persisted_hashmap/tests.rs
+++ b/lib/common/common/src/persisted_hashmap/tests.rs
@@ -9,7 +9,7 @@ use super::fixtures::{Group, TestKey, TestReport, TestValue};
 use super::{Key, MmapHashMap, UniversalHashMap, serialize_hashmap};
 #[cfg(target_os = "linux")]
 use crate::universal_io::IoUringFile;
-use crate::universal_io::{self, MmapFile, UniversalRead};
+use crate::universal_io::{self, MmapFile, OpenOptions, UniversalRead};
 
 #[rustfmt::skip] #[test] fn test_k_str_v_i64()   { run_checks::<str,  i64 >(); }
 #[rustfmt::skip] #[test] fn test_k_str_v_u128()  { run_checks::<str,  u128>(); }
@@ -77,7 +77,7 @@ fn run_checks2<K: ?Sized + TestKey, V: TestValue>(
     run_uio_checks(
         r.group("uio:mmap"),
         &mut rng,
-        &UniversalHashMap::<K, V, MmapFile>::open(&path, Default::default()).unwrap(),
+        &UniversalHashMap::<K, V, MmapFile>::open(&path, OpenOptions::new_for_test()).unwrap(),
         &orig,
         &non_existing_keys,
     );
@@ -85,7 +85,7 @@ fn run_checks2<K: ?Sized + TestKey, V: TestValue>(
     run_uio_checks(
         r.group("uio:io_uring"),
         &mut rng,
-        &UniversalHashMap::<K, V, IoUringFile>::open(&path, Default::default()).unwrap(),
+        &UniversalHashMap::<K, V, IoUringFile>::open(&path, OpenOptions::new_for_test()).unwrap(),
         &orig,
         &non_existing_keys,
     );

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -353,7 +353,8 @@ mod tests {
         ];
         let f = create_temp_file(&data);
 
-        let storage: MmapBitSlice = StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+        let storage: MmapBitSlice =
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         assert_eq!(storage.element_len(), 2);
         assert_eq!(storage.bit_len(), 128);
@@ -406,7 +407,8 @@ mod tests {
         let data = [0xB2u8]; // 0b10110010
         let f = create_temp_file(&data);
 
-        let storage: MmapBitSlice = StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+        let storage: MmapBitSlice =
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         // Lsb0: 0xB2 = bits [0,1,0,0,1,1,0,1]
         assert_eq!(storage.get_bit(0).unwrap(), Some(false));
@@ -425,7 +427,7 @@ mod tests {
         let f = create_temp_file(&[0x00; 8]);
 
         let mut storage: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         // Set bit 3
         storage.replace_bit(3, true).unwrap();
@@ -442,7 +444,7 @@ mod tests {
         let f = create_temp_file(&[0x00; 8]);
 
         let mut storage: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         assert!(storage.replace_bit(storage.bit_len(), true).is_err());
     }
@@ -451,7 +453,7 @@ mod tests {
     fn test_replace_bit() {
         let f = create_temp_file(&[0xFF; 8]); // all bits set
         let mut storage: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         // Replace bit 2 (was true) with false
         let old = storage.replace_bit(2, false).unwrap();
@@ -470,7 +472,7 @@ mod tests {
         let f = create_temp_file(&[0x00; (NUM_BITS / 8) as usize]);
 
         let mut storage: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
         assert_eq!(storage.bit_len(), NUM_BITS);
 
         /// Verify every bit in storage matches the predicate.
@@ -547,14 +549,14 @@ mod tests {
         let f = create_temp_file(&[0x00; 8]);
 
         let mut storage: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         storage.replace_bit(0, true).unwrap();
         storage.flusher()().unwrap();
 
         // Reopen and verify persistence
         let storage2: MmapBitSlice =
-            StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
         assert_eq!(storage2.get_bit(0).unwrap(), Some(true));
     }
 
@@ -562,7 +564,8 @@ mod tests {
     fn test_bit_len() {
         let f = create_temp_file(&[0u8; 16]); // 2 u64 elements
 
-        let storage: MmapBitSlice = StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+        let storage: MmapBitSlice =
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         assert_eq!(storage.element_len(), 2);
         assert_eq!(storage.bit_len(), 128);
@@ -573,7 +576,8 @@ mod tests {
         let data = [0xAB, 0xCD, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let f = create_temp_file(&data);
 
-        let storage: MmapBitSlice = StoredBitSlice::open(f.path(), OpenOptions::default()).unwrap();
+        let storage: MmapBitSlice =
+            StoredBitSlice::open(f.path(), OpenOptions::new_for_test()).unwrap();
 
         let bs = storage.read_all().unwrap();
         assert_eq!(bs.len(), storage.bit_len() as usize);

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -6,8 +6,8 @@ use fs_err as fs;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    OpenOptions, ReadRange, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
-    UserData, local_file_ops,
+    OpenOptions, OpenOptionsExtra, ReadRange, Result, UniversalIoError, UniversalRead,
+    UniversalReadFileOps, UserData, local_file_ops,
 };
 
 mod cached_slice;
@@ -94,7 +94,10 @@ impl UniversalRead for CachedSlice {
             need_sequential: _,
             populate: _,
             advice: _,
-            prevent_caching: _, // This is cached in disk, backed by a mmap
+            extra:
+                OpenOptionsExtra {
+                    prevent_caching: _, // This is cached in disk, backed by a mmap
+                },
         } = options;
 
         debug_assert!(!writeable);

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -92,7 +92,6 @@ impl UniversalRead for CachedSlice {
         let OpenOptions {
             writeable,
             need_sequential: _,
-            disk_parallel: _,
             populate: _,
             advice: _,
             prevent_caching: _, // This is cached in disk, backed by a mmap

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -71,7 +71,6 @@ impl UniversalRead for IoUringFile {
         let OpenOptions {
             writeable,
             need_sequential: _,
-            disk_parallel: _,
             populate: _,
             advice: _,
             prevent_caching,

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -73,10 +73,10 @@ impl UniversalRead for IoUringFile {
             need_sequential: _,
             populate: _,
             advice: _,
-            prevent_caching,
+            extra: OpenOptionsExtra { prevent_caching },
         } = options;
 
-        let direct_io = prevent_caching.unwrap_or(false);
+        let direct_io = prevent_caching;
         let direct_io_flags = if direct_io { nix::libc::O_DIRECT } else { 0 };
 
         let file = fs::OpenOptions::new()

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -22,7 +22,7 @@ fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
 
     let opts = OpenOptions {
         prevent_caching: Some(o_direct),
-        ..Default::default()
+        ..OpenOptions::new_for_test()
     };
 
     // 2. Read data back using `IoUringFile` and verify it matches what was written
@@ -61,7 +61,7 @@ fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
 
     let opts = OpenOptions {
         prevent_caching: Some(o_direct),
-        ..Default::default()
+        ..OpenOptions::new_for_test()
     };
 
     let file = TypedStorage::<IoUringFile, u64>::open(&path, opts)?;
@@ -160,7 +160,7 @@ fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
 
     let opts = OpenOptions {
         prevent_caching: Some(o_direct),
-        ..Default::default()
+        ..OpenOptions::new_for_test()
     };
     let file_a = TypedStorage::<IoUringFile, u64>::open(&path_a, opts)?;
     let file_b = TypedStorage::<IoUringFile, u64>::open(&path_b, opts)?;
@@ -225,7 +225,7 @@ fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
 
     let opts = OpenOptions {
         prevent_caching: Some(o_direct),
-        ..Default::default()
+        ..OpenOptions::new_for_test()
     };
     let file_0 = IoUringFile::open(&path_0, opts)?;
     let file_1 = IoUringFile::open(&path_1, opts)?;
@@ -277,7 +277,7 @@ fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<(
 
     let opts = OpenOptions {
         prevent_caching: Some(o_direct),
-        ..Default::default()
+        ..OpenOptions::new_for_test()
     };
 
     for i in 0..NUM_FILES {
@@ -344,7 +344,7 @@ fn test_io_uring_read_multi_callback_matches_iter() -> Result<()> {
     let data_b: Vec<u64> = (5000..5200).collect();
     fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
 
-    let opts = OpenOptions::default();
+    let opts = OpenOptions::new_for_test();
     let file_a = IoUringFile::open(&path_a, opts)?;
     let file_b = IoUringFile::open(&path_b, opts)?;
     let files = [file_a, file_b];
@@ -413,7 +413,7 @@ fn test_io_uring_eintr_handling() -> Result<()> {
     let data: Vec<u64> = (0..NUM_ELEMENTS).collect();
     fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
-    let file = TypedStorage::<IoUringFile, u64>::open(&path, OpenOptions::default())?;
+    let file = TypedStorage::<IoUringFile, u64>::open(&path, OpenOptions::new_for_test())?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let signals_sent = Arc::new(AtomicU64::new(0));

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -21,7 +21,9 @@ fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytes).unwrap();
 
     let opts = OpenOptions {
-        prevent_caching: Some(o_direct),
+        extra: OpenOptionsExtra {
+            prevent_caching: o_direct,
+        },
         ..OpenOptions::new_for_test()
     };
 
@@ -60,7 +62,9 @@ fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
     let opts = OpenOptions {
-        prevent_caching: Some(o_direct),
+        extra: OpenOptionsExtra {
+            prevent_caching: o_direct,
+        },
         ..OpenOptions::new_for_test()
     };
 
@@ -159,7 +163,9 @@ fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
 
     let opts = OpenOptions {
-        prevent_caching: Some(o_direct),
+        extra: OpenOptionsExtra {
+            prevent_caching: o_direct,
+        },
         ..OpenOptions::new_for_test()
     };
     let file_a = TypedStorage::<IoUringFile, u64>::open(&path_a, opts)?;
@@ -224,7 +230,9 @@ fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_1, bytemuck::cast_slice(&data_1)).unwrap();
 
     let opts = OpenOptions {
-        prevent_caching: Some(o_direct),
+        extra: OpenOptionsExtra {
+            prevent_caching: o_direct,
+        },
         ..OpenOptions::new_for_test()
     };
     let file_0 = IoUringFile::open(&path_0, opts)?;
@@ -276,7 +284,9 @@ fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<(
     let mut files: Vec<IoUringFile> = Vec::new();
 
     let opts = OpenOptions {
-        prevent_caching: Some(o_direct),
+        extra: OpenOptionsExtra {
+            prevent_caching: o_direct,
+        },
         ..OpenOptions::new_for_test()
     };
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -63,7 +63,6 @@ impl UniversalRead for MmapFile {
         let OpenOptions {
             writeable,
             need_sequential,
-            disk_parallel: _,
             populate,
             advice,
             prevent_caching: _, // Whole point of mmap is to cache
@@ -255,7 +254,6 @@ impl MmapFile {
             OpenOptions {
                 writeable: false,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: Populate::No,
                 advice: Some(AdviceSetting::Advice(Advice::Normal)),
                 prevent_caching: None,

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -74,12 +74,7 @@ impl UniversalRead for MmapFile {
             Populate::Blocking => true,
         };
 
-        let mmap = open_mmap(
-            path.as_ref(),
-            writeable,
-            populate,
-            advice.unwrap_or(AdviceSetting::Global),
-        )?;
+        let mmap = open_mmap(path.as_ref(), writeable, populate, advice)?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());
 
         let mmap_seq;
@@ -255,7 +250,7 @@ impl MmapFile {
                 writeable: false,
                 need_sequential: false,
                 populate: Populate::No,
-                advice: Some(AdviceSetting::Advice(Advice::Normal)),
+                advice: AdviceSetting::Advice(Advice::Normal),
                 prevent_caching: None,
             },
         )

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -65,7 +65,10 @@ impl UniversalRead for MmapFile {
             need_sequential,
             populate,
             advice,
-            prevent_caching: _, // Whole point of mmap is to cache
+            extra:
+                OpenOptionsExtra {
+                    prevent_caching: _, // Whole point of mmap is to cache
+                },
         } = options;
 
         let populate = match populate {
@@ -251,7 +254,7 @@ impl MmapFile {
                 need_sequential: false,
                 populate: Populate::No,
                 advice: AdviceSetting::Advice(Advice::Normal),
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -19,7 +19,7 @@ pub use self::traits::{
     UserData,
 };
 pub use self::types::{
-    ByteOffset, FileIndex, Flusher, OpenOptions, Populate, ReadRange, Result, UniversalKind,
-    read_json_via,
+    ByteOffset, FileIndex, Flusher, OpenOptions, OpenOptionsExtra, Populate, ReadRange, Result,
+    UniversalKind, read_json_via,
 };
 pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -108,7 +108,7 @@ impl<R: UniversalRead> DiskCache<R> {
             prevent_caching: Some(true),
             populate: Populate::No,
             need_sequential: false,
-            advice: None,
+            advice: AdviceSetting::Global,
         };
 
         let remote = R::open(remote_path, remote_options)?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -108,7 +108,6 @@ impl<R: UniversalRead> DiskCache<R> {
             prevent_caching: Some(true),
             populate: Populate::No,
             need_sequential: false,
-            disk_parallel: None,
             advice: None,
         };
 
@@ -150,7 +149,6 @@ impl<R: UniversalRead> DiskCache<R> {
         let OpenOptions {
             writeable: _,       // always needs to be writeable
             need_sequential: _, // TODO: add sequential mmap
-            disk_parallel: _,   // unsupported
             populate: _,        // this is handled in populate() function
             advice,
             prevent_caching: _, // TODO: use o_direct

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -105,7 +105,7 @@ impl<R: UniversalRead> DiskCache<R> {
 
         let remote_options = OpenOptions {
             writeable: false,
-            prevent_caching: Some(true),
+            extra: OpenOptionsExtra { prevent_caching: true },
             populate: Populate::No,
             need_sequential: false,
             advice: AdviceSetting::Global,

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -44,9 +44,6 @@ impl From<bool> for Populate {
 pub struct OpenOptions {
     pub writeable: bool,
     pub need_sequential: bool,
-    /// How many parallel requests to the disk we can do.
-    /// If `None`, then use implementation-specific default.
-    pub disk_parallel: Option<usize>,
     /// Populate RAM cache on open, if applicable for this implementation.
     pub populate: Populate,
     /// Use specific mmap advice.
@@ -62,7 +59,6 @@ impl OpenOptions {
         Self {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -142,7 +138,6 @@ where
     let options = OpenOptions {
         writeable: false,
         need_sequential: false,
-        disk_parallel: None,
         populate: Populate::No,
         advice: Some(AdviceSetting::Advice(Advice::Sequential)),
         prevent_caching: Some(false),

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -48,8 +48,16 @@ pub struct OpenOptions {
     pub populate: Populate,
     /// Use specific mmap advice.
     pub advice: AdviceSetting,
+    /// Rarely used options.
+    pub extra: OpenOptionsExtra,
+}
+
+/// Rarely used options.
+/// Usually [`Default::default()`] is fine.
+#[derive(Copy, Clone, Debug)]
+pub struct OpenOptionsExtra {
     /// Whether to try to prevent caching for reads.
-    pub prevent_caching: Option<bool>,
+    pub prevent_caching: bool,
 }
 
 impl OpenOptions {
@@ -61,7 +69,16 @@ impl OpenOptions {
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
+        }
+    }
+}
+
+#[expect(clippy::derivable_impls, reason = "be explicit")]
+impl Default for OpenOptionsExtra {
+    fn default() -> Self {
+        OpenOptionsExtra {
+            prevent_caching: false,
         }
     }
 }
@@ -140,7 +157,7 @@ where
         need_sequential: false,
         populate: Populate::No,
         advice: AdviceSetting::Advice(Advice::Sequential),
-        prevent_caching: Some(false),
+        extra: Default::default(),
     };
 
     let storage = S::open(path, options)?;

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -36,6 +36,10 @@ impl From<bool> for Populate {
     }
 }
 
+/// Options for [`UniversalRead::open`].
+///
+/// No `#[derive(Default)]`. Prefer specifying all options explicitly. (except
+/// for tests and [`OpenOptions::extra`]).
 #[derive(Copy, Clone, Debug)]
 pub struct OpenOptions {
     pub writeable: bool,
@@ -51,8 +55,10 @@ pub struct OpenOptions {
     pub prevent_caching: Option<bool>,
 }
 
-impl Default for OpenOptions {
-    fn default() -> Self {
+impl OpenOptions {
+    /// Default values for [`OpenOptions`].
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_for_test() -> Self {
         Self {
             writeable: true,
             need_sequential: true,

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -47,7 +47,7 @@ pub struct OpenOptions {
     /// Populate RAM cache on open, if applicable for this implementation.
     pub populate: Populate,
     /// Use specific mmap advice.
-    pub advice: Option<AdviceSetting>,
+    pub advice: AdviceSetting,
     /// Whether to try to prevent caching for reads.
     pub prevent_caching: Option<bool>,
 }
@@ -60,7 +60,7 @@ impl OpenOptions {
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         }
     }
@@ -139,7 +139,7 @@ where
         writeable: false,
         need_sequential: false,
         populate: Populate::No,
-        advice: Some(AdviceSetting::Advice(Advice::Sequential)),
+        advice: AdviceSetting::Advice(Advice::Sequential),
         prevent_caching: Some(false),
     };
 

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -106,7 +106,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             populate: Populate::Blocking,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let mut slice_store = TypedStorage::open(&path, options)?;
@@ -128,7 +128,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             populate: Populate::Blocking,
-            advice: Some(AdviceSetting::Advice(Advice::Normal)),
+            advice: AdviceSetting::Advice(Advice::Normal),
             prevent_caching: None,
         };
         let slice_store = TypedStorage::open(&path, options)?;
@@ -162,7 +162,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             populate: Populate::No,
-            advice: Some(AdviceSetting::Advice(Advice::Normal)),
+            advice: AdviceSetting::Advice(Advice::Normal),
             prevent_caching: None,
         };
         self.slice_store = TypedStorage::open(&self.path, options)?;

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -107,7 +107,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             need_sequential: false,
             populate: Populate::Blocking,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let mut slice_store = TypedStorage::open(&path, options)?;
 
@@ -129,7 +129,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             need_sequential: false,
             populate: Populate::Blocking,
             advice: AdviceSetting::Advice(Advice::Normal),
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let slice_store = TypedStorage::open(&path, options)?;
 
@@ -163,7 +163,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             need_sequential: false,
             populate: Populate::No,
             advice: AdviceSetting::Advice(Advice::Normal),
-            prevent_caching: None,
+            extra: Default::default(),
         };
         self.slice_store = TypedStorage::open(&self.path, options)?;
 

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -105,7 +105,6 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::Blocking,
             advice: None,
             prevent_caching: None,
@@ -128,7 +127,6 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::Blocking,
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
@@ -163,7 +161,6 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::No,
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -18,13 +18,15 @@ use crate::tracker::{BlockOffset, PageId};
 
 const BITMASK_NAME: &str = "bitmask.dat";
 
-const OPEN_OPTIONS: OpenOptions = OpenOptions {
-    writeable: true,
-    need_sequential: false,
-    populate: Populate::No,
-    advice: AdviceSetting::Global,
-    prevent_caching: None,
-};
+fn open_options() -> OpenOptions {
+    OpenOptions {
+        writeable: true,
+        need_sequential: false,
+        populate: Populate::No,
+        advice: AdviceSetting::Global,
+        extra: Default::default(),
+    }
+}
 
 type RegionId = u32;
 
@@ -91,7 +93,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let path = Self::bitmask_path(dir);
         create_and_ensure_length(&path, length)?;
 
-        let bitslice = StoredBitSlice::open(&path, OPEN_OPTIONS)?;
+        let bitslice = StoredBitSlice::open(&path, open_options())?;
 
         let bit_len = bitslice.bit_len() as usize;
         assert_eq!(bit_len, length * 8, "Bitmask length mismatch");
@@ -133,7 +135,7 @@ impl<S: UniversalWrite> Bitmask<S> {
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let regions_gaps = BitmaskGaps::open(dir, config.clone())?;
@@ -206,7 +208,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let new_length = (previous_bit_len / u8::BITS as usize) + extra_length;
         create_and_ensure_length(&self.path, new_length)?;
 
-        self.bitslice = StoredBitSlice::open(&self.path, OPEN_OPTIONS)?;
+        self.bitslice = StoredBitSlice::open(&self.path, open_options())?;
 
         let current_bit_len = self.bitslice.bit_len() as usize;
 

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -21,7 +21,6 @@ const BITMASK_NAME: &str = "bitmask.dat";
 const OPEN_OPTIONS: OpenOptions = OpenOptions {
     writeable: true,
     need_sequential: false,
-    disk_parallel: None,
     populate: Populate::No,
     advice: None,
     prevent_caching: None,
@@ -132,7 +131,6 @@ impl<S: UniversalWrite> Bitmask<S> {
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -127,7 +127,17 @@ impl<S: UniversalWrite> Bitmask<S> {
             )));
         }
 
-        let bitslice = StoredBitSlice::open(&path, OpenOptions::default())?;
+        let bitslice = StoredBitSlice::open(
+            &path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
         let regions_gaps = BitmaskGaps::open(dir, config.clone())?;
 
         Ok(Self {

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
 use common::bitvec::BitSlice;
-use common::mmap::create_and_ensure_length;
+use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::universal_io::{MmapFile, OpenOptions, Populate, UniversalWrite};
 use gaps::{BitmaskGaps, RegionGaps};
@@ -22,7 +22,7 @@ const OPEN_OPTIONS: OpenOptions = OpenOptions {
     writeable: true,
     need_sequential: false,
     populate: Populate::No,
-    advice: None,
+    advice: AdviceSetting::Global,
     prevent_caching: None,
 };
 
@@ -132,7 +132,7 @@ impl<S: UniversalWrite> Bitmask<S> {
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -59,7 +59,6 @@ impl<S: UniversalRead> Pages<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::No,
             advice: None,
             prevent_caching: None,

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -62,7 +62,7 @@ impl<S: UniversalRead> Pages<S> {
             need_sequential: true,
             populate: Populate::No,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         let page = S::open(path, options)?;

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
+use common::mmap::AdviceSetting;
 use common::universal_io::{
     FileIndex, Flusher, OpenOptions, Populate, ReadRange, UniversalRead, UniversalWrite,
 };
@@ -60,7 +61,7 @@ impl<S: UniversalRead> Pages<S> {
             writeable: true,
             need_sequential: true,
             populate: Populate::No,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -20,7 +20,6 @@ fn tracker_open_options() -> OpenOptions {
     OpenOptions {
         writeable: true,
         need_sequential: false,
-        disk_parallel: None,
         populate: Populate::No,
         advice: Some(AdviceSetting::Advice(Advice::Random)),
         prevent_caching: None,

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -22,7 +22,7 @@ fn tracker_open_options() -> OpenOptions {
         need_sequential: false,
         populate: Populate::No,
         advice: AdviceSetting::Advice(Advice::Random),
-        prevent_caching: None,
+        extra: Default::default(),
     }
 }
 

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -21,7 +21,7 @@ fn tracker_open_options() -> OpenOptions {
         writeable: true,
         need_sequential: false,
         populate: Populate::No,
-        advice: Some(AdviceSetting::Advice(Advice::Random)),
+        advice: AdviceSetting::Advice(Advice::Random),
         prevent_caching: None,
     }
 }

--- a/lib/segment/benches/buffered_update_bitslice.rs
+++ b/lib/segment/benches/buffered_update_bitslice.rs
@@ -26,7 +26,7 @@ fn buffered_update_bitslice(c: &mut Criterion) {
     )
     .unwrap();
 
-    let bitslice_storage = MmapBitSlice::open(&path, OpenOptions::default()).unwrap();
+    let bitslice_storage = MmapBitSlice::open(&path, OpenOptions::new_for_test()).unwrap();
     let buffered_update_bitslice = BufferedUpdateBitSlice::new(bitslice_storage);
 
     // Set random flags and persist

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -160,9 +160,11 @@ where
 
         let options = OpenOptions {
             writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
             populate: Populate::from(populate),
             advice: Some(AdviceSetting::Global),
-            ..Default::default()
+            prevent_caching: None,
         };
         let flags = StoredBitSlice::open(&path, options)?;
         Ok(flags)

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -116,7 +116,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 populate: Populate::No,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -161,7 +161,7 @@ where
             writeable: true,
             need_sequential: true,
             populate: Populate::from(populate),
-            advice: Some(AdviceSetting::Global),
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let flags = StoredBitSlice::open(&path, options)?;

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -117,7 +117,7 @@ where
                 need_sequential: false,
                 populate: Populate::No,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -162,7 +162,7 @@ where
             need_sequential: true,
             populate: Populate::from(populate),
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let flags = StoredBitSlice::open(&path, options)?;
         Ok(flags)

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -115,7 +115,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: Populate::No,
                 advice: None,
                 prevent_caching: None,
@@ -161,7 +160,6 @@ where
         let options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::from(populate),
             advice: Some(AdviceSetting::Global),
             prevent_caching: None,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -87,7 +87,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Blocking,
                 advice: None,
                 prevent_caching: None,
@@ -104,7 +103,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: Populate::Blocking,
                 advice: None,
                 prevent_caching: None,
@@ -152,7 +150,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,
@@ -191,7 +188,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: Populate::No,
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -89,7 +89,7 @@ where
                 need_sequential: true,
                 populate: Populate::Blocking,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -105,7 +105,7 @@ where
                 need_sequential: false,
                 populate: Populate::Blocking,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -152,7 +152,7 @@ where
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -190,7 +190,7 @@ where
                 need_sequential: false,
                 populate: Populate::No,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         internal_to_version_file.write(0, internal_to_version)?;

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -85,8 +85,12 @@ where
         let deleted_storage = StoredBitSlice::open(
             deleted_path(segment_path),
             OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
                 populate: Populate::Blocking,
-                ..OpenOptions::default()
+                advice: None,
+                prevent_caching: None,
             },
         )?;
 
@@ -143,7 +147,17 @@ where
                 .next_multiple_of(size_of::<u64>()),
         )?;
 
-        let mut deleted_storage = StoredBitSlice::open(&deleted_filepath, OpenOptions::default())?;
+        let mut deleted_storage = StoredBitSlice::open(
+            &deleted_filepath,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
 
         // Set bits for deleted points from the mappings,
         deleted_storage.write_bitslice(mappings.deleted())?;

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -14,7 +14,7 @@ use std::mem::{size_of, size_of_val};
 use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitVec};
-use common::mmap::create_and_ensure_length;
+use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
@@ -88,7 +88,7 @@ where
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Blocking,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -104,7 +104,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 populate: Populate::Blocking,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -151,7 +151,7 @@ where
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -189,7 +189,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 populate: Populate::No,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -128,8 +128,17 @@ impl MmapInvertedIndex<MmapFile> {
                     .next_multiple_of(size_of::<u64>()),
             )?;
 
-            let mut deleted_storage =
-                MmapBitSlice::open(&deleted_points_path, OpenOptions::default())?;
+            let mut deleted_storage = MmapBitSlice::open(
+                &deleted_points_path,
+                OpenOptions {
+                    writeable: true,
+                    need_sequential: true,
+                    disk_parallel: None,
+                    populate: Populate::Auto,
+                    advice: None,
+                    prevent_caching: None,
+                },
+            )?;
             deleted_storage.write_bitslice(&deleted_bitslice)?;
             deleted_storage.flusher()()?;
         }
@@ -182,8 +191,11 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &vocab_path,
             OpenOptions {
                 writeable: false,
+                need_sequential: true,
+                disk_parallel: None,
                 populate: Populate::from(populate),
-                ..OpenOptions::default()
+                advice: None,
+                prevent_caching: None,
             },
         )?;
 
@@ -191,13 +203,25 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &point_to_tokens_count_path,
             OpenOptions {
                 writeable: false,
+                need_sequential: true,
+                disk_parallel: None,
                 populate: Populate::from(populate),
-                ..OpenOptions::default()
+                advice: None,
+                prevent_caching: None,
             },
         )?;
 
-        let deleted_payload_mmap =
-            MmapBitSlice::open(&deleted_points_path, OpenOptions::default())?;
+        let deleted_payload_mmap = MmapBitSlice::open(
+            &deleted_points_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_tokens_count.len()` because it

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -133,7 +133,6 @@ impl MmapInvertedIndex<MmapFile> {
                 OpenOptions {
                     writeable: true,
                     need_sequential: true,
-                    disk_parallel: None,
                     populate: Populate::Auto,
                     advice: None,
                     prevent_caching: None,
@@ -172,7 +171,6 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
         let postings_open_options = OpenOptions {
             writeable: false,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::from(populate),
             advice: Some(AdviceSetting::Advice(Advice::Normal)),
             prevent_caching: None,
@@ -192,7 +190,6 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             OpenOptions {
                 writeable: false,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::from(populate),
                 advice: None,
                 prevent_caching: None,
@@ -204,7 +201,6 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             OpenOptions {
                 writeable: false,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::from(populate),
                 advice: None,
                 prevent_caching: None,
@@ -216,7 +212,6 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -134,7 +134,7 @@ impl MmapInvertedIndex<MmapFile> {
                     writeable: true,
                     need_sequential: true,
                     populate: Populate::Auto,
-                    advice: None,
+                    advice: AdviceSetting::Global,
                     prevent_caching: None,
                 },
             )?;
@@ -172,7 +172,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             writeable: false,
             need_sequential: false,
             populate: Populate::from(populate),
-            advice: Some(AdviceSetting::Advice(Advice::Normal)),
+            advice: AdviceSetting::Advice(Advice::Normal),
             prevent_caching: None,
         };
         let postings = match has_positions {
@@ -191,7 +191,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 writeable: false,
                 need_sequential: true,
                 populate: Populate::from(populate),
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -202,7 +202,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 writeable: false,
                 need_sequential: true,
                 populate: Populate::from(populate),
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -213,7 +213,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -135,7 +135,7 @@ impl MmapInvertedIndex<MmapFile> {
                     need_sequential: true,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
-                    prevent_caching: None,
+                    extra: Default::default(),
                 },
             )?;
             deleted_storage.write_bitslice(&deleted_bitslice)?;
@@ -173,7 +173,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             need_sequential: false,
             populate: Populate::from(populate),
             advice: AdviceSetting::Advice(Advice::Normal),
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let postings = match has_positions {
             false => MmapPostingsEnum::Ids(UniversalPostings::<(), S>::open(
@@ -192,7 +192,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 need_sequential: true,
                 populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -203,7 +203,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 need_sequential: true,
                 populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -214,7 +214,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -128,7 +128,6 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                 OpenOptions {
                     writeable: true,
                     need_sequential: true,
-                    disk_parallel: None,
                     populate: Populate::Auto,
                     advice: None,
                     prevent_caching: None,
@@ -180,7 +179,6 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
         let open_options = OpenOptions {
             writeable: false,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,
@@ -198,7 +196,6 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -130,7 +130,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                     need_sequential: true,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
-                    prevent_caching: None,
+                    extra: Default::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(
@@ -181,7 +181,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             need_sequential: false,
             populate: Populate::from(populate),
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         let counts_per_hash = TypedStorage::open(&counts_per_hash_path, open_options)?;
@@ -198,7 +198,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -10,7 +10,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::ordering_iterator::OrderingIterator;
-use common::mmap::{MmapSlice, create_and_ensure_length};
+use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
@@ -129,7 +129,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                     writeable: true,
                     need_sequential: true,
                     populate: Populate::Auto,
-                    advice: None,
+                    advice: AdviceSetting::Global,
                     prevent_caching: None,
                 },
             )?;
@@ -180,7 +180,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             writeable: false,
             need_sequential: false,
             populate: Populate::from(populate),
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 
@@ -197,7 +197,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -123,7 +123,17 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                     .div_ceil(u8::BITS as usize)
                     .next_multiple_of(size_of::<u64>()),
             )?;
-            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+            let mut deleted = MmapBitSlice::open(
+                &deleted_path,
+                OpenOptions {
+                    writeable: true,
+                    need_sequential: true,
+                    disk_parallel: None,
+                    populate: Populate::Auto,
+                    advice: None,
+                    prevent_caching: None,
+                },
+            )?;
             deleted.set_ascending_bits_batch(
                 dynamic_index
                     .point_to_values
@@ -183,7 +193,17 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payload_mmap = MmapBitSlice::open(
+            &deleted_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_values.len()` because it only

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -45,7 +45,6 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             OpenOptions {
                 writeable: false,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::from(do_populate),
                 advice: None,
                 prevent_caching: None,
@@ -60,7 +59,6 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,
@@ -142,7 +140,6 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 OpenOptions {
                     writeable: true,
                     need_sequential: true,
-                    disk_parallel: None,
                     populate: Populate::Auto,
                     advice: None,
                     prevent_caching: None,

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -47,7 +47,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 need_sequential: true,
                 populate: Populate::from(do_populate),
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
@@ -61,7 +61,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
@@ -142,7 +142,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                     need_sequential: true,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
-                    prevent_caching: None,
+                    extra: Default::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use ahash::HashMap;
 use common::bitvec::{BitSlice, BitSliceExt};
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
-use common::mmap::create_and_ensure_length;
+use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
@@ -46,7 +46,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 writeable: false,
                 need_sequential: true,
                 populate: Populate::from(do_populate),
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -60,7 +60,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;
@@ -141,7 +141,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                     writeable: true,
                     need_sequential: true,
                     populate: Populate::Auto,
-                    advice: None,
+                    advice: AdviceSetting::Global,
                     prevent_caching: None,
                 },
             )?;

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -44,15 +44,28 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &hashmap_path,
             OpenOptions {
                 writeable: false,
+                need_sequential: true,
+                disk_parallel: None,
                 populate: Populate::from(do_populate),
-                ..OpenOptions::default()
+                advice: None,
+                prevent_caching: None,
             },
         )?;
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payload_mmap = MmapBitSlice::open(
+            &deleted_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_values.len()` because it only
@@ -124,7 +137,17 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                     .next_multiple_of(size_of::<u64>()),
             )?;
 
-            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+            let mut deleted = MmapBitSlice::open(
+                &deleted_path,
+                OpenOptions {
+                    writeable: true,
+                    need_sequential: true,
+                    disk_parallel: None,
+                    populate: Populate::Auto,
+                    advice: None,
+                    prevent_caching: None,
+                },
+            )?;
             deleted.set_ascending_bits_batch(
                 point_to_values
                     .iter()

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -85,7 +85,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                     need_sequential: true,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
-                    prevent_caching: None,
+                    extra: Default::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(
@@ -128,7 +128,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             need_sequential: false,
             populate: Populate::from(do_populate),
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let pairs = TypedStorage::open(pairs_path, pairs_options)?;
 
@@ -142,7 +142,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                 need_sequential: true,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -78,7 +78,17 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                     .next_multiple_of(size_of::<u64>()),
             )?;
 
-            let mut deleted = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+            let mut deleted = MmapBitSlice::open(
+                &deleted_path,
+                OpenOptions {
+                    writeable: true,
+                    need_sequential: true,
+                    disk_parallel: None,
+                    populate: Populate::Auto,
+                    advice: None,
+                    prevent_caching: None,
+                },
+            )?;
             deleted.set_ascending_bits_batch(
                 in_memory_index
                     .point_to_values
@@ -127,7 +137,17 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = MmapBitSlice::open(&deleted_path, OpenOptions::default())?;
+        let deleted_payload_mmap = MmapBitSlice::open(
+            &deleted_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: true,
+                disk_parallel: None,
+                populate: Populate::Auto,
+                advice: None,
+                prevent_caching: None,
+            },
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_values.len()` because it only

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -83,7 +83,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                 OpenOptions {
                     writeable: true,
                     need_sequential: true,
-                    disk_parallel: None,
                     populate: Populate::Auto,
                     advice: None,
                     prevent_caching: None,
@@ -127,7 +126,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
         let pairs_options = OpenOptions {
             writeable: false,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::from(do_populate),
             advice: None,
             prevent_caching: None,
@@ -142,7 +140,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             OpenOptions {
                 writeable: true,
                 need_sequential: true,
-                disk_parallel: None,
                 populate: Populate::Auto,
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitSliceExt};
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
-use common::mmap::{MmapSlice, create_and_ensure_length};
+use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, OpenOptions, Populate, TypedStorage};
@@ -84,7 +84,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                     writeable: true,
                     need_sequential: true,
                     populate: Populate::Auto,
-                    advice: None,
+                    advice: AdviceSetting::Global,
                     prevent_caching: None,
                 },
             )?;
@@ -127,7 +127,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             writeable: false,
             need_sequential: false,
             populate: Populate::from(do_populate),
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let pairs = TypedStorage::open(pairs_path, pairs_options)?;
@@ -141,7 +141,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                 writeable: true,
                 need_sequential: true,
                 populate: Populate::Auto,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -169,7 +169,7 @@ where
             writeable: false,
             need_sequential: false,
             populate: Populate::from(populate),
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -170,7 +170,7 @@ where
             need_sequential: false,
             populate: Populate::from(populate),
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         let store = ReadOnly::open(&file_name, open_options)?;

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -168,7 +168,6 @@ where
         let open_options = common::universal_io::OpenOptions {
             writeable: false,
             need_sequential: false,
-            disk_parallel: None,
             populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -55,7 +55,6 @@ pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
             OpenOptions {
                 writeable,
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-                disk_parallel: None,
                 populate: Populate::from(populate),
                 advice: Some(advice),
                 prevent_caching: None,
@@ -86,7 +85,6 @@ pub fn create_chunk<T: bytemuck::Pod, S: UniversalWrite>(
         OpenOptions {
             writeable: true,
             need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-            disk_parallel: None,
             populate: Populate::No, // don't populate newly created chunk, as it's empty and will be filled later
             advice: None,
             prevent_caching: None,

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -57,7 +57,7 @@ pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
                 populate: Populate::from(populate),
                 advice,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 
@@ -87,7 +87,7 @@ pub fn create_chunk<T: bytemuck::Pod, S: UniversalWrite>(
             need_sequential: *MULTI_MMAP_IS_SUPPORTED,
             populate: Populate::No, // don't populate newly created chunk, as it's empty and will be filled later
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         },
     )
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -56,7 +56,7 @@ pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
                 writeable,
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
                 populate: Populate::from(populate),
-                advice: Some(advice),
+                advice,
                 prevent_caching: None,
             },
         )?;
@@ -86,7 +86,7 @@ pub fn create_chunk<T: bytemuck::Pod, S: UniversalWrite>(
             writeable: true,
             need_sequential: *MULTI_MMAP_IS_SUPPORTED,
             populate: Populate::No, // don't populate newly created chunk, as it's empty and will be filled later
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         },
     )

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -123,7 +123,7 @@ where
                 writeable: true,
                 need_sequential: false,
                 populate: populate.map(Populate::from).unwrap_or_default(),
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -124,7 +124,7 @@ where
                 need_sequential: false,
                 populate: populate.map(Populate::from).unwrap_or_default(),
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -122,7 +122,6 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: populate.map(Populate::from).unwrap_or_default(),
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -60,7 +60,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
             writeable: false,
             need_sequential: true,
             populate: Populate::from(populate),
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let storage = TypedStorage::open(vectors_path, options).map_err(|e| {

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -61,7 +61,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
             need_sequential: true,
             populate: Populate::from(populate),
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let storage = TypedStorage::open(vectors_path, options).map_err(|e| {
             crate::common::operation_error::OperationError::service_error(format!(

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -59,7 +59,6 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
         let options = UniversalOpenOptions {
             writeable: false,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::from(populate),
             advice: None,
             prevent_caching: None,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -174,7 +174,7 @@ impl MultivectorOffsetsStorageMmap {
                 writeable: false,
                 need_sequential: false,
                 populate: Populate::No,
-                advice: None,
+                advice: AdviceSetting::Global,
                 prevent_caching: None,
             },
         )?;

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -175,7 +175,7 @@ impl MultivectorOffsetsStorageMmap {
                 need_sequential: false,
                 populate: Populate::No,
                 advice: AdviceSetting::Global,
-                prevent_caching: None,
+                extra: Default::default(),
             },
         )?;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -173,7 +173,6 @@ impl MultivectorOffsetsStorageMmap {
             OpenOptions {
                 writeable: false,
                 need_sequential: false,
-                disk_parallel: None,
                 populate: Populate::No,
                 advice: None,
                 prevent_caching: None,

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
-use common::mmap::{MmapFlusher, advice};
+use common::mmap::{AdviceSetting, MmapFlusher, advice};
 use common::types::PointOffsetType;
 use common::universal_io::{OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
 use fs_err as fs;
@@ -53,7 +53,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             writeable: false,
             need_sequential: true,
             populate: Populate::No,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         }
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -52,7 +52,6 @@ impl<S: UniversalRead> QuantizedStorage<S> {
         OpenOptions {
             writeable: false,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::No,
             advice: None,
             prevent_caching: None,

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -54,7 +54,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             need_sequential: true,
             populate: Populate::No,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         }
     }
 

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -128,7 +128,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -165,7 +164,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -210,7 +208,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -275,7 +272,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -313,7 +309,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,
@@ -360,7 +355,6 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let open_options = OpenOptions {
             writeable: true,
             need_sequential: true,
-            disk_parallel: None,
             populate: Populate::Auto,
             advice: None,
             prevent_caching: None,

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -12,6 +12,7 @@ use api::grpc::qdrant::{
     ReadWholeRequest, ReadWholeResponse,
 };
 use common::generic_consts::Random;
+use common::mmap::AdviceSetting;
 use common::universal_io::{
     FileIndex, MmapFile, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
 };
@@ -129,7 +130,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let length = tokio::task::spawn_blocking(move || {
@@ -165,7 +166,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 
@@ -209,7 +210,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let range = ReadRange::new(byte_offset, length);
@@ -273,7 +274,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 
@@ -310,7 +311,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
         let ranges = ranges
@@ -356,7 +357,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             writeable: true,
             need_sequential: true,
             populate: Populate::Auto,
-            advice: None,
+            advice: AdviceSetting::Global,
             prevent_caching: None,
         };
 

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -131,7 +131,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let length = tokio::task::spawn_blocking(move || {
             let storage = S::open(&path, open_options).map_err(io_error_to_status)?;
@@ -167,7 +167,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         let data = tokio::task::spawn_blocking(move || {
@@ -211,7 +211,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let range = ReadRange::new(byte_offset, length);
         let (storage, range) = tokio::task::spawn_blocking(move || {
@@ -275,7 +275,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         let data = tokio::task::spawn_blocking(move || {
@@ -312,7 +312,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
         let ranges = ranges
             .iter()
@@ -358,7 +358,7 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             need_sequential: true,
             populate: Populate::Auto,
             advice: AdviceSetting::Global,
-            prevent_caching: None,
+            extra: Default::default(),
         };
 
         // Resolve all paths and deduplicate into a file index.

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -13,7 +13,7 @@ use api::grpc::qdrant::{
 };
 use common::generic_consts::Random;
 use common::universal_io::{
-    FileIndex, MmapFile, OpenOptions, ReadRange, UniversalIoError, UniversalRead,
+    FileIndex, MmapFile, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
 };
 use futures::Stream;
 use storage::dispatcher::Dispatcher;
@@ -125,7 +125,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
 
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
         let length = tokio::task::spawn_blocking(move || {
             let storage = S::open(&path, open_options).map_err(io_error_to_status)?;
             storage.len::<u8>().map_err(io_error_to_status)
@@ -155,7 +162,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .check_and_resolve_shard(&auth, &collection_name, shard_id, "read_bytes")
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
 
         let data = tokio::task::spawn_blocking(move || {
             let storage = S::open(&path, open_options).map_err(io_error_to_status)?;
@@ -193,7 +207,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .check_and_resolve_shard(&auth, &collection_name, shard_id, "read_bytes_stream")
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
         let range = ReadRange::new(byte_offset, length);
         let (storage, range) = tokio::task::spawn_blocking(move || {
             let s = S::open(&path, open_options).map_err(io_error_to_status)?;
@@ -251,7 +272,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .check_and_resolve_shard(&auth, &collection_name, shard_id, "read_whole")
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
 
         let data = tokio::task::spawn_blocking(move || {
             let storage = S::open(&path, open_options).map_err(io_error_to_status)?;
@@ -282,7 +310,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
 
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
         let ranges = ranges
             .iter()
             .map(|r| ReadRange::new(r.byte_offset, r.length))
@@ -322,7 +357,14 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let (base, collections_root) = self
             .check_and_resolve_shard(&auth, &collection_name, shard_id, "read_multi")
             .await?;
-        let open_options = OpenOptions::default();
+        let open_options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            disk_parallel: None,
+            populate: Populate::Auto,
+            advice: None,
+            prevent_caching: None,
+        };
 
         // Resolve all paths and deduplicate into a file index.
         let mut path_to_index = HashMap::<PathBuf, FileIndex>::new();


### PR DESCRIPTION
It seems that during migration to UIO we flipped some behavior of how we open files.

E.g., in 1.18.0, every `flags_a.dat` mmap is opened twice. In 1.17.0 they are opened once.
Reason: the default `OpenOptions` has `need_sequential: true`, which opens random + sequential mmaps separately. And it seems that not the only case of flipped behavior.

To avoid such situations, I propose to stop using `OpenOptions::default()` and state every option explicitly, so we have less chance to miss it during the review. (With the exception of some rarely toggled options like `prevent_caching` that could remain be implicit)

So, this PR splits `OpenOptions` into two structs:
- `OpenOptions` - always explicit.
- `OpenOptionsExtra` - can be implicit / defaulted.

Also, in this PR the option `disk_parallel: Option<usize>` is removed (neither used nor implemented).

Also, `advice: Option<AdviceSetting>` and `prevent_caching: Option<bool>` are converted to `advice: AdviceSetting` and `prevent_caching: bool`.
Reason: I'd say `Option` values are confusing. What's the semantical difference between `Some(AdviceSetting::Global)` (aka the default advice setting) and `None`? If we decide to make them different, I'd suggest to introduce `AdviceSetting::Default` instead of wrapping it into an `Option`.

This PR refactors `OpenOptions`, but doesn't correct existing behavior. Correcting option values would be in a separate PR (#9107).