### PR TITLE
Add a test for abort during resharding path

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -281,11 +281,32 @@ impl Collection {
         // Abort all resharding transfer related to this specific resharding operation
         let resharding_transfers =
             shard_holder.get_transfers(|t| t.is_related_to_resharding(&resharding_key));
+        #[cfg(feature = "staging")]
+        let aborted_transfer = !resharding_transfers.is_empty();
         for transfer in resharding_transfers {
             self.abort_shard_transfer(transfer, &shard_holder).await?;
         }
 
         drop(shard_holder); // drop the read lock before acquiring write lock
+
+        // Staging-only: widen the window between aborting the transfer above and
+        // clearing the resharding state below, so tests can kill a peer here and
+        // exercise the non-idempotent replay path. Only when a transfer was actually
+        // aborted, so idempotent no-op aborts don't stall the consensus thread.
+        #[cfg(feature = "staging")]
+        if aborted_transfer
+            && let Some(delay) = std::env::var("QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC")
+                .ok()
+                .map(|val| {
+                    std::time::Duration::from_secs_f64(
+                        val.parse::<f64>()
+                            .expect("invalid QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC value"),
+                    )
+                })
+        {
+            tokio::time::sleep(delay).await;
+        }
+
         let mut shard_holder = self.shards_holder.write().await;
 
         shard_holder

--- a/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
+++ b/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
@@ -1,0 +1,109 @@
+"""Aborting a resharding transfer is not crash-idempotent: it aborts+persists the
+transfer before clearing resharding_state. A peer killed in that window (widened by
+a debug sleep in abort_resharding) replays the abort, finds no transfer, and would
+stay resharding=Some unless the abort is replicated through consensus. Asserts every
+peer converges on no resharding_operations.
+"""
+
+import pathlib
+import threading
+
+from .fixtures import create_collection, upsert_random_points
+from .test_resharding import all_replicas, start_resharding
+from .utils import *
+
+COLLECTION = "test_resharding_down_abort_converges_after_crash"
+
+
+def _resharding_transfer_source(info) -> int | None:
+    for t in info.get("shard_transfers", []):
+        if "resharding" in (t.get("method") or ""):
+            return t["from"]
+    return None
+
+
+def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib.Path):
+    peer_uris, peer_dirs, _ = start_cluster(tmp_path, 3)
+    wait_for(all_peers_are_voters, peer_uris)
+    peer_ids = [get_cluster_info(uri)["peer_id"] for uri in peer_uris]
+    peer_procs = list(processes)  # aligned to peer index; `processes` is mutated below
+
+    create_collection(peer_uris[0], collection=COLLECTION, shard_number=3, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(COLLECTION, peer_uris)
+    upsert_random_points(peer_uris[0], num=20_000, collection_name=COLLECTION)
+
+    resp = start_resharding(peer_uris[0], COLLECTION, direction="down", shard_key=None)
+    assert_http_ok(resp)
+    for uri in peer_uris:
+        wait_for_collection_resharding_operations_count(uri, COLLECTION, 1)
+
+    # Driver is disabled in tests; start the migrate transfer ourselves (dropped
+    # shard 2 -> surviving shard 0, between two distinct peers).
+    info = get_collection_cluster_info(peer_uris[0], COLLECTION)
+    target_shard_id, surviving_shard_id = 2, 0
+    target_peers = [r["peer_id"] for r in all_replicas(info) if r["shard_id"] == target_shard_id]
+    surviving_peers = [r["peer_id"] for r in all_replicas(info) if r["shard_id"] == surviving_shard_id]
+    from_peer_id, to_peer_id = next(
+        (fp, tp) for fp in target_peers for tp in surviving_peers if fp != tp
+    )
+
+    resp = requests.post(f"{peer_uris[0]}/collections/{COLLECTION}/cluster", json={
+        "replicate_shard": {
+            "from_peer_id": from_peer_id, "to_peer_id": to_peer_id,
+            "shard_id": target_shard_id, "to_shard_id": surviving_shard_id,
+            "method": "resharding_stream_records",
+        }
+    })
+    assert_http_ok(resp)
+
+    victim_idx = peer_ids.index(to_peer_id)
+    alive_uri = peer_uris[next(i for i in range(len(peer_uris)) if i != victim_idx)]
+    victim_uri = peer_uris[victim_idx]
+
+    # Wait until the victim itself has the transfer, so a later "gone" means the
+    # abort window, not a peer that simply hasn't applied the transfer start yet.
+    wait_for(
+        lambda: _resharding_transfer_source(get_collection_cluster_info(victim_uri, COLLECTION)) == from_peer_id,
+        wait_for_interval=0.05,
+    )
+
+    # Fire-and-forget: the debug sleep makes the synchronous abort wait time out, but
+    # the op still commits and applies on every peer.
+    def _abort_transfer():
+        try:
+            requests.post(f"{alive_uri}/collections/{COLLECTION}/cluster", json={
+                "abort_transfer": {
+                    "shard_id": target_shard_id, "to_shard_id": surviving_shard_id,
+                    "from_peer_id": from_peer_id, "to_peer_id": to_peer_id,
+                }
+            }, timeout=60)
+        except requests.RequestException:
+            pass
+
+    threading.Thread(target=_abort_transfer, daemon=True).start()
+
+    # Catch the victim paused mid-abort (transfer gone, resharding_state still Some)
+    # and kill it before it clears. Quorum (2/3) is preserved.
+    def _victim_in_window() -> bool:
+        try:
+            vinfo = get_collection_cluster_info(victim_uri, COLLECTION)
+        except requests.RequestException:
+            return False
+        return bool(vinfo.get("resharding_operations")) and _resharding_transfer_source(vinfo) is None
+
+    wait_for(_victim_in_window, wait_for_timeout=30)
+    victim_proc = peer_procs[victim_idx]
+    victim_port = victim_proc.p2p_port
+    processes.remove(victim_proc)
+    victim_proc.kill()
+
+    # Restart (liveness only — the stuck shard may never pass /readyz). The victim
+    # replays the abort, short-circuits to resharding=Some, then converges once it
+    # applies the consensus-replicated Resharding::Abort.
+    peer_uris[victim_idx] = start_peer(
+        peer_dirs[victim_idx], f"peer_restart_{victim_idx}.log", alive_uri, port=victim_port,
+    )
+    wait_for_peer_online(peer_uris[victim_idx], path="/healthz", wait_for_timeout=60)
+
+    for uri in peer_uris:
+        wait_for_collection_resharding_operations_count(uri, COLLECTION, 0, wait_for_timeout=90)

--- a/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
+++ b/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
@@ -1,6 +1,6 @@
 """Aborting a resharding transfer is not crash-idempotent: it aborts+persists the
 transfer before clearing resharding_state. A peer killed in that window (widened by
-a debug sleep in abort_resharding) replays the abort, finds no transfer, and would
+a staging delay in abort_resharding) replays the abort, finds no transfer, and would
 stay resharding=Some unless the abort is replicated through consensus. Asserts every
 peer converges on no resharding_operations.
 """
@@ -23,7 +23,12 @@ def _resharding_transfer_source(info) -> int | None:
 
 
 def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib.Path):
