### PR TITLE
Fix Clippy 1.96

### DIFF
--- a/lib/wal/src/lib.rs
+++ b/lib/wal/src/lib.rs
@@ -267,10 +267,10 @@ impl Wal {
         let start_index = self.open_segment_start_index();
 
         // If there is an empty closed segment, remove it before adding the new one.
-        if let Some(last_closed) = self.closed_segments.last()
-            && last_closed.segment.is_empty()
+        if let Some(empty_segment) = self
+            .closed_segments
+            .pop_if(|last_closed| last_closed.segment.is_empty())
         {
-            let empty_segment = self.closed_segments.pop().unwrap();
             empty_segment.segment.delete()?;
         }
 


### PR DESCRIPTION
Rust [v1.96](https://releases.rs/docs/1.96.0/) is landing tomorrow.

This time around only a single Clippy error to fix.

```
error: manual implementation of `Vec::pop_if`
   --> lib/wal/src/lib.rs:270:9
    |
270 | /         if let Some(last_closed) = self.closed_segments.last()
271 | |             && last_closed.segment.is_empty()
    | |_____________________________________________^
272 |           {
273 |               let empty_segment = self.closed_segments.pop().unwrap();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try refactoring the code using `self.closed_segments.pop_if(|last_closed| last_closed.segment.is_empty());`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#manual_pop_if
    = note: `-D clippy::manual-pop-if` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_pop_if)]`

error: could not compile `wal` (lib) due to 1 previous error
```