### PR TITLE
ci: bump test_many_collections timeout to avoid flaky CI timeouts

### DIFF
--- a/.github/workflows/long-e2e-tests.yml
+++ b/.github/workflows/long-e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run e2e tests
         run: uv --project tests run pytest -n 4 tests/e2e_tests -v --tb=short --durations=5 -m "longrunning"
         shell: bash
-        timeout-minutes: 40
+        timeout-minutes: 50
       - name: Upload test logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/tests/e2e_tests/test_many_collections.py
+++ b/tests/e2e_tests/test_many_collections.py
@@ -7,6 +7,8 @@ from e2e_tests.client_utils import ClientUtils
 
 class TestManyCollections:
     @pytest.mark.longrunning
+    # Override the global 1920s timeout to leave margin.
+    @pytest.mark.timeout(2700)
     @pytest.mark.parametrize("qdrant_compose", [
         {"compose_file": "3-node-cluster.yaml"}
     ], indirect=True)


### PR DESCRIPTION
Look like there is a race between test runtime and pytest timeout. Loosen timeouts a bit.

### All Submissions:

* [X] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [X] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?