### PR TITLE
[TQDT] Turbo quant element

### DIFF
--- a/lib/quantization/src/lib.rs
+++ b/lib/quantization/src/lib.rs
@@ -17,6 +17,8 @@ pub use encoded_storage::{EncodedStorage, EncodedStorageBuilder};
 pub use encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 pub use encoded_vectors_pq::{EncodedQueryPQ, EncodedVectorsPQ};
 pub use encoded_vectors_u8::{EncodedQueryU8, EncodedVectorsU8};
+pub use turboquant::quantization::TurboQuantizer;
+pub use turboquant::{EncodedQueryTQ, TQBits, TQMode};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum EncodingError {

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -176,7 +176,7 @@ impl TurboQuantizer {
 
     /// Total size in bytes of a quantized vector, including both the packed
     /// dimensions and any extras..
-    pub fn quantized_size_for(
+    pub(crate) fn quantized_size_for(
         dim: usize,
         bits: TQBits,
         distance: DistanceType,

--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -176,7 +176,7 @@ impl TurboQuantizer {
 
     /// Total size in bytes of a quantized vector, including both the packed
     /// dimensions and any extras..
-    pub(crate) fn quantized_size_for(
+    pub fn quantized_size_for(
         dim: usize,
         bits: TQBits,
         distance: DistanceType,

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -121,6 +121,30 @@ impl TurboQuantizer {
         })
     }
 
+    /// Like [`Self::new`], but builds a forward-only rotation that skips the
+    /// O(`dim`) per-permutation warm-up [`Self::new`] pays to enable inversion.
+    /// Cheaper to construct, but the resulting quantizer only supports the
+    /// forward (encode/quantize) path — never call
+    /// [`Self::apply_inverse_rotation`] on it.
+    pub fn new_fast_forward(
+        dim: usize,
+        bits: TQBits,
+        mode: TQMode,
+        distance: DistanceType,
+        error_correction: Option<ErrorCorrection>,
+    ) -> Self {
+        let padded_dim = Self::padded_dim(dim, bits);
+        let rotation = HadamardRotation::new_fast_forward(padded_dim);
+        TurboQuantizer {
+            rotation,
+            bits,
+            mode,
+            distance,
+            padded_dim,
+            error_correction,
+        }
+    }
+
     /// Initialize a new TurboQuantizer.
     pub fn new(
         dim: usize,

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -141,6 +141,14 @@ impl TurboQuantizer {
         }
     }
 
+    pub fn quantize_buffer_len(&self) -> usize {
+        self.padded_dim
+    }
+
+    pub fn apply_inverse_rotation(&self, buf: &mut [f64]) {
+        self.rotation.apply_inverse(buf);
+    }
+
     /// Pad, rotate, and length-rescale `vec` into `buf`. After this call `buf`
     /// holds rotated coordinates whose per-vector L2 norm is `sqrt(padded_dim)`,
     /// matching the Lloyd-Max N(0, 1) centroid grid. Returns the original L2

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -165,6 +165,28 @@ impl TurboQuantizer {
         }
     }
 
+    /// Initialize a quantizer for vectors already encoded into fixed-size slots
+    /// of `quantized_size` bytes (packed codebook data plus the metric-specific
+    /// extras trailer). Recovers the padded dimension from the slot size — for
+    /// scoring paths that only carry the on-storage slot, not the logical
+    /// vector dimension.
+    pub fn new_from_quantized_size(
+        quantized_size: usize,
+        bits: TQBits,
+        mode: TQMode,
+        distance: DistanceType,
+    ) -> Self {
+        let extras_size = TqVectorExtras::size_for(bits, distance, mode);
+        let packed_bytes = quantized_size
+            .checked_sub(extras_size)
+            .expect("quantized size shorter than TurboQuant extras trailer");
+        // `packed_bytes = padded_dim * bit_size / 8`; invert to recover the
+        // padded dimension (exact, since `padded_dim * bit_size` is a multiple
+        // of 8 by construction).
+        let padded_dim = packed_bytes * u8::BITS as usize / bits.bit_size() as usize;
+        Self::new(padded_dim, bits, mode, distance, None)
+    }
+
     pub fn quantize_buffer_len(&self) -> usize {
         self.padded_dim
     }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -26,6 +26,13 @@ impl HadamardRotation {
         Self { permutations, dim }
     }
 
+    pub fn new_fast_forward(dim: usize) -> Self {
+        let permutations: [_; N_PERMUTATIONS] =
+            std::array::from_fn(|index| Permutation::new_one_way(PERMUTATION_SEEDS[index], dim));
+
+        Self { permutations, dim }
+    }
+
     pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
         apply_rotation_with_permutations(x, &self.permutations);

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use bytemuck::Pod;
+use bytemuck::{Pod, Zeroable};
 use half::f16;
 use itertools::Itertools;
+use quantization::{DistanceType, EncodedQueryTQ, TQBits, TQMode, TurboQuantizer};
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -22,11 +23,14 @@ where
 {
     type QueryType;
 
-    fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]>;
+    fn slice_from_float_cow(vector: Cow<[VectorElementType]>, distance: Distance) -> Cow<[Self]>;
 
-    fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]>;
+    fn slice_to_float_cow(vector: Cow<[Self]>, distance: Distance) -> Cow<[VectorElementType]>;
 
-    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType;
+    fn query_from_float_cow(
+        vector: Cow<[VectorElementType]>,
+        distance: Distance,
+    ) -> Self::QueryType;
 
     fn quantization_preprocess<'a>(
         quantization_config: &QuantizationConfig,
@@ -48,15 +52,18 @@ where
 impl PrimitiveVectorElement for VectorElementType {
     type QueryType = TypedDenseVector<Self>;
 
-    fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
+    fn slice_from_float_cow(vector: Cow<[VectorElementType]>, _distance: Distance) -> Cow<[Self]> {
         vector
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
         vector
     }
 
-    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+    fn query_from_float_cow(
+        vector: Cow<[VectorElementType]>,
+        _distance: Distance,
+    ) -> Self::QueryType {
         TypedDenseVector::from(vector)
     }
 
@@ -88,15 +95,18 @@ impl PrimitiveVectorElement for VectorElementType {
 impl PrimitiveVectorElement for VectorElementTypeHalf {
     type QueryType = TypedDenseVector<Self>;
 
-    fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
+    fn slice_from_float_cow(vector: Cow<[VectorElementType]>, _distance: Distance) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| f16::from_f32(x)).collect())
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
         Cow::Owned(vector.iter().map(|&x| f16::to_f32(x)).collect_vec())
     }
 
-    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+    fn query_from_float_cow(
+        vector: Cow<[VectorElementType]>,
+        _distance: Distance,
+    ) -> Self::QueryType {
         TypedDenseVector::from(vector.iter().map(|&x| f16::from_f32(x)).collect::<Vec<_>>())
     }
 
@@ -144,11 +154,11 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
 impl PrimitiveVectorElement for VectorElementTypeByte {
     type QueryType = TypedDenseVector<Self>;
 
-    fn slice_from_float_cow(vector: Cow<[VectorElementType]>) -> Cow<[Self]> {
+    fn slice_from_float_cow(vector: Cow<[VectorElementType]>, _distance: Distance) -> Cow<[Self]> {
         Cow::Owned(vector.iter().map(|&x| x as u8).collect())
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
         Cow::Owned(
             vector
                 .iter()
@@ -157,7 +167,10 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
         )
     }
 
-    fn query_from_float_cow(vector: Cow<[VectorElementType]>) -> Self::QueryType {
+    fn query_from_float_cow(
+        vector: Cow<[VectorElementType]>,
+        _distance: Distance,
+    ) -> Self::QueryType {
         TypedDenseVector::from(vector.iter().map(|&x| x as u8).collect::<Vec<_>>())
     }
 
@@ -213,4 +226,115 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
             multivector.as_vec_ref().dim,
         ))
     }
+}
+
+const TQ_BITS: TQBits = TQBits::Bits4;
+const TQ_MODE: TQMode = TQMode::Normal;
+
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    FromBytes,
+    IntoBytes,
+    Immutable,
+    KnownLayout,
+    Zeroable,
+    Pod,
+)]
+#[repr(transparent)]
+pub struct TurboQuantElement(pub u8);
+
+impl PrimitiveVectorElement for TurboQuantElement {
+    type QueryType = EncodedQueryTQ;
+
+    fn slice_from_float_cow(vector: Cow<[VectorElementType]>, distance: Distance) -> Cow<[Self]> {
+        let api_dim = vector.len();
+        let quantizer = TurboQuantizer::new(
+            api_dim,
+            TQ_BITS,
+            TQ_MODE,
+            DistanceType::from(distance),
+            None,
+        );
+        let mut buf = vec![0.0_f64; quantizer.quantize_buffer_len()];
+        let bytes = quantizer.quantize(&vector, &mut buf);
+        Cow::Owned(bytemuck::allocation::cast_vec(bytes))
+    }
+
+    fn slice_to_float_cow(vector: Cow<[Self]>, distance: Distance) -> Cow<[VectorElementType]> {
+        decode_tq(&vector, distance)
+    }
+
+    fn query_from_float_cow(
+        vector: Cow<[VectorElementType]>,
+        distance: Distance,
+    ) -> Self::QueryType {
+        let api_dim = vector.len();
+        let quantizer = TurboQuantizer::new(
+            api_dim,
+            TQ_BITS,
+            TQ_MODE,
+            DistanceType::from(distance),
+            None,
+        );
+        quantizer.precompute_query(&vector)
+    }
+
+    fn quantization_preprocess<'a>(
+        _quantization_config: &QuantizationConfig,
+        distance: Distance,
+        vector: Cow<'a, [Self]>,
+    ) -> Cow<'a, [f32]> {
+        decode_tq(&vector, distance)
+    }
+
+    fn datatype() -> VectorStorageDatatype {
+        VectorStorageDatatype::Uint8
+    }
+
+    fn from_float_multivector(
+        _multivector: CowMultiVector<VectorElementType>,
+    ) -> CowMultiVector<Self> {
+        unimplemented!("TurboQuantElement::from_float_multivector")
+    }
+
+    fn into_float_multivector(
+        _multivector: CowMultiVector<Self>,
+    ) -> CowMultiVector<VectorElementType> {
+        unimplemented!("TurboQuantElement::into_float_multivector")
+    }
+}
+
+pub(crate) fn quantizer_for_tq_slot(slot_len: usize, distance: Distance) -> TurboQuantizer {
+    let tq_distance = DistanceType::from(distance);
+    let extras_size = TurboQuantizer::quantized_size_for(0, TQ_BITS, tq_distance, TQ_MODE);
+    let packed_bytes = slot_len
+        .checked_sub(extras_size)
+        .expect("slot shorter than TurboQuant extras trailer");
+    let padded_dim = padded_bytes_to_dim(packed_bytes);
+    TurboQuantizer::new(padded_dim, TQ_BITS, TQ_MODE, tq_distance, None)
+}
+
+fn decode_tq(
+    vector: &[TurboQuantElement],
+    distance: Distance,
+) -> Cow<'static, [VectorElementType]> {
+    let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+    let bytes: &[u8] = bytemuck::cast_slice(vector);
+    let mut deq = quantizer.dequantize(bytes);
+    quantizer.apply_inverse_rotation(&mut deq);
+    Cow::Owned(deq.into_iter().map(|x| x as f32).collect())
+}
+
+fn padded_bytes_to_dim(packed_bytes: usize) -> usize {
+    let extras = TurboQuantizer::quantized_size_for(0, TQ_BITS, DistanceType::Cosine, TQ_MODE);
+    let probe_dim = 64;
+    let probe_packed =
+        TurboQuantizer::quantized_size_for(probe_dim, TQ_BITS, DistanceType::Cosine, TQ_MODE)
+            - extras;
+    packed_bytes * probe_dim / probe_packed
 }

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -270,7 +270,7 @@ impl PrimitiveVectorElement for TurboQuantElement {
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>, distance: Distance) -> Cow<[Self]> {
         let api_dim = vector.len();
-        let quantizer = TurboQuantizer::new(
+        let quantizer = TurboQuantizer::new_fast_forward(
             api_dim,
             TQBits::Bits4,
             TQMode::Normal,
@@ -306,7 +306,7 @@ impl PrimitiveVectorElement for TurboQuantElement {
         distance: Distance,
     ) -> Self::QueryType {
         let api_dim = vector.len();
-        let quantizer = TurboQuantizer::new(
+        let quantizer = TurboQuantizer::new_fast_forward(
             api_dim,
             TQBits::Bits4,
             TQMode::Normal,

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -25,7 +25,11 @@ where
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>, distance: Distance) -> Cow<[Self]>;
 
-    fn slice_to_float_cow(vector: Cow<[Self]>, distance: Distance) -> Cow<[VectorElementType]>;
+    fn slice_to_float_cow(
+        vector: Cow<[Self]>,
+        distance: Distance,
+        dim: usize,
+    ) -> Cow<[VectorElementType]>;
 
     fn query_from_float_cow(
         vector: Cow<[VectorElementType]>,
@@ -36,6 +40,7 @@ where
         quantization_config: &QuantizationConfig,
         distance: Distance,
         vector: Cow<'a, [Self]>,
+        dim: usize,
     ) -> Cow<'a, [f32]>;
 
     fn datatype() -> VectorStorageDatatype;
@@ -56,7 +61,11 @@ impl PrimitiveVectorElement for VectorElementType {
         vector
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(
+        vector: Cow<[Self]>,
+        _distance: Distance,
+        _dim: usize,
+    ) -> Cow<[VectorElementType]> {
         vector
     }
 
@@ -71,6 +80,7 @@ impl PrimitiveVectorElement for VectorElementType {
         _quantization_config: &QuantizationConfig,
         _distance: Distance,
         vector: Cow<'a, [Self]>,
+        _dim: usize,
     ) -> Cow<'a, [f32]> {
         vector
     }
@@ -99,7 +109,11 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
         Cow::Owned(vector.iter().map(|&x| f16::from_f32(x)).collect())
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(
+        vector: Cow<[Self]>,
+        _distance: Distance,
+        _dim: usize,
+    ) -> Cow<[VectorElementType]> {
         Cow::Owned(vector.iter().map(|&x| f16::to_f32(x)).collect_vec())
     }
 
@@ -114,6 +128,7 @@ impl PrimitiveVectorElement for VectorElementTypeHalf {
         _quantization_config: &QuantizationConfig,
         _distance: Distance,
         vector: Cow<'a, [Self]>,
+        _dim: usize,
     ) -> Cow<'a, [f32]> {
         Cow::Owned(vector.iter().map(|&x| f16::to_f32(x)).collect_vec())
     }
@@ -158,7 +173,11 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
         Cow::Owned(vector.iter().map(|&x| x as u8).collect())
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>, _distance: Distance) -> Cow<[VectorElementType]> {
+    fn slice_to_float_cow(
+        vector: Cow<[Self]>,
+        _distance: Distance,
+        _dim: usize,
+    ) -> Cow<[VectorElementType]> {
         Cow::Owned(
             vector
                 .iter()
@@ -178,6 +197,7 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
         quantization_config: &QuantizationConfig,
         distance: Distance,
         vector: Cow<'a, [Self]>,
+        _dim: usize,
     ) -> Cow<'a, [f32]> {
         if let QuantizationConfig::Binary(_) = quantization_config {
             Cow::Owned(
@@ -262,15 +282,22 @@ impl PrimitiveVectorElement for TurboQuantElement {
         Cow::Owned(bytemuck::allocation::cast_vec(bytes))
     }
 
-    fn slice_to_float_cow(vector: Cow<[Self]>, distance: Distance) -> Cow<[VectorElementType]> {
-        // Output length is `padded_dim` — caller (storage layer with access to
-        // the original `api_dim`) is expected to trim before exposing to API.
-        let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+    fn slice_to_float_cow(
+        vector: Cow<[Self]>,
+        distance: Distance,
+        dim: usize,
+    ) -> Cow<[VectorElementType]> {
+        let quantizer = TurboQuantizer::new(
+            dim,
+            TQBits::Bits4,
+            TQMode::Normal,
+            DistanceType::from(distance),
+            None,
+        );
         let slice: &[Self] = &vector;
         let mut deq = quantizer.dequantize(bytemuck::cast_slice(slice));
-        // Revert the Hadamard rotation so the floats come back in the original
-        // (un-rotated) basis expected by the API.
         quantizer.apply_inverse_rotation(&mut deq);
+        deq.truncate(dim);
         Cow::Owned(deq.into_iter().map(|x| x as f32).collect())
     }
 
@@ -293,15 +320,15 @@ impl PrimitiveVectorElement for TurboQuantElement {
         _quantization_config: &QuantizationConfig,
         distance: Distance,
         vector: Cow<'a, [Self]>,
+        dim: usize,
     ) -> Cow<'a, [f32]> {
-        // Unlike `slice_to_float_cow`, we generally skip the inverse rotation:
-        // the downstream quantizer re-applies its own rotation, so handing it
-        // the already-rotated coordinates avoids a redundant round-trip. This
-        // only holds for rotation-invariant metrics (L2/Cosine/Dot) — Manhattan
-        // (L1) is rotation-sensitive, so there we must revert to the original
-        // basis. Output length is `padded_dim`; the quantization pipeline
-        // truncates to `api_dim` before encoding.
-        let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+        let quantizer = TurboQuantizer::new(
+            dim,
+            TQBits::Bits4,
+            TQMode::Normal,
+            DistanceType::from(distance),
+            None,
+        );
         let slice: &[Self] = &vector;
         let mut deq = quantizer.dequantize(bytemuck::cast_slice(slice));
         if distance == Distance::Manhattan {

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -293,7 +293,7 @@ impl PrimitiveVectorElement for TurboQuantElement {
     }
 
     fn datatype() -> VectorStorageDatatype {
-        VectorStorageDatatype::Uint8
+        VectorStorageDatatype::Turbo4
     }
 
     fn from_float_multivector(

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -353,27 +353,3 @@ impl PrimitiveVectorElement for TurboQuantElement {
         unimplemented!("TurboQuantElement::into_float_multivector")
     }
 }
-
-pub(crate) fn quantizer_for_tq_slot(slot_len: usize, distance: Distance) -> TurboQuantizer {
-    let tq_distance = DistanceType::from(distance);
-    let extras_size =
-        TurboQuantizer::quantized_size_for(0, TQBits::Bits4, tq_distance, TQMode::Normal);
-    let packed_bytes = slot_len
-        .checked_sub(extras_size)
-        .expect("slot shorter than TurboQuant extras trailer");
-    let padded_dim = padded_bytes_to_dim(packed_bytes);
-    TurboQuantizer::new(padded_dim, TQBits::Bits4, TQMode::Normal, tq_distance, None)
-}
-
-fn padded_bytes_to_dim(packed_bytes: usize) -> usize {
-    let extras =
-        TurboQuantizer::quantized_size_for(0, TQBits::Bits4, DistanceType::Cosine, TQMode::Normal);
-    let probe_dim = 64;
-    let probe_packed = TurboQuantizer::quantized_size_for(
-        probe_dim,
-        TQBits::Bits4,
-        DistanceType::Cosine,
-        TQMode::Normal,
-    ) - extras;
-    packed_bytes * probe_dim / probe_packed
-}

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -228,9 +228,6 @@ impl PrimitiveVectorElement for VectorElementTypeByte {
     }
 }
 
-const TQ_BITS: TQBits = TQBits::Bits4;
-const TQ_MODE: TQMode = TQMode::Normal;
-
 #[derive(
     Clone,
     Copy,
@@ -255,8 +252,8 @@ impl PrimitiveVectorElement for TurboQuantElement {
         let api_dim = vector.len();
         let quantizer = TurboQuantizer::new(
             api_dim,
-            TQ_BITS,
-            TQ_MODE,
+            TQBits::Bits4,
+            TQMode::Normal,
             DistanceType::from(distance),
             None,
         );
@@ -266,7 +263,15 @@ impl PrimitiveVectorElement for TurboQuantElement {
     }
 
     fn slice_to_float_cow(vector: Cow<[Self]>, distance: Distance) -> Cow<[VectorElementType]> {
-        decode_tq(&vector, distance)
+        // Output length is `padded_dim` — caller (storage layer with access to
+        // the original `api_dim`) is expected to trim before exposing to API.
+        let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+        let slice: &[Self] = &vector;
+        let mut deq = quantizer.dequantize(bytemuck::cast_slice(slice));
+        // Revert the Hadamard rotation so the floats come back in the original
+        // (un-rotated) basis expected by the API.
+        quantizer.apply_inverse_rotation(&mut deq);
+        Cow::Owned(deq.into_iter().map(|x| x as f32).collect())
     }
 
     fn query_from_float_cow(
@@ -276,8 +281,8 @@ impl PrimitiveVectorElement for TurboQuantElement {
         let api_dim = vector.len();
         let quantizer = TurboQuantizer::new(
             api_dim,
-            TQ_BITS,
-            TQ_MODE,
+            TQBits::Bits4,
+            TQMode::Normal,
             DistanceType::from(distance),
             None,
         );
@@ -289,7 +294,20 @@ impl PrimitiveVectorElement for TurboQuantElement {
         distance: Distance,
         vector: Cow<'a, [Self]>,
     ) -> Cow<'a, [f32]> {
-        decode_tq(&vector, distance)
+        // Unlike `slice_to_float_cow`, we generally skip the inverse rotation:
+        // the downstream quantizer re-applies its own rotation, so handing it
+        // the already-rotated coordinates avoids a redundant round-trip. This
+        // only holds for rotation-invariant metrics (L2/Cosine/Dot) — Manhattan
+        // (L1) is rotation-sensitive, so there we must revert to the original
+        // basis. Output length is `padded_dim`; the quantization pipeline
+        // truncates to `api_dim` before encoding.
+        let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+        let slice: &[Self] = &vector;
+        let mut deq = quantizer.dequantize(bytemuck::cast_slice(slice));
+        if distance == Distance::Manhattan {
+            quantizer.apply_inverse_rotation(&mut deq);
+        }
+        Cow::Owned(deq.into_iter().map(|x| x as f32).collect())
     }
 
     fn datatype() -> VectorStorageDatatype {
@@ -311,30 +329,24 @@ impl PrimitiveVectorElement for TurboQuantElement {
 
 pub(crate) fn quantizer_for_tq_slot(slot_len: usize, distance: Distance) -> TurboQuantizer {
     let tq_distance = DistanceType::from(distance);
-    let extras_size = TurboQuantizer::quantized_size_for(0, TQ_BITS, tq_distance, TQ_MODE);
+    let extras_size =
+        TurboQuantizer::quantized_size_for(0, TQBits::Bits4, tq_distance, TQMode::Normal);
     let packed_bytes = slot_len
         .checked_sub(extras_size)
         .expect("slot shorter than TurboQuant extras trailer");
     let padded_dim = padded_bytes_to_dim(packed_bytes);
-    TurboQuantizer::new(padded_dim, TQ_BITS, TQ_MODE, tq_distance, None)
-}
-
-fn decode_tq(
-    vector: &[TurboQuantElement],
-    distance: Distance,
-) -> Cow<'static, [VectorElementType]> {
-    let quantizer = quantizer_for_tq_slot(vector.len(), distance);
-    let bytes: &[u8] = bytemuck::cast_slice(vector);
-    let mut deq = quantizer.dequantize(bytes);
-    quantizer.apply_inverse_rotation(&mut deq);
-    Cow::Owned(deq.into_iter().map(|x| x as f32).collect())
+    TurboQuantizer::new(padded_dim, TQBits::Bits4, TQMode::Normal, tq_distance, None)
 }
 
 fn padded_bytes_to_dim(packed_bytes: usize) -> usize {
-    let extras = TurboQuantizer::quantized_size_for(0, TQ_BITS, DistanceType::Cosine, TQ_MODE);
+    let extras =
+        TurboQuantizer::quantized_size_for(0, TQBits::Bits4, DistanceType::Cosine, TQMode::Normal);
     let probe_dim = 64;
-    let probe_packed =
-        TurboQuantizer::quantized_size_for(probe_dim, TQ_BITS, DistanceType::Cosine, TQ_MODE)
-            - extras;
+    let probe_packed = TurboQuantizer::quantized_size_for(
+        probe_dim,
+        TQBits::Bits4,
+        DistanceType::Cosine,
+        TQMode::Normal,
+    ) - extras;
     packed_bytes * probe_dim / probe_packed
 }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -507,6 +507,7 @@ impl GpuVectorStorage {
                 (0..vector_storage.total_vector_count()).map(|id| {
                     VectorElementTypeHalf::slice_from_float_cow(
                         vector_storage.get_dense::<Random>(id as PointOffsetType),
+                        vector_storage.distance(),
                     )
                 }),
                 None,
@@ -535,6 +536,7 @@ impl GpuVectorStorage {
                 (0..vector_storage.total_vector_count()).map(|id| {
                     VectorElementTypeHalf::slice_to_float_cow(
                         vector_storage.get_dense::<Random>(id as PointOffsetType),
+                        vector_storage.distance(),
                     )
                 }),
                 None,
@@ -583,9 +585,9 @@ impl GpuVectorStorage {
                     .sum(),
                 vector_storage.total_vector_count(),
                 vector_storage.vector_dim(),
-                vector_storage
-                    .iterate_inner_vectors()
-                    .map(|vector| VectorElementTypeHalf::slice_from_float_cow(vector)),
+                vector_storage.iterate_inner_vectors().map(|vector| {
+                    VectorElementTypeHalf::slice_from_float_cow(vector, vector_storage.distance())
+                }),
                 None,
                 Some(GpuMultivectors::new_multidense(device, vector_storage)?),
                 stopped,
@@ -616,9 +618,9 @@ impl GpuVectorStorage {
                     .sum(),
                 vector_storage.total_vector_count(),
                 vector_storage.vector_dim(),
-                vector_storage
-                    .iterate_inner_vectors()
-                    .map(|vector| VectorElementTypeHalf::slice_to_float_cow(vector)),
+                vector_storage.iterate_inner_vectors().map(|vector| {
+                    VectorElementTypeHalf::slice_to_float_cow(vector, vector_storage.distance())
+                }),
                 None,
                 Some(GpuMultivectors::new_multidense(device, vector_storage)?),
                 stopped,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -537,6 +537,7 @@ impl GpuVectorStorage {
                     VectorElementTypeHalf::slice_to_float_cow(
                         vector_storage.get_dense::<Random>(id as PointOffsetType),
                         vector_storage.distance(),
+                        vector_storage.vector_dim(),
                     )
                 }),
                 None,
@@ -619,7 +620,11 @@ impl GpuVectorStorage {
                 vector_storage.total_vector_count(),
                 vector_storage.vector_dim(),
                 vector_storage.iterate_inner_vectors().map(|vector| {
-                    VectorElementTypeHalf::slice_to_float_cow(vector, vector_storage.distance())
+                    VectorElementTypeHalf::slice_to_float_cow(
+                        vector,
+                        vector_storage.distance(),
+                        vector_storage.vector_dim(),
+                    )
                 }),
                 None,
                 Some(GpuMultivectors::new_multidense(device, vector_storage)?),

--- a/lib/segment/src/spaces/metric_tq.rs
+++ b/lib/segment/src/spaces/metric_tq.rs
@@ -1,0 +1,106 @@
+use common::types::ScoreType;
+use quantization::EncodedQueryTQ;
+
+use crate::data_types::primitive::{TurboQuantElement, quantizer_for_tq_slot};
+use crate::data_types::vectors::{DenseVector, VectorElementType};
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
+use crate::types::Distance;
+
+fn turbo_score_symmetric(
+    v1: &[TurboQuantElement],
+    v2: &[TurboQuantElement],
+    distance: Distance,
+) -> ScoreType {
+    debug_assert_eq!(
+        v1.len(),
+        v2.len(),
+        "TurboQuant symmetric score requires matching slot lengths"
+    );
+    let quantizer = quantizer_for_tq_slot(v1.len(), distance);
+    let v1_bytes: &[u8] = bytemuck::cast_slice(v1);
+    let v2_bytes: &[u8] = bytemuck::cast_slice(v2);
+    quantizer.score_symmetric(v1_bytes, v2_bytes)
+}
+
+fn turbo_score_precomputed(
+    query: &EncodedQueryTQ,
+    vector: &[TurboQuantElement],
+    distance: Distance,
+) -> ScoreType {
+    let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+    let bytes: &[u8] = bytemuck::cast_slice(vector);
+    quantizer.score_precomputed(query, bytes)
+}
+
+impl Metric<TurboQuantElement> for CosineMetric {
+    fn distance() -> Distance {
+        Distance::Cosine
+    }
+
+    fn similarity(v1: &[TurboQuantElement], v2: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_symmetric(v1, v2, Distance::Cosine)
+    }
+
+    fn query_similarity(query: &EncodedQueryTQ, vector: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_precomputed(query, vector, Distance::Cosine)
+    }
+
+    fn preprocess(vector: DenseVector) -> DenseVector {
+        <CosineMetric as Metric<VectorElementType>>::preprocess(vector)
+    }
+}
+
+impl Metric<TurboQuantElement> for EuclidMetric {
+    fn distance() -> Distance {
+        Distance::Euclid
+    }
+
+    fn similarity(v1: &[TurboQuantElement], v2: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_symmetric(v1, v2, Distance::Euclid)
+    }
+
+    fn query_similarity(query: &EncodedQueryTQ, vector: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_precomputed(query, vector, Distance::Euclid)
+    }
+
+    fn preprocess(vector: DenseVector) -> DenseVector {
+        <EuclidMetric as Metric<VectorElementType>>::preprocess(vector)
+    }
+}
+
+impl Metric<TurboQuantElement> for DotProductMetric {
+    fn distance() -> Distance {
+        Distance::Dot
+    }
+
+    fn similarity(v1: &[TurboQuantElement], v2: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_symmetric(v1, v2, Distance::Dot)
+    }
+
+    fn query_similarity(query: &EncodedQueryTQ, vector: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_precomputed(query, vector, Distance::Dot)
+    }
+
+    fn preprocess(vector: DenseVector) -> DenseVector {
+        <DotProductMetric as Metric<VectorElementType>>::preprocess(vector)
+    }
+}
+
+impl Metric<TurboQuantElement> for ManhattanMetric {
+    fn distance() -> Distance {
+        Distance::Manhattan
+    }
+
+    fn similarity(v1: &[TurboQuantElement], v2: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_symmetric(v1, v2, Distance::Manhattan)
+    }
+
+    fn query_similarity(query: &EncodedQueryTQ, vector: &[TurboQuantElement]) -> ScoreType {
+        turbo_score_precomputed(query, vector, Distance::Manhattan)
+    }
+
+    fn preprocess(vector: DenseVector) -> DenseVector {
+        <ManhattanMetric as Metric<VectorElementType>>::preprocess(vector)
+    }
+}

--- a/lib/segment/src/spaces/metric_tq.rs
+++ b/lib/segment/src/spaces/metric_tq.rs
@@ -1,7 +1,7 @@
 use common::types::ScoreType;
-use quantization::EncodedQueryTQ;
+use quantization::{DistanceType, EncodedQueryTQ, TQBits, TQMode, TurboQuantizer};
 
-use crate::data_types::primitive::{TurboQuantElement, quantizer_for_tq_slot};
+use crate::data_types::primitive::TurboQuantElement;
 use crate::data_types::vectors::{DenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
@@ -17,7 +17,12 @@ fn turbo_score_symmetric(
         v2.len(),
         "TurboQuant symmetric score requires matching slot lengths"
     );
-    let quantizer = quantizer_for_tq_slot(v1.len(), distance);
+    let quantizer = TurboQuantizer::new_from_quantized_size(
+        v1.len(),
+        TQBits::Bits4,
+        TQMode::Normal,
+        DistanceType::from(distance),
+    );
     let v1_bytes: &[u8] = bytemuck::cast_slice(v1);
     let v2_bytes: &[u8] = bytemuck::cast_slice(v2);
     quantizer.score_symmetric(v1_bytes, v2_bytes)
@@ -28,7 +33,12 @@ fn turbo_score_precomputed(
     vector: &[TurboQuantElement],
     distance: Distance,
 ) -> ScoreType {
-    let quantizer = quantizer_for_tq_slot(vector.len(), distance);
+    let quantizer = TurboQuantizer::new_from_quantized_size(
+        vector.len(),
+        TQBits::Bits4,
+        TQMode::Normal,
+        DistanceType::from(distance),
+    );
     let bytes: &[u8] = bytemuck::cast_slice(vector);
     quantizer.score_precomputed(query, bytes)
 }

--- a/lib/segment/src/spaces/metric_uint/simple_euclid.rs
+++ b/lib/segment/src/spaces/metric_uint/simple_euclid.rs
@@ -88,8 +88,10 @@ mod tests {
         let dense_vector = DenseVector::from(vec![-10.0, 1.0, 2.0, 3.0, 255., 300.]);
         let preprocessed_vector =
             <EuclidMetric as Metric<VectorElementType>>::preprocess(dense_vector);
-        let typed_dense_vector =
-            VectorElementTypeByte::slice_from_float_cow(Cow::from(preprocessed_vector));
+        let typed_dense_vector = VectorElementTypeByte::slice_from_float_cow(
+            Cow::from(preprocessed_vector),
+            Distance::Euclid,
+        );
         let expected: TypedDenseVector<VectorElementTypeByte> = vec![0, 1, 2, 3, 255, 255];
         assert_eq!(typed_dense_vector, expected);
     }

--- a/lib/segment/src/spaces/mod.rs
+++ b/lib/segment/src/spaces/mod.rs
@@ -9,6 +9,7 @@ pub mod simple_sse;
 pub mod simple_avx;
 
 pub mod metric_f16;
+pub mod metric_tq;
 pub mod metric_uint;
 
 #[cfg(target_arch = "aarch64")]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -20,6 +20,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use num_derive::FromPrimitive;
 use ordered_float::OrderedFloat;
+use quantization::DistanceType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
@@ -314,6 +315,17 @@ pub enum Distance {
     Dot,
     // <https://simple.wikipedia.org/wiki/Manhattan_distance>
     Manhattan,
+}
+
+impl From<Distance> for DistanceType {
+    fn from(distance: Distance) -> Self {
+        match distance {
+            Distance::Cosine => DistanceType::Cosine,
+            Distance::Dot => DistanceType::Dot,
+            Distance::Euclid => DistanceType::L2,
+            Distance::Manhattan => DistanceType::L1,
+        }
+    }
 }
 
 impl Distance {

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -113,14 +113,24 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorS
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
+            .map(|slice| {
+                CowVector::from(T::slice_to_float_cow(
+                    slice,
+                    self.distance,
+                    self.vector_dim(),
+                ))
+            })
             .expect("Vector not found")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
-        self.vectors
-            .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
+        self.vectors.get::<P>(key as VectorOffsetType).map(|slice| {
+            CowVector::from(T::slice_to_float_cow(
+                slice,
+                self.distance,
+                self.vector_dim(),
+            ))
+        })
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -113,14 +113,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorS
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice)))
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
             .expect("Vector not found")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice)))
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
@@ -144,7 +144,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let vector: &[VectorElementType] = vector.try_into()?;
-        let vector = T::slice_from_float_cow(Cow::from(vector));
+        let vector = T::slice_from_float_cow(Cow::from(vector), self.distance);
         self.vectors
             .insert(key as VectorOffsetType, vector.as_ref(), hw_counter)?;
         self.set_deleted(key, false);
@@ -161,7 +161,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
+            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?, self.distance);
             let new_id = self.vectors.push(other_vector.as_ref(), &disposed_hw)?;
             self.set_deleted(new_id as PointOffsetType, other_deleted);
         }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -259,7 +259,7 @@ where
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector).into())
+            .map(|vector| T::slice_to_float_cow(vector, self.distance).into())
             .expect("Vector not found")
     }
 
@@ -277,7 +277,8 @@ where
             .as_ref()
             .unwrap()
             .for_each_in_batch(&point_offsets, |idx, vector| {
-                let vector = CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector)));
+                let vector =
+                    CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector), self.distance));
                 callback(user_data[idx], point_offsets[idx], vector);
             });
     }