-    peer_uris, peer_dirs, _ = start_cluster(tmp_path, 3)
+    # Staging delay widens the window inside abort_resharding so we can kill a peer
+    # between the transfer abort and the resharding-state clear.
+    env = {"QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC": "12"}
+
+    peer_uris, peer_dirs, _ = start_cluster(tmp_path, 3, extra_env=env)
+    skip_if_no_feature(peer_uris[0], "staging")
     wait_for(all_peers_are_voters, peer_uris)
     peer_ids = [get_cluster_info(uri)["peer_id"] for uri in peer_uris]
     peer_procs = list(processes)  # aligned to peer index; `processes` is mutated below
@@ -102,6 +107,7 @@ def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib
     # applies the consensus-replicated Resharding::Abort.
     peer_uris[victim_idx] = start_peer(
         peer_dirs[victim_idx], f"peer_restart_{victim_idx}.log", alive_uri, port=victim_port,
+        extra_env=env,
     )
     wait_for_peer_online(peer_uris[victim_idx], path="/healthz", wait_for_timeout=60)
 


### PR DESCRIPTION
Aborting a resharding transfer is not crash-idempotent: it aborts+persists the transfer before clearing resharding_state. That window may result in peers being divergent from each other that leads to cluster being stuck.

### All Submissions:

* [X] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [X] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
