### PR TITLE
[UIO] Use `UniversalRead::reopen`

### DIFF
--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -57,6 +57,12 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         })
     }
 
+    pub fn reopen(&mut self) -> Result<()> {
+        self.storage.reopen()?;
+        self.element_len = self.storage.len()?;
+        Ok(())
+    }
+
     /// Total number of bits available.
     pub fn bit_len(&self) -> u64 {
         self.element_len * u64::from(BITS_PER_ELEMENT)

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -61,6 +61,10 @@ where
         })
     }
 
+    pub fn reopen(&mut self) -> Result<()> {
+        self.inner.reopen()
+    }
+
     #[inline]
     pub fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         self.inner.read::<P, T>(range)

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -144,11 +144,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
     }
 
     /// Extends the file to fit the new regions
-    pub fn extend(
-        &mut self,
-        fs: &S::Fs,
-        iter: impl ExactSizeIterator<Item = RegionGaps>,
-    ) -> Result<()> {
+    pub fn extend(&mut self, iter: impl ExactSizeIterator<Item = RegionGaps>) -> Result<()> {
         let data: Vec<RegionGaps> = iter.collect();
         if data.is_empty() {
             return Ok(());
@@ -709,9 +705,7 @@ mod tests {
             let config = StorageOptions::default().try_into().unwrap();
             let mut region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
-            region_gaps
-                .extend(&MmapFs, more_gaps.clone().into_iter())
-                .unwrap();
+            region_gaps.extend(more_gaps.clone().into_iter()).unwrap();
             assert_eq!(region_gaps.len().unwrap(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -161,13 +161,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
         create_and_ensure_length(&self.path, new_length_in_bytes)?;
 
-        let options = OpenOptions {
-            writeable: true,
-            need_sequential: false,
-            populate: Populate::No,
-            advice: AdviceSetting::Advice(Advice::Normal),
-        };
-        self.slice_store = TypedStorage::open(fs, &self.path, options, Default::default())?;
+        self.slice_store.reopen()?;
 
         debug_assert_eq!(self.len()? - prev_len, data.len());
 

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -208,7 +208,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let new_length = (previous_bit_len / u8::BITS as usize) + extra_length;
         create_and_ensure_length(&self.path, new_length)?;
 
-        self.bitslice = StoredBitSlice::open(fs, &self.path, open_options(), Default::default())?;
+        self.bitslice.reopen()?;
 
         let current_bit_len = self.bitslice.bit_len() as usize;
 

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -197,7 +197,7 @@ impl<S: UniversalWrite> Bitmask<S> {
     }
 
     /// Extend the bitslice to cover another page
-    pub fn cover_new_page(&mut self, fs: &S::Fs) -> Result<()> {
+    pub fn cover_new_page(&mut self) -> Result<()> {
         let extra_length = Self::length_for_page(&self.config);
 
         // flush outstanding changes
@@ -223,7 +223,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let new_regions = expected_total_full_regions.saturating_sub(current_total_regions);
         let new_gaps =
             vec![RegionGaps::all_free(self.config.region_size_blocks as u16); new_regions];
-        self.regions_gaps.extend(fs, new_gaps.into_iter())?;
+        self.regions_gaps.extend(new_gaps.into_iter())?;
 
         assert_eq!(
             self.regions_gaps.len()? * self.config.region_size_blocks,
@@ -611,7 +611,7 @@ mod tests {
 
         let mut bitmask: MmapBitmask =
             super::Bitmask::create(&MmapFs, dir.path(), options.try_into().unwrap()).unwrap();
-        bitmask.cover_new_page(&MmapFs).unwrap();
+        bitmask.cover_new_page().unwrap();
 
         assert_eq!(bitmask.bitslice.bit_len() as u32, blocks_per_page * 2);
 

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -168,7 +168,7 @@ impl<V: Blob> Gridstore<V> {
         create_and_ensure_length(&path, self.config.page_size_bytes)?;
         self.pages.write().attach_page(&MmapFs, &path)?;
 
-        self.bitmask.write().cover_new_page(&MmapFs)?;
+        self.bitmask.write().cover_new_page()?;
 
         Ok(new_page_id)
     }
@@ -487,7 +487,7 @@ impl<V> Gridstore<V> {
     ) -> crate::Result<Vec<ValuePointer>> {
         let (old_pointers, tracker_flusher) = {
             let mut guard = tracker.write();
-            let old_pointers = guard.write_pending(&MmapFs, pending_updates)?;
+            let old_pointers = guard.write_pending(pending_updates)?;
             let flusher = guard.flusher();
             (old_pointers, flusher)
         };

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -120,7 +120,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     ///
     pub fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
-        let has_new_data = self.tracker.live_reload(fs)?;
+        let has_new_data = self.tracker.live_reload()?;
 
         if !has_new_data {
             return Ok(());

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -321,7 +321,7 @@ impl<S: UniversalRead> Tracker<S> {
         } else {
             // reopen storage to make new data visible
             // For some storages it should be a no-op.
-            self.storage = Self::open_storage(fs, &self.path)?;
+            self.storage.reopen()?;
 
             // Update in-memory state to reflect new pointers
             self.header = new_header;
@@ -584,7 +584,7 @@ where
             self.storage.flusher()()?;
             let new_size = end_offset.next_power_of_two();
             create_and_ensure_length(&self.path, new_size)?;
-            self.storage = fs.open(&self.path, tracker_open_options(), Default::default())?;
+            self.storage.reopen()?;
         }
 
         let pointer = OptionalPointer::from(pointer);

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -307,7 +307,7 @@ impl<S: UniversalRead> Tracker<S> {
     /// - Partial writes are possible, but ignored. Header is a source of truth.
     ///
     /// Returns `true` if there are new changes, `false` if the tracker is already up to date.
-    pub fn live_reload(&mut self, fs: &S::Fs) -> Result<bool> {
+    pub fn live_reload(&mut self) -> Result<bool> {
         let new_header = Self::read_header(&self.storage)?;
 
         if new_header.next_pointer_offset < self.next_pointer_offset {
@@ -499,7 +499,6 @@ where
     #[must_use = "The old pointers need to be freed in the bitmask"]
     pub fn write_pending(
         &mut self,
-        fs: &S::Fs,
         pending_updates: AHashMap<PointOffset, PointerUpdates>,
     ) -> Result<Vec<ValuePointer>> {
         let mut old_pointers = Vec::new();
@@ -513,10 +512,10 @@ where
                         old_pointers.push(old_pointer);
                     }
 
-                    self.persist_pointer(fs, point_offset, Some(new_pointer))?;
+                    self.persist_pointer(point_offset, Some(new_pointer))?;
                 }
                 // Write to empty the pointer
-                None => self.persist_pointer(fs, point_offset, None)?,
+                None => self.persist_pointer(point_offset, None)?,
             }
 
             // Mark all old pointers for removal to free its blocks
@@ -549,9 +548,9 @@ where
     }
 
     #[cfg(test)]
-    pub fn write_pending_and_flush_internal(&mut self, fs: &S::Fs) -> Result<Vec<ValuePointer>> {
+    pub fn write_pending_and_flush_internal(&mut self) -> Result<Vec<ValuePointer>> {
         let pending_updates = std::mem::take(&mut self.pending_updates);
-        let res = self.write_pending(fs, pending_updates)?;
+        let res = self.write_pending(pending_updates)?;
         self.storage.flusher()()?;
         Ok(res)
     }
@@ -566,7 +565,6 @@ where
     /// The file is resized if necessary
     fn persist_pointer(
         &mut self,
-        fs: &S::Fs,
         point_offset: PointOffset,
         pointer: Option<ValuePointer>,
     ) -> Result<()> {
@@ -672,14 +670,14 @@ mod tests {
         assert!(tracker.is_empty());
         tracker.set(0, ValuePointer::new(1, 1, 1));
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         assert!(!tracker.is_empty());
         assert_eq!(tracker.mapping_len().unwrap(), 1);
 
         tracker.set(100, ValuePointer::new(2, 2, 2));
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         assert_eq!(tracker.pointer_count(), 101);
         assert_eq!(tracker.mapping_len().unwrap(), 2);
@@ -698,7 +696,7 @@ mod tests {
         tracker.set(2, ValuePointer::new(3, 3, 3));
         tracker.set(10, ValuePointer::new(10, 10, 10));
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
         assert!(!tracker.is_empty());
         assert_eq!(tracker.mapping_len().unwrap(), 4);
         assert_eq!(tracker.pointer_count(), 11); // accounts for empty slots
@@ -724,7 +722,7 @@ mod tests {
 
         tracker.unset(1).unwrap();
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         // the value has been cleared but the entry is still there
         assert_eq!(tracker.get_raw(1).unwrap(), None);
@@ -737,7 +735,7 @@ mod tests {
         tracker.set(0, ValuePointer::new(10, 10, 10));
         tracker.set(2, ValuePointer::new(30, 30, 30));
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         assert_eq!(tracker.get(0).unwrap(), Some(ValuePointer::new(10, 10, 10)));
         assert_eq!(tracker.get(2).unwrap(), Some(ValuePointer::new(30, 30, 30)));
@@ -761,7 +759,7 @@ mod tests {
                 tracker.set(i as u32, ValuePointer::new(i as u32, i as u32, i as u32));
             }
         }
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         assert_eq!(tracker.mapping_len().unwrap(), value_count / 2);
         assert_eq!(tracker.pointer_count(), value_count as u32 - 1);
@@ -807,7 +805,7 @@ mod tests {
             tracker.set(i, ValuePointer::new(i, i, i));
         }
 
-        tracker.write_pending_and_flush_internal(&MmapFs).unwrap();
+        tracker.write_pending_and_flush_internal().unwrap();
 
         assert_eq!(tracker.mapping_len().unwrap(), 100_000);
         assert!(tracker.mmap_file_size().unwrap() > actual_tracker_size);

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -199,6 +199,7 @@ where
 
             // Don't read the whole file on resize
             let populate = false;
+            // TODO: consider using UniversalRead::reopen
             let flags = Self::open_storage(fs, new_len, &self.directory, populate)?;
 
             // Swap operation. It is important this section is not interrupted by errors.


### PR DESCRIPTION
Builds on top of #9123 

Begins using the new reopen function where applicable.

Mostly affects `Gridstore`, but not yet applied to `DynamicStoredFlags`.