@@ -287,7 +288,7 @@ where
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector).into())
+            .map(|vector| T::slice_to_float_cow(vector, self.distance).into())
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
@@ -331,7 +332,7 @@ where
         let mut deleted_ids = vec![];
         for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
             check_process_stopped(stopped)?;
-            let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
+            let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?, self.distance);
             // Safety: T implements zerocopy::IntoBytes.
             #[expect(deprecated, reason = "legacy code")]
             let raw_bites = unsafe { mmap::transmute_to_u8_slice(vector.as_ref()) };

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -259,7 +259,7 @@ where
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector, self.distance).into())
+            .map(|vector| T::slice_to_float_cow(vector, self.distance, self.vector_dim()).into())
             .expect("Vector not found")
     }
 
@@ -277,8 +277,11 @@ where
             .as_ref()
             .unwrap()
             .for_each_in_batch(&point_offsets, |idx, vector| {
-                let vector =
-                    CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector), self.distance));
+                let vector = CowVector::from(T::slice_to_float_cow(
+                    Cow::Borrowed(vector),
+                    self.distance,
+                    self.vector_dim(),
+                ));
                 callback(user_data[idx], point_offsets[idx], vector);
             });
     }
@@ -288,7 +291,7 @@ where
             .as_ref()
             .unwrap()
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector, self.distance).into())
+            .map(|vector| T::slice_to_float_cow(vector, self.distance, self.vector_dim()).into())
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -43,14 +43,24 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
+            .map(|slice| {
+                CowVector::from(T::slice_to_float_cow(
+                    slice,
+                    self.distance,
+                    self.vectors.dim(),
+                ))
+            })
             .expect("Vector not found")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
