### PR TITLE
[UIO] OpenExtras + slim OpenOptions + remove block-cache singleton

### DIFF
--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use common::generic_consts::{Random, Sequential};
-use common::mmap::AdviceSetting;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
-use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, UniversalRead};
+use common::universal_io::{
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, ReadRange, UniversalRead,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
 use rand::rngs::StdRng;
@@ -70,10 +71,10 @@ fn read_benches<T: bytemuck::Pod + Send, C: UniversalRead>(
 ) {
     let options = OpenOptions {
         writeable: false,
-        need_sequential: true,
         populate: Populate::No,
-        advice: AdviceSetting::Global,
-        extra: Default::default(),
+        access_hint: AccessHint::Default,
+        need_sequential: true,
+        extra: OpenOptionsExtra::default(),
     };
     let storage = C::open(path, options).unwrap();
     let len = FILE_SIZE_BYTES / size_of::<T>() as u64;

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, OnceLock};
 
 use fs_err as fs;
 use fs_err::os::unix::fs::FileExt;
@@ -253,23 +253,6 @@ pub(super) enum CacheRead<'a, O> {
     Hit(&'a [u8]),
     /// Cache miss: caller-produced owned value from the `on_miss` closure.
     Miss(O),
-}
-
-/// Global cache controller. Will be used in production.
-static GLOBAL: OnceLock<Arc<CacheController>> = OnceLock::new();
-
-impl CacheController {
-    pub fn initialize_global(path: &Path, size_bytes: u64) {
-        assert!(GLOBAL.get().is_none(), "disk cacher is already initialized");
-        let cacher = Self::new(path, size_bytes).expect("failed to initialize disk cacher");
-        GLOBAL
-            .set(cacher)
-            .expect("disk cacher is already initialized");
-    }
-
-    pub fn global() -> Option<&'static Arc<CacheController>> {
-        GLOBAL.get()
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -97,13 +97,10 @@ impl UniversalRead for CachedSlice {
         // Disk-cache is backed by a single file
         let OpenOptions {
             writeable,
-            need_sequential: _,
             populate: _,
-            advice: _,
-            extra:
-                OpenOptionsExtra {
-                    prevent_caching: _, // This is cached in disk, backed by a mmap
-                },
+            access_hint: _,
+            need_sequential: _,
+            extra: OpenOptionsExtra { cache_hint: _ }, // This is cached in disk, backed by a mmap
         } = options;
 
         debug_assert!(!writeable);

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -4,10 +4,12 @@ use std::path::{Path, PathBuf};
 
 use fs_err as fs;
 
+use std::sync::Arc;
+
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    Item, OpenOptions, OpenOptionsExtra, ReadRange, Result, UniversalIoError, UniversalRead,
-    UniversalReadFileOps, UserData, local_file_ops,
+    Item, OpenOptions, OpenOptionsExtra, ReadRange, Result, ShardStorageContext, UniversalIoError,
+    UniversalRead, UniversalReadFileOps, UserData, local_file_ops,
 };
 
 mod cached_slice;
@@ -17,7 +19,8 @@ mod pipeline;
 mod tests;
 
 pub use cached_slice::CachedSlice;
-use controller::{CacheController, CacheRead};
+pub use controller::CacheController;
+use controller::CacheRead;
 use pipeline::{BorrowedDiskCacheReadPipeline, OwnedDiskCacheReadPipeline};
 
 use super::UniversalKind;
@@ -57,6 +60,13 @@ struct BlockRequest {
     range: Range<usize>,
 }
 
+/// Per-shard configuration consumed by [`CachedSlice::open_with_extras`].
+#[derive(Debug, Clone)]
+pub struct BlockCacheExtras {
+    /// Controller owning the cache file and block lifecycle.
+    pub controller: Arc<CacheController>,
+}
+
 impl UniversalReadFileOps for CachedSlice {
     fn list_files(prefix_path: &Path) -> Result<Vec<PathBuf>> {
         local_file_ops::local_list_files(prefix_path)
@@ -81,20 +91,31 @@ impl UniversalRead for CachedSlice {
         T: Item,
         U: UserData;
 
-    type OpenExtras = ();
+    type OpenExtras = BlockCacheExtras;
 
-    fn extras_from_context(_: &super::ShardStorageContext) -> Result<()> {
-        Ok(())
+    fn extras_from_context(ctx: &ShardStorageContext) -> Result<BlockCacheExtras> {
+        let cfg = ctx.block_cache.as_ref().ok_or_else(|| {
+            UniversalIoError::uninitialized(
+                "ShardStorageContext::block_cache is not configured for this shard",
+            )
+        })?;
+        Ok(BlockCacheExtras {
+            controller: Arc::clone(&cfg.controller),
+        })
     }
 
-    fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
-        let Some(controller) = CacheController::global() else {
-            return Err(UniversalIoError::uninitialized(
-                "Disk cache was not initialized when trying to register a file",
-            ));
-        };
+    fn open(_path: impl AsRef<Path>, _options: OpenOptions) -> Result<Self> {
+        Err(UniversalIoError::uninitialized(
+            "block-cache backend requires per-shard configuration; \
+             open via `UniversalRead::open_with_extras` with extras from the shard context",
+        ))
+    }
 
-        // Disk-cache is backed by a single file
+    fn open_with_extras(
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extras: BlockCacheExtras,
+    ) -> Result<Self> {
         let OpenOptions {
             writeable,
             populate: _,
@@ -102,10 +123,9 @@ impl UniversalRead for CachedSlice {
             need_sequential: _,
             extra: OpenOptionsExtra { cache_hint: _ }, // This is cached in disk, backed by a mmap
         } = options;
-
         debug_assert!(!writeable);
 
-        Ok(CachedSlice::open(controller, path.as_ref())?)
+        Ok(CachedSlice::open(&extras.controller, path.as_ref())?)
     }
 
     fn reopen(&mut self) -> Result<()> {

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use fs_err as fs;
-
-use std::sync::Arc;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -81,6 +81,12 @@ impl UniversalRead for CachedSlice {
         T: Item,
         U: UserData;
 
+    type OpenExtras = ();
+
+    fn extras_from_context(_: &super::ShardStorageContext) -> Result<()> {
+        Ok(())
+    }
+
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let Some(controller) = CacheController::global() else {
             return Err(UniversalIoError::uninitialized(

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -76,13 +76,13 @@ impl UniversalRead for IoUringFile {
 
         let OpenOptions {
             writeable,
-            need_sequential: _,
             populate: _,
-            advice: _,
-            extra: OpenOptionsExtra { prevent_caching },
+            access_hint: _,
+            need_sequential: _,
+            extra: OpenOptionsExtra { cache_hint },
         } = options;
 
-        let direct_io = prevent_caching;
+        let direct_io = matches!(cache_hint, CacheHint::Bypass);
         let direct_io_flags = if direct_io { nix::libc::O_DIRECT } else { 0 };
 
         let file = fs::OpenOptions::new()

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -64,6 +64,12 @@ impl UniversalRead for IoUringFile {
         T: Item,
         U: UserData;
 
+    type OpenExtras = ();
+
+    fn extras_from_context(_: &super::ShardStorageContext) -> Result<()> {
+        Ok(())
+    }
+
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         // Check that io_uring is supported on this system.
         pool::check_io_uring_support()?;

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -21,9 +21,11 @@ fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytes).unwrap();
 
     let opts = OpenOptions {
-        extra: OpenOptionsExtra {
-            prevent_caching: o_direct,
-        },
+        extra: OpenOptionsExtra::default().with_cache_hint(if o_direct {
+            CacheHint::Bypass
+        } else {
+            CacheHint::Default
+        }),
         ..OpenOptions::new_for_test()
     };
 
@@ -62,9 +64,11 @@ fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
     let opts = OpenOptions {
-        extra: OpenOptionsExtra {
-            prevent_caching: o_direct,
-        },
+        extra: OpenOptionsExtra::default().with_cache_hint(if o_direct {
+            CacheHint::Bypass
+        } else {
+            CacheHint::Default
+        }),
         ..OpenOptions::new_for_test()
     };
 
@@ -163,9 +167,11 @@ fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
 
     let opts = OpenOptions {
-        extra: OpenOptionsExtra {
-            prevent_caching: o_direct,
-        },
+        extra: OpenOptionsExtra::default().with_cache_hint(if o_direct {
+            CacheHint::Bypass
+        } else {
+            CacheHint::Default
+        }),
         ..OpenOptions::new_for_test()
     };
     let file_a = TypedStorage::<IoUringFile, u64>::open(&path_a, opts)?;
@@ -230,9 +236,11 @@ fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_1, bytemuck::cast_slice(&data_1)).unwrap();
 
     let opts = OpenOptions {
-        extra: OpenOptionsExtra {
-            prevent_caching: o_direct,
-        },
+        extra: OpenOptionsExtra::default().with_cache_hint(if o_direct {
+            CacheHint::Bypass
+        } else {
+            CacheHint::Default
+        }),
         ..OpenOptions::new_for_test()
     };
     let file_0 = IoUringFile::open(&path_0, opts)?;
@@ -284,9 +292,11 @@ fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<(
     let mut files: Vec<IoUringFile> = Vec::new();
 
     let opts = OpenOptions {
-        extra: OpenOptionsExtra {
-            prevent_caching: o_direct,
-        },
+        extra: OpenOptionsExtra::default().with_cache_hint(if o_direct {
+            CacheHint::Bypass
+        } else {
+            CacheHint::Default
+        }),
         ..OpenOptions::new_for_test()
     };
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -15,6 +15,22 @@ use super::*;
 use crate::generic_consts::AccessPattern;
 use crate::mmap::{Advice, AdviceSetting, MULTI_MMAP_IS_SUPPORTED, Madviseable as _};
 
+/// Per-shard configuration consumed by [`MmapFile::open_with_extras`].
+#[derive(Debug, Clone, Copy)]
+pub struct MmapExtras {
+    /// Advice applied when the caller passes
+    /// [`AccessHint::Default`](super::AccessHint::Default).
+    pub default_advice: AdviceSetting,
+}
+
+impl Default for MmapExtras {
+    fn default() -> Self {
+        Self {
+            default_advice: AdviceSetting::Global,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct MmapFile {
     path: PathBuf,
@@ -68,65 +84,24 @@ impl UniversalRead for MmapFile {
         T: Item,
         U: UserData;
 
-    type OpenExtras = ();
+    type OpenExtras = MmapExtras;
 
-    fn extras_from_context(_: &super::ShardStorageContext) -> Result<()> {
-        Ok(())
+    fn extras_from_context(ctx: &super::ShardStorageContext) -> Result<MmapExtras> {
+        Ok(MmapExtras {
+            default_advice: ctx.mmap.default_advice,
+        })
     }
 
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
-        let OpenOptions {
-            writeable,
-            populate,
-            access_hint,
-            need_sequential,
-            extra: OpenOptionsExtra { cache_hint: _ }, // mmap can't bypass the page cache
-        } = options;
+        Self::open_inner(path, options, MmapExtras::default())
+    }
 
-        let populate = match populate {
-            Populate::Auto | Populate::No => false, // don't populate by default
-            Populate::PreferBackground | // mmap does not yet implement background populate
-            Populate::Blocking => true,
-        };
-
-        let advice = access_hint_to_advice(access_hint);
-        let mmap = open_mmap(path.as_ref(), writeable, populate, advice)?;
-        let ptr = SendSyncPtr(mmap.as_mut_ptr());
-
-        let mmap_seq;
-        let len;
-        let ptr_seq;
-
-        if need_sequential && *MULTI_MMAP_IS_SUPPORTED {
-            let mmap_seq_ = open_mmap(
-                path.as_ref(),
-                false,
-                false,
-                AdviceSetting::Advice(Advice::Sequential),
-            )?;
-
-            len = std::cmp::min(mmap.len(), mmap_seq_.len());
-            ptr_seq = SendSyncPtr(mmap_seq_.as_mut_ptr());
-            mmap_seq = Some(mmap_seq_);
-        } else {
-            len = mmap.len();
-            ptr_seq = ptr;
-            mmap_seq = None;
-        };
-
-        let mmap = Self {
-            path: path.as_ref().into(),
-            writeable,
-            populate,
-            advice,
-            mmap: Arc::new(Mutex::new(mmap)),
-            mmap_seq: mmap_seq.map(|mmap_seq_| Arc::new(Mutex::new(mmap_seq_))),
-            len,
-            ptr,
-            ptr_seq,
-        };
-
-        Ok(mmap)
+    fn open_with_extras(
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extras: MmapExtras,
+    ) -> Result<Self> {
+        Self::open_inner(path, options, extras)
     }
 
     fn reopen(&mut self) -> Result<()> {
@@ -265,9 +240,71 @@ impl UniversalWrite for MmapFile {
     }
 }
 
-fn access_hint_to_advice(hint: AccessHint) -> AdviceSetting {
+impl MmapFile {
+    fn open_inner(
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extras: MmapExtras,
+    ) -> Result<Self> {
+        let OpenOptions {
+            writeable,
+            populate,
+            access_hint,
+            need_sequential,
+            extra: OpenOptionsExtra { cache_hint: _ }, // mmap can't bypass the page cache
+        } = options;
+        let MmapExtras { default_advice } = extras;
+
+        let populate = match populate {
+            Populate::Auto | Populate::No => false, // don't populate by default
+            Populate::PreferBackground | // mmap does not yet implement background populate
+            Populate::Blocking => true,
+        };
+
+        let advice = access_hint_to_advice(access_hint, default_advice);
+        let mmap = open_mmap(path.as_ref(), writeable, populate, advice)?;
+        let ptr = SendSyncPtr(mmap.as_mut_ptr());
+
+        let mmap_seq;
+        let len;
+        let ptr_seq;
+
+        if need_sequential && *MULTI_MMAP_IS_SUPPORTED {
+            let mmap_seq_ = open_mmap(
+                path.as_ref(),
+                false,
+                false,
+                AdviceSetting::Advice(Advice::Sequential),
+            )?;
+
+            len = std::cmp::min(mmap.len(), mmap_seq_.len());
+            ptr_seq = SendSyncPtr(mmap_seq_.as_mut_ptr());
+            mmap_seq = Some(mmap_seq_);
+        } else {
+            len = mmap.len();
+            ptr_seq = ptr;
+            mmap_seq = None;
+        };
+
+        let mmap = Self {
+            path: path.as_ref().into(),
+            writeable,
+            populate,
+            advice,
+            mmap: Arc::new(Mutex::new(mmap)),
+            mmap_seq: mmap_seq.map(|mmap_seq_| Arc::new(Mutex::new(mmap_seq_))),
+            len,
+            ptr,
+            ptr_seq,
+        };
+
+        Ok(mmap)
+    }
+}
+
+fn access_hint_to_advice(hint: AccessHint, default_advice: AdviceSetting) -> AdviceSetting {
     match hint {
-        AccessHint::Default => AdviceSetting::Global,
+        AccessHint::Default => default_advice,
         AccessHint::Normal => AdviceSetting::Advice(Advice::Normal),
         AccessHint::Sequential => AdviceSetting::Advice(Advice::Sequential),
         AccessHint::Random => AdviceSetting::Advice(Advice::Random),

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -68,6 +68,12 @@ impl UniversalRead for MmapFile {
         T: Item,
         U: UserData;
 
+    type OpenExtras = ();
+
+    fn extras_from_context(_: &super::ShardStorageContext) -> Result<()> {
+        Ok(())
+    }
+
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let OpenOptions {
             writeable,

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -77,13 +77,10 @@ impl UniversalRead for MmapFile {
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         let OpenOptions {
             writeable,
-            need_sequential,
             populate,
-            advice,
-            extra:
-                OpenOptionsExtra {
-                    prevent_caching: _, // Whole point of mmap is to cache
-                },
+            access_hint,
+            need_sequential,
+            extra: OpenOptionsExtra { cache_hint: _ }, // mmap can't bypass the page cache
         } = options;
 
         let populate = match populate {
@@ -92,6 +89,7 @@ impl UniversalRead for MmapFile {
             Populate::Blocking => true,
         };
 
+        let advice = access_hint_to_advice(access_hint);
         let mmap = open_mmap(path.as_ref(), writeable, populate, advice)?;
         let ptr = SendSyncPtr(mmap.as_mut_ptr());
 
@@ -267,6 +265,15 @@ impl UniversalWrite for MmapFile {
     }
 }
 
+fn access_hint_to_advice(hint: AccessHint) -> AdviceSetting {
+    match hint {
+        AccessHint::Default => AdviceSetting::Global,
+        AccessHint::Normal => AdviceSetting::Advice(Advice::Normal),
+        AccessHint::Sequential => AdviceSetting::Advice(Advice::Sequential),
+        AccessHint::Random => AdviceSetting::Advice(Advice::Random),
+    }
+}
+
 fn open_mmap(path: &Path, write: bool, populate: bool, advice: AdviceSetting) -> Result<MmapRaw> {
     // TODO: `fs_err` can cause panic when run on a single-threaded Tokio runtime
     #[expect(clippy::disallowed_types)]
@@ -341,10 +348,10 @@ impl MmapFile {
             path,
             OpenOptions {
                 writeable: false,
-                need_sequential: false,
                 populate: Populate::No,
-                advice: AdviceSetting::Advice(Advice::Normal),
-                extra: Default::default(),
+                access_hint: AccessHint::Normal,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -6,6 +6,7 @@ mod error;
 mod io_uring;
 mod local_file_ops;
 mod mmap;
+mod shard_context;
 mod traits;
 mod types;
 mod wrappers;
@@ -14,6 +15,7 @@ pub use self::error::UniversalIoError;
 #[cfg(target_os = "linux")]
 pub use self::io_uring::IoUringFile;
 pub use self::mmap::MmapFile;
+pub use self::shard_context::ShardStorageContext;
 pub use self::traits::{
     BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalRead, UniversalReadFileOps,
     UniversalWrite, UserData,

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "windows"))]
-#[expect(dead_code, reason = "Not yet used")]
-mod disk_cache;
+#[allow(dead_code, reason = "Block-cache backend is exposed but not yet wired into shards")]
+pub mod disk_cache;
 mod error;
 #[cfg(target_os = "linux")]
 mod io_uring;
@@ -15,7 +15,7 @@ pub use self::error::UniversalIoError;
 #[cfg(target_os = "linux")]
 pub use self::io_uring::IoUringFile;
 pub use self::mmap::MmapFile;
-pub use self::shard_context::{MmapBackendConfig, ShardStorageContext};
+pub use self::shard_context::{BlockCacheBackendConfig, MmapBackendConfig, ShardStorageContext};
 pub use self::traits::{
     BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalRead, UniversalReadFileOps,
     UniversalWrite, UserData,

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(not(target_os = "windows"))]
-#[allow(dead_code, reason = "Block-cache backend is exposed but not yet wired into shards")]
+#[allow(
+    dead_code,
+    reason = "Block-cache backend is exposed but not yet wired into shards"
+)]
 pub mod disk_cache;
 mod error;
 #[cfg(target_os = "linux")]

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -21,7 +21,7 @@ pub use self::traits::{
     UniversalWrite, UserData,
 };
 pub use self::types::{
-    ByteOffset, FileIndex, Flusher, OpenOptions, OpenOptionsExtra, Populate, ReadRange, Result,
-    UniversalKind, read_json_via,
+    AccessHint, ByteOffset, CacheHint, FileIndex, Flusher, OpenOptions, OpenOptionsExtra, Populate,
+    ReadRange, Result, UniversalKind, read_json_via,
 };
 pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -15,7 +15,7 @@ pub use self::error::UniversalIoError;
 #[cfg(target_os = "linux")]
 pub use self::io_uring::IoUringFile;
 pub use self::mmap::MmapFile;
-pub use self::shard_context::ShardStorageContext;
+pub use self::shard_context::{MmapBackendConfig, ShardStorageContext};
 pub use self::traits::{
     BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalRead, UniversalReadFileOps,
     UniversalWrite, UserData,

--- a/lib/common/common/src/universal_io/shard_context.rs
+++ b/lib/common/common/src/universal_io/shard_context.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use crate::mmap::AdviceSetting;
+use crate::universal_io::disk_cache::CacheController;
 
 /// Per-shard context bundling all backend-instance state needed to open files
 /// through any [`UniversalRead`](super::UniversalRead) implementation.
@@ -11,6 +14,10 @@ use crate::mmap::AdviceSetting;
 #[non_exhaustive]
 pub struct ShardStorageContext {
     pub mmap: MmapBackendConfig,
+    /// Block-based disk cache controller. `None` when this shard does not use
+    /// the block cache backend; opening a [`CachedSlice`](super::CachedSlice)
+    /// in that case returns `Uninitialized`.
+    pub block_cache: Option<BlockCacheBackendConfig>,
 }
 
 impl ShardStorageContext {
@@ -35,4 +42,13 @@ impl Default for MmapBackendConfig {
             default_advice: AdviceSetting::Global,
         }
     }
+}
+
+/// Per-shard configuration for the block-based
+/// [`CachedSlice`](super::CachedSlice) backend.
+#[derive(Debug, Clone)]
+pub struct BlockCacheBackendConfig {
+    /// Controller owning the cache file and block lifecycle. Cloned `Arc` is
+    /// cheap; multiple files on the same shard share one controller.
+    pub controller: Arc<CacheController>,
 }

--- a/lib/common/common/src/universal_io/shard_context.rs
+++ b/lib/common/common/src/universal_io/shard_context.rs
@@ -1,0 +1,20 @@
+/// Per-shard context bundling all backend-instance state needed to open files
+/// through any [`UniversalRead`](super::UniversalRead) implementation.
+///
+/// Constructed once at shard load. Each backend implements
+/// [`UniversalRead::extras_from_context`](super::UniversalRead::extras_from_context)
+/// to pull out the slice it needs, so a single shard can mix backends across
+/// its components.
+///
+/// Today this is an empty placeholder. As backends migrate off of process-wide
+/// `OnceLock` singletons, their state (cache controller, mirror dirs, io_uring
+/// runtime, default mmap advice) lands here.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct ShardStorageContext {}
+
+impl ShardStorageContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/lib/common/common/src/universal_io/shard_context.rs
+++ b/lib/common/common/src/universal_io/shard_context.rs
@@ -1,3 +1,5 @@
+use crate::mmap::AdviceSetting;
+
 /// Per-shard context bundling all backend-instance state needed to open files
 /// through any [`UniversalRead`](super::UniversalRead) implementation.
 ///
@@ -5,16 +7,32 @@
 /// [`UniversalRead::extras_from_context`](super::UniversalRead::extras_from_context)
 /// to pull out the slice it needs, so a single shard can mix backends across
 /// its components.
-///
-/// Today this is an empty placeholder. As backends migrate off of process-wide
-/// `OnceLock` singletons, their state (cache controller, mirror dirs, io_uring
-/// runtime, default mmap advice) lands here.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct ShardStorageContext {}
+pub struct ShardStorageContext {
+    pub mmap: MmapBackendConfig,
+}
 
 impl ShardStorageContext {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Per-shard configuration for the [`MmapFile`](super::MmapFile) backend.
+#[derive(Debug, Clone, Copy)]
+pub struct MmapBackendConfig {
+    /// Advice applied when the caller passes
+    /// [`AccessHint::Default`](super::AccessHint::Default). When set to
+    /// [`AdviceSetting::Global`], the process-wide global advice is used —
+    /// this preserves the legacy behavior.
+    pub default_advice: AdviceSetting,
+}
+
+impl Default for MmapBackendConfig {
+    fn default() -> Self {
+        Self {
+            default_advice: AdviceSetting::Global,
+        }
     }
 }

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use super::{BorrowedReadPipeline, Item, OwnedReadPipeline, UniversalReadFileOps, UserData};
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{OpenOptions, ReadRange, Result, UniversalKind};
+use crate::universal_io::{OpenOptions, ReadRange, Result, ShardStorageContext, UniversalKind};
 
 /// Interface for accessing files in a universal way, abstracting away possible
 /// implementations, such as memory map, io_uring, DIRECTIO, S3, etc.
@@ -20,7 +20,39 @@ pub trait UniversalRead: UniversalReadFileOps {
         T: Item,
         U: UserData;
 
+    /// Backend-specific per-`open` extras derived from a
+    /// [`ShardStorageContext`].
+    ///
+    /// Today most backends use `()` while the migration is in progress.
+    /// As each backend grows per-shard configuration (cache controllers,
+    /// io_uring runtime, mirror dirs, default mmap advice), its `OpenExtras`
+    /// becomes a real struct holding that state.
+    type OpenExtras: Clone + Send + Sync;
+
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self>;
+
+    /// Derive this backend's [`OpenExtras`](Self::OpenExtras) from a
+    /// shard-wide context.
+    ///
+    /// Different components in the same shard pick different `S`; each calls
+    /// `S::extras_from_context(&ctx)` to obtain the right per-backend config
+    /// from the shared shard context.
+    fn extras_from_context(ctx: &ShardStorageContext) -> Result<Self::OpenExtras>;
+
+    /// Open with backend-specific extras.
+    ///
+    /// Default impl ignores `extras` and delegates to [`open`](Self::open).
+    /// Backends override this method once their `OpenExtras` carries real
+    /// state. Wrappers (`ReadOnly<S>`, ...) override it to forward extras
+    /// to the inner backend.
+    fn open_with_extras(
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extras: Self::OpenExtras,
+    ) -> Result<Self> {
+        let _ = extras;
+        Self::open(path, options)
+    }
 
     /// Enables live-reloading of files. Append-only files can make the underlying file larger,
     /// so reopening can account for this growth.

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -36,28 +36,83 @@ impl From<bool> for Populate {
     }
 }
 
+/// Universal access-pattern hint passed at open time. Each backend honors or
+/// ignores it independently (mmap maps to `madvise`; io_uring ignores).
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub enum AccessHint {
+    /// Backend picks a default (mmap: process-global `madvise` setting).
+    #[default]
+    Default,
+    /// Standard access; no specific pattern (mmap: `MADV_NORMAL`).
+    Normal,
+    /// Sequential access (mmap: `MADV_SEQUENTIAL`).
+    Sequential,
+    /// Random access (mmap: `MADV_RANDOM`).
+    Random,
+}
+
+impl From<AdviceSetting> for AccessHint {
+    fn from(advice: AdviceSetting) -> Self {
+        match advice {
+            AdviceSetting::Global => AccessHint::Default,
+            AdviceSetting::Advice(Advice::Normal) => AccessHint::Normal,
+            AdviceSetting::Advice(Advice::Sequential) => AccessHint::Sequential,
+            AdviceSetting::Advice(Advice::Random) => AccessHint::Random,
+        }
+    }
+}
+
+/// Universal page-cache hint passed at open time. Each backend honors or
+/// ignores it independently (io_uring uses `O_DIRECT` for `Bypass`; mmap
+/// can't bypass the page cache and ignores).
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub enum CacheHint {
+    /// Use the backend's default caching behavior.
+    #[default]
+    Default,
+    /// Bypass the OS page cache where possible (io_uring: `O_DIRECT`).
+    Bypass,
+}
+
 /// Options for [`UniversalRead::open`].
 ///
-/// No `#[derive(Default)]`. Prefer specifying all options explicitly. (except
-/// for tests and [`OpenOptions::extra`]).
+/// No `#[derive(Default)]`. Callers must explicitly decide
+/// [`writeable`](Self::writeable), [`populate`](Self::populate),
+/// [`access_hint`](Self::access_hint), and
+/// [`need_sequential`](Self::need_sequential) at every call site —
+/// these are the load-shape decisions an opener has to think about.
+/// Rarely-tweaked knobs live in [`extra`](Self::extra) and can be
+/// defaulted via [`OpenOptionsExtra::default()`] or constructed with
+/// builder methods.
 #[derive(Copy, Clone, Debug)]
 pub struct OpenOptions {
     pub writeable: bool,
-    pub need_sequential: bool,
-    /// Populate RAM cache on open, if applicable for this implementation.
     pub populate: Populate,
-    /// Use specific mmap advice.
-    pub advice: AdviceSetting,
-    /// Rarely used options.
+    pub access_hint: AccessHint,
+    /// Request a secondary sequential read path *in addition to* the primary.
+    ///
+    /// Mmap honors by creating a second mmap with `MADV_SEQUENTIAL` for bulk
+    /// reads while the primary serves the access pattern in `access_hint`.
+    /// Other backends ignore.
+    pub need_sequential: bool,
+    /// Rarely-tweaked knobs. `OpenOptionsExtra::default()` for the common case.
     pub extra: OpenOptionsExtra,
 }
 
-/// Rarely used options.
-/// Usually [`Default::default()`] is fine.
-#[derive(Copy, Clone, Debug)]
+/// Rarely-tweaked open-time knobs.
+///
+/// Defaults are correct for the vast majority of opens; tweak via builder
+/// methods (`.with_*`) when a specific backend behavior is required.
+#[derive(Copy, Clone, Debug, Default)]
 pub struct OpenOptionsExtra {
-    /// Whether to try to prevent caching for reads.
-    pub prevent_caching: bool,
+    pub cache_hint: CacheHint,
+}
+
+impl OpenOptionsExtra {
+    pub fn with_cache_hint(mut self, cache_hint: CacheHint) -> Self {
+        self.cache_hint = cache_hint;
+        self
+    }
 }
 
 impl OpenOptions {
@@ -66,19 +121,10 @@ impl OpenOptions {
     pub fn new_for_test() -> Self {
         Self {
             writeable: true,
-            need_sequential: true,
             populate: Populate::Auto,
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
-        }
-    }
-}
-
-#[expect(clippy::derivable_impls, reason = "be explicit")]
-impl Default for OpenOptionsExtra {
-    fn default() -> Self {
-        OpenOptionsExtra {
-            prevent_caching: false,
+            access_hint: AccessHint::Default,
+            need_sequential: true,
+            extra: OpenOptionsExtra::default(),
         }
     }
 }
@@ -154,12 +200,11 @@ where
 {
     let options = OpenOptions {
         writeable: false,
-        need_sequential: false,
         populate: Populate::No,
-        advice: AdviceSetting::Advice(Advice::Sequential),
-        extra: Default::default(),
+        access_hint: AccessHint::Sequential,
+        need_sequential: false,
+        extra: OpenOptionsExtra::default(),
     };
-
     let storage = S::open(path, options)?;
     let bytes = storage.read_whole::<u8>()?;
     serde_json::from_slice(&bytes).map_err(UniversalIoError::from)

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -6,8 +6,8 @@ use bytemuck::TransparentWrapper;
 use super::{BorrowedWrappedReadPipeline, OwnedWrappedReadPipeline};
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    Item, OpenOptions, ReadRange, Result, UniversalKind, UniversalRead, UniversalReadFileOps,
-    UserData,
+    Item, OpenOptions, ReadRange, Result, ShardStorageContext, UniversalKind, UniversalRead,
+    UniversalReadFileOps, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -46,10 +46,28 @@ where
         T: Item,
         U: UserData;
 
+    type OpenExtras = S::OpenExtras;
+
+    #[inline]
+    fn extras_from_context(ctx: &ShardStorageContext) -> Result<Self::OpenExtras> {
+        S::extras_from_context(ctx)
+    }
+
     #[inline]
     fn open(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
         debug_assert!(!options.writeable);
         let io = S::open(path, options)?;
+        Ok(Self(io))
+    }
+
+    #[inline]
+    fn open_with_extras(
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extras: Self::OpenExtras,
+    ) -> Result<Self> {
+        debug_assert!(!options.writeable);
+        let io = S::open_with_extras(path, options, extras)?;
         Ok(Self(io))
     }
 

--- a/lib/gridstore/src/bitmask/gaps.rs
+++ b/lib/gridstore/src/bitmask/gaps.rs
@@ -2,8 +2,10 @@ use std::borrow::Cow;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
-use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
-use common::universal_io::{Flusher, OpenOptions, Populate, TypedStorage, UniversalWrite};
+use common::mmap::create_and_ensure_length;
+use common::universal_io::{
+    AccessHint, Flusher, OpenOptions, OpenOptionsExtra, Populate, TypedStorage, UniversalWrite,
+};
 use itertools::Itertools;
 
 use super::{RegionId, StorageConfig};
@@ -104,10 +106,10 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
         let options = OpenOptions {
             writeable: true,
-            need_sequential: false,
             populate: Populate::Blocking,
-            advice: AdviceSetting::Advice(Advice::Normal),
-            extra: Default::default(),
+            access_hint: AccessHint::Normal,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         let mut slice_store = TypedStorage::open(&path, options)?;
 
@@ -126,10 +128,10 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let path = gaps_file_path(dir);
         let options = OpenOptions {
             writeable: true,
-            need_sequential: false,
             populate: Populate::No,
-            advice: AdviceSetting::Advice(Advice::Normal),
-            extra: Default::default(),
+            access_hint: AccessHint::Normal,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         let slice_store = TypedStorage::open(&path, options)?;
 
@@ -160,10 +162,10 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
         let options = OpenOptions {
             writeable: true,
-            need_sequential: false,
             populate: Populate::No,
-            advice: AdviceSetting::Advice(Advice::Normal),
-            extra: Default::default(),
+            access_hint: AccessHint::Normal,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         self.slice_store = TypedStorage::open(&self.path, options)?;
 

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -5,9 +5,11 @@ use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
 use common::bitvec::BitSlice;
-use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
+use common::mmap::create_and_ensure_length;
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{MmapFile, OpenOptions, Populate, UniversalWrite};
+use common::universal_io::{
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, UniversalWrite,
+};
 use gaps::{BitmaskGaps, RegionGaps};
 use itertools::Itertools;
 
@@ -21,10 +23,10 @@ const BITMASK_NAME: &str = "bitmask.dat";
 fn open_options() -> OpenOptions {
     OpenOptions {
         writeable: true,
-        need_sequential: false,
         populate: Populate::No,
-        advice: AdviceSetting::Advice(Advice::Random),
-        extra: Default::default(),
+        access_hint: AccessHint::Random,
+        need_sequential: false,
+        extra: OpenOptionsExtra::default(),
     }
 }
 
@@ -132,10 +134,10 @@ impl<S: UniversalWrite> Bitmask<S> {
             &path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::Auto,
-                advice: AdviceSetting::Advice(Advice::Random),
-                extra: Default::default(),
+                access_hint: AccessHint::Random,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let regions_gaps = BitmaskGaps::open(dir, config.clone())?;

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 use ahash::{AHashMap, HashSet};
 use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
-use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
-    FileIndex, Flusher, OpenOptions, Populate, ReadRange, UniversalRead, UniversalWrite,
+    AccessHint, FileIndex, Flusher, OpenOptions, OpenOptionsExtra, Populate, ReadRange,
+    UniversalRead, UniversalWrite,
 };
 use itertools::Either;
 
@@ -59,10 +59,10 @@ impl<S: UniversalRead> Pages<S> {
     pub fn attach_page(&mut self, path: &Path) -> Result<()> {
         let options = OpenOptions {
             writeable: true,
-            need_sequential: true,
             populate: Populate::No,
-            advice: AdviceSetting::Advice(Advice::Random),
-            extra: Default::default(),
+            access_hint: AccessHint::Random,
+            need_sequential: true,
+            extra: OpenOptionsExtra::default(),
         };
 
         let page = S::open(path, options)?;

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
-use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
+use common::mmap::create_and_ensure_length;
 use common::universal_io::{
-    OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalWrite,
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, ReadRange, UniversalIoError,
+    UniversalRead, UniversalWrite,
 };
 use smallvec::SmallVec;
 
@@ -19,10 +20,10 @@ pub type PageId = u32;
 fn tracker_open_options() -> OpenOptions {
     OpenOptions {
         writeable: true,
-        need_sequential: false,
         populate: Populate::No,
-        advice: AdviceSetting::Advice(Advice::Random),
-        extra: Default::default(),
+        access_hint: AccessHint::Random,
+        need_sequential: false,
+        extra: OpenOptionsExtra::default(),
     }
 }
 

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -4,10 +4,12 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::mmap::create_and_ensure_length;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalWrite};
+use common::universal_io::{
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, StoredStruct, UniversalWrite,
+};
 use fs_err as fs;
 use itertools::Either;
 
@@ -114,10 +116,10 @@ where
             &status_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::No,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -159,10 +161,10 @@ where
 
         let options = OpenOptions {
             writeable: true,
-            need_sequential: false,
             populate: Populate::from(populate),
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: AccessHint::Default,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         let flags = StoredBitSlice::open(&path, options)?;
         Ok(flags)

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -16,11 +16,11 @@ use std::path::{Path, PathBuf};
 use common::bitvec::{BitSlice, BitVec};
 use common::fs::clear_disk_cache;
 use common::mmap::create_and_ensure_length;
-use common::universal_io::{AccessHint, OpenOptionsExtra};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage, UniversalWrite,
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, SliceBufferedUpdateWrapper, TypedStorage,
+    UniversalWrite,
 };
 use fs_err::File;
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -15,7 +15,8 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitVec};
 use common::fs::clear_disk_cache;
-use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::mmap::create_and_ensure_length;
+use common::universal_io::{AccessHint, OpenOptionsExtra};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
@@ -87,10 +88,10 @@ where
             deleted_path(segment_path),
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::Blocking,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -103,10 +104,10 @@ where
             version_mapping_path(segment_path),
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::Blocking,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -150,10 +151,10 @@ where
             &deleted_filepath,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::Auto,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -188,10 +189,10 @@ where
             &version_filepath,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::No,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         internal_to_version_file.write(0, internal_to_version)?;

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -6,12 +6,13 @@ use common::bitvec::{BitSlice, BitSliceExt, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::clear_disk_cache;
 use common::generic_consts::Random;
-use common::mmap::{Advice, AdviceSetting, MmapSlice, create_and_ensure_length};
+use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UserData,
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, ReadRange, TypedStorage,
+    UniversalRead, UserData,
 };
 use types::ZerocopyPostingValue;
 use uio_postings::UniversalPostings;
@@ -132,10 +133,10 @@ impl MmapInvertedIndex<MmapFile> {
                 &deleted_points_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: false,
                     populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                    extra: Default::default(),
+                    access_hint: AccessHint::Default,
+                    need_sequential: false,
+                    extra: OpenOptionsExtra::default(),
                 },
             )?;
             deleted_storage.write_bitslice(&deleted_bitslice)?;
@@ -170,10 +171,10 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
 
         let postings_open_options = OpenOptions {
             writeable: false,
-            need_sequential: false,
             populate: Populate::from(populate),
-            advice: AdviceSetting::Advice(Advice::Normal),
-            extra: Default::default(),
+            access_hint: AccessHint::Normal,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         let postings = match has_positions {
             false => MmapPostingsEnum::Ids(UniversalPostings::<(), S>::open(
@@ -189,10 +190,10 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &vocab_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: false,
                 populate: Populate::from(populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -200,10 +201,10 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &point_to_tokens_count_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: false,
                 populate: Populate::from(populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -211,10 +212,10 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
             &deleted_points_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::from(populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -10,11 +10,12 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::ordering_iterator::OrderingIterator;
-use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
+use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, ReadRange, TypedStorage,
+    UniversalRead,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -127,10 +128,10 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: false,
                     populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                    extra: Default::default(),
+                    access_hint: AccessHint::Default,
+                    need_sequential: false,
+                    extra: OpenOptionsExtra::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(
@@ -178,10 +179,10 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
 
         let open_options = OpenOptions {
             writeable: false,
-            need_sequential: false,
             populate: Populate::from(populate),
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: AccessHint::Default,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
 
         let counts_per_hash = TypedStorage::open(&counts_per_hash_path, open_options)?;
@@ -195,10 +196,10 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::from(populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/universal_map_index/lifecycle.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use ahash::HashMap;
 use common::bitvec::{BitSlice, BitSliceExt};
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
-use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::mmap::create_and_ensure_length;
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, Populate};
+use common::universal_io::{AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate};
 use fs_err as fs;
 
 use super::super::MapIndexKey;
@@ -44,10 +44,10 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &hashmap_path,
             OpenOptions {
                 writeable: false,
-                need_sequential: false,
                 populate: Populate::from(do_populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let point_to_values = StoredPointToValues::open(path, do_populate)?;
@@ -58,10 +58,10 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::from(do_populate),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
@@ -139,10 +139,10 @@ impl<N: MapIndexKey + Key + ?Sized> UniversalMapIndex<N> {
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: false,
                     populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                    extra: Default::default(),
+                    access_hint: AccessHint::Default,
+                    need_sequential: false,
+                    extra: OpenOptionsExtra::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(

--- a/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mmap_numeric_index/lifecycle.rs
@@ -4,10 +4,12 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitSliceExt};
 use common::fs::{atomic_save_json, clear_disk_cache, read_json};
-use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
+use common::mmap::{MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::MmapBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, OpenOptions, Populate, TypedStorage};
+use common::universal_io::{
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, TypedStorage,
+};
 use fs_err as fs;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
@@ -82,10 +84,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
                 &deleted_path,
                 OpenOptions {
                     writeable: true,
-                    need_sequential: false,
                     populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                    extra: Default::default(),
+                    access_hint: AccessHint::Default,
+                    need_sequential: false,
+                    extra: OpenOptionsExtra::default(),
                 },
             )?;
             deleted.set_ascending_bits_batch(
@@ -125,10 +127,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
 
         let pairs_options = OpenOptions {
             writeable: false,
-            need_sequential: false,
             populate: Populate::from(do_populate),
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: AccessHint::Default,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         };
         let pairs = TypedStorage::open(pairs_path, pairs_options)?;
 
@@ -139,10 +141,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod> Univers
             &deleted_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: Populate::Auto,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/stored_point_to_values.rs
+++ b/lib/segment/src/index/field_index/stored_point_to_values.rs
@@ -167,10 +167,10 @@ where
 
         let open_options = common::universal_io::OpenOptions {
             writeable: false,
-            need_sequential: false,
             populate: Populate::from(populate),
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: common::universal_io::AccessHint::Default,
+            need_sequential: false,
+            extra: common::universal_io::OpenOptionsExtra::default(),
         };
 
         let store = ReadOnly::open(&file_name, open_options)?;

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 use ahash::AHashMap;
 use common::mmap::{AdviceSetting, MULTI_MMAP_IS_SUPPORTED, create_and_ensure_length};
 use common::universal_io::{
-    OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead, UniversalWrite,
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, TypedStorage, UniversalIoError,
+    UniversalRead, UniversalWrite,
 };
 use fs_err as fs;
 
@@ -54,10 +55,10 @@ pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
             &chunk_path,
             OpenOptions {
                 writeable,
-                need_sequential: *MULTI_MMAP_IS_SUPPORTED,
                 populate: Populate::from(populate),
-                advice,
-                extra: Default::default(),
+                access_hint: advice.into(),
+                need_sequential: *MULTI_MMAP_IS_SUPPORTED,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 
@@ -84,10 +85,10 @@ pub fn create_chunk<T: bytemuck::Pod + Send, S: UniversalWrite>(
         &chunk_file_path,
         OpenOptions {
             writeable: true,
+            populate: Populate::No,
+            access_hint: AccessHint::Default,
             need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-            populate: Populate::No, // don't populate newly created chunk, as it's empty and will be filled later
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            extra: OpenOptionsExtra::default(),
         },
     )
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -8,7 +8,6 @@ use common::mmap::AdviceSetting;
 use common::universal_io::{
     AccessHint, OpenOptions, OpenOptionsExtra, Populate, StoredStruct, UniversalWrite,
 };
-
 use fs_err as fs;
 use num_traits::AsPrimitive;
 

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::atomic_save_json;
 use common::mmap::AdviceSetting;
-use common::universal_io::{OpenOptions, Populate, StoredStruct, UniversalWrite};
+use common::universal_io::{
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, StoredStruct, UniversalWrite,
+};
+
 use fs_err as fs;
 use num_traits::AsPrimitive;
 
@@ -121,10 +124,10 @@ where
             status_path,
             OpenOptions {
                 writeable: true,
-                need_sequential: false,
                 populate: populate.map(Populate::from).unwrap_or_default(),
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -8,10 +8,11 @@ use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
+
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange, TypedStorage,
-    UniversalRead,
+    AccessHint, MmapFile, OpenOptions as UniversalOpenOptions, OpenOptionsExtra, Populate,
+    ReadOnly, ReadRange, TypedStorage, UniversalRead,
 };
 use fs_err::{File, OpenOptions};
 
@@ -58,10 +59,10 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
 
         let options = UniversalOpenOptions {
             writeable: false,
-            need_sequential: true,
             populate: Populate::from(populate),
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: AccessHint::Default,
+            need_sequential: true,
+            extra: OpenOptionsExtra::default(),
         };
         let storage = TypedStorage::open(vectors_path, options).map_err(|e| {
             crate::common::operation_error::OperationError::service_error(format!(

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -8,7 +8,6 @@ use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
-
 use common::types::PointOffsetType;
 use common::universal_io::{
     AccessHint, MmapFile, OpenOptions as UniversalOpenOptions, OpenOptionsExtra, Populate,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage.rs
@@ -6,7 +6,9 @@ use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{MmapFile, OpenOptions, Populate, ReadRange, TypedStorage};
+use common::universal_io::{
+    AccessHint, MmapFile, OpenOptions, OpenOptionsExtra, Populate, ReadRange, TypedStorage,
+};
 use fs_err as fs;
 use memmap2::MmapMut;
 use quantization::EncodedVectors;
@@ -172,10 +174,10 @@ impl MultivectorOffsetsStorageMmap {
             path,
             OpenOptions {
                 writeable: false,
-                need_sequential: false,
                 populate: Populate::No,
-                advice: AdviceSetting::Global,
-                extra: Default::default(),
+                access_hint: AccessHint::Default,
+                need_sequential: false,
+                extra: OpenOptionsExtra::default(),
             },
         )?;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -5,9 +5,11 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
-use common::mmap::{AdviceSetting, MmapFlusher, advice};
+use common::mmap::{MmapFlusher, advice};
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead};
+use common::universal_io::{
+    AccessHint, OpenOptions, OpenOptionsExtra, Populate, ReadOnly, ReadRange, UniversalRead,
+};
 use fs_err as fs;
 use memmap2::MmapMut;
 
@@ -51,10 +53,10 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     fn open_options() -> OpenOptions {
         OpenOptions {
             writeable: false,
-            need_sequential: false,
             populate: Populate::No,
-            advice: AdviceSetting::Global,
-            extra: Default::default(),
+            access_hint: AccessHint::Default,
+            need_sequential: false,
+            extra: OpenOptionsExtra::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

Reworks how configuration is passed to `UniversalRead::open` so that:

1. **Backend-instance state lives per-shard, not in process-globals.** Adds a `ShardStorageContext` carrying per-backend config (mmap default advice, block-cache controller, etc.). Each backend declares `type OpenExtras` and `fn extras_from_context(&ShardStorageContext) -> Result<Self::OpenExtras>` so generic-over-`S` code can derive the right extras for whichever backend the shard chose.
2. **`OpenOptions` is slimmer and generalized.** Backend-specific fields (`advice: AdviceSetting` mmap-only, `extra.prevent_caching` io_uring-only) become universal hints (`access_hint: AccessHint`, `cache_hint: CacheHint`) that any backend can honor or ignore. The four load-shape decisions (`writeable`, `populate`, `access_hint`, `need_sequential`) remain explicit struct fields — callers must spell them out at every call site. Only rarely-tweaked knobs go into the `OpenOptionsExtra` builder bag.
3. **Singletons are gone for block cache.** `CacheController::initialize_global` / `global` and the `OnceLock` backing them are deleted. Block cache opens require per-shard extras via `open_with_extras`.

No live behavior changes yet — Step 7 (threading `&ShardStorageContext` through ~39 generic-over-`S` constructors in segment/gridstore) is intentionally deferred to a follow-up PR. Legacy `open(path, options)` continues to work everywhere with sensible defaults; the new `open_with_extras(path, options, extras)` is opt-in.

## Commits (per step)

1. `33b46e278` — Scaffolding: `ShardStorageContext` (empty), `UniversalRead::OpenExtras = ()` everywhere, default-implemented `open_with_extras` that delegates to `open`. `ReadOnly<S>` wrapper forwards extras through.
2. `dc45a32b6` — Slim `OpenOptions`: introduce `AccessHint`/`CacheHint`/`OpenOptionsExtra`. Rewrites ~22 caller sites in `common`/`gridstore`/`segment`/`collection`. Adds `From<AdviceSetting> for AccessHint` so the deep `madvise: AdviceSetting` parameter chain through `chunked_vectors`/`segment_constructor_base` keeps working until Step 7.
3. `61cb60714` — `MmapFile`: real `MmapExtras { default_advice }` derived from `ShardStorageContext::mmap`. When the caller passes `AccessHint::Default`, mmap now uses the shard's default advice instead of the process-global setting.
4. `cedead72a` — Block disk cache: real `BlockCacheExtras { controller: Arc<CacheController> }` derived from `ShardStorageContext::block_cache`. Deletes the `OnceLock<Arc<CacheController>>` and the `initialize_global`/`global` API.
5. `3b2dc5e2a` — Apply rustfmt.

## What's intentionally not in this PR

- **io_uring extras.** The io_uring backend uses a `thread_local!` runtime pool, not a process-wide `OnceLock` — there's no singleton to remove, and the thread-local pool is the right shape. Backend stays at `type OpenExtras = ()`.
- **`simple_disk_cache` cleanup.** That module is orphaned (no `mod simple_disk_cache;`) AND its `impl UniversalRead` doesn't match the current trait (uses removed `type ReadPipeline`, `UniversalKind::SimpleDiskCache`, misses `OpenExtras`/`extras_from_context`/`reopen`). Bringing it up-to-date is a separate rewrite, not just singleton removal.
- **Threading `&ShardStorageContext` through generic constructors.** ~39 files of `<S: UniversalRead>` in segment/gridstore would need a `ctx` parameter, plus shard-layer wiring in `lib/collection/`. Best as a focused follow-up PR.

## Test plan

- [ ] `cargo check -p common -p gridstore -p segment -p collection --tests` clean (verified locally).
- [ ] `cargo check -p common --benches` clean (verified locally).
- [ ] `cargo +nightly fmt --all -- --check` clean (verified locally; pre-push hook passed).
- [ ] CI green for the workspace.