### PR TITLE
Fix abort transfer resharding idempotency

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use futures::Future;
+use tokio::sync::RwLockWriteGuard;
 
 use super::Collection;
 use crate::config::ShardingMethod;
@@ -278,19 +279,26 @@ impl Collection {
             }
         }
 
+        drop(shard_holder); // drop the read lock before acquiring write lock
+        let mut shard_holder = self.shards_holder.write().await;
+
+        // Abort resharding before the related transfers to keep this
+        // idempotent on replay: if we aborted a transfer first and crashed,
+        // on restart the transfer would be gone and we'd no longer detect
+        // it as resharding-related, leaving resharding running.
+        shard_holder
+            .abort_resharding(resharding_key.clone(), force)
+            .await?;
+
+        let shard_holder = RwLockWriteGuard::downgrade(shard_holder);
+
         // Abort all resharding transfer related to this specific resharding operation
         let resharding_transfers =
             shard_holder.get_transfers(|t| t.is_related_to_resharding(&resharding_key));
         for transfer in resharding_transfers {
             self.abort_shard_transfer(transfer, &shard_holder).await?;
         }
-
-        drop(shard_holder); // drop the read lock before acquiring write lock
-        let mut shard_holder = self.shards_holder.write().await;
-
-        shard_holder
-            .abort_resharding(resharding_key.clone(), force)
-            .await?;
+        drop(shard_holder);
 
         // Decrease the persisted shard count, ensures we don't load dropped shard on restart
         if resharding_key.direction == ReshardingDirection::Up {

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -295,6 +295,16 @@ impl Collection {
         // Abort all resharding transfer related to this specific resharding operation
         let resharding_transfers =
             shard_holder.get_transfers(|t| t.is_related_to_resharding(&resharding_key));
+
+        // Staging-only: pause after clearing resharding state but before aborting the transfer, so a test can kill this peer mid-abort.
+        #[cfg(feature = "staging")]
+        if !resharding_transfers.is_empty()
+            && let Ok(secs) = std::env::var("QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC")
+            && let Ok(secs) = secs.parse::<f64>()
+        {
+            tokio::time::sleep(std::time::Duration::from_secs_f64(secs)).await;
+        }
+
         for transfer in resharding_transfers {
             self.abort_shard_transfer(transfer, &shard_holder).await?;
         }

--- a/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
+++ b/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
@@ -1,0 +1,115 @@
+"""abort_resharding clears (and persists) resharding_state before aborting the related
+transfer. A peer killed in that window (widened by a debug sleep) — state already
+cleared, transfer still present — replays the abort and converges, because the
+persisted cleared state makes the replay idempotent. Asserts every peer converges on
+no resharding_operations.
+"""
+
+import pathlib
+import threading
+
+from .fixtures import create_collection, upsert_random_points
+from .test_resharding import all_replicas, start_resharding
+from .utils import *
+
+COLLECTION = "test_resharding_down_abort_converges_after_crash"
+
+
+def _resharding_transfer_source(info) -> int | None:
+    for t in info.get("shard_transfers", []):
+        if "resharding" in (t.get("method") or ""):
+            return t["from"]
+    return None
+
+
+def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib.Path):
+    env = {"QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC": "12"}
+    peer_uris, peer_dirs, _ = start_cluster(tmp_path, 3, extra_env=env)
+    skip_if_no_feature(peer_uris[0], "staging")
+    wait_for(all_peers_are_voters, peer_uris)
+    peer_ids = [get_cluster_info(uri)["peer_id"] for uri in peer_uris]
+    peer_procs = list(processes)  # aligned to peer index; `processes` is mutated below
+
+    create_collection(peer_uris[0], collection=COLLECTION, shard_number=3, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(COLLECTION, peer_uris)
+    upsert_random_points(peer_uris[0], num=20_000, collection_name=COLLECTION)
+
+    resp = start_resharding(peer_uris[0], COLLECTION, direction="down", shard_key=None)
+    assert_http_ok(resp)
+    for uri in peer_uris:
+        wait_for_collection_resharding_operations_count(uri, COLLECTION, 1)
+
+    # Driver is disabled in tests; start the migrate transfer ourselves (dropped
+    # shard 2 -> surviving shard 0, between two distinct peers).
+    info = get_collection_cluster_info(peer_uris[0], COLLECTION)
+    target_shard_id, surviving_shard_id = 2, 0
+    target_peers = [r["peer_id"] for r in all_replicas(info) if r["shard_id"] == target_shard_id]
+    surviving_peers = [r["peer_id"] for r in all_replicas(info) if r["shard_id"] == surviving_shard_id]
+    from_peer_id, to_peer_id = next(
+        (fp, tp) for fp in target_peers for tp in surviving_peers if fp != tp
+    )
+
+    resp = requests.post(f"{peer_uris[0]}/collections/{COLLECTION}/cluster", json={
+        "replicate_shard": {
+            "from_peer_id": from_peer_id, "to_peer_id": to_peer_id,
+            "shard_id": target_shard_id, "to_shard_id": surviving_shard_id,
+            "method": "resharding_stream_records",
+        }
+    })
+    assert_http_ok(resp)
+
+    victim_idx = peer_ids.index(to_peer_id)
+    alive_uri = peer_uris[next(i for i in range(len(peer_uris)) if i != victim_idx)]
+    victim_uri = peer_uris[victim_idx]
+
+    # Wait until the victim itself has the transfer, so a later "gone" means the
+    # abort window, not a peer that simply hasn't applied the transfer start yet.
+    wait_for(
+        lambda: _resharding_transfer_source(get_collection_cluster_info(victim_uri, COLLECTION)) == from_peer_id,
+        wait_for_interval=0.05,
+    )
+
+    # Fire-and-forget: the debug sleep makes the synchronous abort wait time out, but
+    # the op still commits and applies on every peer.
+    def _abort_transfer():
+        try:
+            requests.post(f"{alive_uri}/collections/{COLLECTION}/cluster", json={
+                "abort_transfer": {
+                    "shard_id": target_shard_id, "to_shard_id": surviving_shard_id,
+                    "from_peer_id": from_peer_id, "to_peer_id": to_peer_id,
+                }
+            }, timeout=60)
+        except requests.RequestException:
+            pass
+
+    threading.Thread(target=_abort_transfer, daemon=True).start()
+
+    # Catch the victim paused mid-abort (resharding_state already cleared, transfer
+    # still present) and kill it before it aborts the transfer. Quorum (2/3) is preserved.
+    def _victim_in_window() -> bool:
+        try:
+            vinfo = get_collection_cluster_info(victim_uri, COLLECTION)
+        except requests.RequestException:
+            return False
+        return not vinfo.get("resharding_operations") and _resharding_transfer_source(vinfo) is not None
+
+    wait_for(_victim_in_window, wait_for_timeout=30)
+    victim_proc = peer_procs[victim_idx]
+    victim_port = victim_proc.p2p_port
+    processes.remove(victim_proc)
+    victim_proc.kill()
+
+    # Restart (liveness only — the stuck shard may never pass /readyz). The victim
+    # replays the abort against an already-cleared, persisted resharding_state and
+    # converges.
+    peer_uris[victim_idx] = start_peer(
+        peer_dirs[victim_idx], f"peer_restart_{victim_idx}.log", alive_uri, port=victim_port,
+    )
+    wait_for_peer_online(peer_uris[victim_idx], path="/healthz", wait_for_timeout=60)
+
+    try:
+        for uri in peer_uris:
+            wait_for_collection_resharding_operations_count(uri, COLLECTION, 0, wait_for_timeout=30)
+    except Exception:
+        stuck = {u: n for u in peer_uris if (n := len(get_collection_cluster_info(u, COLLECTION).get("resharding_operations") or []))}
+        raise AssertionError(f"peers still resharding after 30s: {stuck}")


### PR DESCRIPTION
The consensus operation for aborting resharding did not behave in an idempotent manner.

I attempted to implement this in <https://github.com/qdrant/qdrant/pull/8917>, but it turns out there's a second code path that conflicts with that change. This second path also (incorrectly) aborted the transfer before resharding, breaking consensus WAL replay.

This simply reorders this second place so that we always abort resharding before the transfer is aborted.

A test is included to assert correct behavior. The test fails without this change.

I'd consider this a hotfix. I'd rather remove the second path for aborting the transfer but it isn't immediately obvious to apply that because we call it from multiple places with different contexts. This hotfix is good enough to be merged and released without side effects.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
