### PR TITLE
docs: fix read operation typo

### DIFF
--- a/lib/collection/src/shards/replica_set/execute_read_operation.rs
+++ b/lib/collection/src/shards/replica_set/execute_read_operation.rs
@@ -18,7 +18,7 @@ impl ShardReplicaSet {
     /// Execute read op. on replica set:
     /// 1 - Prefer local replica
     /// 2 - Otherwise uses `read_fan_out_ratio` to compute list of active remote shards.
-    /// 3 - Fallbacks to all remaining shards if the optimisations fails.
+    /// 3 - Falls back to all remaining shards if the optimization fails.
     /// It does not report failing peer_ids to the consensus.
     pub async fn execute_read_operation<Res, F>(
         &self,


### PR DESCRIPTION
## Summary

Fix a typo in the `execute_read_operation` doc comment referenced by the typo-cleanup issue.

## Test plan

- Not run (doc comment change only)
- Verified diff is limited to the comment text

Ref #3455