### PR TITLE
feat(edge): expose HNSW healing threshold via EdgeOptimizersConfig

### DIFF
--- a/lib/edge/python/src/config/optimizers.rs
+++ b/lib/edge/python/src/config/optimizers.rs
@@ -13,7 +13,7 @@ pub struct PyEdgeOptimizersConfig(pub EdgeOptimizersConfig);
 #[pymethods]
 impl PyEdgeOptimizersConfig {
     #[new]
-    #[pyo3(signature = (deleted_threshold=None, vacuum_min_vector_number=None, default_segment_number=None, max_segment_size=None, indexing_threshold=None, prevent_unoptimized=None))]
+    #[pyo3(signature = (deleted_threshold=None, vacuum_min_vector_number=None, default_segment_number=None, max_segment_size=None, indexing_threshold=None, prevent_unoptimized=None, healing_threshold=None))]
     pub fn new(
         deleted_threshold: Option<f64>,
         vacuum_min_vector_number: Option<usize>,
@@ -21,6 +21,7 @@ impl PyEdgeOptimizersConfig {
         max_segment_size: Option<usize>,
         indexing_threshold: Option<usize>,
         prevent_unoptimized: Option<bool>,
+        healing_threshold: Option<f64>,
     ) -> Self {
         Self(EdgeOptimizersConfig {
             deleted_threshold,
@@ -29,6 +30,7 @@ impl PyEdgeOptimizersConfig {
             max_segment_size,
             indexing_threshold,
             prevent_unoptimized,
+            healing_threshold,
         })
     }
 
@@ -60,6 +62,11 @@ impl PyEdgeOptimizersConfig {
     #[getter]
     pub fn prevent_unoptimized(&self) -> Option<bool> {
         self.0.prevent_unoptimized
+    }
+
+    #[getter]
+    pub fn healing_threshold(&self) -> Option<f64> {
+        self.0.healing_threshold
     }
 
     pub fn __repr__(&self) -> String {

--- a/lib/edge/src/config/optimizers.rs
+++ b/lib/edge/src/config/optimizers.rs
@@ -30,6 +30,11 @@ pub struct EdgeOptimizersConfig {
     /// If true, block updates when unoptimized segments exceed indexing threshold.
     #[serde(default)]
     pub prevent_unoptimized: Option<bool>,
+    /// HNSW healing threshold: max ratio of missing points to allow reusing an old HNSW graph
+    /// instead of rebuilding from scratch. Set to `0.0` to disable healing entirely (always
+    /// rebuild), or up to `1.0` to always attempt reuse. Default is `0.3`.
+    #[serde(default)]
+    pub healing_threshold: Option<f64>,
 }
 
 impl EdgeOptimizersConfig {
@@ -43,5 +48,28 @@ impl EdgeOptimizersConfig {
 
     pub fn get_max_segment_size_kb(&self, num_indexing_threads: usize) -> usize {
         get_max_segment_size_kb(self.max_segment_size, num_indexing_threads)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_edge_optimizers_config_serialization() {
+        let config = EdgeOptimizersConfig {
+            healing_threshold: Some(0.5),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"healing_threshold\":0.5"));
+
+        let deserialized: EdgeOptimizersConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.healing_threshold, Some(0.5));
+
+        let empty_json = "{}";
+        let empty_config: EdgeOptimizersConfig = serde_json::from_str(empty_json).unwrap();
+        assert_eq!(empty_config.healing_threshold, None);
     }
 }

--- a/lib/edge/src/optimize.rs
+++ b/lib/edge/src/optimize.rs
@@ -84,12 +84,12 @@ impl EdgeShard {
         let cfg = self.config();
         let segment_optimizer_config = cfg.segment_optimizer_config();
         let global_hnsw_config = cfg.hnsw_config;
-        let hnsw_global_config = HnswGlobalConfig {
-            healing_threshold: cfg
-                .optimizers
-                .healing_threshold
-                .unwrap_or_else(|| HnswGlobalConfig::default().healing_threshold),
-        };
+        let healing_threshold = cfg
+            .optimizers
+            .healing_threshold
+            .filter(|v| v.is_finite() && (0.0..=1.0).contains(v))
+            .unwrap_or_else(|| HnswGlobalConfig::default().healing_threshold);
+        let hnsw_global_config = HnswGlobalConfig { healing_threshold };
         let num_indexing_threads = max_num_indexing_threads(&segment_optimizer_config);
         let threshold_config = cfg.optimizer_thresholds(num_indexing_threads);
         let default_segments_number = cfg.optimizers.get_number_segments();

--- a/lib/edge/src/optimize.rs
+++ b/lib/edge/src/optimize.rs
@@ -84,7 +84,12 @@ impl EdgeShard {
         let cfg = self.config();
         let segment_optimizer_config = cfg.segment_optimizer_config();
         let global_hnsw_config = cfg.hnsw_config;
-        let hnsw_global_config = HnswGlobalConfig::default();
+        let hnsw_global_config = HnswGlobalConfig {
+            healing_threshold: cfg
+                .optimizers
+                .healing_threshold
+                .unwrap_or_else(|| HnswGlobalConfig::default().healing_threshold),
+        };
         let num_indexing_threads = max_num_indexing_threads(&segment_optimizer_config);
         let threshold_config = cfg.optimizer_thresholds(num_indexing_threads);
         let default_segments_number = cfg.optimizers.get_number_segments();


### PR DESCRIPTION
### Summary

Exposes the HNSW healing threshold (`healing_threshold`) in the qdrant-edge crate — the last remaining HNSW parameter that was not configurable from `EdgeConfig`.

### Motivation

Previously, `build_blocking_optimizers` hardcoded `HnswGlobalConfig::default()` (0.3). This controls whether old HNSW
graph layers are reused or rebuilt during `shard.optimize()`. On constrained edge devices (mobile/IoT), the healing process can be unexpectedly CPU and memory intensive.

With this change, users can tune the behavior:
- `0.0` — disable healing entirely; always rebuild clean graphs (predictable memory, higher CPU)
- `1.0` — always attempt reuse (lower CPU, potential graph fragmentation)
- `0.3` — Default when unset: (preserves existing behavior)

### Changes

- `lib/edge/src/config/optimizers.rs` — added  `healing_threshold: Option<f64>` to `EdgeOptimizersConfig`
- `lib/edge/src/optimize.rs` — replaced `HnswGlobalConfig::default()`  with config-driven construction, falling back to `0.3` via
  `unwrap_or_else`
 - `lib/edge/python/src/config/optimizers.rs` — updated `PyEdgeOptimizersConfig` constructor and getter

### Testing

- New `test_edge_optimizers_config_serialization` verifies:
  - JSON round-trip for `Some(0.5)`
  - Missing field deserializes to `None` (legacy configs safe)
- All 14 existing edge optimization tests pass

### I confirm that

- [x] Targets `dev` branch
- [x] `cargo +nightly fmt --all` passes
- [x] Existing tests pass
- [x] No breaking changes (new `Option` field, default when absent)