### PR TITLE
fix(transfer): skip non-transient errors during queue proxy WAL replay

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -931,7 +931,7 @@ async fn transfer_operations_batch(
             batch_upd.push(operation);
         }
 
-        remote_shard
+        match remote_shard
             .forward_update_batch(
                 batch_upd,
                 wait,
@@ -939,12 +939,28 @@ async fn transfer_operations_batch(
                 WriteOrdering::Weak,
                 hw_measurement_acc.clone(),
             )
-            .await?;
-
-        return Ok(());
+            .await
+        {
+            Ok(_) => return Ok(()),
+            // A transient error is a delivery failure: let the caller retry the whole batch.
+            Err(err) if err.is_transient() => return Err(err),
+            // A non-transient error means some operation in the batch is permanently
+            // rejected by the remote (e.g. bad request, missing point). The batch is
+            // applied sequentially and aborts at the first such operation, so we cannot
+            // tell which one failed. Re-send the batch one-by-one to isolate and skip
+            // the offending operation(s); see the loop below.
+            Err(err) => {
+                log::warn!(
+                    "Non-transient error transferring batch of updates to peer {}, \
+                     retrying operations individually: {err}",
+                    remote_shard.peer_id,
+                );
+            }
+        }
     }
 
-    // Fallback to one-by-one transfer, in case the remote shard doesn't support batch updates
+    // One-by-one transfer. Used both when the remote does not support batch updates and
+    // as the isolation path after a non-transient batch failure.
     for (_idx, operation) in batch {
         let mut operation = operation.clone();
 
@@ -954,7 +970,7 @@ async fn transfer_operations_batch(
             clock_tag.force = true;
         }
 
-        remote_shard
+        match remote_shard
             .forward_update(
                 operation,
                 wait,
@@ -962,7 +978,24 @@ async fn transfer_operations_batch(
                 WriteOrdering::Weak,
                 hw_measurement_acc.clone(),
             )
-            .await?;
+            .await
+        {
+            Ok(_) => {}
+            // Transient errors are delivery failures: let the caller retry the batch.
+            Err(err) if err.is_transient() => return Err(err),
+            // A non-transient error means the operation is permanently rejected by the
+            // remote. This operation was replayed from the WAL, so it was already applied
+            // (and rejected the same way) on the sender - the sender's state therefore
+            // reflects it as a no-op. Skipping it here keeps both sides consistent and
+            // prevents a single bad operation from aborting the whole shard transfer.
+            Err(err) => {
+                log::warn!(
+                    "Skipping operation permanently rejected by peer {} during shard \
+                     transfer (non-transient): {err}",
+                    remote_shard.peer_id,
+                );
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Fix for the shard-transfer abort reproduced by the test in #9125.

**Base branch is `test/snapshot-transfer-missing-point` on purpose**, so this PR's CI runs `test_shard_snapshot_transfer_with_missing_point_updates` *with the fix* and shows it **green** (it fails on the test branch / `dev` alone). Rebase onto `dev` before merging.

## Problem

During a shard transfer the queue proxy replays operations from the sender's WAL to the receiver (`transfer_operations_batch`). Some are partial updates (`set_payload`, `update_vectors`, …) that the receiver rejects with a **non-transient** error — most commonly `NotFound: No point with id ...` for a point that does not exist on the receiver, but equally any other client-caused bad request.

These ops are forwarded with `WriteOrdering::Weak` + `force = true`, which routes through `update_local` and bypasses the missing-point tolerance in `handle_failed_replicas` (added in #5991 for the *live* forwarded-update path). The error propagates and aborts the transfer:

```
ERROR collection::shards::transfer::driver: Failed to transfer shard ...: NotFound "No point with id ... found"
```

The only safety net is bounded retries (queue-level `BATCH_RETRIES`, driver-level `MAX_RETRY_COUNT`). Under sustained load they are exhausted, the receiver replica is marked `Dead`, and the transfer aborts (consensus auto-restarts it, failing the same way while load continues).

## Fix

Handle the error where the semantic context lives — the **transmitter** (`transfer_operations_batch`):

- **Skip non-transient errors** and continue. A replayed WAL op that the remote rejects non-transiently was already applied (and rejected the same way) on the sender, so the sender's state reflects it as a no-op → skipping keeps both sides consistent.
- **Propagate transient errors** so the caller retries delivery (network/timeout/unavailable).
- The batch update API aborts at the first failing op and can't tell us which one, so a non-transient *batch* error **falls back to one-by-one** sending to isolate and skip the offending op(s).

### Design notes
- **Transmitter, not receiver:** the queue proxy is the component that knows it's replaying historical WAL ops; the receiver's `update_local` shouldn't assume its caller's intent.
- **Non-transient, not just missing-point:** unlike #5991 (which deliberately narrowed to missing-point on the *live* path, where ops aren't pre-adjudicated), replayed ops have already been adjudicated on the sender, so any non-transient rejection is safe to skip. This also covers bad requests beyond missing points.
- **Covers WAL-delta too**, since it forwards through the same queue-proxy path.

## Verification

- Test branch alone (no fix): test **fails** reliably (replica goes `Dead`, never `Active`).
- With this fix: test **passes** (~25s). Logs show ~1.2k `Skipping operation permanently rejected ... No point with id ...` and **0** driver-level transfer aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)