### PR TITLE
Append-only mutable segment: groundwork (filter fix + point_id refactor)

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -106,14 +106,20 @@ impl<'a> PointMappingsRefEnum<'a> {
         }
     }
 
-    /// Wrap an iterator of internal IDs so that points at or above the
-    /// mapping's deferred threshold are excluded.
+    /// Wrap an iterator of internal IDs so that soft-deleted points and (when
+    /// requested) points at or above the mapping's deferred threshold are
+    /// excluded.
+    ///
+    /// Intended for iterators sourced outside the mapping (e.g. field-index
+    /// outputs) where neither the deleted bitslice nor the deferred threshold
+    /// are applied implicitly. The bitslice check guards against stale
+    /// postings for tombstoned internal IDs (a single bit test per element,
+    /// negligible overhead).
     ///
     /// For [`DeferredBehavior::IncludeAll`] — or when the mapping has no
-    /// deferred threshold — the iterator is returned unchanged. Intended for
-    /// iterators sourced outside the mapping (e.g., field-index outputs) where
-    /// the threshold isn't applied implicitly.
-    pub fn filter_deferred<I>(
+    /// deferred threshold — the threshold cutoff is skipped, but the
+    /// deleted-bitslice filter is always applied.
+    pub fn filter_deferred_and_deleted<I>(
         self,
         iter: I,
         deferred_behavior: DeferredBehavior,
@@ -121,9 +127,14 @@ impl<'a> PointMappingsRefEnum<'a> {
     where
         I: Iterator<Item = PointOffsetType>,
     {
+        let deleted = self.deleted();
         match deferred_behavior.apply(self.deferred_internal_id()) {
-            None => Either::Left(iter),
-            Some(cutoff) => Either::Right(iter.filter(move |&id| id < cutoff)),
+            None => Either::Left(
+                iter.filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false)),
+            ),
+            Some(cutoff) => Either::Right(iter.filter(move |&id| {
+                id < cutoff && !deleted.get_bit(id as usize).unwrap_or(false)
+            })),
         }
     }
 
@@ -170,6 +181,14 @@ impl<'a> PointMappingsRefEnum<'a> {
         match self {
             PointMappingsRefEnum::Plain(m) => m.deferred_internal_id(),
             PointMappingsRefEnum::Compressed(_) => None,
+        }
+    }
+
+    /// Soft-deleted point bitslice for this mapping.
+    fn deleted(self) -> &'a BitSlice {
+        match self {
+            PointMappingsRefEnum::Plain(m) => m.deleted(),
+            PointMappingsRefEnum::Compressed(m) => m.deleted(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -129,12 +129,14 @@ impl<'a> PointMappingsRefEnum<'a> {
     {
         let deleted = self.deleted();
         match deferred_behavior.apply(self.deferred_internal_id()) {
-            None => Either::Left(
-                iter.filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false)),
-            ),
-            Some(cutoff) => Either::Right(iter.filter(move |&id| {
-                id < cutoff && !deleted.get_bit(id as usize).unwrap_or(false)
-            })),
+            None => {
+                Either::Left(iter.filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false)))
+            }
+            Some(cutoff) => {
+                Either::Right(iter.filter(move |&id| {
+                    id < cutoff && !deleted.get_bit(id as usize).unwrap_or(false)
+                }))
+            }
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -351,7 +351,7 @@ impl<'a> BatchFilteredSearcher<'a> {
     /// searcher's `point_deleted` bitslice.
     ///
     /// Does not apply deferred-point filtering — wrap with
-    /// `PointMappingsRefEnum::filter_deferred` (or compose otherwise) before
+    /// `PointMappingsRefEnum::filter_deferred_and_deleted` (or compose otherwise) before
     /// passing to [`Self::peek_top_iter`] when deferred awareness is needed.
     ///
     /// The returned iterator borrows the underlying bitslice (lifetime `'a`),
@@ -367,7 +367,7 @@ impl<'a> BatchFilteredSearcher<'a> {
     /// Score every non-deleted point without deferred filtering.
     ///
     /// Production paths compose `iter_not_deleted` with
-    /// `PointMappingsRefEnum::filter_deferred` and call
+    /// `PointMappingsRefEnum::filter_deferred_and_deleted` and call
     /// [`Self::peek_top_iter`] directly.
     #[cfg(feature = "testing")]
     pub fn peek_top_all(

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -146,12 +146,10 @@ impl VectorIndexRead for PlainVectorIndex {
                 batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
             }
             None => {
-                let iter = id_tracker
-                    .point_mappings()
-                    .filter_deferred_and_deleted(
-                        batch_searcher.iter_not_deleted(),
-                        DeferredBehavior::Exclude,
-                    );
+                let iter = id_tracker.point_mappings().filter_deferred_and_deleted(
+                    batch_searcher.iter_not_deleted(),
+                    DeferredBehavior::Exclude,
+                );
                 batch_searcher.peek_top_iter(iter, &is_stopped)?
             }
         };

--- a/lib/segment/src/index/plain_vector_index.rs
+++ b/lib/segment/src/index/plain_vector_index.rs
@@ -148,7 +148,10 @@ impl VectorIndexRead for PlainVectorIndex {
             None => {
                 let iter = id_tracker
                     .point_mappings()
-                    .filter_deferred(batch_searcher.iter_not_deleted(), DeferredBehavior::Exclude);
+                    .filter_deferred_and_deleted(
+                        batch_searcher.iter_not_deleted(),
+                        DeferredBehavior::Exclude,
+                    );
                 batch_searcher.peek_top_iter(iter, &is_stopped)?
             }
         };

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
@@ -82,12 +82,10 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 searcher.peek_top_iter(filtered_points, &is_stopped)?
             }
             None => {
-                let iter = id_tracker
-                    .point_mappings()
-                    .filter_deferred_and_deleted(
-                        searcher.iter_not_deleted(),
-                        DeferredBehavior::Exclude,
-                    );
+                let iter = id_tracker.point_mappings().filter_deferred_and_deleted(
+                    searcher.iter_not_deleted(),
+                    DeferredBehavior::Exclude,
+                );
                 searcher.peek_top_iter(iter, &is_stopped)?
             }
         };

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
@@ -84,7 +84,10 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             None => {
                 let iter = id_tracker
                     .point_mappings()
-                    .filter_deferred(searcher.iter_not_deleted(), DeferredBehavior::Exclude);
+                    .filter_deferred_and_deleted(
+                        searcher.iter_not_deleted(),
+                        DeferredBehavior::Exclude,
+                    );
                 searcher.peek_top_iter(iter, &is_stopped)?
             }
         };

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -181,7 +181,10 @@ where
                 // Each primary iterator (and the flattened stream) can yield items in
                 // non-sorted order depending on the field-index type and primary condition.
                 let joined_primary_iterator = point_mappings
-                    .filter_deferred(primary_iterators.into_iter().flatten(), deferred_behavior)
+                    .filter_deferred_and_deleted(
+                        primary_iterators.into_iter().flatten(),
+                        deferred_behavior,
+                    )
                     .stop_if(is_stopped);
 
                 return Ok(if all_conditions_are_primary {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -518,15 +518,18 @@ impl NonAppendableSegmentEntry for Segment {
         match internal_id {
             // Point does already not exist anymore
             None => Ok(false),
-            Some(internal_id) => {
-                self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
+            Some(internal_id) => self.handle_point_version_and_failure(
+                op_num,
+                point_id,
+                Some(internal_id),
+                |segment| {
                     segment.delete_point_internal(internal_id, hw_counter)?;
 
                     segment.version_tracker.set_payload(Some(op_num));
 
                     Ok((true, Some(internal_id)))
-                })
-            }
+                },
+            ),
         }
     }
 
@@ -646,16 +649,26 @@ impl SegmentEntry for Segment {
         check_named_vectors(&vectors, &self.segment_config)?;
         vectors.preprocess(|name| self.config().vector_data.get(name).unwrap());
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(op_num, stored_internal_point, |segment| {
-            if let Some(existing_internal_id) = stored_internal_point {
-                segment.replace_all_vectors(existing_internal_id, op_num, &vectors, hw_counter)?;
-                Ok((true, Some(existing_internal_id)))
-            } else {
-                let new_index =
-                    segment.insert_new_vectors(point_id, op_num, &vectors, hw_counter)?;
-                Ok((false, Some(new_index)))
-            }
-        })
+        self.handle_point_version_and_failure(
+            op_num,
+            point_id,
+            stored_internal_point,
+            |segment| {
+                if let Some(existing_internal_id) = stored_internal_point {
+                    segment.replace_all_vectors(
+                        existing_internal_id,
+                        op_num,
+                        &vectors,
+                        hw_counter,
+                    )?;
+                    Ok((true, Some(existing_internal_id)))
+                } else {
+                    let new_index =
+                        segment.insert_new_vectors(point_id, op_num, &vectors, hw_counter)?;
+                    Ok((false, Some(new_index)))
+                }
+            },
+        )
     }
 
     fn update_vectors(
@@ -672,12 +685,15 @@ impl SegmentEntry for Segment {
             None => Err(OperationError::PointIdError {
                 missed_point_id: point_id,
             }),
-            Some(internal_id) => {
-                self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
+            Some(internal_id) => self.handle_point_version_and_failure(
+                op_num,
+                point_id,
+                Some(internal_id),
+                |segment| {
                     segment.update_vectors(internal_id, op_num, vectors, hw_counter)?;
                     Ok((true, Some(internal_id)))
-                })
-            }
+                },
+            ),
         }
     }
 
