### PR TITLE
Restore pre-UIO-migration OpenOptions behavior

### DIFF
--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -127,7 +127,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            populate: Populate::Blocking,
+            populate: Populate::No,
             advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -106,7 +106,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             writeable: true,
             need_sequential: false,
             populate: Populate::Blocking,
-            advice: AdviceSetting::Global,
+            advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };
         let mut slice_store = TypedStorage::open(&path, options)?;

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
 use common::bitvec::BitSlice;
-use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::universal_io::{MmapFile, OpenOptions, Populate, UniversalWrite};
 use gaps::{BitmaskGaps, RegionGaps};
@@ -23,7 +23,7 @@ fn open_options() -> OpenOptions {
         writeable: true,
         need_sequential: false,
         populate: Populate::No,
-        advice: AdviceSetting::Global,
+        advice: AdviceSetting::Advice(Advice::Random),
         extra: Default::default(),
     }
 }
@@ -134,7 +134,7 @@ impl<S: UniversalWrite> Bitmask<S> {
                 writeable: true,
                 need_sequential: false,
                 populate: Populate::Auto,
-                advice: AdviceSetting::Global,
+                advice: AdviceSetting::Advice(Advice::Random),
                 extra: Default::default(),
             },
         )?;

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -132,7 +132,7 @@ impl<S: UniversalWrite> Bitmask<S> {
             &path,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
-use common::mmap::AdviceSetting;
+use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
     FileIndex, Flusher, OpenOptions, Populate, ReadRange, UniversalRead, UniversalWrite,
 };
@@ -61,7 +61,7 @@ impl<S: UniversalRead> Pages<S> {
             writeable: true,
             need_sequential: true,
             populate: Populate::No,
-            advice: AdviceSetting::Global,
+            advice: AdviceSetting::Advice(Advice::Random),
             extra: Default::default(),
         };
 

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -159,7 +159,7 @@ where
 
         let options = OpenOptions {
             writeable: true,
-            need_sequential: true,
+            need_sequential: false,
             populate: Populate::from(populate),
             advice: AdviceSetting::Global,
             extra: Default::default(),

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -86,7 +86,7 @@ where
             deleted_path(segment_path),
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Blocking,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
@@ -149,7 +149,7 @@ where
             &deleted_filepath,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -212,7 +212,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                populate: Populate::Auto,
+                populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
             },

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -132,7 +132,7 @@ impl MmapInvertedIndex<MmapFile> {
                 &deleted_points_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: true,
+                    need_sequential: false,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
                     extra: Default::default(),
@@ -189,7 +189,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &vocab_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
@@ -200,7 +200,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &point_to_tokens_count_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
@@ -211,7 +211,7 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &deleted_points_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -196,7 +196,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                populate: Populate::Auto,
+                populate: Populate::from(populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
             },

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -127,7 +127,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: true,
+                    need_sequential: false,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
                     extra: Default::default(),
@@ -195,7 +195,7 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -44,7 +44,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &hashmap_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::from(do_populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
@@ -58,7 +58,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
@@ -139,7 +139,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: true,
+                    need_sequential: false,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
                     extra: Default::default(),

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -59,7 +59,7 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                populate: Populate::Auto,
+                populate: Populate::from(do_populate),
                 advice: AdviceSetting::Global,
                 extra: Default::default(),
             },

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -82,7 +82,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: true,
+                    need_sequential: false,
                     populate: Populate::Auto,
                     advice: AdviceSetting::Global,
                     extra: Default::default(),
@@ -139,7 +139,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: true,
+                need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,
                 extra: Default::default(),

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -51,7 +51,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     fn open_options() -> OpenOptions {
         OpenOptions {
             writeable: false,
-            need_sequential: true,
+            need_sequential: false,
             populate: Populate::No,
             advice: AdviceSetting::Global,
             extra: Default::default(),

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -12,7 +12,7 @@ use api::grpc::qdrant::{
     ReadWholeRequest, ReadWholeResponse,
 };
 use common::generic_consts::Random;
-use common::mmap::AdviceSetting;
+use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
     FileIndex, MmapFile, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
 };
@@ -127,10 +127,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let path = Self::resolve_path(&base, &collections_root, &path)?;
 
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };
         let length = tokio::task::spawn_blocking(move || {
@@ -163,10 +163,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };
 
@@ -207,10 +207,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Sequential),
             extra: Default::default(),
         };
         let range = ReadRange::new(byte_offset, length);
@@ -271,10 +271,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .await?;
         let path = Self::resolve_path(&base, &collections_root, &path)?;
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Sequential),
             extra: Default::default(),
         };
 
@@ -308,10 +308,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
         let path = Self::resolve_path(&base, &collections_root, &path)?;
 
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };
         let ranges = ranges
@@ -354,10 +354,10 @@ impl<S: UniversalRead + Send + Sync + 'static> StorageRead for StorageReadServic
             .check_and_resolve_shard(&auth, &collection_name, shard_id, "read_multi")
             .await?;
         let open_options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::Auto,
-            advice: AdviceSetting::Global,
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Advice(Advice::Normal),
             extra: Default::default(),
         };
 


### PR DESCRIPTION
Continuation of #9104.
Restores `OpenOptions` behavior to match v1.17.0.
Also, updates `OpenOptions` for tonic storage_read_api (didn't exist before UIO).