### PR TITLE
[TQDT] Asymmetric query support in scorer

### DIFF
--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -8,7 +8,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
-use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::data_types::vectors::{TypedDenseVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
 
 pub trait PrimitiveVectorElement
@@ -18,11 +18,13 @@ where
     Self: FromBytes + Immutable + IntoBytes + KnownLayout,
     Self: Pod,
 {
-    type QueryType: ?Sized;
+    type QueryType;
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
 
     fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]>;
+
+    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType;
 
     fn quantization_preprocess<'a>(
         quantization_config: &QuantizationConfig,
@@ -42,7 +44,7 @@ where
 }
 
 impl PrimitiveVectorElement for VectorElementType {
-    type QueryType = [Self];
+    type QueryType = TypedDenseVector<Self>;
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         vector
@@ -50,6 +52,10 @@ impl PrimitiveVectorElement for VectorElementType {
 
     fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]> {
         vector
+    }
+
+    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+        TypedDenseVector::from(vector)
     }
 
     fn quantization_preprocess<'a>(
@@ -78,7 +84,7 @@ impl PrimitiveVectorElement for VectorElementType {
 }
 
 impl PrimitiveVectorElement for VectorElementTypeHalf {
-    type QueryType = [Self];
+    type QueryType = TypedDenseVector<Self>;
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| f16::from_f32(x)).collect())
@@ -86,6 +92,10 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
 
     fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]> {
         Cow::Owned(vector.iter().map(|&x| f16::to_f32(x)).collect_vec())
+    }
+
+    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+        TypedDenseVector::from(vector.iter().map(|&x| f16::from_f32(x)).collect::<Vec<_>>())
     }
 
     fn quantization_preprocess<'a>(
@@ -130,7 +140,7 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
 }
 
 impl PrimitiveVectorElement for VectorElementTypeByte {
-    type QueryType = [Self];
+    type QueryType = TypedDenseVector<Self>;
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| x as u8).collect())
@@ -143,6 +153,10 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
                 .map(|&x| VectorElementType::from(x))
                 .collect_vec(),
         )
+    }
+
+    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+        TypedDenseVector::from(vector.iter().map(|&x| x as u8).collect::<Vec<_>>())
     }
 
     fn quantization_preprocess<'a>(

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -18,6 +18,8 @@ where
     Self: FromBytes + Immutable + IntoBytes + KnownLayout,
     Self: Pod,
 {
+    type QueryType: ?Sized;
+
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
 
     fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]>;
@@ -40,6 +42,8 @@ where
 }
 
 impl PrimitiveVectorElement for VectorElementType {
+    type QueryType = [Self];
+
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         vector
     }
@@ -74,6 +78,8 @@ impl PrimitiveVectorElement for VectorElementType {
 }
 
 impl PrimitiveVectorElement for VectorElementTypeHalf {
+    type QueryType = [Self];
+
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| f16::from_f32(x)).collect())
     }
@@ -124,6 +130,8 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
 }
 
 impl PrimitiveVectorElement for VectorElementTypeByte {
+    type QueryType = [Self];
+
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| x as u8).collect())
     }

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -8,7 +8,9 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::named_vectors::CowMultiVector;
 use super::vectors::TypedMultiDenseVector;
