### PR TITLE
[UIO] More `read_json_via`

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/mod.rs
@@ -165,30 +165,31 @@ impl<S: UniversalRead> MmapInvertedIndex<S> {
         let point_to_tokens_count_path = path.join(POINT_TO_TOKENS_COUNT_FILE);
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
-        // If postings don't exist, assume the index doesn't exist on disk
-        if !postings_path.is_file() {
-            return Ok(None);
-        }
-
         let postings_open_options = OpenOptions {
             writeable: false,
             need_sequential: false,
             populate: Populate::from(populate),
             advice: AdviceSetting::Advice(Advice::Normal),
         };
-        let postings = match has_positions {
-            false => MmapPostingsEnum::Ids(UniversalPostings::<(), S>::open(
+
+        let Some(postings) = (match has_positions {
+            false => UniversalPostings::<(), S>::open(
                 fs,
                 &postings_path,
                 postings_open_options,
                 Default::default(),
-            )?),
-            true => MmapPostingsEnum::WithPositions(UniversalPostings::<Positions, S>::open(
+            )?
+            .map(MmapPostingsEnum::Ids),
+            true => UniversalPostings::<Positions, S>::open(
                 fs,
                 &postings_path,
                 postings_open_options,
                 Default::default(),
-            )?),
+            )?
+            .map(MmapPostingsEnum::WithPositions),
+        }) else {
+            // If postings don't exist, assume the index doesn't exist on disk
+            return Ok(None);
         };
         let vocab = UniversalHashMap::<str, TokenId, S>::open(
             fs,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/uio_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mmap_inverted_index/uio_postings.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use common::generic_consts::{Random, Sequential};
 use common::universal_io::{
-    OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
+    OkNotFound, OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs
 };
 use posting_list::{PostingList, PostingListView};
 use zerocopy::FromBytes;
@@ -44,23 +44,27 @@ struct HeadersBatch<'a> {
 
 impl<V: ZerocopyPostingValue, S: UniversalRead> UniversalPostings<V, S> {
     /// Open the postings file at `path` via the `S` storage backend.
+    ///
+    /// Returns `Ok(None)` if the file is not found
     pub fn open(
         fs: &S::Fs,
         path: impl Into<PathBuf>,
         options: OpenOptions,
         extra: <S::Fs as UniversalReadFs>::OpenExtra,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Option<Self>> {
         let path = path.into();
-        let storage = fs.open(&path, options, extra)?;
+        let Some(storage) = fs.open(&path, options, extra).ok_not_found()? else {
+            return Ok(None);
+        };
 
         let header = storage.read::<Sequential, PostingsHeader>(ReadRange::one(0))?[0];
 
-        Ok(Self {
+        Ok(Some(Self {
             _path: path,
             storage,
             header,
             _value_type: PhantomData,
-        })
+        }))
     }
 
     /// Hint the storage backend to populate any RAM cache backing this file.

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/lifecycle.rs
@@ -7,14 +7,15 @@ use common::binary_search::binary_search_by;
 use common::bitvec::{BitSlice, BitSliceExt};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::fs::{atomic_save_json, clear_disk_cache, read_json};
+use common::fs::{atomic_save_json, clear_disk_cache};
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -172,13 +173,14 @@ impl<S: UniversalRead> StoredGeoMapIndex<S> {
         let points_map_path = path.join(POINTS_MAP);
         let points_map_ids_path = path.join(POINTS_MAP_IDS);
 
-        // If stats file doesn't exist, assume the index doesn't exist on disk
-        if !stats_path.is_file() {
+        let Some(stats) =
+            read_json_via::<_, StoredGeoMapIndexStat>(fs, &stats_path).ok_not_found()?
+        else {
+            // If stats file doesn't exist, assume the index doesn't exist on disk
             return Ok(None);
-        }
+        };
 
         let populate = !is_on_disk;
-        let stats: StoredGeoMapIndexStat = read_json(&stats_path)?;
 
         let open_options = OpenOptions {
             writeable: false,

--- a/lib/segment/src/index/field_index/numeric_index/universal_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/universal_numeric_index/lifecycle.rs
@@ -8,7 +8,7 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFs, OpenOptions, Populate, TypedStorage, UniversalRead, read_json_via,
+    MmapFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -125,13 +125,14 @@ where
         let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
-        // If config doesn't exist, assume the index doesn't exist on disk
-        if !config_path.is_file() {
+        let Some(config) =
+            read_json_via::<_, UniversalNumericIndexConfig>(fs, &config_path).ok_not_found()?
+        else {
+            // If config doesn't exist, assume the index doesn't exist on disk
             return Ok(None);
-        }
+        };
 
         let histogram = Histogram::<T>::load_via(fs, path)?;
-        let config: UniversalNumericIndexConfig = read_json_via(fs, &config_path)?;
         let do_populate = !is_on_disk;
 
         let pairs_options = OpenOptions {

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use common::fs::{atomic_save_json, read_json};
+use common::fs::atomic_save_json;
+use common::universal_io::{OkNotFound, UniversalReadFs, read_json_via};
 use serde::{Deserialize, Serialize};
 
 use crate::common::operation_error::OperationResult;
@@ -57,8 +58,8 @@ impl HnswGraphConfig {
         path.join(HNSW_INDEX_CONFIG_FILE)
     }
 
-    pub fn load(path: &Path) -> OperationResult<Self> {
-        Ok(read_json(path)?)
+    pub fn load_via<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> OperationResult<Option<Self>> {
+        Ok(read_json_via(fs, path).ok_not_found()?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::universal_io::MmapFs;
 
 use self::telemetry::HNSWSearchesTelemetry;
 use crate::common::BYTES_IN_KB;
@@ -68,30 +69,31 @@ impl HNSWIndex {
         } = args;
 
         let config_path = HnswGraphConfig::get_config_path(path);
-        let config = if config_path.exists() {
-            HnswGraphConfig::load(&config_path)?
-        } else {
-            let vector_storage = vector_storage.borrow();
-            let available_vectors = vector_storage.available_vector_count();
-            let full_scan_threshold = vector_storage
-                .size_of_available_vectors_in_bytes()
-                .checked_div(available_vectors)
-                .and_then(|avg_vector_size| {
-                    hnsw_config
-                        .full_scan_threshold
-                        .saturating_mul(BYTES_IN_KB)
-                        .checked_div(avg_vector_size)
-                })
-                .unwrap_or(1);
+        let config = match HnswGraphConfig::load_via(&MmapFs, &config_path)? {
+            Some(config) => config,
+            None => {
+                let vector_storage = vector_storage.borrow();
+                let available_vectors = vector_storage.available_vector_count();
+                let full_scan_threshold = vector_storage
+                    .size_of_available_vectors_in_bytes()
+                    .checked_div(available_vectors)
+                    .and_then(|avg_vector_size| {
+                        hnsw_config
+                            .full_scan_threshold
+                            .saturating_mul(BYTES_IN_KB)
+                            .checked_div(avg_vector_size)
+                    })
+                    .unwrap_or(1);
 
-            HnswGraphConfig::new(
-                hnsw_config.m,
-                hnsw_config.ef_construct,
-                full_scan_threshold,
-                hnsw_config.max_indexing_threads,
-                hnsw_config.payload_m,
-                available_vectors,
-            )
+                HnswGraphConfig::new(
+                    hnsw_config.m,
+                    hnsw_config.ef_construct,
+                    full_scan_threshold,
+                    hnsw_config.max_indexing_threads,
+                    hnsw_config.payload_m,
+                    available_vectors,
+                )
+            }
         };
 
         let do_convert = LINK_COMPRESSION_CONVERT_EXISTING;


### PR DESCRIPTION
Cleans up more places where we were using plain `read_json(..)`, and swaps to use `read_json_via(..)`.

Additionally handles the NotFound case with universal io for:
- mmap numeric index
- mmap geo index
- hnsw config
- mmap full-text postings
