### PR TITLE
Fix WAL replay dropping points after delete_named_vector

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -784,7 +784,10 @@ impl LocalShard {
         // reference a vector name that was since removed by `delete_named_vector`; replaying
         // such an operation against the post-deletion segment config fails validation and the
         // whole operation (with its points) is dropped. We strip the dead names before applying.
-        let valid_vector_names: HashSet<_> = {
+        //
+        // Seeded from the current config and grown as the replay re-applies `CreateVectorName`
+        // operations, so a name that is created and used within the replay window stays valid.
+        let mut valid_vector_names: HashSet<_> = {
             let params = &self.collection_config.read().await.params;
             params
                 .vectors
@@ -808,6 +811,12 @@ impl LocalShard {
             })?;
             if let Some(clock_tag) = update.clock_tag {
                 newest_clocks.advance_clock(clock_tag);
+            }
+
+            // A historical `CreateVectorName` makes its name valid for every operation that
+            // follows it in the WAL; track it before stripping so those references survive.
+            if let Some(name) = update.operation.created_vector_name() {
+                valid_vector_names.insert(name.clone());
             }
 
             update.operation.retain_vector_names(&valid_vector_names);

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -20,7 +20,7 @@ pub mod indexed_only;
 pub mod testing;
 mod wal_ops;
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
@@ -780,8 +780,27 @@ impl LocalShard {
         // (`SerdeWal::read_all` may even start reading WAL from some already truncated
         // index *occasionally*), but the storage can handle it.
 
+        // Vector names that currently exist in the collection. Historical WAL operations may
+        // reference a vector name that was since removed by `delete_named_vector`; replaying
+        // such an operation against the post-deletion segment config fails validation and the
+        // whole operation (with its points) is dropped. We strip the dead names before applying.
+        let valid_vector_names: HashSet<_> = {
+            let params = &self.collection_config.read().await.params;
+            params
+                .vectors
+                .params_iter()
+                .map(|(name, _)| name.to_owned())
+                .chain(
+                    params
+                        .sparse_vectors
+                        .iter()
+                        .flat_map(|sparse| sparse.keys().cloned()),
+                )
+                .collect()
+        };
+
         for entry in wal.read_range(from..to) {
-            let (op_num, update) = entry.map_err(|e| {
+            let (op_num, mut update) = entry.map_err(|e| {
                 CollectionError::service_error(format!(
                     "Failed to read WAL during recovery of {}: {e}",
                     self.path.display(),
@@ -790,6 +809,8 @@ impl LocalShard {
             if let Some(clock_tag) = update.clock_tag {
                 newest_clocks.advance_clock(clock_tag);
             }
+
+            update.operation.retain_vector_names(&valid_vector_names);
 
             // Capture the operation type before `update.operation` is moved, so we can
             // report it if applying this operation turns out to be slow.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -374,6 +374,17 @@ impl ShardReplicaSet {
         }
     }
 
+    /// Synchronously flush every segment in the local shard. Test-only — `stop_gracefully`
+    /// signals the periodic flush worker to stop but never triggers a final flush, so
+    /// tests that need on-disk consistency without waiting for the periodic tick use this.
+    #[cfg(test)]
+    pub(crate) async fn force_flush_local_for_test(&self) {
+        use crate::shards::shard::Shard;
+        if let Some(Shard::Local(local)) = &*self.local.read().await {
+            local.full_flush();
+        }
+    }
+
     pub fn shard_key(&self) -> Option<ShardKey> {
         self.shard_key.read().clone()
     }

--- a/lib/collection/src/tests/delete_vector_name_replay.rs
+++ b/lib/collection/src/tests/delete_vector_name_replay.rs
@@ -1,0 +1,670 @@
+//! Reproducer for the WAL replay bug introduced by `delete_named_vector`.
+//!
+//! Hypothesis: `Collection::delete_named_vector` removes the vector from the persisted
+//! `CollectionParams` but does NOT reconcile the WAL. Historical Upsert entries that
+//! still reference the deleted vector name fail at WAL replay on reload, dropping
+//! their target points entirely.
+//!
+//! Procedure:
+//!   1. Build a collection with two named dense vectors `a` and `b`.
+//!   2. Upsert a single point that populates both `a` and `b`.
+//!   3. Call `delete_named_vector("b")`.
+//!   4. Close the collection and reopen it.
+//!   5. Assert the point survives reload.
+//!
+//! If the test fails, the bug is confirmed.
+
+use std::collections::{BTreeMap, HashSet};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::data_types::vector_name_config::{DenseVectorConfig, VectorNameConfig};
+use segment::types::{Distance, WithPayloadInterface, WithVector};
+use tempfile::Builder;
+
+use crate::collection::{Collection, RequestShardTransfer};
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorPersisted,
+    VectorStructPersisted, WriteOrdering,
+};
+use crate::operations::shard_selector_internal::ShardSelectorInternal;
+use crate::operations::shared_storage_config::SharedStorageConfig;
+use crate::operations::types::{PointRequestInternal, VectorsConfig};
+use crate::operations::vector_params_builder::VectorParamsBuilder;
+use crate::optimizers_builder::OptimizersConfig;
+use crate::shards::channel_service::ChannelService;
+use crate::shards::collection_shard_distribution::CollectionShardDistribution;
+use crate::shards::replica_set::replica_set_state::ReplicaState;
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+use crate::shards::shard::{PeerId, ShardId};
+
+const PEER_ID: PeerId = 1;
+const COLLECTION_NAME: &str = "test";
+
+fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(|_, _, _| {})
+}
+
+/// Synchronously flush every local shard's segments so subsequent `stop_gracefully` +
+/// reload doesn't have to replay the original Upsert from the WAL.
+async fn force_flush_all_local(collection: &Collection) {
+    let shards_holder = collection.shards_holder();
+    let holder = shards_holder.read().await;
+    for replica_set in holder.all_shards() {
+        replica_set.force_flush_local_for_test().await;
+    }
+}
+
+fn dummy_request_shard_transfer() -> RequestShardTransfer {
+    Arc::new(|_| {})
+}
+fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_, _| {})
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "windows", ignore = "too slow on Windows CI")]
+async fn delete_named_vector_then_reload_loses_points() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let collection_dir = Builder::new().prefix("dvn_repro_coll").tempdir().unwrap();
+    let snapshots_dir = Builder::new().prefix("dvn_repro_snap").tempdir().unwrap();
+
+    // Two dense named vectors, single shard, single replica.
+    let mut dense_vectors = BTreeMap::new();
+    dense_vectors.insert(
+        "a".to_string(),
+        VectorParamsBuilder::new(4, Distance::Dot).build(),
+    );
+    dense_vectors.insert(
+        "b".to_string(),
+        VectorParamsBuilder::new(4, Distance::Dot).build(),
+    );
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Multi(dense_vectors),
+        sparse_vectors: None,
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+
+    let optimizer_config = OptimizersConfig {
+        deleted_threshold: 0.9,
+        vacuum_min_vector_number: 1000,
+        default_segment_number: 1,
+        max_segment_size: None,
+        #[expect(deprecated)]
+        memmap_threshold: None,
+        indexing_threshold: Some(50_000),
+        flush_interval_sec: 30,
+        // Disable the optimizer — this bug must be observable without any optimizer
+        // activity. If the test fails with the optimizer disabled, it's a WAL replay
+        // bug, not a proxy-segment race.
+        max_optimization_threads: Some(0),
+        prevent_unoptimized: None,
+    };
+
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+        wal_retain_closed: 1,
+    };
+
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config,
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+
+    let shards: AHashMap<ShardId, HashSet<PeerId>> =
+        AHashMap::from_iter([(0, HashSet::from([PEER_ID]))]);
+
+    let collection = Collection::new(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution { shards },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    collection
+        .set_shard_replica_state(0, PEER_ID, ReplicaState::Active, None)
+        .await
+        .unwrap();
+
+    // Upsert a single point with both vectors.
+    let point_id = 42u64.into();
+    let mut named = std::collections::HashMap::new();
+    named.insert(
+        "a".to_string(),
+        VectorPersisted::Dense(vec![0.1, 0.2, 0.3, 0.4]),
+    );
+    named.insert(
+        "b".to_string(),
+        VectorPersisted::Dense(vec![0.5, 0.6, 0.7, 0.8]),
+    );
+    let point = PointStructPersisted {
+        id: point_id,
+        vector: VectorStructPersisted::Named(named),
+        payload: None,
+    };
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(vec![point]),
+    ));
+    collection
+        .update_from_client_simple(
+            upsert,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("initial upsert failed");
+
+    // Confirm the point is there with both vectors before we touch the schema.
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: vec![point_id],
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("pre-delete retrieve failed");
+    assert_eq!(
+        records.len(),
+        1,
+        "point should exist before delete_named_vector",
+    );
+
+    // Drop the `b` vector schema-wide.
+    collection
+        .delete_named_vector("b".to_string())
+        .await
+        .expect("delete_named_vector(b) failed");
+
+    // Confirm the point still exists with just `a` while we're live.
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: vec![point_id],
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("post-delete live retrieve failed");
+    assert_eq!(
+        records.len(),
+        1,
+        "point should survive live delete_named_vector",
+    );
+
+    // Close and reopen.
+    collection.stop_gracefully().await;
+    drop(collection);
+
+    let collection = Collection::load(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        Arc::new(SharedStorageConfig::default()),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await;
+
+    // The point must still exist after reload. If the WAL replay bug is real, the
+    // historical Upsert that included `b` was rejected (because `b` is no longer in
+    // the persisted CollectionParams), and the point is dropped.
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: vec![point_id],
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("post-reload retrieve failed");
+    assert_eq!(
+        records.len(),
+        1,
+        "point should survive WAL replay after delete_named_vector — \
+         if this fails, the WAL replay drops historical Upserts whose named-vector \
+         map references the (since-deleted) vector name",
+    );
+}
+
+/// Paired with the test above: same workload, but explicit `force_flush_all_local()` between
+/// the Upsert and the `delete_named_vector` so the original Upsert is baked into segment
+/// storage before close. WAL replay on reload then doesn't have to apply the Upsert against
+/// the post-deletion config, and the point survives.
+///
+/// If the FIRST test fails (point lost) and THIS test passes (point preserved), the bug is
+/// specifically: "WAL replay rejects historical Upserts whose named-vector map references a
+/// since-deleted vector name". With the flush, the Upsert is already in segment storage and
+/// the replay window starts past it.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "windows", ignore = "too slow on Windows CI")]
+async fn delete_named_vector_after_flush_survives_reload() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let collection_dir = Builder::new().prefix("dvn_flushed_coll").tempdir().unwrap();
+    let snapshots_dir = Builder::new().prefix("dvn_flushed_snap").tempdir().unwrap();
+
+    let mut dense_vectors = BTreeMap::new();
+    dense_vectors.insert(
+        "a".to_string(),
+        VectorParamsBuilder::new(4, Distance::Dot).build(),
+    );
+    dense_vectors.insert(
+        "b".to_string(),
+        VectorParamsBuilder::new(4, Distance::Dot).build(),
+    );
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Multi(dense_vectors),
+        sparse_vectors: None,
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+    let optimizer_config = OptimizersConfig {
+        deleted_threshold: 0.9,
+        vacuum_min_vector_number: 1000,
+        default_segment_number: 1,
+        max_segment_size: None,
+        #[expect(deprecated)]
+        memmap_threshold: None,
+        indexing_threshold: Some(50_000),
+        flush_interval_sec: 30,
+        max_optimization_threads: Some(0),
+        prevent_unoptimized: None,
+    };
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+        wal_retain_closed: 1,
+    };
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config,
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+    let shards: AHashMap<ShardId, HashSet<PeerId>> =
+        AHashMap::from_iter([(0, HashSet::from([PEER_ID]))]);
+
+    let collection = Collection::new(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution { shards },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    collection
+        .set_shard_replica_state(0, PEER_ID, ReplicaState::Active, None)
+        .await
+        .unwrap();
+
+    let point_id = 42u64.into();
+    let mut named = std::collections::HashMap::new();
+    named.insert(
+        "a".to_string(),
+        VectorPersisted::Dense(vec![0.1, 0.2, 0.3, 0.4]),
+    );
+    named.insert(
+        "b".to_string(),
+        VectorPersisted::Dense(vec![0.5, 0.6, 0.7, 0.8]),
+    );
+    let point = PointStructPersisted {
+        id: point_id,
+        vector: VectorStructPersisted::Named(named),
+        payload: None,
+    };
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(vec![point]),
+    ));
+    collection
+        .update_from_client_simple(
+            upsert,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("upsert failed");
+
+    // The critical difference vs. the first test: flush the segment so the Upsert is
+    // durably applied before we drop the vector schema.
+    force_flush_all_local(&collection).await;
+
+    collection
+        .delete_named_vector("b".to_string())
+        .await
+        .expect("delete_named_vector(b) failed");
+
+    collection.stop_gracefully().await;
+    drop(collection);
+
+    let collection = Collection::load(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        Arc::new(SharedStorageConfig::default()),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await;
+
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: vec![point_id],
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("post-reload retrieve failed");
+    assert_eq!(
+        records.len(),
+        1,
+        "with a flush between Upsert and delete_named_vector, the point should \
+         survive reload — the original Upsert was applied to segment storage before \
+         the vector was dropped, so WAL replay doesn't have to redo it",
+    );
+}
+
+/// Multi-cycle counterpart to `delete_named_vector_after_flush_survives_reload`: 10
+/// rounds of `CreateVectorName → upsert → flush → DeleteVectorName`, each with its own
+/// fresh dynamically-added vector name. After all cycles close + reopen and assert
+/// every point is still retrievable.
+///
+/// This passes — establishing that the bug is not "any Create+Delete cycle corrupts
+/// segment state", but specifically "an unflushed Upsert with a since-deleted vector
+/// name fails WAL replay". Flushing each cycle's upsert before its DeleteVectorName
+/// closes the bug window, even across many cycles.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "windows", ignore = "too slow on Windows CI")]
+async fn repeated_create_then_delete_vector_name_with_flush_survives_reload() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let collection_dir = Builder::new().prefix("dvn_cycle_coll").tempdir().unwrap();
+    let snapshots_dir = Builder::new().prefix("dvn_cycle_snap").tempdir().unwrap();
+
+    // Start with just `a` — `b` will be created dynamically.
+    let mut dense_vectors = BTreeMap::new();
+    dense_vectors.insert(
+        "a".to_string(),
+        VectorParamsBuilder::new(4, Distance::Dot).build(),
+    );
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Multi(dense_vectors),
+        sparse_vectors: None,
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+    let optimizer_config = OptimizersConfig {
+        deleted_threshold: 0.9,
+        vacuum_min_vector_number: 1000,
+        default_segment_number: 1,
+        max_segment_size: None,
+        #[expect(deprecated)]
+        memmap_threshold: None,
+        indexing_threshold: Some(50_000),
+        flush_interval_sec: 30,
+        max_optimization_threads: Some(0),
+        prevent_unoptimized: None,
+    };
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+        wal_retain_closed: 1,
+    };
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config,
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+    let shards: AHashMap<ShardId, HashSet<PeerId>> =
+        AHashMap::from_iter([(0, HashSet::from([PEER_ID]))]);
+
+    let collection = Collection::new(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution { shards },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    collection
+        .set_shard_replica_state(0, PEER_ID, ReplicaState::Active, None)
+        .await
+        .unwrap();
+
+    const NUM_CYCLES: u64 = 10;
+    let mut point_ids = Vec::with_capacity(NUM_CYCLES as usize);
+
+    for i in 0..NUM_CYCLES {
+        let name = format!("v_{i}");
+        // 1. Dynamically create the vector.
+        let cfg = VectorNameConfig::dense(DenseVectorConfig {
+            size: 4,
+            distance: Distance::Dot,
+            multivector_config: None,
+            datatype: None,
+        });
+        collection
+            .create_named_vector(name.clone(), cfg, HwMeasurementAcc::new())
+            .await
+            .unwrap_or_else(|e| panic!("create_named_vector({name:?}) failed: {e:?}"));
+
+        // 2. Upsert a unique point that includes the new vector.
+        let point_id = (100 + i).into();
+        point_ids.push(point_id);
+        let mut named = std::collections::HashMap::new();
+        named.insert(
+            "a".to_string(),
+            VectorPersisted::Dense(vec![0.1, 0.2, 0.3, 0.4]),
+        );
+        named.insert(
+            name.clone(),
+            VectorPersisted::Dense(vec![0.5, 0.6, 0.7, i as f32 / 10.0]),
+        );
+        let point = PointStructPersisted {
+            id: point_id,
+            vector: VectorStructPersisted::Named(named),
+            payload: None,
+        };
+        let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        collection
+            .update_from_client_simple(
+                upsert,
+                true,
+                None,
+                WriteOrdering::default(),
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("upsert cycle {i} failed: {e:?}"));
+
+        // 3. Flush so the upsert is baked into segment storage.
+        force_flush_all_local(&collection).await;
+
+        // 4. Drop the dynamically-added vector.
+        collection
+            .delete_named_vector(name.clone())
+            .await
+            .unwrap_or_else(|e| panic!("delete_named_vector({name:?}) failed: {e:?}"));
+    }
+
+    // All N points should still be there live.
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: point_ids.clone(),
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("post-cycles live retrieve failed");
+    assert_eq!(
+        records.len(),
+        NUM_CYCLES as usize,
+        "all {NUM_CYCLES} points should survive the live cycles",
+    );
+
+    // Close and reopen.
+    collection.stop_gracefully().await;
+    drop(collection);
+
+    let collection = Collection::load(
+        COLLECTION_NAME.to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_dir.path(),
+        Arc::new(SharedStorageConfig::default()),
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await;
+
+    let records = collection
+        .retrieve(
+            PointRequestInternal {
+                ids: point_ids.clone(),
+                with_payload: Some(WithPayloadInterface::Bool(false)),
+                with_vector: WithVector::Bool(true),
+            },
+            None,
+            &ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("post-reload retrieve failed");
+    let returned_ids: Vec<_> = records.iter().map(|r| r.id).collect();
+    let missing: Vec<_> = point_ids
+        .iter()
+        .filter(|id| !returned_ids.contains(id))
+        .copied()
+        .collect();
+    assert_eq!(
+        records.len(),
+        NUM_CYCLES as usize,
+        "all {NUM_CYCLES} points should survive reload after their respective \
+         CreateVectorName + Upsert + Flush + DeleteVectorName cycles. \
+         Missing: {missing:?}",
+    );
+}

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod deferred_points_dedup;
 mod deferred_points_tests;
+mod delete_vector_name_replay;
 mod fix_payload_indices;
 pub mod fixtures;
 mod hw_metrics;

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -106,6 +106,8 @@ impl CollectionUpdateOperations {
     /// points with it. Stripping the dead names lets the rest of the operation apply, matching
     /// the live outcome (the point survives, just without the deleted vector).
     ///
+    /// This does not touch `VectorNameOperation` responsible for creating/deleting a named vector.
+    ///
     /// Only affects the named-vector variants; the default (unnamed) vector is left untouched.
     pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
         match self {

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -109,6 +109,11 @@ impl CollectionUpdateOperations {
     /// This does not touch `VectorNameOperation` responsible for creating/deleting a named vector.
     ///
     /// Only affects the named-vector variants; the default (unnamed) vector is left untouched.
+    ///
+    /// Note: this is best-effort. Stripping a vector from an early operation silently changes the
+    /// behavior of a later operation that depended on it (e.g. a `has_vector` filter or
+    /// `UpdateVectors`), so the replayed timeline can still diverge from the live one. Tracked in
+    /// <https://github.com/qdrant/qdrant/issues/9386>.
     pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
         match self {
             Self::PointOperation(op) => op.retain_vector_names(valid),

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -120,6 +120,27 @@ impl CollectionUpdateOperations {
             Self::StagingOperation(_) => (),
         }
     }
+
+    /// If this operation creates a named vector, return the name it introduces.
+    ///
+    /// Used during WAL replay to grow the set of valid vector names: a historical
+    /// `CreateVectorName` must make its name valid for the operations that follow it in
+    /// the WAL, otherwise a later upsert referencing it would be wrongly stripped by
+    /// [`Self::retain_vector_names`].
+    pub fn created_vector_name(&self) -> Option<&VectorNameBuf> {
+        match self {
+            Self::VectorNameOperation(VectorNameOperations::CreateVectorName(op)) => {
+                Some(&op.vector_name)
+            }
+            Self::VectorNameOperation(VectorNameOperations::DeleteVectorName(_))
+            | Self::PointOperation(_)
+            | Self::VectorOperation(_)
+            | Self::PayloadOperation(_)
+            | Self::FieldIndexOperation(_) => None,
+            #[cfg(feature = "staging")]
+            Self::StagingOperation(_) => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants, Hash)]

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -7,8 +7,10 @@ pub mod staging;
 pub mod vector_name_ops;
 pub mod vector_ops;
 
+use std::collections::HashSet;
+
 use segment::json_path::JsonPath;
-use segment::types::{PayloadFieldSchema, PointIdType};
+use segment::types::{PayloadFieldSchema, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
 
@@ -89,6 +91,27 @@ impl CollectionUpdateOperations {
             Self::PointOperation(op) => op.retain_point_ids(filter),
             Self::VectorOperation(op) => op.retain_point_ids(filter),
             Self::PayloadOperation(op) => op.retain_point_ids(filter),
+            Self::FieldIndexOperation(_) => (),
+            Self::VectorNameOperation(_) => (),
+            #[cfg(feature = "staging")]
+            Self::StagingOperation(_) => (),
+        }
+    }
+
+    /// Drop named-vector references to vector names not in `valid`.
+    ///
+    /// Used during WAL replay: a historical operation may reference a vector name that was
+    /// since removed by `delete_named_vector`. Without this, such an operation fails segment
+    /// validation (`VectorNameNotExists`) and is dropped wholesale on reload, taking its
+    /// points with it. Stripping the dead names lets the rest of the operation apply, matching
+    /// the live outcome (the point survives, just without the deleted vector).
+    ///
+    /// Only affects the named-vector variants; the default (unnamed) vector is left untouched.
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        match self {
+            Self::PointOperation(op) => op.retain_vector_names(valid),
+            Self::VectorOperation(op) => op.retain_vector_names(valid),
+            Self::PayloadOperation(_) => (),
             Self::FieldIndexOperation(_) => (),
             Self::VectorNameOperation(_) => (),
             #[cfg(feature = "staging")]

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -143,6 +143,21 @@ impl PointOperations {
             Self::SyncPoints(op) => op.points.retain(|point| filter(&point.id)),
         }
     }
+
+    /// Drop named-vector references to names not in `valid`. See
+    /// [`CollectionUpdateOperations::retain_vector_names`].
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        match self {
+            Self::UpsertPoints(op) => op.retain_vector_names(valid),
+            Self::UpsertPointsConditional(op) => op.points_op.retain_vector_names(valid),
+            Self::SyncPoints(op) => {
+                for point in &mut op.points {
+                    point.vector.retain_vector_names(valid);
+                }
+            }
+            Self::DeletePoints { .. } | Self::DeletePointsByFilter(_) => (),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, EnumDiscriminants, Hash)]
@@ -190,6 +205,19 @@ impl PointInsertOperationsInternal {
                 }
             }
             PointInsertOperationsInternal::PointsList(points) => points,
+        }
+    }
+
+    /// Drop named-vector references to names not in `valid`. See
+    /// [`CollectionUpdateOperations::retain_vector_names`].
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        match self {
+            Self::PointsBatch(batch) => batch.vectors.retain_vector_names(valid),
+            Self::PointsList(points) => {
+                for point in points {
+                    point.vector.retain_vector_names(valid);
+                }
+            }
         }
     }
 
@@ -317,6 +345,16 @@ pub enum BatchVectorStructPersisted {
     Single(Vec<DenseVector>),
     MultiDense(Vec<MultiDenseVector>),
     Named(HashMap<VectorNameBuf, Vec<VectorPersisted>>),
+}
+
+impl BatchVectorStructPersisted {
+    /// Drop named-vector references to names not in `valid`. See
+    /// [`CollectionUpdateOperations::retain_vector_names`].
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        if let BatchVectorStructPersisted::Named(named) = self {
+            named.retain(|name, _| valid.contains(name));
+        }
+    }
 }
 
 impl Hash for BatchVectorStructPersisted {
@@ -492,6 +530,16 @@ pub enum VectorStructPersisted {
     Single(DenseVector),
     MultiDense(MultiDenseVector),
     Named(HashMap<VectorNameBuf, VectorPersisted>),
+}
+
+impl VectorStructPersisted {
+    /// Drop named-vector references to names not in `valid`. See
+    /// [`CollectionUpdateOperations::retain_vector_names`].
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        if let VectorStructPersisted::Named(named) = self {
+            named.retain(|name, _| valid.contains(name));
+        }
+    }
 }
 
 impl std::hash::Hash for VectorStructPersisted {
@@ -801,4 +849,69 @@ where
         index += 1;
         retain
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dense(v: f32) -> VectorPersisted {
+        VectorPersisted::Dense(vec![v])
+    }
+
+    #[test]
+    fn retain_vector_names_strips_list_batch_and_delete() {
+        let valid: HashSet<VectorNameBuf> = ["a".to_string()].into_iter().collect();
+
+        // PointsList: the deleted name `b` is stripped, `a` survives.
+        let mut list =
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(vec![
+                PointStructPersisted {
+                    id: 1.into(),
+                    vector: VectorStructPersisted::Named(
+                        [("a".to_string(), dense(0.1)), ("b".to_string(), dense(0.2))]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    payload: None,
+                },
+            ]));
+        list.retain_vector_names(&valid);
+        let PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(points)) =
+            &list
+        else {
+            unreachable!()
+        };
+        let VectorStructPersisted::Named(named) = &points[0].vector else {
+            unreachable!()
+        };
+        assert_eq!(named.keys().cloned().collect::<Vec<_>>(), vec!["a"]);
+
+        // PointsBatch: per-name entries are dropped, ids/payloads length untouched.
+        let mut batch = PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(
+            BatchPersisted {
+                ids: vec![1.into(), 2.into()],
+                vectors: BatchVectorStructPersisted::Named(
+                    [
+                        ("a".to_string(), vec![dense(0.1), dense(0.2)]),
+                        ("b".to_string(), vec![dense(0.3), dense(0.4)]),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                payloads: None,
+            },
+        ));
+        batch.retain_vector_names(&valid);
+        let PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsBatch(batch)) =
+            &batch
+        else {
+            unreachable!()
+        };
+        let BatchVectorStructPersisted::Named(named) = &batch.vectors else {
+            unreachable!()
+        };
+        assert_eq!(named.keys().cloned().collect::<Vec<_>>(), vec!["a"]);
+        assert_eq!(batch.ids.len(), 2);
+    }
 }

