### PR TITLE
[UIO] Introduce `UniversalRead::reopen`

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::io;
 use std::ops::Range;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, CacheRead, FileId};
@@ -14,6 +14,8 @@ use super::{BLOCK_SIZE, BlockId, BlockOffset, BlockRequest, CacheController, Cac
 /// (not `Vec<u8>`) so alignment is always correct.
 #[derive(Debug)]
 pub struct CachedSlice {
+    pub(crate) path: PathBuf,
+
     /// The id assigned by the controller for this file.
     file_id: FileId,
 
@@ -21,7 +23,7 @@ pub struct CachedSlice {
     len_bytes: usize,
 
     /// The controller backing this structure.
-    controller: Arc<CacheController>,
+    pub(crate) controller: Arc<CacheController>,
 }
 
 impl CachedSlice {
@@ -29,6 +31,7 @@ impl CachedSlice {
     pub fn open(controller: &Arc<CacheController>, path: &Path) -> io::Result<Self> {
         let (file_id, len) = controller.open_file(path)?;
         Ok(Self {
+            path: path.to_path_buf(),
             file_id,
             len_bytes: len,
             controller: Arc::clone(controller),

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -105,6 +105,12 @@ impl UniversalRead for CachedSlice {
         Ok(CachedSlice::open(controller, path.as_ref())?)
     }
 
+    fn reopen(&mut self) -> Result<()> {
+        // TODO: revise if this is the best way to reopen
+        *self = CachedSlice::open(&self.controller, &self.path)?;
+        Ok(())
+    }
+
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         let elem_start = usize::try_from(range.byte_offset).expect("range.start is within usize")
             / size_of::<T>();

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -95,6 +95,10 @@ impl UniversalRead for IoUringFile {
         Ok(file)
     }
 
+    fn reopen(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         if self.direct_io {
             // direct_io needs special handling

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -1,11 +1,13 @@
 mod pipeline;
 
 use std::borrow::Cow;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::{fs, slice};
+use std::{fs, io, slice};
 
 use memmap2::MmapRaw;
+use parking_lot::Mutex;
 
 use self::pipeline::{BorrowedMmapReadPipeline, OwnedMmapReadPipeline};
 use super::traits::UniversalReadFileOps;
@@ -17,9 +19,16 @@ use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as
 pub struct MmapFile {
     path: PathBuf,
 
+    #[cfg_attr(target_os = "linux", expect(dead_code))]
+    writeable: bool,
+    #[cfg_attr(target_os = "linux", expect(dead_code))]
+    populate: bool,
+    #[cfg_attr(target_os = "linux", expect(dead_code))]
+    advice: AdviceSetting,
+
     // `mmap` and `mmap_seq` own the mmaps.
-    mmap: Arc<MmapRaw>,
-    mmap_seq: Option<MmapRaw>,
+    mmap: Arc<Mutex<MmapRaw>>,
+    mmap_seq: Option<Arc<Mutex<MmapRaw>>>,
 
     // `len`, `ptr`, `ptr_seq` contain the same values as `mmap`, `mmap_seq`,
     // but duplicated here to avoid `Arc`/`Option` overhead in hot loops.
@@ -103,14 +112,88 @@ impl UniversalRead for MmapFile {
 
         let mmap = Self {
             path: path.as_ref().into(),
-            mmap: Arc::new(mmap),
-            mmap_seq,
+            writeable,
+            populate,
+            advice,
+            mmap: Arc::new(Mutex::new(mmap)),
+            mmap_seq: mmap_seq.map(|mmap_seq_| Arc::new(Mutex::new(mmap_seq_))),
             len,
             ptr,
             ptr_seq,
         };
 
         Ok(mmap)
+    }
+
+    fn reopen(&mut self) -> Result<()> {
+        let old_len = self.len as u64;
+        let new_len = fs_err::File::open(self.path())?.metadata()?.len();
+        if new_len < old_len {
+            return Err(UniversalIoError::Io(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "Reopen encountered a smaller file than expected; old_len: {old_len}, new_len: {new_len}"
+                ),
+            )));
+        }
+        if new_len == old_len {
+            return Ok(());
+        }
+
+        let mut mmap = self.mmap.lock();
+        let mut mmap_seq = self.mmap_seq.as_ref().map(|m| m.lock());
+        cfg_select! {
+            // in linux, we can use `MmapRaw::remap`
+            target_os = "linux" => {
+                // SAFETY:
+                // We use may_move = true, since `remap` can fail if we don't allow it.
+                // It is safe to allow moving since we are holding `&mut self`
+                let remap_options = memmap2::RemapOptions::new().may_move(true);
+                unsafe {
+                    mmap.remap(new_len as usize, remap_options)?;
+                    mmap_seq.as_mut().map(|m| m.remap(new_len as usize, remap_options)).transpose()?;
+                };
+
+                // Whether or not `remap` moved the memory region let's update the pointers
+                let ptr = SendSyncPtr(mmap.as_mut_ptr());
+                let ptr_seq = mmap_seq.as_ref().map(|m| SendSyncPtr(m.as_mut_ptr())).unwrap_or(self.ptr);
+                let len = new_len as usize;
+            }
+            // otherwise, let's open again
+            _ => {
+                *mmap = open_mmap(
+                    self.path.as_ref(),
+                    self.writeable,
+                    self.populate,
+                    self.advice,
+                )?;
+                let ptr = SendSyncPtr(mmap.as_mut_ptr());
+
+                let ptr_seq;
+                let len;
+                if let Some(mmap_seq) = mmap_seq.as_mut() {
+                    let mmap_seq_ = open_mmap(
+                        self.path(),
+                        false,
+                        false,
+                        AdviceSetting::Advice(Advice::Sequential),
+                    )?;
+                    **mmap_seq = mmap_seq_;
+
+                    len = std::cmp::min(mmap.len(), mmap_seq.len());
+                    ptr_seq = SendSyncPtr(mmap_seq.as_mut_ptr());
+                } else {
+                    len = mmap.len();
+                    ptr_seq = ptr;
+                }
+            }
+        }
+
+        self.ptr = ptr;
+        self.ptr_seq = ptr_seq;
+        self.len = len;
+
+        Ok(())
     }
 
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
@@ -125,14 +208,14 @@ impl UniversalRead for MmapFile {
     }
 
     fn populate(&self) -> Result<()> {
-        self.mmap.populate();
+        self.mmap.lock().populate();
         Ok(())
     }
 
     fn clear_ram_cache(&self) -> Result<()> {
-        self.mmap.clear_cache();
+        self.mmap.lock().clear_cache();
         if let Some(mmap_seq) = &self.mmap_seq {
-            mmap_seq.clear_cache();
+            mmap_seq.lock().clear_cache();
         }
         Ok(())
     }
@@ -166,6 +249,7 @@ impl UniversalWrite for MmapFile {
         let mmap = self.mmap.clone();
         let flusher = move || {
             // flushing empty mmap returns error on some platforms
+            let mmap = mmap.lock();
             if mmap.len() > 0 {
                 mmap.flush()?;
             }

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -156,7 +156,7 @@ impl UniversalRead for MmapFile {
 
                 // Whether or not `remap` moved the memory region let's update the pointers
                 let ptr = SendSyncPtr(mmap.as_mut_ptr());
-                let ptr_seq = mmap_seq.as_ref().map(|m| SendSyncPtr(m.as_mut_ptr())).unwrap_or(self.ptr);
+                let ptr_seq = mmap_seq.as_ref().map(|m| SendSyncPtr(m.as_mut_ptr())).unwrap_or(ptr);
                 let len = new_len as usize;
             }
             // otherwise, let's open again

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -22,6 +22,12 @@ pub trait UniversalRead: UniversalReadFileOps {
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>;
 
+    /// Enables live-reloading of files. Append-only files can make the underlying file larger,
+    /// so reopening can account for this growth.
+    ///
+    /// This may be a no-op in some implementations.
+    fn reopen(&mut self) -> Result<()>;
+
     /// Prefer [`read_batch`] if you need high performance.
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>>;
 

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -53,6 +53,11 @@ where
     }
 
     #[inline]
+    fn reopen(&mut self) -> Result<()> {
+        self.0.reopen()
+    }
+
+    #[inline]
     fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         self.0.read::<P, T>(range)
     }


### PR DESCRIPTION
In order to make reopening for live-reload scenarios more efficient and explicit, this PR introduces a new function for `UniversalRead` trait, which just takes `&mut self`. 

It has the following properties for each backend:
- `IoUringFile`: no-op.
- `MmapFile`: leverage `MmapRaw::remap` on linux, re-opens normally elsewhere.
- `CachesSlice`: TBD, currently just re-opens.
- `DiskCache`: (not impl yet) reuse bitmask, grows local file, and only prefetches if populate was set.
- `S3`: probably no-op.