### PR TITLE
Add read-only service mode flag

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -304,6 +304,11 @@ service:
   # Uncomment to enable.
   # read_only_api_key: your_secret_read_only_api_key_here
 
+  # Force the service to reject write and manage operations.
+  # Read-only mode is intended for single-node deployments only.
+  # Can also be enabled with the `--read-only` CLI argument.
+  # read_only: false
+
   # Uncomment to enable JWT Role Based Access Control (RBAC).
   # If enabled, you can generate JWT tokens with fine-grained rules for access control.
   # Use generated token instead of API key.

--- a/lib/storage/src/rbac/mod.rs
+++ b/lib/storage/src/rbac/mod.rs
@@ -120,6 +120,24 @@ impl Access {
         Self::Global(GlobalAccessMode::Read)
     }
 
+    /// Restrict the access object to read-only permissions while preserving
+    /// collection scoping where possible.
+    pub fn into_read_only(self) -> Self {
+        match self {
+            Self::Global(_) => Self::Global(GlobalAccessMode::Read),
+            Self::Collection(collections) => Self::Collection(CollectionAccessList(
+                collections
+                    .0
+                    .into_iter()
+                    .map(|mut collection| {
+                        collection.access = CollectionAccessMode::Read;
+                        collection
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
     /// Check if the user has global access.
     pub fn check_global_access(
         &self,
@@ -382,5 +400,45 @@ impl AccessCollectionBuilder {
 impl From<AccessCollectionBuilder> for Access {
     fn from(builder: AccessCollectionBuilder) -> Self {
         Access::Collection(CollectionAccessList(builder.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_access_can_be_restricted_to_read_only() {
+        let access = Access::full("test").into_read_only();
+
+        assert_eq!(access, Access::full_ro("test"));
+    }
+
+    #[test]
+    fn collection_access_can_be_restricted_to_read_only() {
+        let access = Access::Collection(CollectionAccessList(vec![
+            CollectionAccess {
+                collection: "first".to_string(),
+                access: CollectionAccessMode::ReadWrite,
+                #[expect(deprecated)]
+                payload: None,
+            },
+            CollectionAccess {
+                collection: "second".to_string(),
+                access: CollectionAccessMode::PointsReadWrite,
+                #[expect(deprecated)]
+                payload: None,
+            },
+        ]))
+        .into_read_only();
+
+        let Access::Collection(collections) = access else {
+            panic!("expected collection access");
+        };
+
+        assert!(collections
+            .0
+            .iter()
+            .all(|collection| collection.access == CollectionAccessMode::Read));
     }
 }

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -159,18 +159,18 @@ impl AuthKeys {
         &self,
         get_header: impl Fn(&'a str) -> Option<&'a str>,
     ) -> Result<(Access, InferenceToken, AuthType, Option<String>), AuthError> {
+        if self.read_only_mode && !self.has_any_key() {
+            return Ok((
+                Access::full_ro("Read-only mode without configured API keys"),
+                InferenceToken(None),
+                AuthType::None,
+                None,
+            ));
+        }
+
         let Some(key) = get_header(HTTP_HEADER_API_KEY)
             .or_else(|| get_header("authorization").and_then(|v| v.strip_prefix("Bearer ")))
         else {
-            if self.read_only_mode && !self.has_any_key() {
-                return Ok((
-                    Access::full_ro("Read-only mode without configured API keys"),
-                    InferenceToken(None),
-                    AuthType::None,
-                    None,
-                ));
-            }
-
             return Err(AuthError::Unauthorized(
                 "Must provide an API key or an Authorization bearer token".to_string(),
             ));

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -45,6 +45,9 @@ pub struct AuthKeys {
 
     /// Table of content, needed to do stateful validation of JWT
     toc: Arc<TableOfContent>,
+
+    /// Whether the whole service should restrict requests to read-only access.
+    read_only_mode: bool,
 }
 
 #[derive(Debug)]
@@ -106,17 +109,18 @@ impl AuthKeys {
         }
     }
 
-    /// Defines the auth scheme given the service config
+    /// Defines the auth scheme given the service config.
     ///
-    /// Returns None if no scheme is specified.
+    /// Returns None if no API keys or service-wide read-only mode are configured.
     pub fn try_create(service_config: &ServiceConfig, toc: Arc<TableOfContent>) -> Option<Self> {
         match (
             service_config.api_key.clone(),
             service_config.alt_api_key.clone(),
             service_config.read_only_api_key.clone(),
+            service_config.read_only,
         ) {
-            (None, None, None) => None,
-            (read_write, alt_read_write, read_only) => {
+            (None, None, None, false) => None,
+            (read_write, alt_read_write, read_only, read_only_mode) => {
                 let (jwt_parser, alt_jwt_parser) = Self::get_jwt_parser(service_config);
 
                 Some(Self {
@@ -126,8 +130,25 @@ impl AuthKeys {
                     jwt_parser,
                     alt_jwt_parser,
                     toc,
+                    read_only_mode,
                 })
             }
+        }
+    }
+
+    fn has_any_key(&self) -> bool {
+        self.read_write.is_some()
+            || self.alt_read_write.is_some()
+            || self.read_only.is_some()
+            || self.jwt_parser.is_some()
+            || self.alt_jwt_parser.is_some()
+    }
+
+    fn apply_read_only_mode(&self, access: Access) -> Access {
+        if self.read_only_mode {
+            access.into_read_only()
+        } else {
+            access
         }
     }
 
@@ -141,6 +162,15 @@ impl AuthKeys {
         let Some(key) = get_header(HTTP_HEADER_API_KEY)
             .or_else(|| get_header("authorization").and_then(|v| v.strip_prefix("Bearer ")))
         else {
+            if self.read_only_mode && !self.has_any_key() {
+                return Ok((
+                    Access::full_ro("Read-only mode without configured API keys"),
+                    InferenceToken(None),
+                    AuthType::None,
+                    None,
+                ));
+            }
+
             return Err(AuthError::Unauthorized(
                 "Must provide an API key or an Authorization bearer token".to_string(),
             ));
@@ -148,7 +178,7 @@ impl AuthKeys {
 
         if self.can_write(key) {
             return Ok((
-                Access::full("Read-write access by key"),
+                self.apply_read_only_mode(Access::full("Read-write access by key")),
                 InferenceToken(None),
                 AuthType::ApiKey,
                 None,
@@ -157,7 +187,7 @@ impl AuthKeys {
 
         if self.can_read(key) {
             return Ok((
-                Access::full_ro("Read-only access by key"),
+                self.apply_read_only_mode(Access::full_ro("Read-only access by key")),
                 InferenceToken(None),
                 AuthType::ApiKey,
                 None,
@@ -184,7 +214,12 @@ impl AuthKeys {
                 self.validate_value_exists(&value_exists).await?;
             }
 
-            return Ok((access, InferenceToken(sub), AuthType::Jwt, subject));
+            return Ok((
+                self.apply_read_only_mode(access),
+                InferenceToken(sub),
+                AuthType::Jwt,
+                subject,
+            ));
         }
 
         // JTW parser exists, but can't decode the token

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,11 @@ struct Args {
     #[arg(long, action, default_value_t = false)]
     disable_telemetry: bool,
 
+    /// Force the service to reject write and manage operations.
+    /// Read-only mode is only supported for single-node deployments.
+    #[arg(long, action, default_value_t = false)]
+    read_only: bool,
+
     /// Run stacktrace collector. Used for debugging.
     #[arg(long, action, default_value_t = false)]
     stacktrace: bool,
@@ -370,7 +375,8 @@ fn main() -> anyhow::Result<()> {
     // Settings & global state
     //
 
-    let settings = Settings::new(args.config_path)?;
+    let mut settings = Settings::new(args.config_path)?;
+    settings.service.read_only |= args.read_only;
 
     // Set global feature flags, sourced from configuration
     init_feature_flags(settings.feature_flags);
@@ -446,6 +452,10 @@ fn main() -> anyhow::Result<()> {
 
     // Validate as soon as possible, but we must initialize logging first
     settings.validate_and_warn();
+
+    if settings.service.read_only && settings.cluster.enabled {
+        anyhow::bail!("Read-only mode is not supported for distributed deployments");
+    }
 
     //
     // Storage directory & filesystem compatibility

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -61,6 +61,8 @@ pub struct ServiceConfig {
 
     pub read_only_api_key: Option<String>,
     #[serde(default)]
+    pub read_only: bool,
+    #[serde(default)]
     pub jwt_rbac: Option<bool>,
 
     /// Enforce API key / JWT authentication on the internal (p2p) gRPC API.


### PR DESCRIPTION
This adds a first read-only mode slice for single-node deployments:

- Adds a `--read-only` CLI flag
- Adds `service.read_only` config support
- Restricts request access to read-only permissions while preserving collection scoping
- Rejects read-only mode for distributed deployments
- Documents the config option
- Adds tests for access restriction behavior

I could not run local Rust checks in this environment because cargo/rustfmt are not installed.