### PR TITLE
feat(id_tracker): IncludeAll skips shadowed actives, deferred-aware lookups (PR C)

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -94,13 +94,18 @@ impl<'a> PointMappingsRefEnum<'a> {
     /// `deferred_behavior`:
     /// - [`DeferredBehavior::Exclude`] applies the mapping's own threshold;
     /// - [`DeferredBehavior::IncludeAll`] yields every point regardless of the
-    ///   threshold.
+    ///   threshold, but skips shadowed actives so each external id is
+    ///   yielded at most once (the deferred head takes precedence).
     pub fn iter_internal_with_behavior(
         self,
         deferred_behavior: DeferredBehavior,
     ) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
         if deferred_behavior.include_all_points() {
-            self.iter_internal()
+            let shadowed = self.shadowed();
+            Box::new(
+                self.iter_internal()
+                    .filter(move |&id| !shadowed.get_bit(id as usize).unwrap_or(false)),
+            )
         } else {
             self.iter_internal_visible()
         }
@@ -116,9 +121,14 @@ impl<'a> PointMappingsRefEnum<'a> {
     /// postings for tombstoned internal IDs (a single bit test per element,
     /// negligible overhead).
     ///
-    /// For [`DeferredBehavior::IncludeAll`] — or when the mapping has no
-    /// deferred threshold — the threshold cutoff is skipped, but the
-    /// deleted-bitslice filter is always applied.
+    /// For [`DeferredBehavior::Exclude`] — points at or above the cutoff are
+    /// dropped on top of the deleted check.
+    /// For [`DeferredBehavior::IncludeAll`] — every non-deleted point is
+    /// yielded, except shadowed actives (an active whose external id has
+    /// been overridden by a deferred mutation). Skipping shadowed actives
+    /// is what gives the IncludeAll consumer a one-yield-per-external
+    /// guarantee in the presence of append-only mutations into a deferred
+    /// segment.
     pub fn filter_deferred_and_deleted<I>(
         self,
         iter: I,
@@ -130,7 +140,11 @@ impl<'a> PointMappingsRefEnum<'a> {
         let deleted = self.deleted();
         match deferred_behavior.apply(self.deferred_internal_id()) {
             None => {
-                Either::Left(iter.filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false)))
+                let shadowed = self.shadowed();
+                Either::Left(iter.filter(move |&id| {
+                    !deleted.get_bit(id as usize).unwrap_or(false)
+                        && !shadowed.get_bit(id as usize).unwrap_or(false)
+                }))
             }
             Some(cutoff) => {
                 Either::Right(iter.filter(move |&id| {
@@ -191,6 +205,15 @@ impl<'a> PointMappingsRefEnum<'a> {
         match self {
             PointMappingsRefEnum::Plain(m) => m.deleted(),
             PointMappingsRefEnum::Compressed(m) => m.deleted(),
+        }
+    }
+
+    /// Shadowed-active bitslice for this mapping. Empty for compressed
+    /// mappings (immutable trackers can't carry deferred mutations).
+    fn shadowed(self) -> &'a BitSlice {
+        match self {
+            PointMappingsRefEnum::Plain(m) => m.shadowed_bitslice(),
+            PointMappingsRefEnum::Compressed(_) => BitSlice::empty(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -39,6 +39,21 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         }
     }
 
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        match self {
+            ReadOnlyIdTrackerEnum::Appendable(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
+            ReadOnlyIdTrackerEnum::Immutable(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
+        }
+    }
+
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.external_id(internal_id),

--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -42,6 +42,24 @@ impl IdTrackerRead for IdTrackerEnum {
         }
     }
 
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        match self {
+            IdTrackerEnum::MutableIdTracker(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
+            IdTrackerEnum::ImmutableIdTracker(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
+            IdTrackerEnum::InMemoryIdTracker(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
+        }
+    }
+
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         match self {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -134,6 +134,20 @@ pub trait IdTrackerRead {
     /// Excludes soft deleted points.
     fn internal_id(&self, external_id: PointIdType) -> Option<PointOffsetType>;
 
+    /// Returns the internal id of `external_id` under explicit deferred
+    /// semantics — see [`PointMappings::internal_id_with_behavior`].
+    ///
+    /// Default impl ignores the behavior argument so non-appendable
+    /// trackers (which never carry deferred mutations) keep their
+    /// previous semantics for free.
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        _deferred_behavior: DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        self.internal_id(external_id)
+    }
+
     /// Return external ID for internal point, defined by user
     ///
     /// Excludes soft deleted points.
@@ -226,20 +240,18 @@ pub trait IdTrackerRead {
         point_ids: &[PointIdType],
         deferred_behavior: DeferredBehavior,
     ) -> (Vec<PointIdType>, Vec<PointOffsetType>) {
-        // Non-appendable trackers never carry a deferred threshold (it's set
-        // only via `MutableIdTracker::open`, guarded by `appendable_flag` in
-        // the segment constructor), so we don't need an appendable check here.
-        let deferred_cutoff = deferred_behavior.apply(self.deferred_internal_id());
-
+        // For Exclude, the deferred-aware lookup returns the active head
+        // only — there's no need for the post-lookup cutoff filter the
+        // old impl carried. For IncludeAll, the lookup prefers the
+        // deferred head over a shadowed active so each ext yields its
+        // latest version exactly once.
         let mut ids = Vec::with_capacity(point_ids.len());
         let mut offsets = Vec::with_capacity(point_ids.len());
         for &point_id in point_ids {
-            let Some(internal_id) = self.internal_id(point_id) else {
+            let Some(internal_id) = self.internal_id_with_behavior(point_id, deferred_behavior)
+            else {
                 continue;
             };
-            if deferred_cutoff.is_some_and(|cutoff| internal_id >= cutoff) {
-                continue;
-            }
             ids.push(point_id);
             offsets.push(internal_id);
         }

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -68,6 +68,15 @@ impl IdTrackerRead for InMemoryIdTracker {
         self.mappings.internal_id(&external_id)
     }
 
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        self.mappings
+            .internal_id_with_behavior(&external_id, deferred_behavior)
+    }
+
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
     }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -179,6 +179,15 @@ impl IdTrackerRead for MutableIdTracker {
         self.mappings.internal_id(&external_id)
     }
 
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        self.mappings
+            .internal_id_with_behavior(&external_id, deferred_behavior)
+    }
+
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
     }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
@@ -18,6 +18,15 @@ impl IdTrackerRead for ReadOnlyAppendableIdTracker {
         self.mappings.internal_id(&external_id)
     }
 
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        self.mappings
+            .internal_id_with_behavior(&external_id, deferred_behavior)
+    }
+
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
     }

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -185,14 +185,43 @@ impl PointMappings {
     /// back to deferred — preserves "any matching id" semantics from before
     /// the split, where every ext lived in a single map.
     pub(crate) fn internal_id(&self, external_id: &PointIdType) -> Option<PointOffsetType> {
-        let active = match external_id {
+        let active = self.internal_id_active(external_id);
+        active.or_else(|| self.internal_id_deferred(external_id))
+    }
+
+    /// Internal id for `external_id` with explicit deferred semantics.
+    ///
+    /// - [`DeferredBehavior::Exclude`] returns the active head only. An ext
+    ///   that only has a deferred head returns `None` — query paths see no
+    ///   deferred mutations at all.
+    /// - [`DeferredBehavior::IncludeAll`] prefers the deferred head (the
+    ///   latest mutation) and falls back to active for points that never
+    ///   crossed the cutoff. Yields each ext at most once.
+    pub(crate) fn internal_id_with_behavior(
+        &self,
+        external_id: &PointIdType,
+        deferred_behavior: common::types::DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        if deferred_behavior.include_all_points() {
+            self.internal_id_deferred(external_id)
+                .or_else(|| self.internal_id_active(external_id))
+        } else {
+            self.internal_id_active(external_id)
+        }
+    }
+
+    fn internal_id_active(&self, external_id: &PointIdType) -> Option<PointOffsetType> {
+        match external_id {
             PointIdType::NumId(num) => self.external_to_internal_num.get(num).copied(),
             PointIdType::Uuid(uuid) => self.external_to_internal_uuid.get(uuid).copied(),
-        };
-        active.or_else(|| match external_id {
+        }
+    }
+
+    fn internal_id_deferred(&self, external_id: &PointIdType) -> Option<PointOffsetType> {
+        match external_id {
             PointIdType::NumId(num) => self.external_to_internal_num_deferred.get(num).copied(),
             PointIdType::Uuid(uuid) => self.external_to_internal_uuid_deferred.get(uuid).copied(),
-        })
+        }
     }
 
     pub(crate) fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
@@ -510,13 +539,9 @@ impl PointMappings {
             .unwrap_or(false)
     }
 
-    /// Read-only view of the shadowed bitslice — for callers that want to
-    /// pass it into pre-existing filter pipelines without going through
-    /// `is_shadowed` per element.
-    #[expect(
-        dead_code,
-        reason = "consumed by PR C's filter_deferred_and_deleted IncludeAll path"
-    )]
+    /// Read-only view of the shadowed bitslice — used by
+    /// `PointMappingsRefEnum::filter_deferred_and_deleted` in
+    /// [`DeferredBehavior::IncludeAll`] mode to skip shadowed actives.
     pub(crate) fn shadowed_bitslice(&self) -> &BitSlice {
         &self.shadowed
     }
@@ -749,6 +774,81 @@ mod set_link_shadow_tests {
         assert!(!m.is_shadowed(7));
         // Active-first lookup falls through to deferred.
         assert_eq!(m.internal_id(&ext(7)), Some(7));
+    }
+
+    #[test]
+    fn internal_id_with_behavior_prefers_deferred_on_include_all() {
+        use common::types::DeferredBehavior;
+
+        let mut m = fresh_mapping(Some(5));
+        m.set_link(ext(7), 2);
+        m.set_link(ext(7), 7);
+
+        // Exclude: visible-only — active head, even though it's shadowed.
+        assert_eq!(
+            m.internal_id_with_behavior(&ext(7), DeferredBehavior::Exclude),
+            Some(2)
+        );
+        // IncludeAll: the latest — the deferred head wins.
+        assert_eq!(
+            m.internal_id_with_behavior(&ext(7), DeferredBehavior::IncludeAll),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn internal_id_with_behavior_excludes_deferred_only_in_exclude() {
+        use common::types::DeferredBehavior;
+
+        // Fresh insert above the cutoff — no active head.
+        let mut m = fresh_mapping(Some(5));
+        m.set_link(ext(7), 7);
+
+        // Exclude readers never see deferred-only ext ids.
+        assert_eq!(
+            m.internal_id_with_behavior(&ext(7), DeferredBehavior::Exclude),
+            None
+        );
+        // IncludeAll consumers do.
+        assert_eq!(
+            m.internal_id_with_behavior(&ext(7), DeferredBehavior::IncludeAll),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn filter_deferred_and_deleted_skips_shadowed_on_include_all() {
+        use common::types::DeferredBehavior;
+
+        use crate::id_tracker::PointMappingsRefEnum;
+
+        // Cutoff = 5. Three points:
+        // - ext 7: active at 2, deferred at 7 (active shadowed)
+        // - ext 8: active at 3 only (never crossed cutoff)
+        // - ext 9: deferred at 8 only (fresh insert above cutoff)
+        let mut m = fresh_mapping(Some(5));
+        m.set_link(ext(7), 2);
+        m.set_link(ext(7), 7);
+        m.set_link(ext(8), 3);
+        m.set_link(ext(9), 8);
+
+        let r = PointMappingsRefEnum::Plain(&m);
+        let candidates: Vec<PointOffsetType> = vec![2, 3, 7, 8];
+
+        // Exclude: visible-only path — drops everything above cutoff.
+        let exclude: Vec<_> = r
+            .filter_deferred_and_deleted(candidates.iter().copied(), DeferredBehavior::Exclude)
+            .collect();
+        assert_eq!(exclude, vec![2, 3]);
+
+        // IncludeAll: every ext yields exactly one slot — its latest.
+        // Shadowed 2 (ext 7's stale active) is filtered out; 7 (its deferred
+        // head) is kept. Plain active 3 (ext 8) is kept. Deferred-only 8
+        // (ext 9) is kept.
+        let include_all: Vec<_> = r
+            .filter_deferred_and_deleted(candidates.iter().copied(), DeferredBehavior::IncludeAll)
+            .collect();
+        assert_eq!(include_all, vec![3, 7, 8]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Step 3 of the deferred-aware id tracker stack. PR B introduced the shadow bit on `set_link`; this PR teaches the read paths to honour it so the optimiser (and any other `DeferredBehavior::IncludeAll` consumer) sees each external id exactly once, with the deferred head winning over the now-shadowed active.

Stacked on **#9247** (PR B).

## What changes

- **`PointMappings::internal_id_with_behavior(ext, behavior)`**
  - `Exclude` → active head only (deferred-only ext → `None`).
  - `IncludeAll` → deferred head preferred, fallback active.
- **`IdTrackerRead::internal_id_with_behavior`** trait method with a default that delegates to `internal_id` — non-appendable trackers stay on their current semantics for free.
- **`PointMappingsRefEnum::iter_internal_with_behavior(IncludeAll)`** filters shadowed actives via the new `shadowed_bitslice()` accessor.
- **`PointMappingsRefEnum::filter_deferred_and_deleted(IncludeAll)`** also filters shadowed actives — single-yield-per-external for field-index/output iterators.
- **`resolve_external_ids`** uses the deferred-aware lookup; the old post-lookup `id >= cutoff` filter is gone — the lookup is correct at the source.

## What does **not** change yet

- No production Exclude path observably differs — queries still resolve via `internal_id` and the active head.
- The optimiser doesn't switch to `IncludeAll` here; that's a follow-up where it picks up the dedup automatically.
- No telemetry yet (PR D).

## Test plan

- [x] 3 new unit tests cover the new code paths:
  - IncludeAll prefers deferred over shadowed active;
  - Exclude returns None for deferred-only ext ids;
  - `filter_deferred_and_deleted` over a mixed candidate list yields Exclude→actives-below-cutoff, IncludeAll→every-head-no-shadowed.
- [x] All existing `id_tracker` tests pass.
- [x] `cargo check --all-targets` + `cargo clippy --all-targets` clean across the workspace.

## Next in the stack

- **PR D** — telemetry / counters. `available_point_count` semantics preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)