### PR TITLE
[TQDT] (Suggestion) Use fast forward rotations where inverse is not needed

### DIFF
--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -121,6 +121,30 @@ impl TurboQuantizer {
         })
     }
 
+    /// Like [`Self::new`], but builds a forward-only rotation that skips the
+    /// O(`dim`) per-permutation warm-up [`Self::new`] pays to enable inversion.
+    /// Cheaper to construct, but the resulting quantizer only supports the
+    /// forward (encode/quantize) path — never call
+    /// [`Self::apply_inverse_rotation`] on it.
+    pub fn new_fast_forward(
+        dim: usize,
+        bits: TQBits,
+        mode: TQMode,
+        distance: DistanceType,
+        error_correction: Option<ErrorCorrection>,
+    ) -> Self {
+        let padded_dim = Self::padded_dim(dim, bits);
+        let rotation = HadamardRotation::new_fast_forward(padded_dim);
+        TurboQuantizer {
+            rotation,
+            bits,
+            mode,
+            distance,
+            padded_dim,
+            error_correction,
+        }
+    }
+
     /// Initialize a new TurboQuantizer.
     pub fn new(
         dim: usize,

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -26,6 +26,13 @@ impl HadamardRotation {
         Self { permutations, dim }
     }
 
+    pub fn new_fast_forward(dim: usize) -> Self {
+        let permutations: [_; N_PERMUTATIONS] =
+            std::array::from_fn(|index| Permutation::new_one_way(PERMUTATION_SEEDS[index], dim));
+
+        Self { permutations, dim }
+    }
+
     pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
         apply_rotation_with_permutations(x, &self.permutations);

--- a/lib/segment/src/data_types/primitive.rs
+++ b/lib/segment/src/data_types/primitive.rs
@@ -253,7 +253,7 @@ impl PrimitiveVectorElement for TurboQuantElement {
 
     fn slice_from_float_cow(vector: Cow<[VectorElementType]>, distance: Distance) -> Cow<[Self]> {
         let api_dim = vector.len();
-        let quantizer = TurboQuantizer::new(
+        let quantizer = TurboQuantizer::new_fast_forward(
             api_dim,
             TQ_BITS,
             TQ_MODE,
@@ -274,7 +274,7 @@ impl PrimitiveVectorElement for TurboQuantElement {
         distance: Distance,
     ) -> Self::QueryType {
         let api_dim = vector.len();
-        let quantizer = TurboQuantizer::new(
+        let quantizer = TurboQuantizer::new_fast_forward(
             api_dim,
             TQ_BITS,
             TQ_MODE,


### PR DESCRIPTION
Depends on #9250

In a [previous PR](https://github.com/qdrant/qdrant/pull/9106), fast forward support was added to permutations and rotations.
This PR builds on top of #9250 and uses this fast forward rotation path.