@@ -693,8 +709,11 @@ impl SegmentEntry for Segment {
             None => Err(OperationError::PointIdError {
                 missed_point_id: point_id,
             }),
-            Some(internal_id) => {
-                self.handle_point_version_and_failure(op_num, Some(internal_id), |segment| {
+            Some(internal_id) => self.handle_point_version_and_failure(
+                op_num,
+                point_id,
+                Some(internal_id),
+                |segment| {
                     let vector_data = segment
                         .vector_data
                         .get(vector_name)
@@ -709,8 +728,8 @@ impl SegmentEntry for Segment {
                     }
 
                     Ok((is_deleted, Some(internal_id)))
-                })
-            }
+                },
+            ),
         }
     }
 
@@ -722,20 +741,22 @@ impl SegmentEntry for Segment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
-            Some(internal_id) => {
-                segment.payload_index.borrow_mut().overwrite_payload(
-                    internal_id,
-                    full_payload,
-                    hw_counter,
-                )?;
-                segment.version_tracker.set_payload(Some(op_num));
+        self.handle_point_version_and_failure(op_num, point_id, internal_id, |segment| {
+            match internal_id {
+                Some(internal_id) => {
+                    segment.payload_index.borrow_mut().overwrite_payload(
+                        internal_id,
+                        full_payload,
+                        hw_counter,
+                    )?;
+                    segment.version_tracker.set_payload(Some(op_num));
 
-                Ok((true, Some(internal_id)))
+                    Ok((true, Some(internal_id)))
+                }
+                None => Err(OperationError::PointIdError {
+                    missed_point_id: point_id,
+                }),
             }
-            None => Err(OperationError::PointIdError {
-                missed_point_id: point_id,
-            }),
         })
     }
 
