### PR TITLE
test(consensus): batch initial upsert in snapshot-transfer missing-point test

### DIFF
--- a/tests/consensus_tests/test_shard_snapshot_transfer_missing_point.py
+++ b/tests/consensus_tests/test_shard_snapshot_transfer_missing_point.py
@@ -134,8 +134,12 @@ def test_shard_snapshot_transfer_with_missing_point_updates(tmp_path: pathlib.Pa
         peer_api_uris=peer_api_uris,
     )
 
-    # Insert some initial real points
-    upsert_random_points(peer_api_uris[0], INITIAL_POINTS)
+    # Insert some initial real points. Batch the insert: a single 20k-point
+    # request saturates all cores long enough to starve the consensus thread
+    # (cascading leader elections) and to blow past the 2000ms per-shard update
+    # healthcheck deadline, which returns a flaky 408 here before the actual
+    # test even starts.
+    upsert_random_points(peer_api_uris[0], INITIAL_POINTS, batch_size=1000)
 
     # Concurrent background load:
     #  - real insertions of new points


### PR DESCRIPTION
## Problem

`test_shard_snapshot_transfer_with_missing_point_updates` is flaky on CI, failing with a 408:

```
status code 408 ... 'Timeout: 1 out of 3 shards failed to apply operation.
First error: ... "Healthcheck timeout 2000ms exceeded"'
```

Investigating a failing run's logs showed the failure happens during **test setup**, before the actual snapshot-transfer logic runs:

- The failing `PUT /points` was the *only* points request logged on the peer, started at 06:50:45 and 408'd 55.9s later — the background load and snapshot transfer never started.
- It corresponds to the initial dataset insert (`upsert_random_points(peer_api_uris[0], INITIAL_POINTS)`), which sent all **20,000 points (dense + sparse vectors) in a single HTTP request** because no `batch_size` was passed.
- That one request saturated all cores long enough to starve the raft consensus thread — cascading leader elections (term 1→2→3→4) and inter-peer gRPC `Timeout expired` errors within a few seconds of each other.
- While forwarding points to a shard, the per-shard pre-update healthcheck exceeded its 2000 ms deadline under that load, failing the `wait=true` write → 408.

Fast/idle machines squeak under the 2 s deadline; loaded CI runners tip over → flaky.

## Fix

Batch the initial insert into 1k-point requests (`batch_size=1000`), so no single request monopolizes the CPU and starves consensus. This matches the convention every other large initial upsert in the suite already follows (e.g. `test_resharding_down_abort_converges_after_crash.py` does exactly `num=20_000, batch_size=1_000`).

No change to the behavior actually under test — only to how the setup dataset is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)