-use crate::data_types::vectors::{TypedDenseVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::data_types::vectors::{
+    TypedDenseVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+};
 use crate::types::{Distance, QuantizationConfig, VectorStorageDatatype};
 
 pub trait PrimitiveVectorElement

--- a/lib/segment/src/spaces/metric.rs
+++ b/lib/segment/src/spaces/metric.rs
@@ -11,12 +11,16 @@ pub trait Metric<T: PrimitiveVectorElement> {
     /// Greater the value - closer the vectors
     fn similarity(v1: &[T], v2: &[T]) -> ScoreType;
 
-    /// Necessary vector transformations performed before adding it to the collection (like normalization)
+    /// Similarity between query and vector, where query can be in a different format (like quantized)
+    fn query_similarity(query: &T::QueryType, vector: &[T]) -> ScoreType;
+
+    /// Necessary vector transformations performed before adding it to the collection
+    /// Like normalization or rotations.
     /// If no transformation is needed - returns the same vector
     fn preprocess(vector: DenseVector) -> DenseVector;
 }
 
 pub trait MetricPostProcessing {
-    /// correct metric score for displaying
+    /// Correct metric score for displaying
     fn postprocess(score: ScoreType) -> ScoreType;
 }

--- a/lib/segment/src/spaces/metric_f16/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_cosine.rs
@@ -1,7 +1,7 @@
 use common::types::ScoreType;
 
 use super::simple_dot::dot_similarity_half;
-use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::dot::avx_dot_similarity_half;
@@ -57,7 +57,7 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
         dot_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_cosine.rs
@@ -57,7 +57,10 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
         dot_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeHalf>,
+        vector: &[VectorElementTypeHalf],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_cosine.rs
@@ -57,6 +57,10 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
         dot_similarity_half(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         #[cfg(target_arch = "x86_64")]
         {

--- a/lib/segment/src/spaces/metric_f16/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_dot.rs
@@ -51,7 +51,10 @@ impl Metric<VectorElementTypeHalf> for DotProductMetric {
         dot_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeHalf>,
+        vector: &[VectorElementTypeHalf],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_dot.rs
@@ -1,7 +1,7 @@
 use common::types::ScoreType;
 use half::f16;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::dot::avx_dot_similarity_half;
@@ -51,7 +51,7 @@ impl Metric<VectorElementTypeHalf> for DotProductMetric {
         dot_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_dot.rs
@@ -51,6 +51,10 @@ impl Metric<VectorElementTypeHalf> for DotProductMetric {
         dot_similarity_half(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_f16/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_euclid.rs
@@ -2,7 +2,7 @@ use common::types::ScoreType;
 use half::f16;
 use num_traits::Float;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::euclid::avx_euclid_similarity_half;
@@ -52,7 +52,7 @@ impl Metric<VectorElementTypeHalf> for EuclidMetric {
         euclid_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_euclid.rs
@@ -52,7 +52,10 @@ impl Metric<VectorElementTypeHalf> for EuclidMetric {
         euclid_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeHalf>,
+        vector: &[VectorElementTypeHalf],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_euclid.rs
@@ -52,6 +52,10 @@ impl Metric<VectorElementTypeHalf> for EuclidMetric {
         euclid_similarity_half(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
@@ -52,7 +52,10 @@ impl Metric<VectorElementTypeHalf> for ManhattanMetric {
         manhattan_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeHalf>,
+        vector: &[VectorElementTypeHalf],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
@@ -52,6 +52,10 @@ impl Metric<VectorElementTypeHalf> for ManhattanMetric {
         manhattan_similarity_half(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_manhattan.rs
@@ -2,7 +2,7 @@ use common::types::ScoreType;
 use half::f16;
 use num_traits::Float;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeHalf};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeHalf};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_f16::avx::manhattan::avx_manhattan_similarity_half;
@@ -52,7 +52,7 @@ impl Metric<VectorElementTypeHalf> for ManhattanMetric {
         manhattan_similarity_half(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeHalf], vector: &[VectorElementTypeHalf]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeHalf>, vector: &[VectorElementTypeHalf]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_cosine.rs
@@ -50,7 +50,10 @@ impl Metric<VectorElementTypeByte> for CosineMetric {
         cosine_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeByte>,
+        vector: &[VectorElementTypeByte],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_cosine.rs
@@ -50,6 +50,10 @@ impl Metric<VectorElementTypeByte> for CosineMetric {
         cosine_similarity_bytes(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_uint/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_cosine.rs
@@ -1,6 +1,6 @@
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeByte};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeByte};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_uint::avx2::cosine::avx_cosine_similarity_bytes;
@@ -50,7 +50,7 @@ impl Metric<VectorElementTypeByte> for CosineMetric {
         cosine_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_dot.rs
@@ -50,6 +50,10 @@ impl Metric<VectorElementTypeByte> for DotProductMetric {
         dot_similarity_bytes(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_uint/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_dot.rs
@@ -50,7 +50,10 @@ impl Metric<VectorElementTypeByte> for DotProductMetric {
         dot_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeByte>,
+        vector: &[VectorElementTypeByte],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_dot.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_dot.rs
@@ -1,6 +1,6 @@
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeByte};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeByte};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_uint::avx2::dot::avx_dot_similarity_bytes;
@@ -50,7 +50,7 @@ impl Metric<VectorElementTypeByte> for DotProductMetric {
         dot_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_euclid.rs
@@ -50,7 +50,10 @@ impl Metric<VectorElementTypeByte> for EuclidMetric {
         euclid_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeByte>,
+        vector: &[VectorElementTypeByte],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_euclid.rs
@@ -50,6 +50,10 @@ impl Metric<VectorElementTypeByte> for EuclidMetric {
         euclid_similarity_bytes(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_uint/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_euclid.rs
@@ -1,6 +1,6 @@
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeByte};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeByte};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_uint::avx2::euclid::avx_euclid_similarity_bytes;
@@ -50,7 +50,7 @@ impl Metric<VectorElementTypeByte> for EuclidMetric {
         euclid_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
@@ -50,6 +50,10 @@ impl Metric<VectorElementTypeByte> for ManhattanMetric {
         manhattan_similarity_bytes(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }

--- a/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
@@ -1,6 +1,6 @@
 use common::types::ScoreType;
 
-use crate::data_types::vectors::{DenseVector, VectorElementTypeByte};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementTypeByte};
 use crate::spaces::metric::Metric;
 #[cfg(target_arch = "x86_64")]
 use crate::spaces::metric_uint::avx2::manhattan::avx_manhattan_similarity_bytes;
@@ -50,7 +50,7 @@ impl Metric<VectorElementTypeByte> for ManhattanMetric {
         manhattan_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementTypeByte], vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_manhattan.rs
@@ -50,7 +50,10 @@ impl Metric<VectorElementTypeByte> for ManhattanMetric {
         manhattan_similarity_bytes(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementTypeByte>, vector: &[VectorElementTypeByte]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementTypeByte>,
+        vector: &[VectorElementTypeByte],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -66,7 +66,10 @@ impl Metric<VectorElementType> for EuclidMetric {
         euclid_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementType>,
+        vector: &[VectorElementType],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -114,7 +117,10 @@ impl Metric<VectorElementType> for ManhattanMetric {
         manhattan_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementType>,
+        vector: &[VectorElementType],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -162,7 +168,10 @@ impl Metric<VectorElementType> for DotProductMetric {
         dot_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementType>,
+        vector: &[VectorElementType],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -187,7 +196,10 @@ impl Metric<VectorElementType> for CosineMetric {
         DotProductMetric::similarity(v1, v2)
     }
 
-    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(
+        query: &TypedDenseVector<VectorElementType>,
+        vector: &[VectorElementType],
+    ) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -66,6 +66,10 @@ impl Metric<VectorElementType> for EuclidMetric {
         euclid_similarity(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }
@@ -108,6 +112,10 @@ impl Metric<VectorElementType> for ManhattanMetric {
         }
 
         manhattan_similarity(v1, v2)
+    }
+
+    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+        Self::similarity(query, vector)
     }
 
     fn preprocess(vector: DenseVector) -> DenseVector {
@@ -154,6 +162,10 @@ impl Metric<VectorElementType> for DotProductMetric {
         dot_similarity(v1, v2)
     }
 
+    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+        Self::similarity(query, vector)
+    }
+
     fn preprocess(vector: DenseVector) -> DenseVector {
         vector
     }
@@ -173,6 +185,10 @@ impl Metric<VectorElementType> for CosineMetric {
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         DotProductMetric::similarity(v1, v2)
+    }
+
+    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+        Self::similarity(query, vector)
     }
 
     fn preprocess(vector: DenseVector) -> DenseVector {

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -8,7 +8,7 @@ use super::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::simple_sse::*;
 use super::tools::is_length_zero_or_normalized;
-use crate::data_types::vectors::{DenseVector, VectorElementType};
+use crate::data_types::vectors::{DenseVector, TypedDenseVector, VectorElementType};
 use crate::types::Distance;
 
 #[cfg(target_arch = "x86_64")]
@@ -66,7 +66,7 @@ impl Metric<VectorElementType> for EuclidMetric {
         euclid_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -114,7 +114,7 @@ impl Metric<VectorElementType> for ManhattanMetric {
         manhattan_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -162,7 +162,7 @@ impl Metric<VectorElementType> for DotProductMetric {
         dot_similarity(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
         Self::similarity(query, vector)
     }
 
@@ -187,7 +187,7 @@ impl Metric<VectorElementType> for CosineMetric {
         DotProductMetric::similarity(v1, v2)
     }
 
-    fn query_similarity(query: &[VectorElementType], vector: &[VectorElementType]) -> ScoreType {
+    fn query_similarity(query: &TypedDenseVector<VectorElementType>, vector: &[VectorElementType]) -> ScoreType {
         Self::similarity(query, vector)
     }
 

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -42,17 +42,17 @@ impl<
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
-        TInputQuery: Query<DenseVector>
-            + TransformInto<TStoredQuery, DenseVector, TElement::QueryType>,
+        TInputQuery:
+            Query<DenseVector> + TransformInto<TStoredQuery, DenseVector, TElement::QueryType>,
     {
         let mut dim = 0;
         let query = query
             .transform(|vector| {
                 dim = vector.len();
                 let preprocessed_vector = TMetric::preprocess(vector);
-                Ok(TElement::query_from_float_cow(
-                    Cow::from(preprocessed_vector),
-                ))
+                Ok(TElement::query_from_float_cow(Cow::from(
+                    preprocessed_vector,
+                )))
             })
             .unwrap();
 

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -8,7 +8,7 @@ use common::types::{PointOffsetType, ScoreType};
 use zerocopy::FromBytes;
 
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{DenseVector, TypedDenseVector};
+use crate::data_types::vectors::DenseVector;
 use crate::spaces::metric::Metric;
 use crate::vector_storage::DenseVectorStorage;
 use crate::vector_storage::query::{Query, TransformInto};
@@ -19,7 +19,7 @@ pub struct CustomQueryScorer<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
     TVectorStorage: DenseVectorStorage<TElement>,
-    TStoredQuery: Query<TypedDenseVector<TElement>>,
+    TStoredQuery: Query<TElement::QueryType>,
 > {
     vector_storage: &'a TVectorStorage,
     query: TStoredQuery,
@@ -33,7 +33,7 @@ impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
     TVectorStorage: DenseVectorStorage<TElement>,
-    TStoredQuery: Query<TypedDenseVector<TElement>>,
+    TStoredQuery: Query<TElement::QueryType>,
 > CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TStoredQuery>
 {
     pub fn new<TInputQuery>(
@@ -43,16 +43,16 @@ impl<
     ) -> Self
     where
         TInputQuery: Query<DenseVector>
-            + TransformInto<TStoredQuery, DenseVector, TypedDenseVector<TElement>>,
+            + TransformInto<TStoredQuery, DenseVector, TElement::QueryType>,
     {
         let mut dim = 0;
         let query = query
             .transform(|vector| {
                 dim = vector.len();
                 let preprocessed_vector = TMetric::preprocess(vector);
-                Ok(TypedDenseVector::from(TElement::slice_from_float_cow(
+                Ok(TElement::query_from_float_cow(
                     Cow::from(preprocessed_vector),
-                )))
+                ))
             })
             .unwrap();
 
@@ -77,7 +77,7 @@ impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
     TVectorStorage: DenseVectorStorage<TElement>,
-    TStoredQuery: Query<TypedDenseVector<TElement>>,
+    TStoredQuery: Query<TElement::QueryType>,
 > QueryScorer for CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TStoredQuery>
 {
     type TVector = [TElement];
@@ -106,7 +106,7 @@ impl<
 
         self.query.score_by(|example| {
             cpu_counter.incr();
-            TMetric::similarity(example, against)
+            TMetric::query_similarity(example, against)
         })
     }
 

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -20,7 +20,7 @@ pub struct MetricQueryScorer<
     TVectorStorage: DenseVectorStorage<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
-    query: TypedDenseVector<TElement>,
+    query: TElement::QueryType,
     metric: PhantomData<TMetric>,
     hardware_counter: HardwareCounterCell,
 }
@@ -48,9 +48,7 @@ impl<
         }
 
         Self {
-            query: TypedDenseVector::from(TElement::slice_from_float_cow(Cow::from(
-                preprocessed_vector,
-            ))),
+            query: TElement::query_from_float_cow(Cow::from(preprocessed_vector)),
             vector_storage,
             metric: PhantomData,
             hardware_counter,
@@ -70,7 +68,7 @@ impl<
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
         self.hardware_counter.vector_io_read().incr();
-        TMetric::similarity(&self.query, &self.vector_storage.get_dense::<Random>(idx))
+        TMetric::query_similarity(&self.query, &self.vector_storage.get_dense::<Random>(idx))
     }
 
     #[inline]
@@ -82,14 +80,14 @@ impl<
 
         self.vector_storage
             .for_each_in_dense_batch(ids, |idx, vector| {
-                scores[idx] = TMetric::similarity(&self.query, vector);
+                scores[idx] = TMetric::query_similarity(&self.query, vector);
             });
     }
 
     #[inline]
     fn score(&self, v2: &[TElement]) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
-        TMetric::similarity(&self.query, v2)
+        TMetric::query_similarity(&self.query, v2)
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {


### PR DESCRIPTION
## Summary
Introduces an asymmetric representation for the query side of dense scoring, so the query type no longer has to mirror the stored element type.

Add `PrimitiveVectorElement::QueryType` associated type, along with `query_from_float_cow` to build it from a `Cow<[f32]>`.
Add `Metric::query_similarity(query: &T::QueryType, vector: &[T])` alongside the existing symmetric `similarity(&[T], &[T])`.
`CustomQueryScorer` and `MetricQueryScorer` now store the query as `TElement::QueryType` and score through `query_similarity`.

## Why
Today `QueryType` is set to `TypedDenseVector<Self>` for all existing element types (`f32`, `f16`, `u8`) and `query_similarity` is a one-line wrapper over similarity — there is no behavior or performance change for current users. The associated type is the seam needed to plug in an element type whose query carries a struct (e.g. lookup tables for a quantized scorer) rather than a raw slice of stored elements.

### Scope
Dense path only. Multi-vector scorers are intentionally left as-is — applying the same change there involves a flattened-storage layout and per-sub-query construction worth isolating in a follow-up PR.

