### PR TITLE
Reject unknown gRPC enum integers with InvalidArgument

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2178,9 +2178,11 @@ impl TryFrom<OrderBy> for segment::data_types::order_by::OrderBy {
         } = value;
 
         let direction = direction
-            .and_then(|x|
-                // XXX: Invalid values silently converted to None
-                Direction::try_from(x).ok())
+            .map(|x| {
+                Direction::try_from(x)
+                    .map_err(|_| Status::invalid_argument(format!("Cannot convert Direction: {x}")))
+            })
+            .transpose()?
             .map(segment::data_types::order_by::Direction::from);
 
         let start_from = start_from

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -803,9 +803,12 @@ impl TryFrom<api::grpc::qdrant::SparseVectorParams> for SparseVectorParams {
                 })
                 .transpose()?,
             modifier: modifier
-                .and_then(|x|
-                    // XXX: Invalid values silently converted to None
-                    api::grpc::qdrant::Modifier::try_from(x).ok())
+                .map(|x| {
+                    api::grpc::qdrant::Modifier::try_from(x).map_err(|_| {
+                        Status::invalid_argument(format!("Cannot convert Modifier: {x}"))
+                    })
+                })
+                .transpose()?
                 .map(Modifier::from),
         })
     }

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -253,7 +253,12 @@ fn convert_query_with_inferred(
             let reco_query = RecoQuery::new(positives, negatives);
 
             let strategy = strategy
-                .and_then(|x| grpc::RecommendStrategy::try_from(x).ok())
+                .map(|x| {
+                    grpc::RecommendStrategy::try_from(x).map_err(|_| {
+                        Status::invalid_argument(format!("Unknown recommend strategy: {x}"))
+                    })
+                })
+                .transpose()?
                 .map(RecommendStrategy::from)
                 .unwrap_or_default();
 
@@ -606,5 +611,54 @@ mod tests {
                 .message()
                 .contains("positive is missing"),
         );
+    }
+
+    fn make_recommend_query(strategy: Option<i32>) -> grpc::Query {
+        grpc::Query {
+            variant: Some(api::grpc::qdrant::query::Variant::Recommend(
+                RecommendInput {
+                    positive: vec![grpc::VectorInput {
+                        variant: Some(Variant::Dense(grpc::DenseVector {
+                            data: vec![1.0, 2.0, 3.0],
+                        })),
+                    }],
+                    negative: vec![],
+                    strategy,
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn test_convert_query_rejects_unknown_recommend_strategy() {
+        let inferred = create_test_inferred_batch();
+        let query = make_recommend_query(Some(9999));
+
+        let result = convert_query_with_inferred(query, &inferred);
+        let err = result.expect_err("unknown strategy should be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("Unknown recommend strategy"),
+            "unexpected message: {}",
+            err.message(),
+        );
+    }
+
+    #[test]
+    fn test_convert_query_accepts_known_recommend_strategy() {
+        let inferred = create_test_inferred_batch();
+        let query = make_recommend_query(Some(grpc::RecommendStrategy::BestScore as i32));
+
+        let result = convert_query_with_inferred(query, &inferred);
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_convert_query_accepts_missing_recommend_strategy() {
+        let inferred = create_test_inferred_batch();
+        let query = make_recommend_query(None);
+
+        let result = convert_query_with_inferred(query, &inferred);
+        assert!(result.is_ok(), "expected ok, got {result:?}");
     }
 }

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -937,8 +937,11 @@ fn convert_field_type(
     field_index_params: Option<PayloadIndexParams>,
 ) -> Result<Option<PayloadFieldSchema>, Status> {
     let field_type_parsed = field_type
-        .map(|x| FieldType::try_from(x).ok())
-        .ok_or_else(|| Status::invalid_argument("cannot convert field_type"))?;
+        .map(|x| {
+            FieldType::try_from(x)
+                .map_err(|_| Status::invalid_argument(format!("Unknown field type: {x}")))
+        })
+        .transpose()?;
 
     let field_schema = match (field_type_parsed, field_index_params) {
         (
@@ -1013,8 +1016,8 @@ fn convert_field_type(
             FieldType::Datetime => Some(PayloadSchemaType::Datetime.into()),
             FieldType::Uuid => Some(PayloadSchemaType::Uuid.into()),
         },
-        (None, Some(_)) => return Err(Status::invalid_argument("field type is missing")),
-        (None, None) => None,
+        (None, Some(_)) => return Err(Status::invalid_argument("field_type is missing")),
+        (None, None) => return Err(Status::invalid_argument("field_type is required")),
     };
 
     Ok(field_schema)
@@ -1172,4 +1175,67 @@ pub async fn delete_vector_name(
 
     let response = points_operation_response_internal(timing, result, None);
     Ok(Response::new(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_field_type_rejects_unknown_int() {
+        let err = convert_field_type(Some(9999), None)
+            .expect_err("unknown FieldType integer should be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("Unknown field type"),
+            "unexpected message: {}",
+            err.message(),
+        );
+    }
+
+    #[test]
+    fn convert_field_type_rejects_unknown_int_with_params() {
+        let params = PayloadIndexParams {
+            index_params: Some(IndexParams::KeywordIndexParams(
+                grpc::qdrant::KeywordIndexParams::default(),
+            )),
+        };
+        let err = convert_field_type(Some(9999), Some(params))
+            .expect_err("unknown FieldType integer should be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("Unknown field type"),
+            "unexpected message: {}",
+            err.message(),
+        );
+    }
+
+    #[test]
+    fn convert_field_type_requires_field_type() {
+        let err =
+            convert_field_type(None, None).expect_err("missing field_type should be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn convert_field_type_requires_field_type_when_params_present() {
+        let params = PayloadIndexParams {
+            index_params: Some(IndexParams::KeywordIndexParams(
+                grpc::qdrant::KeywordIndexParams::default(),
+            )),
+        };
+        let err = convert_field_type(None, Some(params))
+            .expect_err("missing field_type with params should be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn convert_field_type_accepts_known_field_type() {
+        let schema = convert_field_type(Some(FieldType::Keyword as i32), None)
+            .expect("known FieldType should be accepted");
+        assert_eq!(
+            schema,
+            Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)),
+        );
+    }
 }


### PR DESCRIPTION
Attempt to fix old `XXX` in the codebase: four gRPC conversion sites used `EnumType::try_from(x).ok()` and silently
dropped invalid integer enum values to `None` or the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved API validation**: Invalid parameters in API requests (direction values, modifier values, recommendation strategies, and field types) are now properly rejected with error messages instead of being silently ignored or dropped. This ensures clearer feedback when requests contain invalid arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qdrant/qdrant/pull/9142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->