### PR TITLE
Fix stale snapshot transfer recovery comment on failure/cancellation

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -25,6 +25,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{self, ShardConfig};
+use crate::shards::shard_holder::recovery_guard::RecoveryProgressHandle;
 use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
 use crate::shards::shard_holder::{SHARD_KEY_MAPPING_FILE, ShardHolder, shard_not_found_error};
 use crate::shards::shard_path;
@@ -327,6 +328,7 @@ impl Collection {
         this_peer_id: PeerId,
         is_distributed: bool,
         temp_dir: &Path,
+        recovery_progress: Option<RecoveryProgressHandle>,
         cancel: cancel::CancellationToken,
     ) -> CollectionResult<impl Future<Output = CollectionResult<()>> + 'static> {
         // `ShardHolder::validate_shard_snapshot` is cancel safe, so we explicitly cancel it
@@ -351,6 +353,7 @@ impl Collection {
                     this_peer_id,
                     is_distributed,
                     &temp_dir,
+                    recovery_progress,
                     cancel,
                 )
                 .await?;

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -86,7 +86,40 @@ pub struct ShardHolder {
     sharding_method: ShardingMethod,
     /// Active snapshot recoveries on this peer (destination side of transfers).
     /// Tracks progress of downloading, unpacking, and restoring snapshots.
-    active_recoveries: Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>,
+    /// Entries are added and removed via [`ShardRecoveryGuard`].
+    active_recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
+}
+
+/// RAII guard for tracking an active snapshot recovery on the destination side.
+///
+/// While held, the recovery progress is registered in [`ShardHolder::active_recoveries`]
+/// so it can be reported in the transfer status. On drop - including early returns,
+/// errors, and cancellation - the entry is removed again, ensuring that stale recovery
+/// comments are never reported for subsequent transfers.
+pub struct ShardRecoveryGuard {
+    active_recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
+    shard_id: ShardId,
+    progress: Arc<Mutex<RecoveryProgress>>,
+}
+
+impl ShardRecoveryGuard {
+    /// Shared recovery progress, used to update the current recovery stage.
+    pub fn progress(&self) -> &Arc<Mutex<RecoveryProgress>> {
+        &self.progress
+    }
+}
+
+impl Drop for ShardRecoveryGuard {
+    fn drop(&mut self) {
+        let mut active_recoveries = self.active_recoveries.lock();
+        // Only remove our own entry, in case a newer recovery for the same shard
+        // has already replaced it.
+        if let Some(current) = active_recoveries.get(&self.shard_id)
+            && Arc::ptr_eq(current, &self.progress)
+        {
+            active_recoveries.remove(&self.shard_id);
+        }
+    }
 }
 
 impl ShardHolder {
@@ -129,7 +162,7 @@ impl ShardHolder {
             key_mapping,
             shard_id_to_key_mapping,
             sharding_method,
-            active_recoveries: Mutex::new(HashMap::new()),
+            active_recoveries: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -476,18 +509,21 @@ impl ShardHolder {
         (incoming, outgoing)
     }
 
-    /// Start tracking recovery progress for a shard (destination side)
-    pub fn start_shard_recovery(&self, shard_id: ShardId) -> Arc<Mutex<RecoveryProgress>> {
+    /// Start tracking recovery progress for a shard (destination side).
+    ///
+    /// Returns a [`ShardRecoveryGuard`] that must be held for the duration of the
+    /// recovery. Dropping the guard - on success, error, or cancellation - stops
+    /// tracking and removes the progress entry.
+    pub fn start_shard_recovery(&self, shard_id: ShardId) -> ShardRecoveryGuard {
         let progress = Arc::new(Mutex::new(RecoveryProgress::new()));
         self.active_recoveries
             .lock()
             .insert(shard_id, Arc::clone(&progress));
-        progress
-    }
-
-    /// Stop tracking recovery progress for a shard
-    pub fn finish_shard_recovery(&self, shard_id: ShardId) {
-        self.active_recoveries.lock().remove(&shard_id);
+        ShardRecoveryGuard {
+            active_recoveries: Arc::clone(&self.active_recoveries),
+            shard_id,
+            progress,
+        }
     }
 
     pub fn get_shard_transfer_info(

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -55,7 +55,9 @@ use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::ShardConfig;
-use crate::shards::shard_holder::recovery_guard::{ActiveRecoveries, ShardRecoveryGuard};
+use crate::shards::shard_holder::recovery_guard::{
+    ActiveRecoveries, RecoveryProgressHandle, ShardRecoveryGuard,
+};
 use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::{CollectionId, check_shard_path, shard_initializing_flag_path};
 
@@ -1237,6 +1239,7 @@ impl ShardHolder {
         this_peer_id: PeerId,
         is_distributed: bool,
         temp_dir: &Path,
+        recovery_progress: Option<RecoveryProgressHandle>,
         cancel: cancel::CancellationToken,
     ) -> CollectionResult<()> {
         if !self.contains_shard(shard_id) {
@@ -1252,8 +1255,9 @@ impl ShardHolder {
             .tempdir_in(temp_dir)?;
 
         // Set unpacking stage
-        self.active_recoveries
-            .set_stage(shard_id, RecoveryStage::Unpacking);
+        if let Some(recovery_progress) = &recovery_progress {
+            recovery_progress.lock().set_stage(RecoveryStage::Unpacking);
+        }
 
         let extract = {
             let snapshot_temp_dir = snapshot_temp_dir.path().to_path_buf();
@@ -1293,8 +1297,9 @@ impl ShardHolder {
         extract.await??;
 
         // Set restoring stage
-        self.active_recoveries
-            .set_stage(shard_id, RecoveryStage::Restoring);
+        if let Some(recovery_progress) = &recovery_progress {
+            recovery_progress.lock().set_stage(RecoveryStage::Restoring);
+        }
 
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,3 +1,4 @@
+pub mod recovery_guard;
 mod resharding;
 pub(crate) mod shard_mapping;
 pub mod shared_shard_holder;
@@ -18,7 +19,6 @@ use fs_err as fs;
 use fs_err::{File, tokio as tokio_fs};
 use futures::{Future, StreamExt, TryStreamExt as _, stream};
 use itertools::Itertools;
-use parking_lot::Mutex;
 use segment::json_path::JsonPath;
 use segment::types::{PayloadFieldSchema, ShardKey, SnapshotFormat};
 use segment::utils::fs::move_all;
@@ -34,7 +34,7 @@ pub use self::shared_shard_holder::*;
 use super::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use super::resharding::{ReshardState, ReshardingStage};
 use super::transfer::RecoveryStage;
-use super::transfer::transfer_tasks_pool::{RecoveryProgress, TransferTasksPool};
+use super::transfer::transfer_tasks_pool::TransferTasksPool;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::common::adaptive_handle::AdaptiveSearchHandle;
 use crate::common::collection_size_stats::CollectionSizeStats;
@@ -55,6 +55,7 @@ use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::ShardConfig;
+use crate::shards::shard_holder::recovery_guard::{ActiveRecoveries, ShardRecoveryGuard};
 use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
 use crate::shards::{CollectionId, check_shard_path, shard_initializing_flag_path};
 
@@ -87,39 +88,7 @@ pub struct ShardHolder {
     /// Active snapshot recoveries on this peer (destination side of transfers).
     /// Tracks progress of downloading, unpacking, and restoring snapshots.
     /// Entries are added and removed via [`ShardRecoveryGuard`].
-    active_recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
-}
-
-/// RAII guard for tracking an active snapshot recovery on the destination side.
-///
-/// While held, the recovery progress is registered in [`ShardHolder::active_recoveries`]
-/// so it can be reported in the transfer status. On drop - including early returns,
-/// errors, and cancellation - the entry is removed again, ensuring that stale recovery
-/// comments are never reported for subsequent transfers.
-pub struct ShardRecoveryGuard {
-    active_recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
-    shard_id: ShardId,
-    progress: Arc<Mutex<RecoveryProgress>>,
-}
-
-impl ShardRecoveryGuard {
-    /// Shared recovery progress, used to update the current recovery stage.
-    pub fn progress(&self) -> &Arc<Mutex<RecoveryProgress>> {
-        &self.progress
-    }
-}
-
-impl Drop for ShardRecoveryGuard {
-    fn drop(&mut self) {
-        let mut active_recoveries = self.active_recoveries.lock();
-        // Only remove our own entry, in case a newer recovery for the same shard
-        // has already replaced it.
-        if let Some(current) = active_recoveries.get(&self.shard_id)
-            && Arc::ptr_eq(current, &self.progress)
-        {
-            active_recoveries.remove(&self.shard_id);
-        }
-    }
+    active_recoveries: ActiveRecoveries,
 }
 
 impl ShardHolder {
@@ -162,7 +131,7 @@ impl ShardHolder {
             key_mapping,
             shard_id_to_key_mapping,
             sharding_method,
-            active_recoveries: Arc::new(Mutex::new(HashMap::new())),
+            active_recoveries: ActiveRecoveries::default(),
         })
     }
 
@@ -515,15 +484,7 @@ impl ShardHolder {
     /// recovery. Dropping the guard - on success, error, or cancellation - stops
     /// tracking and removes the progress entry.
     pub fn start_shard_recovery(&self, shard_id: ShardId) -> ShardRecoveryGuard {
-        let progress = Arc::new(Mutex::new(RecoveryProgress::new()));
-        self.active_recoveries
-            .lock()
-            .insert(shard_id, Arc::clone(&progress));
-        ShardRecoveryGuard {
-            active_recoveries: Arc::clone(&self.active_recoveries),
-            shard_id,
-            progress,
-        }
+        self.active_recoveries.start(shard_id)
     }
 
     pub fn get_shard_transfer_info(
@@ -541,13 +502,7 @@ impl ShardHolder {
 
             // Check for active recovery on destination shard first, then sender task status
             let target_shard = to_shard_id.unwrap_or(shard_id);
-            let recovery_comment = self
-                .active_recoveries
-                .lock()
-                .get(&target_shard)
-                .and_then(|p| p.lock().format_comment());
-
-            let comment = recovery_comment.or_else(|| {
+            let comment = self.active_recoveries.comment(target_shard).or_else(|| {
                 tasks_pool
                     .get_task_status(&shard_transfer.key())
                     .map(|p| p.comment)
@@ -1297,9 +1252,8 @@ impl ShardHolder {
             .tempdir_in(temp_dir)?;
 
         // Set unpacking stage
-        if let Some(progress) = self.active_recoveries.lock().get(&shard_id) {
-            progress.lock().set_stage(RecoveryStage::Unpacking);
-        }
+        self.active_recoveries
+            .set_stage(shard_id, RecoveryStage::Unpacking);
 
         let extract = {
             let snapshot_temp_dir = snapshot_temp_dir.path().to_path_buf();
@@ -1339,9 +1293,8 @@ impl ShardHolder {
         extract.await??;
 
         // Set restoring stage
-        if let Some(progress) = self.active_recoveries.lock().get(&shard_id) {
-            progress.lock().set_stage(RecoveryStage::Restoring);
-        }
+        self.active_recoveries
+            .set_stage(shard_id, RecoveryStage::Restoring);
 
         // `ShardHolder::recover_local_shard_from` is *not* cancel safe
         // (see `ShardReplicaSet::restore_local_replica_from`)

--- a/lib/collection/src/shards/shard_holder/recovery_guard.rs
+++ b/lib/collection/src/shards/shard_holder/recovery_guard.rs
@@ -7,6 +7,14 @@ use crate::shards::shard::ShardId;
 use crate::shards::transfer::RecoveryStage;
 use crate::shards::transfer::transfer_tasks_pool::RecoveryProgress;
 
+/// Shared handle to a single recovery's progress.
+///
+/// Obtained from a [`ShardRecoveryGuard`] via [`ShardRecoveryGuard::progress_handle`]
+/// and threaded into the recovery sub-steps so they update *this* recovery's progress
+/// directly, rather than re-resolving the current map entry by shard id (which a newer
+/// recovery for the same shard may have already replaced).
+pub type RecoveryProgressHandle = Arc<Mutex<RecoveryProgress>>;
+
 /// Tracks active snapshot recoveries on a peer (destination side of transfers),
 /// keyed by shard id.
 ///
@@ -15,7 +23,7 @@ use crate::shards::transfer::transfer_tasks_pool::RecoveryProgress;
 /// removes the entry again on drop.
 #[derive(Clone, Default)]
 pub struct ActiveRecoveries {
-    recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
+    recoveries: Arc<Mutex<HashMap<ShardId, RecoveryProgressHandle>>>,
 }
 
 impl ActiveRecoveries {
@@ -41,16 +49,9 @@ impl ActiveRecoveries {
             .and_then(|progress| progress.lock().format_comment())
     }
 
-    /// Update the recovery stage for `shard_id`, if a recovery is active.
-    pub fn set_stage(&self, shard_id: ShardId, stage: RecoveryStage) {
-        if let Some(progress) = self.recoveries.lock().get(&shard_id) {
-            progress.lock().set_stage(stage);
-        }
-    }
-
     /// Remove the entry for `shard_id`, but only if it still points at `progress`,
     /// so a newer recovery for the same shard is never clobbered.
-    fn remove(&self, shard_id: ShardId, progress: &Arc<Mutex<RecoveryProgress>>) {
+    fn remove(&self, shard_id: ShardId, progress: &RecoveryProgressHandle) {
         let mut recoveries = self.recoveries.lock();
         if let Some(current) = recoveries.get(&shard_id)
             && Arc::ptr_eq(current, progress)
@@ -69,13 +70,20 @@ impl ActiveRecoveries {
 pub struct ShardRecoveryGuard {
     active_recoveries: ActiveRecoveries,
     shard_id: ShardId,
-    progress: Arc<Mutex<RecoveryProgress>>,
+    progress: RecoveryProgressHandle,
 }
 
 impl ShardRecoveryGuard {
-    /// Shared recovery progress, used to update the current recovery stage.
-    pub fn progress(&self) -> &Arc<Mutex<RecoveryProgress>> {
-        &self.progress
+    /// Update the recovery stage of *this* recovery.
+    pub fn set_stage(&self, stage: RecoveryStage) {
+        self.progress.lock().set_stage(stage);
+    }
+
+    /// A shared handle to this recovery's progress, for threading into recovery
+    /// sub-steps that need to update the stage. Bound to this guard's own entry, so
+    /// updates never leak into a newer recovery for the same shard.
+    pub fn progress_handle(&self) -> RecoveryProgressHandle {
+        Arc::clone(&self.progress)
     }
 }
 

--- a/lib/collection/src/shards/shard_holder/recovery_guard.rs
+++ b/lib/collection/src/shards/shard_holder/recovery_guard.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::shards::shard::ShardId;
+use crate::shards::transfer::RecoveryStage;
+use crate::shards::transfer::transfer_tasks_pool::RecoveryProgress;
+
+/// Tracks active snapshot recoveries on a peer (destination side of transfers),
+/// keyed by shard id.
+///
+/// This is a cheaply cloneable handle around a shared map. Recoveries are started
+/// via [`ActiveRecoveries::start`], which returns a [`ShardRecoveryGuard`] that
+/// removes the entry again on drop.
+#[derive(Clone, Default)]
+pub struct ActiveRecoveries {
+    recoveries: Arc<Mutex<HashMap<ShardId, Arc<Mutex<RecoveryProgress>>>>>,
+}
+
+impl ActiveRecoveries {
+    /// Start tracking a recovery for `shard_id`, returning a guard that stops
+    /// tracking on drop.
+    pub fn start(&self, shard_id: ShardId) -> ShardRecoveryGuard {
+        let progress = Arc::new(Mutex::new(RecoveryProgress::new()));
+        self.recoveries
+            .lock()
+            .insert(shard_id, Arc::clone(&progress));
+        ShardRecoveryGuard {
+            active_recoveries: self.clone(),
+            shard_id,
+            progress,
+        }
+    }
+
+    /// Format the recovery progress comment for `shard_id`, if a recovery is active.
+    pub fn comment(&self, shard_id: ShardId) -> Option<String> {
+        self.recoveries
+            .lock()
+            .get(&shard_id)
+            .and_then(|progress| progress.lock().format_comment())
+    }
+
+    /// Update the recovery stage for `shard_id`, if a recovery is active.
+    pub fn set_stage(&self, shard_id: ShardId, stage: RecoveryStage) {
+        if let Some(progress) = self.recoveries.lock().get(&shard_id) {
+            progress.lock().set_stage(stage);
+        }
+    }
+
+    /// Remove the entry for `shard_id`, but only if it still points at `progress`,
+    /// so a newer recovery for the same shard is never clobbered.
+    fn remove(&self, shard_id: ShardId, progress: &Arc<Mutex<RecoveryProgress>>) {
+        let mut recoveries = self.recoveries.lock();
+        if let Some(current) = recoveries.get(&shard_id)
+            && Arc::ptr_eq(current, progress)
+        {
+            recoveries.remove(&shard_id);
+        }
+    }
+}
+
+/// RAII guard for tracking an active snapshot recovery on the destination side.
+///
+/// While held, the recovery progress is registered in [`ActiveRecoveries`] so it can
+/// be reported in the transfer status. On drop - including early returns, errors, and
+/// cancellation - the entry is removed again, ensuring that stale recovery comments
+/// are never reported for subsequent transfers.
+pub struct ShardRecoveryGuard {
+    active_recoveries: ActiveRecoveries,
+    shard_id: ShardId,
+    progress: Arc<Mutex<RecoveryProgress>>,
+}
+
+impl ShardRecoveryGuard {
+    /// Shared recovery progress, used to update the current recovery stage.
+    pub fn progress(&self) -> &Arc<Mutex<RecoveryProgress>> {
+        &self.progress
+    }
+}
+
+impl Drop for ShardRecoveryGuard {
+    fn drop(&mut self) {
+        self.active_recoveries.remove(self.shard_id, &self.progress);
+    }
+}

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -560,6 +560,8 @@ async fn upload_shard_snapshot(
             snapshot_data,
             priority.unwrap_or_default(),
             RecoveryType::Full,
+            // Direct API recovery is not tracked as a transfer-side recovery
+            None,
             cancel,
         )
         .await?;
@@ -741,6 +743,8 @@ async fn recover_partial_snapshot(
             snapshot_data,
             priority.unwrap_or_default(),
             RecoveryType::Partial,
+            // Direct API recovery is not tracked as a transfer-side recovery
+            None,
             cancel,
         )
         .await?;
@@ -919,6 +923,8 @@ async fn recover_partial_snapshot_from(
             snapshot_data,
             SnapshotPriority::NoSync,
             RecoveryType::Partial,
+            // Direct API recovery is not tracked as a transfer-side recovery
+            None,
             cancel,
         )
         .await?;

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -312,6 +312,7 @@ pub async fn recover_shard_snapshot(
 /// # Cancel safety
 ///
 /// This function is *not* cancel safe.
+#[allow(clippy::too_many_arguments)]
 pub async fn recover_shard_snapshot_impl(
     toc: &TableOfContent,
     collection: &Collection,

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -187,8 +187,9 @@ pub async fn recover_shard_snapshot(
         let (collection, download_dir) =
             cancel::future::cancel_on_token(cancel.clone(), pre_recovery_task).await??;
 
-        // Once recovery tracking starts, `finish_shard_recovery` must run on all paths
-        let recovery_progress = collection
+        // Guard tracks recovery progress and removes it on drop, on every exit path
+        // (success, error, or cancellation), so stale timings are never reported.
+        let recovery_guard = collection
             .shards_holder()
             .read()
             .await
@@ -220,7 +221,8 @@ pub async fn recover_shard_snapshot(
                         return Err(StorageError::bad_input(description));
                     }
 
-                    recovery_progress
+                    recovery_guard
+                        .progress()
                         .lock()
                         .set_stage(RecoveryStage::Downloading);
 
@@ -297,12 +299,9 @@ pub async fn recover_shard_snapshot(
         )
         .await;
 
-        // Finish tracking recovery progress
-        collection
-            .shards_holder()
-            .read()
-            .await
-            .finish_shard_recovery(shard_id);
+        // `recovery_guard` is dropped here (and on every early return above),
+        // which stops tracking recovery progress for this shard.
+        drop(recovery_guard);
 
         result
     })

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -9,6 +9,7 @@ use collection::operations::snapshot_ops::{
 use collection::operations::verification::VerificationPass;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::shard::ShardId;
+use collection::shards::shard_holder::recovery_guard::RecoveryProgressHandle;
 use collection::shards::transfer::RecoveryStage;
 use shard::snapshots::snapshot_data::SnapshotData;
 use shard::snapshots::snapshot_manifest::{RecoveryType, SnapshotManifest};
@@ -221,10 +222,7 @@ pub async fn recover_shard_snapshot(
                         return Err(StorageError::bad_input(description));
                     }
 
-                    recovery_guard
-                        .progress()
-                        .lock()
-                        .set_stage(RecoveryStage::Downloading);
+                    recovery_guard.set_stage(RecoveryStage::Downloading);
 
                     let client = client.client(api_key.as_deref())?;
                     snapshots::download::download_snapshot(
@@ -295,6 +293,7 @@ pub async fn recover_shard_snapshot(
             snapshot_data,
             snapshot_priority,
             RecoveryType::Full,
+            Some(recovery_guard.progress_handle()),
             cancel,
         )
         .await;
@@ -320,6 +319,7 @@ pub async fn recover_shard_snapshot_impl(
     snapshot_data: SnapshotData,
     priority: SnapshotPriority,
     recovery_type: RecoveryType,
+    recovery_progress: Option<RecoveryProgressHandle>,
     cancel: cancel::CancellationToken,
 ) -> Result<(), StorageError> {
     let _recover_tracker_guard = toc
@@ -342,6 +342,7 @@ pub async fn recover_shard_snapshot_impl(
             toc.is_distributed(),
             // Default temporary path to storage dir, to allow faster recovery within the same volume
             &toc.optional_temp_or_storage_temp_path()?,
+            recovery_progress,
             cancel,
         )
         .await?


### PR DESCRIPTION
## Problem

When transferring shard snapshots between replicas, the transfer status "comment" can report **old timings for new transfers**, especially after a transfer was cancelled or failed.

The comment is assembled in `ShardHolder::get_shard_transfer_info`, which **prefers** the destination-side *recovery* comment over the sender's task status:

```rust
let recovery_comment = self.active_recoveries.lock().get(&target_shard)
    .and_then(|p| p.lock().format_comment());
let comment = recovery_comment.or_else(|| { /* sender task status */ });
```

Recovery progress lives in `active_recoveries`, keyed by shard id. Entries were added by `start_shard_recovery` and removed only by `finish_shard_recovery`, which in `recover_shard_snapshot` (`src/common/snapshots.rs`) was called **on the success path only**. The acknowledged contract — *"Once recovery tracking starts, `finish_shard_recovery` must run on all paths"* — was violated by two early-return paths:

1. `clear_local_shard_for_snapshot_recovery(shard_id).await?`
2. `cancel_on_token(cancel.clone(), download_task).await??` (download error/checksum mismatch, **or** cancellation — the future is spawned via `spawn_cancel_on_drop`)

On any of those, the `RecoveryProgress` entry leaked. Because `stage_elapsed_secs` is computed live from a fixed `Instant`, a leaked entry keeps reporting its last stage with an **ever-growing** elapsed time (e.g. `Downloading (3617.42s)`) for subsequent transfers of the same shard, until the next recovery overwrites it or the node restarts.

## Fix

Replace the manual `start_shard_recovery` / `finish_shard_recovery` pair with an RAII `ShardRecoveryGuard` returned by `start_shard_recovery`. Dropping the guard removes the progress entry, which happens on **every** exit path — success, error, and cancellation. The guard only removes its own entry (verified with `Arc::ptr_eq`), so it never clobbers a newer recovery that has already replaced it.

## Test plan

- `cargo check -p collection` and `cargo check --bin qdrant` pass
- `cargo clippy -p collection --lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)