--- a/lib/shard/src/operations/vector_ops.rs
+++ b/lib/shard/src/operations/vector_ops.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use segment::types::{Filter, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use strum::{EnumDiscriminants, EnumIter};
@@ -33,6 +35,21 @@ impl VectorOperations {
             Self::UpdateVectors(op) => op.points.retain(|point| filter(&point.id)),
             Self::DeleteVectors(points, _) => points.points.retain(filter),
             Self::DeleteVectorsByFilter(_, _) => (),
+        }
+    }
+
+    /// Drop named-vector references to names not in `valid`. See
+    /// [`super::CollectionUpdateOperations::retain_vector_names`].
+    pub fn retain_vector_names(&mut self, valid: &HashSet<VectorNameBuf>) {
+        match self {
+            Self::UpdateVectors(op) => {
+                for point in &mut op.points {
+                    point.vector.retain_vector_names(valid);
+                }
+            }
+            Self::DeleteVectors(_, names) | Self::DeleteVectorsByFilter(_, names) => {
+                names.retain(|name| valid.contains(name));
+            }
         }
     }
 }


### PR DESCRIPTION
An Upsert sitting in unflushed WAL when `delete_named_vector(X)` is called still references `X`. 

On reopen, WAL replay rejects it (`Not existing vector name error: X`) and the target point is lost.

**Fix:** in `LocalShard::load_from_wal`, strip references to vector names not in the current collection config before applying each replayed op (`CollectionUpdateOperations::retain_vector_names`). 

The point survives with its remaining vectors, matching live behavior.

**Tests** (`lib/collection/src/tests/delete_vector_name_replay.rs`):
1. `delete_named_vector_then_reload_loses_points` — the repro; now passes with the fix.
2. `delete_named_vector_after_flush_survives_reload` — flushing before the delete already closed the window.
3. `repeated_create_then_delete_vector_name_with_flush_survives_reload` — the bug is the unflushed-Upsert variant, not any Create+Delete cycle.

Adds a `#[cfg(test)]` helper `force_flush_local_for_test` on `ShardReplicaSet`.

Note: scoped to the optimizer-off WAL-replay path. The optimizer-on proxy-segment schema race is separate and not addressed here.
