### PR TITLE
fix: treat empty API key strings as unset

### DIFF
--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -264,3 +264,86 @@ impl AuthKeys {
         can_write || alt_can_write
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use collection::shards::channel_service::ChannelService;
+    use common::budget::ResourceBudget;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::settings::Settings;
+
+    /// Service config from the bundled defaults, with the given API keys set.
+    fn config(api_key: Option<&str>, alt: Option<&str>, read_only: Option<&str>) -> ServiceConfig {
+        let mut cfg = Settings::new(None).unwrap().service;
+        cfg.api_key = api_key.map(String::from);
+        cfg.alt_api_key = alt.map(String::from);
+        cfg.read_only_api_key = read_only.map(String::from);
+        cfg
+    }
+
+    /// An empty, temp-dir backed `TableOfContent`. `try_create` only stores it,
+    /// so this is enough to exercise key parsing. `TempDir` must outlive `toc`.
+    fn test_toc() -> (Arc<TableOfContent>, TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = Settings::new(None).unwrap().storage;
+        cfg.storage_path = dir.path().to_path_buf();
+        cfg.snapshots_path = dir.path().join("snapshots");
+        cfg.temp_path = None;
+        let toc = TableOfContent::new(
+            &cfg,
+            ResourceBudget::default(),
+            ChannelService::new(6333, false, None, None),
+            0,
+            None,
+        )
+        .unwrap();
+        (Arc::new(toc), dir)
+    }
+
+    #[test]
+    fn empty_api_keys_are_treated_as_unset() {
+        let (toc, _dir) = test_toc();
+        for cfg in [
+            config(Some(""), None, None),
+            config(None, None, Some("")),
+            config(Some(""), Some(""), Some("")),
+        ] {
+            assert!(AuthKeys::try_create(&cfg, toc.clone()).is_none());
+        }
+    }
+
+    #[test]
+    fn single_char_api_keys_are_used() {
+        let (toc, _dir) = test_toc();
+
+        let rw = AuthKeys::try_create(&config(Some("x"), None, None), toc.clone()).unwrap();
+        assert!(rw.can_write("x"));
+        assert!(!rw.can_write(""));
+        assert!(!rw.can_write("y"));
+
+        let ro = AuthKeys::try_create(&config(None, None, Some("r")), toc).unwrap();
+        assert!(ro.can_read("r"));
+        assert!(!ro.can_read(""));
+        assert!(!ro.can_write("r"));
+    }
+
+    #[test]
+    fn empty_jwt_secret_is_treated_as_unset() {
+        let mut cfg = config(Some(""), Some(""), None);
+        cfg.jwt_rbac = Some(true);
+        let (parser, alt_parser) = AuthKeys::get_jwt_parser(&cfg);
+        assert!(parser.is_none());
+        assert!(alt_parser.is_none());
+    }
+
+    #[test]
+    fn single_char_jwt_secret_is_used() {
+        let mut cfg = config(Some("x"), None, None);
+        cfg.jwt_rbac = Some(true);
+        let (parser, alt_parser) = AuthKeys::get_jwt_parser(&cfg);
+        assert!(parser.is_some());
+        assert!(alt_parser.is_none());
+    }
+}

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -95,10 +95,12 @@ impl AuthKeys {
                 service_config
                     .api_key
                     .as_ref()
+                    .filter(|s| !s.is_empty())
                     .map(|secret| JwtParser::new(secret)),
                 service_config
                     .alt_api_key
                     .as_ref()
+                    .filter(|s| !s.is_empty())
                     .map(|secret| JwtParser::new(secret)),
             )
         } else {

--- a/src/common/auth/mod.rs
+++ b/src/common/auth/mod.rs
@@ -110,10 +110,11 @@ impl AuthKeys {
     ///
     /// Returns None if no scheme is specified.
     pub fn try_create(service_config: &ServiceConfig, toc: Arc<TableOfContent>) -> Option<Self> {
+        let non_empty = |k: Option<String>| k.filter(|k| !k.is_empty());
         match (
-            service_config.api_key.clone(),
-            service_config.alt_api_key.clone(),
-            service_config.read_only_api_key.clone(),
+            non_empty(service_config.api_key.clone()),
+            non_empty(service_config.alt_api_key.clone()),
+            non_empty(service_config.read_only_api_key.clone()),
         ) {
             (None, None, None) => None,
             (read_write, alt_read_write, read_only) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,11 +289,20 @@ fn init_channel_service(
     persistent_consensus_state: &Persistent,
     is_distributed_deployment: bool,
 ) -> anyhow::Result<ChannelService> {
+    // Empty API keys are treated as unset (as in `AuthKeys::try_create`), so they
+    // are not attached to outgoing internal requests as empty `api-key` headers.
+    let api_key = settings.service.api_key.clone().filter(|k| !k.is_empty());
+    let alt_api_key = settings
+        .service
+        .alt_api_key
+        .clone()
+        .filter(|k| !k.is_empty());
+
     let mut channel_service = ChannelService::new(
         settings.service.http_port,
         settings.service.enable_tls,
-        settings.service.api_key.clone(),
-        settings.service.alt_api_key.clone(),
+        api_key.clone(),
+        alt_api_key,
     );
 
     if is_distributed_deployment {
@@ -309,7 +318,7 @@ fn init_channel_service(
             connection_timeout,
             settings.cluster.p2p.connection_pool_size,
             tls_config,
-            settings.service.api_key.clone(),
+            api_key,
         ));
         channel_service.id_to_address = persistent_consensus_state.peer_address_by_id.clone();
         channel_service.id_to_metadata = persistent_consensus_state.peer_metadata_by_id.clone();
@@ -813,4 +822,27 @@ fn main() -> anyhow::Result<()> {
     drop(toc_arc);
     drop(settings);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_api_keys_are_not_forwarded_on_internal_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let persistent = Persistent::load_or_init(dir.path(), true, false, None).unwrap();
+        let mut settings = Settings::new(None).unwrap();
+
+        settings.service.api_key = Some(String::new());
+        settings.service.alt_api_key = Some(String::new());
+        let channel_service = init_channel_service(&settings, &persistent, false).unwrap();
+        assert_eq!(channel_service.api_key, None);
+        assert_eq!(channel_service.alt_api_key, None);
+
+        settings.service.api_key = Some("x".to_string());
+        let channel_service = init_channel_service(&settings, &persistent, false).unwrap();
+        assert_eq!(channel_service.api_key.as_deref(), Some("x"));
+        assert_eq!(channel_service.alt_api_key, None);
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -346,6 +346,26 @@ impl Settings {
 
     pub fn validate_and_warn(&self) {
         //
+        // API keys
+        //
+        // An empty key is treated as unset (see `AuthKeys::try_create`), so a key
+        // that unexpectedly resolves to an empty string (e.g. an unset environment
+        // variable or a secret that resolved to nothing) silently disables that
+        // credential rather than enforcing it. Warn so the misconfiguration is visible.
+        for (name, key) in [
+            ("api_key", &self.service.api_key),
+            ("alt_api_key", &self.service.alt_api_key),
+            ("read_only_api_key", &self.service.read_only_api_key),
+        ] {
+            if key.as_deref().is_some_and(str::is_empty) {
+                log::warn!(
+                    "Service {name} is set but empty, it is treated as unset and \
+                     authentication may be disabled",
+                );
+            }
+        }
+
+        //
         // JWT RBAC
         //
         // Using HMAC-SHA256, recommended secret size is 32 bytes


### PR DESCRIPTION
### Description

When `QDRANT__SERVICE__READ_ONLY_API_KEY` (or any API key) is set to an
empty string (common with `${VAR:-}` in Docker Compose), the empty value
passes constant-time comparison against empty request headers, silently
granting access without credentials.

Filter empty strings to `None` in `AuthKeys::try_create` so they're
treated the same as unset keys.

Closes #8856

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
