### PR TITLE
[UIO] Introduce `OwnedReadPipeline::schedule_whole`

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::CachedSlice;
-use crate::generic_consts::{AccessPattern, Random};
+use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::{
     BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError,
     UniversalRead, UserData,
@@ -89,6 +89,17 @@ where
         // FIXME: This is a temporary stub implementation.
         self.pending = Some((user_data, range));
         Ok(())
+    }
+
+    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
+        let length = self.file.len::<T>() as u64;
+        self.schedule::<Sequential>(
+            user_data,
+            ReadRange {
+                byte_offset: 0,
+                length,
+            },
+        )
     }
 
     fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -5,9 +5,10 @@ use ::io_uring::types::Fd;
 
 use super::pool::IO_URING_QUEUE_LENGTH;
 use super::{IoUringFile, IoUringRuntime};
-use crate::generic_consts::AccessPattern;
+use crate::generic_consts::{AccessPattern, Sequential};
 use crate::universal_io::{
-    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError,
+    UniversalRead, UserData,
 };
 
 pub struct BorrowedIoUringPipeline<'file, T, U>
@@ -92,6 +93,18 @@ where
             self.inner
                 .schedule(user_data, self.file.fd(), self.file.direct_io, range)
         }
+    }
+
+    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
+        let length = self.file.len::<T>()?;
+
+        self.schedule::<Sequential>(
+            user_data,
+            ReadRange {
+                byte_offset: 0,
+                length,
+            },
+        )
     }
 
     fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 use super::{MmapFile, read};
 use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::{
-    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError,
+    UniversalRead, UserData,
 };
 
 pub struct BorrowedMmapReadPipeline<'file, T, U> {
@@ -77,6 +78,17 @@ where
         }
         self.pending = Some((user_data, range, P::IS_SEQUENTIAL));
         Ok(())
+    }
+
+    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
+        let length = self.file.len::<T>()?;
+        self.schedule::<Sequential>(
+            user_data,
+            ReadRange {
+                byte_offset: 0,
+                length,
+            },
+        )
     }
 
     fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -74,6 +74,10 @@ where
     where
         P: AccessPattern;
 
+    /// Like `Self::schedule`, but doesn't need to know file length upfront.
+    /// Reads the entire file.
+    fn schedule_whole(&mut self, user_data: U) -> Result<()>;
+
     /// See [`BorrowedReadPipeline::wait()`].
     fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>>;
 }

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -93,6 +93,11 @@ where
     }
 
     #[inline]
+    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
+        self.inner.schedule_whole(user_data)
+    }
+
+    #[inline]
     fn wait(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
         self.inner.wait()
     }


### PR DESCRIPTION
Adds a `schedule_whole` function to the owned pipeline trait, so that we don't need to know the length of the file upfront to be able to schedule a read of the entire file.

Right now it does not provide any advantage, since every implementation calls `len::<T>()` synchronously, but will help avoid a network call in cases like S3.

For more context, see [this comment](https://github.com/qdrant/qdrant/pull/9097#discussion_r3276841855) in #9097.