-        self.vectors
-            .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
+        self.vectors.get::<P>(key as VectorOffsetType).map(|slice| {
+            CowVector::from(T::slice_to_float_cow(
+                slice,
+                self.distance,
+                self.vectors.dim(),
+            ))
+        })
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -43,14 +43,14 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice)))
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
             .expect("Vector not found")
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get::<P>(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice)))
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice, self.distance)))
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -111,7 +111,7 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage
         // In memory so no optimization to be done for access pattern
         self.vectors
             .get_opt(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into())))
+            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into(), self.distance)))
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
@@ -135,7 +135,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let vector: &[VectorElementType] = vector.try_into()?;
-        let vector = T::slice_from_float_cow(Cow::from(vector));
+        let vector = T::slice_from_float_cow(Cow::from(vector), self.distance);
         self.vectors
             .insert(key as VectorOffsetType, vector.as_ref())?;
         self.set_deleted(key, false);
@@ -151,7 +151,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
             // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
+            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?, self.distance);
             let new_id = self.vectors.push(other_vector.as_ref())? as PointOffsetType;
             self.set_deleted(new_id, other_deleted);
         }

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -109,9 +109,13 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage
     /// Get vector by key, if it exists.
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         // In memory so no optimization to be done for access pattern
-        self.vectors
-            .get_opt(key as VectorOffsetType)
-            .map(|slice| CowVector::from(T::slice_to_float_cow(slice.into(), self.distance)))
+        self.vectors.get_opt(key as VectorOffsetType).map(|slice| {
+            CowVector::from(T::slice_to_float_cow(
+                slice.into(),
+                self.distance,
+                self.vector_dim(),
+            ))
+        })
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -62,6 +62,7 @@ where
                     quantization_config,
                     TMetric::distance(),
                     Cow::Borrowed(&original_vector),
