### PR TITLE
Durably flush optimized segments before dropping source data

### DIFF
--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -582,6 +582,27 @@ fn finish_optimization(
             .try_for_each(|chunk| read_segment_holder.deduplicate_points(chunk, hw_counter))?;
     }
 
+    // Durably flush the whole holder before `drop_data` removes the source segments below.
+    //
+    // A write that lands on a point in a frozen source segment is handled by copy-on-write: the
+    // point is relocated into an appendable segment and deleted from the source (see
+    // `apply_points_with_conditional_move`, which records a flush dependency so the new location is
+    // persisted before the source-side deletion). The merged segment does NOT carry those relocated
+    // points — their source-side deletion is replayed into it — so an appendable segment, not the
+    // merged one, holds their only live copy.
+    //
+    // `drop_data` below physically deletes the source segments. Once they are gone, a relocated
+    // point is recoverable only if its appendable segment is durable, because the WAL may be
+    // acknowledged (and truncated) only up to a version whose data is on disk. Flushing just the
+    // merged segment would leave the relocation target's durability to the async flush worker,
+    // which can truncate the WAL past a relocated point before its data reaches disk — losing it on
+    // reload. This reproducibly drops points in the reload-divergence soak test.
+    //
+    // It must be `flush_all`, not a hand-picked subset: the relocation target can be any appendable
+    // segment, and only this path flushes in flush-dependency order. Already-persisted segments
+    // early-out, so the extra cost is bounded.
+    read_segment_holder.flush_all(true, true)?;
+
     drop(read_segment_holder);
     // Allow updates again
     drop(update_guard);


### PR DESCRIPTION
## Problem

A restart during optimization can permanently lose points: gone after reload, unrecoverable on reopen, and WAL replay logs `No point with id X found`. 

The WAL was acked past the point's op, but no on-disk segment holds it.

## Cause

Writes to a point in a frozen source segment are copy-on-write: the point is **relocated into an appendable segment and deleted from the source**. 

The merged segment replays that deletion, so it does *not* hold the relocated point — an appendable segment does.

`finish_optimization` then `drop_data()`s the sources (deletes them from disk). 

After that, a relocated point survives only if its appendable segment is durable.

Flushing just the merged segment leaves that to the async flush worker, which can ack/truncate the WAL past the point before its data hits disk → lost on reload.

## Fix

`flush_all(true, true)` before `drop_data`. Must be `flush_all`, not a subset: the relocation target can be any appendable segment, and only this path flushes in flush-dependency order (target before source). 

Already-persisted segments early-out, so the cost is bounded.

## Testing

Soak harness, single shard / single optimizer thread / no deferred points (seed 2): without the fix (or flushing only the merged segment) it loses points within ~25k ops; with `flush_all`, 200k+ ops across many restarts, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