@@ -748,21 +769,23 @@ impl SegmentEntry for Segment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
-            Some(internal_id) => {
-                segment.payload_index.borrow_mut().set_payload(
-                    internal_id,
-                    payload,
-                    key,
-                    hw_counter,
-                )?;
-                segment.version_tracker.set_payload(Some(op_num));
+        self.handle_point_version_and_failure(op_num, point_id, internal_id, |segment| {
+            match internal_id {
+                Some(internal_id) => {
+                    segment.payload_index.borrow_mut().set_payload(
+                        internal_id,
+                        payload,
+                        key,
+                        hw_counter,
+                    )?;
+                    segment.version_tracker.set_payload(Some(op_num));
 
-                Ok((true, Some(internal_id)))
+                    Ok((true, Some(internal_id)))
+                }
+                None => Err(OperationError::PointIdError {
+                    missed_point_id: point_id,
+                }),
             }
-            None => Err(OperationError::PointIdError {
-                missed_point_id: point_id,
-            }),
         })
     }
 
@@ -774,19 +797,21 @@ impl SegmentEntry for Segment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
-            Some(internal_id) => {
-                segment
-                    .payload_index
-                    .borrow_mut()
-                    .delete_payload(internal_id, key, hw_counter)?;
-                segment.version_tracker.set_payload(Some(op_num));
+        self.handle_point_version_and_failure(op_num, point_id, internal_id, |segment| {
+            match internal_id {
+                Some(internal_id) => {
+                    segment
+                        .payload_index
+                        .borrow_mut()
+                        .delete_payload(internal_id, key, hw_counter)?;
+                    segment.version_tracker.set_payload(Some(op_num));
 
-                Ok((true, Some(internal_id)))
+                    Ok((true, Some(internal_id)))
+                }
+                None => Err(OperationError::PointIdError {
+                    missed_point_id: point_id,
+                }),
             }
-            None => Err(OperationError::PointIdError {
-                missed_point_id: point_id,
-            }),
         })
     }
 
