### PR TITLE
Use `assert_matches!`

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -293,6 +293,8 @@ pub enum DocumentOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -304,7 +306,7 @@ mod tests {
         let valid_bm25_config = serde_json::to_string(&json).unwrap();
         let options: DocumentOptions = serde_json::from_str(&valid_bm25_config).unwrap();
         // Bm25 option is used only for schema, actual deserialization will happen in specialized code
-        assert!(matches!(options, DocumentOptions::Common(_)));
+        assert_matches!(options, DocumentOptions::Common(_));
     }
 }
 

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -105,6 +105,7 @@ impl CollectionUpdater {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::sync::atomic::AtomicBool;
 
     use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -213,7 +214,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         let res = upsert_points(&segments.read(), 100, &points, &hw_counter);
-        assert!(matches!(res, Ok(1)));
+        assert_matches!(res, Ok(1));
 
         let records = retrieve_blocking(
             segments.clone(),

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -763,6 +763,7 @@ fn get_hnsw_ef_construct(config: &SegmentConfig, vector_name: &VectorName) -> Op
 mod tests {
     #![expect(clippy::wildcard_enum_match_arm, reason = "test code")]
 
+    use std::assert_matches;
     use std::sync::atomic::AtomicBool;
 
     use ahash::AHashSet;
@@ -995,7 +996,7 @@ mod tests {
             HwMeasurementAcc::new(),
             DeferredBehavior::Exclude,
         );
-        assert!(matches!(records, Err(OperationError::Timeout { .. })));
+        assert_matches!(records, Err(OperationError::Timeout { .. }));
     }
 
     #[test]

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -397,6 +397,7 @@ pub fn check_grouping_field(
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
     use std::sync::Arc;
 
     use api::rest::{PointInsertOperations, PointStruct, PointsList, SearchRequestInternal};
@@ -564,10 +565,7 @@ mod test {
             ..StrictModeConfig::default()
         };
         let res = check_resident_memory(&cfg, || Some(usize::MAX));
-        assert!(
-            matches!(res, Err(CollectionError::StrictMode { .. })),
-            "expected StrictMode error but got {res:?}",
-        );
+        assert_matches!(res, Err(CollectionError::StrictMode { .. }));
     }
 
     #[test]

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod shard_mapping;
 pub mod shared_shard_holder;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::debug_assert_matches;
 use std::ops::Deref as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -305,11 +306,9 @@ impl ShardHolder {
         let ids_to_key = self.get_shard_id_to_key_mapping();
         for shard_id in self.shards.keys() {
             let shard_key = ids_to_key.get(shard_id).cloned();
-            debug_assert!(
-                matches!(
-                    (self.sharding_method, &shard_key),
-                    (ShardingMethod::Auto, None) | (ShardingMethod::Custom, Some(_)),
-                ),
+            debug_assert_matches!(
+                (self.sharding_method, &shard_key),
+                (ShardingMethod::Auto, None) | (ShardingMethod::Custom, Some(_)),
                 "auto sharding cannot have shard key, custom sharding must have shard key ({:?}, {shard_key:?})",
                 self.sharding_method,
             );

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -97,10 +98,10 @@ async fn test_hw_metrics_cancellation() {
             .await;
 
         // Ensure we triggered a timeout and the search didn't exit too early.
-        assert!(matches!(
+        assert_matches!(
             search_res.unwrap_err(),
             CollectionError::Timeout { description: _ }
-        ));
+        );
     }
 
     // Cancellation and draining hardware counters is asynchronous on CI runners.

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -100,7 +100,7 @@ async fn test_hw_metrics_cancellation() {
         // Ensure we triggered a timeout and the search didn't exit too early.
         assert_matches!(
             search_res.unwrap_err(),
-            CollectionError::Timeout { description: _ }
+            CollectionError::Timeout { description: _ },
         );
     }
 

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod snapshot_test;
 mod sparse_vectors_validation_tests;
 mod wal_recovery_test;
 
+use std::assert_matches;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -217,7 +218,7 @@ async fn test_cancel_optimization() {
         assert!(log.len() <= expected_optimization_count);
         for status in log {
             assert_eq!(status.name, "indexing");
-            assert!(matches!(status.status, TrackerStatus::Cancelled(_)));
+            assert_matches!(status.status, TrackerStatus::Cancelled(_));
         }
     }
 

--- a/lib/collection/src/tests/shard_query.rs
+++ b/lib/collection/src/tests/shard_query.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::sync::Arc;
 
 use common::budget::ResourceBudget;
@@ -86,7 +87,7 @@ async fn test_shard_query_rrf_rescoring() {
     let expected_error = CollectionError::bad_input(
         "Validation failed: cannot apply Fusion without prefetches".to_string(),
     );
-    assert!(matches!(sources_scores, Err(err) if err == expected_error));
+    assert_matches!(sources_scores, Err(err) if err == expected_error);
 
     // RRF query with single prefetch
     let nearest_query = QueryEnum::Nearest(NamedQuery::new(

--- a/lib/collection/src/tests/shard_telemetry.rs
+++ b/lib/collection/src/tests/shard_telemetry.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -62,7 +63,7 @@ async fn test_shard_telemetry() {
         let telemetry = shard
             .get_telemetry_data(details, Duration::from_millis(10))
             .await;
-        assert!(matches!(telemetry, Err(CollectionError::Timeout { .. })));
+        assert_matches!(telemetry, Err(CollectionError::Timeout { .. }));
 
         drop(write_segment_holder_guard);
         let telemetry = shard

--- a/lib/collection/tests/integration/multi_vec_test.rs
+++ b/lib/collection/tests/integration/multi_vec_test.rs
@@ -1,5 +1,6 @@
 #![expect(clippy::wildcard_enum_match_arm, reason = "test code")]
 
+use std::assert_matches;
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -187,10 +188,7 @@ async fn test_multi_vec_with_shards(shard_number: u32) {
         )
         .await;
 
-    assert!(
-        matches!(result, Err(CollectionError::BadInput { .. })),
-        "{result:?}"
-    );
+    assert_matches!(result, Err(CollectionError::BadInput { .. }));
 
     let full_search_request = SearchRequestInternal {
         vector: NamedVector {

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -328,6 +328,7 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::io::Write;
 
     use tempfile::NamedTempFile;
@@ -594,6 +595,6 @@ mod tests {
         let bs = storage.read_all().unwrap();
         assert_eq!(bs.len(), storage.bit_len() as usize);
         // With mmap backend, read_all returns Cow::Borrowed (zero-copy)
-        assert!(matches!(bs, Cow::Borrowed(_)));
+        assert_matches!(bs, Cow::Borrowed(_));
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -54,6 +54,8 @@ impl DiskCacheConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use fs_err as fs;
 
     use super::DiskCacheConfig;
@@ -99,9 +101,6 @@ mod tests {
         let cfg = DiskCacheConfig::new(remote_dir, local_dir).unwrap();
         let err = cfg.local_path_for(&outside).unwrap_err();
 
-        assert!(
-            matches!(err, crate::universal_io::UniversalIoError::NotFound { .. }),
-            "expected NotFound, got {err:?}",
-        );
+        assert_matches!(err, crate::universal_io::UniversalIoError::NotFound { .. });
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -230,12 +230,9 @@ mod tests_mod {
                 length: 100,
             })
             .unwrap_err();
-        assert!(
-            matches!(
-                err,
-                crate::universal_io::UniversalIoError::OutOfBounds { .. }
-            ),
-            "expected OutOfBounds, got {err:?}",
+        assert_matches!(
+            err,
+            crate::universal_io::UniversalIoError::OutOfBounds { .. },
         );
     }
 
@@ -313,13 +310,10 @@ mod tests_mod {
         scn.truncate_remote(BLOCK_SIZE * 2);
 
         let err = cache.reopen().unwrap_err();
-        assert!(
-            matches!(
-                &err,
-                crate::universal_io::UniversalIoError::Io(io_err)
-                    if io_err.kind() == ErrorKind::UnexpectedEof,
-            ),
-            "expected Io(UnexpectedEof), got: {err:?}",
+        assert_matches!(
+            &err,
+            crate::universal_io::UniversalIoError::Io(io_err)
+                if io_err.kind() == ErrorKind::UnexpectedEof,
         );
     }
 
@@ -347,12 +341,9 @@ mod tests_mod {
                 length: BLOCK_SIZE as u64,
             })
             .unwrap_err();
-        assert!(
-            matches!(
-                err,
-                crate::universal_io::UniversalIoError::OutOfBounds { .. },
-            ),
-            "expected OutOfBounds before reopen, got: {err:?}",
+        assert_matches!(
+            err,
+            crate::universal_io::UniversalIoError::OutOfBounds { .. },
         );
 
         cache.reopen().unwrap();

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -165,7 +166,7 @@ mod tests_mod {
             .unwrap();
         let start = start as usize;
         let end = start + len as usize;
-        assert!(matches!(bytes, Cow::Borrowed(_)));
+        assert_matches!(bytes, Cow::Borrowed(_));
         assert_eq!(bytes.as_ref(), &scn.data[start..end]);
     }
 

--- a/lib/common/io_bridge_object_store/src/pipeline/inner.rs
+++ b/lib/common/io_bridge_object_store/src/pipeline/inner.rs
@@ -153,6 +153,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use ahash::AHashMap;
 
     use super::*;
@@ -183,7 +185,7 @@ mod tests {
         let err = inner
             .schedule(&runtime, 999, async { Ok(avec(&[0])) })
             .unwrap_err();
-        assert!(matches!(err, UniversalIoError::QueueIsFull));
+        assert_matches!(err, UniversalIoError::QueueIsFull);
     }
 
     #[test]
@@ -237,7 +239,7 @@ mod tests {
             })
             .expect("schedule");
         let err = inner.wait().unwrap_err();
-        assert!(matches!(err, UniversalIoError::TaskPanicked(msg) if msg == "boom"));
+        assert_matches!(err, UniversalIoError::TaskPanicked(msg) if msg == "boom");
     }
 
     /// Two distinct runtimes feed reply responses into one pipeline; both

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use std::assert_matches;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -99,7 +100,7 @@ fn test_not_found() {
     let file = BlobFile::<Arc<AmazonS3>>::open(&rustfs_aws_config(), runtime, "does-not-exist")
         .expect("open builds the store without IO");
     let err = file.read_whole::<u8>().unwrap_err();
-    assert!(matches!(err, UniversalIoError::NotFound { .. }));
+    assert_matches!(err, UniversalIoError::NotFound { .. });
 }
 
 #[test]

--- a/lib/edge/src/bm25_embed.rs
+++ b/lib/edge/src/bm25_embed.rs
@@ -224,6 +224,8 @@ fn build_tokens_processor(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -268,7 +270,7 @@ mod tests {
             ..Default::default()
         };
         let err = EdgeBm25::new(cfg).expect_err("klingon should not be accepted");
-        assert!(matches!(err, EdgeBm25Error::UnsupportedLanguage(ref s) if s == "klingon"));
+        assert_matches!(err, EdgeBm25Error::UnsupportedLanguage(ref s) if s == "klingon");
     }
 
     #[test]
@@ -278,6 +280,6 @@ mod tests {
             ..Default::default()
         };
         let err = EdgeBm25::new(cfg).expect_err("avg_len=0 should not be accepted");
-        assert!(matches!(err, EdgeBm25Error::Bm25(_)));
+        assert_matches!(err, EdgeBm25Error::Bm25(_));
     }
 }

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -1,3 +1,4 @@
+use std::debug_assert_matches;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 
@@ -102,7 +103,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
             .iter(0, max_id, usize::MAX, callback, hw_counter)?;
 
         // we set usize::MAX as the max iteration, so we should always iterate the entire thing.
-        debug_assert!(matches!(control_flow, ControlFlow::Break(())));
+        debug_assert_matches!(control_flow, ControlFlow::Break(()));
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/tests/histogram_tests.rs
+++ b/lib/segment/src/index/field_index/tests/histogram_tests.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::cell::Cell;
 use std::collections::BTreeSet;
 use std::collections::Bound::{Excluded, Included, Unbounded};
@@ -125,7 +126,7 @@ pub fn test_range_by_cardinality(histogram: &Histogram<f64>) {
     let to = histogram.get_range_by_size(from, range_size);
     let estimation = histogram.estimate(from, to);
     eprintln!("({from:?} - {to:?}) -> {estimation:?} / {range_size}");
-    assert!(matches!(to, Unbounded));
+    assert_matches!(to, Unbounded);
 }
 
 pub fn request_histogram(histogram: &Histogram<f64>, points_index: &BTreeSet<Point<f64>>) {

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_immutable_payload_index_files;
 mod test_vector_name_ops;
 
+use std::assert_matches;
 use std::sync::atomic::AtomicBool;
 
 use ahash::AHashSet;
@@ -378,8 +379,9 @@ fn test_check_consistency() {
     assert_eq!(search_result[0].id, 4.into());
 
     // querying by external id is broken
-    assert!(
-        matches!(segment.vector(DEFAULT_VECTOR_NAME, 6.into(), &hw_counter), Err(PointIdError {missed_point_id }) if missed_point_id == 6.into())
+    assert_matches!(
+        segment.vector(DEFAULT_VECTOR_NAME, 6.into(), &hw_counter),
+        Err(PointIdError { missed_point_id }) if missed_point_id == 6.into(),
     );
 
     // but querying by internal id still works

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -4096,6 +4096,8 @@ pub(crate) mod test_utils {
 mod tests {
     #![expect(clippy::wildcard_enum_match_arm, reason = "test code")]
 
+    use std::assert_matches;
+
     use itertools::Itertools;
     use rstest::rstest;
     use serde_json;
@@ -4204,17 +4206,17 @@ mod tests {
         // IsEmptyCondition (no "key" field at top level, uses "is_empty" instead)
         let is_empty_json = r#"{"is_empty": {"key": "optional_field"}}"#;
         let condition: Condition = serde_json::from_str(is_empty_json).unwrap();
-        assert!(matches!(condition, Condition::IsEmpty(_)));
+        assert_matches!(condition, Condition::IsEmpty(_));
 
         // HasIdCondition
         let has_id_json = r#"{"has_id": [1, 2, 3]}"#;
         let condition: Condition = serde_json::from_str(has_id_json).unwrap();
-        assert!(matches!(condition, Condition::HasId(_)));
+        assert_matches!(condition, Condition::HasId(_));
 
         // Nested Filter
         let nested_json = r#"{"nested": {"key": "items", "filter": {"must": []}}}"#;
         let condition: Condition = serde_json::from_str(nested_json).unwrap();
-        assert!(matches!(condition, Condition::Nested(_)));
+        assert_matches!(condition, Condition::Nested(_));
     }
 
     #[test]

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -106,11 +107,11 @@ fn test_byte_storage_hnsw(
             .vector_storage
             .borrow();
         let raw_storage: &VectorStorageEnum = &borrowed_storage;
-        assert!(matches!(
+        assert_matches!(
             raw_storage,
             &VectorStorageEnum::DenseAppendableMemmapByte(_)
                 | &VectorStorageEnum::DenseAppendableMemmapHalf(_),
-        ));
+        );
     }
 
     for n in 0..num_vectors {

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -245,11 +246,11 @@ fn test_byte_storage_binary_quantization_hnsw(
             .vector_storage
             .borrow();
         let raw_storage: &VectorStorageEnum = &borrowed_storage;
-        assert!(matches!(
+        assert_matches!(
             raw_storage,
             &VectorStorageEnum::DenseAppendableMemmapByte(_)
                 | &VectorStorageEnum::DenseAppendableMemmapHalf(_),
-        ));
+        );
     }
 
     let hw_counter = HardwareCounterCell::new();

--- a/lib/shard/src/operations/payload_ops.rs
+++ b/lib/shard/src/operations/payload_ops.rs
@@ -207,6 +207,8 @@ impl fmt::Display for PointsSelectorValidationError {
 mod tests {
     #![expect(clippy::wildcard_enum_match_arm, reason = "test code")]
 
+    use std::assert_matches;
+
     use segment::types::{Payload, PayloadContainer};
     use serde_json::Value;
 
@@ -276,7 +278,7 @@ mod tests {
                     .next()
                     .cloned();
 
-                assert!(matches!(payload_type_json, Some(Value::Object(_))))
+                assert_matches!(payload_type_json, Some(Value::Object(_)))
             }
             _ => panic!("Wrong operation"),
         }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -4,6 +4,7 @@
 //! The collection layer provides the strategy via `OptimizationStrategy`.
 
 use std::collections::HashSet;
+use std::debug_assert_matches;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -760,9 +761,10 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
             // Also helps to ensure the delete propagation behavior in
             // `optimize_segment_propagate_changes` remains  sound.
             // See: <https://github.com/qdrant/qdrant/pull/7208>
-            debug_assert!(
-                matches!(proxy.wrapped_segment(), LockedSegment::Original(_)),
-                "during optimization, wrapped segment must not be another proxy segment"
+            debug_assert_matches!(
+                proxy.wrapped_segment(),
+                LockedSegment::Original(_),
+                "during optimization, wrapped segment must not be another proxy segment",
             );
 
             // Now that this write lock froze the wrapped segment, finalize the proxy: this syncs

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -1,3 +1,5 @@
+use std::assert_matches;
+
 use ahash::AHashSet;
 use ordered_float::OrderedFloat;
 use segment::common::operation_error::OperationError;
@@ -495,10 +497,10 @@ fn test_detect_max_depth() {
     assert_eq!(request.prefetches_depth(), 65);
 
     // assert error
-    assert!(matches!(
+    assert_matches!(
         PlannedQuery::try_from(vec![request]),
         Err(OperationError::ValidationError { description }) if description == "prefetches depth 65 exceeds max depth 64",
-    ));
+    );
 }
 
 fn dummy_core_prefetch(limit: usize) -> ShardPrefetch {

--- a/lib/storage/src/audit_reader.rs
+++ b/lib/storage/src/audit_reader.rs
@@ -410,7 +410,7 @@ mod tests {
         );
         assert_matches!(
             matches_query_result(&event, &query_before),
-            MatchResult::NoMatch
+            MatchResult::NoMatch,
         );
     }
 

--- a/lib/storage/src/audit_reader.rs
+++ b/lib/storage/src/audit_reader.rs
@@ -235,6 +235,7 @@ fn read_entries_from_file(
     Ok(Vec::from(window))
 }
 
+#[derive(Debug)]
 enum MatchResult {
     Match,
     NoMatch,
@@ -321,6 +322,8 @@ fn event_field_matches(event: &AuditEvent, key: &str, expected: &str) -> Option<
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::audit::AuditResult;
     use crate::rbac::AuthType;
@@ -377,10 +380,7 @@ mod tests {
             HashMap::from([("method".to_string(), "upsert_points".to_string())]),
             None,
         );
-        assert!(matches!(
-            matches_query_result(&event, &query),
-            MatchResult::Match
-        ));
+        assert_matches!(matches_query_result(&event, &query), MatchResult::Match);
 
         let query2 = AuditLogQuery::new(
             None,
@@ -388,10 +388,7 @@ mod tests {
             HashMap::from([("method".to_string(), "delete_points".to_string())]),
             None,
         );
-        assert!(matches!(
-            matches_query_result(&event, &query2),
-            MatchResult::NoMatch
-        ));
+        assert_matches!(matches_query_result(&event, &query2), MatchResult::NoMatch);
     }
 
     #[test]
@@ -403,10 +400,7 @@ mod tests {
             HashMap::new(),
             None,
         );
-        assert!(matches!(
-            matches_query_result(&event, &query),
-            MatchResult::Match
-        ));
+        assert_matches!(matches_query_result(&event, &query), MatchResult::Match);
 
         let query_before = AuditLogQuery::new(
             Some("2024-06-16T00:00:00Z".parse().unwrap()),
@@ -414,10 +408,10 @@ mod tests {
             HashMap::new(),
             None,
         );
-        assert!(matches!(
+        assert_matches!(
             matches_query_result(&event, &query_before),
             MatchResult::NoMatch
-        ));
+        );
     }
 
     #[test]

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -488,7 +488,7 @@ mod tests {
         // Some errors can't be corrected
         assert_matches!(
             wal.append_entries(broken_entry),
-            Err(StorageError::ServiceError { .. })
+            Err(StorageError::ServiceError { .. }),
         );
     }
 

--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -400,6 +400,8 @@ fn into_raft_result<T>(result: Result<Option<T>, StorageError>) -> raft::Result<
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use raft::eraftpb::Entry;
 
     use super::*;
@@ -484,10 +486,10 @@ mod tests {
         }];
 
         // Some errors can't be corrected
-        assert!(matches!(
+        assert_matches!(
             wal.append_entries(broken_entry),
             Err(StorageError::ServiceError { .. })
-        ));
+        );
     }
 
     #[test]

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1196,6 +1196,7 @@ pub fn raft_error_other(e: impl std::error::Error) -> raft::Error {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::sync::{Arc, mpsc};
 
     use collection::shards::shard::PeerId;
@@ -1610,11 +1611,9 @@ mod tests {
 
         consensus.apply_snapshot(&snapshot).unwrap().unwrap();
 
-        assert!(
-            matches!(
-                rx.try_recv(),
-                Err(tokio::sync::broadcast::error::TryRecvError::Empty),
-            ),
+        assert_matches!(
+            rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty),
             "awaiter must not be notified when snapshot does not satisfy the operation",
         );
         assert!(

--- a/src/common/auth/jwt_parser.rs
+++ b/src/common/auth/jwt_parser.rs
@@ -189,7 +189,7 @@ mod tests {
 
         assert_matches!(
             JwtParser::new("wrong-secret").decode(&token),
-            Some(Err(AuthError::Forbidden(_)))
+            Some(Err(AuthError::Forbidden(_))),
         );
 
         assert!(JwtParser::new("secret").decode("foo.bar.baz").is_none());

--- a/src/common/auth/jwt_parser.rs
+++ b/src/common/auth/jwt_parser.rs
@@ -54,6 +54,8 @@ impl JwtParser {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use serde_json::json;
     use storage::rbac::{
         Access, CollectionAccess, CollectionAccessList, CollectionAccessMode, GlobalAccessMode,
@@ -145,10 +147,7 @@ mod tests {
 
         let secret = "secret";
         let parser = JwtParser::new(secret);
-        assert!(matches!(
-            parser.decode(&token),
-            Some(Err(AuthError::Forbidden(_)))
-        ));
+        assert_matches!(parser.decode(&token), Some(Err(AuthError::Forbidden(_))));
 
         // Remove the exp claim and it should work
         claims.exp = None;
@@ -174,7 +173,7 @@ mod tests {
         let secret = "secret";
         let parser = JwtParser::new(secret);
 
-        assert!(matches!(parser.decode(&token), Some(Ok(_))));
+        assert_matches!(parser.decode(&token), Some(Ok(_)));
     }
 
     #[test]
@@ -188,10 +187,10 @@ mod tests {
         };
         let token = create_token(&claims);
 
-        assert!(matches!(
+        assert_matches!(
             JwtParser::new("wrong-secret").decode(&token),
             Some(Err(AuthError::Forbidden(_)))
-        ));
+        );
 
         assert!(JwtParser::new("secret").decode("foo.bar.baz").is_none());
     }

--- a/src/common/inference/service.rs
+++ b/src/common/inference/service.rs
@@ -397,6 +397,7 @@ fn merge_position_items<I>(
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
     use std::collections::HashMap;
 
     use api::rest::Bm25Config;
@@ -505,7 +506,7 @@ mod test {
             if input.model == BM25_LOCAL_MODEL_NAME {
                 // In our test-setup, only BM25 returns sparse vectors. Normal inference is mocked
                 // and always returns dense vectors.
-                assert!(matches!(response, VectorPersisted::Sparse(..)));
+                assert_matches!(response, VectorPersisted::Sparse(..));
                 let bm25_config = InferenceInput::parse_bm25_config(input.options).unwrap();
 
                 // Re-run bm25 and check that response is correct.


### PR DESCRIPTION
Rust 1.96 [added](https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/#assert-matching-patterns) `assert_matches!()`. This makes use of it.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
