### PR TITLE
sparse: use zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,6 +7567,7 @@ dependencies = [
  "sparse",
  "tempfile",
  "validator",
+ "zerocopy",
 ]
 
 [[package]]

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -48,12 +48,12 @@ fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
     let query_vectors = Csr::open(Dataset::NeurIps2023Queries.download().unwrap())
         .unwrap()
         .iter()
-        .map(|v| v.unwrap())
+        .unwrap()
         .collect_vec();
     sparse_vector_index_search_benchmark_impl(
         c,
         "neurips2023-1M",
-        dataset_vectors.iter().map(|v| v.unwrap()),
+        dataset_vectors.iter().unwrap(),
         &query_vectors,
     );
 }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -32,6 +32,7 @@ validator = { workspace = true }
 itertools = { workspace = true }
 parking_lot = { workspace = true }
 log = { workspace = true }
+zerocopy = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -34,8 +34,11 @@ pub fn bench_search(c: &mut Criterion) {
     bench_uniform_random(c, "random-500k", 500_000);
 
     {
-        let query_vectors =
-            loaders::load_csr_vecs(Dataset::NeurIps2023Queries.download().unwrap()).unwrap();
+        let query_vectors = Csr::open(Dataset::NeurIps2023Queries.download().unwrap())
+            .unwrap()
+            .iter()
+            .unwrap()
+            .collect::<Vec<_>>();
 
         let index_1m = load_csr_index(Dataset::NeurIps2023_1M.download().unwrap(), 1.0).unwrap();
         run_bench(c, "neurips2023-1M", index_1m, &query_vectors);
@@ -220,12 +223,8 @@ fn load_csr_index(path: impl AsRef<Path>, ratio: f32) -> io::Result<InvertedInde
     let count = (csr.len() as f32 * ratio) as usize;
     let bar =
         ProgressBar::with_draw_target(Some(count as u64), ProgressDrawTarget::stderr_with_hz(12));
-    for (row, vec) in bar.wrap_iter(csr.iter().take(count).enumerate()) {
-        builder.add(
-            row as u32,
-            vec.map(|v| v.into_remapped())
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-        );
+    for (row, vec) in bar.wrap_iter(csr.iter()?.take(count).enumerate()) {
+        builder.add(row as u32, vec.into_remapped());
     }
     bar.finish_and_clear();
     Ok(builder.build())

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -132,6 +132,11 @@ impl SparseVector {
         Ok(vector)
     }
 
+    #[cfg(feature = "testing")]
+    pub fn new_unchecked(indices: Vec<DimId>, values: Vec<DimWeight>) -> Self {
+        SparseVector { indices, values }
+    }
+
     /// Sort this vector by indices.
     ///
     /// Sorting is required for scoring and overlap checks.

--- a/lib/sparse/src/common/types.rs
+++ b/lib/sparse/src/common/types.rs
@@ -2,14 +2,15 @@ use std::fmt::Debug;
 
 use half::slice::HalfFloatSliceExt;
 use itertools::{Itertools, MinMaxResult};
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 pub type DimOffset = u32;
 pub type DimId = u32;
 pub type DimId64 = u64;
 pub type DimWeight = f32;
 
-pub trait Weight: PartialEq + Copy + Debug + 'static {
-    type QuantizationParams: Copy + PartialEq + Debug;
+pub trait Weight: PartialEq + Copy + Debug + FromBytes + Immutable + KnownLayout + 'static {
+    type QuantizationParams: Copy + PartialEq + Debug + FromBytes + Immutable + KnownLayout;
 
     fn quantization_params_for(
         values: impl ExactSizeIterator<Item = DimWeight> + Clone,
@@ -97,7 +98,8 @@ impl Weight for u8 {
     }
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Copy, Clone, Debug, FromBytes, Immutable, KnownLayout)]
+#[repr(transparent)]
 pub struct QuantizedU8(u8);
 
 impl From<QuantizedU8> for DimWeight {
@@ -106,7 +108,8 @@ impl From<QuantizedU8> for DimWeight {
     }
 }
 
-#[derive(PartialEq, Default, Copy, Clone, Debug)]
+#[derive(PartialEq, Default, Copy, Clone, Debug, FromBytes, Immutable, KnownLayout)]
+#[repr(C)]
 pub struct QuantizedU8Params {
     /// Minimum value in the range
     min: f32,

--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -8,6 +8,7 @@ use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::types::PointOffsetType;
 #[cfg(debug_assertions)]
 use itertools::Itertools as _;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use super::posting_list_common::{
     GenericPostingElement, PostingElement, PostingElementEx, PostingListIter,
@@ -47,9 +48,9 @@ pub struct CompressedPostingListView<'a, W: Weight> {
     hw_counter: &'a HardwareCounterCell,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
-pub struct CompressedPostingChunk<W> {
+pub struct CompressedPostingChunk<W: Weight> {
     /// Initial data point id. Used for decompression.
     initial: PointOffsetType,
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -7,20 +7,18 @@ use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::{atomic_save_json, read_json};
-use common::mmap::{Advice, AdviceSetting, Madviseable};
+use common::mmap::{Advice, AdviceSetting, Madviseable, create_and_ensure_length, open_read_mmap};
 #[expect(deprecated, reason = "legacy code")]
-use common::mmap::{
-    create_and_ensure_length, open_read_mmap, transmute_from_u8_to_slice, transmute_to_u8,
-    transmute_to_u8_slice,
-};
+use common::mmap::{transmute_to_u8, transmute_to_u8_slice};
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{Result, UniversalIoError};
+use common::universal_io::Result;
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use super::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
-use super::{INDEX_FILE_NAME, out_of_bounds};
+use super::{INDEX_FILE_NAME, corrupted_index, out_of_bounds};
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset, Weight};
 use crate::index::compressed_posting_list::{
@@ -62,7 +60,7 @@ pub struct InvertedIndexCompressedMmap<W> {
     _phantom: PhantomData<W>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
 struct PostingListFileHeader<W: Weight> {
     pub ids_start: u64,
@@ -191,14 +189,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             return Err(out_of_bounds(id, self.file_header.posting_count));
         }
 
-        // TODO Safety.
-        let header: PostingListFileHeader<W> = unsafe {
-            self.slice_part::<PostingListFileHeader<W>>(
-                u64::from(id) * Self::HEADER_SIZE as u64,
-                1u32,
-            )
-        }[0]
-        .clone();
+        let header = self.read_header(id)?.clone();
 
         hw_counter.vector_io_read().incr_delta(Self::HEADER_SIZE);
 
@@ -207,14 +198,7 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             + u64::from(header.chunks_count) * size_of::<CompressedPostingChunk<W>>() as u64;
 
         let remainders_end = if id + 1 < self.file_header.posting_count as DimId {
-            // TODO Safety
-            (unsafe {
-                self.slice_part::<PostingListFileHeader<W>>(
-                    u64::from(id + 1) * Self::HEADER_SIZE as u64,
-                    1u32,
-                )
-            })[0]
-                .ids_start
+            self.read_header(id + 1)?.ids_start
         } else {
             self.mmap.len() as u64
         };
@@ -223,44 +207,43 @@ impl<W: Weight> InvertedIndexCompressedMmap<W> {
             .checked_sub(remainders_start)
             .is_some_and(|len| len % size_of::<GenericPostingElement<W>>() as u64 != 0)
         {
-            return Err(UniversalIoError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Sparse index is corrupted",
-            )));
+            return Err(corrupted_index());
         }
 
+        let id_data = self.byte_slice(header.ids_start, u64::from(header.ids_len))?;
+        let chunks = <[CompressedPostingChunk<W>]>::ref_from_bytes(self.byte_slice(
+            header.ids_start + u64::from(header.ids_len),
+            u64::from(header.chunks_count) * size_of::<CompressedPostingChunk<W>>() as u64,
+        )?)
+        .map_err(|_| corrupted_index())?;
+        let remainders = <[GenericPostingElement<W>]>::ref_from_bytes(
+            &self.mmap[remainders_start as usize..remainders_end as usize],
+        )
+        .map_err(|_| corrupted_index())?;
+
         Ok(CompressedPostingListView::new(
-            // TODO Safety
-            unsafe { self.slice_part(header.ids_start, header.ids_len) },
-            // TODO Safety
-            unsafe {
-                self.slice_part(
-                    header.ids_start + u64::from(header.ids_len),
-                    header.chunks_count,
-                )
-            },
-            // TODO Safety
-            unsafe {
-                #[expect(deprecated, reason = "legacy code")]
-                transmute_from_u8_to_slice(
-                    &self.mmap[remainders_start as usize..remainders_end as usize],
-                )
-            },
+            id_data,
+            chunks,
+            remainders,
             header.last_id.checked_sub(1),
             header.quantization_params,
             hw_counter,
         ))
     }
 
-    // TODO Safety
-    unsafe fn slice_part<T>(&self, start: impl Into<u64>, count: impl Into<u64>) -> &[T] {
-        let start = start.into() as usize;
-        let end = start + count.into() as usize * size_of::<T>();
-        // Safety: safe because of the method safety invariants.
-        #[expect(deprecated, reason = "legacy code")]
-        unsafe {
-            transmute_from_u8_to_slice(&self.mmap[start..end])
-        }
+    fn read_header(&self, id: DimId) -> Result<&PostingListFileHeader<W>> {
+        let start = id as usize * Self::HEADER_SIZE;
+        let end = start + Self::HEADER_SIZE;
+        let bytes = self.mmap.get(start..end).ok_or_else(corrupted_index)?;
+        PostingListFileHeader::<W>::ref_from_bytes(bytes).map_err(|_| corrupted_index())
+    }
+
+    fn byte_slice(&self, start: u64, len: u64) -> Result<&[u8]> {
+        let start = start as usize;
+        let end = start
+            .checked_add(len as usize)
+            .ok_or_else(corrupted_index)?;
+        self.mmap.get(start..end).ok_or_else(corrupted_index)
     }
 
     pub fn convert_and_save<P: AsRef<Path>>(

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -97,3 +97,11 @@ pub(crate) fn out_of_bounds(id: DimOffset, len: usize) -> UniversalIoError {
         format!("DimOffset {id} out of bounds. Index contains {len} posting lists."),
     ))
 }
+
+/// Error returned when on-disk index bytes fail length or alignment checks.
+pub(crate) fn corrupted_index() -> UniversalIoError {
+    UniversalIoError::Io(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "Sparse index is corrupted",
+    ))
+}

--- a/lib/sparse/src/index/loaders.rs
+++ b/lib/sparse/src/index/loaders.rs
@@ -1,14 +1,11 @@
 use std::collections::HashMap;
 use std::io::{self, BufRead as _, BufReader, Lines};
-use std::mem::size_of;
 use std::path::Path;
 
-use common::mmap::{Advice, AdviceSetting};
-#[expect(deprecated, reason = "legacy code")]
-use common::mmap::{open_read_mmap, transmute_from_u8, transmute_from_u8_to_slice};
+use common::mmap::{Advice, AdviceSetting, open_read_mmap};
 use fs_err::File;
 use memmap2::Mmap;
-use validator::ValidationErrors;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use crate::common::sparse_vector::SparseVector;
 
@@ -26,16 +23,11 @@ use crate::common::sparse_vector::SparseVector;
 /// | data    | `u32[nnz]`    | 4*nnz      | 24+8*(nrow+1)+4*nnz |
 pub struct Csr {
     mmap: Mmap,
-
     nrow: usize,
-    nnz: usize,
-    intptr: Vec<u64>,
 }
 
-const CSR_HEADER_SIZE: usize = size_of::<CsrHeader>();
-
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, KnownLayout)]
 pub struct CsrHeader {
     nrow: u64,
     ncol: u64,
@@ -44,11 +36,10 @@ pub struct CsrHeader {
 
 impl Csr {
     pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
-        Self::from_mmap(open_read_mmap(
-            path.as_ref(),
-            AdviceSetting::from(Advice::Normal),
-            false,
-        )?)
+        let mmap = open_read_mmap(path.as_ref(), AdviceSetting::from(Advice::Normal), false)?;
+        let (header, _) = CsrHeader::ref_from_prefix(mmap.as_ref()).map_err(csr_error)?;
+        let nrow = header.nrow as usize;
+        Ok(Self { mmap, nrow })
     }
 
     #[inline]
@@ -57,100 +48,27 @@ impl Csr {
         self.nrow
     }
 
-    pub fn iter(&self) -> CsrIter<'_> {
-        CsrIter { csr: self, row: 0 }
-    }
-
-    fn from_mmap(mmap: Mmap) -> io::Result<Self> {
-        // Safety: CsrHeader is a POD type.
-        #[expect(deprecated, reason = "legacy code")]
-        let CsrHeader { nrow, ncol, nnz } =
-            unsafe { transmute_from_u8(&mmap.as_ref()[..CSR_HEADER_SIZE]) };
-        let (nrow, _ncol, nnz) = (*nrow as usize, *ncol as usize, *nnz as usize);
-
-        // Safety: correct alignment.
-        let indptr = Vec::from(unsafe {
-            #[expect(deprecated, reason = "legacy code")]
-            transmute_from_u8_to_slice::<u64>(
-                &mmap.as_ref()[CSR_HEADER_SIZE..CSR_HEADER_SIZE + size_of::<u64>() * (nrow + 1)],
-            )
-        });
-        if !indptr.array_windows().all(|[a, b]| a <= b) || indptr.last() != Some(&(nnz as u64)) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid indptr array",
-            ));
-        }
-
-        Ok(Self {
-            mmap,
-            nrow,
-            nnz,
-            intptr: indptr,
-        })
-    }
-
-    #[inline]
-    unsafe fn vec(&self, row: usize) -> Result<SparseVector, ValidationErrors> {
-        const _: () = assert!(
-            cfg!(feature = "testing"),
-            "This unsafe block should be used only in internal benchmarks"
-        );
-        unsafe {
-            let start = *self.intptr.get_unchecked(row) as usize;
-            let end = *self.intptr.get_unchecked(row + 1) as usize;
-
-            let mut pos = CSR_HEADER_SIZE + size_of::<u64>() * (self.nrow + 1);
-
-            #[expect(deprecated, reason = "legacy code")]
-            let indices = transmute_from_u8_to_slice::<u32>(
-                self.mmap
-                    .as_ref()
-                    .get_unchecked(pos + size_of::<u32>() * start..pos + size_of::<u32>() * end),
-            );
-            pos += size_of::<u32>() * self.nnz;
-
-            #[expect(deprecated, reason = "legacy code")]
-            let data = transmute_from_u8_to_slice::<f32>(
-                self.mmap
-                    .as_ref()
-                    .get_unchecked(pos + size_of::<f32>() * start..pos + size_of::<f32>() * end),
-            );
-
-            SparseVector::new(indices.to_vec(), data.to_vec())
-        }
+    pub fn iter(&self) -> io::Result<impl ExactSizeIterator<Item = SparseVector> + '_> {
+        let (header, bytes) = CsrHeader::ref_from_prefix(self.mmap.as_ref()).map_err(csr_error)?;
+        let nrow = header.nrow as usize;
+        let nnz = header.nnz as usize;
+        let (indptr, bytes) =
+            <[u64]>::ref_from_prefix_with_elems(bytes, nrow + 1).map_err(csr_error)?;
+        let (indices, bytes) =
+            <[u32]>::ref_from_prefix_with_elems(bytes, nnz).map_err(csr_error)?;
+        let (data, _) = <[f32]>::ref_from_prefix_with_elems(bytes, nnz).map_err(csr_error)?;
+        Ok(indptr.array_windows().map(move |&[start, end]| {
+            let (start, end) = (start as usize, end as usize);
+            SparseVector::new_unchecked(indices[start..end].to_vec(), data[start..end].to_vec())
+        }))
     }
 }
 