@@ -797,19 +822,21 @@ impl SegmentEntry for Segment {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
         let internal_id = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(op_num, internal_id, |segment| match internal_id {
-            Some(internal_id) => {
-                segment
-                    .payload_index
-                    .borrow_mut()
-                    .clear_payload(internal_id, hw_counter)?;
-                segment.version_tracker.set_payload(Some(op_num));
+        self.handle_point_version_and_failure(op_num, point_id, internal_id, |segment| {
+            match internal_id {
+                Some(internal_id) => {
+                    segment
+                        .payload_index
+                        .borrow_mut()
+                        .clear_payload(internal_id, hw_counter)?;
+                    segment.version_tracker.set_payload(Some(op_num));
 
-                Ok((true, Some(internal_id)))
+                    Ok((true, Some(internal_id)))
+                }
+                None => Err(OperationError::PointIdError {
+                    missed_point_id: point_id,
+                }),
             }
-            None => Err(OperationError::PointIdError {
-                missed_point_id: point_id,
-            }),
         })
     }
 }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -649,26 +649,16 @@ impl SegmentEntry for Segment {
         check_named_vectors(&vectors, &self.segment_config)?;
         vectors.preprocess(|name| self.config().vector_data.get(name).unwrap());
         let stored_internal_point = self.id_tracker.borrow().internal_id(point_id);
-        self.handle_point_version_and_failure(
-            op_num,
-            point_id,
-            stored_internal_point,
-            |segment| {
-                if let Some(existing_internal_id) = stored_internal_point {
-                    segment.replace_all_vectors(
-                        existing_internal_id,
-                        op_num,
-                        &vectors,
-                        hw_counter,
-                    )?;
-                    Ok((true, Some(existing_internal_id)))
-                } else {
-                    let new_index =
-                        segment.insert_new_vectors(point_id, op_num, &vectors, hw_counter)?;
-                    Ok((false, Some(new_index)))
-                }
-            },
-        )
+        self.handle_point_version_and_failure(op_num, point_id, stored_internal_point, |segment| {
+            if let Some(existing_internal_id) = stored_internal_point {
+                segment.replace_all_vectors(existing_internal_id, op_num, &vectors, hw_counter)?;
+                Ok((true, Some(existing_internal_id)))
+            } else {
+                let new_index =
+                    segment.insert_new_vectors(point_id, op_num, &vectors, hw_counter)?;
+                Ok((false, Some(new_index)))
+            }
+        })
     }
 
     fn update_vectors(
@@ -800,10 +790,11 @@ impl SegmentEntry for Segment {
         self.handle_point_version_and_failure(op_num, point_id, internal_id, |segment| {
             match internal_id {
                 Some(internal_id) => {
-                    segment
-                        .payload_index
-                        .borrow_mut()
-                        .delete_payload(internal_id, key, hw_counter)?;
+                    segment.payload_index.borrow_mut().delete_payload(
+                        internal_id,
+                        key,
+                        hw_counter,
+                    )?;
                     segment.version_tracker.set_payload(Some(op_num));
 
                     Ok((true, Some(internal_id)))

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -217,13 +217,12 @@ impl Segment {
                 // Recover error state
                 match &self.error_status {
                     None => {} // all good
-                    Some(error) => {
-                        if error.point_id == Some(point_id) {
-                            // Fixed
-                            log::info!("Recovered from error: {}", error.error);
-                            self.error_status = None;
-                        }
+                    Some(error) if error.point_id == Some(point_id) => {
+                        // Fixed
+                        log::info!("Recovered from error: {}", error.error);
+                        self.error_status = None;
                     }
+                    Some(_) => {}
                 }
             }
             Some(error) => {

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -177,6 +177,7 @@ impl Segment {
     /// # Arguments
     ///
     /// * `op_num` - sequential operation of the current operation
+    /// * `point_id` - external id of the point the operation targets; used for error correlation.
     /// * `op_point_offset` - If point offset is specified, handler will use point version for comparison.
     ///   Otherwise, it will be applied without version checks.
     /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside) and optionally new offset of the changed point.
@@ -187,6 +188,7 @@ impl Segment {
     pub(super) fn handle_point_version_and_failure<F>(
         &mut self,
         op_num: SeqNumberType,
+        point_id: PointIdType,
         op_point_offset: Option<PointOffsetType>,
         operation: F,
     ) -> OperationResult<bool>
@@ -216,10 +218,7 @@ impl Segment {
                 match &self.error_status {
                     None => {} // all good
                     Some(error) => {
-                        let point_id = op_point_offset.and_then(|point_offset| {
-                            self.id_tracker.borrow().external_id(point_offset)
-                        });
-                        if error.point_id == point_id {
+                        if error.point_id == Some(point_id) {
                             // Fixed
                             log::info!("Recovered from error: {}", error.error);
                             self.error_status = None;
@@ -233,11 +232,9 @@ impl Segment {
                     "Segment {:?} operation error: {error}",
                     self.segment_path.as_path(),
                 );
-                let point_id = op_point_offset
-                    .and_then(|point_offset| self.id_tracker.borrow().external_id(point_offset));
                 self.error_status = Some(SegmentFailedState {
                     version: op_num,
-                    point_id,
+                    point_id: Some(point_id),
                     error,
                 });
             }


### PR DESCRIPTION
## Summary

Two preparatory changes on the path to an optional append-only mode for the mutable segment (mark-as-delete + insert at a fresh internal id instead of overwriting). Standalone-safe; no behavior change beyond the bug fix.

- **refactor: pass `point_id` into `handle_point_version_and_failure`** — drops the `external_id` reverse lookup that the helper was doing solely to build error correlation; callers already have the id. Mechanical, all 8 entry-point call sites updated.
- **fix: `filter_deferred_and_deleted` also consults the deleted bitslice** — closes a correctness gap surfaced while auditing the append-only path. Field-index primary-clause iterators (and the analogous plain/sparse vector-index paths) route through `PointMappingsRefEnum` to apply the deferred-threshold cutoff; the old `filter_deferred` only applied that threshold, so any soft-deleted internal id sitting below the cutoff slipped through whenever its field-index posting was still live. Adding a bitslice check here is a single bit test per element and lets the upcoming append-only mode rely on \"mark deleted; leave postings stale\" without breaking queries today. Renamed for clarity; 4 call sites + 2 doc references updated.
- **style: cargo +nightly fmt** — nightly rustfmt nits.

## Test plan

- [ ] CI green
- [ ] Sanity: existing field-index integration tests still pass (no behavior change expected for live points; tombstoned ids are now correctly filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)