### PR TITLE
Recreate workers/optimizers async to not block consensus

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -314,8 +314,8 @@ impl Collection {
     /// (see `LocalShard::on_optimizer_config_update`).
     pub fn recreate_optimizers_background(&self) {
         // Single-flight: only spawn a task if none is running. Otherwise the request is coalesced
-        // into a pending re-run handled by the task that is already running.
-        if !self.recreate_optimizers_state.lock().request() {
+        // into a queued re-run handled by the task that is already running.
+        if !self.recreate_optimizers_state.request() {
             return;
         }
 
@@ -337,11 +337,11 @@ impl Collection {
                     ),
                 }
 
-                // Run again if a request arrived while we were running, otherwise stop. The check
-                // and the `running` reset happen under one lock (in `finish_run`), so a request
-                // arriving exactly now is never lost: it either sees `running` still set (and sets
-                // `pending`, handled by the next iteration) or sees it cleared (and spawns afresh).
-                if !recreate_state.lock().finish_run() {
+                // Run again if a request arrived while we were running, otherwise stop. The
+                // decision is a single atomic compare-and-swap (in `finish_run`), so a request
+                // arriving exactly now is never lost: it either still sees us running (and queues a
+                // re-run, handled by the next iteration) or sees us idle (and spawns a fresh task).
+                if !recreate_state.finish_run() {
                     break;
                 }
             }

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -31,8 +31,8 @@ impl Collection {
     /// Updates collection params:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_params_from_diff(
         &self,
         params_diff: CollectionParamsDiff,
@@ -48,8 +48,8 @@ impl Collection {
     /// Updates HNSW config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_hnsw_config_from_diff(
         &self,
         hnsw_config_diff: HnswConfigDiff,
@@ -65,8 +65,8 @@ impl Collection {
     /// Updates vectors config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_vectors_from_diff(
         &self,
         update_vectors_diff: &VectorsConfigDiff,
@@ -83,8 +83,8 @@ impl Collection {
     /// Updates sparse vectors config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_sparse_vectors_from_other(
         &self,
         update_vectors_diff: &SparseVectorsConfig,
@@ -101,8 +101,8 @@ impl Collection {
     /// Updates shard optimization params:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_optimizer_params_from_diff(
         &self,
         optimizer_config_diff: OptimizersConfigDiff,
@@ -118,8 +118,8 @@ impl Collection {
     /// Updates quantization config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` must be called to create new optimizers using
-    /// the updated configuration.
+    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
+    /// called to create new optimizers using the updated configuration.
     pub async fn update_quantization_config_from_diff(
         &self,
         quantization_config_diff: QuantizationConfigDiff,

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -16,6 +16,7 @@ use crate::operations::types::*;
 use crate::shards::replica_set::Change;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::PeerId;
+use crate::shards::shard_holder::SharedShardHolder;
 
 /// Old logic for aborting shard transfers on shard drop, had a bug: it dropped all transfers
 /// regardless of the shard id. In order to keep consensus consistent, we can only
@@ -302,19 +303,53 @@ impl Collection {
     /// Partially blocking. Stopping existing optimizers is blocking. Starting new optimizers is
     /// not blocking.
     ///
+    /// Stopping existing optimizers waits for in-flight optimizations to finish, which can take a
+    /// long time. On any path that goes through consensus, prefer
+    /// [`Collection::recreate_optimizers_background`] instead, which never blocks the caller.
+    ///
     /// ## Cancel safety
     ///
     /// This function is cancel safe, and will always run to completion.
     pub async fn recreate_optimizers_blocking(&self) -> CollectionResult<()> {
+        tokio::task::spawn(Self::recreate_optimizers(self.shards_holder.clone())).await??;
+        Ok(())
+    }
+
+    /// Recreate the optimizers on all shards for this collection, in the background.
+    ///
+    /// Like [`Collection::recreate_optimizers_blocking`], but returns immediately and performs all
+    /// the work - stopping the existing workers and starting new ones - in a detached task.
+    ///
+    /// Stopping the existing workers waits for in-flight optimizations to finish, which can take a
+    /// long time. This variant must be used on any path that goes through consensus, where blocking
+    /// the caller stalls the whole consensus loop and can take down a cluster.
+    ///
+    /// Any error is logged rather than returned: the configuration change that triggers the
+    /// recreation has already been applied and persisted by the time we get here, so there is no
+    /// caller left to propagate it to.
+    pub fn recreate_optimizers_background(&self) {
         let shards_holder = self.shards_holder.clone();
+        let collection_id = self.id.clone();
         tokio::task::spawn(async move {
-            let shard_holder = shards_holder.read().await;
-            let updates = shard_holder
-                .all_shards()
-                .map(|replica_set| replica_set.on_optimizer_config_update());
-            future::try_join_all(updates).await
-        })
-        .await??;
+            if let Err(err) = Self::recreate_optimizers(shards_holder).await {
+                log::error!(
+                    "Failed to recreate optimizers for collection {collection_id} in background: {err}",
+                );
+            }
+        });
+    }
+
+    /// Stop the existing optimizers on all shards and start new ones using the current config.
+    ///
+    /// Shared implementation for [`Collection::recreate_optimizers_blocking`] and
+    /// [`Collection::recreate_optimizers_background`]. Takes an owned [`SharedShardHolder`] so the
+    /// returned future is `'static` and can be spawned as a detached task.
+    async fn recreate_optimizers(shards_holder: SharedShardHolder) -> CollectionResult<()> {
+        let shard_holder = shards_holder.read().await;
+        let updates = shard_holder
+            .all_shards()
+            .map(|replica_set| replica_set.on_optimizer_config_update());
+        future::try_join_all(updates).await?;
         Ok(())
     }
 

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -31,8 +31,8 @@ impl Collection {
     /// Updates collection params:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_params_from_diff(
         &self,
         params_diff: CollectionParamsDiff,
@@ -48,8 +48,8 @@ impl Collection {
     /// Updates HNSW config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_hnsw_config_from_diff(
         &self,
         hnsw_config_diff: HnswConfigDiff,
@@ -65,8 +65,8 @@ impl Collection {
     /// Updates vectors config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_vectors_from_diff(
         &self,
         update_vectors_diff: &VectorsConfigDiff,
@@ -83,8 +83,8 @@ impl Collection {
     /// Updates sparse vectors config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_sparse_vectors_from_other(
         &self,
         update_vectors_diff: &SparseVectorsConfig,
@@ -101,8 +101,8 @@ impl Collection {
     /// Updates shard optimization params:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_optimizer_params_from_diff(
         &self,
         optimizer_config_diff: OptimizersConfigDiff,
@@ -118,8 +118,8 @@ impl Collection {
     /// Updates quantization config:
     /// Saves new params on disk
     ///
-    /// After this, `recreate_optimizers_blocking` or `recreate_optimizers_background` must be
-    /// called to create new optimizers using the updated configuration.
+    /// After this, `recreate_optimizers_background` must be called to create new optimizers using
+    /// the updated configuration.
     pub async fn update_quantization_config_from_diff(
         &self,
         quantization_config_diff: QuantizationConfigDiff,
@@ -294,56 +294,64 @@ impl Collection {
         Ok(())
     }
 
-    /// Recreate the optimizers on all shards for this collection
-    ///
-    /// This will stop existing optimizers, and start new ones with new configurations.
-    ///
-    /// # Blocking
-    ///
-    /// Partially blocking. Stopping existing optimizers is blocking. Starting new optimizers is
-    /// not blocking.
-    ///
-    /// Stopping existing optimizers waits for in-flight optimizations to finish, which can take a
-    /// long time. On any path that goes through consensus, prefer
-    /// [`Collection::recreate_optimizers_background`] instead, which never blocks the caller.
-    ///
-    /// ## Cancel safety
-    ///
-    /// This function is cancel safe, and will always run to completion.
-    pub async fn recreate_optimizers_blocking(&self) -> CollectionResult<()> {
-        tokio::task::spawn(Self::recreate_optimizers(self.shards_holder.clone())).await??;
-        Ok(())
-    }
-
     /// Recreate the optimizers on all shards for this collection, in the background.
     ///
-    /// Like [`Collection::recreate_optimizers_blocking`], but returns immediately and performs all
-    /// the work - stopping the existing workers and starting new ones - in a detached task.
+    /// Returns immediately and performs all the work - stopping the existing workers and starting
+    /// new ones - in a detached task. Stopping the existing workers waits for in-flight
+    /// optimizations to finish, which can take a long time. This is why it runs in the background:
+    /// it is reached from paths that go through consensus, where blocking the caller stalls the
+    /// whole consensus loop and can take down a cluster.
     ///
-    /// Stopping the existing workers waits for in-flight optimizations to finish, which can take a
-    /// long time. This variant must be used on any path that goes through consensus, where blocking
-    /// the caller stalls the whole consensus loop and can take down a cluster.
+    /// At most one recreation runs at a time. If one is already running, this records that another
+    /// run is needed and returns; the running task then runs once more when it finishes, picking up
+    /// the latest config. Any number of requests that arrive while a task is running collapse into a
+    /// single additional run (recreation always rebuilds from the current config, so coalescing is
+    /// safe - the last run reflects the latest state).
     ///
-    /// Any error is logged rather than returned: the configuration change that triggers the
+    /// Errors are logged rather than returned: the configuration change that triggers the
     /// recreation has already been applied and persisted by the time we get here, so there is no
-    /// caller left to propagate it to.
+    /// caller left to propagate them to. Failures are also surfaced as optimizer errors per shard
+    /// (see `LocalShard::on_optimizer_config_update`).
     pub fn recreate_optimizers_background(&self) {
+        // Single-flight: only spawn a task if none is running. Otherwise the request is coalesced
+        // into a pending re-run handled by the task that is already running.
+        if !self.recreate_optimizers_state.lock().request() {
+            return;
+        }
+
         let shards_holder = self.shards_holder.clone();
         let collection_id = self.id.clone();
+        let recreate_state = self.recreate_optimizers_state.clone();
         tokio::task::spawn(async move {
-            if let Err(err) = Self::recreate_optimizers(shards_holder).await {
-                log::error!(
-                    "Failed to recreate optimizers for collection {collection_id} in background: {err}",
-                );
+            loop {
+                // Run the recreation as a child task, so a panic is contained (surfaced as a
+                // `JoinError`) and never unwinds the coordinator loop below - which would otherwise
+                // leave `running` stuck and wedge all future recreations.
+                match tokio::task::spawn(Self::recreate_optimizers(shards_holder.clone())).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => log::error!(
+                        "Failed to recreate optimizers for collection {collection_id} in background: {err}",
+                    ),
+                    Err(err) => log::error!(
+                        "Optimizer recreation task for collection {collection_id} failed: {err}",
+                    ),
+                }
+
+                // Run again if a request arrived while we were running, otherwise stop. The check
+                // and the `running` reset happen under one lock (in `finish_run`), so a request
+                // arriving exactly now is never lost: it either sees `running` still set (and sets
+                // `pending`, handled by the next iteration) or sees it cleared (and spawns afresh).
+                if !recreate_state.lock().finish_run() {
+                    break;
+                }
             }
         });
     }
 
     /// Stop the existing optimizers on all shards and start new ones using the current config.
     ///
-    /// Shared implementation for [`Collection::recreate_optimizers_blocking`] and
-    /// [`Collection::recreate_optimizers_background`]. Takes an owned [`SharedShardHolder`] so the
-    /// returned future is `'static` and can be spawned as a detached task.
+    /// Implementation behind [`Collection::recreate_optimizers_background`]. Takes an owned
+    /// [`SharedShardHolder`] so the returned future is `'static` and can be spawned as a task.
     async fn recreate_optimizers(shards_holder: SharedShardHolder) -> CollectionResult<()> {
         let shard_holder = shards_holder.read().await;
         let updates = shard_holder

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -62,6 +62,108 @@ use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{CollectionId, replica_set};
 use crate::telemetry::CollectionsAggregatedTelemetry;
 
+/// Coordinates background optimizer recreation so at most one recreation runs at a time.
+///
+/// See [`Collection::recreate_optimizers_background`].
+#[derive(Default)]
+struct RecreateOptimizersState {
+    /// A background recreation task is currently running.
+    running: bool,
+    /// A recreation was requested while a task was already running. When the running task
+    /// finishes it runs once more, to converge to the latest configuration.
+    pending: bool,
+}
+
+impl RecreateOptimizersState {
+    /// Register a recreation request.
+    ///
+    /// Returns `true` if the caller must spawn a new recreation task, or `false` if a task is
+    /// already running - in which case the request is coalesced into a single pending re-run.
+    fn request(&mut self) -> bool {
+        if self.running {
+            self.pending = true;
+            false
+        } else {
+            self.running = true;
+            true
+        }
+    }
+
+    /// Record that the running task finished one recreation.
+    ///
+    /// Returns `true` if it must run again (a request arrived while it was running), or `false` if
+    /// it should stop. When it stops, `running` is cleared so the next request spawns a new task.
+    fn finish_run(&mut self) -> bool {
+        if self.pending {
+            self.pending = false;
+            true
+        } else {
+            self.running = false;
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod recreate_optimizers_state_tests {
+    use super::RecreateOptimizersState;
+
+    #[test]
+    fn first_request_spawns() {
+        let mut state = RecreateOptimizersState::default();
+        assert!(state.request(), "first request must spawn a task");
+        assert!(state.running);
+        assert!(!state.pending);
+    }
+
+    #[test]
+    fn request_while_running_is_coalesced() {
+        let mut state = RecreateOptimizersState::default();
+        assert!(state.request());
+
+        // Several requests arrive while the task runs: none spawns, all collapse into one re-run.
+        assert!(!state.request());
+        assert!(!state.request());
+        assert!(state.running);
+        assert!(state.pending);
+    }
+
+    #[test]
+    fn finish_without_pending_stops() {
+        let mut state = RecreateOptimizersState::default();
+        state.request();
+
+        assert!(!state.finish_run(), "no pending request, so it must stop");
+        assert!(!state.running);
+        assert!(!state.pending);
+    }
+
+    #[test]
+    fn finish_with_pending_runs_once_more_then_stops() {
+        let mut state = RecreateOptimizersState::default();
+        state.request();
+        state.request(); // coalesced -> pending
+
+        assert!(state.finish_run(), "pending request, so it must run again");
+        assert!(state.running, "still considered running across the re-run");
+        assert!(!state.pending, "pending consumed by the re-run");
+
+        // No further requests during the re-run: now it stops.
+        assert!(!state.finish_run());
+        assert!(!state.running);
+    }
+
+    #[test]
+    fn request_after_stop_spawns_again() {
+        let mut state = RecreateOptimizersState::default();
+        state.request();
+        state.finish_run(); // stops
+
+        assert!(state.request(), "a request after stopping must spawn a new task");
+        assert!(state.running);
+    }
+}
+
 /// Collection's data is split into several shards.
 pub struct Collection {
     pub(crate) id: CollectionId,
@@ -91,6 +193,9 @@ pub struct Collection {
     collection_stats_cache: CollectionSizeStatsCache,
     // Background tasks to clean shards
     shard_clean_tasks: ShardCleanTasks,
+    // Coordinates background optimizer recreation: at most one runs at a time, and requests that
+    // arrive while one is running are coalesced into a single re-run.
+    recreate_optimizers_state: Arc<parking_lot::Mutex<RecreateOptimizersState>>,
 }
 
 pub type RequestShardTransfer = Arc<dyn Fn(ShardTransfer) + Send + Sync>;
@@ -200,6 +305,7 @@ impl Collection {
             optimizer_resource_budget,
             collection_stats_cache,
             shard_clean_tasks: Default::default(),
+            recreate_optimizers_state: Default::default(),
         })
     }
 
@@ -319,6 +425,7 @@ impl Collection {
             optimizer_resource_budget,
             collection_stats_cache,
             shard_clean_tasks: Default::default(),
+            recreate_optimizers_state: Default::default(),
         }
     }
 

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use clean::ShardCleanTasks;
@@ -64,43 +65,58 @@ use crate::telemetry::CollectionsAggregatedTelemetry;
 
 /// Coordinates background optimizer recreation so at most one recreation runs at a time.
 ///
+/// This tracks two things - "a task is running" and "another run is queued" - packed into a single
+/// atomic. They cannot be two independent atomics: deciding to stop (in [`Self::finish_run`]) and
+/// deciding to coalesce (in [`Self::request`]) each read *and* write a combination of the two, so
+/// the transition must be one atomic compare-and-swap. With separate atomics a request could be
+/// lost - a task stops while a concurrent request believes it coalesced into it.
+///
 /// See [`Collection::recreate_optimizers_background`].
 #[derive(Default)]
 struct RecreateOptimizersState {
-    /// A background recreation task is currently running.
-    running: bool,
-    /// A recreation was requested while a task was already running. When the running task
-    /// finishes it runs once more, to converge to the latest configuration.
-    pending: bool,
+    state: AtomicU8,
 }
+
+/// No recreation task is running.
+const RECREATE_IDLE: u8 = 0;
+/// A recreation task is running; no further run is queued.
+const RECREATE_RUNNING: u8 = 1;
+/// A recreation task is running and another run is queued for when it finishes.
+const RECREATE_RUNNING_PENDING: u8 = 2;
 
 impl RecreateOptimizersState {
     /// Register a recreation request.
     ///
     /// Returns `true` if the caller must spawn a new recreation task, or `false` if a task is
-    /// already running - in which case the request is coalesced into a single pending re-run.
-    fn request(&mut self) -> bool {
-        if self.running {
-            self.pending = true;
-            false
-        } else {
-            self.running = true;
-            true
-        }
+    /// already running - in which case the request is coalesced into a single queued re-run.
+    fn request(&self) -> bool {
+        let prev =
+            self.state
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                    RECREATE_IDLE => Some(RECREATE_RUNNING),
+                    RECREATE_RUNNING => Some(RECREATE_RUNNING_PENDING),
+                    // Already queued, nothing to change.
+                    _ => None,
+                });
+        // We must spawn exactly when we moved the state out of idle.
+        prev == Ok(RECREATE_IDLE)
     }
 
     /// Record that the running task finished one recreation.
     ///
     /// Returns `true` if it must run again (a request arrived while it was running), or `false` if
-    /// it should stop. When it stops, `running` is cleared so the next request spawns a new task.
-    fn finish_run(&mut self) -> bool {
-        if self.pending {
-            self.pending = false;
-            true
-        } else {
-            self.running = false;
-            false
-        }
+    /// it should stop. When it stops, the state returns to idle so the next request spawns anew.
+    fn finish_run(&self) -> bool {
+        let prev =
+            self.state
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                    RECREATE_RUNNING_PENDING => Some(RECREATE_RUNNING),
+                    RECREATE_RUNNING => Some(RECREATE_IDLE),
+                    // Idle would mean finish_run was called without a running task.
+                    _ => None,
+                });
+        // We run again exactly when we consumed a queued re-run.
+        prev == Ok(RECREATE_RUNNING_PENDING)
     }
 }
 
@@ -110,57 +126,38 @@ mod recreate_optimizers_state_tests {
 
     #[test]
     fn first_request_spawns() {
-        let mut state = RecreateOptimizersState::default();
+        let state = RecreateOptimizersState::default();
         assert!(state.request(), "first request must spawn a task");
-        assert!(state.running);
-        assert!(!state.pending);
     }
 
     #[test]
-    fn request_while_running_is_coalesced() {
-        let mut state = RecreateOptimizersState::default();
+    fn requests_while_running_are_coalesced() {
+        let state = RecreateOptimizersState::default();
         assert!(state.request());
 
         // Several requests arrive while the task runs: none spawns, all collapse into one re-run.
         assert!(!state.request());
         assert!(!state.request());
-        assert!(state.running);
-        assert!(state.pending);
     }
 
     #[test]
-    fn finish_without_pending_stops() {
-        let mut state = RecreateOptimizersState::default();
+    fn finish_without_pending_stops_then_next_request_spawns() {
+        let state = RecreateOptimizersState::default();
         state.request();
 
-        assert!(!state.finish_run(), "no pending request, so it must stop");
-        assert!(!state.running);
-        assert!(!state.pending);
+        assert!(!state.finish_run(), "no queued request, so it must stop");
+        // Back to idle: a fresh request spawns a new task again.
+        assert!(state.request(), "a request after stopping must spawn a new task");
     }
 
     #[test]
     fn finish_with_pending_runs_once_more_then_stops() {
-        let mut state = RecreateOptimizersState::default();
+        let state = RecreateOptimizersState::default();
         state.request();
-        state.request(); // coalesced -> pending
+        state.request(); // coalesced -> queued re-run
 
-        assert!(state.finish_run(), "pending request, so it must run again");
-        assert!(state.running, "still considered running across the re-run");
-        assert!(!state.pending, "pending consumed by the re-run");
-
-        // No further requests during the re-run: now it stops.
-        assert!(!state.finish_run());
-        assert!(!state.running);
-    }
-
-    #[test]
-    fn request_after_stop_spawns_again() {
-        let mut state = RecreateOptimizersState::default();
-        state.request();
-        state.finish_run(); // stops
-
-        assert!(state.request(), "a request after stopping must spawn a new task");
-        assert!(state.running);
+        assert!(state.finish_run(), "queued request, so it must run again");
+        assert!(!state.finish_run(), "no further requests, so it stops");
     }
 }
 
@@ -195,7 +192,7 @@ pub struct Collection {
     shard_clean_tasks: ShardCleanTasks,
     // Coordinates background optimizer recreation: at most one runs at a time, and requests that
     // arrive while one is running are coalesced into a single re-run.
-    recreate_optimizers_state: Arc<parking_lot::Mutex<RecreateOptimizersState>>,
+    recreate_optimizers_state: Arc<RecreateOptimizersState>,
 }
 
 pub type RequestShardTransfer = Arc<dyn Fn(ShardTransfer) + Send + Sync>;

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -63,104 +63,6 @@ use crate::shards::transfer::{ShardTransfer, ShardTransferMethod};
 use crate::shards::{CollectionId, replica_set};
 use crate::telemetry::CollectionsAggregatedTelemetry;
 
-/// Coordinates background optimizer recreation so at most one recreation runs at a time.
-///
-/// This tracks two things - "a task is running" and "another run is queued" - packed into a single
-/// atomic. They cannot be two independent atomics: deciding to stop (in [`Self::finish_run`]) and
-/// deciding to coalesce (in [`Self::request`]) each read *and* write a combination of the two, so
-/// the transition must be one atomic compare-and-swap. With separate atomics a request could be
-/// lost - a task stops while a concurrent request believes it coalesced into it.
-///
-/// See [`Collection::recreate_optimizers_background`].
-#[derive(Default)]
-struct RecreateOptimizersState {
-    state: AtomicU8,
-}
-
-/// No recreation task is running.
-const RECREATE_IDLE: u8 = 0;
-/// A recreation task is running; no further run is queued.
-const RECREATE_RUNNING: u8 = 1;
-/// A recreation task is running and another run is queued for when it finishes.
-const RECREATE_RUNNING_PENDING: u8 = 2;
-
-impl RecreateOptimizersState {
-    /// Register a recreation request.
-    ///
-    /// Returns `true` if the caller must spawn a new recreation task, or `false` if a task is
-    /// already running - in which case the request is coalesced into a single queued re-run.
-    fn request(&self) -> bool {
-        let prev =
-            self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
-                    RECREATE_IDLE => Some(RECREATE_RUNNING),
-                    RECREATE_RUNNING => Some(RECREATE_RUNNING_PENDING),
-                    // Already queued, nothing to change.
-                    _ => None,
-                });
-        // We must spawn exactly when we moved the state out of idle.
-        prev == Ok(RECREATE_IDLE)
-    }
-
-    /// Record that the running task finished one recreation.
-    ///
-    /// Returns `true` if it must run again (a request arrived while it was running), or `false` if
-    /// it should stop. When it stops, the state returns to idle so the next request spawns anew.
-    fn finish_run(&self) -> bool {
-        let prev =
-            self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
-                    RECREATE_RUNNING_PENDING => Some(RECREATE_RUNNING),
-                    RECREATE_RUNNING => Some(RECREATE_IDLE),
-                    // Idle would mean finish_run was called without a running task.
-                    _ => None,
-                });
-        // We run again exactly when we consumed a queued re-run.
-        prev == Ok(RECREATE_RUNNING_PENDING)
-    }
-}
-
-#[cfg(test)]
-mod recreate_optimizers_state_tests {
-    use super::RecreateOptimizersState;
-
-    #[test]
-    fn first_request_spawns() {
-        let state = RecreateOptimizersState::default();
-        assert!(state.request(), "first request must spawn a task");
-    }
-
-    #[test]
-    fn requests_while_running_are_coalesced() {
-        let state = RecreateOptimizersState::default();
-        assert!(state.request());
-
-        // Several requests arrive while the task runs: none spawns, all collapse into one re-run.
-        assert!(!state.request());
-        assert!(!state.request());
-    }
-
-    #[test]
-    fn finish_without_pending_stops_then_next_request_spawns() {
-        let state = RecreateOptimizersState::default();
-        state.request();
-
-        assert!(!state.finish_run(), "no queued request, so it must stop");
-        // Back to idle: a fresh request spawns a new task again.
-        assert!(state.request(), "a request after stopping must spawn a new task");
-    }
-
-    #[test]
-    fn finish_with_pending_runs_once_more_then_stops() {
-        let state = RecreateOptimizersState::default();
-        state.request();
-        state.request(); // coalesced -> queued re-run
-
-        assert!(state.finish_run(), "queued request, so it must run again");
-        assert!(!state.finish_run(), "no further requests, so it stops");
-    }
-}
-
 /// Collection's data is split into several shards.
 pub struct Collection {
     pub(crate) id: CollectionId,
@@ -1069,5 +971,103 @@ struct CollectionVersion;
 impl StorageVersion for CollectionVersion {
     fn current_raw() -> &'static str {
         env!("CARGO_PKG_VERSION")
+    }
+}
+
+/// Coordinates background optimizer recreation so at most one recreation runs at a time.
+///
+/// This tracks two things - "a task is running" and "another run is queued" - packed into a single
+/// atomic. They cannot be two independent atomics: deciding to stop (in [`Self::finish_run`]) and
+/// deciding to coalesce (in [`Self::request`]) each read *and* write a combination of the two, so
+/// the transition must be one atomic compare-and-swap. With separate atomics a request could be
+/// lost - a task stops while a concurrent request believes it coalesced into it.
+///
+/// See [`Collection::recreate_optimizers_background`].
+#[derive(Default)]
+struct RecreateOptimizersState {
+    state: AtomicU8,
+}
+
+/// No recreation task is running.
+const RECREATE_IDLE: u8 = 0;
+/// A recreation task is running; no further run is queued.
+const RECREATE_RUNNING: u8 = 1;
+/// A recreation task is running and another run is queued for when it finishes.
+const RECREATE_RUNNING_PENDING: u8 = 2;
+
+impl RecreateOptimizersState {
+    /// Register a recreation request.
+    ///
+    /// Returns `true` if the caller must spawn a new recreation task, or `false` if a task is
+    /// already running - in which case the request is coalesced into a single queued re-run.
+    fn request(&self) -> bool {
+        let prev =
+            self.state
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                    RECREATE_IDLE => Some(RECREATE_RUNNING),
+                    RECREATE_RUNNING => Some(RECREATE_RUNNING_PENDING),
+                    // Already queued, nothing to change.
+                    _ => None,
+                });
+        // We must spawn exactly when we moved the state out of idle.
+        prev == Ok(RECREATE_IDLE)
+    }
+
+    /// Record that the running task finished one recreation.
+    ///
+    /// Returns `true` if it must run again (a request arrived while it was running), or `false` if
+    /// it should stop. When it stops, the state returns to idle so the next request spawns anew.
+    fn finish_run(&self) -> bool {
+        let prev =
+            self.state
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                    RECREATE_RUNNING_PENDING => Some(RECREATE_RUNNING),
+                    RECREATE_RUNNING => Some(RECREATE_IDLE),
+                    // Idle would mean finish_run was called without a running task.
+                    _ => None,
+                });
+        // We run again exactly when we consumed a queued re-run.
+        prev == Ok(RECREATE_RUNNING_PENDING)
+    }
+}
+
+#[cfg(test)]
+mod recreate_optimizers_state_tests {
+    use super::RecreateOptimizersState;
+
+    #[test]
+    fn first_request_spawns() {
+        let state = RecreateOptimizersState::default();
+        assert!(state.request(), "first request must spawn a task");
+    }
+
+    #[test]
+    fn requests_while_running_are_coalesced() {
+        let state = RecreateOptimizersState::default();
+        assert!(state.request());
+
+        // Several requests arrive while the task runs: none spawns, all collapse into one re-run.
+        assert!(!state.request());
+        assert!(!state.request());
+    }
+
+    #[test]
+    fn finish_without_pending_stops_then_next_request_spawns() {
+        let state = RecreateOptimizersState::default();
+        state.request();
+
+        assert!(!state.finish_run(), "no queued request, so it must stop");
+        // Back to idle: a fresh request spawns a new task again.
+        assert!(state.request(), "a request after stopping must spawn a new task");
+    }
+
+    #[test]
+    fn finish_with_pending_runs_once_more_then_stops() {
+        let state = RecreateOptimizersState::default();
+        state.request();
+        state.request(); // coalesced -> queued re-run
+
+        assert!(state.finish_run(), "queued request, so it must run again");
+        assert!(!state.finish_run(), "no further requests, so it stops");
     }
 }

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1058,7 +1058,10 @@ mod recreate_optimizers_state_tests {
 
         assert!(!state.finish_run(), "no queued request, so it must stop");
         // Back to idle: a fresh request spawns a new task again.
-        assert!(state.request(), "a request after stopping must spawn a new task");
+        assert!(
+            state.request(),
+            "a request after stopping must spawn a new task"
+        );
     }
 
     #[test]

--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -193,8 +193,11 @@ impl Collection {
 
         self.print_warnings().await;
 
+        // Recreate optimizers in the background: this path is reached from consensus (Raft snapshot
+        // application), and stopping the existing optimizers can take a long time, which would
+        // otherwise stall the consensus loop.
         if recreate_optimizers {
-            self.recreate_optimizers_blocking().await?;
+            self.recreate_optimizers_background();
         }
 
         Ok(())

--- a/lib/collection/src/collection/vector_name_schema.rs
+++ b/lib/collection/src/collection/vector_name_schema.rs
@@ -40,7 +40,11 @@ impl Collection {
         // Refresh shard optimizers so the cached `SegmentOptimizerConfig` picks up the
         // new vector schema. Otherwise optimization-built destination segments use the
         // stale dim and panic on dim mismatch when copying from sources with the new dim.
-        self.recreate_optimizers_blocking().await?;
+        //
+        // Done in the background: this path is reached from consensus, where blocking can stall the
+        // whole cluster. The refresh itself is unchanged - it already ran on a spawned task either
+        // way - so this does not widen the window in which the stale config is in effect.
+        self.recreate_optimizers_background();
 
         Ok(())
     }
@@ -67,7 +71,10 @@ impl Collection {
         // Refresh shard optimizers so the cached `SegmentOptimizerConfig` drops the
         // removed vector. Without this, optimization keeps allocating storage for it
         // using the old config.
-        self.recreate_optimizers_blocking().await?;
+        //
+        // Done in the background: this path is reached from consensus, where blocking can stall the
+        // whole cluster.
+        self.recreate_optimizers_background();
 
         Ok(())
     }

--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -33,10 +33,28 @@ impl LocalShard {
     /// Handles updates to the optimizer configuration by rebuilding optimizers
     /// and restarting the update handler's workers with the new configuration.
     ///
+    /// On failure, the error is recorded as an optimizer error on this shard, so it is exposed in
+    /// the collection's optimizer status. This matters especially for background recreation, where
+    /// the error would otherwise only be logged with no caller left to propagate it to.
+    ///
     /// ## Cancel safety
     ///
     /// This function is **not** cancel safe.
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
+        let result = self.on_optimizer_config_update_impl().await;
+
+        // Surface a failed recreation as an optimizer error, so it shows up in the optimizer status
+        // instead of being silently lost on the background recreation path.
+        if let Err(err) = &result {
+            self.segments
+                .write()
+                .report_optimizer_error(format!("Failed to recreate optimizers: {err}"));
+        }
+
+        result
+    }
+
+    async fn on_optimizer_config_update_impl(&self) -> CollectionResult<()> {
         let mut update_handler = self.update_handler.lock().await;
 
         // Signal all workers to stop

--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -37,14 +37,17 @@ impl LocalShard {
     ///
     /// This function is **not** cancel safe.
     pub async fn on_optimizer_config_update(&self) -> CollectionResult<()> {
-        let config = self.collection_config.read().await;
         let mut update_handler = self.update_handler.lock().await;
 
         // Signal all workers to stop
         update_handler.stop_flush_worker();
         update_handler.stop_update_worker();
 
-        // Wait for workers to finish and get pending operations from the old channel
+        // Wait for workers to finish and get pending operations from the old channel.
+        //
+        // This can take a long time, because in-flight optimizations are awaited before they stop.
+        // We deliberately do not hold the `collection_config` read lock across this wait, so a
+        // concurrent collection config update is not blocked on acquiring the config write lock.
         let update_receiver = update_handler.wait_workers_stops().await?;
 
         let update_receiver = match update_receiver {
@@ -65,6 +68,11 @@ impl LocalShard {
             }
         };
 
+        // Read the latest config now that the workers have stopped, and build new optimizers from
+        // it. Reading it here (rather than before the wait) also ensures we pick up the most recent
+        // config if it changed again while we were waiting.
+        let config = self.collection_config.read().await;
+
         let new_optimizers = build_optimizers(
             &self.path,
             &config.params,
@@ -81,6 +89,9 @@ impl LocalShard {
             .optimizer_config
             .prevent_unoptimized
             .unwrap_or_default();
+
+        drop(config);
+
         update_handler.run_workers(update_receiver);
 
         self.optimizers.store(new_optimizers);

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -202,8 +202,12 @@ impl TableOfContent {
         collection.print_warnings().await;
 
         // Recreate optimizers
+        //
+        // This runs in the background and does not block: this path is reached from consensus, and
+        // stopping the existing optimizers can take a long time (in-flight optimizations are
+        // awaited), which would otherwise stall the consensus loop and can take down a cluster.
         if recreate_optimizers {
-            collection.recreate_optimizers_blocking().await?;
+            collection.recreate_optimizers_background();
         }
         Ok(true)
     }

--- a/tests/consensus_tests/test_collection_update_not_blocked_by_busy_worker.py
+++ b/tests/consensus_tests/test_collection_update_not_blocked_by_busy_worker.py
@@ -1,0 +1,130 @@
+"""
+Test that a collection update applied through consensus is not blocked by a busy
+update worker.
+
+A collection config update (PATCH /collections/{name}) triggers recreation of the
+shard optimizers. Recreating optimizers stops the update worker, which first has to
+finish whatever operation it is currently running. If that recreation runs
+*synchronously* on the consensus apply thread, a long-running update operation stalls
+the whole consensus loop and the collection update hangs - which can take down a
+cluster. The recreation must instead happen in the background, so the update returns
+right away.
+
+Repro:
+  1. Keep the shard's update worker busy for a long time with a staging `delay`
+     operation.
+  2. Send a collection config update through consensus.
+  3. The update must return promptly, not wait for the delay to finish.
+
+Requires the `staging` feature (for the `delay` debug operation); skipped otherwise.
+
+Usage:
+    pytest tests/consensus_tests/test_collection_update_not_blocked_by_busy_worker.py -s -v
+"""
+
+import os
+import pathlib
+import time
+
+import requests
+
+os.environ.setdefault(
+    "PYTEST_CURRENT_TEST", "test_collection_update_not_blocked_by_busy_worker"
+)
+
+from .utils import (
+    assert_http_ok,
+    assert_project_root,
+    check_collection_green,
+    skip_if_no_feature,
+    start_cluster,
+    wait_for,
+)
+
+COLLECTION = "update_not_blocked"
+DIM = 4
+
+# How long the update worker is kept busy by the staging delay operation.
+DELAY_SEC = 20.0
+# Time to let the worker actually pick up and start processing the delay before we send
+# the collection update. The worker only blocks on an operation it has already started;
+# a queued-but-not-yet-started delay would simply be dropped when the worker stops, so
+# we must make sure it is genuinely in-flight to exercise the blocking path.
+WORKER_BUSY_WAIT_SEC = 4.0
+# Generous client-side timeout: with the fix the PATCH returns near-instantly, without
+# it the request blocks for ~(DELAY_SEC - WORKER_BUSY_WAIT_SEC) (or errors out earlier).
+PATCH_CLIENT_TIMEOUT_SEC = 30.0
+# The collection update must return well before the delay would finish. With the fix it
+# is sub-second; without it, it is ~16s. 10s cleanly separates the two.
+MAX_PATCH_SEC = 10.0
+
+
+def create_collection(peer_uri: str):
+    r = requests.put(
+        f"{peer_uri}/collections/{COLLECTION}",
+        json={
+            "vectors": {"size": DIM, "distance": "Cosine"},
+            "shard_number": 1,
+            "replication_factor": 1,
+        },
+    )
+    assert_http_ok(r)
+
+
+def submit_delay(peer_uri: str, duration_sec: float):
+    """Submit a staging delay operation to keep the shard's update worker busy.
+
+    Sent with wait=false so the call returns immediately while the worker processes the
+    delay in the background.
+    """
+    r = requests.post(
+        f"{peer_uri}/collections/{COLLECTION}/debug?wait=false",
+        json={"delay": {"duration_sec": duration_sec}},
+    )
+    assert_http_ok(r)
+
+
+def test_collection_update_not_blocked_by_busy_worker(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_uris, _, _ = start_cluster(tmp_path, 1)
+    peer_uri = peer_uris[0]
+
+    # The `delay` debug operation is only available with the staging feature.
+    skip_if_no_feature(peer_uri, "staging")
+
+    create_collection(peer_uri)
+    wait_for(check_collection_green, peer_uri, COLLECTION, wait_for_timeout=30)
+
+    # Keep the update worker busy for a long time, then let it actually start the delay.
+    submit_delay(peer_uri, DELAY_SEC)
+    time.sleep(WORKER_BUSY_WAIT_SEC)
+
+    # Send a collection config update through consensus. Any optimizers_config change
+    # triggers optimizer recreation, which must not block the consensus apply thread on
+    # the busy worker.
+    start = time.time()
+    try:
+        r = requests.patch(
+            f"{peer_uri}/collections/{COLLECTION}",
+            json={"optimizers_config": {"default_segment_number": 2}},
+            timeout=PATCH_CLIENT_TIMEOUT_SEC,
+        )
+    except requests.exceptions.Timeout:
+        elapsed = time.time() - start
+        raise AssertionError(
+            f"Collection update did not return within {PATCH_CLIENT_TIMEOUT_SEC}s "
+            f"(waited {elapsed:.1f}s) - consensus apply was blocked by the busy update worker"
+        )
+    elapsed = time.time() - start
+
+    assert_http_ok(r)
+    assert elapsed < MAX_PATCH_SEC, (
+        f"Collection update took {elapsed:.1f}s (>= {MAX_PATCH_SEC}s) while the update worker "
+        f"was busy for {DELAY_SEC}s - consensus apply was blocked instead of recreating "
+        f"optimizers in the background"
+    )
+    print(
+        f"Collection update returned in {elapsed:.2f}s while the update worker was busy "
+        f"for {DELAY_SEC}s"
+    )


### PR DESCRIPTION
When the optimizer configuration of a collection changes, we recreate workers (such as the update worker and optimizers).

To achieve this, we first stop, finish and destruct running workers. We wait for them to be complete. Then we recreate workers and optimizers with the updated configuration.

If the update worker is currently processing an expensive operation. This process if taking down the update worker can take a very long time. It means this process is blocking, affected by what workers are currently doing.

Some consensus operations depend on this. An obvious example is the update collection configuration API. This is a huge problem, because it may block consensus for a long time. That cascades into unstable consensus and failing nodes.

This PR resolves the problem by moving this expensive process into the background. The consensus operation immediately goes through, and workers/optimizers are recreated in the background.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
