### PR TITLE
[UIO] Load `GraphLinks` with any backend

### DIFF
--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -9,6 +9,9 @@ pub enum UniversalIoError {
     #[error(transparent)]
     Mmap(#[from] crate::mmap::Error),
 
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+
     #[error("Bytemuck cast error: {0:?}")]
     BytemuckCast(bytemuck::PodCastError),
 

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -24,6 +24,6 @@ pub use self::traits::{
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, OpenOptions, Populate, ReadRange, Result, UniversalKind,
-    read_json_via,
+    read_bin_via, read_json_via, read_whole_via,
 };
 pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -7,7 +7,7 @@
 ///
 /// `Default` is required so callers can construct a neutral extras value
 /// (e.g. `<Fs::OpenExtra>::default()`) and then chain typed setters.
-pub trait OpenExtra: Default + Clone {
+pub trait OpenExtra: Default {
     /// Hint that the open should bypass the OS page cache. Backends that
     /// support it (e.g. `io_uring` via `O_DIRECT`) honor the flag; backends
     /// where it's meaningless (mmap, block-cache) treat this as a no-op.

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -7,7 +7,7 @@
 ///
 /// `Default` is required so callers can construct a neutral extras value
 /// (e.g. `<Fs::OpenExtra>::default()`) and then chain typed setters.
-pub trait OpenExtra: Default {
+pub trait OpenExtra: Default + Clone {
     /// Hint that the open should bypass the OS page cache. Backends that
     /// support it (e.g. `io_uring` via `O_DIRECT`) honor the flag; backends
     /// where it's meaningless (mmap, block-cache) treat this as a no-op.

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use serde::de::DeserializeOwned;
@@ -147,6 +148,26 @@ pub type Flusher = Box<dyn FnOnce() -> Result<()> + Send>;
 
 pub type Result<T, E = UniversalIoError> = std::result::Result<T, E>;
 
+pub fn read_whole_via<Fs, T>(
+    fs: &Fs,
+    path: impl AsRef<Path>,
+    callback: impl FnOnce(Cow<'_, [u8]>) -> Result<T, UniversalIoError>,
+) -> Result<T, UniversalIoError>
+where
+    Fs: UniversalReadFs,
+{
+    use super::UniversalRead;
+    let options = OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        populate: Populate::No,
+        advice: AdviceSetting::Advice(Advice::Sequential),
+    };
+    let storage = fs.open(path, options, Default::default())?;
+    let bytes = storage.read_whole::<u8>()?;
+    callback(bytes)
+}
+
 /// Open a file via universal io, read it as a whole, and deserialize as JSON.
 ///
 /// Uses a single logical read when the backend overrides
@@ -156,15 +177,21 @@ where
     Fs: UniversalReadFs,
     T: DeserializeOwned,
 {
-    use super::UniversalRead;
-    let options = OpenOptions {
-        writeable: false,
-        need_sequential: false,
-        populate: Populate::No,
-        advice: AdviceSetting::Advice(Advice::Sequential),
-    };
+    read_whole_via(fs, path, |bytes| {
+        serde_json::from_slice(&bytes).map_err(UniversalIoError::from)
+    })
+}
 
-    let storage = fs.open(path, options, Default::default())?;
-    let bytes = storage.read_whole::<u8>()?;
-    serde_json::from_slice(&bytes).map_err(UniversalIoError::from)
+/// Open a file via universal io, read it as a whole, and deserialize as bincode.
+///
+/// Uses a single logical read when the backend overrides
+/// [`UniversalRead::read_whole`](super::UniversalRead::read_whole).
+pub fn read_bin_via<Fs, T>(fs: &Fs, path: impl AsRef<Path>) -> Result<T>
+where
+    Fs: UniversalReadFs,
+    T: DeserializeOwned,
+{
+    read_whole_via(fs, path, |bytes| {
+        bincode::deserialize(&bytes).map_err(UniversalIoError::from)
+    })
 }

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -165,7 +165,12 @@ where
     };
     let storage = fs.open(path, options, Default::default())?;
     let bytes = storage.read_whole::<u8>()?;
-    callback(bytes)
+
+    let callback_t = callback(bytes)?;
+
+    storage.clear_ram_cache()?;
+
+    Ok(callback_t)
 }
 
 /// Open a file via universal io, read it as a whole, and deserialize as JSON.

--- a/lib/segment/benches/fixture.rs
+++ b/lib/segment/benches/fixture.rs
@@ -8,7 +8,7 @@ use rand::rngs::StdRng;
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use segment::fixtures::index_fixtures::TestRawScorerProducer;
 use segment::index::hnsw_index::HnswM;
-use segment::index::hnsw_index::graph_layers::GraphLayers;
+use segment::index::hnsw_index::graph_layers::{GraphLayers, LoadOption};
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use segment::index::hnsw_index::graph_links::GraphLinksFormatParam;
 use segment::index::hnsw_index::hnsw::SINGLE_THREADED_HNSW_BUILD_THRESHOLD;
@@ -54,7 +54,7 @@ where
         let updated_ago = updated_ago(&graph_layers_path).unwrap_or_else(|_| "???".to_string());
         eprintln!("Loading cached links (built {updated_ago} ago) from {graph_layers_path:?}.");
         eprintln!("Delete the directory above if code related to HNSW graph building is changed");
-        GraphLayers::load(&path, false, false).unwrap()
+        GraphLayers::load(&path, LoadOption::ram_from_mmap(), false).unwrap()
     } else {
         let mut graph_layers_builder =
             GraphLayersBuilder::new(num_vectors, HnswM::new2(m), ef_construct, 10, use_heuristic);

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -156,7 +156,8 @@ impl From<UniversalIoError> for OperationError {
             UniversalIoError::Io(err) => Self::from(err),
             UniversalIoError::Mmap(err) => Self::from(err),
 
-            UniversalIoError::BytemuckCast(_)
+            UniversalIoError::Bincode(_)
+            | UniversalIoError::BytemuckCast(_)
             | UniversalIoError::ZerocopySize(_)
             | UniversalIoError::IoUringNotSupported(_)
             | UniversalIoError::NotFound { .. }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -675,8 +675,17 @@ impl GraphLayers {
             GraphLinksFormat::Plain,
         ] {
             let path = GraphLayers::get_links_path(dir, format);
-            if path.exists() {
-                return GraphLinks::load_from_file(&path, load_option, format);
+            match &load_option {
+                LoadOption::OnDiskMmap => {
+                    if path.exists() {
+                        return GraphLinks::load_from_mmap(&path, format);
+                    }
+                }
+                LoadOption::RamFromUniversal { fs, open_extra } => {
+                    if fs.exists(&path)? {
+                        return GraphLinks::load_from_universal_file(fs, open_extra.clone(), &path, format);
+                    }
+                }
             }
         }
         Err(OperationError::service_error("No links file found"))
@@ -699,9 +708,10 @@ impl GraphLayers {
 
         let start = std::time::Instant::now();
 
-        let links = GraphLinks::load_from_file(
+        let links = GraphLinks::load_from_universal_file(
+            &MmapFs,
+            (),
             &plain_path,
-            LoadOption::ram_from_mmap(),
             GraphLinksFormat::Plain,
         )?;
         let original_size = fs::metadata(&plain_path)?.len();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -655,7 +655,8 @@ impl GraphLayers {
         };
 
         if compress {
-            // TODO: use `Fs` within this function?
+            // TODO: use `Fs` within this function? It writes data, and we don't have `UniversalWriteFs` yet.
+            //       It is not enabled as per `LINK_COMPRESSION_CONVERT_EXISTING` anyway.
             Self::convert_to_compressed(dir, HnswM::new(graph_data.m, graph_data.m0))?;
         }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -33,6 +33,7 @@ use std::sync::atomic::AtomicBool;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::fs::{atomic_save, read_bin};
 use common::types::{PointOffsetType, ScoredPointOffset};
+use common::universal_io::{MmapFs, UniversalReadFs};
 use fs_err as fs;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -621,8 +622,35 @@ impl GraphLayers {
     }
 }
 
+pub enum LoadOption<Fs: UniversalReadFs> {
+    /// Open as a mmap without populating it.
+    OnDiskMmap,
+    /// Load whole file into RAM using a generic backend.
+    RamFromUniversal { fs: Fs, open_extra: Fs::OpenExtra },
+}
+
+impl LoadOption<MmapFs> {
+    pub fn on_disk_mmap() -> Self {
+        Self::OnDiskMmap
+    }
+
+    pub fn ram_from_mmap() -> Self {
+        Self::RamFromUniversal {
+            fs: MmapFs,
+            open_extra: (),
+        }
+    }
+}
+
 impl GraphLayers {
-    pub fn load(dir: &Path, on_disk: bool, compress: bool) -> OperationResult<Self> {
+    pub fn load<Fs>(
+        dir: &Path,
+        load_option: LoadOption<Fs>,
+        compress: bool,
+    ) -> OperationResult<Self>
+    where
+        Fs: UniversalReadFs,
+    {
         let graph_data: GraphLayerData = read_bin(&GraphLayers::get_path(dir))?;
 
         if compress {
@@ -631,13 +659,16 @@ impl GraphLayers {
 
         Ok(Self {
             hnsw_m: HnswM::new(graph_data.m, graph_data.m0),
-            links: Self::load_links(dir, on_disk)?,
+            links: Self::load_links(dir, load_option)?,
             entry_points: graph_data.entry_points.into_owned(),
             visited_pool: VisitedPool::new(),
         })
     }
 
-    fn load_links(dir: &Path, on_disk: bool) -> OperationResult<GraphLinks> {
+    fn load_links<Fs>(dir: &Path, load_option: LoadOption<Fs>) -> OperationResult<GraphLinks>
+    where
+        Fs: UniversalReadFs,
+    {
         for format in [
             GraphLinksFormat::CompressedWithVectors,
             GraphLinksFormat::Compressed,
@@ -645,7 +676,7 @@ impl GraphLayers {
         ] {
             let path = GraphLayers::get_links_path(dir, format);
             if path.exists() {
-                return GraphLinks::load_from_file(&path, on_disk, format);
+                return GraphLinks::load_from_file(&path, load_option, format);
             }
         }
         Err(OperationError::service_error("No links file found"))
@@ -668,7 +699,11 @@ impl GraphLayers {
 
         let start = std::time::Instant::now();
 
-        let links = GraphLinks::load_from_file(&plain_path, true, GraphLinksFormat::Plain)?;
+        let links = GraphLinks::load_from_file(
+            &plain_path,
+            LoadOption::ram_from_mmap(),
+            GraphLinksFormat::Plain,
+        )?;
         let original_size = fs::metadata(&plain_path)?.len();
         atomic_save(&compressed_path, |writer| {
             let edges = links.to_edges();
@@ -862,7 +897,7 @@ mod tests {
         let res1 = search_in_graph(&query, top, &vector_holder, &graph1);
         drop(graph1);
 
-        let graph2 = GraphLayers::load(dir.path(), false, compress).unwrap();
+        let graph2 = GraphLayers::load(dir.path(), LoadOption::ram_from_mmap(), compress).unwrap();
         if compress {
             assert_eq!(graph2.links.format(), GraphLinksFormat::Compressed);
         } else {

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -33,7 +33,7 @@ use std::sync::atomic::AtomicBool;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::fs::{atomic_save, read_bin};
 use common::types::{PointOffsetType, ScoredPointOffset};
-use common::universal_io::{MmapFs, UniversalReadFs};
+use common::universal_io::{MmapFs, UniversalReadFs, read_bin_via};
 use fs_err as fs;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -626,7 +626,7 @@ pub enum LoadOption<Fs: UniversalReadFs> {
     /// Open as a mmap without populating it.
     OnDiskMmap,
     /// Load whole file into RAM using a generic backend.
-    RamFromUniversal { fs: Fs, open_extra: Fs::OpenExtra },
+    RamFromUniversal { fs: Fs },
 }
 
 impl LoadOption<MmapFs> {
@@ -635,10 +635,7 @@ impl LoadOption<MmapFs> {
     }
 
     pub fn ram_from_mmap() -> Self {
-        Self::RamFromUniversal {
-            fs: MmapFs,
-            open_extra: (),
-        }
+        Self::RamFromUniversal { fs: MmapFs }
     }
 }
 
@@ -651,9 +648,14 @@ impl GraphLayers {
     where
         Fs: UniversalReadFs,
     {
-        let graph_data: GraphLayerData = read_bin(&GraphLayers::get_path(dir))?;
+        let graph_data_path = GraphLayers::get_path(dir);
+        let graph_data: GraphLayerData = match &load_option {
+            LoadOption::OnDiskMmap => read_bin(&graph_data_path)?,
+            LoadOption::RamFromUniversal { fs } => read_bin_via(fs, &graph_data_path)?,
+        };
 
         if compress {
+            // TODO: use `Fs` within this function?
             Self::convert_to_compressed(dir, HnswM::new(graph_data.m, graph_data.m0))?;
         }
 
@@ -681,9 +683,9 @@ impl GraphLayers {
                         return GraphLinks::load_from_mmap(&path, format);
                     }
                 }
-                LoadOption::RamFromUniversal { fs, open_extra } => {
+                LoadOption::RamFromUniversal { fs } => {
                     if fs.exists(&path)? {
-                        return GraphLinks::load_from_universal_file(fs, open_extra.clone(), &path, format);
+                        return GraphLinks::load_from_universal_file(fs, &path, format);
                     }
                 }
             }
@@ -708,12 +710,8 @@ impl GraphLayers {
 
         let start = std::time::Instant::now();
 
-        let links = GraphLinks::load_from_universal_file(
-            &MmapFs,
-            (),
-            &plain_path,
-            GraphLinksFormat::Plain,
-        )?;
+        let links =
+            GraphLinks::load_from_universal_file(&MmapFs, &plain_path, GraphLinksFormat::Plain)?;
         let original_size = fs::metadata(&plain_path)?.len();
         atomic_save(&compressed_path, |writer| {
             let edges = links.to_edges();

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -22,7 +22,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
 #[cfg(test)]
 use crate::index::hnsw_index::graph_layers::SearchAlgorithm;
-use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase};
+use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LoadOption};
 use crate::index::hnsw_index::graph_links::serialize_graph_links;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -225,7 +225,11 @@ impl GraphLayersBuilder {
             atomic_save(&links_path, |writer| {
                 serialize_graph_links(edges, format_param, self.hnsw_m, writer)
             })?;
-            links = GraphLinks::load_from_file(&links_path, true, format_param.as_format())?;
+            links = GraphLinks::load_from_file(
+                &links_path,
+                LoadOption::on_disk_mmap(),
+                format_param.as_format(),
+            )?;
         } else {
             // Since we'll keep it in the RAM anyway, we can afford to build in the RAM too.
             links = GraphLinks::new_from_edges(edges, format_param, self.hnsw_m)?;

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -22,7 +22,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::hnsw_index::entry_points::EntryPoints;
 #[cfg(test)]
 use crate::index::hnsw_index::graph_layers::SearchAlgorithm;
-use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase, LoadOption};
+use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase};
 use crate::index::hnsw_index::graph_links::serialize_graph_links;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -225,11 +225,7 @@ impl GraphLayersBuilder {
             atomic_save(&links_path, |writer| {
                 serialize_graph_links(edges, format_param, self.hnsw_m, writer)
             })?;
-            links = GraphLinks::load_from_file(
-                &links_path,
-                LoadOption::on_disk_mmap(),
-                format_param.as_format(),
-            )?;
+            links = GraphLinks::load_from_mmap(&links_path, format_param.as_format())?;
         } else {
             // Since we'll keep it in the RAM anyway, we can afford to build in the RAM too.
             links = GraphLinks::new_from_edges(edges, format_param, self.hnsw_m)?;

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use common::generic_consts::Sequential;
 use common::mmap::{Advice, AdviceSetting, Madviseable, open_read_mmap};
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{UniversalReadFs, read_whole_via};
 use memmap2::Mmap;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -218,28 +218,13 @@ impl GraphLinksEnum {
 impl GraphLinks {
     pub fn load_from_universal_file<F>(
         fs: &F,
-        open_extra: F::OpenExtra,
         path: &Path,
         format: GraphLinksFormat,
     ) -> OperationResult<Self>
     where
         F: UniversalReadFs,
     {
-        let file = fs.open(
-            path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate: Populate::No, // We are about to read everything blockingly anyway
-                advice: AdviceSetting::Advice(Advice::Sequential),
-            },
-            open_extra,
-        )?;
-
-        let bytes = file.read_whole::<u8>()?.into_owned();
-
-        // Now that we've loaded into an owned Vec we can clear RAM from file.
-        file.clear_ram_cache()?;
+        let bytes = read_whole_via(fs, path, |bytes| Ok(bytes.into_owned()))?;
 
         Self::try_new(GraphLinksEnum::Ram(bytes), |x| {
             GraphLinksView::load(x.as_bytes(), format)

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -231,7 +231,7 @@ impl GraphLinks {
             OpenOptions {
                 writeable: false,
                 need_sequential: false,
-                populate: Populate::PreferBackground,
+                populate: Populate::No, // We are about to read everything blockingly anyway
                 advice: AdviceSetting::Advice(Advice::Sequential),
             },
             open_extra,

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -12,7 +12,6 @@ use memmap2::Mmap;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::hnsw_index::HnswM;
-use crate::index::hnsw_index::graph_layers::LoadOption;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
@@ -247,26 +246,12 @@ impl GraphLinks {
         })
     }
 
-    pub fn load_from_file<Fs>(
-        path: &Path,
-        load_option: LoadOption<Fs>,
-        format: GraphLinksFormat,
-    ) -> OperationResult<Self>
-    where
-        Fs: UniversalReadFs,
-    {
-        match load_option {
-            LoadOption::OnDiskMmap => {
-                let populate = false;
-                let mmap = open_read_mmap(path, AdviceSetting::Advice(Advice::Random), populate)?;
-                Self::try_new(GraphLinksEnum::Mmap(Arc::new(mmap)), |x| {
-                    GraphLinksView::load(x.as_bytes(), format)
-                })
-            }
-            LoadOption::RamFromUniversal { fs, open_extra } => {
-                Self::load_from_universal_file(&fs, open_extra, path, format)
-            }
-        }
+    pub fn load_from_mmap(path: &Path, format: GraphLinksFormat) -> OperationResult<Self> {
+        let populate = false;
+        let mmap = open_read_mmap(path, AdviceSetting::Advice(Advice::Random), populate)?;
+        Self::try_new(GraphLinksEnum::Mmap(Arc::new(mmap)), |x| {
+            GraphLinksView::load(x.as_bytes(), format)
+        })
     }
 
     pub fn new_from_edges(
@@ -541,8 +526,7 @@ mod tests {
         })
         .unwrap();
 
-        let cmp_links =
-            GraphLinks::load_from_file(&links_file, LoadOption::on_disk_mmap(), format).unwrap();
+        let cmp_links = GraphLinks::load_from_mmap(&links_file, format).unwrap();
         check_links(links, &cmp_links, &vectors);
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links.rs
@@ -7,10 +7,12 @@ use std::sync::Arc;
 use common::generic_consts::Sequential;
 use common::mmap::{Advice, AdviceSetting, Madviseable, open_read_mmap};
 use common::types::PointOffsetType;
+use common::universal_io::{OpenOptions, Populate, UniversalRead, UniversalReadFs};
 use memmap2::Mmap;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::hnsw_index::HnswM;
+use crate::index::hnsw_index::graph_layers::LoadOption;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
@@ -215,16 +217,56 @@ impl GraphLinksEnum {
 }
 
 impl GraphLinks {
-    pub fn load_from_file(
+    pub fn load_from_universal_file<F>(
+        fs: &F,
+        open_extra: F::OpenExtra,
         path: &Path,
-        on_disk: bool,
         format: GraphLinksFormat,
-    ) -> OperationResult<Self> {
-        let populate = !on_disk;
-        let mmap = open_read_mmap(path, AdviceSetting::Advice(Advice::Random), populate)?;
-        Self::try_new(GraphLinksEnum::Mmap(Arc::new(mmap)), |x| {
+    ) -> OperationResult<Self>
+    where
+        F: UniversalReadFs,
+    {
+        let file = fs.open(
+            path,
+            OpenOptions {
+                writeable: false,
+                need_sequential: false,
+                populate: Populate::PreferBackground,
+                advice: AdviceSetting::Advice(Advice::Sequential),
+            },
+            open_extra,
+        )?;
+
+        let bytes = file.read_whole::<u8>()?.into_owned();
+
+        // Now that we've loaded into an owned Vec we can clear RAM from file.
+        file.clear_ram_cache()?;
+
+        Self::try_new(GraphLinksEnum::Ram(bytes), |x| {
             GraphLinksView::load(x.as_bytes(), format)
         })
+    }
+
+    pub fn load_from_file<Fs>(
+        path: &Path,
+        load_option: LoadOption<Fs>,
+        format: GraphLinksFormat,
+    ) -> OperationResult<Self>
+    where
+        Fs: UniversalReadFs,
+    {
+        match load_option {
+            LoadOption::OnDiskMmap => {
+                let populate = false;
+                let mmap = open_read_mmap(path, AdviceSetting::Advice(Advice::Random), populate)?;
+                Self::try_new(GraphLinksEnum::Mmap(Arc::new(mmap)), |x| {
+                    GraphLinksView::load(x.as_bytes(), format)
+                })
+            }
+            LoadOption::RamFromUniversal { fs, open_extra } => {
+                Self::load_from_universal_file(&fs, open_extra, path, format)
+            }
+        }
     }
 
     pub fn new_from_edges(
@@ -499,7 +541,8 @@ mod tests {
         })
         .unwrap();
 
-        let cmp_links = GraphLinks::load_from_file(&links_file, true, format).unwrap();
+        let cmp_links =
+            GraphLinks::load_from_file(&links_file, LoadOption::on_disk_mmap(), format).unwrap();
         check_links(links, &cmp_links, &vectors);
     }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -8,7 +8,7 @@ use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_layers::{GraphLayers, LoadOption};
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::types::HnswConfig;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -98,7 +98,13 @@ impl HNSWIndex {
 
         let is_on_disk = hnsw_config.on_disk.unwrap_or(false);
 
-        let graph = GraphLayers::load(path, is_on_disk, do_convert)?;
+        let load_option = if is_on_disk {
+            LoadOption::on_disk_mmap()
+        } else {
+            LoadOption::ram_from_mmap()
+        };
+
+        let graph = GraphLayers::load(path, load_option, do_convert)?;
 
         Ok(HNSWIndex {
             id_tracker,

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -260,6 +260,7 @@ pub fn io_error_to_status(e: UniversalIoError) -> Status {
         UniversalIoError::Uninitialized { description } => {
             Status::internal(format!("Uninitialized: {description}"))
         }
+        UniversalIoError::Bincode(e) => Status::internal(format!("Bincode error: {e}")),
         UniversalIoError::BytemuckCast(e) => Status::internal(format!("Bytemuck cast error: {e}")),
         UniversalIoError::ZerocopySize(e) => Status::internal(e),
         UniversalIoError::QueueIsFull => Status::internal(e.to_string()),


### PR DESCRIPTION
A simple change to leverage loading the full `GraphLinks` with any backend. We still use mmap, but the PR makes it easy to pick any other.

We still keep `Mmap` for on-disk setting, but this PR adds the posibility to load the entire thing into a `Vec<u8>` using any backend by replacing `on_disk: bool` parameter for:

```rust
pub enum LoadOption<Fs: UniversalReadFs> {
    /// Open as a mmap without populating it.
    OnDiskMmap,
    /// Load whole file into RAM using a generic backend.
    RamFromUniversal { fs: Fs },
}
```

## New behavior
With this changes, when opening with `on_disk: false` parameter, it will:
1. open a mmap
2. read the whole file
3. copy it into owned `Vec`
4. Finally, clear file cache. 

So, for a brief moment during startup, it may use double the amount of memory than before.