+                    original_vector.len(),
                 );
                 Ok(quantized_storage.encode_query(&original_vector_prequantized))
             })

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -51,6 +51,7 @@ where
                 let preprocessed_vector = TMetric::preprocess(raw_vector);
                 let original_vector = TypedDenseVector::from(TElement::slice_from_float_cow(
                     Cow::Owned(preprocessed_vector),
+                    TMetric::distance(),
                 ));
                 Ok(original_vector)
             })

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -75,6 +75,7 @@ where
                     quantization_config,
                     TMetric::distance(),
                     Cow::Borrowed(&original_vector.flattened_vectors),
+                    original_vector.flattened_vectors.len(),
                 );
                 Ok(quantized_multivector_storage.encode_query(&original_vector_prequantized))
             })

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -47,7 +47,8 @@ where
         let mut query = Vec::new();
         for inner_vector in raw_query.multi_vectors() {
             let inner_preprocessed = TMetric::preprocess(inner_vector.to_vec());
-            let inner_converted = TElement::slice_from_float_cow(Cow::Owned(inner_preprocessed));
+            let inner_converted =
+                TElement::slice_from_float_cow(Cow::Owned(inner_preprocessed), TMetric::distance());
             let inner_prequantized = TElement::quantization_preprocess(
                 quantization_config,
                 TMetric::distance(),

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -47,12 +47,14 @@ where
         let mut query = Vec::new();
         for inner_vector in raw_query.multi_vectors() {
             let inner_preprocessed = TMetric::preprocess(inner_vector.to_vec());
+            let inner_dim = inner_preprocessed.len();
             let inner_converted =
                 TElement::slice_from_float_cow(Cow::Owned(inner_preprocessed), TMetric::distance());
             let inner_prequantized = TElement::quantization_preprocess(
                 quantization_config,
                 TMetric::distance(),
                 inner_converted,
+                inner_dim,
             );
             query.extend_from_slice(&inner_prequantized);
         }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -37,12 +37,14 @@ where
         TMetric: Metric<TElement>,
     {
         let raw_preprocessed_query = TMetric::preprocess(raw_query);
+        let dim = raw_preprocessed_query.len();
         let original_query =
             TElement::slice_from_float_cow(Cow::Owned(raw_preprocessed_query), TMetric::distance());
         let original_query_prequantized = TElement::quantization_preprocess(
             quantization_config,
             TMetric::distance(),
             original_query,
+            dim,
         );
         let query = quantized_data.encode_query(&original_query_prequantized);
 

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -37,7 +37,8 @@ where
         TMetric: Metric<TElement>,
     {
         let raw_preprocessed_query = TMetric::preprocess(raw_query);
-        let original_query = TElement::slice_from_float_cow(Cow::Owned(raw_preprocessed_query));
+        let original_query =
+            TElement::slice_from_float_cow(Cow::Owned(raw_preprocessed_query), TMetric::distance());
         let original_query_prequantized = TElement::quantization_preprocess(
             quantization_config,
             TMetric::distance(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -757,7 +757,12 @@ impl QuantizedVectors {
         let datatype = vector_storage.datatype();
         let vectors = (0..count as PointOffsetType).map(|i| {
             let vector = vector_storage.get_dense::<Sequential>(i);
-            PrimitiveVectorElement::quantization_preprocess(quantization_config, distance, vector)
+            PrimitiveVectorElement::quantization_preprocess(
+                quantization_config,
+                distance,
+                vector,
+                dim,
+            )
         });
         let on_disk_vector_storage = vector_storage.is_on_disk();
 
@@ -856,7 +861,12 @@ impl QuantizedVectors {
         let datatype = vector_storage.datatype();
         let multi_vector_config = *vector_storage.multi_vector_config();
         let vectors = vector_storage.iterate_inner_vectors().map(|vector| {
-            PrimitiveVectorElement::quantization_preprocess(quantization_config, distance, vector)
+            PrimitiveVectorElement::quantization_preprocess(
+                quantization_config,
+                distance,
+                vector,
+                dim,
+            )
         });
         let inner_vectors_count = vectors.clone().count();
         let vectors_count = vector_storage.total_vector_count();

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -50,9 +50,10 @@ impl<
             .transform(|vector| {
                 dim = vector.len();
                 let preprocessed_vector = TMetric::preprocess(vector);
-                Ok(TElement::query_from_float_cow(Cow::from(
-                    preprocessed_vector,
-                )))
+                Ok(TElement::query_from_float_cow(
+                    Cow::from(preprocessed_vector),
+                    TMetric::distance(),
+                ))
             })
             .unwrap();
 

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -48,7 +48,10 @@ impl<
         }
 
         Self {
-            query: TElement::query_from_float_cow(Cow::from(preprocessed_vector)),
+            query: TElement::query_from_float_cow(
+                Cow::from(preprocessed_vector),
+                TMetric::distance(),
+            ),
             vector_storage,
             metric: PhantomData,
             hardware_counter,


### PR DESCRIPTION
Add TurboQuantElement as a PrimitiveVectorElement
Exposes a 4-bit TurboQuant codebook as a storage element type so dense storage can hold quantized bytes natively. Uses the asymmetric-query path (QueryType = EncodedQueryTQ). Type + trait skeleton only — storage slot-sizing wiring is a follow-up.