### PR TITLE
[codex] Fix integer match+range payload index filtering

### DIFF
--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -4,7 +4,7 @@ use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use serde_json::Value;
 
-use super::StructPayloadIndexReadView;
+use super::{StructPayloadIndexReadView, has_only_match_and_range};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
@@ -36,10 +36,28 @@ where
             Condition::Field(field_condition) => field_indexes
                 .get(&field_condition.key)
                 .and_then(|indexes| {
-                    indexes.iter().find_map(move |index| {
-                        let hw_acc = hw_counter.new_accumulator();
-                        index.condition_checker(field_condition, hw_acc)
-                    })
+                    if has_only_match_and_range(field_condition) {
+                        let checkers = indexes
+                            .iter()
+                            .filter_map(|index| {
+                                let hw_acc = hw_counter.new_accumulator();
+                                index.condition_checker(field_condition, hw_acc)
+                            })
+                            .collect::<Vec<_>>();
+
+                        if checkers.len() < 2 {
+                            None
+                        } else {
+                            Some(Box::new(move |point_id| {
+                                checkers.iter().any(|checker| checker(point_id))
+                            }) as ConditionCheckerFn)
+                        }
+                    } else {
+                        indexes.iter().find_map(move |index| {
+                            let hw_acc = hw_counter.new_accumulator();
+                            index.condition_checker(field_condition, hw_acc)
+                        })
+                    }
                 })
                 .unwrap_or_else(|| {
                     let hw = hw_counter.fork();

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -1,13 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
-use super::StructPayloadIndexReadView;
+use super::{StructPayloadIndexReadView, has_only_match_and_range};
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexRead, PrimaryCondition, ResolvedHasId,
 };
+use crate::index::query_estimator::combine_should_estimations;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::struct_filter_context::StructFilterContext;
 use crate::json_path::JsonPath;
@@ -37,14 +38,38 @@ where
             key: full_path,
             ..condition.clone()
         };
