### PR TITLE
Use batched reads in vector and payload storage

### DIFF
--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -377,18 +377,17 @@ impl<V: Blob> Gridstore<V> {
         self.with_view(|view| view.get_value::<P>(point_offset, hw_counter))
     }
 
-    pub fn for_each_in_batch<P, F, E>(
+    pub fn read_values<P, U, E>(
         &self,
-        offsets: &[PointOffset],
-        callback: F,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
         hw_counter_cell: &CounterCell,
-    ) -> std::result::Result<(), E>
+    ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
         E: From<GridstoreError>,
     {
-        self.with_view(|view| view.for_each_in_batch::<P, F, E>(offsets, callback, hw_counter_cell))
+        self.with_view(|view| view.read_values::<P, _, _>(point_offsets, callback, hw_counter_cell))
     }
 
     #[cfg(test)]

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -2,6 +2,7 @@ use std::debug_assert_matches;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 
+use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::AccessPattern;
@@ -106,6 +107,20 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         debug_assert_matches!(control_flow, ControlFlow::Break(()));
 
         Ok(())
+    }
+
+    pub fn read_values<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        E: From<GridstoreError>,
+    {
+        self.view()
+            .read_values::<P, _, _>(point_offsets, callback, hw_counter_cell)
     }
 
     /// Return the storage size in bytes (approximate: total page capacity).

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1313,13 +1313,12 @@ fn test_read_batch_from_pages_congruent_with_read_from_pages() {
 
     let mut batch_results: Vec<Option<Vec<u8>>> = vec![None; pointers.len()];
 
-    let pointers_opt: Vec<_> = pointers.into_iter().map(Some).collect();
     pages
         .read_batch_from_pages::<Random, _, GridstoreError>(
-            pointers_opt,
             &storage.config,
-            |idx, raw_opt| {
-                batch_results[idx] = raw_opt.map(|raw| raw.into_owned());
+            pointers.into_iter().enumerate(),
+            |idx, bytes| {
+                batch_results[idx] = Some(bytes.into_owned());
                 Ok(())
             },
         )
@@ -1374,9 +1373,9 @@ fn test_for_each_in_batch_congruent_with_get_value() {
 
     let mut batch_results: Vec<Option<Payload>> = vec![None; offsets.len()];
     storage
-        .for_each_in_batch::<Random, _, GridstoreError>(
-            &offsets,
-            |idx, value| {
+        .read_values::<Random, _, GridstoreError>(
+            offsets.iter().copied().enumerate(),
+            |idx, _, value| {
                 batch_results[idx] = value;
                 Ok(())
             },

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -13,7 +13,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PointOffset, Tracker, ValuePointer};
+use crate::tracker::{PointOffset, Tracker, ValuePointer, ValuePointersBatch};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {
@@ -109,33 +109,42 @@ impl<'a, V: Blob, S: UniversalRead> GridstoreView<'a, V, S> {
         Ok(Some(value))
     }
 
-    pub fn for_each_in_batch<P, F, E>(
+    pub fn read_values<P, U, E>(
         &self,
-        point_offsets: &[PointOffset],
-        mut callback: F,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
         hw_counter_cell: &CounterCell,
-    ) -> std::result::Result<(), E>
+    ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
         E: From<GridstoreError>,
     {
-        // Resolve all pointers in a single batched tracker read so async backends
-        // (e.g. io_uring) can fetch them in parallel.
-        let pointers = self.tracker.get_batch(point_offsets)?;
+        let point_offsets = point_offsets
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
-        // Stream decoded values straight to the caller — no intermediate buffer.
-        // The callback `idx` maps 1-to-1 to `point_offsets`; missing offsets are
-        // delivered as `None`.
-        self.pages
-            .read_batch_from_pages::<P, _, E>(pointers, self.config, |idx, raw_opt| {
-                let value = raw_opt.map(|raw| {
-                    hw_counter_cell.incr_delta(raw.len());
-                    let decompressed = self.decompress(raw);
-                    V::from_bytes(&decompressed)
-                });
-                callback(idx, value)
-            })
+        let ValuePointersBatch {
+            valid,
+            empty,
+            out_of_range,
+        } = self.tracker.get_batch(point_offsets)?;
+
+        self.pages.read_batch_from_pages::<P, _, _>(
+            self.config,
+            valid.into_iter(),
+            |(user_data, point_offset), bytes| {
+                hw_counter_cell.incr_delta(bytes.len());
+
+                let decompressed = self.decompress(bytes);
+                let value = V::from_bytes(&decompressed);
+                callback(user_data, point_offset, Some(value))
+            },
+        )?;
+
+        for (user_data, point_offset) in empty.into_iter().chain(out_of_range) {
+            callback(user_data, point_offset, None)?;
+        }
+
+        Ok(())
     }
 
     /// Iterate over all the values in the storage.

--- a/lib/gridstore/src/lib.rs
+++ b/lib/gridstore/src/lib.rs
@@ -13,7 +13,7 @@ pub use gridstore::{Gridstore, GridstoreReader, GridstoreView};
 
 use crate::error::GridstoreError;
 
-pub(crate) type Result<T> = std::result::Result<T, GridstoreError>;
+pub(crate) type Result<T, E = GridstoreError> = std::result::Result<T, E>;
 
 /// Concrete tracker type used by gridstore (universal io over mmap).
 pub(crate) type TrackerMmap = tracker::Tracker<MmapFile>;

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
@@ -236,108 +237,113 @@ impl<S: UniversalRead> Pages<S> {
         Ok(Cow::Owned(unsafe { assume_init_vec(buffer) }))
     }
 
-    /// Batch-read values pointed to by `pointers`, invoking `callback` for each
-    /// input slot.
-    ///
-    /// The callback is invoked once per slot in `pointers`, receiving the slot
-    /// index and `Some(bytes)` for set pointers (in arbitrary order — io_uring
-    /// completions may interleave) or `None` for empty slots (after all data
-    /// arrives). The callback's error type `E` flows back through the function
-    /// so callers don't have to bridge it themselves.
-    pub fn read_batch_from_pages<P, F, E>(
+    /// Batch-read values and execute callback for each value
+    pub fn read_batch_from_pages<P, U, E>(
         &self,
-        pointers: Vec<Option<ValuePointer>>,
         config: &StorageConfig,
-        mut callback: F,
-    ) -> std::result::Result<(), E>
+        pointers: impl Iterator<Item = (U, ValuePointer)>,
+        mut callback: impl FnMut(U, Cow<'_, [u8]>) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<Cow<'_, [u8]>>) -> std::result::Result<(), E>,
         E: From<GridstoreError>,
     {
-        struct ReadMeta {
-            value_idx: usize,
-            buffer_offset: usize,
-            len_bytes: usize,
-            len_pages: usize,
+        struct Progress<U> {
+            buffer: Vec<MaybeUninit<u8>>,
+            pages_read: usize,
+            pages_len: usize,
+            user_data: U,
         }
 
-        let mut empty_values = Vec::new(); // expect (almost) no values
+        struct ReadMeta<U> {
+            value_idx: usize,
+            buffer_offset: usize,
+            user_data: Option<U>,
+        }
+
+        // Multi-page values need buffering, because chunks for the same value may arrive out-of-order
+        // or interleaved with chunks for other values.
+        //
+        // Single-page reads (common case) bypass this map entirely.
+        let pending = RefCell::new(AHashMap::new());
 
         let reads = pointers
-            .iter()
-            .copied()
             .enumerate()
-            .flat_map(|(value_idx, pointer_opt)| {
-                if pointer_opt.is_none() {
-                    empty_values.push(value_idx);
-                }
-                pointer_opt.into_iter().flat_map(move |pointer| {
-                    let len_bytes = pointer.length as usize;
-                    let len_pages = Self::value_len_pages(pointer, config);
+            .flat_map(|(value_idx, (user_data, pointer))| {
+                let ranges = Self::get_page_value_ranges(pointer, config);
 
-                    Self::get_page_value_ranges(pointer, config).map(
-                        move |(buffer_offset, page_idx, range)| {
-                            let meta = ReadMeta {
-                                value_idx,
-                                buffer_offset,
-                                len_bytes,
-                                len_pages,
-                            };
+                let bytes_len = pointer.length as usize;
+                let pages_len = Self::value_len_pages(pointer, config);
 
-                            let page = &self.pages[page_idx as usize];
-                            (meta, page, range)
+                let mut user_data = if pages_len <= 1 {
+                    Some(user_data)
+                } else {
+                    pending.borrow_mut().insert(
+                        value_idx,
+                        Progress {
+                            buffer: vec![MaybeUninit::uninit(); bytes_len],
+                            pages_read: 0,
+                            pages_len,
+                            user_data,
                         },
-                    )
+                    );
+
+                    None
+                };
+
+                ranges.map(move |(buffer_offset, page_idx, range)| {
+                    let meta = ReadMeta {
+                        value_idx,
+                        buffer_offset,
+                        user_data: user_data.take(),
+                    };
+
+                    let page = &self.pages[page_idx as usize];
+                    (meta, page, range)
                 })
             });
 
-        let chunks = S::read_multi_iter::<P, u8, _>(reads).map_err(GridstoreError::from)?;
-
-        // Multi-page values need buffering since chunks for the same value may
-        // arrive interleaved with chunks for other values. Single-page reads
-        // (the common case, including zero-length) bypass this map entirely.
-        let mut pending: AHashMap<usize, (Vec<MaybeUninit<u8>>, usize)> = AHashMap::new();
-
-        for result in chunks {
+        for result in S::read_multi_iter::<P, _, _>(reads).map_err(GridstoreError::from)? {
             let (meta, bytes) = result.map_err(GridstoreError::from)?;
 
             let ReadMeta {
                 value_idx,
                 buffer_offset,
-                len_bytes,
-                len_pages,
+                user_data,
             } = meta;
 
-            if len_pages <= 1 {
-                callback(value_idx, Some(bytes))?;
+            if let Some(user_data) = user_data {
+                debug_assert!(
+                    !pending.borrow().contains_key(&value_idx),
+                    "single-page value"
+                );
+
+                callback(user_data, bytes)?;
                 continue;
             }
 
-            let (value_buffer, pages_read) = pending
-                .entry(value_idx)
-                .or_insert_with(|| (vec![MaybeUninit::uninit(); len_bytes], 0));
+            let mut pending = pending.borrow_mut();
 
-            value_buffer[buffer_offset..buffer_offset + bytes.len()].write_copy_of_slice(&bytes);
+            let progress = pending.get_mut(&value_idx).expect("multi-page value");
+            progress.buffer[buffer_offset..buffer_offset + bytes.len()].write_copy_of_slice(&bytes);
+            progress.pages_read += 1;
 
-            *pages_read += 1;
+            if progress.pages_read >= progress.pages_len {
+                let progress = pending.remove(&value_idx).expect("multi-page value");
 
-            if *pages_read >= len_pages {
-                let (value_buffer, _) = pending.remove(&value_idx).expect("value exists");
-                let value_buffer = unsafe { assume_init_vec(value_buffer) };
+                let Progress {
+                    buffer, user_data, ..
+                } = progress;
 
-                callback(value_idx, Some(Cow::Owned(value_buffer)))?;
+                let buffer = unsafe { assume_init_vec(buffer) };
+                callback(user_data, Cow::Owned(buffer))?;
             }
         }
 
         debug_assert!(
-            pending.is_empty(),
-            "all valid pointers should have been delivered",
+            pending.borrow().is_empty(),
+            "all multi-page values have been read"
         );
-
-        for idx in empty_values {
-            callback(idx, None)?;
-        }
 
         Ok(())
     }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 use ahash::{AHashMap, AHashSet};
@@ -98,6 +99,23 @@ impl ValuePointer {
             page_id,
             block_offset,
             length,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValuePointersBatch<U> {
+    pub valid: Vec<(U, ValuePointer)>,
+    pub empty: Vec<U>,
+    pub out_of_range: Vec<U>,
+}
+
+impl<U> Default for ValuePointersBatch<U> {
+    fn default() -> Self {
+        Self {
+            valid: Vec::new(),
+            empty: Vec::new(),
+            out_of_range: Vec::new(),
         }
     }
 }
@@ -368,49 +386,56 @@ impl<S: UniversalRead> Tracker<S> {
 
     /// Get the page pointers for a batch of point offsets.
     ///
-    /// Issues a single batched read against the underlying storage so async
-    /// backends (e.g. io_uring) can fetch all entries in parallel. Pending
-    /// updates and out-of-range offsets are handled before/after the batch
-    /// read, mirroring [`get`](Self::get).
-    pub fn get_batch(&self, point_offsets: &[PointOffset]) -> Result<Vec<Option<ValuePointer>>> {
-        let item_size = std::mem::size_of::<OptionalPointer>();
-        let header_size = std::mem::size_of::<TrackerHeader>();
+    /// Issues a single batched read against the underlying storage, so async backends can fetch
+    /// all entries in parallel.
+    pub fn get_batch<U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+    ) -> Result<ValuePointersBatch<U>> {
+        let header_size = size_of::<TrackerHeader>();
+        let item_size = size_of::<OptionalPointer>();
+
         let storage_len = self.storage.len::<u8>()?;
 
-        let mut result: Vec<Option<ValuePointer>> = vec![None; point_offsets.len()];
-        let mut storage_reads: Vec<(usize, ReadRange)> = Vec::with_capacity(point_offsets.len());
+        let pointers = RefCell::new(ValuePointersBatch::default());
 
-        for (i, &point_offset) in point_offsets.iter().enumerate() {
-            // Pending updates take precedence over storage.
+        let ranges = point_offsets.filter_map(|(user_data, point_offset)| {
             if let Some(pending) = self.pending_updates.get(&point_offset) {
-                if pending.is_empty() {
-                    debug_assert!(false, "pending updates must not be empty");
-                } else {
-                    result[i] = pending.current;
-                    continue;
+                debug_assert!(!pending.is_empty(), "pending updates must not be empty");
+
+                if let Some(pointer) = pending.current {
+                    pointers.borrow_mut().valid.push((user_data, pointer));
+                    return None;
                 }
             }
 
-            let start_offset = header_size + point_offset as usize * item_size;
-            let end_offset = start_offset + item_size;
-            if end_offset as u64 > storage_len {
-                // Out of range, leave as None.
-                continue;
+            let byte_offset = header_size + item_size * point_offset as usize;
+
+            if storage_len < (byte_offset + item_size) as _ {
+                pointers.borrow_mut().out_of_range.push(user_data);
+                return None;
             }
 
-            storage_reads.push((i, ReadRange::one(start_offset as u64)));
+            Some((user_data, ReadRange::one(byte_offset as _)))
+        });
+
+        let pointers_iter = self
+            .storage
+            .read_iter::<Random, OptionalPointer, _>(ranges)?;
+
+        for result in pointers_iter {
+            let (user_data, pointer) = result?;
+            let &[pointer] = pointer.as_ref() else {
+                unreachable!();
+            };
+
+            match pointer.to_option() {
+                Some(pointer) => pointers.borrow_mut().valid.push((user_data, pointer)),
+                None => pointers.borrow_mut().empty.push(user_data),
+            }
         }
 
-        let reads = storage_reads
-            .iter()
-            .map(|(i, range)| (*i, &self.storage, *range));
-
-        for read_result in S::read_multi_iter::<Random, OptionalPointer, _>(reads)? {
-            let (i, opt_slice) = read_result?;
-            result[i] = opt_slice[0].to_option();
-        }
-
-        Ok(result)
+        Ok(pointers.into_inner())
     }
 
     /// Iterate over the pointers in the tracker

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -124,6 +124,10 @@ name = "vector_search"
 harness = false
 
 [[bench]]
+name = "read_vectors"
+harness = false
+
+[[bench]]
 name = "hnsw_build_graph"
 harness = false
 

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -128,6 +128,10 @@ name = "read_vectors"
 harness = false
 
 [[bench]]
+name = "read_payloads"
+harness = false
+
+[[bench]]
 name = "hnsw_build_graph"
 harness = false
 

--- a/lib/segment/benches/read_payloads.rs
+++ b/lib/segment/benches/read_payloads.rs
@@ -1,0 +1,120 @@
+use std::cell::LazyCell;
+use std::hint::black_box;
+use std::ops::Deref as _;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::{AccessPattern, Random, Sequential};
+use common::types::PointOffsetType;
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::prelude::{SliceRandom, StdRng};
+use rand::{RngExt, SeedableRng};
+use segment::payload_json;
+use segment::payload_storage::mmap_payload_storage::MmapPayloadStorage;
+use segment::payload_storage::{PayloadStorage, PayloadStorageRead};
+use segment::types::Payload;
+use tempfile::{Builder, TempDir};
+
+const RNG_SEED: u64 = 42;
+const POINT_COUNT: usize = 10_000;
+const READ_BATCH_SIZE: usize = 1024;
+const TAGS_COUNT: usize = 4;
+
+criterion_main!(benches);
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+}
+
+fn bench(c: &mut Criterion) {
+    let sequential_keys: Vec<_> = (0..READ_BATCH_SIZE as PointOffsetType).collect();
+
+    let mut random_keys: Vec<_> = (0..POINT_COUNT as PointOffsetType).collect();
+    random_keys.shuffle(&mut StdRng::seed_from_u64(RNG_SEED));
+    random_keys.truncate(READ_BATCH_SIZE);
+
+    let mut group = c.benchmark_group("read-payloads");
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage(tmpdir.path()));
+
+        group.bench_function("mmap/sequential", |b| {
+            b.iter(|| read_payloads::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("mmap/random", |b| {
+            b.iter(|| read_payloads::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    group.finish();
+}
+
+fn tmpdir() -> TempDir {
+    Builder::new()
+        .prefix("read-payloads-bench")
+        .tempdir()
+        .expect("tempdir created")
+}
+
+fn storage(path: &Path) -> MmapPayloadStorage {
+    let mut storage = MmapPayloadStorage::open_or_create(path.to_path_buf(), true)
+        .expect("mmap payload storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let payload = random_payload(&mut rng, point_id);
+
+        storage
+            .overwrite(point_id, &payload, &hw_counter)
+            .expect("payload inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn random_payload(rng: &mut StdRng, point_id: PointOffsetType) -> Payload {
+    let tags: Vec<_> = (0..TAGS_COUNT)
+        .map(|_| format!("tag-{}", rng.random_range(0..64)))
+        .collect();
+
+    payload_json! {
+        "point_id": point_id,
+        "price": rng.random_range(0..1_000_000),
+        "rating": rng.random::<f64>(),
+        "active": rng.random_bool(0.8),
+        "category": format!("category-{}", rng.random_range(0..32)),
+        "tags": tags,
+    }
+}
+
+fn read_payloads<P, S>(storage: &S, point_offsets: &[PointOffsetType]) -> usize
+where
+    P: AccessPattern,
+    S: PayloadStorageRead,
+{
+    let point_offsets = point_offsets.iter().map(|&point_offset| ((), point_offset));
+    let hw_counter = HardwareCounterCell::disposable();
+
+    let mut fields_read = 0;
+    storage
+        .read_payloads::<P, _>(
+            point_offsets,
+            |_, payload| {
+                fields_read += payload.len();
+                Ok(())
+            },
+            &hw_counter,
+        )
+        .expect("payloads read");
+
+    black_box(fields_read)
+}

--- a/lib/segment/benches/read_vectors.rs
+++ b/lib/segment/benches/read_vectors.rs
@@ -1,0 +1,165 @@
+use std::cell::LazyCell;
+use std::hint::black_box;
+use std::ops::Deref as _;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::{AccessPattern, Random, Sequential};
+use common::mmap::AdviceSetting;
+use common::types::PointOffsetType;
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::prelude::{SliceRandom, StdRng};
+use rand::{RngExt, SeedableRng};
+use segment::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType, VectorRef};
+use segment::types::{Distance, MultiVectorConfig};
+use segment::vector_storage::dense::appendable_dense_vector_storage::{
+    AppendableMmapDenseVectorStorage, open_appendable_memmap_vector_storage_impl,
+};
+use segment::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
+    AppendableMmapMultiDenseVectorStorage, open_appendable_memmap_multi_vector_storage_impl,
+};
+use segment::vector_storage::{VectorStorage, VectorStorageRead};
+use tempfile::{Builder, TempDir};
+
+const RNG_SEED: u64 = 42;
+const POINT_COUNT: usize = 10_000;
+const MAX_VECTORS_PER_POINT: usize = 8;
+const VECTOR_DIM: usize = 128;
+const READ_BATCH_SIZE: usize = 1024;
+
+criterion_main!(benches);
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+}
+
+fn bench(c: &mut Criterion) {
+    let sequential_keys: Vec<_> = (0..READ_BATCH_SIZE as PointOffsetType).collect();
+
+    let mut random_keys: Vec<_> = (0..POINT_COUNT as PointOffsetType).collect();
+    random_keys.shuffle(&mut StdRng::seed_from_u64(RNG_SEED));
+    random_keys.truncate(READ_BATCH_SIZE);
+
+    let mut group = c.benchmark_group("read-vectors");
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage_dense(tmpdir.path()));
+
+        group.bench_function("appendable-mmap-dense/sequential", |b| {
+            b.iter(|| read_vectors::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("appendable-mmap-dense/random", |b| {
+            b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage_multi(tmpdir.path()));
+
+        group.bench_function("appendable-mmap-multi-dense/sequential", |b| {
+            b.iter(|| read_vectors::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("appendable-mmap-multi-dense/random", |b| {
+            b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    group.finish();
+}
+
+fn tmpdir() -> TempDir {
+    Builder::new()
+        .prefix("read-vectors-bench")
+        .tempdir()
+        .expect("tempdir created")
+}
+
+fn storage_dense(path: &Path) -> AppendableMmapDenseVectorStorage<VectorElementType> {
+    let mut storage = open_appendable_memmap_vector_storage_impl(
+        path,
+        VECTOR_DIM,
+        Distance::Dot,
+        AdviceSetting::Global,
+        true,
+    )
+    .expect("appendable mmap dense storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut vector_buffer = vec![0.0; VECTOR_DIM];
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let vector = random_vector(&mut rng, &mut vector_buffer, VECTOR_DIM);
+
+        storage
+            .insert_vector(point_id, VectorRef::from(vector), &hw_counter)
+            .expect("vector inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn storage_multi(path: &Path) -> AppendableMmapMultiDenseVectorStorage<VectorElementType> {
+    let mut storage = open_appendable_memmap_multi_vector_storage_impl(
+        path,
+        VECTOR_DIM,
+        Distance::Dot,
+        MultiVectorConfig::default(),
+        AdviceSetting::Global,
+        true,
+    )
+    .expect("appendable mmap multi dense storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut vector_buffer = vec![0.0; MAX_VECTORS_PER_POINT * VECTOR_DIM];
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let vectors_count = rng.random_range(1..=MAX_VECTORS_PER_POINT);
+        let vector = random_vector(&mut rng, &mut vector_buffer, vectors_count * VECTOR_DIM);
+        let vector = TypedMultiDenseVectorRef::new(vector, VECTOR_DIM);
+
+        storage
+            .insert_vector(point_id, VectorRef::from(vector), &hw_counter)
+            .expect("vector inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn random_vector<'a>(
+    rng: &mut StdRng,
+    buffer: &'a mut [VectorElementType],
+    dim: usize,
+) -> &'a [VectorElementType] {
+    let buffer = &mut buffer[..dim];
+    buffer.fill_with(|| rng.random());
+    buffer
+}
+
+fn read_vectors<P, S>(storage: &S, point_offsets: &[PointOffsetType]) -> usize
+where
+    P: AccessPattern,
+    S: VectorStorageRead,
+{
+    let point_offsets = point_offsets.iter().map(|&point_offset| ((), point_offset));
+
+    let mut bytes_read = 0;
+    storage.read_vectors::<P, _>(point_offsets, |_, _, vector| {
+        bytes_read += vector.estimate_size_in_bytes();
+    });
+
+    black_box(bytes_read)
+}

--- a/lib/segment/benches/read_vectors.rs
+++ b/lib/segment/benches/read_vectors.rs
@@ -18,13 +18,16 @@ use segment::vector_storage::dense::appendable_dense_vector_storage::{
 use segment::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, open_appendable_memmap_multi_vector_storage_impl,
 };
+use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::{VectorStorage, VectorStorageRead};
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use tempfile::{Builder, TempDir};
 
 const RNG_SEED: u64 = 42;
 const POINT_COUNT: usize = 10_000;
 const MAX_VECTORS_PER_POINT: usize = 8;
 const VECTOR_DIM: usize = 128;
+const SPARSE_MAX_DIM: usize = 1000;
 const READ_BATCH_SIZE: usize = 1024;
 
 criterion_main!(benches);
@@ -66,6 +69,19 @@ fn bench(c: &mut Criterion) {
         });
 
         group.bench_function("appendable-mmap-multi-dense/random", |b| {
+            b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage_sparse(tmpdir.path()));
+
+        group.bench_function("mmap-sparse/sequential", |b| {
+            b.iter(|| read_vectors::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("mmap-sparse/random", |b| {
             b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
         });
     }
@@ -130,6 +146,27 @@ fn storage_multi(path: &Path) -> AppendableMmapMultiDenseVectorStorage<VectorEle
 
         storage
             .insert_vector(point_id, VectorRef::from(vector), &hw_counter)
+            .expect("vector inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn storage_sparse(path: &Path) -> MmapSparseVectorStorage {
+    let mut storage =
+        MmapSparseVectorStorage::open_or_create(path).expect("mmap sparse storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let vector = random_sparse_vector(&mut rng, SPARSE_MAX_DIM);
+
+        storage
+            .insert_vector(point_id, VectorRef::from(&vector), &hw_counter)
             .expect("vector inserted");
     }
 

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
@@ -33,13 +33,12 @@ where
 
         self.storage
             .view()
-            .for_each_in_batch::<Random, _, GridstoreError>(
-                new_points,
-                |idx, maybe_values: Option<Vec<_>>| {
+            .read_values::<Random, _, GridstoreError>(
+                new_points.iter().copied().enumerate(),
+                |_, point_offset, maybe_values: Option<Vec<_>>| {
                     let Some(values) = maybe_values else {
                         return Ok(());
                     };
-                    let point_offset = new_points[idx];
                     for value in values {
                         in_memory_storage.ingest(point_offset, value);
                     }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 use serde_json::Value;
 
@@ -138,6 +139,13 @@ pub trait PayloadIndexRead {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
 }
 
 /// Trait for payload index with mutating operations.

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 use fs_err as fs;
@@ -161,6 +162,15 @@ impl PayloadIndexRead for PlainPayloadIndex {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         unreachable!()
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        _callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        unimplemented!()
     }
 
     fn numeric_index_for(&self, _key: &PayloadKeyType) -> Option<impl NumericFieldIndexRead + '_> {

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -5,6 +5,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::either_variant::EitherVariant;
+use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 
@@ -274,5 +275,16 @@ where
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         self.payload.borrow().get_sequential(point_id, hw_counter)
+    }
+
+    fn read_payloads<AP: AccessPattern, U>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload
+            .borrow()
+            .read_payloads::<AP, _>(point_ids, callback, hw_counter)
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -53,6 +54,20 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
                 return Ok(());
             }
         }
+        Ok(())
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for (user_data, point_offset) in point_offsets {
+            let payload = self.get(point_offset, hw_counter)?;
+            callback(user_data, payload)?;
+        }
+
         Ok(())
     }
 

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::{Random, Sequential};
+use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::types::PointOffsetType;
 use fs_err as fs;
 use gridstore::config::StorageOptions;
@@ -115,6 +115,22 @@ impl PayloadStorageRead for MmapPayloadStorage {
     ) -> OperationResult<OwnedPayloadRef<'_>> {
         let payload = self.get(point_offset, hw_counter)?;
         Ok(OwnedPayloadRef::from(payload))
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.read_values::<P, _, _>(
+            point_offsets,
+            |user_data, _, payload| {
+                let payload = payload.unwrap_or_default();
+                callback(user_data, payload)
+            },
+            hw_counter.payload_io_read_counter(),
+        )
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -40,6 +41,13 @@ pub trait PayloadStorageRead {
         point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<OwnedPayloadRef<'_>>;
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
 
     /// Iterate over all stored payload and apply the provided callback.
     /// Stop iteration if callback returns false or error.

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -71,6 +72,24 @@ impl PayloadStorageRead for PayloadStorageEnum {
                 s.payload_ref(point_offset, hw_counter)
             }
             PayloadStorageEnum::MmapPayloadStorage(s) => s.payload_ref(point_offset, hw_counter),
+        }
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                s.read_payloads::<P, _>(point_offsets, callback, hw_counter)
+            }
+
+            PayloadStorageEnum::MmapPayloadStorage(s) => {
+                s.read_payloads::<P, _>(point_offsets, callback, hw_counter)
+            }
         }
     }
 

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -1,5 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::{Random, Sequential};
+use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -41,6 +41,24 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     ) -> OperationResult<OwnedPayloadRef<'_>> {
         let payload = self.get(point_offset, hw_counter)?;
         Ok(OwnedPayloadRef::from(payload))
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // TODO: `hw_counter`!?
+
+        self.storage.read_values::<P, _, _>(
+            point_offsets,
+            |user_data, _, payload| {
+                let payload = payload.unwrap_or_default();
+                callback(user_data, payload)
+            },
+            hw_counter.payload_io_read_counter(),
+        )
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/segment/read_view/payload.rs
+++ b/lib/segment/src/segment/read_view/payload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
@@ -18,6 +19,16 @@ where
     TPS: PayloadStorageRead,
     TVD: VectorDataRead,
 {
+    pub fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload_index
+            .read_payloads::<P, _>(point_offsets, callback, hw_counter)
+    }
+
     /// Retrieve payload by internal ID.
     #[inline]
     pub fn payload_by_offset(

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, ScoredPointOffset};
 
@@ -108,17 +109,26 @@ where
         // mirrors what a future batched payload fetcher would consume —
         // `&resolved_offsets` becomes its input directly.
         if with_payload.enable {
-            for (&id, &offset) in resolved_ids.iter().zip(&resolved_offsets) {
-                check_stopped(is_stopped)?;
-                let payload = self.payload_by_offset(offset, hw_counter)?;
-                let payload = match &with_payload.payload_selector {
-                    Some(selector) => selector.process(payload),
-                    None => payload,
-                };
-                if let Some(record) = records.get_mut(&id) {
-                    record.payload = Some(payload);
-                }
-            }
+            let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
+
+            self.read_payloads::<Random, _>(
+                point_offsets,
+                |point_id, payload| {
+                    check_stopped(is_stopped)?;
+
+                    let payload = match &with_payload.payload_selector {
+                        Some(selector) => selector.process(payload),
+                        None => payload,
+                    };
+
+                    if let Some(record) = records.get_mut(&point_id) {
+                        record.payload = Some(payload);
+                    }
+
+                    Ok(())
+                },
+                hw_counter,
+            )?;
         }
 
         Ok(records)

--- a/lib/segment/src/vector_storage/chunked_vectors/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/mod.rs
@@ -46,7 +46,8 @@ mod tests {
             let random_offset = 666;
             let batch_size = 10;
 
-            let batch_ids = (random_offset..random_offset + batch_size).collect::<Vec<_>>();
+            let batch_ids = (random_offset as u32..random_offset as u32 + batch_size as u32)
+                .collect::<Vec<_>>();
             let mut vectors_buffer = Vec::with_capacity(batch_size);
             chunked_mmap.for_each_in_batch(&batch_ids, |i, vec| {
                 assert_eq!(i, vectors_buffer.len());

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -179,7 +179,10 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         }
     }
 
-    pub fn for_each_in_batch<F: FnMut(usize, &[T])>(&self, keys: &[PointOffsetType], mut f: F) {
+    pub fn for_each_in_batch<F>(&self, keys: &[PointOffsetType], mut callback: F)
+    where
+        F: FnMut(usize, &[T]),
+    {
         #[cfg(target_os = "linux")]
         if TypedStorage::<S, T>::kind() == common::universal_io::UniversalKind::IoUring {
             let point_offsets = keys
@@ -189,7 +192,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
                 .map(|(index, point_offset)| (index, point_offset, 1));
 
             for (idx, vectors) in self.iter_vectors::<Random, _>(point_offsets) {
-                f(idx, &vectors);
+                callback(idx, &vectors);
             }
 
             return;
@@ -214,7 +217,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
             for (vector_idx, vec) in vectors.iter().enumerate() {
-                f(batch_offset + vector_idx, vec.as_ref());
+                callback(batch_offset + vector_idx, vec.as_ref());
             }
         }
     }

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -179,13 +179,14 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         }
     }
 
-    pub fn for_each_in_batch<F: FnMut(usize, &[T]), O: VectorOffset>(&self, keys: &[O], mut f: F) {
+    pub fn for_each_in_batch<F: FnMut(usize, &[T])>(&self, keys: &[PointOffsetType], mut f: F) {
         #[cfg(target_os = "linux")]
         if TypedStorage::<S, T>::kind() == common::universal_io::UniversalKind::IoUring {
             let point_offsets = keys
                 .iter()
+                .copied()
                 .enumerate()
-                .map(|(index, offset)| (index, offset.offset(), offset.multi_vector_count()));
+                .map(|(index, point_offset)| (index, point_offset, 1));
 
             for (idx, vectors) in self.iter_vectors::<Random, _>(point_offsets) {
                 f(idx, &vectors);
@@ -205,7 +206,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             let (vectors, _) = maybe_uninit_fill_from(
                 &mut vectors_buffer,
                 keys.iter().map(|&key| {
-                    self.get_many_impl(key.offset(), key.multi_vector_count(), force_sequential)
+                    self.get_many_impl(key.offset(), 1, force_sequential)
                         .expect("vectors read")
                 }),
             );

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::AdviceSetting;
+use common::types::PointOffsetType;
 use common::universal_io::{
-    ReadRange, TypedStorage, UniversalIoError, UniversalRead, read_json_via,
+    ReadRange, TypedStorage, UniversalIoError, UniversalRead, UserData, read_json_via,
 };
 use fs_err as fs;
 use num_traits::AsPrimitive;
@@ -181,7 +182,12 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
     pub fn for_each_in_batch<F: FnMut(usize, &[T]), O: VectorOffset>(&self, keys: &[O], mut f: F) {
         #[cfg(target_os = "linux")]
         if TypedStorage::<S, T>::kind() == common::universal_io::UniversalKind::IoUring {
-            for (idx, vectors) in self.iter(keys) {
+            let point_offsets = keys
+                .iter()
+                .enumerate()
+                .map(|(index, offset)| (index, offset.offset(), offset.multi_vector_count()));
+
+            for (idx, vectors) in self.iter_vectors::<Random, _>(point_offsets) {
                 f(idx, &vectors);
             }
 
@@ -212,21 +218,26 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         }
     }
 
-    pub fn iter<O>(&self, offsets: &[O]) -> impl Iterator<Item = (usize, Cow<'_, [T]>)>
+    /// Iterate over flattened multi-vectors
+    pub fn iter_vectors<P, U>(
+        &self,
+        offsets: impl Iterator<Item = (U, PointOffsetType, u32)>,
+    ) -> impl Iterator<Item = (U, Cow<'_, [T]>)>
     where
-        O: VectorOffset,
+        P: AccessPattern,
+        U: UserData,
     {
-        let reads = offsets.iter().enumerate().map(|(idx, offset)| {
+        let reads = offsets.map(|(user_data, offset, count)| {
             let (chunk_idx, range) = self
-                .read_range(offset.offset(), offset.multi_vector_count())
+                .read_range(offset as _, count as _)
                 .expect("vectors exist");
 
             let chunk = &self.chunks[chunk_idx];
-            (idx, chunk, range)
+            (user_data, chunk, range)
         });
 
         // access pattern does not matter for io_uring
-        TypedStorage::<S, T>::read_multi_iter::<Random, _>(reads)
+        TypedStorage::read_multi_iter::<P, _>(reads)
             .expect("iterator initialized")
             .map(|result| result.expect("vector read"))
     }

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -117,6 +117,21 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorS
             .expect("Vector not found")
     }
 
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let keys = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset, 1));
+
+        for ((user_data, point_offset), vector) in self.vectors.iter_vectors::<P, _>(keys) {
+            let vector = CowVector::from(T::slice_to_float_cow(vector));
+            callback(user_data, point_offset, vector);
+        }
+    }
+
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get::<P>(key as VectorOffsetType)

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -88,8 +88,11 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
             .expect("mmap vector not found")
     }
 
-    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(&self, keys: &[PointOffsetType], f: F) {
-        self.vectors.for_each_in_batch(keys, f);
+    fn for_each_in_dense_batch<F>(&self, keys: &[PointOffsetType], callback: F)
+    where
+        F: FnMut(usize, &[T]),
+    {
+        self.vectors.for_each_in_batch(keys, callback);
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -47,6 +47,21 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
             .expect("Vector not found")
     }
 
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let keys = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset, 1));
+
+        for ((user_data, point_offset), vector) in self.vectors.iter_vectors::<P, _>(keys) {
+            let vector = CowVector::from(T::slice_to_float_cow(vector));
+            callback(user_data, point_offset, vector);
+        }
+    }
+
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get::<P>(key as VectorOffsetType)

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -152,34 +152,6 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
         deleted.clear_cache()?;
         Ok(())
     }
-
-    fn iter_vectors<P: AccessPattern, U>(
-        &self,
-        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
-    ) -> impl Iterator<Item = (U, Cow<'_, [T]>)> {
-        let point_offsets = keys
-            .into_iter()
-            .map(|(user_data, point_offset)| (user_data, point_offset as _, 1));
-
-        let vector_offsets =
-            self.offsets
-                .iter_vectors::<P, _>(point_offsets)
-                .map(|(user_data, multi_offset)| {
-                    let &[multi_offset] = multi_offset.as_ref() else {
-                        unreachable!("multi-vector offsets are stored as vectors of length 1");
-                    };
-
-                    let MultivectorMmapOffset {
-                        offset,
-                        count,
-                        capacity: _,
-                    } = multi_offset;
-
-                    (user_data, offset, count)
-                });
-
-        self.vectors.iter_vectors::<P, _>(vector_offsets)
-    }
 }
 
 impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDenseVectorStorage<T> {
@@ -206,7 +178,13 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     {
         let point_offsets = keys.iter().copied().enumerate();
 
-        for (index, flattened) in self.iter_vectors::<Sequential, _>(point_offsets) {
+        let vectors = super::read_only::iter_vectors::<Sequential, _, _, _>(
+            &self.offsets,
+            &self.vectors,
+            point_offsets,
+        );
+
+        for (index, flattened) in vectors {
             let vector = TypedMultiDenseVectorRef::new(&flattened, self.vector_dim());
             callback(index, vector)
         }
@@ -274,7 +252,13 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
             .into_iter()
             .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
-        for ((user_data, point_offset), flattened) in self.iter_vectors::<P, _>(point_offsets) {
+        let vectors = super::read_only::iter_vectors::<P, _, _, _>(
+            &self.offsets,
+            &self.vectors,
+            point_offsets,
+        );
+
+        for ((user_data, point_offset), flattened) in vectors {
             let vector = CowVector::MultiDense(T::into_float_multivector(
                 flattened_to_multi_vector(flattened, self.vectors.dim()),
             ));

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -178,7 +178,12 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
         let mut point_indexes = Vec::with_capacity(keys.len());
         let mut offsets = Vec::with_capacity(keys.len());
 
-        for (point_index, offset) in self.offsets.iter(keys) {
+        let point_offsets = keys
+            .iter()
+            .enumerate()
+            .map(|(index, &point_offset)| (index, point_offset, 1));
+
+        for (point_index, offset) in self.offsets.iter_vectors::<Random, _>(point_offsets) {
             // `PointOffsetType::multi_vector_count` is always 1, and `self.offsets` is `ChunkedVectors`
             // with vector dimension set to 1, so we expect to get an `offset` "vector" of exactly 1 value
             let &[offset] = offset.as_ref() else {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -38,9 +38,9 @@ const DELETED_DIR_PATH: &str = "deleted";
 #[derive(Copy, Clone, Debug, Default, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct MultivectorMmapOffset {
-    offset: u32,
-    count: u32,
-    capacity: u32,
+    pub offset: u32,
+    pub count: u32,
+    pub capacity: u32,
 }
 
 impl VectorOffset for MultivectorMmapOffset {
@@ -50,6 +50,22 @@ impl VectorOffset for MultivectorMmapOffset {
 
     fn multi_vector_count(self) -> usize {
         self.count as _
+    }
+}
+
+pub(crate) fn flattened_to_multi_vector<T: PrimitiveVectorElement>(
+    flattened: Cow<'_, [T]>,
+    dim: usize,
+) -> CowMultiVector<'_, T> {
+    match flattened {
+        Cow::Borrowed(flattened_vectors) => CowMultiVector::Borrowed(TypedMultiDenseVectorRef {
+            flattened_vectors,
+            dim,
+        }),
+        Cow::Owned(flattened_vectors) => CowMultiVector::Owned(TypedMultiDenseVector {
+            flattened_vectors,
+            dim,
+        }),
     }
 }
 
@@ -76,16 +92,7 @@ where
         .expect("mmap_offset must not be empty");
     let flattened =
         vectors.get_many::<P>(mmap_offset.offset(), mmap_offset.multi_vector_count())?;
-    Some(match flattened {
-        Cow::Borrowed(slice) => CowMultiVector::Borrowed(TypedMultiDenseVectorRef {
-            flattened_vectors: slice,
-            dim: vectors.dim(),
-        }),
-        Cow::Owned(vec) => CowMultiVector::Owned(TypedMultiDenseVector {
-            flattened_vectors: vec,
-            dim: vectors.dim(),
-        }),
-    })
+    Some(flattened_to_multi_vector(flattened, vectors.dim()))
 }
 
 #[derive(Debug)]

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -189,6 +189,8 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     }
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send {
+        // TODO: Implement based on `iter_vectors`!?
+
         (0..self.total_vector_count()).flat_map(move |key| {
             let mmap_offset = self
                 .offsets

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -157,6 +157,34 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
         deleted.clear_cache()?;
         Ok(())
     }
+
+    fn iter_vectors<P: AccessPattern, U>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+    ) -> impl Iterator<Item = (U, Cow<'_, [T]>)> {
+        let point_offsets = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| (user_data, point_offset as _, 1));
+
+        let vector_offsets =
+            self.offsets
+                .iter_vectors::<P, _>(point_offsets)
+                .map(|(user_data, multi_offset)| {
+                    let &[multi_offset] = multi_offset.as_ref() else {
+                        unreachable!("multi-vector offsets are stored as vectors of length 1");
+                    };
+
+                    let MultivectorMmapOffset {
+                        offset,
+                        count,
+                        capacity: _,
+                    } = multi_offset;
+
+                    (user_data, offset, count)
+                });
+
+        self.vectors.iter_vectors::<P, _>(vector_offsets)
+    }
 }
 
 impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDenseVectorStorage<T> {
@@ -262,6 +290,24 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
 
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt::<P>(key).expect("vector not found")
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let point_offsets = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
+
+        for ((user_data, point_offset), flattened) in self.iter_vectors::<P, _>(point_offsets) {
+            let vector = CowVector::MultiDense(T::into_float_multivector(
+                flattened_to_multi_vector(flattened, self.vectors.dim()),
+            ));
+
+            callback(user_data, point_offset, vector);
+        }
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -102,7 +102,6 @@ pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     distance: Distance,
     multi_vector_config: MultiVectorConfig,
     deleted_count: usize,
-    _phantom: std::marker::PhantomData<T>,
 }
 
 impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
@@ -144,7 +143,6 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
             distance: _,
             multi_vector_config: _,
             deleted_count: _,
-            _phantom,
         } = self;
 
         vectors.clear_cache()?;
@@ -566,7 +564,6 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
         distance,
         multi_vector_config,
         deleted_count,
-        _phantom: Default::default(),
     })
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -27,8 +27,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
     open_appendable_memmap_vector_storage_half,
 };
 use crate::vector_storage::{
-    MultiVectorStorage, VectorOffset, VectorOffsetType, VectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 const VECTORS_DIR_PATH: &str = "vectors";
@@ -41,16 +40,6 @@ pub struct MultivectorMmapOffset {
     pub offset: u32,
     pub count: u32,
     pub capacity: u32,
-}
-
-impl VectorOffset for MultivectorMmapOffset {
-    fn offset(self) -> VectorOffsetType {
-        self.offset as _
-    }
-
-    fn multi_vector_count(self) -> usize {
-        self.count as _
-    }
 }
 
 pub(crate) fn flattened_to_multi_vector<T: PrimitiveVectorElement>(
@@ -86,12 +75,18 @@ where
     P: AccessPattern,
     S: UniversalRead,
 {
-    let mmap_offset = *offsets
-        .get::<P>(key as VectorOffsetType)?
-        .first()
-        .expect("mmap_offset must not be empty");
-    let flattened =
-        vectors.get_many::<P>(mmap_offset.offset(), mmap_offset.multi_vector_count())?;
+    let &[multi_offset] = offsets.get::<P>(key as VectorOffsetType)?.as_ref() else {
+        unreachable!("multi-vector offsets are stored as vectors of length 1");
+    };
+
+    let MultivectorMmapOffset {
+        offset,
+        count,
+        capacity: _,
+    } = multi_offset;
+
+    let flattened = vectors.get_many::<P>(offset as _, count as _)?;
+
     Some(flattened_to_multi_vector(flattened, vectors.dim()))
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -209,34 +209,12 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     where
         F: FnMut(usize, TypedMultiDenseVectorRef<'_, T>),
     {
-        // Collect multi-vector offsets
-        let mut point_indexes = Vec::with_capacity(keys.len());
-        let mut offsets = Vec::with_capacity(keys.len());
+        let point_offsets = keys.iter().copied().enumerate();
 
-        let point_offsets = keys
-            .iter()
-            .enumerate()
-            .map(|(index, &point_offset)| (index, point_offset, 1));
-
-        for (point_index, offset) in self.offsets.iter_vectors::<Random, _>(point_offsets) {
-            // `PointOffsetType::multi_vector_count` is always 1, and `self.offsets` is `ChunkedVectors`
-            // with vector dimension set to 1, so we expect to get an `offset` "vector" of exactly 1 value
-            let &[offset] = offset.as_ref() else {
-                unreachable!();
-            };
-
-            point_indexes.push(point_index);
-            offsets.push(offset);
+        for (index, flattened) in self.iter_vectors::<Sequential, _>(point_offsets) {
+            let vector = TypedMultiDenseVectorRef::new(&flattened, self.vector_dim());
+            callback(index, vector)
         }
-
-        // Fetch multi-vectors
-        self.vectors
-            .for_each_in_batch(&offsets, |offset_index, vectors| {
-                let point_index = point_indexes[offset_index];
-                let vector = TypedMultiDenseVectorRef::new(vectors, self.vector_dim());
-
-                callback(point_index, vector);
-            });
     }
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send {

--- a/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
@@ -55,25 +55,10 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     ) {
         let point_offsets = keys
             .into_iter()
-            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset as _, 1));
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
-        let vector_offsets = self.offsets.iter_vectors::<P, _>(point_offsets).map(
-            |((user_data, point_offset), multi_offset)| {
-                let &[multi_offset] = multi_offset.as_ref() else {
-                    unreachable!("multi-vector offsets are stored as vectors of length 1");
-                };
-
-                let MultivectorMmapOffset {
-                    offset,
-                    count,
-                    capacity: _,
-                } = multi_offset;
-
-                ((user_data, point_offset), offset, count)
-            },
-        );
-
-        let vectors = self.vectors.iter_vectors::<P, _>(vector_offsets);
+        let vectors =
+            super::iter_vectors::<P, _, _, _>(&self.offsets, &self.vectors, point_offsets);
 
         for ((user_data, point_offset), flattened) in vectors {
             let vector = CowVector::MultiDense(T::into_float_multivector(

--- a/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
@@ -9,7 +9,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
-    MultivectorMmapOffset, read_multi_vector,
+    MultivectorMmapOffset, flattened_to_multi_vector, read_multi_vector,
 };
 
 #[derive(Debug)]
@@ -46,6 +46,42 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
 
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt::<P>(key).expect("vector not found")
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let point_offsets = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset as _, 1));
+
+        let vector_offsets = self.offsets.iter_vectors::<P, _>(point_offsets).map(
+            |((user_data, point_offset), multi_offset)| {
+                let &[multi_offset] = multi_offset.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as vectors of length 1");
+                };
+
+                let MultivectorMmapOffset {
+                    offset,
+                    count,
+                    capacity: _,
+                } = multi_offset;
+
+                ((user_data, point_offset), offset, count)
+            },
+        );
+
+        let vectors = self.vectors.iter_vectors::<P, _>(vector_offsets);
+
+        for ((user_data, point_offset), flattened) in vectors {
+            let vector = CowVector::MultiDense(T::into_float_multivector(
+                flattened_to_multi_vector(flattened, self.vectors.dim()),
+            ));
+
+            callback(user_data, point_offset, vector);
+        }
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -1,1 +1,45 @@
 pub mod chunked_vector_storage;
+
+use std::borrow::Cow;
+
+use common::generic_consts::AccessPattern;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+
+pub fn iter_vectors<'a, P, T, U, S>(
+    offsets: &'a ChunkedVectorsRead<MultivectorMmapOffset, S>,
+    vectors: &'a ChunkedVectorsRead<T, S>,
+    keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+) -> impl Iterator<Item = (U, Cow<'a, [T]>)>
+where
+    P: AccessPattern,
+    T: PrimitiveVectorElement,
+    S: UniversalRead,
+{
+    let point_offsets = keys
+        .into_iter()
+        .map(|(user_data, point_offset)| (user_data, point_offset as _, 1));
+
+    let vector_offsets =
+        offsets
+            .iter_vectors::<P, _>(point_offsets)
+            .map(|(user_data, multi_offset)| {
+                let &[multi_offset] = multi_offset.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as vectors of length 1");
+                };
+
+                let MultivectorMmapOffset {
+                    offset,
+                    count,
+                    capacity: _,
+                } = multi_offset;
+
+                (user_data, offset, count)
+            });
+
+    vectors.iter_vectors::<P, _>(vector_offsets)
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -53,7 +53,12 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
         &self,
         offsets: &[PointOffsetType],
     ) -> impl Iterator<Item = (usize, Cow<'_, [u8]>)> {
-        self.data.iter(offsets)
+        let offsets = offsets
+            .iter()
+            .enumerate()
+            .map(|(index, &offset)| (index, offset, 1));
+
+        self.data.iter_vectors::<Random, _>(offsets)
     }
 
     fn upsert_vector(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -335,13 +335,20 @@ impl MultivectorOffsetsStorage for MultivectorOffsetsStorageChunkedMmap {
         &self,
         ids: &[PointOffsetType],
     ) -> impl Iterator<Item = (usize, MultivectorOffset)> {
-        self.data.iter(ids).map(|(idx, offset)| {
-            let [offset] = offset.as_ref() else {
-                unreachable!("multi-vector offsets are stored as a single-element slice");
-            };
+        let point_offsets = ids
+            .iter()
+            .enumerate()
+            .map(|(idx, &point_offset)| (idx, point_offset, 1));
 
-            (idx, *offset)
-        })
+        self.data
+            .iter_vectors::<Random, _>(point_offsets)
+            .map(|(idx, multi_offset)| {
+                let &[multi_offset] = multi_offset.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as vectors of length 1");
+                };
+
+                (idx, multi_offset)
+            })
     }
 
     fn len(&self) -> usize {

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -210,14 +210,19 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
     where
         F: FnMut(usize, SparseVector),
     {
-        self.storage.for_each_in_batch::<Random, _, OperationError>(
-            keys,
-            |idx, vector| {
-                if let Some(vector) = vector {
-                    callback(idx, SparseVector::try_from(vector)?);
-                }
-                Ok(())
-            },
+        let point_offsets = keys.iter().copied().enumerate();
+
+        let callback = |value_idx, _, sparse_vector| {
+            if let Some(sparse_vector) = sparse_vector {
+                callback(value_idx, SparseVector::try_from(sparse_vector)?);
+            }
+
+            Ok(())
+        };
+
+        self.storage.read_values::<Random, _, _>(
+            point_offsets,
+            callback,
             HardwareCounterCell::disposable().vector_io_read(),
         )
     }
@@ -243,6 +248,30 @@ impl VectorStorageRead for MmapSparseVectorStorage {
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt::<P>(key)
             .unwrap_or_else(CowVector::default_sparse)
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let callback = |user_data, point_offset, sparse_vector| -> OperationResult<()> {
+            let Some(sparse_vector) = sparse_vector else {
+                return Ok(());
+            };
+
+            let sparse_vector = SparseVector::try_from(sparse_vector)?;
+            callback(user_data, point_offset, CowVector::from(sparse_vector));
+            Ok(())
+        };
+
+        self.storage
+            .read_values::<P, _, _>(
+                keys.into_iter(),
+                callback,
+                HardwareCounterCell::disposable().vector_io_read(),
+            )
+            .expect("sparse vectors read")
     }
 
     /// Get vector by key, if it exists.

--- a/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
@@ -6,6 +6,7 @@ use common::universal_io::UniversalRead;
 use gridstore::GridstoreReader;
 use sparse::common::sparse_vector::SparseVector;
 
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
@@ -44,6 +45,30 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt::<P>(key)
             .unwrap_or_else(CowVector::default_sparse)
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let callback = |user_data, point_offset, sparse_vector| -> OperationResult<()> {
+            let Some(sparse_vector) = sparse_vector else {
+                return Ok(());
+            };
+
+            let sparse_vector = SparseVector::try_from(sparse_vector)?;
+            callback(user_data, point_offset, CowVector::from(sparse_vector));
+            Ok(())
+        };
+
+        self.storage
+            .read_values::<P, _, _>(
+                keys.into_iter(),
+                callback,
+                HardwareCounterCell::disposable().vector_io_read(),
+            )
+            .expect("sparse vectors read")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -39,10 +39,6 @@ pub type VectorOffsetType = usize;
 /// Generalized vector offset.
 pub trait VectorOffset: Copy + fmt::Debug {
     fn offset(self) -> VectorOffsetType;
-
-    fn multi_vector_count(self) -> usize {
-        1
-    }
 }
 
 impl VectorOffset for PointOffsetType {


### PR DESCRIPTION
This PR implements `read_vectors` method for dense/multi-dense/quantized storage types that are missing it.

[Retrieve path already uses `read_vectors`][retrieve-read-vectors], we only need to implement it efficiently.

Sparse vector storage is implemented in a follow-up PR: #9194.

[retrieve-read-vectors]: https://github.com/qdrant/qdrant/blob/4cca907e95a8ba303d88b39eab8e750fe3a52ae0/lib/segment/src/segment/read_view/vectors.rs#L84-L94

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
