### PR TITLE
When clearing shard for snapshot transfer, use temporary dummy shard

### DIFF
--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -330,12 +330,18 @@ impl ShardReplicaSet {
         }
     }
 
-    /// Drop the in-memory local shard (if any) and remove its on-disk data files.
+    /// Replace the in-memory local shard (if any) with a dummy and remove its on-disk
+    /// data files.
     ///
     /// Used by shard snapshot transfers to free disk space before the receiving node
     /// downloads the new snapshot, avoiding having both the old data and the incoming
     /// snapshot on disk at the same time. The configuration files and replica state
     /// are preserved, so the shard directory remains a valid (empty) shard.
+    ///
+    /// A dummy shard is left in place of the real one so that APIs still report a local
+    /// shard while the data is being cleared and recovered, rather than reporting none.
+    /// The subsequent `restore_local_replica_from` call drops this dummy and installs
+    /// the recovered shard.
     ///
     /// Only safe to call while the shard is in a state that prevents user requests
     /// (`PartialSnapshot` during a shard transfer). Do NOT call this from a
@@ -372,7 +378,13 @@ impl ShardReplicaSet {
         flag_file.sync_all().await?;
         sync_parent_dir_async(&shard_flag).await?;
 
-        if let Some(shard) = local.take() {
+        // Replace the local shard with a dummy rather than removing it entirely, so APIs
+        // keep reporting a local shard while the data is cleared and the replacement
+        // snapshot is recovered. `restore_local_replica_from` drops this dummy afterwards.
+        let dummy = Shard::Dummy(DummyShard::new(
+            "Local shard is being cleared for snapshot recovery",
+        ));
+        if let Some(shard) = local.replace(dummy) {
             shard.stop_gracefully().await;
         }
 


### PR DESCRIPTION
Since <https://github.com/qdrant/qdrant/pull/8782> we clear a local shard first when it receives a snapshot based transfer.

The existing implementation completely removed the local shard from in-memory structures. That creates a state inconsistency and is observable by users and other nodes.

This resolves the problem by leaving a dummy shard in place of the cleared shard. The dummy shard is replaced once the snapshot is recovered. A random kill or restart keeps the state intact.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