-        indexes
-            .iter()
-            .find_map(|index| {
-                index
-                    .estimate_cardinality(&full_path_condition, hw_counter)
-                    .transpose()
+        if has_only_match_and_range(&full_path_condition) {
+            let estimations = indexes
+                .iter()
+                .filter_map(|index| {
+                    index
+                        .estimate_cardinality(&full_path_condition, hw_counter)
+                        .transpose()
+                })
+                .collect::<OperationResult<Vec<_>>>()?;
+
+            Ok(match estimations.len() {
+                0 | 1 => None,
+                _ => {
+                    let mut combined =
+                        combine_should_estimations(&estimations, self.available_point_count());
+                    if !combined.primary_clauses.is_empty() {
+                        combined.primary_clauses =
+                            vec![PrimaryCondition::Condition(Box::new(full_path_condition))];
+                    }
+                    Some(combined)
+                }
             })
-            .transpose()
+        } else {
+            indexes
+                .iter()
+                .find_map(|index| {
+                    index
+                        .estimate_cardinality(&full_path_condition, hw_counter)
+                        .transpose()
+                })
+                .transpose()
+        }
     }
 
     pub(super) fn query_field<'q>(
@@ -57,12 +82,27 @@ where
                 let Some(field_indexes) = self.field_indexes.get(&field_condition.key) else {
                     return Ok(None);
                 };
-                field_indexes
-                    .iter()
-                    .find_map(|field_index| {
-                        field_index.filter(field_condition, hw_counter).transpose()
-                    })
-                    .transpose()
+                if has_only_match_and_range(field_condition) {
+                    let iterators = field_indexes
+                        .iter()
+                        .filter_map(|field_index| {
+                            field_index.filter(field_condition, hw_counter).transpose()
+                        })
+                        .collect::<OperationResult<Vec<_>>>()?;
+
+                    if iterators.len() < 2 {
+                        Ok(None)
+                    } else {
+                        Ok(Some(Box::new(iterators.into_iter().flatten())))
+                    }
+                } else {
+                    field_indexes
+                        .iter()
+                        .find_map(|field_index| {
+                            field_index.filter(field_condition, hw_counter).transpose()
+                        })
+                        .transpose()
+                }
             }
             PrimaryCondition::Ids(ids) => {
                 Ok(Some(Box::new(ids.resolved_point_offsets.iter().copied())))

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::FieldIndexRead;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::PayloadStorageRead;
-use crate::types::{PayloadKeyType, VectorNameBuf};
+use crate::types::{FieldCondition, PayloadKeyType, VectorNameBuf};
 use crate::vector_storage::VectorStorageRead;
 
 /// Read-only view over a [`StructPayloadIndex`].
@@ -69,4 +69,15 @@ where
     pub fn available_point_count(&self) -> usize {
         self.id_tracker.available_point_count()
     }
+}
+
+pub(super) fn has_only_match_and_range(condition: &FieldCondition) -> bool {
+    condition.r#match.is_some()
+        && condition.range.is_some()
+        && condition.geo_radius.is_none()
+        && condition.geo_bounding_box.is_none()
+        && condition.geo_polygon.is_none()
+        && condition.values_count.is_none()
+        && condition.is_empty.is_none()
+        && condition.is_null.is_none()
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -45,7 +45,8 @@ use segment::types::{
     AnyVariants, Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoLineString,
     GeoPoint, GeoPolygon, GeoRadius, HnswConfig, HnswGlobalConfig, Indexes, IsEmptyCondition,
     Match, Payload, PayloadField, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
-    Range, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType, WithPayload,
+    Range, RangeInterface, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType,
+    WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tempfile::{Builder, TempDir};
@@ -725,6 +726,117 @@ fn test_integer_index_types(test_segments: &TestSegments) -> Result<()> {
         ensure!(!has_map_index);
         ensure!(has_int_index);
     }
+    Ok(())
+}
+
+#[test]
+fn test_integer_match_and_range_same_field_condition_uses_both_indexes() -> Result<()> {
+    let plain_dir = Builder::new().prefix("plain_segment").tempdir()?;
+    let indexed_dir = Builder::new().prefix("indexed_segment").tempdir()?;
+    let lookup_only_dir = Builder::new().prefix("lookup_only_segment").tempdir()?;
+    let mut plain_segment = build_simple_segment(plain_dir.path(), DIM, Distance::Dot)?;
+    let mut indexed_segment = build_simple_segment(indexed_dir.path(), DIM, Distance::Dot)?;
+    let mut lookup_only_segment = build_simple_segment(lookup_only_dir.path(), DIM, Distance::Dot)?;
+
+    let hw_counter = HardwareCounterCell::new();
+    let key = JsonPath::new("n");
+    let mut opnum = 0;
+
+    for (point_id, value) in [(0_u64, 5_i64), (1_u64, 999_i64), (2_u64, 42_i64)] {
+        let vector = vec![point_id as f32; DIM];
+        let payload = payload_json! {"n": value};
+        let point_id = point_id.into();
+
+        for segment in [
+            &mut plain_segment,
+            &mut indexed_segment,
+            &mut lookup_only_segment,
+        ] {
+            segment.upsert_point(opnum, point_id, only_default_vector(&vector), &hw_counter)?;
+            segment.set_full_payload(opnum, point_id, &payload, &hw_counter)?;
+        }
+        opnum += 1;
+    }
+
+    let integer_params = |lookup, range| {
+        FieldParams(PayloadSchemaParams::Integer(IntegerIndexParams {
+            r#type: IntegerIndexType::Integer,
+            lookup: Some(lookup),
+            range: Some(range),
+            is_principal: None,
+            on_disk: None,
+            enable_hnsw: None,
+        }))
+    };
+
+    indexed_segment.create_field_index(
+        opnum,
+        &key,
+        Some(&integer_params(true, true)),
+        &hw_counter,
+    )?;
+    opnum += 1;
+    lookup_only_segment.create_field_index(
+        opnum,
+        &key,
+        Some(&integer_params(true, false)),
+        &hw_counter,
+    )?;
+
+    let mut field_condition = FieldCondition::new_match(key, 999.into());
+    field_condition.range = Some(RangeInterface::Float(Range {
+        lt: None,
+        gt: None,
+        gte: Some(OrderedFloat(0.)),
+        lte: Some(OrderedFloat(10.)),
+    }));
+    let filter = Filter::new_must(Condition::Field(field_condition));
+
+    let query_external_ids = |segment: &Segment| -> Result<Vec<u64>> {
+        let is_stopped = AtomicBool::new(false);
+        let internal_ids = segment
+            .payload_index
+            .borrow()
+            .with_view(|v| v.query_points(&filter, &hw_counter, &is_stopped))?;
+
+        let id_tracker = segment.id_tracker.borrow();
+        let mut external_ids = internal_ids
+            .into_iter()
+            .map(|internal_id| id_tracker.external_id(internal_id).unwrap().as_u64())
+            .collect::<Vec<_>>();
+        external_ids.sort_unstable();
+        Ok(external_ids)
+    };
+
+    let plain_ids = query_external_ids(&plain_segment)?;
+    let indexed_ids = query_external_ids(&indexed_segment)?;
+    let lookup_only_ids = query_external_ids(&lookup_only_segment)?;
+
+    assert_eq!(plain_ids, vec![0, 1]);
+    assert_eq!(indexed_ids, plain_ids);
+    assert_eq!(lookup_only_ids, plain_ids);
+
+    let check_filter_context = |segment: &Segment| {
+        let (range_match_id, exact_match_id, non_match_id) = {
+            let id_tracker = segment.id_tracker.borrow();
+            (
+                id_tracker.internal_id(0.into()).unwrap(),
+                id_tracker.internal_id(1.into()).unwrap(),
+                id_tracker.internal_id(2.into()).unwrap(),
+            )
+        };
+
+        segment.payload_index.borrow().with_view(|v| {
+            let filter_context = v.filter_context(&filter, &hw_counter).unwrap();
+            assert!(filter_context.check(range_match_id));
+            assert!(filter_context.check(exact_match_id));
+            assert!(!filter_context.check(non_match_id));
+        });
+    };
+
+    check_filter_context(&indexed_segment);
+    check_filter_context(&lookup_only_segment);
+
     Ok(())
 }
 


### PR DESCRIPTION
﻿Fixes #9066.

## Summary
- combine index-backed `match` and `range` handling for a `FieldCondition` that contains exactly those two sub-conditions
- keep the optimized path only when both index branches are available; otherwise fall back to full payload checking so partial index coverage cannot change results
- add a regression test that compares plain payload evaluation, lookup+range integer indexing, and lookup-only fallback behavior

## Root cause
Plain payload evaluation treats sub-conditions inside one `FieldCondition` as OR clauses. An integer payload index with both lookup and range enabled is represented by separate lookup and numeric index implementations. The read view used the first index that could serve the condition, so the `match` branch could be selected while valid `range` matches were skipped.

This keeps the fix cheap for the maintainer-requested case: when both integer index branches are present, we OR the existing index checkers/iterators/estimations instead of doing a full payload scan. When the index set only covers one branch, we intentionally fall back to the existing payload checker.

## Validation
- [x] Baseline reproduction: applying only the regression test to `origin/dev` fails with indexed result `[1]` vs expected `[0, 1]`
- [x] `cargo +nightly fmt --all`
- [x] `cargo +nightly test -p segment --test integration test_integer_match_and_range_same_field_condition_uses_both_indexes`
- [x] `cargo +nightly test -p segment --test integration payload_index_test::test_read_operations`
- [x] `cargo clippy --workspace --all-features`

Note: targeted `cargo +nightly clippy -p segment --test integration -- -D warnings` currently fails on unrelated existing lints in `index_selector.rs`, `hnsw/build.rs`, `struct_payload_index/build.rs`, and `chunked_vectors/write.rs`.

## Checklist
- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in the Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (`9066 in:body` returned no open PRs.)
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


