### PR TITLE
[#9159 alternative] Oversample with approx facet

### DIFF
--- a/lib/collection/src/collection/facet.rs
+++ b/lib/collection/src/collection/facet.rs
@@ -33,6 +33,9 @@ impl Collection {
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<FacetResponse> {
         let response_limit = request.limit;
+        if response_limit == 0 {
+            return Ok(FacetResponse::default());
+        }
         if !request.exact {
             // Approximate facet sends only the established limit between shards.
             //

--- a/lib/collection/src/collection/facet.rs
+++ b/lib/collection/src/collection/facet.rs
@@ -12,10 +12,52 @@ use crate::operations::consistency_params::ReadConsistency;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::CollectionResult;
 
+/// Multiplier applied to the user-facing `limit` to derive the per-shard
+/// over-fetch cap when running approximate facet queries. With unique-per-point
+/// values (e.g. UUIDs), every distinct value has count = 1, so the practical
+/// accuracy of approximate top-k is bounded by what each shard returns; the
+/// factor is a trade-off between per-shard payload/work and result accuracy.
+const FACET_OVERSAMPLE_FACTOR: usize = 4;
+
+/// Lower bound for the per-shard over-fetch cap, so small `limit` values still
+/// have enough headroom to absorb cross-shard rank differences.
+const FACET_MIN_OVERSAMPLE: usize = 128;
+
 impl Collection {
     pub async fn facet(
         &self,
+        mut request: FacetParams,
+        shard_selection: ShardSelectorInternal,
+        read_consistency: Option<ReadConsistency>,
+        timeout: Option<Duration>,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<FacetResponse> {
+        let response_limit = request.limit;
+        if !request.exact {
+            // Approximate facet sends only the established limit between shards.
+            //
+            // Oversample to preserve accuracy.
+            request.limit = request
+                .limit
+                .saturating_mul(FACET_OVERSAMPLE_FACTOR)
+                .max(FACET_MIN_OVERSAMPLE);
+        };
+
+        self.facet_internal(
+            request,
+            response_limit,
+            shard_selection,
+            read_consistency,
+            timeout,
+            hw_measurement_acc,
+        )
+        .await
+    }
+
+    pub async fn facet_internal(
+        &self,
         request: FacetParams,
+        response_limit: usize,
         shard_selection: ShardSelectorInternal,
         read_consistency: Option<ReadConsistency>,
         timeout: Option<Duration>,
@@ -25,7 +67,6 @@ impl Collection {
             return Ok(FacetResponse::default());
         }
 
-        let limit = request.limit;
         let request = Arc::new(request);
 
         let shard_holder = self.shards_holder.read().await;
@@ -52,6 +93,6 @@ impl Collection {
             }
         }
 
-        Ok(FacetResponse::top_hits(aggregated_results, limit))
+        Ok(FacetResponse::top_hits(aggregated_results, response_limit))
     }
 }

--- a/lib/collection/src/collection/facet.rs
+++ b/lib/collection/src/collection/facet.rs
@@ -24,6 +24,61 @@ const FACET_OVERSAMPLE_FACTOR: usize = 4;
 const FACET_MIN_OVERSAMPLE: usize = 128;
 
 impl Collection {
+    /// Entry point for a facet request. Applies oversampling (for approximate
+    /// queries) before fanning out to shards. This runs *once*, on the node
+    /// that received the client request; peer nodes enter through
+    /// [`Collection::facet_internal`] instead and never re-oversample.
+    ///
+    /// How `limit` flows through a distributed cluster for an approximate query.
+    /// `L` is the user limit (here `L = 10`); `N` is the oversampled per-shard
+    /// limit `N = max(L * 4, 128) = 128`:
+    ///
+    /// ```text
+    ///                            Client  (limit = L = 10)
+    ///                               │
+    ///                               ▼
+    ///   ┌── Node A: Collection::facet ───────────────────────────────────┐
+    ///   │     request.limit:   L  ──oversample──▶  N = 128               │
+    ///   │     response_limit:  L = 10  (kept for the final truncation)   │
+    ///   │                              │                                 │
+    ///   │                              ▼                                 │
+    ///   │     Collection::facet_internal(limit = N, response_limit = L)  │
+    ///   │              ┌───────────────┴────────────────┐                │
+    ///   │              ▼ local shard                    ▼ remote shard   │
+    ///   │     approx_facet(limit = N)          gRPC FacetCountsInternal  │
+    ///   │     returns ≤ N hits                       { limit = N }       │
+    ///   │              │                                 │               │
+    ///   └──────────────┼─────────────────────────────────┼───────────────┘
+    ///                  │                                 ▼
+    ///                  │     ┌── Node B: facet_counts_internal ──────────┐
+    ///                  │     │     toc.facet_internal: peer_limit = N    │
+    ///                  │     │     (NOT re-oversampled)                  │
+    ///                  │     │              │                            │
+    ///                  │     │              ▼                            │
+    ///                  │     │     Collection::facet_internal(           │
+    ///                  │     │         limit = N, response_limit = N)    │
+    ///                  │     │     approx_facet(limit = N)               │
+    ///                  │     │     top_hits(.., N)  ──▶  ≤ N hits        │
+    ///                  │     └──────────────┬────────────────────────────┘
+    ///                  │                    │
+    ///                  └─────────┬──────────┘
+    ///                            ▼
+    ///   Node A:  aggregate all shard hits (sum counts per value)
+    ///            top_hits(aggregated, response_limit = L)  ──▶  L = 10 hits
+    ///                            │
+    ///                            ▼
+    ///                          Client  (L = 10 results)
+    /// ```
+    ///
+    /// Key points:
+    /// - Oversampling (`L` → `N`) happens only here, on the entry node. Each
+    ///   shard — local or remote — returns up to `N` values, giving the final
+    ///   aggregation enough headroom to absorb cross-shard rank differences.
+    /// - Remote peers are reached via the internal gRPC path, which calls
+    ///   `facet_internal` directly with `peer_limit = N`, so the limit is *not*
+    ///   multiplied a second time.
+    /// - Only the final aggregation on the entry node truncates back to the
+    ///   user-facing `response_limit = L`.
     pub async fn facet(
         &self,
         mut request: FacetParams,

--- a/lib/collection/src/shards/local_shard/facet.rs
+++ b/lib/collection/src/shards/local_shard/facet.rs
@@ -76,17 +76,16 @@ impl LocalShard {
             })
         })?;
 
-        // We can't just select top values, because we need to aggregate across segments,
-        // which we can't assume to select the same best top.
-        //
-        // We need all values to be able to aggregate correctly across segments
+        // Per-segment top-k selection is unsafe (same value can rank
+        // differently across segments), so we must merge the full per-segment
+        // maps. Once merged, we can safely keep only `limit` hits — the
+        // coordinator oversamples enough to keep cross-shard aggregation
+        // accurate.
         let top_hits = merged_hits
             .map(|map| {
-                map.iter()
-                    .map(|(value, count)| FacetValueHit {
-                        value: value.to_owned(),
-                        count: *count,
-                    })
+                map.into_iter()
+                    .map(|(value, count)| FacetValueHit { value, count })
+                    .k_largest(request.limit)
                     .collect_vec()
             })
             .unwrap_or_default();

--- a/lib/storage/src/content_manager/toc/point_ops_internal.rs
+++ b/lib/storage/src/content_manager/toc/point_ops_internal.rs
@@ -41,8 +41,17 @@ impl TableOfContent {
     ) -> StorageResult<FacetResponse> {
         let collection = self.get_collection_unchecked(collection_name).await?;
 
+        let peer_limit = request.limit;
+
         let res = collection
-            .facet(request, shard_selection, None, timeout, hw_measurement_acc)
+            .facet_internal(
+                request,
+                peer_limit,
+                shard_selection,
+                None,
+                timeout,
+                hw_measurement_acc,
+            )
             .await?;
 
         Ok(res)


### PR DESCRIPTION
As an alternative solution to #9159, which I like the oversampling approach. 

This PR keeps it simpler by not needing to propagate `output_limit` everywhere. Instead, it just uses our `*_internal` method approach to set the inner limit differently whether it is the coordinator node or another peer.