### PR TITLE
Clear id tracker page cache after building a segment

### DIFF
--- a/lib/common/common/src/universal_io/wrappers/buffered_update.rs
+++ b/lib/common/common/src/universal_io/wrappers/buffered_update.rs
@@ -51,6 +51,17 @@ where
         );
         self.pending_updates.lock().insert(index, value);
     }
+
+    /// Hint to the OS that pages backing the underlying storage can be reclaimed.
+    pub fn clear_cache(&self) -> Result<(), UniversalIoError> {
+        let Self {
+            slice,
+            len: _,
+            pending_updates: _,
+            is_alive_lock: _,
+        } = self;
+        slice.read().clear_ram_cache()
+    }
 }
 
 impl<S, T> SliceBufferedUpdateWrapper<S, T>

--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -221,4 +221,12 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.immutable_files(),
         }
     }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.clear_cache(),
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.clear_cache(),
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.clear_cache(),
+        }
+    }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -99,6 +99,28 @@ pub trait IdTracker: IdTrackerRead + fmt::Debug {
     fn immutable_files(&self) -> Vec<PathBuf> {
         Vec::new()
     }
+
+    /// Hint to the OS that the page cache backing this tracker's on-disk files
+    /// can be reclaimed.
+    ///
+    /// Used after building/optimizing a segment to avoid leaving cold id-tracker
+    /// pages resident in the page cache. The default implementation is a no-op
+    /// for fully in-memory trackers without backing files.
+    fn clear_cache(&self) -> OperationResult<()> {
+        Ok(())
+    }
+
+    /// Clear the page cache for this tracker's on-disk files, but only if the
+    /// tracker data is expected to live on disk rather than in RAM.
+    ///
+    /// The id tracker currently always loads its data into RAM and has no
+    /// on-disk mode, so for now this unconditionally clears the cache. Once an
+    /// on-disk mode is added, this should be gated on that configuration,
+    /// mirroring the vector and payload storages.
+    fn clear_cache_if_on_disk(&self) -> OperationResult<()> {
+        // TODO: gate on an on-disk flag once the id tracker supports it.
+        self.clear_cache()
+    }
 }
 
 pub trait IdTrackerRead {

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -14,6 +14,7 @@ use std::mem::{size_of, size_of_val};
 use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitVec};
+use common::fs::clear_disk_cache;
 use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
@@ -345,5 +346,23 @@ impl<S: UniversalWrite + Debug + Send + Sync + 'static> IdTracker for ImmutableI
 
     fn immutable_files(&self) -> Vec<PathBuf> {
         vec![mappings_path(&self.path)]
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        let Self {
+            path,
+            deleted_wrapper,
+            internal_to_version: _, // kept in RAM
+            internal_to_version_wrapper,
+            mappings: _, // kept in RAM, file dropped via `path` below
+        } = self;
+        // `deleted` and `internal_to_version` are mmap-backed: page them out via
+        // `madvise`, which works on actively mapped pages.
+        deleted_wrapper.clear_cache()?;
+        internal_to_version_wrapper.clear_cache()?;
+        // `mappings` is read into RAM and is not mmap-backed, so its file pages
+        // can't be reached through a mapping. Drop them with `fadvise` instead.
+        clear_disk_cache(&mappings_path(path))?;
+        Ok(())
     }
 }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
 use common::bitvec::BitSlice;
+use common::fs::clear_disk_cache;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
 use fs_err::File;
@@ -381,5 +382,23 @@ impl IdTracker for MutableIdTracker {
     #[inline]
     fn files(&self) -> Vec<PathBuf> {
         Self::segment_files(&self.segment_path)
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        let Self {
+            segment_path,
+            internal_to_version: _, // kept in RAM
+            mappings: _,            // kept in RAM
+            pending_versions: _,
+            pending_mappings: _,
+            is_alive_lock: _,
+            mappings_expected_len: _,
+        } = self;
+        // Mappings and versions live in RAM; the on-disk files are append-only
+        // logs that aren't mmap-backed, so drop their page cache with `fadvise`.
+        for file in Self::segment_files(segment_path) {
+            clear_disk_cache(&file)?;
+        }
+        Ok(())
     }
 }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -723,6 +723,10 @@ impl SegmentBuilder {
             // Clear cache for payload index to avoid cache pollution
             payload_index_arc.borrow().clear_cache_if_on_disk()?;
 
+            // The id tracker is loaded into RAM but its on-disk files are written
+            // during the build; drop their page cache to avoid cache pollution.
+            id_tracker_arc.borrow().clear_cache_if_on_disk()?;
+
             // We're done with CPU-intensive tasks, release CPU permit
             debug_assert_eq!(
                 Arc::strong_count(&permit),


### PR DESCRIPTION
## Problem

The segment builder evicts the page cache of vector storage, quantized vectors, payload, payload index and the vector index after a build (to avoid cache pollution), but the **id tracker was never cleared**.

Its on-disk files (`mappings`, `versions`, `deleted` bitslice) are written during the build and stay resident in the page cache. After each optimization the id tracker files linger as cache even though they are meant to be on-disk only — observable as `id_tracker.cached_bytes > 0` while `expected_cache_bytes == 0` in `GET /collections/{name}/memory`. Across a full re-index this accumulates and is only released by dropping caches / restarting.

## Change

- Add `IdTracker::clear_cache` (default no-op) plus a `clear_cache_if_on_disk` policy wrapper.
- Implement eviction for both trackers:
  - `ImmutableIdTracker` pages out its two mmap-backed storages via `madvise(MADV_PAGEOUT)` and drops the RAM-loaded `mappings` file via `fadvise(POSIX_FADV_DONTNEED)` (a plain `madvise` can't reach it since it isn't mmap-backed).
  - `MutableIdTracker` drops its append-only log files via `fadvise(POSIX_FADV_DONTNEED)`.
- `SegmentBuilder` calls `clear_cache_if_on_disk`, mirroring the payload index.

The id tracker has no on-disk mode yet, so `clear_cache_if_on_disk` unconditionally clears for now; a `TODO` marks where to gate it once an on-disk mode exists.

## Test

`cargo test -p segment id_tracker` and the `segment_builder` integration tests pass.