### PR TITLE
Use batched reads in sparse vector storage

### DIFF
--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -376,23 +376,17 @@ impl<V: Blob> Gridstore<V> {
         self.with_view(|view| view.get_value::<P>(point_offset, hw_counter))
     }
 
-    pub fn for_each_in_batch<P, F, E>(
+    pub fn read_values<P, U, E>(
         &self,
-        offsets: &[PointOffset],
-        mut callback: F,
-        hw_counter: &HardwareCounterCell,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
     ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<V>) -> Result<(), E>,
         E: From<GridstoreError>,
     {
-        // TODO: `hw_counter`!?
-
-        self.with_view(|view| {
-            let offsets = offsets.iter().copied().enumerate();
-            view.read_values::<P, _, _>(offsets, |value_idx, _, value| callback(value_idx, value))
-        })
+        // TODO: Track HW usage!?
+        self.with_view(|view| view.read_values::<P, _, _>(point_offsets, callback))
     }
 
     #[cfg(test)]

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -379,15 +379,20 @@ impl<V: Blob> Gridstore<V> {
     pub fn for_each_in_batch<P, F, E>(
         &self,
         offsets: &[PointOffset],
-        callback: F,
+        mut callback: F,
         hw_counter: &HardwareCounterCell,
-    ) -> std::result::Result<(), E>
+    ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
+        F: FnMut(usize, Option<V>) -> Result<(), E>,
         E: From<GridstoreError>,
     {
-        self.with_view(|view| view.for_each_in_batch::<P, F, E>(offsets, callback, hw_counter))
+        // TODO: `hw_counter`!?
+
+        self.with_view(|view| {
+            let offsets = offsets.iter().copied().enumerate();
+            view.read_values::<P, _, _>(offsets, |value_idx, _, value| callback(value_idx, value))
+        })
     }
 
     #[cfg(test)]

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -107,6 +107,19 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         Ok(())
     }
 
+    pub fn read_values<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        E: From<GridstoreError>,
+    {
+        // TODO: Track HW usage!?
+        self.view().read_values::<P, _, _>(point_offsets, callback)
+    }
+
     /// Return the storage size in bytes (approximate: total page capacity).
     ///
     /// For the precise used-space calculation, use [`super::Gridstore::get_storage_size_bytes`].

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1373,13 +1373,12 @@ fn test_for_each_in_batch_congruent_with_get_value() {
 
     let mut batch_results: Vec<Option<Payload>> = vec![None; offsets.len()];
     storage
-        .for_each_in_batch::<Random, _, GridstoreError>(
-            &offsets,
-            |idx, value| {
+        .read_values::<Random, _, GridstoreError>(
+            offsets.iter().copied().enumerate(),
+            |idx, _, value| {
                 batch_results[idx] = value;
                 Ok(())
             },
-            &hw_counter,
         )
         .unwrap();
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1313,13 +1313,12 @@ fn test_read_batch_from_pages_congruent_with_read_from_pages() {
 
     let mut batch_results: Vec<Option<Vec<u8>>> = vec![None; pointers.len()];
 
-    let pointers_opt: Vec<_> = pointers.into_iter().map(Some).collect();
     pages
         .read_batch_from_pages::<Random, _, GridstoreError>(
-            pointers_opt,
             &storage.config,
-            |idx, raw_opt| {
-                batch_results[idx] = raw_opt.map(|raw| raw.into_owned());
+            pointers.into_iter().enumerate(),
+            |idx, bytes| {
+                batch_results[idx] = Some(bytes.into_owned());
                 Ok(())
             },
         )

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -108,39 +108,38 @@ impl<'a, V: Blob, S: UniversalRead> GridstoreView<'a, V, S> {
         Ok(Some(value))
     }
 
-    pub fn for_each_in_batch<P, F, E>(
+    pub fn read_values<P, U, E>(
         &self,
-        point_offsets: &[PointOffset],
-        mut callback: impl FnMut(usize, Option<V>) -> Result<(), E>,
-        hw_counter: &HardwareCounterCell,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<V>) -> Result<(), E>,
     ) -> Result<(), E>
     where
         P: AccessPattern,
         E: From<GridstoreError>,
     {
-        // TODO: `hw_counter`!?
+        // TODO: Track HW usage!?
 
-        let point_offsets = point_offsets.iter().cloned().enumerate();
-        let pointers = self.tracker.get_batch(point_offsets)?;
+        let point_offsets = point_offsets
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
         let ValuePointersBatch {
             valid,
             empty,
             out_of_range,
-        } = pointers;
+        } = self.tracker.get_batch(point_offsets)?;
 
         self.pages.read_batch_from_pages::<P, _, _>(
             self.config,
             valid.into_iter(),
-            |value_idx, bytes| {
+            |(user_data, point_offset), bytes| {
                 let decompressed = self.decompress(bytes);
                 let value = V::from_bytes(&decompressed);
-                callback(value_idx, Some(value))
+                callback(user_data, point_offset, Some(value))
             },
         )?;
 
-        for value_idx in empty.into_iter().chain(out_of_range) {
-            callback(value_idx, None)?;
+        for (user_data, point_offset) in empty.into_iter().chain(out_of_range) {
+            callback(user_data, point_offset, None)?;
         }
 
         Ok(())

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -12,7 +12,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PointOffset, Tracker, ValuePointer};
+use crate::tracker::{PointOffset, Tracker, ValuePointer, ValuePointersBatch};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {
@@ -111,30 +111,39 @@ impl<'a, V: Blob, S: UniversalRead> GridstoreView<'a, V, S> {
     pub fn for_each_in_batch<P, F, E>(
         &self,
         point_offsets: &[PointOffset],
-        mut callback: F,
+        mut callback: impl FnMut(usize, Option<V>) -> Result<(), E>,
         hw_counter: &HardwareCounterCell,
-    ) -> std::result::Result<(), E>
+    ) -> Result<(), E>
     where
         P: AccessPattern,
-        F: FnMut(usize, Option<V>) -> std::result::Result<(), E>,
         E: From<GridstoreError>,
     {
-        // Resolve all pointers in a single batched tracker read so async backends
-        // (e.g. io_uring) can fetch them in parallel.
+        // TODO: `hw_counter`!?
+
+        let point_offsets = point_offsets.iter().cloned().enumerate();
         let pointers = self.tracker.get_batch(point_offsets)?;
 
-        // Stream decoded values straight to the caller — no intermediate buffer.
-        // The callback `idx` maps 1-to-1 to `point_offsets`; missing offsets are
-        // delivered as `None`.
-        self.pages
-            .read_batch_from_pages::<P, _, E>(pointers, self.config, |idx, raw_opt| {
-                let value = raw_opt.map(|raw| {
-                    hw_counter.payload_io_read_counter().incr_delta(raw.len());
-                    let decompressed = self.decompress(raw);
-                    V::from_bytes(&decompressed)
-                });
-                callback(idx, value)
-            })
+        let ValuePointersBatch {
+            valid,
+            empty,
+            out_of_range,
+        } = pointers;
+
+        self.pages.read_batch_from_pages::<P, _, _>(
+            self.config,
+            valid.into_iter(),
+            |value_idx, bytes| {
+                let decompressed = self.decompress(bytes);
+                let value = V::from_bytes(&decompressed);
+                callback(value_idx, Some(value))
+            },
+        )?;
+
+        for value_idx in empty.into_iter().chain(out_of_range) {
+            callback(value_idx, None)?;
+        }
+
+        Ok(())
     }
 
     /// Iterate over all the values in the storage.

--- a/lib/gridstore/src/lib.rs
+++ b/lib/gridstore/src/lib.rs
@@ -13,7 +13,7 @@ pub use gridstore::{Gridstore, GridstoreReader, GridstoreView};
 
 use crate::error::GridstoreError;
 
-pub(crate) type Result<T> = std::result::Result<T, GridstoreError>;
+pub(crate) type Result<T, E = GridstoreError> = std::result::Result<T, E>;
 
 /// Concrete tracker type used by gridstore (universal io over mmap).
 pub(crate) type TrackerMmap = tracker::Tracker<MmapFile>;

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
@@ -234,6 +235,116 @@ impl<S: UniversalRead> Pages<S> {
         }
 
         Ok(Cow::Owned(unsafe { assume_init_vec(buffer) }))
+    }
+
+    pub fn read_batch_from_pages_wip<P, U, E>(
+        &self,
+        config: &StorageConfig,
+        pointers: impl Iterator<Item = (U, ValuePointer)>,
+        mut callback: impl FnMut(U, Cow<'_, [u8]>) -> Result<(), E>,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        E: From<GridstoreError>,
+    {
+        struct Progress<U> {
+            buffer: Vec<MaybeUninit<u8>>,
+            pages_read: usize,
+            pages_len: usize,
+            user_data: U,
+        }
+
+        struct ReadMeta<U> {
+            value_idx: usize,
+            buffer_offset: usize,
+            user_data: Option<U>,
+        }
+
+        // Multi-page values need buffering, because chunks for the same value may arrive out-of-order
+        // or interleaved with chunks for other values.
+        //
+        // Single-page reads (common case) bypass this map entirely.
+        let pending = RefCell::new(AHashMap::new());
+
+        let reads = pointers
+            .enumerate()
+            .flat_map(|(value_idx, (user_data, pointer))| {
+                let ranges = Self::get_page_value_ranges(pointer, config);
+
+                let bytes_len = pointer.length as usize;
+                let pages_len = Self::value_len_pages(pointer, config);
+
+                let mut user_data = if pages_len <= 1 {
+                    Some(user_data)
+                } else {
+                    pending.borrow_mut().insert(
+                        value_idx,
+                        Progress {
+                            buffer: vec![MaybeUninit::uninit(); bytes_len],
+                            pages_read: 0,
+                            pages_len,
+                            user_data,
+                        },
+                    );
+
+                    None
+                };
+
+                ranges.map(move |(buffer_offset, page_idx, range)| {
+                    let meta = ReadMeta {
+                        value_idx,
+                        buffer_offset,
+                        user_data: user_data.take(),
+                    };
+
+                    let page = &self.pages[page_idx as usize];
+                    (meta, page, range)
+                })
+            });
+
+        for result in S::read_multi_iter::<P, _, _>(reads).map_err(GridstoreError::from)? {
+            let (meta, bytes) = result.map_err(GridstoreError::from)?;
+
+            let ReadMeta {
+                value_idx,
+                buffer_offset,
+                user_data,
+            } = meta;
+
+            if let Some(user_data) = user_data {
+                debug_assert!(
+                    !pending.borrow().contains_key(&value_idx),
+                    "single-page value"
+                );
+
+                callback(user_data, bytes)?;
+                continue;
+            }
+
+            let mut pending = pending.borrow_mut();
+
+            let progress = pending.get_mut(&value_idx).expect("multi-page value");
+            progress.buffer[buffer_offset..buffer_offset + bytes.len()].write_copy_of_slice(&bytes);
+            progress.pages_read += 1;
+
+            if progress.pages_read >= progress.pages_len {
+                let progress = pending.remove(&value_idx).expect("multi-page value");
+
+                let Progress {
+                    buffer, user_data, ..
+                } = progress;
+
+                let buffer = unsafe { assume_init_vec(buffer) };
+                callback(user_data, Cow::Owned(buffer))?;
+            }
+        }
+
+        debug_assert!(
+            pending.borrow().is_empty(),
+            "all multi-page values have been read"
+        );
+
+        Ok(())
     }
 
     /// Batch-read values pointed to by `pointers`, invoking `callback` for each

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -237,7 +237,8 @@ impl<S: UniversalRead> Pages<S> {
         Ok(Cow::Owned(unsafe { assume_init_vec(buffer) }))
     }
 
-    pub fn read_batch_from_pages_wip<P, U, E>(
+    /// Batch-read values and execute callback for each value
+    pub fn read_batch_from_pages<P, U, E>(
         &self,
         config: &StorageConfig,
         pointers: impl Iterator<Item = (U, ValuePointer)>,
@@ -343,112 +344,6 @@ impl<S: UniversalRead> Pages<S> {
             pending.borrow().is_empty(),
             "all multi-page values have been read"
         );
-
-        Ok(())
-    }
-
-    /// Batch-read values pointed to by `pointers`, invoking `callback` for each
-    /// input slot.
-    ///
-    /// The callback is invoked once per slot in `pointers`, receiving the slot
-    /// index and `Some(bytes)` for set pointers (in arbitrary order — io_uring
-    /// completions may interleave) or `None` for empty slots (after all data
-    /// arrives). The callback's error type `E` flows back through the function
-    /// so callers don't have to bridge it themselves.
-    pub fn read_batch_from_pages<P, F, E>(
-        &self,
-        pointers: Vec<Option<ValuePointer>>,
-        config: &StorageConfig,
-        mut callback: F,
-    ) -> std::result::Result<(), E>
-    where
-        P: AccessPattern,
-        F: FnMut(usize, Option<Cow<'_, [u8]>>) -> std::result::Result<(), E>,
-        E: From<GridstoreError>,
-    {
-        struct ReadMeta {
-            value_idx: usize,
-            buffer_offset: usize,
-            len_bytes: usize,
-            len_pages: usize,
-        }
-
-        let mut empty_values = Vec::new(); // expect (almost) no values
-
-        let reads = pointers
-            .iter()
-            .copied()
-            .enumerate()
-            .flat_map(|(value_idx, pointer_opt)| {
-                if pointer_opt.is_none() {
-                    empty_values.push(value_idx);
-                }
-                pointer_opt.into_iter().flat_map(move |pointer| {
-                    let len_bytes = pointer.length as usize;
-                    let len_pages = Self::value_len_pages(pointer, config);
-
-                    Self::get_page_value_ranges(pointer, config).map(
-                        move |(buffer_offset, page_idx, range)| {
-                            let meta = ReadMeta {
-                                value_idx,
-                                buffer_offset,
-                                len_bytes,
-                                len_pages,
-                            };
-
-                            let page = &self.pages[page_idx as usize];
-                            (meta, page, range)
-                        },
-                    )
-                })
-            });
-
-        let chunks = S::read_multi_iter::<P, u8, _>(reads).map_err(GridstoreError::from)?;
-
-        // Multi-page values need buffering since chunks for the same value may
-        // arrive interleaved with chunks for other values. Single-page reads
-        // (the common case, including zero-length) bypass this map entirely.
-        let mut pending: AHashMap<usize, (Vec<MaybeUninit<u8>>, usize)> = AHashMap::new();
-
-        for result in chunks {
-            let (meta, bytes) = result.map_err(GridstoreError::from)?;
-
-            let ReadMeta {
-                value_idx,
-                buffer_offset,
-                len_bytes,
-                len_pages,
-            } = meta;
-
-            if len_pages <= 1 {
-                callback(value_idx, Some(bytes))?;
-                continue;
-            }
-
-            let (value_buffer, pages_read) = pending
-                .entry(value_idx)
-                .or_insert_with(|| (vec![MaybeUninit::uninit(); len_bytes], 0));
-
-            value_buffer[buffer_offset..buffer_offset + bytes.len()].write_copy_of_slice(&bytes);
-
-            *pages_read += 1;
-
-            if *pages_read >= len_pages {
-                let (value_buffer, _) = pending.remove(&value_idx).expect("value exists");
-                let value_buffer = unsafe { assume_init_vec(value_buffer) };
-
-                callback(value_idx, Some(Cow::Owned(value_buffer)))?;
-            }
-        }
-
-        debug_assert!(
-            pending.is_empty(),
-            "all valid pointers should have been delivered",
-        );
-
-        for idx in empty_values {
-            callback(idx, None)?;
-        }
 
         Ok(())
     }

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -384,7 +384,11 @@ impl<S: UniversalRead> Tracker<S> {
         }
     }
 
-    pub fn get_batch_wip<U>(
+    /// Get the page pointers for a batch of point offsets.
+    ///
+    /// Issues a single batched read against the underlying storage, so async backends can fetch
+    /// all entries in parallel.
+    pub fn get_batch<U>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffset)>,
     ) -> Result<ValuePointersBatch<U>> {
@@ -432,53 +436,6 @@ impl<S: UniversalRead> Tracker<S> {
         }
 
         Ok(pointers.into_inner())
-    }
-
-    /// Get the page pointers for a batch of point offsets.
-    ///
-    /// Issues a single batched read against the underlying storage so async
-    /// backends (e.g. io_uring) can fetch all entries in parallel. Pending
-    /// updates and out-of-range offsets are handled before/after the batch
-    /// read, mirroring [`get`](Self::get).
-    pub fn get_batch(&self, point_offsets: &[PointOffset]) -> Result<Vec<Option<ValuePointer>>> {
-        let item_size = std::mem::size_of::<OptionalPointer>();
-        let header_size = std::mem::size_of::<TrackerHeader>();
-        let storage_len = self.storage.len::<u8>()?;
-
-        let mut result: Vec<Option<ValuePointer>> = vec![None; point_offsets.len()];
-        let mut storage_reads: Vec<(usize, ReadRange)> = Vec::with_capacity(point_offsets.len());
-
-        for (i, &point_offset) in point_offsets.iter().enumerate() {
-            // Pending updates take precedence over storage.
-            if let Some(pending) = self.pending_updates.get(&point_offset) {
-                if pending.is_empty() {
-                    debug_assert!(false, "pending updates must not be empty");
-                } else {
-                    result[i] = pending.current;
-                    continue;
-                }
-            }
-
-            let start_offset = header_size + point_offset as usize * item_size;
-            let end_offset = start_offset + item_size;
-            if end_offset as u64 > storage_len {
-                // Out of range, leave as None.
-                continue;
-            }
-
-            storage_reads.push((i, ReadRange::one(start_offset as u64)));
-        }
-
-        let reads = storage_reads
-            .iter()
-            .map(|(i, range)| (*i, &self.storage, *range));
-
-        for read_result in S::read_multi_iter::<Random, OptionalPointer, _>(reads)? {
-            let (i, opt_slice) = read_result?;
-            result[i] = opt_slice[0].to_option();
-        }
-
-        Ok(result)
     }
 
     /// Iterate over the pointers in the tracker

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 use ahash::{AHashMap, AHashSet};
@@ -98,6 +99,23 @@ impl ValuePointer {
             page_id,
             block_offset,
             length,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValuePointersBatch<U> {
+    pub valid: Vec<(U, ValuePointer)>,
+    pub empty: Vec<U>,
+    pub out_of_range: Vec<U>,
+}
+
+impl<U> Default for ValuePointersBatch<U> {
+    fn default() -> Self {
+        Self {
+            valid: Vec::new(),
+            empty: Vec::new(),
+            out_of_range: Vec::new(),
         }
     }
 }
@@ -364,6 +382,56 @@ impl<S: UniversalRead> Tracker<S> {
             // No pending update, use real data
             None => self.get_raw(point_offset),
         }
+    }
+
+    pub fn get_batch_wip<U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+    ) -> Result<ValuePointersBatch<U>> {
+        let header_size = size_of::<TrackerHeader>();
+        let item_size = size_of::<OptionalPointer>();
+
+        let storage_len = self.storage.len::<u8>()?;
+
+        let pointers = RefCell::new(ValuePointersBatch::default());
+
+        let ranges = point_offsets.filter_map(|(user_data, point_offset)| {
+            if let Some(pending) = self.pending_updates.get(&point_offset) {
+                debug_assert!(!pending.is_empty(), "pending updates must not be empty");
+
+                if let Some(pointer) = pending.current {
+                    pointers.borrow_mut().valid.push((user_data, pointer));
+                    return None;
+                }
+            }
+
+            let byte_offset = header_size + item_size * point_offset as usize;
+
+            if storage_len < (byte_offset + item_size) as _ {
+                pointers.borrow_mut().out_of_range.push(user_data);
+                return None;
+            }
+
+            Some((user_data, ReadRange::one(byte_offset as _)))
+        });
+
+        let pointers_iter = self
+            .storage
+            .read_iter::<Random, OptionalPointer, _>(ranges)?;
+
+        for result in pointers_iter {
+            let (user_data, pointer) = result?;
+            let &[pointer] = pointer.as_ref() else {
+                unreachable!();
+            };
+
+            match pointer.to_option() {
+                Some(pointer) => pointers.borrow_mut().valid.push((user_data, pointer)),
+                None => pointers.borrow_mut().empty.push(user_data),
+            }
+        }
+
+        Ok(pointers.into_inner())
     }
 
     /// Get the page pointers for a batch of point offsets.

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -127,6 +127,10 @@ name = "read_vectors"
 harness = false
 
 [[bench]]
+name = "read_payloads"
+harness = false
+
+[[bench]]
 name = "hnsw_build_graph"
 harness = false
 

--- a/lib/segment/benches/read_payloads.rs
+++ b/lib/segment/benches/read_payloads.rs
@@ -1,0 +1,120 @@
+use std::cell::LazyCell;
+use std::hint::black_box;
+use std::ops::Deref as _;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::{AccessPattern, Random, Sequential};
+use common::types::PointOffsetType;
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::prelude::{SliceRandom, StdRng};
+use rand::{RngExt, SeedableRng};
+use segment::payload_json;
+use segment::payload_storage::mmap_payload_storage::MmapPayloadStorage;
+use segment::payload_storage::{PayloadStorage, PayloadStorageRead};
+use segment::types::Payload;
+use tempfile::{Builder, TempDir};
+
+const RNG_SEED: u64 = 42;
+const POINT_COUNT: usize = 10_000;
+const READ_BATCH_SIZE: usize = 1024;
+const TAGS_COUNT: usize = 4;
+
+criterion_main!(benches);
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+}
+
+fn bench(c: &mut Criterion) {
+    let sequential_keys: Vec<_> = (0..READ_BATCH_SIZE as PointOffsetType).collect();
+
+    let mut random_keys: Vec<_> = (0..POINT_COUNT as PointOffsetType).collect();
+    random_keys.shuffle(&mut StdRng::seed_from_u64(RNG_SEED));
+    random_keys.truncate(READ_BATCH_SIZE);
+
+    let mut group = c.benchmark_group("read-payloads");
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage(tmpdir.path()));
+
+        group.bench_function("mmap/sequential", |b| {
+            b.iter(|| read_payloads::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("mmap/random", |b| {
+            b.iter(|| read_payloads::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    group.finish();
+}
+
+fn tmpdir() -> TempDir {
+    Builder::new()
+        .prefix("read-payloads-bench")
+        .tempdir()
+        .expect("tempdir created")
+}
+
+fn storage(path: &Path) -> MmapPayloadStorage {
+    let mut storage = MmapPayloadStorage::open_or_create(path.to_path_buf(), true)
+        .expect("mmap payload storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let payload = random_payload(&mut rng, point_id);
+
+        storage
+            .overwrite(point_id, &payload, &hw_counter)
+            .expect("payload inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn random_payload(rng: &mut StdRng, point_id: PointOffsetType) -> Payload {
+    let tags: Vec<_> = (0..TAGS_COUNT)
+        .map(|_| format!("tag-{}", rng.random_range(0..64)))
+        .collect();
+
+    payload_json! {
+        "point_id": point_id,
+        "price": rng.random_range(0..1_000_000),
+        "rating": rng.random::<f64>(),
+        "active": rng.random_bool(0.8),
+        "category": format!("category-{}", rng.random_range(0..32)),
+        "tags": tags,
+    }
+}
+
+fn read_payloads<P, S>(storage: &S, point_offsets: &[PointOffsetType]) -> usize
+where
+    P: AccessPattern,
+    S: PayloadStorageRead,
+{
+    let point_offsets = point_offsets.iter().map(|&point_offset| ((), point_offset));
+    let hw_counter = HardwareCounterCell::disposable();
+
+    let mut fields_read = 0;
+    storage
+        .read_payloads::<P, _>(
+            point_offsets,
+            |_, payload| {
+                fields_read += payload.len();
+                Ok(())
+            },
+            &hw_counter,
+        )
+        .expect("payloads read");
+
+    black_box(fields_read)
+}

--- a/lib/segment/benches/read_vectors.rs
+++ b/lib/segment/benches/read_vectors.rs
@@ -18,13 +18,16 @@ use segment::vector_storage::dense::appendable_dense_vector_storage::{
 use segment::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     AppendableMmapMultiDenseVectorStorage, open_appendable_memmap_multi_vector_storage_impl,
 };
+use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::{VectorStorage, VectorStorageRead};
+use sparse::common::sparse_vector_fixture::random_sparse_vector;
 use tempfile::{Builder, TempDir};
 
 const RNG_SEED: u64 = 42;
 const POINT_COUNT: usize = 10_000;
 const MAX_VECTORS_PER_POINT: usize = 8;
 const VECTOR_DIM: usize = 128;
+const SPARSE_MAX_DIM: usize = 1000;
 const READ_BATCH_SIZE: usize = 1024;
 
 criterion_main!(benches);
@@ -66,6 +69,19 @@ fn bench(c: &mut Criterion) {
         });
 
         group.bench_function("appendable-mmap-multi-dense/random", |b| {
+            b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
+        });
+    }
+
+    {
+        let tmpdir = tmpdir();
+        let storage = LazyCell::new(|| storage_sparse(tmpdir.path()));
+
+        group.bench_function("mmap-sparse/sequential", |b| {
+            b.iter(|| read_vectors::<Sequential, _>(storage.deref(), &sequential_keys));
+        });
+
+        group.bench_function("mmap-sparse/random", |b| {
             b.iter(|| read_vectors::<Random, _>(storage.deref(), &random_keys));
         });
     }
@@ -130,6 +146,27 @@ fn storage_multi(path: &Path) -> AppendableMmapMultiDenseVectorStorage<VectorEle
 
         storage
             .insert_vector(point_id, VectorRef::from(vector), &hw_counter)
+            .expect("vector inserted");
+    }
+
+    storage.flusher()().expect("storage flushed");
+    storage.populate().expect("storage populated");
+
+    storage
+}
+
+fn storage_sparse(path: &Path) -> MmapSparseVectorStorage {
+    let mut storage =
+        MmapSparseVectorStorage::open_or_create(path).expect("mmap sparse storage opened");
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let hw_counter = HardwareCounterCell::disposable();
+
+    for point_id in 0..POINT_COUNT as PointOffsetType {
+        let vector = random_sparse_vector(&mut rng, SPARSE_MAX_DIM);
+
+        storage
+            .insert_vector(point_id, VectorRef::from(&vector), &hw_counter)
             .expect("vector inserted");
     }
 

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 use serde_json::Value;
 
@@ -138,6 +139,13 @@ pub trait PayloadIndexRead {
         point_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
 }
 
 /// Trait for payload index with mutating operations.

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 use fs_err as fs;
@@ -161,6 +162,15 @@ impl PayloadIndexRead for PlainPayloadIndex {
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         unreachable!()
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        _callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        unimplemented!()
     }
 
     fn numeric_index_for(&self, _key: &PayloadKeyType) -> Option<impl NumericFieldIndexRead + '_> {

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -5,6 +5,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::either_variant::EitherVariant;
+use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType, ScoreType};
 
@@ -274,5 +275,16 @@ where
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
         self.payload.borrow().get_sequential(point_id, hw_counter)
+    }
+
+    fn read_payloads<AP: AccessPattern, U>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload
+            .borrow()
+            .read_payloads::<AP, _>(point_ids, callback, hw_counter)
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -53,6 +54,20 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
                 return Ok(());
             }
         }
+        Ok(())
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for (user_data, point_offset) in point_offsets {
+            let payload = self.get(point_offset, hw_counter)?;
+            callback(user_data, payload)?;
+        }
+
         Ok(())
     }
 

--- a/lib/segment/src/payload_storage/mmap_payload_storage.rs
+++ b/lib/segment/src/payload_storage/mmap_payload_storage.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::{Random, Sequential};
+use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::types::PointOffsetType;
 use fs_err as fs;
 use gridstore::config::StorageOptions;
@@ -115,6 +115,21 @@ impl PayloadStorageRead for MmapPayloadStorage {
     ) -> OperationResult<OwnedPayloadRef<'_>> {
         let payload = self.get(point_offset, hw_counter)?;
         Ok(OwnedPayloadRef::from(payload))
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // TODO: `hw_counter`!?
+
+        self.storage
+            .read_values::<P, _, _>(point_offsets, |user_data, _, payload| {
+                let payload = payload.unwrap_or_default();
+                callback(user_data, payload)
+            })
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -40,6 +41,13 @@ pub trait PayloadStorageRead {
         point_offset: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<OwnedPayloadRef<'_>>;
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
 
     /// Iterate over all stored payload and apply the provided callback.
     /// Stop iteration if callback returns false or error.

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
@@ -71,6 +72,24 @@ impl PayloadStorageRead for PayloadStorageEnum {
                 s.payload_ref(point_offset, hw_counter)
             }
             PayloadStorageEnum::MmapPayloadStorage(s) => s.payload_ref(point_offset, hw_counter),
+        }
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemoryPayloadStorage(s) => {
+                s.read_payloads::<P, _>(point_offsets, callback, hw_counter)
+            }
+
+            PayloadStorageEnum::MmapPayloadStorage(s) => {
+                s.read_payloads::<P, _>(point_offsets, callback, hw_counter)
+            }
         }
     }
 

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -1,5 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::{Random, Sequential};
+use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -41,6 +41,21 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     ) -> OperationResult<OwnedPayloadRef<'_>> {
         let payload = self.get(point_offset, hw_counter)?;
         Ok(OwnedPayloadRef::from(payload))
+    }
+
+    fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // TODO: `hw_counter`!?
+
+        self.storage
+            .read_values::<P, _, _>(point_offsets, |user_data, _, payload| {
+                let payload = payload.unwrap_or_default();
+                callback(user_data, payload)
+            })
     }
 
     fn iter<F>(&self, mut callback: F, hw_counter: &HardwareCounterCell) -> OperationResult<()>

--- a/lib/segment/src/segment/read_view/payload.rs
+++ b/lib/segment/src/segment/read_view/payload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
@@ -18,6 +19,16 @@ where
     TPS: PayloadStorageRead,
     TVD: VectorDataRead,
 {
+    pub fn read_payloads<P: AccessPattern, U>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload_index
+            .read_payloads::<P, _>(point_offsets, callback, hw_counter)
+    }
+
     /// Retrieve payload by internal ID.
     #[inline]
     pub fn payload_by_offset(

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, ScoredPointOffset};
 
@@ -108,17 +109,26 @@ where
         // mirrors what a future batched payload fetcher would consume —
         // `&resolved_offsets` becomes its input directly.
         if with_payload.enable {
-            for (&id, &offset) in resolved_ids.iter().zip(&resolved_offsets) {
-                check_stopped(is_stopped)?;
-                let payload = self.payload_by_offset(offset, hw_counter)?;
-                let payload = match &with_payload.payload_selector {
-                    Some(selector) => selector.process(payload),
-                    None => payload,
-                };
-                if let Some(record) = records.get_mut(&id) {
-                    record.payload = Some(payload);
-                }
-            }
+            let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
+
+            self.read_payloads::<Random, _>(
+                point_offsets,
+                |point_id, payload| {
+                    check_stopped(is_stopped)?;
+
+                    let payload = match &with_payload.payload_selector {
+                        Some(selector) => selector.process(payload),
+                        None => payload,
+                    };
+
+                    if let Some(record) = records.get_mut(&point_id) {
+                        record.payload = Some(payload);
+                    }
+
+                    Ok(())
+                },
+                hw_counter,
+            )?;
         }
 
         Ok(records)

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -247,6 +247,26 @@ impl VectorStorageRead for MmapSparseVectorStorage {
             .unwrap_or_else(CowVector::default_sparse)
     }
 
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let callback = |user_data, point_offset, sparse_vector| -> OperationResult<()> {
+            let Some(sparse_vector) = sparse_vector else {
+                return Ok(());
+            };
+
+            let sparse_vector = SparseVector::try_from(sparse_vector)?;
+            callback(user_data, point_offset, CowVector::from(sparse_vector));
+            Ok(())
+        };
+
+        self.storage
+            .read_values::<P, _, _>(keys.into_iter(), callback)
+            .expect("sparse vectors read")
+    }
+
     /// Get vector by key, if it exists.
     ///
     /// Ignore any error

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -210,16 +210,18 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
     where
         F: FnMut(usize, SparseVector),
     {
-        self.storage.for_each_in_batch::<Random, _, OperationError>(
-            keys,
-            |idx, vector| {
-                if let Some(vector) = vector {
-                    callback(idx, SparseVector::try_from(vector)?);
-                }
-                Ok(())
-            },
-            &HardwareCounterCell::disposable(),
-        )
+        let point_offsets = keys.iter().copied().enumerate();
+
+        let callback = |value_idx, _, sparse_vector| {
+            if let Some(sparse_vector) = sparse_vector {
+                callback(value_idx, SparseVector::try_from(sparse_vector)?);
+            }
+
+            Ok(())
+        };
+
+        self.storage
+            .read_values::<Random, _, _>(point_offsets, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
@@ -6,6 +6,7 @@ use common::universal_io::UniversalRead;
 use gridstore::GridstoreReader;
 use sparse::common::sparse_vector::SparseVector;
 
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
@@ -44,6 +45,26 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.get_vector_opt::<P>(key)
             .unwrap_or_else(CowVector::default_sparse)
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let callback = |user_data, point_offset, sparse_vector| -> OperationResult<()> {
+            let Some(sparse_vector) = sparse_vector else {
+                return Ok(());
+            };
+
+            let sparse_vector = SparseVector::try_from(sparse_vector)?;
+            callback(user_data, point_offset, CowVector::from(sparse_vector));
+            Ok(())
+        };
+
+        self.storage
+            .read_values::<P, _, _>(keys.into_iter(), callback)
+            .expect("sparse vectors read")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {


### PR DESCRIPTION
Follow-up to #9113.

This PR implements (or refactor existing methods into) `read_values` for Gridstore and then implements `read_vectors` for sparse vector storage.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
