### PR TITLE
[DiskCache tests] Fix reopen on windows

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -125,6 +125,16 @@ where
         Ok(self.remote.get().expect("just set or already set"))
     }
 
+    /// Drop the cached remote handle, releasing any mapping it holds on the
+    /// remote file. The next access re-opens it lazily via [`Self::remote`].
+    ///
+    /// Test-only: required so tests can shrink the remote on Windows, where a
+    /// file with an active memory mapping cannot be resized.
+    #[cfg(test)]
+    pub(super) fn release_remote(&mut self) {
+        self.remote = OnceLock::new();
+    }
+
     /// Return the cached [`LocalState`], initializing it on first call.
     pub(super) fn local_state(&self) -> Result<&LocalState> {
         if let Some(state) = self.local.get() {

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -240,7 +240,6 @@ mod tests_mod {
 
     /// Reopen with no prior reads leaves the local mirror untouched.
     #[test]
-    #[cfg_attr(target_os = "windows", ignore)] // FIXME: don't ignore, fix reopen on windows
     fn reopen_without_prior_reads_keeps_local_uninitialized() {
         let scn = Scenario::new(BLOCK_SIZE * 2);
         let mut cache = scn.open::<R>(PREFILL);
@@ -262,7 +261,6 @@ mod tests_mod {
     /// Reopen on an unchanged remote must not resize, repopulate, or mutate
     /// the fetched bitmap.
     #[test]
-    #[cfg_attr(target_os = "windows", ignore)] // FIXME: don't ignore, fix reopen on windows
     fn reopen_no_growth_does_not_repopulate() {
         let scn = Scenario::new(BLOCK_SIZE * 3);
         let mut cache = scn.open::<R>(PREFILL);
@@ -296,7 +294,6 @@ mod tests_mod {
 
     /// Reopening over a shrunk remote must fail with `UnexpectedEof`.
     #[test]
-    #[cfg_attr(target_os = "windows", ignore)] // FIXME: don't ignore, fix reopen on windows
     fn reopen_with_smaller_remote_fails() {
         let mut scn = Scenario::new(BLOCK_SIZE * 4);
         let mut cache = scn.open::<R>(PREFILL);
@@ -324,7 +321,6 @@ mod tests_mod {
     /// Reads into the new section must fail before reopen (local mirror is at
     /// the old length) and succeed after reopen.
     #[test]
-    #[cfg_attr(target_os = "windows", ignore)] // FIXME: don't ignore, fix reopen on windows
     fn reopen_growth_visible_after_reopen() {
         let mut scn = Scenario::new(BLOCK_SIZE * 2);
         let mut cache = scn.open::<R>(PREFILL);
@@ -369,7 +365,6 @@ mod tests_mod {
     /// populated, reopen must invalidate that block so the next read re-fetches
     /// it instead of returning the zero-filled bytes left by `set_len`.
     #[test]
-    #[cfg_attr(target_os = "windows", ignore)] // FIXME: don't ignore, fix reopen on windows
     fn reopen_growth_refetches_partial_tail_block() {
         // Non-block-aligned remote: block 1 holds only 100 real bytes.
         let mut scn = Scenario::new(BLOCK_SIZE + 100);

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -305,6 +305,10 @@ mod tests_mod {
             })
             .unwrap();
 
+        // The read above may have mapped the remote. Windows cannot shrink a
+        // file with an active mapping, so drop the cache's remote handle before
+        // shrinking the remote on disk. `reopen` re-opens it lazily afterward.
+        cache.release_remote();
         scn.truncate_remote(BLOCK_SIZE * 2);
 
         let err = cache.reopen().unwrap_err();


### PR DESCRIPTION
Builds after #9185, but just to avoid merge conflicts.

One test for `DiskCache::reopen` were broken on windows because the test scenario was shrinking a file with an active mmap. 

This PR adds a test helper to drop the remote mmap during the test.

Additionally, reenables every other `reopen` ignored test in windows