### PR TITLE
fix(tests): deflake test_resharding_down_abort_converges_when_killed_mid_abort

### DIFF
--- a/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
+++ b/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
@@ -62,12 +62,21 @@ def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib
     alive_uri = peer_uris[next(i for i in range(len(peer_uris)) if i != victim_idx)]
     victim_uri = peer_uris[victim_idx]
 
-    # Wait until the victim itself has the transfer, so a later "gone" means the
-    # abort window, not a peer that simply hasn't applied the transfer start yet.
-    wait_for(
-        lambda: _resharding_transfer_source(get_collection_cluster_info(victim_uri, COLLECTION)) == from_peer_id,
-        wait_for_interval=0.05,
-    )
+    # Wait until BOTH the abort target and the victim have applied the transfer
+    # start. alive_uri must have it: the abort_transfer request below checks
+    # `check_transfer_exists` against alive_uri's *local* state and returns 404 if
+    # the transfer-start hasn't replicated there yet — and the fire-and-forget
+    # thread swallows that 404, so the transfer would just complete naturally and
+    # the abort window would never open. The victim must have it so that a later
+    # "gone" means the abort window, not a peer that simply hasn't applied the
+    # transfer start yet.
+    def _both_have_transfer() -> bool:
+        return all(
+            _resharding_transfer_source(get_collection_cluster_info(uri, COLLECTION)) == from_peer_id
+            for uri in (alive_uri, victim_uri)
+        )
+
+    wait_for(_both_have_transfer, wait_for_interval=0.05)
 
     # Fire-and-forget: the debug sleep makes the synchronous abort wait time out, but
     # the op still commits and applies on every peer.


### PR DESCRIPTION
## Problem

`test_resharding_down_abort_converges_when_killed_mid_abort` is flaky on CI:

```
Exception: Timeout waiting for condition _victim_in_window to be satisfied in 30 seconds
```

## Root cause

A consensus-replication race that the test silently swallows.

The test starts a resharding migrate-transfer, waits until the **victim** peer sees the transfer, then fires a fire-and-forget `abort_transfer` request at a **different** peer (`alive_uri`).

In the failing run:
- The abort `POST` hit `alive_uri` and returned **`404`** at `21:57:25.038`.
- `alive_uri` only applied the transfer-start consensus entry 3 ms later, at `21:57:25.041`.

The abort handler (`src/common/collections.rs:457`) validates against the receiving node's **local** state via `check_transfer_exists`. Since `alive_uri` hadn't replicated the transfer-start yet, it returned `404 not_found`. The fire-and-forget thread only catches `requests.RequestException` — a `404` *response* doesn't raise — so the failure was swallowed. The transfer then **completed naturally** (~9 s later), resharding was never aborted (driver disabled in tests), and the window the test polls for never opened → 30 s timeout.

The test bug: it waited for the **victim** to have the transfer but sent the abort to **`alive_uri`**, whose application of the transfer-start can lag.

## Fix

Wait until **both** `alive_uri` (the abort target that gates the 404) **and** the victim have applied the transfer-start before firing the abort. This closes the race while adding only milliseconds of wait, well within the transfer's ~9 s lifetime. Also replaces the victim-only lambda with a named helper for a clearer timeout message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)