### PR TITLE
wal: fix WAL lock on Android (use fs4 flock instead of std try_lock)

### DIFF
--- a/lib/wal/src/lib.rs
+++ b/lib/wal/src/lib.rs
@@ -152,7 +152,16 @@ impl Wal {
             dir
         };
 
-        dir.try_lock()?;
+        // Use `fs4`'s `flock(2)`-based lock rather than `dir.try_lock()`.
+        //
+        // `dir.try_lock()` resolves to the inherent `fs_err`/`std` `File::try_lock`,
+        // which is gated to a fixed list of targets in stdlib and returns
+        // `ErrorKind::Unsupported` ("try_lock() not supported") on others — notably
+        // Android. `fs4::FileExt::try_lock` issues a direct `flock(LOCK_EX | LOCK_NB)`
+        // syscall, which Android supports. We call it via UFCS on the underlying
+        // `std::fs::File` because the trait method collides with the inherent one
+        // (which would otherwise win method resolution).
+        fs4::FileExt::try_lock(dir.file())?;
 
         // Holds open segments in the directory.
         let mut open_segments: Vec<OpenSegment> = Vec::new();


### PR DESCRIPTION
## Problem

Opening (creating or loading) a shard on Android fails with:

```
QdrantEdge.createShard(...): Failed to create shard:
Service runtime error: failed to open WAL ...: Can't init WAL:
Error { kind: Unsupported, message: "try_lock() not supported" }
```

## Root cause

In `lib/wal/src/lib.rs`, `dir.try_lock()?` resolves to the inherent
`fs_err::File::try_lock`, which forwards to **std's** `File::try_lock`. Rust's
stdlib (1.89+) gates that method to a fixed target list that intentionally
excludes `target_os = "android"`, so on Android it returns
`ErrorKind::Unsupported` with `"try_lock() not supported"`.

This regressed in #8770 ("Update fs4 from 0.13.1 to 1.0.0"), which replaced the
previous `fs4::FileExt::try_lock_exclusive()` (a `flock(2)` syscall Android
supports) with the std-backed `dir.try_lock()`.

## Fix

Dispatch explicitly to `fs4::FileExt::try_lock` on the underlying
`std::fs::File` (`dir.file()`), which on Unix routes through
`rustix::fs::flock(fd, NonBlockingLockExclusive)` — the `flock(LOCK_EX | LOCK_NB)`
syscall Android supports. On Windows it uses `LockFileEx`, unchanged.

UFCS is required because fs4 1.1.0 renamed its method to `try_lock`, colliding
by name with the inherent method, which otherwise wins method resolution.

### Notes
- No `Cargo.toml`/feature change needed — `fs4` is already a dependency and its
  `FileExt` impl for `std::fs::File` is unconditional.
- Error semantics preserved: fs4's `TryLockError` (incl. `WouldBlock` for a
  contended lock) implements `From<TryLockError> for io::Error`, so the `?`
  conversion works as before.

## Testing
- `cargo check -p wal` clean
- All 37 `wal` lib tests pass (incl. `check_reopen`, which exercises the lock path)
- Not built against a real Android target here (no NDK in env); the fix is
  target-agnostic but an Android `cargo check` is worth a confirming run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)