### PR TITLE
[UIO] Require `T: Send` on `UniversalRead`

### DIFF
--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -62,7 +62,7 @@ fn benches(c: &mut Criterion) {
     }
 }
 
-fn read_benches<T: bytemuck::Pod, C: UniversalRead>(
+fn read_benches<T: bytemuck::Pod + Send, C: UniversalRead>(
     c: &mut Criterion,
     impl_name: &str, // Corresponds to `C`
     elem_size: &str, // Corresponds to `T`

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -6,7 +6,7 @@ use fs_err as fs;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    OpenOptions, OpenOptionsExtra, ReadRange, Result, UniversalIoError, UniversalRead,
+    Item, OpenOptions, OpenOptionsExtra, ReadRange, Result, UniversalIoError, UniversalRead,
     UniversalReadFileOps, UserData, local_file_ops,
 };
 
@@ -72,13 +72,13 @@ impl UniversalRead for CachedSlice {
         = BorrowedDiskCacheReadPipeline<'a, T, U>
     where
         Self: 'a,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     type OwnedReadPipeline<T, U>
         = OwnedDiskCacheReadPipeline<T, U>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -111,7 +111,7 @@ impl UniversalRead for CachedSlice {
         Ok(())
     }
 
-    fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         let elem_start = usize::try_from(range.byte_offset).expect("range.start is within usize")
             / size_of::<T>();
         let elem_length = usize::try_from(range.length).expect("range.length is within usize");

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -3,13 +3,13 @@ use std::borrow::Cow;
 use super::CachedSlice;
 use crate::generic_consts::{AccessPattern, Random};
 use crate::universal_io::{
-    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UniversalRead,
-    UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError,
+    UniversalRead, UserData,
 };
 
 pub struct BorrowedDiskCacheReadPipeline<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     result: Option<(U, Cow<'file, [T]>)>,
@@ -17,7 +17,7 @@ where
 
 impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedDiskCacheReadPipeline<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = CachedSlice;
@@ -61,7 +61,7 @@ pub struct OwnedDiskCacheReadPipeline<T, U> {
 
 impl<T, U> OwnedReadPipeline<T, U> for OwnedDiskCacheReadPipeline<T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = CachedSlice;

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -20,7 +20,7 @@ use self::error::*;
 use self::pipeline::{BorrowedIoUringPipeline, OwnedIoUringPipeline};
 use self::pool::*;
 use self::runtime::*;
-use super::traits::UniversalReadFileOps;
+use super::traits::{Item, UniversalReadFileOps};
 use super::*;
 use crate::generic_consts::AccessPattern;
 
@@ -55,13 +55,13 @@ impl UniversalRead for IoUringFile {
     type BorrowedReadPipeline<'a, T, U>
         = BorrowedIoUringPipeline<'a, T, U>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     type OwnedReadPipeline<T, U>
         = OwnedIoUringPipeline<T, U>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -99,7 +99,7 @@ impl UniversalRead for IoUringFile {
         Ok(())
     }
 
-    fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         if self.direct_io {
             // direct_io needs special handling
             return self

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -7,12 +7,12 @@ use super::pool::IO_URING_QUEUE_LENGTH;
 use super::{IoUringFile, IoUringRuntime};
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
 };
 
 pub struct BorrowedIoUringPipeline<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     inner: IoUringPipelineInner<'file, T, U>,
@@ -20,7 +20,7 @@ where
 
 impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedIoUringPipeline<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = IoUringFile;
@@ -56,7 +56,7 @@ where
 
 pub struct OwnedIoUringPipeline<T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     file: ManuallyDrop<IoUringFile>,
@@ -65,7 +65,7 @@ where
 
 impl<T, U> OwnedReadPipeline<T, U> for OwnedIoUringPipeline<T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = IoUringFile;
@@ -101,7 +101,7 @@ where
 
 impl<T, U> Drop for OwnedIoUringPipeline<T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     fn drop(&mut self) {
@@ -116,7 +116,7 @@ where
 
 struct IoUringPipelineInner<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     runtime: IoUringRuntime<'file, T, U>,
@@ -124,7 +124,7 @@ where
 
 impl<'file, T, U> IoUringPipelineInner<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     fn new() -> Result<Self> {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -10,7 +10,7 @@ use memmap2::MmapRaw;
 use parking_lot::Mutex;
 
 use self::pipeline::{BorrowedMmapReadPipeline, OwnedMmapReadPipeline};
-use super::traits::UniversalReadFileOps;
+use super::traits::{Item, UniversalReadFileOps};
 use super::*;
 use crate::generic_consts::AccessPattern;
 use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as _};
@@ -59,13 +59,13 @@ impl UniversalRead for MmapFile {
     type BorrowedReadPipeline<'a, T, U>
         = BorrowedMmapReadPipeline<'a, T, U>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     type OwnedReadPipeline<T, U>
         = OwnedMmapReadPipeline<T, U>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
@@ -196,7 +196,7 @@ impl UniversalRead for MmapFile {
         Ok(())
     }
 
-    fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         let mmap = self.as_bytes::<P>();
         let items = read(mmap, range)?;
         Ok(Cow::Borrowed(items))

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use super::{MmapFile, read};
 use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::{
-    BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UniversalIoError, UserData,
 };
 
 pub struct BorrowedMmapReadPipeline<'file, T, U> {
@@ -12,7 +12,7 @@ pub struct BorrowedMmapReadPipeline<'file, T, U> {
 
 impl<'file, T, U> BorrowedReadPipeline<'file, T, U> for BorrowedMmapReadPipeline<'file, T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = MmapFile;
@@ -51,7 +51,7 @@ pub struct OwnedMmapReadPipeline<T, U> {
 
 impl<T, U> OwnedReadPipeline<T, U> for OwnedMmapReadPipeline<T, U>
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = MmapFile;

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -15,8 +15,8 @@ pub use self::error::UniversalIoError;
 pub use self::io_uring::IoUringFile;
 pub use self::mmap::MmapFile;
 pub use self::traits::{
-    BorrowedReadPipeline, OwnedReadPipeline, UniversalRead, UniversalReadFileOps, UniversalWrite,
-    UserData,
+    BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalRead, UniversalReadFileOps,
+    UniversalWrite, UserData,
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, OpenOptions, OpenOptionsExtra, Populate, ReadRange, Result,

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -20,3 +20,13 @@ pub use write::UniversalWrite;
 /// This trait exists for documentation/code navigation purposes only.
 pub trait UserData {}
 impl<T> UserData for T {}
+
+/// Element type read from or written to a universal I/O storage.
+///
+/// Acts as a short alias for `bytemuck::Pod + Send`. The [`Send`] bound is
+/// required because some [`UniversalRead`] implementations transfer item
+/// buffers across threads (e.g. background fetch in disk-cache / future
+/// async backends). All `Pod` types in practice are plain bytes and thus
+/// naturally [`Send`], so the bound does not restrict realistic usage.
+pub trait Item: bytemuck::Pod + Send {}
+impl<T: bytemuck::Pod + Send> Item for T {}

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -20,12 +20,13 @@
 
 use std::borrow::Cow;
 
+use super::Item;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{ReadRange, Result, UserData};
 
 pub trait BorrowedReadPipeline<'file, T, U>: Sized
 where
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File: 'file;

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-use super::{BorrowedReadPipeline, OwnedReadPipeline, UniversalReadFileOps, UserData};
+use super::{BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalReadFileOps, UserData};
 use crate::generic_consts::{AccessPattern, Sequential};
 use crate::universal_io::{OpenOptions, ReadRange, Result, UniversalKind};
 
@@ -12,12 +12,12 @@ pub trait UniversalRead: UniversalReadFileOps {
     type BorrowedReadPipeline<'file, T, U>: BorrowedReadPipeline<'file, T, U, File = Self>
     where
         Self: 'file,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     type OwnedReadPipeline<T, U>: OwnedReadPipeline<T, U, File = Self>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>;
@@ -29,13 +29,13 @@ pub trait UniversalRead: UniversalReadFileOps {
     fn reopen(&mut self) -> Result<()>;
 
     /// Prefer [`read_batch`] if you need high performance.
-    fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>>;
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>>;
 
     /// Read the entire file in one logical access.
     ///
     /// Implementations may override this to avoid the two accesses that would result from
     /// `len()` followed by `read(0..len())`. Default implementation does exactly that.
-    fn read_whole<T: bytemuck::Pod>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
         let range = ReadRange {
             byte_offset: 0,
             length: self.len::<T>()?,
@@ -51,7 +51,7 @@ pub trait UniversalRead: UniversalReadFileOps {
     ) -> Result<()>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
     {
         for record in self.read_iter::<P, T, U>(ranges)? {
@@ -70,7 +70,7 @@ pub trait UniversalRead: UniversalReadFileOps {
     ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
     {
         let reads = ranges
@@ -99,7 +99,7 @@ pub trait UniversalRead: UniversalReadFileOps {
     ) -> Result<()>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
         Self: 'a,
     {
@@ -118,7 +118,7 @@ pub trait UniversalRead: UniversalReadFileOps {
     ) -> Result<impl Iterator<Item = Result<(U, Cow<'a, [T]>)>>>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
         Self: 'a,
     {

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -6,7 +6,8 @@ use bytemuck::TransparentWrapper;
 use super::{BorrowedWrappedReadPipeline, OwnedWrappedReadPipeline};
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps, UserData,
+    Item, OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps,
+    UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -36,13 +37,13 @@ where
         = BorrowedWrappedReadPipeline<'file, Self, S::BorrowedReadPipeline<'file, T, U>>
     where
         Self: 'file,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     type OwnedReadPipeline<T, U>
         = OwnedWrappedReadPipeline<Self, S::OwnedReadPipeline<T, U>>
     where
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData;
 
     #[inline]
@@ -58,12 +59,12 @@ where
     }
 
     #[inline]
-    fn read<P: AccessPattern, T: bytemuck::Pod>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
         self.0.read::<P, T>(range)
     }
 
     #[inline]
-    fn read_whole<T: bytemuck::Pod>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
         self.0.read_whole()
     }
 
@@ -75,7 +76,7 @@ where
     ) -> Result<()>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
     {
         self.0.read_batch::<P, T, U>(ranges, callback)
@@ -88,7 +89,7 @@ where
     ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
     {
         self.0.read_iter::<P, T, U>(ranges)
@@ -116,7 +117,7 @@ where
     ) -> Result<()>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
         Self: 'a,
     {
@@ -133,7 +134,7 @@ where
     ) -> Result<impl Iterator<Item = Result<(U, Cow<'a, [T]>)>>>
     where
         P: AccessPattern,
-        T: bytemuck::Pod,
+        T: Item,
         U: UserData,
         Self: 'a,
     {

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -7,8 +7,8 @@ use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    ByteOffset, FileIndex, Flusher, OpenOptions, ReadRange, Result, UniversalKind, UniversalRead,
-    UniversalReadFileOps, UniversalWrite, UserData,
+    ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, Result, UniversalKind,
+    UniversalRead, UniversalReadFileOps, UniversalWrite, UserData,
 };
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
@@ -60,7 +60,7 @@ where
 impl<S, T> TypedStorage<S, T>
 where
     S: UniversalRead,
-    T: bytemuck::Pod,
+    T: Item,
 {
     #[inline]
     pub fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -4,7 +4,9 @@ use std::marker::PhantomData;
 use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::{BorrowedReadPipeline, OwnedReadPipeline, ReadRange, Result, UserData};
+use crate::universal_io::{
+    BorrowedReadPipeline, Item, OwnedReadPipeline, ReadRange, Result, UserData,
+};
 
 /// Default implementation of [`BorrowedReadPipeline`] for wrappers.
 pub struct BorrowedWrappedReadPipeline<'a, File, Inner> {
@@ -17,7 +19,7 @@ impl<'a, File, Inner, T, U> BorrowedReadPipeline<'a, T, U>
 where
     File: TransparentWrapper<Inner::File>,
     Inner: BorrowedReadPipeline<'a, T, U>,
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = File;
@@ -62,7 +64,7 @@ impl<File, Inner, T, U> OwnedReadPipeline<T, U> for OwnedWrappedReadPipeline<Fil
 where
     File: TransparentWrapper<Inner::File>,
     Inner: OwnedReadPipeline<T, U>,
-    T: bytemuck::Pod,
+    T: Item,
     U: UserData,
 {
     type File = File;

--- a/lib/segment/src/index/field_index/numeric_point.rs
+++ b/lib/segment/src/index/field_index/numeric_point.rs
@@ -75,7 +75,7 @@ const fn derive_point_padding<T: bytemuck::Pod>() -> usize {
 
 /// A trait that should represent common properties of integer and floating point types.
 /// In particular, i64 and f64.
-pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod {
+pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod + Send {
     /// This is to be able to derive [`bytemuck::Pod`] for [`Point<T>`], which is required for safe de/serialization.
     ///
     /// Since we need ['Point<T>`] to be repr(packed), this padding must be picked to be the next multiple of the largest
@@ -86,7 +86,8 @@ pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod {
         + PartialEq
         + PartialOrd
         + Serialize
-        + for<'de> serde::Deserialize<'de>;
+        + for<'de> serde::Deserialize<'de>
+        + Send;
 
     fn min_value() -> Self;
     fn max_value() -> Self;

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -18,7 +18,7 @@ fn check_mmap_file_name_pattern(file_name: &str) -> Option<usize> {
         .and_then(|file_name| file_name.parse::<usize>().ok())
 }
 
-pub fn read_chunks<T: bytemuck::Pod, S: UniversalRead>(
+pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
     directory: &Path,
     advice: AdviceSetting,
     populate: bool,
@@ -72,7 +72,7 @@ pub fn chunk_name(directory: &Path, chunk_id: usize) -> PathBuf {
     ))
 }
 
-pub fn create_chunk<T: bytemuck::Pod, S: UniversalWrite>(
+pub fn create_chunk<T: bytemuck::Pod + Send, S: UniversalWrite>(
     directory: &Path,
     chunk_id: usize,
     chunk_length_bytes: usize,

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -25,7 +25,7 @@ use crate::vector_storage::{VectorOffset, VectorOffsetType};
 /// not refreshed afterwards. Mutating storage uses [`super::ChunkedVectors`]
 /// which wraps this and adds a writable status mmap.
 #[derive(Debug)]
-pub struct ChunkedVectorsRead<T: bytemuck::Pod, S: UniversalRead> {
+pub struct ChunkedVectorsRead<T: bytemuck::Pod + Send, S: UniversalRead> {
     pub(super) config: ChunkedVectorsConfig,
     /// Number of vectors currently stored. Snapshot for read-only mode; for
     /// [`super::ChunkedVectors`] this is kept in sync with the writable status
@@ -35,7 +35,7 @@ pub struct ChunkedVectorsRead<T: bytemuck::Pod, S: UniversalRead> {
     pub(super) directory: PathBuf,
 }
 
-impl<T: bytemuck::Pod, S: UniversalRead> ChunkedVectorsRead<T, S> {
+impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
     pub(super) fn config_file(directory: &Path) -> PathBuf {
         directory.join(CONFIG_FILE_NAME)
     }

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -20,7 +20,7 @@ use crate::vector_storage::common::CHUNK_SIZE;
 #[derive(Debug)]
 pub struct ChunkedVectors<T, S>
 where
-    T: bytemuck::Pod,
+    T: bytemuck::Pod + Send,
     S: UniversalWrite + Send + 'static,
 {
     inner: ChunkedVectorsRead<T, S>,
@@ -29,7 +29,7 @@ where
 
 impl<T, S> Deref for ChunkedVectors<T, S>
 where
-    T: bytemuck::Pod,
+    T: bytemuck::Pod + Send,
     S: UniversalWrite + Send + 'static,
 {
     type Target = ChunkedVectorsRead<T, S>;
@@ -41,7 +41,7 @@ where
 
 impl<T, S> ChunkedVectors<T, S>
 where
-    T: bytemuck::Pod,
+    T: bytemuck::Pod + Send,
     S: UniversalWrite + Send + 'static,
 {
     pub fn ensure_status_file(directory: &Path) -> OperationResult<PathBuf> {


### PR DESCRIPTION

Sync-to-async bridge requires T to be `Send`, as we want to pass alighned buffer into async runtime, where it will be filled from the download stream.

Current workaround: https://github.com/qdrant/qdrant/pull/9093/changes#r3292796197 

 
---

## Summary

- Add a `pub trait Item: bytemuck::Pod + Send` marker (mirroring the existing `UserData` pattern in `traits/mod.rs`) and use it in place of `T: bytemuck::Pod` on the read side of `UniversalRead`, its pipeline traits, and all impls/wrappers.
- Some `UniversalRead` implementations buffer `Vec<MaybeUninit<T>>` that may be transferred across threads in future async backends; tightening the bound makes that explicit at the trait level instead of leaving each caller to add `+ Send` ad-hoc.
- Write paths (`UniversalWrite`, `IoUringRuntime`) keep the looser `bytemuck::Pod` bound since they only borrow `&[T]`.
- Downstream fallout fixed in `chunked_vectors/{chunks,read,write}.rs`, `segment::numeric_point::Numericable` (now also requires `Send`), and the universal-io bench.

## Soundness

`bytemuck::Pod` types are essentially plain bytes — every concrete `T` used in the codebase (`u8`, `u32`, `u64`, `Point<T>`, vector chunk element types) is already `Send`. No runtime behaviour changes; the bound just narrows what the trait accepts.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test -p common --lib universal_io` — all 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)