### PR TITLE
Fix flaky resharding abort-crash test: batch the initial load

### DIFF
--- a/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
+++ b/tests/consensus_tests/test_resharding_down_abort_converges_after_crash.py
@@ -32,7 +32,11 @@ def test_resharding_down_abort_converges_when_killed_mid_abort(tmp_path: pathlib
 
     create_collection(peer_uris[0], collection=COLLECTION, shard_number=3, replication_factor=2)
     wait_collection_exists_and_active_on_all_peers(COLLECTION, peer_uris)
-    upsert_random_points(peer_uris[0], num=20_000, collection_name=COLLECTION)
+    # Batch the load: a single large `wait=true` upsert keeps a replica busy past
+    # the hardcoded 2s inter-node health-check under CI load, which fails the
+    # write with a transient "Healthcheck timeout 2000ms exceeded" before
+    # resharding even starts. 1000-point ops stay well under that threshold.
+    upsert_random_points(peer_uris[0], num=20_000, collection_name=COLLECTION, batch_size=1_000)
 
     resp = start_resharding(peer_uris[0], COLLECTION, direction="down", shard_key=None)
     assert_http_ok(resp)


### PR DESCRIPTION
## Problem

`test_resharding_down_abort_converges_when_killed_mid_abort` flakes on CI with:

```
408 ... Timeout: 1 out of 3 shards failed to apply operation.
First error: Deadline Exceeded ... "Healthcheck timeout 2000ms exceeded"
```

The failing request is the **initial data load** — a single 20,000-point `wait=true` upsert into a fresh 3-shard × 2-replica collection (before resharding even starts).

## Cause

When a coordinator forwards a write to a replica, `TransportChannelPool::make_request` races the request against a channel health-check with a hardcoded **2s `HEALTH_CHECK_TIMEOUT`** (`lib/api/src/grpc/transport_channel_pool.rs`). One 20k-point op keeps a replica busy (ingest + HNSW) well past 2s under CI CPU contention (the failure shows ~32s server-side), so it misses the health ping and the forward is failed as if the replica were dead.

This is **the only resharding test that does a 20k single-shot upsert** — the others load ~1k (or use `replication_factor=1`), which finishes far under 2s. That's why it flakes and they don't, rather than this being a generic issue.

## Fix

Batch the load at 1,000 points (`batch_size=1_000`), so each op stays well under the health-check window — the same effective pattern the stable resharding tests already use. Data, shard contents, and the `resharding_stream_records` transfer-in-flight behavior are unchanged (batching only changes how the 20k is written). One-line change; no retry needed and no shared-fixture change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)