### PR TITLE
Attempt to fix flaky test_hw_metrics_cancellation test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,13 @@ failure-output = "immediate-final"
 # save junit report
 [profile.ci.junit]
 path = "junit.xml"
+
+# The `test_hw_metrics_cancellation` test relies on a search timeout, which might
+# not be scheduled at all if the CI runner's CPU pressure is too high.
+# This is because `spawn_blocking` sometimes doesn't spawn a new worker thread before
+# the test's search timeout is reached.
+# To trick nextest into not running other tests in parallel, we override this test
+# specifically and force it to get all CPUs allocated.
+[[profile.default.overrides]]
+filter = 'package(collection) and test(test_hw_metrics_cancellation)'
+threads-required = "num-test-threads"

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::{HwMeasurementAcc, HwSharedDrain};
 use common::save_on_disk::SaveOnDisk;
-use rand::rngs::ThreadRng;
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng, rng};
 use segment::data_types::vectors::{NamedQuery, VectorInternal, VectorStructInternal};
 use shard::query::query_enum::QueryEnum;
 use shard::search::CoreSearchRequestBatch;
@@ -57,7 +57,7 @@ async fn test_hw_metrics_cancellation() {
     .await
     .unwrap();
 
-    let upsert_ops = make_random_points_upsert_op(40_000, DIM);
+    let upsert_ops = make_random_points_upsert_op(50_000, DIM);
     shard
         .update(
             upsert_ops.into(),
@@ -93,7 +93,9 @@ async fn test_hw_metrics_cancellation() {
             .do_search(
                 Arc::new(req),
                 &current_runtime,
-                Duration::from_millis(300), // Very short duration to hit timeout before the search finishes
+                // Short but not extremely short timeout to not conflict with os-thread spawning overhead.
+                // (For more information see https://github.com/qdrant/qdrant/pull/9233)
+                Duration::from_millis(350),
                 hw_counter,
             )
             .await;
@@ -124,7 +126,9 @@ async fn test_hw_metrics_cancellation() {
 fn make_random_points_upsert_op(len: usize, dim: usize) -> CollectionUpdateOperations {
     let mut points = vec![];
 
-    let mut rand = rng();
+    // ThreadRng is too slow for creating 40k vectors @ 2048 dimensions each.
+    // SmallRng cuts total test duration in half (20s->10s).
+    let mut rand = SmallRng::seed_from_u64(0xC0FFEE);
 
     for i in 0..len as u64 {
         let rand_vector = rand_vector(dim, &mut rand);
@@ -140,6 +144,6 @@ fn make_random_points_upsert_op(len: usize, dim: usize) -> CollectionUpdateOpera
     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(op))
 }
 
-fn rand_vector(size: usize, rand: &mut ThreadRng) -> Vec<f32> {
+fn rand_vector(size: usize, rand: &mut impl Rng) -> Vec<f32> {
     (0..size).map(|_| rand.next_u32() as f32).collect()
 }

--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -27,7 +27,9 @@ use crate::tests::fixtures::create_collection_config_with_dim;
 async fn test_hw_metrics_cancellation() {
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
-    let mut config = create_collection_config_with_dim(512);
+    const DIM: usize = 2048;
+
+    let mut config = create_collection_config_with_dim(DIM);
     config.optimizer_config.indexing_threshold = None;
 
     let collection_name = "test".to_string();
@@ -55,7 +57,7 @@ async fn test_hw_metrics_cancellation() {
     .await
     .unwrap();
 
-    let upsert_ops = make_random_points_upsert_op(10_000);
+    let upsert_ops = make_random_points_upsert_op(40_000, DIM);
     shard
         .update(
             upsert_ops.into(),
@@ -71,7 +73,7 @@ async fn test_hw_metrics_cancellation() {
         searches: vec![CoreSearchRequest {
             query: QueryEnum::Nearest(NamedQuery {
                 using: None,
-                query: VectorInternal::from(rand_vector(512, &mut rand)),
+                query: VectorInternal::from(rand_vector(DIM, &mut rand)),
             }),
             filter: None,
             params: None,
@@ -91,7 +93,7 @@ async fn test_hw_metrics_cancellation() {
             .do_search(
                 Arc::new(req),
                 &current_runtime,
-                Duration::from_millis(10), // Very short duration to hit timeout before the search finishes
+                Duration::from_millis(300), // Very short duration to hit timeout before the search finishes
                 hw_counter,
             )
             .await;
@@ -119,13 +121,13 @@ async fn test_hw_metrics_cancellation() {
     assert!(outer_hw.get_cpu() > 0);
 }
 
-fn make_random_points_upsert_op(len: usize) -> CollectionUpdateOperations {
+fn make_random_points_upsert_op(len: usize, dim: usize) -> CollectionUpdateOperations {
     let mut points = vec![];
 
     let mut rand = rng();
 
     for i in 0..len as u64 {
-        let rand_vector = rand_vector(512, &mut rand);
+        let rand_vector = rand_vector(dim, &mut rand);
         points.push(PointStructPersisted {
             id: segment::types::ExtendedPointId::NumId(i),
             vector: VectorStructInternal::from(rand_vector).into(),


### PR DESCRIPTION
Attempt to fix flaky test https://github.com/qdrant/qdrant/issues/9184

# Root cause (confirmed)
This test artificially creates a timeout during a search and asserts that hw-counter will still catch _some_ cpu usage when cancelled mid-flight.
Since the search is quite fast, we currently use a very short timeout (10ms) to be sure the search really timeouts.

However, we're running our tests with `cargo nextest` on CI, meaning all tests are executed in parallel with 1 test per core.
This leaves little room for the `spawn_blocking` to spawn and run the blocking part of the search request.
In that scenario, the search doesn't start at all and we reach the 10ms timeout with `cpu_counter=0` as no cpu was consumed yet.

This causes the `Timeout waiting for cancellation metrics to be drained` panic [here](https://github.com/qdrant/qdrant/blob/master/lib/collection/src/tests/hw_metrics.rs#L112) where we are waiting to see cpu_counter having a non zero value.

# The Fix
Since os scheduling is not predictable from our tests and we don't have much control over it, there is no direct fix for this.

This PR still has two changes I propose to try on CI and see if they are already good enough to fix the flakes.
  - Force this test to **never run in parallel** with other tests.
  - Increasing the search timeout and the time the search takes to complete.

I'm still able to reproduce this flake locally if the system load is high, but the rate is significantly lower (and the local scenario is much more heavy than on CI).
The first fix _should_ prevent such a high load on CI runners so I think this is a good first approach to this flaky test.

# Drawbacks
The test now locally runs in 11s (before ~2s) and no other tests are run in parallel with this test (the other tests are still executed in parallel).
Also, the test now creates 50k vectors with 2048 dimensions so it needs minimum of 400MB memory. But since no other test is running in parallel and our CI runners have min 7GB memory, this is negligible.  

# Next steps
If we see the flake again, we could also implement a manual retry logic in this test.
Since [we are already retrying tests once](https://github.com/qdrant/qdrant/blob/master/.config/nextest.toml#L3) on failure, I decided to not make things more complicated than it might need to be and left this open for a future change.