### PR TITLE
[TQDT] Static Rotations

### DIFF
--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -54,12 +54,15 @@ pub struct Permutation {
     count: usize,
     /// LCG state after all forward-pass random draws, used as starting
     /// point for the reverse pass.
-    end_state: u64,
+    end_state: Option<u64>,
 }
 
 impl Permutation {
     /// Create a new permutation for `count` elements seeded by `seed`.
-    pub fn new(seed: u64, count: usize) -> Self {
+    ///
+    /// Unlike [`Self::new_one_way`], the result supports [`Self::unpermute`].
+    /// Both constructors produce identical output from [`Self::permute`] for the same seed.
+    pub fn new_reversible(seed: u64, count: usize) -> Self {
         let mut rng = ReversibleLcg::new(seed);
         for _ in 1..count {
             rng.next();
@@ -67,7 +70,19 @@ impl Permutation {
         Self {
             seed,
             count,
-            end_state: rng.state,
+            end_state: Some(rng.state),
+        }
+    }
+
+    /// Create a forward-only permutation. Skips the O(`count`) LCG warm-up
+    /// that [`Self::new_reversible`] does to record `end_state`. Can only be
+    /// used for [`Self::permute`]; calling [`Self::unpermute`] will panic.
+    #[inline]
+    pub fn new_one_way(seed: u64, count: usize) -> Self {
+        Self {
+            seed,
+            count,
+            end_state: None,
         }
     }
 
@@ -82,9 +97,17 @@ impl Permutation {
     }
 
     /// Apply the inverse permutation in-place (reversed Fisher-Yates).
+    ///
+    /// # Panics
+    ///
+    /// Panics if this permutation was created with [`Self::new_one_way`].
     pub fn unpermute(&self, arr: &mut [f64]) {
         debug_assert_eq!(arr.len(), self.count);
-        let rng = ReversibleLcg::new(self.end_state);
+        let end_state = self
+            .end_state
+            .expect("`unpermute` requires a `Permutation` built with `new_reversible`");
+
+        let rng = ReversibleLcg::new(end_state);
         for (i, rand) in (1..self.count).zip(rng.rev()) {
             let j = Self::bounded_rand(rand, i as u64 + 1) as usize;
             arr.swap(i, j);
@@ -120,7 +143,7 @@ mod tests {
     fn permute_unpermute_roundtrip() {
         for &count in &[2, 5, 64, 128, 300, 1000, 1024, 2048] {
             let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
-            let perm = Permutation::new(42, count);
+            let perm = Permutation::new_reversible(42, count);
 
             let mut arr = original.clone();
             perm.permute(&mut arr);
@@ -143,8 +166,8 @@ mod tests {
         for &count in &[63, 64, 65] {
             let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
 
-            let p1 = Permutation::new(1, count);
-            let p2 = Permutation::new(2, count);
+            let p1 = Permutation::new_reversible(1, count);
+            let p2 = Permutation::new_reversible(2, count);
 
             let mut a = original.clone();
             let mut b = original.clone();
@@ -160,7 +183,7 @@ mod tests {
 
     #[test]
     fn edge_case_count_zero() {
-        let perm = Permutation::new(0, 0);
+        let perm = Permutation::new_reversible(0, 0);
         let mut arr = vec![];
         perm.permute(&mut arr);
         assert!(arr.is_empty());
@@ -170,7 +193,7 @@ mod tests {
 
     #[test]
     fn edge_case_count_one() {
-        let perm = Permutation::new(0, 1);
+        let perm = Permutation::new_reversible(0, 1);
         let mut arr = vec![42.0];
         perm.permute(&mut arr);
         assert_eq!(arr, vec![42.0]);
@@ -181,7 +204,7 @@ mod tests {
     #[test]
     fn edge_case_count_two() {
         let original = vec![1.0, 2.0];
-        let perm = Permutation::new(99, 2);
+        let perm = Permutation::new_reversible(99, 2);
         let mut arr = original.clone();
         perm.permute(&mut arr);
         perm.unpermute(&mut arr);
@@ -192,7 +215,7 @@ mod tests {
     fn permute_is_a_valid_permutation() {
         for &count in &[99, 100, 101] {
             let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
-            let perm = Permutation::new(42, count);
+            let perm = Permutation::new_reversible(42, count);
 
             let mut arr = original.clone();
             perm.permute(&mut arr);
@@ -218,7 +241,7 @@ mod tests {
         let mut seen = HashSet::new();
         for seed in 0..10_000u64 {
             let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
-            let perm = Permutation::new(seed, count);
+            let perm = Permutation::new_reversible(seed, count);
             let mut arr = original;
             perm.permute(&mut arr);
             seen.insert(arr.iter().map(|&v| v as u32).collect::<Vec<_>>());
@@ -236,8 +259,8 @@ mod tests {
         for &count in &[99, 100, 101] {
             let original: Vec<f64> = (0..count).map(|i| i as f64).collect();
 
-            let p1 = Permutation::new(42, count);
-            let p2 = Permutation::new(42, count);
+            let p1 = Permutation::new_reversible(42, count);
+            let p2 = Permutation::new_reversible(42, count);
 
             let mut a = original.clone();
             let mut b = original.clone();

--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -63,20 +63,27 @@ impl Permutation {
     /// Unlike [`Self::new_one_way`], the result supports [`Self::unpermute`].
     /// Both constructors produce identical output from [`Self::permute`] for the same seed.
     pub fn new_reversible(seed: u64, count: usize) -> Self {
-        let mut rng = ReversibleLcg::new(seed);
-        for _ in 1..count {
-            rng.next();
-        }
         Self {
             seed,
             count,
-            end_state: Some(rng.state),
+            end_state: Some(Self::calculate_end_state(seed, count)),
         }
     }
 
+    fn calculate_end_state(seed: u64, count: usize) -> u64 {
+        let mut rng = ReversibleLcg::new(seed);
+
+        for _ in 1..count {
+            rng.next();
+        }
+
+        rng.state
+    }
+
     /// Create a forward-only permutation. Skips the O(`count`) LCG warm-up
-    /// that [`Self::new_reversible`] does to record `end_state`. Can only be
-    /// used for [`Self::permute`]; calling [`Self::unpermute`] will panic.
+    /// that [`Self::new_reversible`] does to record `end_state`. Intended for
+    /// [`Self::permute`]; calling [`Self::unpermute`] still works but pays the
+    /// warm-up lazily (and trips a `debug_assert` to flag the mismatch).
     #[inline]
     pub fn new_one_way(seed: u64, count: usize) -> Self {
         Self {
@@ -98,14 +105,23 @@ impl Permutation {
 
     /// Apply the inverse permutation in-place (reversed Fisher-Yates).
     ///
-    /// # Panics
-    ///
-    /// Panics if this permutation was created with [`Self::new_one_way`].
+    /// If this permutation was created with [`Self::new_one_way`], the missing
+    /// `end_state` is recomputed on demand at O(`count`) extra cost. A
+    /// `debug_assert` flags the unexpected path in debug builds.
     pub fn unpermute(&self, arr: &mut [f64]) {
         debug_assert_eq!(arr.len(), self.count);
+
         let end_state = self
             .end_state
-            .expect("`unpermute` requires a `Permutation` built with `new_reversible`");
+            // Lazily calculate the end state when the `Permutation` was created with `new_one_way`.
+            // This path shouldn't normally be hit — but recomputing is cheaper than panicking.
+            .unwrap_or_else(|| {
+                debug_assert!(
+                    false,
+                    "unpermute was called on a `Permutation` created without `new_reversible`"
+                );
+                Self::calculate_end_state(self.seed, self.count)
+            });
 
         let rng = ReversibleLcg::new(end_state);
         for (i, rand) in (1..self.count).zip(rng.rev()) {

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -99,26 +99,26 @@ impl TurboQuantizer {
     /// regardless of whether the encoded vectors are stored in RAM or mmap.
     pub(crate) fn heap_size_bytes(&self) -> usize {
         let Self {
-            rotation,
+            rotation: _,
             bits: _,
             mode: _,
             distance: _,
             padded_dim: _,
             error_correction,
         } = self;
-        rotation.heap_size_bytes()
-            + error_correction.as_ref().map_or(0, |ec| {
-                let ErrorCorrection {
-                    shift,
-                    scale,
-                    d_prime_sq_i16,
-                    weight_scale: _,
-                    mm_const: _,
-                } = ec;
-                shift.capacity() * size_of::<f32>()
-                    + scale.capacity() * size_of::<f32>()
-                    + d_prime_sq_i16.capacity() * size_of::<i16>()
-            })
+
+        error_correction.as_ref().map_or(0, |ec| {
+            let ErrorCorrection {
+                shift,
+                scale,
+                d_prime_sq_i16,
+                weight_scale: _,
+                mm_const: _,
+            } = ec;
+            shift.capacity() * size_of::<f32>()
+                + scale.capacity() * size_of::<f32>()
+                + d_prime_sq_i16.capacity() * size_of::<i16>()
+        })
     }
 
     /// Initialize a new TurboQuantizer.

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -33,15 +33,7 @@ impl HadamardRotation {
 
     pub fn apply_inverse(&self, y: &mut [f64]) {
         debug_assert_eq!(y.len(), self.dim);
-
-        // WHT + normalize
-        wht_normalized_chunks(y);
-
-        // Apply inverse permutations backwards.
-        for permutation in self.permutations.iter().rev() {
-            permutation.unpermute(y);
-            wht_normalized_chunks(y);
-        }
+        apply_inverse_rotation_with_permutations(y, &self.permutations);
     }
 }
 
@@ -78,6 +70,19 @@ pub fn random_vector_rotation(x: &mut [f64]) {
         std::array::from_fn(|index| Permutation::new_one_way(PERMUTATION_SEEDS[index], dim));
 
     apply_rotation_with_permutations(x, &permutations);
+}
+
+/// Inverts the rotated `y` back. Produces bit-identical output to
+/// [`HadamardRotation::apply_inverse`].
+pub fn random_vector_rotation_inverse(y: &mut [f64]) {
+    let dim = y.len();
+
+    // `new_reversible` does an O(dim) LCG warm-up to record `end_state`, which
+    // `unpermute` needs. Cost is paid once per call; no heap allocation.
+    let permutations: [_; N_PERMUTATIONS] =
+        std::array::from_fn(|index| Permutation::new_reversible(PERMUTATION_SEEDS[index], dim));
+
+    apply_inverse_rotation_with_permutations(y, &permutations);
 }
 
 /// Decompose `dim` into a sequence of decreasing power-of-2 chunk sizes
@@ -118,6 +123,21 @@ fn apply_rotation_with_permutations(x: &mut [f64], permutations: &[Permutation; 
     for permutation in permutations {
         permutation.permute(x);
         wht_normalized_chunks(x);
+    }
+}
+
+/// Apply the inverse of a Hadamard rotation to `y` using the given `permutations`.
+fn apply_inverse_rotation_with_permutations(
+    y: &mut [f64],
+    permutations: &[Permutation; N_PERMUTATIONS],
+) {
+    // WHT + normalize
+    wht_normalized_chunks(y);
+
+    // Apply inverse permutations backwards.
+    for permutation in permutations.iter().rev() {
+        permutation.unpermute(y);
+        wht_normalized_chunks(y);
     }
 }
 
@@ -261,6 +281,43 @@ mod test {
                 "rotation didn't spread energy enough, stddev ratio {ratio_after} ({})",
                 ratio_after / ratio_before
             );
+        }
+    }
+
+    /// Verify the free-function API (`random_vector_rotation` /
+    /// `random_vector_rotation_inverse`) matches the struct API bit-for-bit
+    /// and is its own inverse. Without this, a wrong seed index, a forgotten
+    /// `.rev()`, or a swapped helper in either free function would slip past
+    /// `hadamard_roundtrip` (which only exercises the struct).
+    #[test]
+    fn static_rotation_matches_struct_and_roundtrips() {
+        for &dim in &[128, 300, 1024, 1536] {
+            let mut rng = StdRng::seed_from_u64(7);
+            let input: Vec<f64> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+
+            let rot = HadamardRotation::new(dim);
+
+            // Forward: free function must be bit-identical to struct.
+            let mut via_static = input.clone();
+            let mut via_struct = input.clone();
+            random_vector_rotation(&mut via_static);
+            rot.apply(&mut via_struct);
+            assert_eq!(via_static, via_struct, "dim={dim}: forward mismatch");
+
+            // Inverse: free function must be bit-identical to struct.
+            let mut inv_static = via_static.clone();
+            let mut inv_struct = via_struct.clone();
+            random_vector_rotation_inverse(&mut inv_static);
+            rot.apply_inverse(&mut inv_struct);
+            assert_eq!(inv_static, inv_struct, "dim={dim}: inverse mismatch");
+
+            // Forward-then-inverse via free functions recovers the input.
+            for (orig, recovered) in input.iter().zip(&inv_static) {
+                assert!(
+                    (orig - recovered).abs() < 1e-5,
+                    "dim={dim}: static roundtrip failed: {orig} vs {recovered}",
+                );
+            }
         }
     }
 

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -16,85 +16,32 @@ pub struct HadamardRotation {
 
     /// Original dimension.
     dim: usize,
-
-    /// Sequence of power-of-2 chunk sizes that exactly cover `dim`.
-    /// Produced by greedily taking the largest power-of-2 that fits the remainder.
-    chunk_sizes: Vec<usize>,
-
-    /// Precomputed normalization factors: `1.0 / sqrt(chunk_size)` for each chunk.
-    chunk_norms: Vec<f64>,
 }
 
 impl HadamardRotation {
     pub fn new(dim: usize) -> Self {
-        let chunk_sizes = compute_chunk_sizes(dim);
-
-        let chunk_norms: Vec<f64> = chunk_sizes
-            .iter()
-            .map(|&s| 1.0 / (s as f64).sqrt())
-            .collect();
-
         let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|index| Permutation::new(PERMUTATION_SEEDS[index], dim));
+            std::array::from_fn(|index| Permutation::new_reversible(PERMUTATION_SEEDS[index], dim));
 
-        Self {
-            permutations,
-            dim,
-            chunk_sizes,
-            chunk_norms,
-        }
-    }
-
-    /// Heap memory owned by the rotation tables. The permutations are stored
-    /// inline (no heap), so only the chunk metadata vectors are counted.
-    pub(super) fn heap_size_bytes(&self) -> usize {
-        let Self {
-            permutations: _,
-            dim: _,
-            chunk_sizes,
-            chunk_norms,
-        } = self;
-        chunk_sizes.capacity() * size_of::<usize>() + chunk_norms.capacity() * size_of::<f64>()
+        Self { permutations, dim }
     }
 
     pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
-
-        // Apply WHT + normalize to each variable-size chunk.
-        self.wht_normalized_chunks(x);
-
-        // Permute then WHT+normalize for each permutation.
-        for permutation in &self.permutations {
-            permutation.permute(x);
-            self.wht_normalized_chunks(x);
-        }
+        apply_rotation_with_permutations(x, &self.permutations);
     }
 
     pub fn apply_inverse(&self, y: &mut [f64]) {
         debug_assert_eq!(y.len(), self.dim);
 
         // WHT + normalize
-        self.wht_normalized_chunks(y);
+        wht_normalized_chunks(y);
 
         // Apply inverse permutations backwards.
         for permutation in self.permutations.iter().rev() {
             permutation.unpermute(y);
-            self.wht_normalized_chunks(y);
+            wht_normalized_chunks(y);
         }
-    }
-
-    /// Apply WHT + normalization to variable-size chunks.
-    fn wht_normalized_chunks(&self, buf: &mut [f64]) {
-        let mut offset = 0;
-        for (&size, &norm) in self.chunk_sizes.iter().zip(&self.chunk_norms) {
-            let chunk = &mut buf[offset..offset + size];
-            simd::hadamard::wht_dispatch(chunk);
-            for v in chunk.iter_mut() {
-                *v *= norm;
-            }
-            offset += size;
-        }
-        debug_assert_eq!(offset, buf.len());
     }
 }
 
@@ -121,6 +68,18 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
     }
 }
 
+/// Randomly rotates `x` in place. Produces bit-identical output to
+/// [`HadamardRotation::apply`]; invert with [`HadamardRotation::apply_inverse`].
+pub fn random_vector_rotation(x: &mut [f64]) {
+    let dim = x.len();
+
+    // Building the permutations on every call is cheap: `new_one_way` skips the LCG warm-up.
+    let permutations: [_; N_PERMUTATIONS] =
+        std::array::from_fn(|index| Permutation::new_one_way(PERMUTATION_SEEDS[index], dim));
+
+    apply_rotation_with_permutations(x, &permutations);
+}
+
 /// Decompose `dim` into a sequence of decreasing power-of-2 chunk sizes
 /// that sum to exactly `dim`. No padding is needed.
 ///
@@ -135,16 +94,50 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
 ///  1536 | [1024, 512]
 ///  4096 | [4096]
 /// ```
-fn compute_chunk_sizes(dim: usize) -> Vec<usize> {
+fn compute_chunk_sizes(dim: usize) -> impl Iterator<Item = usize> {
     debug_assert!(dim > 0);
-    let mut sizes = Vec::with_capacity(dim.count_ones() as usize);
+
     let mut bits = dim;
-    while bits != 0 {
+    std::iter::from_fn(move || {
+        if bits == 0 {
+            return None;
+        }
+
         let highest = 1 << bits.ilog2();
-        sizes.push(highest);
         bits ^= highest;
+        Some(highest)
+    })
+}
+
+/// Apply a Hadamard rotation to `x` using the given `permutations`.
+fn apply_rotation_with_permutations(x: &mut [f64], permutations: &[Permutation; N_PERMUTATIONS]) {
+    // Apply WHT + normalize to each variable-size chunk.
+    wht_normalized_chunks(x);
+
+    // Permute then WHT+normalize for each permutation.
+    for permutation in permutations {
+        permutation.permute(x);
+        wht_normalized_chunks(x);
     }
-    sizes
+}
+
+/// Apply WHT + normalization to variable-size chunks.
+fn wht_normalized_chunks(buf: &mut [f64]) {
+    let mut offset = 0;
+
+    for size in compute_chunk_sizes(buf.len()) {
+        let chunk = &mut buf[offset..offset + size];
+
+        simd::hadamard::wht_dispatch(chunk);
+
+        let norm = 1.0 / (size as f64).sqrt();
+        for v in chunk.iter_mut() {
+            *v *= norm;
+        }
+
+        offset += size;
+    }
+    debug_assert_eq!(offset, buf.len());
 }
 
 #[cfg(test)]
@@ -158,7 +151,7 @@ mod test {
     fn test_compute_chunk_sizes() {
         // All chunks must be powers of two.
         for dim in [5, 128, 129, 300, 700, 712, 1536, 4096] {
-            let sizes = compute_chunk_sizes(dim);
+            let sizes = compute_chunk_sizes(dim).collect::<Vec<_>>();
             assert!(
                 sizes.iter().all(|s| s.is_power_of_two()),
                 "dim={dim}: not all power-of-2: {sizes:?}"
@@ -176,10 +169,16 @@ mod test {
         }
 
         // Specific cases.
-        assert_eq!(compute_chunk_sizes(128), vec![128]);
-        assert_eq!(compute_chunk_sizes(700), vec![512, 128, 32, 16, 8, 4]);
-        assert_eq!(compute_chunk_sizes(1536), vec![1024, 512]);
-        assert_eq!(compute_chunk_sizes(4096), vec![4096]);
+        assert_eq!(compute_chunk_sizes(128).collect::<Vec<_>>(), vec![128]);
+        assert_eq!(
+            compute_chunk_sizes(700).collect::<Vec<_>>(),
+            vec![512, 128, 32, 16, 8, 4],
+        );
+        assert_eq!(
+            compute_chunk_sizes(1536).collect::<Vec<_>>(),
+            vec![1024, 512]
+        );
+        assert_eq!(compute_chunk_sizes(4096).collect::<Vec<_>>(), vec![4096]);
     }
 
     /// Test that Hadamard rotation spreads energy across dimensions,


### PR DESCRIPTION
Attempt at making rotations static so they can be used without having to own a `HadamardRotation` object.

There is a very small performance regression since we do a little bit more math on each call of `apply`.
| dim  | new       | old       | Δ (new − old) | Δ %    |
  |------|-----------|-----------|----------------|--------|
  |  128 |   905.8 ns |   895.4 ns |   +10.3 ns    | +1.15% |
  |  384 |  2.935 µs |  2.917 µs |   +18.4 ns    | +0.63% |
  |  768 |  5.893 µs |  5.860 µs |   +33.1 ns    | +0.57% |
  | 1024 |  8.142 µs |  8.039 µs |  +103.3 ns    | +1.28% |
  | 1536 | 11.729 µs | 11.696 µs |   +32.3 ns    | +0.28% |
  | 4096 | 33.714 µs | 33.648 µs |   +66.0 ns    | +0.20% |