-/// Iterator over the rows of a CSR matrix.
-pub struct CsrIter<'a> {
-    csr: &'a Csr,
-    row: usize,
-}
-
-impl Iterator for CsrIter<'_> {
-    type Item = Result<SparseVector, ValidationErrors>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        (self.row < self.csr.nrow).then(|| {
-            let vec = unsafe { self.csr.vec(self.row) };
-            self.row += 1;
-            vec
-        })
-    }
-}
-
-impl ExactSizeIterator for CsrIter<'_> {
-    fn len(&self) -> usize {
-        self.csr.nrow - self.row
-    }
-}
-
-pub fn load_csr_vecs(path: impl AsRef<Path>) -> io::Result<Vec<SparseVector>> {
-    Csr::open(path)?
-        .iter()
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+fn csr_error(e: impl std::fmt::Display) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("invalid CSR format: {e}"),
+    )
 }
 
 /// Stream of sparse vectors in JSON format.

--- a/lib/sparse/src/index/posting_list_common.rs
+++ b/lib/sparse/src/index/posting_list_common.rs
@@ -1,10 +1,11 @@
 use common::types::PointOffsetType;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use crate::common::types::DimWeight;
 
 pub const DEFAULT_MAX_NEXT_WEIGHT: DimWeight = f32::NEG_INFINITY;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct GenericPostingElement<W> {
     /// Record ID
@@ -22,7 +23,7 @@ pub struct PostingElement {
     pub weight: DimWeight,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct PostingElementEx {
     /// Record ID


### PR DESCRIPTION
This PR refactors `InvertedIndexCompressedMmap` to use `zerocopy` for mmap reads instead of unsafe transmutes. This should simplify subsequent conversion to UIO.

Also, use `zerocopy` for `loaders::Csr` (used only for benchmark datasets).

Q: Why only reads?
A: For writes we need to derive `zerocopy::IntoBytes`. Struct paddings + generics like `GenericPostingElement` + `zerocopy::IntoBytes` is a complicated story. Let's keep using `unsafe { transmute_to_u8_slice(…) }`.

Q: Why not `bytemuck`?
A: Same complicated story with `bytemuck::Pod`. Zerocopy, at least, lets us derive `FromBytes`.
This won't stop us from using `UniversalRead::read<T: bytemuck::Pod>()` because we have to read sparse posting list as `Cow<[u8]>` anyway.