### PR TITLE
[DiskCache] use and impl `schedule_whole`

### DIFF
--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(target_os = "linux"), expect(clippy::unit_arg))]
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -15,7 +15,9 @@ pub use self::error::UniversalIoError;
 #[cfg(target_os = "linux")]
 pub use self::io_uring::{IoUringFile, IoUringFs, IoUringOpenExtra};
 pub use self::mmap::{MmapFile, MmapFs};
-pub use self::simple_disk_cache::{DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext};
+pub use self::simple_disk_cache::{
+    DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
+};
 pub use self::traits::{
     BorrowedReadPipeline, Item, OpenExtra, OwnedReadPipeline, UniversalRead, UniversalReadFileOps,
     UniversalReadFs, UniversalWrite, UserData,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::io::{self, ErrorKind};
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -12,7 +13,7 @@ use crate::generic_consts::{AccessPattern, Sequential};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::pipeline::{DiskCachePipeline, OwnedDiskCachePipeline};
-use crate::universal_io::simple_disk_cache::to_block_range;
+use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
 use crate::universal_io::{
     BorrowedReadPipeline, OpenOptions, OwnedReadPipeline, Populate, ReadRange, Result,
     UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs, UserData,
@@ -78,10 +79,7 @@ pub(super) enum InitSource<R: UniversalRead> {
 
 impl<R> DiskCache<R>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
+    R: DiskCacheRemote,
 {
     pub(super) fn new(
         remote_fs: R::Fs,
@@ -229,10 +227,7 @@ where
 
 impl<R> UniversalRead for DiskCache<R>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
+    R: DiskCacheRemote,
 {
     type Fs = DiskCacheFs<R>;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 use std::io::{self, ErrorKind};
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -13,6 +12,7 @@ use crate::generic_consts::{AccessPattern, Sequential};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::pipeline::{DiskCachePipeline, OwnedDiskCachePipeline};
+use crate::universal_io::simple_disk_cache::to_block_range;
 use crate::universal_io::{
     BorrowedReadPipeline, OpenOptions, OwnedReadPipeline, Populate, ReadRange, Result,
     UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs, UserData,
@@ -73,13 +73,7 @@ pub(super) enum InitSource<R: UniversalRead> {
     /// Build an empty local mmap and let reads fill blocks on demand.
     FromScratch,
     /// Wait for the prefill pipeline.
-    FromPrefiller(R::OwnedReadPipeline<Range<u32>>),
-}
-
-impl<R: UniversalRead> InitSource<R> {
-    pub(super) fn from_prefiller(pipe: R::OwnedReadPipeline<Range<u32>>) -> Self {
-        Self::FromPrefiller(pipe)
-    }
+    FromPrefiller(R::OwnedReadPipeline<()>),
 }
 
 impl<R> DiskCache<R>
@@ -87,7 +81,7 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
 {
     pub(super) fn new(
         remote_fs: R::Fs,
@@ -148,7 +142,11 @@ where
     ///
     /// If `allow_from_scratch` is false, this method will avoid initializing if `InitSource::FromScratch` is set.
     /// This is helpful for [`Self::reopen`] scenario where we can avoid work if no reads have taken place.
-    pub(super) fn init_local_state(&self, allow_from_scratch: bool, known_length: Option<u64>) -> Result<()> {
+    pub(super) fn init_local_state(
+        &self,
+        allow_from_scratch: bool,
+        known_length: Option<u64>,
+    ) -> Result<()> {
         // Only the first thread is able to initialize.
         let mut guard = self.init_lock.lock();
         if self.local.get().is_some() {
@@ -164,7 +162,7 @@ where
             }
             InitSource::FromPrefiller(mut pipe) => {
                 match pipe.wait()? {
-                    Some((blocks_range, bytes)) => {
+                    Some((_, bytes)) => {
                         let local = LocalState::new(
                             &self.local_path,
                             // TODO: if we want partial prefill, we should still create local state with
@@ -172,6 +170,7 @@ where
                             bytes.len() as u64,
                             self.open_options,
                         )?;
+                        let blocks_range = to_block_range(0..bytes.len() as u64);
                         unsafe { local.write_mmap_bytes(&bytes, blocks_range) };
                         local
                     }
@@ -200,7 +199,7 @@ where
     fn new_local_state_from_scratch(&self, known_length: Option<u64>) -> Result<LocalState> {
         let len = match known_length {
             Some(len) => len,
-            None => self.remote()?.len::<u8>()?
+            None => self.remote()?.len::<u8>()?,
         };
         LocalState::new(&self.local_path, len, self.open_options)
     }
@@ -233,7 +232,7 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
 {
     type Fs = DiskCacheFs<R>;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -139,7 +139,7 @@ where
             return Ok(state);
         }
 
-        self.init_local_state(true)?;
+        self.init_local_state(true, None)?;
 
         Ok(self.local.get().expect("just initialized"))
     }
@@ -148,7 +148,7 @@ where
     ///
     /// If `allow_from_scratch` is false, this method will avoid initializing if `InitSource::FromScratch` is set.
     /// This is helpful for [`Self::reopen`] scenario where we can avoid work if no reads have taken place.
-    fn init_local_state(&self, allow_from_scratch: bool) -> Result<()> {
+    pub(super) fn init_local_state(&self, allow_from_scratch: bool, known_length: Option<u64>) -> Result<()> {
         // Only the first thread is able to initialize.
         let mut guard = self.init_lock.lock();
         if self.local.get().is_some() {
@@ -160,7 +160,7 @@ where
                 if !allow_from_scratch {
                     return Ok(());
                 }
-                self.new_local_state_from_scratch()?
+                self.new_local_state_from_scratch(known_length)?
             }
             InitSource::FromPrefiller(mut pipe) => {
                 match pipe.wait()? {
@@ -184,7 +184,7 @@ where
                             return Ok(());
                         }
                         // init from scratch
-                        self.new_local_state_from_scratch()?
+                        self.new_local_state_from_scratch(known_length)?
                     }
                 }
             }
@@ -197,8 +197,11 @@ where
         Ok(())
     }
 
-    fn new_local_state_from_scratch(&self) -> Result<LocalState> {
-        let len = self.remote()?.len::<u8>()?;
+    fn new_local_state_from_scratch(&self, known_length: Option<u64>) -> Result<LocalState> {
+        let len = match known_length {
+            Some(len) => len,
+            None => self.remote()?.len::<u8>()?
+        };
         LocalState::new(&self.local_path, len, self.open_options)
     }
 
@@ -248,7 +251,7 @@ where
 
     fn reopen(&mut self) -> Result<()> {
         // Wait for InitSource::Prefill, if set.
-        self.init_local_state(false)?;
+        self.init_local_state(false, None)?;
 
         if self.local.get().is_none() {
             return Ok(());

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, InitSource};
 use crate::mmap::AdviceSetting;
@@ -87,10 +88,7 @@ where
 
 impl<R> UniversalReadFs for DiskCacheFs<R>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
+    R: DiskCacheRemote,
 {
     type File = DiskCache<R>;
     type OpenExtra = <R::Fs as UniversalReadFs>::OpenExtra;

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -1,12 +1,9 @@
 use std::fmt::Debug;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, InitSource};
-use super::to_block_range;
-use crate::generic_consts::Sequential;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
     OpenExtra, OpenOptions, OwnedReadPipeline, Populate, Result, UniversalIoError, UniversalRead,
@@ -93,7 +90,7 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
 {
     type File = DiskCache<R>;
     type OpenExtra = <R::Fs as UniversalReadFs>::OpenExtra;
@@ -135,14 +132,12 @@ where
                     extra.clone(),
                 )?;
 
-                let remote_len = remote.len::<u8>()?;
-                let blocks_range = to_block_range(0..remote_len);
-
                 let mut pipeline = R::OwnedReadPipeline::new(remote)?;
-                // FIXME: check `can_schedule` in a loop first
-                pipeline.schedule::<Sequential>(blocks_range, 0..remote_len, 1)?;
 
-                InitSource::from_prefiller(pipeline)
+                // FIXME: check `can_schedule` in a loop first
+                pipeline.schedule_whole(())?;
+
+                InitSource::FromPrefiller(pipeline)
             }
         };
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -13,6 +13,26 @@ pub use config::DiskCacheConfig;
 pub use file::DiskCache;
 pub use fs::{DiskCacheFs, DiskCacheFsContext};
 
+use crate::universal_io::{UniversalRead, UniversalReadFs};
+
+/// Trait bundle for remote backends that can be cached by [`DiskCache`].
+pub trait DiskCacheRemote:
+    UniversalRead<
+        Fs: Clone + Send + Sync + UniversalReadFs<OpenExtra: Clone + Send + Sync>,
+        OwnedReadPipeline<()>: Send,
+    > + Clone
+{
+}
+
+impl<R> DiskCacheRemote for R
+where
+    R: UniversalRead + Clone,
+    R::Fs: Clone + Send + Sync,
+    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
+    R::OwnedReadPipeline<()>: Send,
+{
+}
+
 /// Files are logically split into fixed-size blocks; the roaring bitmap
 /// tracks population on a per-block basis.
 ///

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -12,9 +12,16 @@ use crate::universal_io::{
 
 struct RemoteMeta<File, U> {
     file: File,
-    blocks_range: Range<u32>,
-    read_range: Range<u64>,
+    scheduled_read: ScheduledRead,
     user_data: U,
+}
+
+enum ScheduledRead {
+    Range {
+        blocks_range: Range<u32>,
+        read_range: Range<u64>,
+    },
+    Whole,
 }
 
 /// Outcome of [`plan_schedule`]: either the requested range is already available
@@ -112,8 +119,7 @@ where
 unsafe fn commit_and_read<'a, R>(
     file: &'a DiskCache<R>,
     bytes: &[u8],
-    blocks_range: Range<u32>,
-    read_range: Range<u64>,
+    scheduled_read: ScheduledRead,
 ) -> universal_io::Result<&'a [u8]>
 where
     R: UniversalRead + Clone,
@@ -121,7 +127,28 @@ where
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
     R::OwnedReadPipeline<Range<u32>>: Send,
 {
-    let local = file.local_state()?;
+    let mut known_len = None;
+    let (blocks_range, read_range) = match scheduled_read {
+        ScheduledRead::Range {
+            blocks_range,
+            read_range,
+        } => (blocks_range, read_range),
+        ScheduledRead::Whole => {
+            // derive whole ranges from the actual bytes returned.
+            let byte_len = bytes.len() as u64;
+            known_len = Some(byte_len);
+            let blocks_range = to_block_range(0..byte_len);
+            (blocks_range, 0..byte_len)
+        }
+    };
+
+    let local = if let Some(state) = file.local.get() {
+        state
+    } else {
+        file.init_local_state(true, known_len)?;
+        file.local.get().expect("just initialized")
+    };
+
     unsafe {
         local.write_mmap_bytes(bytes, blocks_range);
         local.read_mmap_bytes::<Random>(read_range)
@@ -206,8 +233,10 @@ where
             } => {
                 let remote_meta = RemoteMeta {
                     file,
-                    blocks_range,
-                    read_range: range,
+                    scheduled_read: ScheduledRead::Range {
+                        blocks_range,
+                        read_range: range,
+                    },
                     user_data,
                 };
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
@@ -236,13 +265,12 @@ where
 
         let RemoteMeta {
             file,
-            blocks_range,
-            read_range,
+            scheduled_read,
             user_data,
         } = remote_meta;
 
         // SAFETY: `blocks_range` and `read_range` match what was scheduled.
-        let items = unsafe { commit_and_read::<R>(file, &bytes, blocks_range, read_range)? };
+        let items = unsafe { commit_and_read::<R>(file, &bytes, scheduled_read)? };
         Ok(Some((user_data, ACow::Borrowed(items))))
     }
 }
@@ -325,8 +353,10 @@ where
             } => {
                 let remote_meta = RemoteMeta {
                     file: (),
-                    blocks_range,
-                    read_range: range,
+                    scheduled_read: ScheduledRead::Range {
+                        blocks_range,
+                        read_range: range,
+                    },
                     user_data,
                 };
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
@@ -337,9 +367,24 @@ where
     }
 
     fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        // todo: check if we have the entire file already local, if not, call schedule_whole on self.remote_pipeline
-        let length = self.file.len::<u8>()?;
-        self.schedule::<Sequential>(user_data, 0..length, 1)
+        // If local has already been initialized, use the mmap length
+        if let Some(local) = self.file.local.get() {
+            let length = local.mmap().len::<u8>()?;
+            return self.schedule::<Sequential>(
+                user_data,
+                0..length,
+                1
+            );
+        }
+
+        // Use schedule_whole on the remote pipeline directly
+        let remote_meta = RemoteMeta {
+            file: (),
+            scheduled_read: ScheduledRead::Whole,
+            user_data,
+        };
+        let remote_pipeline = self.get_or_init_remote_pipeline()?;
+        remote_pipeline.schedule_whole(remote_meta)
     }
 
     fn wait(&mut self) -> universal_io::Result<Option<(U, ACow<'_>)>> {
@@ -358,12 +403,13 @@ where
 
         let RemoteMeta {
             file: _,
-            blocks_range,
-            read_range,
+            scheduled_read,
             user_data,
         } = remote_meta;
 
-        let items = unsafe { commit_and_read::<R>(&self.file, &bytes, blocks_range, read_range)? };
+        let items =
+            // TODO: if schedule_whole is used other than during `open`, `commit_and_read` will call `remote.len()` regardless.
+            unsafe { commit_and_read::<R>(&self.file, &bytes, scheduled_read)? };
         Ok(Some((user_data, ACow::Borrowed(items))))
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -4,10 +4,12 @@ use std::ops::Range;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
-use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCache, to_block_range};
+use crate::universal_io::simple_disk_cache::{
+    BLOCK_SIZE, DiskCache, DiskCacheRemote, to_block_range,
+};
 use crate::universal_io::traits::BorrowedReadPipeline;
 use crate::universal_io::{
-    self, OwnedReadPipeline, Result, UniversalIoError, UniversalRead, UniversalReadFs, UserData,
+    self, OwnedReadPipeline, Result, UniversalIoError, UniversalRead, UserData,
 };
 
 struct RemoteMeta<File, U> {
@@ -96,11 +98,7 @@ unsafe fn read_local<R>(
     is_sequential: bool,
 ) -> universal_io::Result<&[u8]>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
-    T: bytemuck::Pod,
+    R: DiskCacheRemote,
 {
     if range.is_empty() {
         return Ok(&[]);
@@ -123,11 +121,7 @@ unsafe fn commit_and_read<'a, R>(
     scheduled_read: ScheduledRead,
 ) -> universal_io::Result<&'a [u8]>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
-    T: bytemuck::Pod,
+    R: DiskCacheRemote,
 {
     let mut known_len = None;
     let (blocks_range, read_range) = match scheduled_read {
@@ -190,11 +184,7 @@ where
 
 impl<'file, R, U> BorrowedReadPipeline<'file, U> for DiskCachePipeline<'file, R, U>
 where
-    R: UniversalRead + Clone + 'file,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
-    T: Item,
+    R: DiskCacheRemote + 'file,
 {
     type File = DiskCache<R>;
 
@@ -292,11 +282,7 @@ where
 
 impl<R, U> OwnedDiskCachePipeline<R, U>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
-    T: bytemuck::Pod,
+    R: DiskCacheRemote,
     U: UserData,
 {
     fn get_or_init_remote_pipeline(
@@ -313,11 +299,7 @@ where
 
 impl<R, U> OwnedReadPipeline<U> for OwnedDiskCachePipeline<R, U>
 where
-    R: UniversalRead + Clone,
-    R::Fs: Clone + Send + Sync,
-    <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<()>: Send,
-    T: bytemuck::Pod,
+    R: DiskCacheRemote,
 {
     type File = DiskCache<R>;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -99,7 +99,8 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
+    T: bytemuck::Pod,
 {
     if range.is_empty() {
         return Ok(&[]);
@@ -125,7 +126,8 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
+    T: bytemuck::Pod,
 {
     let mut known_len = None;
     let (blocks_range, read_range) = match scheduled_read {
@@ -191,8 +193,8 @@ where
     R: UniversalRead + Clone + 'file,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
-    U: UserData,
+    R::OwnedReadPipeline<()>: Send,
+    T: Item,
 {
     type File = DiskCache<R>;
 
@@ -293,7 +295,8 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
+    R::OwnedReadPipeline<()>: Send,
+    T: bytemuck::Pod,
     U: UserData,
 {
     fn get_or_init_remote_pipeline(
@@ -313,8 +316,8 @@ where
     R: UniversalRead + Clone,
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-    R::OwnedReadPipeline<Range<u32>>: Send,
-    U: UserData,
+    R::OwnedReadPipeline<()>: Send,
+    T: bytemuck::Pod,
 {
     type File = DiskCache<R>;
 
@@ -370,11 +373,7 @@ where
         // If local has already been initialized, use the mmap length
         if let Some(local) = self.file.local.get() {
             let length = local.mmap().len::<u8>()?;
-            return self.schedule::<Sequential>(
-                user_data,
-                0..length,
-                1
-            );
+            return self.schedule::<Sequential>(user_data, 0..length, 1);
         }
 
         // Use schedule_whole on the remote pipeline directly

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use fs_err as fs;
 
-use super::{BLOCK_SIZE, DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext};
+use super::{
+    BLOCK_SIZE, DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
+};
 use crate::generic_consts::Sequential;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
@@ -51,11 +53,8 @@ impl Scenario {
 
     fn open<R>(&self, prefill: bool) -> DiskCache<R>
     where
-        R: UniversalRead + Clone,
-        R::Fs: Clone + Send + Sync,
+        R: DiskCacheRemote,
         <R::Fs as UniversalReadFileOps>::ContextConfig: Default,
-        <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-        R::OwnedReadPipeline<()>: Send,
     {
         let populate = if prefill {
             Populate::PreferBackground

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -55,7 +55,7 @@ impl Scenario {
         R::Fs: Clone + Send + Sync,
         <R::Fs as UniversalReadFileOps>::ContextConfig: Default,
         <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
-        R::OwnedReadPipeline<std::ops::Range<u32>>: Send,
+        R::OwnedReadPipeline<()>: Send,
     {
         let populate = if prefill {
             Populate::PreferBackground


### PR DESCRIPTION
This PR does 3 things:
- simplify verbosity of trait bounds for `R`, by bundling them into `DiskCacheRemote` trait.
- use `schedule_whole` for background prefill.
- impl `schedule_whole` in case we want to use it directly for `DiskCache`.