### PR TITLE
fix: validate hnsw_ef parameter must be at least 1

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -343,8 +343,9 @@ impl StrictModeVerification for SearchParams {
         // Validate hnsw_ef lower bound
         if let Some(hnsw_ef) = self.hnsw_ef {
             if hnsw_ef < 1 {
-                return Err(CollectionError::bad_request(
-                    "hnsw_ef must be at least 1",
+                return Err(CollectionError::strict_mode(
+                    format!("Invalid value {hnsw_ef} for \"hnsw_ef\""),
+                    "Set \"hnsw_ef\" to at least 1.",
                 ));
             }
         }
@@ -689,11 +690,8 @@ mod test {
             hnsw_ef: Some(1),
             ..SearchParams::default()
         };
-        assert_strict_mode_success(
-            discover_fixture(None, None, Some(valid_params)),
-            collection,
-        )
-        .await;
+        assert_strict_mode_success(discover_fixture(None, None, Some(valid_params)), collection)
+            .await;
     }
 
     async fn assert_strict_mode_error<R: StrictModeVerification>(

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -340,6 +340,15 @@ impl StrictModeVerification for SearchParams {
             "oversampling",
         )?;
 
+        // Validate hnsw_ef lower bound
+        if let Some(hnsw_ef) = self.hnsw_ef {
+            if hnsw_ef < 1 {
+                return Err(CollectionError::bad_request(
+                    "hnsw_ef must be at least 1",
+                ));
+            }
+        }
+
         check_limit_opt(
             self.hnsw_ef,
             strict_mode_config.search_max_hnsw_ef,
@@ -436,6 +445,7 @@ mod test {
         test_request_exact(&collection).await;
         test_search_batch_limit(&collection).await;
         test_upsert_batch_limit(&collection).await;
+        test_hnsw_ef_validation(&collection).await;
     }
 
     async fn test_query_limit(collection: &Collection) {
@@ -660,6 +670,30 @@ mod test {
             update_mode: None,
         });
         assert_strict_mode_success(request, collection).await;
+    }
+
+    async fn test_hnsw_ef_validation(collection: &Collection) {
+        // Test that hnsw_ef=0 is rejected
+        let invalid_params = SearchParams {
+            hnsw_ef: Some(0),
+            ..SearchParams::default()
+        };
+        assert_strict_mode_error(
+            discover_fixture(None, None, Some(invalid_params)),
+            collection,
+        )
+        .await;
+
+        // Test that hnsw_ef=1 is accepted
+        let valid_params = SearchParams {
+            hnsw_ef: Some(1),
+            ..SearchParams::default()
+        };
+        assert_strict_mode_success(
+            discover_fixture(None, None, Some(valid_params)),
+            collection,
+        )
+        .await;
     }
 
     async fn assert_strict_mode_error<R: StrictModeVerification>(


### PR DESCRIPTION
## All Submissions

- [ ] PR targets `dev` branch (not `master`), branch created from `dev`
- [ ] Followed Contributing guidelines (docs/CONTRIBUTING.md)
- [ ] Checked for duplicate open PRs

## New Feature Submissions

- [ ] Tests pass
- [ ] Code formatted with `cargo +nightly fmt --all`
- [ ] Code checked with `cargo clippy --workspace --all-features`

## Core Feature Changes

- [ ] Explanation of changes and rationale
- [ ] New tests written (as applicable)
- [ ] Tests run successfully locally

## Summary

The search API was accepting `hnsw_ef=0` in search parameters and returning HTTP 200 OK with results, despite this value being semantically invalid for the HNSW algorithm. The HNSW `ef` parameter controls the size of the dynamic candidate list during graph traversal—a value of 0 makes no sense as it would mean considering zero candidates.

The root cause is that `SearchParams` validation in `lib/collection/src/operations/verification/mod.rs` only checked the upper bound (`search_max_hnsw_ef`) in strict mode but had no lower-bound check. This differs from similar parameters like `ef_construct` which validates with `#[validate(range(min = 4))]` in the config.

This fix adds a lower-bound check in the `SearchParams::check_custom` method that rejects any `hnsw_ef < 1` with a `BadRequest` error. A regression test was added to verify that `hnsw_ef=0` is now rejected while `hnsw_ef=1` passes validation.

Fixes #9017
