### PR TITLE
Rename indexes variants

### DIFF
--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -61,7 +61,7 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
         &MmapFs,
         mutable_index,
         dir.path(),
-        false,
+        true,
         &deleted_points,
     )
     .unwrap();

--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -8,7 +8,7 @@ use rand::{RngExt, SeedableRng};
 use segment::common::operation_error::OperationResult;
 use segment::index::field_index::numeric_index::NumericIndexRead;
 use segment::index::field_index::numeric_index::mutable_numeric_index::InMemoryNumericIndex;
-use segment::index::field_index::numeric_index::universal_numeric_index::UniversalNumericIndex;
+use segment::index::field_index::numeric_index::on_disk_numeric_index::OnDiskNumericIndex;
 use tempfile::Builder;
 
 mod prof;
@@ -57,7 +57,7 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
         })
     });
 
-    let mmap_index = UniversalNumericIndex::<_, MmapFile>::build(
+    let mmap_index = OnDiskNumericIndex::<_, MmapFile>::build(
         &MmapFs,
         mutable_index,
         dir.path(),

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -24,14 +24,14 @@ use crate::index::query_optimization::rescore_formula::value_retriever::Variable
 use crate::types::FieldCondition;
 
 pub enum BoolIndex {
-    Mmap(MutableBoolIndex),
+    Mutable(MutableBoolIndex),
     Immutable(ImmutableBoolIndex),
 }
 
 impl From<MutableBoolIndex> for BoolIndex {
     #[inline]
     fn from(index: MutableBoolIndex) -> Self {
-        BoolIndex::Mmap(index)
+        BoolIndex::Mutable(index)
     }
 }
 
@@ -45,8 +45,7 @@ impl From<ImmutableBoolIndex> for BoolIndex {
 impl BoolIndex {
     pub fn get_mutability_type(&self) -> IndexMutability {
         match self {
-            // Mmap bool index can be both mutable and immutable, so we pick mutable
-            BoolIndex::Mmap(_) => IndexMutability::Mutable,
+            BoolIndex::Mutable(_) => IndexMutability::Mutable,
             BoolIndex::Immutable(_) => IndexMutability::Immutable,
         }
     }
@@ -66,42 +65,42 @@ impl BoolIndexRead for BoolIndex {
 
     fn trues_flags(&self) -> &Self::Flags {
         match self {
-            BoolIndex::Mmap(index) => index.trues_flags(),
+            BoolIndex::Mutable(index) => index.trues_flags(),
             BoolIndex::Immutable(index) => index.trues_flags(),
         }
     }
 
     fn falses_flags(&self) -> &Self::Flags {
         match self {
-            BoolIndex::Mmap(index) => index.falses_flags(),
+            BoolIndex::Mutable(index) => index.falses_flags(),
             BoolIndex::Immutable(index) => index.falses_flags(),
         }
     }
 
     fn indexed_count(&self) -> usize {
         match self {
-            BoolIndex::Mmap(index) => index.indexed_count(),
+            BoolIndex::Mutable(index) => index.indexed_count(),
             BoolIndex::Immutable(index) => index.indexed_count(),
         }
     }
 
     fn telemetry_index_type(&self) -> &'static str {
         match self {
-            BoolIndex::Mmap(index) => index.telemetry_index_type(),
+            BoolIndex::Mutable(index) => index.telemetry_index_type(),
             BoolIndex::Immutable(index) => index.telemetry_index_type(),
         }
     }
 
     fn trues_count(&self) -> usize {
         match self {
-            BoolIndex::Mmap(index) => index.trues_count(),
+            BoolIndex::Mutable(index) => index.trues_count(),
             BoolIndex::Immutable(index) => index.trues_count(),
         }
     }
 
     fn falses_count(&self) -> usize {
         match self {
-            BoolIndex::Mmap(index) => index.falses_count(),
+            BoolIndex::Mutable(index) => index.falses_count(),
             BoolIndex::Immutable(index) => index.falses_count(),
         }
     }
@@ -149,14 +148,14 @@ impl PayloadFieldIndexRead for BoolIndex {
 impl PayloadFieldIndex for BoolIndex {
     fn wipe(self) -> OperationResult<()> {
         match self {
-            BoolIndex::Mmap(index) => index.wipe(),
+            BoolIndex::Mutable(index) => index.wipe(),
             BoolIndex::Immutable(index) => index.wipe(),
         }
     }
 
     fn flusher(&self) -> crate::common::Flusher {
         match self {
-            BoolIndex::Mmap(index) => index.flusher(),
+            BoolIndex::Mutable(index) => index.flusher(),
             BoolIndex::Immutable(index) => index.flusher(),
         }
     }
@@ -167,7 +166,7 @@ impl PayloadFieldIndex for BoolIndex {
 
     fn immutable_files(&self) -> Vec<std::path::PathBuf> {
         match self {
-            BoolIndex::Mmap(index) => index.immutable_files(),
+            BoolIndex::Mutable(index) => index.immutable_files(),
             BoolIndex::Immutable(index) => index.immutable_files(),
         }
     }
@@ -231,7 +230,7 @@ impl ValueIndexer for BoolIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
-            BoolIndex::Mmap(index) => index.add_many(id, values, hw_counter),
+            BoolIndex::Mutable(index) => index.add_many(id, values, hw_counter),
             BoolIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable bool index",
             )),
@@ -251,7 +250,7 @@ impl ValueIndexer for BoolIndex {
 
     fn remove_point(&mut self, id: PointOffsetType) -> OperationResult<()> {
         match self {
-            BoolIndex::Mmap(index) => index.remove_point(id),
+            BoolIndex::Mutable(index) => index.remove_point(id),
             BoolIndex::Immutable(index) => index.remove_point(id),
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
@@ -38,8 +38,8 @@ impl FullTextIndex {
         };
 
         let index = if effective_is_on_disk {
-            // Use on mmap directly
-            Some(Self::Mmap(Box::new(mmap_index)))
+            // Use on-disk directly
+            Some(Self::OnDisk(Box::new(mmap_index)))
         } else {
             // Load into RAM, use mmap as backing storage
             Some(Self::Immutable(ImmutableFullTextIndex::open_mmap(
@@ -65,8 +65,8 @@ impl FullTextIndex {
                 debug_assert!(false, "Immutable index should be initialized before use");
                 Ok(())
             }
-            Self::Mmap(_) => {
-                debug_assert!(false, "Mmap index should be initialized before use");
+            Self::OnDisk(_) => {
+                debug_assert!(false, "On-disk index should be initialized before use");
                 Ok(())
             }
         }
@@ -115,7 +115,7 @@ impl FullTextIndex {
         match self {
             FullTextIndex::Mutable(_) => IndexMutability::Mutable,
             FullTextIndex::Immutable(_) => IndexMutability::Immutable,
-            FullTextIndex::Mmap(_) => IndexMutability::Immutable,
+            FullTextIndex::OnDisk(_) => IndexMutability::Immutable,
         }
     }
 
@@ -124,7 +124,7 @@ impl FullTextIndex {
             // Mutable / Immutable keep their inverted index fully in RAM —
             // there is nothing to populate.
             Self::Mutable(_) | Self::Immutable(_) => Ok(()),
-            Self::Mmap(index) => index.populate(),
+            Self::OnDisk(index) => index.populate(),
         }
     }
 
@@ -132,7 +132,7 @@ impl FullTextIndex {
         match self {
             Self::Mutable(index) => index.clear_cache(),
             Self::Immutable(index) => index.clear_cache(),
-            Self::Mmap(index) => index.clear_cache(),
+            Self::OnDisk(index) => index.clear_cache(),
         }
     }
 
@@ -140,7 +140,7 @@ impl FullTextIndex {
         match self {
             Self::Mutable(index) => index.files(),
             Self::Immutable(index) => index.files(),
-            Self::Mmap(index) => index.files(),
+            Self::OnDisk(index) => index.files(),
         }
     }
 
@@ -148,7 +148,7 @@ impl FullTextIndex {
         match self {
             Self::Mutable(_) => Vec::new(),
             Self::Immutable(index) => index.immutable_files(),
-            Self::Mmap(index) => index.immutable_files(),
+            Self::OnDisk(index) => index.immutable_files(),
         }
     }
 }
@@ -167,8 +167,8 @@ impl ValueIndexer for FullTextIndex {
             Self::Immutable(_) => Err(OperationError::service_error(
                 "Cannot add values to immutable text index",
             )),
-            Self::Mmap(_) => Err(OperationError::service_error(
-                "Cannot add values to mmap text index",
+            Self::OnDisk(_) => Err(OperationError::service_error(
+                "Cannot add values to on-disk text index",
             )),
         }
     }
@@ -181,7 +181,7 @@ impl ValueIndexer for FullTextIndex {
         match self {
             FullTextIndex::Mutable(index) => index.remove_point(id)?,
             FullTextIndex::Immutable(index) => index.remove_point(id),
-            FullTextIndex::Mmap(index) => index.remove_point(id),
+            FullTextIndex::OnDisk(index) => index.remove_point(id),
         }
         Ok(())
     }
@@ -192,7 +192,7 @@ impl PayloadFieldIndex for FullTextIndex {
         match self {
             Self::Mutable(index) => index.wipe(),
             Self::Immutable(index) => index.wipe(),
-            Self::Mmap(index) => index.wipe(),
+            Self::OnDisk(index) => index.wipe(),
         }
     }
 
@@ -200,7 +200,7 @@ impl PayloadFieldIndex for FullTextIndex {
         match self {
             Self::Mutable(index) => index.flusher(),
             Self::Immutable(index) => index.flusher(),
-            Self::Mmap(index) => index.flusher(),
+            Self::OnDisk(index) => index.flusher(),
         }
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index/lifecycle.rs
@@ -207,7 +207,7 @@ impl FieldIndexBuilderTrait for FullTextMmapIndexBuilder {
         };
 
         let text_index = if is_on_disk {
-            FullTextIndex::Mmap(Box::new(mmap_index))
+            FullTextIndex::OnDisk(Box::new(mmap_index))
         } else {
             FullTextIndex::Immutable(ImmutableFullTextIndex::open_mmap(mmap_index)?)
         };

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 pub enum FullTextIndex {
     Mutable(MutableFullTextIndex),
     Immutable(ImmutableFullTextIndex),
-    Mmap(Box<MmapFullTextIndex<MmapFile>>),
+    OnDisk(Box<MmapFullTextIndex<MmapFile>>),
 }
 
 pub struct FullTextGridstoreIndexBuilder {

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -24,7 +24,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.tokenizer(),
             Self::Immutable(index) => index.tokenizer(),
-            Self::Mmap(index) => index.tokenizer(),
+            Self::OnDisk(index) => index.tokenizer(),
         }
     }
 
@@ -32,7 +32,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.telemetry_index_type(),
             Self::Immutable(index) => index.telemetry_index_type(),
-            Self::Mmap(index) => index.telemetry_index_type(),
+            Self::OnDisk(index) => index.telemetry_index_type(),
         }
     }
 
@@ -40,7 +40,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.points_count(),
             Self::Immutable(index) => index.points_count(),
-            Self::Mmap(index) => index.points_count(),
+            Self::OnDisk(index) => index.points_count(),
         }
     }
 
@@ -48,7 +48,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.values_count(point_id),
             Self::Immutable(index) => index.values_count(point_id),
-            Self::Mmap(index) => index.values_count(point_id),
+            Self::OnDisk(index) => index.values_count(point_id),
         }
     }
 
@@ -56,7 +56,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.values_is_empty(point_id),
             Self::Immutable(index) => index.values_is_empty(point_id),
-            Self::Mmap(index) => index.values_is_empty(point_id),
+            Self::OnDisk(index) => index.values_is_empty(point_id),
         }
     }
 
@@ -69,7 +69,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.for_each_token_id(iter, hw_counter, f),
             Self::Immutable(index) => index.for_each_token_id(iter, hw_counter, f),
-            Self::Mmap(index) => index.for_each_token_id(iter, hw_counter, f),
+            Self::OnDisk(index) => index.for_each_token_id(iter, hw_counter, f),
         }
     }
 
@@ -81,7 +81,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.filter_query(query, hw_counter),
             Self::Immutable(index) => index.filter_query(query, hw_counter),
-            Self::Mmap(index) => index.filter_query(query, hw_counter),
+            Self::OnDisk(index) => index.filter_query(query, hw_counter),
         }
     }
 
@@ -96,7 +96,7 @@ impl FullTextIndexRead for FullTextIndex {
             Self::Immutable(index) => {
                 index.estimate_query_cardinality(query, condition, hw_counter)
             }
-            Self::Mmap(index) => index.estimate_query_cardinality(query, condition, hw_counter),
+            Self::OnDisk(index) => index.estimate_query_cardinality(query, condition, hw_counter),
         }
     }
 
@@ -104,7 +104,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.check_match(query, point_id),
             Self::Immutable(index) => index.check_match(query, point_id),
-            Self::Mmap(index) => index.check_match(query, point_id),
+            Self::OnDisk(index) => index.check_match(query, point_id),
         }
     }
 
@@ -117,7 +117,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => index.for_each_payload_block_inner(threshold, key, f),
             Self::Immutable(index) => index.for_each_payload_block_inner(threshold, key, f),
-            Self::Mmap(index) => index.for_each_payload_block_inner(threshold, key, f),
+            Self::OnDisk(index) => index.for_each_payload_block_inner(threshold, key, f),
         }
     }
 
@@ -125,7 +125,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => FullTextIndexRead::get_storage_type(index),
             Self::Immutable(index) => FullTextIndexRead::get_storage_type(index),
-            Self::Mmap(index) => FullTextIndexRead::get_storage_type(index.as_ref()),
+            Self::OnDisk(index) => FullTextIndexRead::get_storage_type(index.as_ref()),
         }
     }
 
@@ -133,7 +133,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => FullTextIndexRead::ram_usage_bytes(index),
             Self::Immutable(index) => FullTextIndexRead::ram_usage_bytes(index),
-            Self::Mmap(index) => FullTextIndexRead::ram_usage_bytes(index.as_ref()),
+            Self::OnDisk(index) => FullTextIndexRead::ram_usage_bytes(index.as_ref()),
         }
     }
 
@@ -141,7 +141,7 @@ impl FullTextIndexRead for FullTextIndex {
         match self {
             Self::Mutable(index) => FullTextIndexRead::is_on_disk(index),
             Self::Immutable(index) => FullTextIndexRead::is_on_disk(index),
-            Self::Mmap(index) => FullTextIndexRead::is_on_disk(index.as_ref()),
+            Self::OnDisk(index) => FullTextIndexRead::is_on_disk(index.as_ref()),
         }
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/builders.rs
+++ b/lib/segment/src/index/field_index/geo_index/builders.rs
@@ -41,7 +41,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(GeoMapIndex::Storage(Box::new(StoredGeoMapIndex::build(
+        Ok(GeoMapIndex::OnDisk(Box::new(StoredGeoMapIndex::build(
             &MmapFs,
             self.in_memory_index,
             &self.path,
@@ -71,7 +71,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexGridstoreBuilder {
             "index must be initialized exactly once",
         );
         self.index.replace(
-            GeoMapIndex::new_gridstore(self.dir.clone(), true)?.ok_or_else(|| {
+            GeoMapIndex::new_mutable(self.dir.clone(), true)?.ok_or_else(|| {
                 OperationError::service_error("Failed to open GeoMapIndex after creating it")
             })?,
         );

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -17,7 +17,7 @@ use crate::types::GeoPoint;
 
 impl ImmutableGeoMapIndex {
     /// Open and load the immutable geo index from mmap storage.
-    pub fn open_mmap(index: StoredGeoMapIndex<MmapFile>) -> OperationResult<Self> {
+    pub fn load_from_on_disk(index: StoredGeoMapIndex<MmapFile>) -> OperationResult<Self> {
         let index = Box::new(index);
         let counts_per_hash = index
             .storage

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -34,11 +34,11 @@ const GEO_QUERY_MAX_REGION: usize = 12;
 pub enum GeoMapIndex {
     Mutable(MutableGeoMapIndex),
     Immutable(ImmutableGeoMapIndex),
-    Storage(Box<StoredGeoMapIndex<MmapFile>>),
+    OnDisk(Box<StoredGeoMapIndex<MmapFile>>),
 }
 
 impl GeoMapIndex {
-    pub fn new_mmap(
+    pub fn new_on_disk(
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,
@@ -46,23 +46,23 @@ impl GeoMapIndex {
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) =
+        let Some(on_disk_index) =
             StoredGeoMapIndex::open(&MmapFs, path, effective_is_on_disk, deleted_points)?
         else {
             return Ok(None);
         };
 
         let index = if effective_is_on_disk {
-            GeoMapIndex::Storage(Box::new(mmap_index))
+            GeoMapIndex::OnDisk(Box::new(on_disk_index))
         } else {
-            GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(mmap_index)?)
+            GeoMapIndex::Immutable(ImmutableGeoMapIndex::load_from_on_disk(on_disk_index)?)
         };
 
         Ok(Some(index))
     }
 
-    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
-        Ok(MutableGeoMapIndex::open_gridstore(dir, create_if_missing)?.map(GeoMapIndex::Mutable))
+    pub fn new_mutable(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
+        Ok(MutableGeoMapIndex::open(dir, create_if_missing)?.map(GeoMapIndex::Mutable))
     }
 
     pub fn builder_mmap(
@@ -86,7 +86,7 @@ impl GeoMapIndex {
         match self {
             Self::Mutable(_) => IndexMutability::Mutable,
             Self::Immutable(_) => IndexMutability::Immutable,
-            Self::Storage(_) => IndexMutability::Immutable,
+            Self::OnDisk(_) => IndexMutability::Immutable,
         }
     }
 }
@@ -96,7 +96,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.points_count(),
             GeoMapIndex::Immutable(index) => index.points_count(),
-            GeoMapIndex::Storage(index) => index.points_count(),
+            GeoMapIndex::OnDisk(index) => index.points_count(),
         }
     }
 
@@ -104,7 +104,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.points_values_count(),
             GeoMapIndex::Immutable(index) => index.points_values_count(),
-            GeoMapIndex::Storage(index) => index.points_values_count(),
+            GeoMapIndex::OnDisk(index) => index.points_values_count(),
         }
     }
 
@@ -112,7 +112,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.max_values_per_point(),
             GeoMapIndex::Immutable(index) => index.max_values_per_point(),
-            GeoMapIndex::Storage(index) => index.max_values_per_point(),
+            GeoMapIndex::OnDisk(index) => index.max_values_per_point(),
         }
     }
 
@@ -126,7 +126,7 @@ impl GeoMapIndexRead for GeoMapIndex {
             GeoMapIndex::Immutable(index) => {
                 GeoMapIndexRead::points_of_hash(index, hash, hw_counter)
             }
-            GeoMapIndex::Storage(index) => index.points_of_hash(hash, hw_counter),
+            GeoMapIndex::OnDisk(index) => index.points_of_hash(hash, hw_counter),
         }
     }
 
@@ -140,7 +140,7 @@ impl GeoMapIndexRead for GeoMapIndex {
             GeoMapIndex::Immutable(index) => {
                 GeoMapIndexRead::values_of_hash(index, hash, hw_counter)
             }
-            GeoMapIndex::Storage(index) => index.values_of_hash(hash, hw_counter),
+            GeoMapIndex::OnDisk(index) => index.values_of_hash(hash, hw_counter),
         }
     }
 
@@ -157,7 +157,7 @@ impl GeoMapIndexRead for GeoMapIndex {
             GeoMapIndex::Immutable(index) => {
                 GeoMapIndexRead::check_values_any(index, idx, hw_counter, check_fn)
             }
-            GeoMapIndex::Storage(index) => index.check_values_any(idx, hw_counter, check_fn),
+            GeoMapIndex::OnDisk(index) => index.check_values_any(idx, hw_counter, check_fn),
         }
     }
 
@@ -165,7 +165,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::values_count(index, idx),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::values_count(index, idx),
-            GeoMapIndex::Storage(index) => index.values_count(idx),
+            GeoMapIndex::OnDisk(index) => index.values_count(idx),
         }
     }
 
@@ -173,7 +173,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::get_values(index, idx),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::get_values(index, idx),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::get_values(index.as_ref(), idx),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::get_values(index.as_ref(), idx),
         }
     }
 
@@ -184,7 +184,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::iterator(index, values),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::iterator(index, values),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::iterator(index.as_ref(), values),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::iterator(index.as_ref(), values),
         }
     }
 
@@ -195,7 +195,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.points_per_hash_filtered(filter),
             GeoMapIndex::Immutable(index) => index.points_per_hash_filtered(filter),
-            GeoMapIndex::Storage(index) => index.points_per_hash_filtered(filter),
+            GeoMapIndex::OnDisk(index) => index.points_per_hash_filtered(filter),
         }
     }
 
@@ -203,7 +203,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::get_storage_type(index),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::get_storage_type(index),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::get_storage_type(index.as_ref()),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::get_storage_type(index.as_ref()),
         }
     }
 
@@ -211,7 +211,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::ram_usage_bytes(index),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::ram_usage_bytes(index),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::ram_usage_bytes(index.as_ref()),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::ram_usage_bytes(index.as_ref()),
         }
     }
 
@@ -219,14 +219,14 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(_) => false,
             GeoMapIndex::Immutable(_) => false,
-            GeoMapIndex::Storage(index) => index.is_on_disk(),
+            GeoMapIndex::OnDisk(index) => index.is_on_disk(),
         }
     }
 
     fn populate(&self) -> OperationResult<()> {
         match self {
             GeoMapIndex::Mutable(_) | GeoMapIndex::Immutable(_) => Ok(()),
-            GeoMapIndex::Storage(index) => index.populate(),
+            GeoMapIndex::OnDisk(index) => index.populate(),
         }
     }
 
@@ -234,7 +234,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::clear_cache(index),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::clear_cache(index),
-            GeoMapIndex::Storage(index) => index.clear_cache(),
+            GeoMapIndex::OnDisk(index) => index.clear_cache(),
         }
     }
 
@@ -242,7 +242,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => GeoMapIndexRead::files(index),
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::files(index),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::files(index.as_ref()),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::files(index.as_ref()),
         }
     }
 
@@ -250,7 +250,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(_) => vec![],
             GeoMapIndex::Immutable(index) => GeoMapIndexRead::immutable_files(index),
-            GeoMapIndex::Storage(index) => GeoMapIndexRead::immutable_files(index.as_ref()),
+            GeoMapIndex::OnDisk(index) => GeoMapIndexRead::immutable_files(index.as_ref()),
         }
     }
 
@@ -258,7 +258,7 @@ impl GeoMapIndexRead for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(_) => "mutable_geo",
             GeoMapIndex::Immutable(_) => "immutable_geo",
-            GeoMapIndex::Storage(_) => "mmap_geo",
+            GeoMapIndex::OnDisk(_) => "mmap_geo",
         }
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
@@ -28,7 +28,7 @@ impl MutableGeoMapIndex {
     /// The `create_if_missing` parameter indicates whether to create a new Gridstore if it does
     /// not exist. If false and files don't exist, the load function will indicate nothing could be
     /// loaded.
-    pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
+    pub fn open(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
             Gridstore::open_or_create(path, GRIDSTORE_OPTIONS).map_err(|err| {
                 OperationError::service_error(format!(

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
@@ -44,7 +44,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let mut mutable = MutableGeoMapIndex::open_gridstore(dir.path().to_path_buf(), true)
+            let mut mutable = MutableGeoMapIndex::open(dir.path().to_path_buf(), true)
                 .unwrap()
                 .unwrap();
             // point 0: Berlin, 1 value

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -32,7 +32,7 @@ impl ValueIndexer for GeoMapIndex {
             GeoMapIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable geo index",
             )),
-            GeoMapIndex::Storage(_) => Err(OperationError::service_error(
+            GeoMapIndex::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap geo index",
             )),
         }
@@ -61,7 +61,7 @@ impl ValueIndexer for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.remove_point(id),
             GeoMapIndex::Immutable(index) => index.remove_point(id),
-            GeoMapIndex::Storage(index) => {
+            GeoMapIndex::OnDisk(index) => {
                 index.remove_point(id);
                 Ok(())
             }
@@ -89,7 +89,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.wipe(),
             GeoMapIndex::Immutable(index) => index.wipe(),
-            GeoMapIndex::Storage(index) => index.wipe(),
+            GeoMapIndex::OnDisk(index) => index.wipe(),
         }
     }
 
@@ -97,7 +97,7 @@ impl PayloadFieldIndex for GeoMapIndex {
         match self {
             GeoMapIndex::Mutable(index) => index.flusher(),
             GeoMapIndex::Immutable(index) => index.flusher(),
-            GeoMapIndex::Storage(index) => index.flusher(),
+            GeoMapIndex::OnDisk(index) => index.flusher(),
         }
     }
 

--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -101,7 +101,7 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         {
-            let mut mutable = MutableGeoMapIndex::open_gridstore(dir.path().to_path_buf(), true)
+            let mut mutable = MutableGeoMapIndex::open(dir.path().to_path_buf(), true)
                 .unwrap()
                 .unwrap();
             mutable

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -56,15 +56,15 @@ type Database = ();
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum IndexType {
-    MutableGridstore,
-    Mmap,
-    RamMmap,
+    Mutable,
+    OnDisk,
+    Immutable,
 }
 
 enum IndexBuilder {
     MutableGridstore(GeoMapIndexGridstoreBuilder),
     Mmap(GeoMapIndexMmapBuilder),
-    RamMmap(GeoMapIndexMmapBuilder),
+    Immutable(GeoMapIndexMmapBuilder),
 }
 
 impl IndexBuilder {
@@ -77,7 +77,7 @@ impl IndexBuilder {
         match self {
             IndexBuilder::MutableGridstore(builder) => builder.add_point(id, payload, hw_counter),
             IndexBuilder::Mmap(builder) => builder.add_point(id, payload, hw_counter),
-            IndexBuilder::RamMmap(builder) => builder.add_point(id, payload, hw_counter),
+            IndexBuilder::Immutable(builder) => builder.add_point(id, payload, hw_counter),
         }
     }
 
@@ -85,13 +85,14 @@ impl IndexBuilder {
         match self {
             IndexBuilder::MutableGridstore(builder) => builder.finalize(),
             IndexBuilder::Mmap(builder) => builder.finalize(),
-            IndexBuilder::RamMmap(builder) => {
-                let GeoMapIndex::Storage(index) = builder.finalize()? else {
+            IndexBuilder::Immutable(builder) => {
+                let GeoMapIndex::OnDisk(index) = builder.finalize()? else {
                     panic!("expected mmap index");
                 };
 
-                let index =
-                    GeoMapIndex::Immutable(ImmutableGeoMapIndex::open_mmap(*index).unwrap());
+                let index = GeoMapIndex::Immutable(
+                    ImmutableGeoMapIndex::load_from_on_disk(*index).unwrap(),
+                );
                 Ok(index)
             }
         }
@@ -127,15 +128,15 @@ fn create_builder(index_type: IndexType) -> (IndexBuilder, TempDir, Database) {
     let db = ();
 
     let mut builder = match index_type {
-        IndexType::MutableGridstore => IndexBuilder::MutableGridstore(
-            GeoMapIndex::builder_gridstore(temp_dir.path().to_path_buf()),
-        ),
-        IndexType::Mmap => IndexBuilder::Mmap(GeoMapIndex::builder_mmap(
+        IndexType::Mutable => IndexBuilder::MutableGridstore(GeoMapIndex::builder_gridstore(
+            temp_dir.path().to_path_buf(),
+        )),
+        IndexType::OnDisk => IndexBuilder::Mmap(GeoMapIndex::builder_mmap(
             temp_dir.path(),
             true,
             &empty_deleted(),
         )),
-        IndexType::RamMmap => IndexBuilder::RamMmap(GeoMapIndex::builder_mmap(
+        IndexType::Immutable => IndexBuilder::Immutable(GeoMapIndex::builder_mmap(
             temp_dir.path(),
             false,
             &empty_deleted(),
@@ -144,7 +145,7 @@ fn create_builder(index_type: IndexType) -> (IndexBuilder, TempDir, Database) {
     match &mut builder {
         IndexBuilder::MutableGridstore(builder) => builder.init().unwrap(),
         IndexBuilder::Mmap(builder) => builder.init().unwrap(),
-        IndexBuilder::RamMmap(builder) => builder.init().unwrap(),
+        IndexBuilder::Immutable(builder) => builder.init().unwrap(),
     }
     (builder, temp_dir, db)
 }
@@ -216,9 +217,9 @@ fn radius_to_polygon(circle: &GeoRadius) -> GeoPolygon {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn test_polygon_with_exclusion(#[case] index_type: IndexType) {
     fn check_cardinality_match(
         hashes: Vec<GeoHash>,
@@ -290,9 +291,9 @@ fn test_polygon_with_exclusion(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn match_cardinality(#[case] index_type: IndexType) {
     fn check_cardinality_match(
         hashes: Vec<GeoHash>,
@@ -342,9 +343,9 @@ fn match_cardinality(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn geo_indexed_filtering(#[case] index_type: IndexType) {
     fn check_geo_indexed_filtering<F>(
         field_condition: FieldCondition,
@@ -408,9 +409,9 @@ fn geo_indexed_filtering(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn test_payload_blocks(#[case] index_type: IndexType) {
     let (field_index, _, _) = build_random_index(1000, 5, index_type);
     let hw_counter = HardwareCounterCell::new();
@@ -446,9 +447,9 @@ fn test_payload_blocks(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn match_cardinality_point_with_multi_far_geo_payload(#[case] index_type: IndexType) {
     let (mut builder, _, _) = create_builder(index_type);
 
@@ -537,9 +538,9 @@ fn match_cardinality_point_with_multi_far_geo_payload(#[case] index_type: IndexT
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn match_cardinality_point_with_multi_close_geo_payload(#[case] index_type: IndexType) {
     let (mut builder, _, _) = create_builder(index_type);
     let geo_values = json!([
@@ -582,9 +583,9 @@ fn match_cardinality_point_with_multi_close_geo_payload(#[case] index_type: Inde
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn load_from_disk(#[case] index_type: IndexType) {
     let temp_dir = {
         let (mut builder, temp_dir, _) = create_builder(index_type);
@@ -606,16 +607,14 @@ fn load_from_disk(#[case] index_type: IndexType) {
     };
 
     let new_index = match index_type {
-        IndexType::MutableGridstore => {
-            GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true)
-                .unwrap()
-                .unwrap()
-        }
-        IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &empty_deleted())
+        IndexType::Mutable => GeoMapIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => GeoMapIndex::Immutable(
-            ImmutableGeoMapIndex::open_mmap(
+        IndexType::OnDisk => GeoMapIndex::new_on_disk(temp_dir.path(), false, &empty_deleted())
+            .unwrap()
+            .unwrap(),
+        IndexType::Immutable => GeoMapIndex::Immutable(
+            ImmutableGeoMapIndex::load_from_on_disk(
                 StoredGeoMapIndex::open(&MmapFs, temp_dir.path(), false, &empty_deleted())
                     .unwrap()
                     .unwrap(),
@@ -651,9 +650,9 @@ fn load_from_disk(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
     let temp_dir = {
         let (mut builder, temp_dir, _) = create_builder(index_type);
@@ -678,7 +677,7 @@ fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
         index.flusher()().unwrap();
 
         assert_eq!(index.points_count(), 1);
-        if index_type != IndexType::Mmap {
+        if index_type != IndexType::OnDisk {
             assert_eq!(index.points_values_count(), 2);
         }
         drop(index);
@@ -686,16 +685,14 @@ fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
     };
 
     let new_index = match index_type {
-        IndexType::MutableGridstore => {
-            GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true)
-                .unwrap()
-                .unwrap()
-        }
-        IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &deleted_with(&[1]))
+        IndexType::Mutable => GeoMapIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => GeoMapIndex::Immutable(
-            ImmutableGeoMapIndex::open_mmap(
+        IndexType::OnDisk => GeoMapIndex::new_on_disk(temp_dir.path(), false, &deleted_with(&[1]))
+            .unwrap()
+            .unwrap(),
+        IndexType::Immutable => GeoMapIndex::Immutable(
+            ImmutableGeoMapIndex::load_from_on_disk(
                 StoredGeoMapIndex::open(&MmapFs, temp_dir.path(), false, &deleted_with(&[1]))
                     .unwrap()
                     .unwrap(),
@@ -704,15 +701,15 @@ fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
         ),
     };
     assert_eq!(new_index.points_count(), 1);
-    if index_type != IndexType::Mmap {
+    if index_type != IndexType::OnDisk {
         assert_eq!(new_index.points_values_count(), 2);
     }
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn test_empty_index_cardinality(#[case] index_type: IndexType) {
     let polygon = GeoPolygon {
         exterior: GeoLineString {
@@ -786,9 +783,9 @@ fn test_empty_index_cardinality(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn query_across_antimeridian(#[case] index_type: IndexType) {
     let (mut builder, _, _) = create_builder(index_type);
     let geo_values = json!([
@@ -840,7 +837,7 @@ fn query_across_antimeridian(#[case] index_type: IndexType) {
 /// Removing a point with duplicate geo values in a multi-value geo field
 /// must not produce spurious "no points for hash X was found" warnings.
 #[rstest]
-#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mutable)]
 fn test_remove_point_with_duplicate_geo_values(#[case] index_type: IndexType) {
     let (mut builder, _temp_dir, _db) = create_builder(index_type);
     let hw_counter = HardwareCounterCell::new();
@@ -892,7 +889,7 @@ fn test_remove_point_with_duplicate_geo_values(#[case] index_type: IndexType) {
 /// must be reversed on removal. Otherwise `values_per_hash` drifts upward permanently.
 #[test]
 fn test_values_per_hash_drift_on_duplicate_geo_removal() {
-    let (mut builder, _temp_dir, _db) = create_builder(IndexType::MutableGridstore);
+    let (mut builder, _temp_dir, _db) = create_builder(IndexType::Mutable);
     let hw_counter = HardwareCounterCell::new();
 
     // Point 0 has 3 identical geo values (same geohash produced 3 times).
@@ -948,7 +945,7 @@ fn test_values_per_hash_drift_on_duplicate_geo_removal() {
 /// Simulate the user's scenario: frequently adding and removing points
 /// with geo payloads.
 #[rstest]
-#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mutable)]
 fn test_frequent_add_remove_geo_points(#[case] index_type: IndexType) {
     let (mut builder, _temp_dir, _db) = create_builder(index_type);
     let hw_counter = HardwareCounterCell::new();
@@ -993,8 +990,8 @@ fn test_frequent_add_remove_geo_points(#[case] index_type: IndexType) {
 }
 
 #[rstest]
-#[case(&[IndexType::MutableGridstore, IndexType::Mmap, IndexType::RamMmap], false)]
-#[case(&[IndexType::MutableGridstore, IndexType::RamMmap], true)]
+#[case(&[IndexType::Mutable, IndexType::OnDisk, IndexType::Immutable], false)]
+#[case(&[IndexType::Mutable, IndexType::Immutable], true)]
 fn test_congruence(#[case] types: &[IndexType], #[case] deleted: bool) {
     const POINT_COUNT: usize = 500;
 
@@ -1107,12 +1104,12 @@ fn test_all_points_congruence() {
     const POINT_COUNT: usize = 500;
 
     let (mut mutable_index, _mutable_tmp, _) =
-        build_random_index(POINT_COUNT, 20, IndexType::MutableGridstore);
+        build_random_index(POINT_COUNT, 20, IndexType::Mutable);
     let (mut immutable_index, _immutable_tmp, _) =
-        build_random_index(POINT_COUNT, 20, IndexType::RamMmap);
-    let (mut mmap_index, _mmap_tmp, _) = build_random_index(POINT_COUNT, 20, IndexType::Mmap);
+        build_random_index(POINT_COUNT, 20, IndexType::Immutable);
+    let (mut mmap_index, _mmap_tmp, _) = build_random_index(POINT_COUNT, 20, IndexType::OnDisk);
 
-    let GeoMapIndex::Storage(storage_index) = &mmap_index else {
+    let GeoMapIndex::OnDisk(storage_index) = &mmap_index else {
         panic!("expected Mmap variant to build into Storage");
     };
 
@@ -1216,7 +1213,7 @@ fn test_all_points_congruence() {
         mmap_index.remove_point(id).unwrap();
     }
 
-    let GeoMapIndex::Storage(storage_index) = &mmap_index else {
+    let GeoMapIndex::OnDisk(storage_index) = &mmap_index else {
         panic!("expected Mmap variant to build into Storage");
     };
 
@@ -1232,9 +1229,9 @@ fn test_all_points_congruence() {
 /// Reload contract: runtime deletions are not persisted by the mmap geo
 /// index. Callers must re-supply the deletion bitslice on reload.
 #[rstest]
-#[case(IndexType::MutableGridstore)]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn test_geo_index_reload(#[case] index_type: IndexType) {
     let temp_dir = {
         let (mut builder, temp_dir, _) = create_builder(index_type);
@@ -1267,16 +1264,14 @@ fn test_geo_index_reload(#[case] index_type: IndexType) {
 
     let deleted = deleted_with(&[2, 3, 6]);
     let new_index = match index_type {
-        IndexType::MutableGridstore => {
-            GeoMapIndex::new_gridstore(temp_dir.path().to_path_buf(), true)
-                .unwrap()
-                .unwrap()
-        }
-        IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &deleted)
+        IndexType::Mutable => GeoMapIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => GeoMapIndex::Immutable(
-            ImmutableGeoMapIndex::open_mmap(
+        IndexType::OnDisk => GeoMapIndex::new_on_disk(temp_dir.path(), false, &deleted)
+            .unwrap()
+            .unwrap(),
+        IndexType::Immutable => GeoMapIndex::Immutable(
+            ImmutableGeoMapIndex::load_from_on_disk(
                 StoredGeoMapIndex::open(&MmapFs, temp_dir.path(), false, &deleted)
                     .unwrap()
                     .unwrap(),
@@ -1337,8 +1332,8 @@ fn test_geo_index_reload(#[case] index_type: IndexType) {
 /// bitslice shorter than `point_to_values.len()`, missing entries must
 /// default to live, not deleted.
 #[rstest]
-#[case(IndexType::Mmap)]
-#[case(IndexType::RamMmap)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
 fn test_geo_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
     let temp_dir = {
         let (mut builder, temp_dir, _) = create_builder(index_type);
@@ -1359,18 +1354,18 @@ fn test_geo_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
     let mut short_deleted = BitVec::repeat(false, 2);
     short_deleted.set(1, true);
     let new_index = match index_type {
-        IndexType::Mmap => GeoMapIndex::new_mmap(temp_dir.path(), false, &short_deleted)
+        IndexType::OnDisk => GeoMapIndex::new_on_disk(temp_dir.path(), false, &short_deleted)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => GeoMapIndex::Immutable(
-            ImmutableGeoMapIndex::open_mmap(
+        IndexType::Immutable => GeoMapIndex::Immutable(
+            ImmutableGeoMapIndex::load_from_on_disk(
                 StoredGeoMapIndex::open(&MmapFs, temp_dir.path(), false, &short_deleted)
                     .unwrap()
                     .unwrap(),
             )
             .unwrap(),
         ),
-        IndexType::MutableGridstore => unreachable!(),
+        IndexType::Mutable => unreachable!(),
     };
 
     let berlin_radius = GeoRadius {

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -31,20 +31,9 @@ use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
 #[derive(Copy, Clone)]
 pub enum IndexSelector<'a> {
     /// On disk or in-memory index on mmaps, non-appendable
-    Mmap(IndexSelectorMmap<'a>),
+    NonAppendable { dir: &'a Path, is_on_disk: bool },
     /// In-memory index on gridstore, appendable
-    Gridstore(IndexSelectorGridstore<'a>),
-}
-
-#[derive(Copy, Clone)]
-pub struct IndexSelectorMmap<'a> {
-    pub dir: &'a Path,
-    pub is_on_disk: bool,
-}
-
-#[derive(Copy, Clone)]
-pub struct IndexSelectorGridstore<'a> {
-    pub dir: &'a Path,
+    Appendable { dir: &'a Path },
 }
 
 impl IndexSelector<'_> {
@@ -304,10 +293,10 @@ impl IndexSelector<'_> {
         Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
     {
         Ok(match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => {
                 MapIndex::new_mmap(&map_dir(dir, field), *is_on_disk, deleted_points)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 MapIndex::new_gridstore(map_dir(dir, field), create_if_missing)?
             }
         })
@@ -324,10 +313,12 @@ impl IndexSelector<'_> {
         Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
     {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
-                MapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk, deleted_points),
-            ),
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => make_mmap(MapIndex::builder_mmap(
+                &map_dir(dir, field),
+                *is_on_disk,
+                deleted_points,
+            )),
+            IndexSelector::Appendable { dir } => {
                 make_gridstore(MapIndex::builder_gridstore(map_dir(dir, field)))
             }
         }
@@ -343,10 +334,10 @@ impl IndexSelector<'_> {
         Vec<T>: Blob,
     {
         Ok(match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => {
                 NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
             }
         })
@@ -364,10 +355,10 @@ impl IndexSelector<'_> {
         Vec<T>: Blob,
     {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
+            IndexSelector::NonAppendable { dir, is_on_disk } => make_mmap(
                 NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points),
             ),
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))
             }
         }
@@ -380,10 +371,10 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<GeoMapIndex>> {
         Ok(match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => {
                 GeoMapIndex::new_mmap(&map_dir(dir, field), *is_on_disk, deleted_points)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 GeoMapIndex::new_gridstore(map_dir(dir, field), create_if_missing)?
             }
         })
@@ -397,19 +388,12 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> FieldIndexBuilder {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => make_mmap(
+            IndexSelector::NonAppendable { dir, is_on_disk } => make_mmap(
                 GeoMapIndex::builder_mmap(&map_dir(dir, field), *is_on_disk, deleted_points),
             ),
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 make_gridstore(GeoMapIndex::builder_gridstore(map_dir(dir, field)))
             }
-        }
-    }
-
-    fn dir(&self) -> &Path {
-        match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => dir,
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => dir,
         }
     }
 
@@ -418,8 +402,11 @@ impl IndexSelector<'_> {
     /// Gridstore segments are appendable/mutable.
     pub fn default_mutability(&self) -> IndexMutability {
         match self {
-            IndexSelector::Mmap(_) => IndexMutability::Immutable,
-            IndexSelector::Gridstore(_) => IndexMutability::Mutable,
+            IndexSelector::NonAppendable {
+                dir: _,
+                is_on_disk: _,
+            } => IndexMutability::Immutable,
+            IndexSelector::Appendable { dir: _ } => IndexMutability::Mutable,
         }
     }
 
@@ -428,13 +415,15 @@ impl IndexSelector<'_> {
         field: &JsonPath,
         total_point_count: usize,
     ) -> OperationResult<FieldIndexBuilder> {
-        let null_dir = null_dir(self.dir(), field);
         let builder = match self {
-            IndexSelector::Mmap(_) => FieldIndexBuilder::ImmutableNullIndex(
-                ImmutableNullIndex::builder(&null_dir, total_point_count)?,
-            ),
-            IndexSelector::Gridstore(_) => FieldIndexBuilder::MutableNullIndex(
-                MutableNullIndex::builder(&null_dir, total_point_count)?,
+            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
+                FieldIndexBuilder::ImmutableNullIndex(ImmutableNullIndex::builder(
+                    &null_dir(dir, field),
+                    total_point_count,
+                )?)
+            }
+            IndexSelector::Appendable { dir } => FieldIndexBuilder::MutableNullIndex(
+                MutableNullIndex::builder(&null_dir(dir, field), total_point_count)?,
             ),
         };
         Ok(builder)
@@ -448,27 +437,28 @@ impl IndexSelector<'_> {
         mutability: IndexMutability,
     ) -> OperationResult<Option<FieldIndex>> {
         let total_point_count = id_tracker.total_point_count();
-        let null_dir = null_dir(self.dir(), field);
         // `MutableNullIndex` and `ImmutableNullIndex` share the same on-disk
         // format; stored mutability picks which in-memory wrapper to build.
         // Gridstore segments are always appendable, so the null index is
         // always mutable regardless of the stored mutability marker.
         match (self, mutability) {
-            (IndexSelector::Mmap(_), IndexMutability::Immutable) => Ok(ImmutableNullIndex::open(
-                &null_dir,
-                total_point_count,
-                id_tracker.deleted_point_bitslice(),
-            )?
-            .map(NullIndex::Immutable)
-            .map(FieldIndex::NullIndex)),
-            (IndexSelector::Mmap(_), IndexMutability::Mutable)
-            | (IndexSelector::Gridstore(_), _) => {
-                Ok(
-                    MutableNullIndex::open(&null_dir, total_point_count, create_if_missing)?
-                        .map(NullIndex::Mutable)
-                        .map(FieldIndex::NullIndex),
-                )
+            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Immutable) => {
+                Ok(ImmutableNullIndex::open(
+                    &null_dir(dir, field),
+                    total_point_count,
+                    id_tracker.deleted_point_bitslice(),
+                )?
+                .map(NullIndex::Immutable)
+                .map(FieldIndex::NullIndex))
             }
+            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Mutable)
+            | (IndexSelector::Appendable { dir }, _) => Ok(MutableNullIndex::open(
+                &null_dir(dir, field),
+                total_point_count,
+                create_if_missing,
+            )?
+            .map(NullIndex::Mutable)
+            .map(FieldIndex::NullIndex)),
         }
     }
 
@@ -480,10 +470,10 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<FullTextIndex>> {
         Ok(match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => {
                 FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk, deleted_points)?
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 FullTextIndex::new_gridstore(text_dir(dir, field), config, create_if_missing)?
             }
         })
@@ -496,7 +486,7 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> FieldIndexBuilder {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk } => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(
                     text_dir(dir, field),
                     config,
@@ -504,25 +494,22 @@ impl IndexSelector<'_> {
                     deleted_points,
                 ))
             }
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
-                FieldIndexBuilder::FullTextGridstoreIndex(FullTextIndex::builder_gridstore(
-                    text_dir(dir, field),
-                    config,
-                ))
-            }
+            IndexSelector::Appendable { dir } => FieldIndexBuilder::FullTextGridstoreIndex(
+                FullTextIndex::builder_gridstore(text_dir(dir, field), config),
+            ),
         }
     }
 
     fn bool_builder(&self, field: &JsonPath) -> OperationResult<FieldIndexBuilder> {
         match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
                 let dir = bool_dir(dir, field);
                 Ok(FieldIndexBuilder::BoolMmapIndex(
                     ImmutableBoolIndex::builder(&dir)?,
                 ))
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 let dir = bool_dir(dir, field);
                 Ok(FieldIndexBuilder::BoolGridstoreIndex(
                     MutableBoolIndex::builder(&dir)?,
@@ -539,7 +526,7 @@ impl IndexSelector<'_> {
         mutability: IndexMutability,
     ) -> OperationResult<Option<BoolIndex>> {
         Ok(match self {
-            IndexSelector::Mmap(IndexSelectorMmap { dir, is_on_disk: _ }) => {
+            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
                 let dir = bool_dir(dir, field);
                 // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
                 // format; stored mutability picks which in-memory wrapper to build.
@@ -553,7 +540,7 @@ impl IndexSelector<'_> {
                 }
             }
             // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
-            IndexSelector::Gridstore(IndexSelectorGridstore { dir }) => {
+            IndexSelector::Appendable { dir } => {
                 let dir = bool_dir(dir, field);
                 MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
             }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -525,24 +525,17 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
         mutability: IndexMutability,
     ) -> OperationResult<Option<BoolIndex>> {
-        Ok(match self {
-            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
+        // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
+        // format; stored mutability picks which in-memory wrapper to build.
+        Ok(match (self, mutability) {
+            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Immutable) => {
                 let dir = bool_dir(dir, field);
-                // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
-                // format; stored mutability picks which in-memory wrapper to build.
-                match mutability {
-                    IndexMutability::Immutable => {
-                        ImmutableBoolIndex::open(&dir, deleted_points)?.map(BoolIndex::Immutable)
-                    }
-                    IndexMutability::Mutable => {
-                        MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
-                    }
-                }
+                ImmutableBoolIndex::open(&dir, deleted_points)?.map(BoolIndex::Immutable)
             }
-            // Skip Gridstore for boolean index, mmap index is simpler and is also mutable
-            IndexSelector::Appendable { dir } => {
+            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Mutable)
+            | (IndexSelector::Appendable { dir }, _) => {
                 let dir = bool_dir(dir, field);
-                MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mmap)
+                MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mutable)
             }
         })
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -372,10 +372,10 @@ impl IndexSelector<'_> {
     ) -> OperationResult<Option<GeoMapIndex>> {
         Ok(match self {
             IndexSelector::NonAppendable { dir, is_on_disk } => {
-                GeoMapIndex::new_mmap(&map_dir(dir, field), *is_on_disk, deleted_points)?
+                GeoMapIndex::new_on_disk(&map_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
-                GeoMapIndex::new_gridstore(map_dir(dir, field), create_if_missing)?
+                GeoMapIndex::new_mutable(map_dir(dir, field), create_if_missing)?
             }
         })
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -335,10 +335,10 @@ impl IndexSelector<'_> {
     {
         Ok(match self {
             IndexSelector::NonAppendable { dir, is_on_disk } => {
-                NumericIndex::new_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
+                NumericIndex::new_immutable(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
-                NumericIndex::new_gridstore(numeric_dir(dir, field), create_if_missing)?
+                NumericIndex::new_mutable(numeric_dir(dir, field), create_if_missing)?
             }
         })
     }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -452,13 +452,16 @@ impl IndexSelector<'_> {
                 .map(FieldIndex::NullIndex))
             }
             (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Mutable)
-            | (IndexSelector::Appendable { dir }, _) => Ok(MutableNullIndex::open(
-                &null_dir(dir, field),
-                total_point_count,
-                create_if_missing,
-            )?
-            .map(NullIndex::Mutable)
-            .map(FieldIndex::NullIndex)),
+            | (IndexSelector::Appendable { dir }, IndexMutability::Mutable)
+            | (IndexSelector::Appendable { dir }, IndexMutability::Immutable) => {
+                Ok(MutableNullIndex::open(
+                    &null_dir(dir, field),
+                    total_point_count,
+                    create_if_missing,
+                )?
+                .map(NullIndex::Mutable)
+                .map(FieldIndex::NullIndex))
+            }
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/builders.rs
+++ b/lib/segment/src/index/field_index/map_index/builders.rs
@@ -32,7 +32,7 @@ where
         match &mut self.0 {
             MapIndex::Mutable(index) => index.clear(),
             MapIndex::Immutable(_) => unreachable!(),
-            MapIndex::Mmap(_) => unreachable!(),
+            MapIndex::OnDisk(_) => unreachable!(),
         }
     }
 
@@ -110,7 +110,7 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        Ok(MapIndex::Mmap(Box::new(UniversalMapIndex::build(
+        Ok(MapIndex::OnDisk(Box::new(UniversalMapIndex::build(
             &MmapFs,
             &self.path,
             self.point_to_values,

--- a/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/facet_index_impl.rs
@@ -32,9 +32,11 @@ where
             MapIndex::Immutable(index) => index.for_points_values(points, |idx, slice| {
                 f(idx, &mut slice.iter().map(|v| v.borrow().into()));
             }),
-            MapIndex::Mmap(index) => index.for_points_values(points, hw_counter, |idx, vals| {
-                f(idx, &mut vals.map(|v| v.into()));
-            })?,
+            MapIndex::OnDisk(index) => {
+                index.for_points_values(points, hw_counter, |idx, vals| {
+                    f(idx, &mut vals.map(|v| v.into()));
+                })?
+            }
         }
         Ok(())
     }

--- a/lib/segment/src/index/field_index/map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/lifecycle.rs
@@ -38,7 +38,7 @@ where
         };
 
         let index = if effective_is_on_disk {
-            MapIndex::Mmap(Box::new(universal_index))
+            MapIndex::OnDisk(Box::new(universal_index))
         } else {
             // Load into RAM, use mmap as backing storage
             MapIndex::Immutable(ImmutableMapIndex::open_mmap(universal_index)?)
@@ -73,7 +73,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.flusher(),
             MapIndex::Immutable(index) => index.flusher(),
-            MapIndex::Mmap(index) => index.flusher(),
+            MapIndex::OnDisk(index) => index.flusher(),
         }
     }
 
@@ -81,7 +81,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.wipe(),
             MapIndex::Immutable(index) => index.wipe(),
-            MapIndex::Mmap(index) => index.wipe(),
+            MapIndex::OnDisk(index) => index.wipe(),
         }
     }
 
@@ -89,7 +89,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.remove_point(id),
             MapIndex::Immutable(index) => index.remove_point(id),
-            MapIndex::Mmap(index) => {
+            MapIndex::OnDisk(index) => {
                 index.remove_point(id);
                 Ok(())
             }
@@ -100,7 +100,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.files(),
             MapIndex::Immutable(index) => index.files(),
-            MapIndex::Mmap(index) => index.files(),
+            MapIndex::OnDisk(index) => index.files(),
         }
     }
 
@@ -108,7 +108,7 @@ where
         match self {
             MapIndex::Mutable(_) => vec![],
             MapIndex::Immutable(index) => index.immutable_files(),
-            MapIndex::Mmap(index) => index.immutable_files(),
+            MapIndex::OnDisk(index) => index.immutable_files(),
         }
     }
 
@@ -118,7 +118,7 @@ where
         match self {
             MapIndex::Mutable(_) => {}
             MapIndex::Immutable(_) => {}
-            MapIndex::Mmap(index) => index.populate()?,
+            MapIndex::OnDisk(index) => index.populate()?,
         }
         Ok(())
     }
@@ -128,7 +128,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.clear_cache()?,
             MapIndex::Immutable(index) => index.clear_cache()?,
-            MapIndex::Mmap(index) => index.clear_cache()?,
+            MapIndex::OnDisk(index) => index.clear_cache()?,
         }
         Ok(())
     }

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -40,5 +40,5 @@ where
     /// Loaded in RAM, use immutable storage format
     Immutable(ImmutableMapIndex<N>),
     /// Served directly from storage (via mmap), use immutable format
-    Mmap(Box<UniversalMapIndex<N>>),
+    OnDisk(Box<UniversalMapIndex<N>>),
 }

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -209,7 +209,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.check_values_any(idx, hw_counter, check_fn),
             MapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),
-            MapIndex::Mmap(index) => index.check_values_any(idx, hw_counter, check_fn),
+            MapIndex::OnDisk(index) => index.check_values_any(idx, hw_counter, check_fn),
         }
     }
 
@@ -224,7 +224,7 @@ where
         let boxed: Box<dyn Iterator<Item = Cow<'a, N>> + 'a> = match self {
             MapIndex::Mutable(index) => Box::new(index.get_values(idx, hw_counter)?),
             MapIndex::Immutable(index) => Box::new(index.get_values(idx, hw_counter)?),
-            MapIndex::Mmap(index) => Box::new(index.get_values(idx, hw_counter)?),
+            MapIndex::OnDisk(index) => Box::new(index.get_values(idx, hw_counter)?),
         };
         Some(boxed)
     }
@@ -233,7 +233,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.values_count(idx),
             MapIndex::Immutable(index) => index.values_count(idx),
-            MapIndex::Mmap(index) => index.values_count(idx),
+            MapIndex::OnDisk(index) => index.values_count(idx),
         }
     }
 
@@ -241,7 +241,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.get_indexed_points(),
             MapIndex::Immutable(index) => index.get_indexed_points(),
-            MapIndex::Mmap(index) => index.get_indexed_points(),
+            MapIndex::OnDisk(index) => index.get_indexed_points(),
         }
     }
 
@@ -249,7 +249,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.get_values_count(),
             MapIndex::Immutable(index) => index.get_values_count(),
-            MapIndex::Mmap(index) => index.get_values_count(),
+            MapIndex::OnDisk(index) => index.get_values_count(),
         }
     }
 
@@ -257,7 +257,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.get_unique_values_count(),
             MapIndex::Immutable(index) => index.get_unique_values_count(),
-            MapIndex::Mmap(index) => index.get_unique_values_count(),
+            MapIndex::OnDisk(index) => index.get_unique_values_count(),
         }
     }
 
@@ -265,7 +265,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.get_count_for_value(value, hw_counter),
             MapIndex::Immutable(index) => index.get_count_for_value(value, hw_counter),
-            MapIndex::Mmap(index) => index.get_count_for_value(value, hw_counter),
+            MapIndex::OnDisk(index) => index.get_count_for_value(value, hw_counter),
         }
     }
 
@@ -273,7 +273,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.get_iterator(value, hw_counter),
             MapIndex::Immutable(index) => index.get_iterator(value, hw_counter),
-            MapIndex::Mmap(index) => index.get_iterator(value, hw_counter),
+            MapIndex::OnDisk(index) => index.get_iterator(value, hw_counter),
         }
     }
 
@@ -281,7 +281,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.for_each_value(f),
             MapIndex::Immutable(index) => index.for_each_value(f),
-            MapIndex::Mmap(index) => index.for_each_value(f),
+            MapIndex::OnDisk(index) => index.for_each_value(f),
         }
     }
 
@@ -299,7 +299,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
             MapIndex::Immutable(index) => index.for_each_count_per_value(deferred_internal_id, f),
-            MapIndex::Mmap(index) => index.for_each_count_per_value(deferred_internal_id, f),
+            MapIndex::OnDisk(index) => index.for_each_count_per_value(deferred_internal_id, f),
         }
     }
 
@@ -311,7 +311,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.for_each_value_map(hw_counter, f),
             MapIndex::Immutable(index) => index.for_each_value_map(hw_counter, f),
-            MapIndex::Mmap(index) => index.for_each_value_map(hw_counter, f),
+            MapIndex::OnDisk(index) => index.for_each_value_map(hw_counter, f),
         }
     }
 
@@ -319,7 +319,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.storage_type(),
             MapIndex::Immutable(index) => index.storage_type(),
-            MapIndex::Mmap(index) => index.storage_type(),
+            MapIndex::OnDisk(index) => index.storage_type(),
         }
     }
 
@@ -327,7 +327,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.ram_usage_bytes(),
             MapIndex::Immutable(index) => index.ram_usage_bytes(),
-            MapIndex::Mmap(index) => index.ram_usage_bytes(),
+            MapIndex::OnDisk(index) => index.ram_usage_bytes(),
         }
     }
 
@@ -335,7 +335,7 @@ where
         match self {
             MapIndex::Mutable(_) => "mutable_map",
             MapIndex::Immutable(_) => "immutable_map",
-            MapIndex::Mmap(_) => "mmap_map",
+            MapIndex::OnDisk(_) => "mmap_map",
         }
     }
 }
@@ -353,7 +353,7 @@ where
             index_type: match self {
                 MapIndex::Mutable(_) => "mutable_map",
                 MapIndex::Immutable(_) => "immutable_map",
-                MapIndex::Mmap(_) => "mmap_map",
+                MapIndex::OnDisk(_) => "mmap_map",
             },
         }
     }
@@ -393,7 +393,7 @@ where
         match self {
             MapIndex::Mutable(_) => false,
             MapIndex::Immutable(_) => false,
-            MapIndex::Mmap(index) => index.is_on_disk(),
+            MapIndex::OnDisk(index) => index.is_on_disk(),
         }
     }
 
@@ -401,7 +401,7 @@ where
         match self {
             Self::Mutable(_) => IndexMutability::Mutable,
             Self::Immutable(_) => IndexMutability::Immutable,
-            Self::Mmap(_) => IndexMutability::Immutable,
+            Self::OnDisk(_) => IndexMutability::Immutable,
         }
     }
 
@@ -409,7 +409,7 @@ where
         match self {
             Self::Mutable(index) => index.storage_type(),
             Self::Immutable(index) => index.storage_type(),
-            Self::Mmap(index) => index.storage_type(),
+            Self::OnDisk(index) => index.storage_type(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
@@ -31,7 +31,7 @@ impl ValueIndexer for MapIndex<str> {
                 "Can't add values to immutable map index",
             )),
             MapIndex::OnDisk(_) => Err(OperationError::service_error(
-                "Can't add values to mmap map index",
+                "Can't add values to on-disk map index",
             )),
         }
     }

--- a/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
+++ b/lib/segment/src/index/field_index/map_index/value_indexer_impl.rs
@@ -30,7 +30,7 @@ impl ValueIndexer for MapIndex<str> {
             MapIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable map index",
             )),
-            MapIndex::Mmap(_) => Err(OperationError::service_error(
+            MapIndex::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap map index",
             )),
         }
@@ -62,7 +62,7 @@ impl ValueIndexer for MapIndex<IntPayloadType> {
             MapIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable map index",
             )),
-            MapIndex::Mmap(_) => Err(OperationError::service_error(
+            MapIndex::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap map index",
             )),
         }
@@ -91,7 +91,7 @@ impl ValueIndexer for MapIndex<UuidIntType> {
             MapIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable map index",
             )),
-            MapIndex::Mmap(_) => Err(OperationError::service_error(
+            MapIndex::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap map index",
             )),
         }

--- a/lib/segment/src/index/field_index/numeric_index/builders.rs
+++ b/lib/segment/src/index/field_index/numeric_index/builders.rs
@@ -13,6 +13,7 @@ use super::on_disk_numeric_index::OnDiskNumericIndex;
 use super::storage::NumericIndexInner;
 use super::{Encodable, NumericIndex, NumericIndexIntoInnerValue};
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::numeric_index::immutable_numeric_index::ImmutableNumericIndex;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::stored_point_to_values::StoredValue;
 use crate::index::field_index::{FieldIndexBuilderTrait, ValueIndexer};
@@ -123,15 +124,23 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        let inner = OnDiskNumericIndex::build(
+        let populate = !self.is_on_disk;
+        let on_disk_index = OnDiskNumericIndex::build(
             &MmapFs,
             self.in_memory_index,
             &self.path,
-            self.is_on_disk,
+            populate,
             &self.deleted_points,
         )?;
+
+        let inner = if self.is_on_disk {
+            NumericIndexInner::OnDisk(on_disk_index)
+        } else {
+            NumericIndexInner::Immutable(ImmutableNumericIndex::load_from_on_disk(on_disk_index))
+        };
+
         Ok(NumericIndex {
-            inner: NumericIndexInner::OnDisk(inner),
+            inner,
             _phantom: PhantomData,
         })
     }
@@ -173,7 +182,7 @@ where
             "index must be initialized exactly once",
         );
         self.index.replace(
-            NumericIndex::new_gridstore(self.dir.clone(), true)?
+            NumericIndex::new_mutable(self.dir.clone(), true)?
                 // unwrap safety: cannot fail because create_if_missing is true
                 .unwrap(),
         );

--- a/lib/segment/src/index/field_index/numeric_index/builders.rs
+++ b/lib/segment/src/index/field_index/numeric_index/builders.rs
@@ -36,7 +36,7 @@ where
         match &mut self.0.inner {
             NumericIndexInner::Mutable(index) => index.clear(),
             NumericIndexInner::Immutable(_) => unreachable!(),
-            NumericIndexInner::Mmap(_) => unreachable!(),
+            NumericIndexInner::OnDisk(_) => unreachable!(),
         }
     }
 
@@ -131,7 +131,7 @@ where
             &self.deleted_points,
         )?;
         Ok(NumericIndex {
-            inner: NumericIndexInner::Mmap(inner),
+            inner: NumericIndexInner::OnDisk(inner),
             _phantom: PhantomData,
         })
     }

--- a/lib/segment/src/index/field_index/numeric_index/builders.rs
+++ b/lib/segment/src/index/field_index/numeric_index/builders.rs
@@ -9,8 +9,8 @@ use gridstore::Blob;
 use serde_json::Value;
 
 use super::mutable_numeric_index::InMemoryNumericIndex;
+use super::on_disk_numeric_index::OnDiskNumericIndex;
 use super::storage::NumericIndexInner;
-use super::universal_numeric_index::UniversalNumericIndex;
 use super::{Encodable, NumericIndex, NumericIndexIntoInnerValue};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::numeric_point::Numericable;
@@ -123,7 +123,7 @@ where
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {
-        let inner = UniversalNumericIndex::build(
+        let inner = OnDiskNumericIndex::build(
             &MmapFs,
             self.in_memory_index,
             &self.path,

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/lifecycle.rs
@@ -27,7 +27,7 @@ where
     /// Numeric's body has no fallible reads to propagate (`from_mmap` is
     /// infallible; `clear_cache` errors are warn-and-continue, matching the
     /// other variants).
-    pub(in super::super) fn open_mmap(index: UniversalNumericIndex<T>) -> Self {
+    pub(in super::super) fn load_from_on_disk(index: UniversalNumericIndex<T>) -> Self {
         // Load in-memory index from mmap storage
         let InMemoryNumericIndex {
             map,
@@ -35,11 +35,11 @@ where
             points_count,
             max_values_per_point,
             point_to_values,
-        } = InMemoryNumericIndex::from_mmap(&index);
+        } = InMemoryNumericIndex::from_on_disk(&index);
 
-        // Index is now loaded into memory, clear cache of backing mmap storage
+        // Index is now loaded into memory, clear cache of backing storage
         if let Err(err) = index.clear_cache() {
-            log::warn!("Failed to clear mmap cache of ram mmap numeric index: {err}");
+            log::warn!("Failed to clear cache of on-disk numeric index: {err}");
         }
 
         let mut result = Self {

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/lifecycle.rs
@@ -2,11 +2,12 @@ use std::ops::Bound;
 use std::path::PathBuf;
 
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::Encodable;
 use super::super::mutable_numeric_index::InMemoryNumericIndex;
-use super::super::universal_numeric_index::UniversalNumericIndex;
+use super::super::on_disk_numeric_index::OnDiskNumericIndex;
 use super::{ImmutableNumericIndex, NumericKeySortedVec};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
@@ -15,9 +16,11 @@ use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stored_point_to_values::StoredValue;
 
-impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> ImmutableNumericIndex<T>
+impl<T, S> ImmutableNumericIndex<T, S>
 where
     Vec<T>: Blob,
+    T: Encodable + Numericable + StoredValue + Send + Sync + Default,
+    S: UniversalRead,
 {
     /// Open and load immutable numeric index from mmap storage.
     ///
@@ -27,7 +30,7 @@ where
     /// Numeric's body has no fallible reads to propagate (`from_mmap` is
     /// infallible; `clear_cache` errors are warn-and-continue, matching the
     /// other variants).
-    pub(in super::super) fn load_from_on_disk(index: UniversalNumericIndex<T>) -> Self {
+    pub(in super::super) fn load_from_on_disk(index: OnDiskNumericIndex<T, S>) -> Self {
         // Load in-memory index from mmap storage
         let InMemoryNumericIndex {
             map,

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
@@ -1,9 +1,10 @@
 use std::ops::Bound;
 
 use common::bitvec::{BitSliceExt as _, BitVec};
+use common::universal_io::{MmapFile, UniversalRead};
 
 use super::Encodable;
-use super::universal_numeric_index::UniversalNumericIndex;
+use super::on_disk_numeric_index::OnDiskNumericIndex;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues;
 use crate::index::field_index::numeric_point::{Numericable, Point};
@@ -12,14 +13,17 @@ use crate::index::field_index::stored_point_to_values::StoredValue;
 mod lifecycle;
 mod read_ops;
 
-pub struct ImmutableNumericIndex<T: Encodable + Numericable + StoredValue + Default> {
+pub struct ImmutableNumericIndex<
+    T: Encodable + Numericable + StoredValue + Default,
+    S: UniversalRead = MmapFile,
+> {
     pub(super) map: NumericKeySortedVec<T>,
     pub(super) histogram: Histogram<T>,
     pub(super) points_count: usize,
     pub(super) max_values_per_point: usize,
     pub(super) point_to_values: ImmutablePointToValues<T>,
     // Backing storage, source of state, persists deletions
-    pub(super) storage: Box<UniversalNumericIndex<T>>,
+    pub(super) storage: Box<OnDiskNumericIndex<T, S>>,
     /// Snapshot of approximate RAM usage at construction time.
     /// Not refreshed on `remove_point`.
     pub(super) cached_ram_usage_bytes: usize,

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
@@ -2,6 +2,7 @@ use std::ops::Bound;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::Encodable;
@@ -13,7 +14,11 @@ use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::stored_point_to_values::StoredValue;
 use crate::index::payload_config::StorageType;
 
-impl<T: Encodable + Numericable + StoredValue + Default> ImmutableNumericIndex<T> {
+impl<T, S> ImmutableNumericIndex<T, S>
+where
+    T: Encodable + Numericable + StoredValue + Default,
+    S: UniversalRead,
+{
     pub(super) fn compute_ram_usage_bytes(&self) -> usize {
         let Self {
             map,
@@ -29,10 +34,11 @@ impl<T: Encodable + Numericable + StoredValue + Default> ImmutableNumericIndex<T
     }
 }
 
-impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> NumericIndexRead<T>
-    for ImmutableNumericIndex<T>
+impl<T, S> NumericIndexRead<T> for ImmutableNumericIndex<T, S>
 where
     Vec<T>: Blob,
+    T: Encodable + Numericable + StoredValue + Send + Sync + Default,
+    S: UniversalRead,
 {
     fn check_values_any(
         &self,
@@ -104,9 +110,7 @@ where
     }
 
     fn storage_type(&self) -> StorageType {
-        StorageType::Mmap {
-            is_on_disk: self.storage.is_on_disk(),
-        }
+        StorageType::Mmap { is_on_disk: false }
     }
 
     /// Approximate RAM usage in bytes for in-memory structures (cached at construction).

--- a/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
@@ -30,7 +30,7 @@ where
     Vec<T>: Blob,
 {
     /// Load immutable mmap based index, either in RAM or on disk
-    pub fn new_mmap(
+    pub fn new_immutable(
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,
@@ -43,7 +43,7 @@ where
         }))
     }
 
-    pub fn new_gridstore(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
+    pub fn new_mutable(dir: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let index = NumericIndexInner::new_gridstore(dir, create_if_missing)?;
 
         Ok(index.map(|inner| Self {

--- a/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
@@ -82,7 +82,7 @@ where
         match &self.inner {
             NumericIndexInner::Mutable(_) => IndexMutability::Mutable,
             NumericIndexInner::Immutable(_) => IndexMutability::Immutable,
-            NumericIndexInner::Mmap(_) => IndexMutability::Immutable,
+            NumericIndexInner::OnDisk(_) => IndexMutability::Immutable,
         }
     }
 
@@ -90,7 +90,7 @@ where
         match &self.inner {
             NumericIndexInner::Mutable(index) => index.storage_type(),
             NumericIndexInner::Immutable(index) => index.storage_type(),
-            NumericIndexInner::Mmap(index) => StorageType::Mmap {
+            NumericIndexInner::OnDisk(index) => StorageType::Mmap {
                 is_on_disk: index.is_on_disk(),
             },
         }

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -5,11 +5,11 @@ mod lifecycle;
 pub mod mutable_numeric_index;
 mod numeric_field_index;
 pub mod numeric_index_read;
+pub mod on_disk_numeric_index;
 mod query;
 mod read_only;
 mod read_ops;
 mod storage;
-pub mod universal_numeric_index;
 mod value_indexer;
 
 use std::marker::PhantomData;

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
@@ -60,16 +60,16 @@ impl<T: Encodable + Numericable + Default> FromIterator<(PointOffsetType, T)>
 }
 
 impl<T: Encodable + Numericable + Default + StoredValue> InMemoryNumericIndex<T> {
-    /// Construct in-memroy index from given mmap index
+    /// Construct in-memory index from given on-disk index
     ///
     /// # Warning
     ///
-    /// Expensive because this reads the full mmap index.
-    pub(in super::super) fn from_mmap(mmap_index: &UniversalNumericIndex<T>) -> Self {
-        let point_count = mmap_index.storage.point_to_values.len();
+    /// Expensive because this reads the full on-disk index.
+    pub(in super::super) fn from_on_disk(on_disk_index: &UniversalNumericIndex<T>) -> Self {
+        let point_count = on_disk_index.storage.point_to_values.len();
 
         (0..point_count as PointOffsetType)
-            .filter_map(|idx| mmap_index.get_values(idx).map(|values| (idx, values)))
+            .filter_map(|idx| on_disk_index.get_values(idx).map(|values| (idx, values)))
             .flat_map(|(idx, values)| values.into_iter().map(move |value| (idx, value)))
             .collect::<InMemoryNumericIndex<T>>()
     }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
@@ -4,13 +4,14 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, Gridstore};
 
 use super::super::Encodable;
 use super::super::lifecycle::{HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
 use super::super::numeric_index_read::NumericIndexRead;
-use super::super::universal_numeric_index::UniversalNumericIndex;
+use super::super::on_disk_numeric_index::OnDiskNumericIndex;
 use super::{InMemoryNumericIndex, MutableNumericIndex, default_gridstore_options};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -65,7 +66,9 @@ impl<T: Encodable + Numericable + Default + StoredValue> InMemoryNumericIndex<T>
     /// # Warning
     ///
     /// Expensive because this reads the full on-disk index.
-    pub(in super::super) fn from_on_disk(on_disk_index: &UniversalNumericIndex<T>) -> Self {
+    pub(in super::super) fn from_on_disk<S: UniversalRead>(
+        on_disk_index: &OnDiskNumericIndex<T, S>,
+    ) -> Self {
         let point_count = on_disk_index.storage.point_to_values.len();
 
         (0..point_count as PointOffsetType)

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -38,7 +38,7 @@ where
         fs: &S::Fs,
         in_memory_index: InMemoryNumericIndex<T>,
         path: &Path,
-        is_on_disk: bool,
+        populate: bool,
         deleted_points: &BitSlice,
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
@@ -109,7 +109,7 @@ where
             deleted.flusher()()?;
         }
 
-        Self::open(fs, path, is_on_disk, deleted_points)?.ok_or_else(|| {
+        Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open UniversalNumericIndex after building it")
         })
     }

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use super::super::Encodable;
 use super::super::mutable_numeric_index::InMemoryNumericIndex;
-use super::{CONFIG_PATH, DELETED_PATH, PAIRS_PATH, Storage, UniversalNumericIndex};
+use super::{CONFIG_PATH, DELETED_PATH, OnDiskNumericIndex, PAIRS_PATH, Storage};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::histogram::Histogram;
@@ -28,7 +28,7 @@ struct UniversalNumericIndexConfig {
     max_values_per_point: usize,
 }
 
-impl<T, S> UniversalNumericIndex<T, S>
+impl<T, S> OnDiskNumericIndex<T, S>
 where
     T: Encodable + Numericable + Default + StoredValue + bytemuck::Pod,
     S: UniversalRead,
@@ -118,7 +118,7 @@ where
     pub fn open(
         fs: &S::Fs,
         path: &Path,
-        is_on_disk: bool,
+        populate: bool,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
@@ -133,17 +133,16 @@ where
         };
 
         let histogram = Histogram::<T>::load_via(fs, path)?;
-        let do_populate = !is_on_disk;
 
         let pairs_options = OpenOptions {
             writeable: false,
             need_sequential: false,
-            populate: Populate::from(do_populate),
+            populate: Populate::from(populate),
             advice: AdviceSetting::Global,
         };
         let pairs = TypedStorage::open(fs, pairs_path, pairs_options, Default::default())?;
 
-        let point_to_values = StoredPointToValues::open(fs, path, do_populate)?;
+        let point_to_values = StoredPointToValues::open(fs, path, populate)?;
         let mut deleted = deleted_points.to_owned();
 
         let deleted_payload_mmap = StoredBitSlice::<S>::open(
@@ -179,12 +178,15 @@ where
             histogram,
             deleted_count,
             max_values_per_point: config.max_values_per_point,
-            is_on_disk,
         }))
     }
 }
 
-impl<T: Encodable + Numericable + Default + StoredValue + 'static> UniversalNumericIndex<T> {
+impl<T, S> OnDiskNumericIndex<T, S>
+where
+    T: Encodable + Numericable + Default + StoredValue + 'static,
+    S: UniversalRead,
+{
     pub fn wipe(self) -> OperationResult<()> {
         let files = self.files();
         let path = self.path.clone();
@@ -253,7 +255,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static> UniversalNume
             histogram: _,
             deleted_count: _,
             max_values_per_point: _,
-            is_on_disk: _,
         } = self;
         let Storage {
             deleted: _,
@@ -273,7 +274,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static> UniversalNume
             histogram,
             deleted_count: _,
             max_values_per_point: _,
-            is_on_disk: _,
         } = self;
 
         histogram.ram_usage_bytes() + storage.ram_usage_bytes()

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
@@ -18,9 +18,6 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 /// Immutable numeric index served directly from a [`UniversalRead`] storage
 /// backend.
 ///
-/// The storage parameter `S` defaults to [`MmapFile`], but any `UniversalRead`
-/// implementation works — e.g. io_uring or disk-cache wrappers.
-///
 /// On-disk state (`data.bin`, `deleted.bin`, `point_to_values.*`, etc.) is
 /// written once during [`Self::build`] and not mutated afterwards: `deleted.bin`
 /// records only the points whose payload was empty at build time.
@@ -30,7 +27,7 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 /// only updates the in-memory bitvec. Callers must re-supply the authoritative
 /// deletion set (typically `id_tracker.deleted_point_bitslice()`) via the
 /// `deleted_points` argument to [`Self::open`] on reload.
-pub struct UniversalNumericIndex<
+pub struct OnDiskNumericIndex<
     T: Encodable + Numericable + Default + StoredValue + 'static,
     S: UniversalRead = MmapFile,
 > {
@@ -39,7 +36,6 @@ pub struct UniversalNumericIndex<
     pub(super) histogram: Histogram<T>,
     pub(super) deleted_count: usize,
     pub(super) max_values_per_point: usize,
-    pub(super) is_on_disk: bool,
 }
 
 pub(in super::super) struct Storage<

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -12,7 +12,7 @@ use itertools::Either;
 
 use super::super::Encodable;
 use super::super::numeric_index_read::NumericIndexRead;
-use super::UniversalNumericIndex;
+use super::OnDiskNumericIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
@@ -20,7 +20,7 @@ use crate::index::field_index::stored_point_to_values::StoredValue;
 use crate::index::payload_config::StorageType;
 
 impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalRead>
-    NumericIndexRead<T> for UniversalNumericIndex<T, S>
+    NumericIndexRead<T> for OnDiskNumericIndex<T, S>
 {
     fn check_values_any(
         &self,
@@ -30,7 +30,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     ) -> bool {
         // FIXME: don't silently ignore error — propagate it once
         // [`NumericIndexRead::check_values_any`] returns `OperationResult`.
-        let hw_counter = self.make_conditioned_counter(hw_counter);
+        let hw_counter = ConditionedCounter::always(hw_counter);
 
         if self.storage.deleted.get_bit(idx as usize) == Some(false) {
             self.storage
@@ -77,7 +77,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         end_bound: Bound<Point<T>>,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<impl Iterator<Item = PointOffsetType> + 'a> {
-        let hw_counter = self.make_conditioned_counter(hw_counter);
+        let hw_counter = ConditionedCounter::always(hw_counter);
 
         Ok(self
             .values_range_iterator(start_bound, end_bound)?
@@ -126,9 +126,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     }
 
     fn storage_type(&self) -> StorageType {
-        StorageType::Mmap {
-            is_on_disk: self.is_on_disk,
-        }
+        StorageType::Mmap { is_on_disk: true }
     }
 
     fn ram_usage_bytes(&self) -> usize {
@@ -141,7 +139,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
 }
 
 impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalRead>
-    UniversalNumericIndex<T, S>
+    OnDiskNumericIndex<T, S>
 {
     /// Binary search within `[lo, hi)` range of `pairs` storage.
     ///
@@ -236,14 +234,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         Ok(iter.filter(move |point| !deleted.get_bit(point.idx as usize).unwrap_or(true)))
     }
 
-    fn make_conditioned_counter<'a>(
-        &self,
-        hw_counter: &'a HardwareCounterCell,
-    ) -> ConditionedCounter<'a> {
-        ConditionedCounter::new(self.is_on_disk, hw_counter)
-    }
-
     pub fn is_on_disk(&self) -> bool {
-        self.is_on_disk
+        true
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
@@ -11,7 +11,7 @@ use gridstore::Blob;
 use super::super::Encodable;
 use super::super::immutable_numeric_index::ImmutableNumericIndex;
 use super::super::mutable_numeric_index::MutableNumericIndex;
-use super::super::universal_numeric_index::UniversalNumericIndex;
+use super::super::on_disk_numeric_index::OnDiskNumericIndex;
 use super::NumericIndexInner;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
@@ -36,7 +36,7 @@ where
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
         let Some(on_disk_index) =
-            UniversalNumericIndex::open(&MmapFs, path, effective_is_on_disk, deleted_points)?
+            OnDiskNumericIndex::open(&MmapFs, path, !effective_is_on_disk, deleted_points)?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
@@ -35,7 +35,7 @@ where
         let effective_is_on_disk =
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
-        let Some(mmap_index) =
+        let Some(on_disk_index) =
             UniversalNumericIndex::open(&MmapFs, path, effective_is_on_disk, deleted_points)?
         else {
             // Files don't exist, cannot load
@@ -43,12 +43,12 @@ where
         };
 
         if effective_is_on_disk {
-            // Use on mmap directly
-            Ok(Some(NumericIndexInner::Mmap(mmap_index)))
+            // Use on-disk directly
+            Ok(Some(NumericIndexInner::OnDisk(on_disk_index)))
         } else {
-            // Load into RAM, use mmap as backing storage
+            // Load into RAM, use on-disk as backing storage
             Ok(Some(NumericIndexInner::Immutable(
-                ImmutableNumericIndex::open_mmap(mmap_index),
+                ImmutableNumericIndex::load_from_on_disk(on_disk_index),
             )))
         }
     }
@@ -62,7 +62,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.flusher(),
             NumericIndexInner::Immutable(index) => index.flusher(),
-            NumericIndexInner::Mmap(index) => index.flusher(),
+            NumericIndexInner::OnDisk(index) => index.flusher(),
         }
     }
 
@@ -70,7 +70,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.files(),
             NumericIndexInner::Immutable(index) => index.files(),
-            NumericIndexInner::Mmap(index) => index.files(),
+            NumericIndexInner::OnDisk(index) => index.files(),
         }
     }
 
@@ -78,7 +78,7 @@ where
         match self {
             NumericIndexInner::Mutable(_) => vec![],
             NumericIndexInner::Immutable(index) => index.immutable_files(),
-            NumericIndexInner::Mmap(index) => index.immutable_files(),
+            NumericIndexInner::OnDisk(index) => index.immutable_files(),
         }
     }
 
@@ -86,7 +86,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.remove_point(idx)?,
             NumericIndexInner::Immutable(index) => index.remove_point(idx),
-            NumericIndexInner::Mmap(index) => index.remove_point(idx),
+            NumericIndexInner::OnDisk(index) => index.remove_point(idx),
         }
         Ok(())
     }
@@ -97,7 +97,7 @@ where
         match self {
             NumericIndexInner::Mutable(_) => {}   // Not a mmap
             NumericIndexInner::Immutable(_) => {} // Not a mmap
-            NumericIndexInner::Mmap(index) => index.populate()?,
+            NumericIndexInner::OnDisk(index) => index.populate()?,
         }
         Ok(())
     }
@@ -105,11 +105,11 @@ where
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
-            // Only clears backing mmap storage if used, not in-memory representation
+            // Only clears backing on-disk storage if used, not in-memory representation
             NumericIndexInner::Mutable(index) => index.clear_cache()?,
-            // Only clears backing mmap storage if used, not in-memory representation
+            // Only clears backing on-disk storage if used, not in-memory representation
             NumericIndexInner::Immutable(index) => index.clear_cache()?,
-            NumericIndexInner::Mmap(index) => index.clear_cache()?,
+            NumericIndexInner::OnDisk(index) => index.clear_cache()?,
         }
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/storage/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/mod.rs
@@ -39,7 +39,10 @@ pub enum NumericIndexInner<T: Encodable + Numericable + StoredValue + Send + Syn
 where
     Vec<T>: Blob,
 {
+    /// Loaded in RAM, use mutable storage format
     Mutable(MutableNumericIndex<T>),
+    /// Loaded in RAM, use immutable storage format
     Immutable(ImmutableNumericIndex<T>),
-    Mmap(UniversalNumericIndex<T>),
+    /// Served directly from storage (via mmap), use immutable format
+    OnDisk(UniversalNumericIndex<T>),
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/mod.rs
@@ -31,7 +31,7 @@ use gridstore::Blob;
 use super::Encodable;
 use super::immutable_numeric_index::ImmutableNumericIndex;
 use super::mutable_numeric_index::MutableNumericIndex;
-use super::universal_numeric_index::UniversalNumericIndex;
+use super::on_disk_numeric_index::OnDiskNumericIndex;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::stored_point_to_values::StoredValue;
 
@@ -44,5 +44,5 @@ where
     /// Loaded in RAM, use immutable storage format
     Immutable(ImmutableNumericIndex<T>),
     /// Served directly from storage (via mmap), use immutable format
-    OnDisk(UniversalNumericIndex<T>),
+    OnDisk(OnDiskNumericIndex<T>),
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/lifecycle.rs
@@ -8,7 +8,8 @@ use super::super::super::Encodable;
 use super::super::super::mutable_numeric_index::read_only::ReadOnlyAppendableNumericIndex;
 use super::ReadOnlyNumericIndexInner;
 use crate::common::operation_error::OperationResult;
-use crate::index::field_index::numeric_index::universal_numeric_index::UniversalNumericIndex;
+use crate::index::field_index::numeric_index::immutable_numeric_index::ImmutableNumericIndex;
+use crate::index::field_index::numeric_index::on_disk_numeric_index::OnDiskNumericIndex;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::stored_point_to_values::StoredValue;
 use crate::index::payload_config::IndexMutability;
@@ -54,12 +55,18 @@ where
             is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
 
         let Some(mmap_index) =
-            UniversalNumericIndex::open(fs, path, effective_is_on_disk, deleted_points)?
+            OnDiskNumericIndex::open(fs, path, !effective_is_on_disk, deleted_points)?
         else {
             return Ok(None);
         };
 
-        Ok(Some(Self::Immutable(mmap_index)))
+        let index = if effective_is_on_disk {
+            Self::OnDisk(mmap_index)
+        } else {
+            Self::Immutable(ImmutableNumericIndex::load_from_on_disk(mmap_index))
+        };
+
+        Ok(Some(index))
     }
 
     /// Reports the on-disk format's mutability, mirroring
@@ -80,6 +87,7 @@ where
         match self {
             Self::Appendable(_) => IndexMutability::Mutable,
             Self::Immutable(_) => IndexMutability::Immutable,
+            Self::OnDisk(_) => IndexMutability::Immutable,
         }
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/mod.rs
@@ -3,7 +3,8 @@ use gridstore::Blob;
 
 use super::super::Encodable;
 use super::super::mutable_numeric_index::read_only::ReadOnlyAppendableNumericIndex;
-use super::super::universal_numeric_index::UniversalNumericIndex;
+use super::super::on_disk_numeric_index::OnDiskNumericIndex;
+use crate::index::field_index::numeric_index::immutable_numeric_index::ImmutableNumericIndex;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::stored_point_to_values::StoredValue;
 
@@ -25,6 +26,8 @@ pub enum ReadOnlyNumericIndexInner<
 {
     /// Loads into RAM from appendable (Gridstore) storage format
     Appendable(ReadOnlyAppendableNumericIndex<T, S>),
+    /// Loads into RAM from storage in immutable format
+    Immutable(ImmutableNumericIndex<T, S>),
     /// Directly reads from storage in immutable format
-    Immutable(UniversalNumericIndex<T, S>),
+    OnDisk(OnDiskNumericIndex<T, S>),
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
@@ -40,6 +40,9 @@ where
             ReadOnlyNumericIndexInner::Immutable(index) => {
                 index.check_values_any(idx, check_fn, hw_counter)
             }
+            ReadOnlyNumericIndexInner::OnDisk(index) => {
+                index.check_values_any(idx, check_fn, hw_counter)
+            }
         }
     }
 
@@ -47,6 +50,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.get_values(idx),
             ReadOnlyNumericIndexInner::Immutable(index) => index.get_values(idx),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.get_values(idx),
         }
     }
 
@@ -54,6 +58,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.values_count(idx),
             ReadOnlyNumericIndexInner::Immutable(index) => index.values_count(idx),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.values_count(idx),
         }
     }
 
@@ -61,6 +66,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.total_unique_values_count(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.total_unique_values_count(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.total_unique_values_count(),
         }
     }
 
@@ -75,6 +81,9 @@ where
                 Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
             }
             ReadOnlyNumericIndexInner::Immutable(index) => {
+                Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
+            }
+            ReadOnlyNumericIndexInner::OnDisk(index) => {
                 Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
             }
         };
@@ -93,6 +102,9 @@ where
             ReadOnlyNumericIndexInner::Immutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound)?)
             }
+            ReadOnlyNumericIndexInner::OnDisk(index) => {
+                Box::new(index.orderable_values_range(start_bound, end_bound)?)
+            }
         };
         Ok(boxed)
     }
@@ -101,6 +113,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.get_histogram(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.get_histogram(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.get_histogram(),
         }
     }
 
@@ -108,6 +121,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.get_points_count(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.get_points_count(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.get_points_count(),
         }
     }
 
@@ -115,6 +129,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.get_max_values_per_point(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.get_max_values_per_point(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.get_max_values_per_point(),
         }
     }
 
@@ -122,6 +137,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.storage_type(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.storage_type(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.storage_type(),
         }
     }
 
@@ -129,6 +145,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.ram_usage_bytes(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.ram_usage_bytes(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.ram_usage_bytes(),
         }
     }
 
@@ -136,6 +153,7 @@ where
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => index.telemetry_index_type(),
             ReadOnlyNumericIndexInner::Immutable(index) => index.telemetry_index_type(),
+            ReadOnlyNumericIndexInner::OnDisk(index) => index.telemetry_index_type(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
@@ -38,7 +38,7 @@ where
             NumericIndexInner::Immutable(index) => {
                 index.check_values_any(idx, check_fn, hw_counter)
             }
-            NumericIndexInner::Mmap(index) => index.check_values_any(idx, check_fn, hw_counter),
+            NumericIndexInner::OnDisk(index) => index.check_values_any(idx, check_fn, hw_counter),
         }
     }
 
@@ -46,7 +46,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.get_values(idx),
             NumericIndexInner::Immutable(index) => index.get_values(idx),
-            NumericIndexInner::Mmap(index) => index.get_values(idx),
+            NumericIndexInner::OnDisk(index) => index.get_values(idx),
         }
     }
 
@@ -54,7 +54,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.values_count(idx),
             NumericIndexInner::Immutable(index) => index.values_count(idx),
-            NumericIndexInner::Mmap(index) => index.values_count(idx),
+            NumericIndexInner::OnDisk(index) => index.values_count(idx),
         }
     }
 
@@ -62,7 +62,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.total_unique_values_count(),
             NumericIndexInner::Immutable(index) => index.total_unique_values_count(),
-            NumericIndexInner::Mmap(index) => index.total_unique_values_count(),
+            NumericIndexInner::OnDisk(index) => index.total_unique_values_count(),
         }
     }
 
@@ -79,7 +79,7 @@ where
             NumericIndexInner::Immutable(index) => {
                 Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
             }
-            NumericIndexInner::Mmap(index) => {
+            NumericIndexInner::OnDisk(index) => {
                 Box::new(index.values_range(start_bound, end_bound, hw_counter)?)
             }
         };
@@ -98,7 +98,7 @@ where
             NumericIndexInner::Immutable(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound)?)
             }
-            NumericIndexInner::Mmap(index) => {
+            NumericIndexInner::OnDisk(index) => {
                 Box::new(index.orderable_values_range(start_bound, end_bound)?)
             }
         };
@@ -109,7 +109,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.get_histogram(),
             NumericIndexInner::Immutable(index) => index.get_histogram(),
-            NumericIndexInner::Mmap(index) => index.get_histogram(),
+            NumericIndexInner::OnDisk(index) => index.get_histogram(),
         }
     }
 
@@ -117,7 +117,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.get_points_count(),
             NumericIndexInner::Immutable(index) => index.get_points_count(),
-            NumericIndexInner::Mmap(index) => index.get_points_count(),
+            NumericIndexInner::OnDisk(index) => index.get_points_count(),
         }
     }
 
@@ -125,7 +125,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.get_max_values_per_point(),
             NumericIndexInner::Immutable(index) => index.get_max_values_per_point(),
-            NumericIndexInner::Mmap(index) => index.get_max_values_per_point(),
+            NumericIndexInner::OnDisk(index) => index.get_max_values_per_point(),
         }
     }
 
@@ -133,7 +133,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.storage_type(),
             NumericIndexInner::Immutable(index) => index.storage_type(),
-            NumericIndexInner::Mmap(index) => index.storage_type(),
+            NumericIndexInner::OnDisk(index) => index.storage_type(),
         }
     }
 
@@ -142,7 +142,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.ram_usage_bytes(),
             NumericIndexInner::Immutable(index) => index.ram_usage_bytes(),
-            NumericIndexInner::Mmap(index) => index.ram_usage_bytes(),
+            NumericIndexInner::OnDisk(index) => index.ram_usage_bytes(),
         }
     }
 
@@ -150,7 +150,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.telemetry_index_type(),
             NumericIndexInner::Immutable(index) => index.telemetry_index_type(),
-            NumericIndexInner::Mmap(index) => index.telemetry_index_type(),
+            NumericIndexInner::OnDisk(index) => index.telemetry_index_type(),
         }
     }
 }
@@ -177,7 +177,7 @@ where
         match self {
             NumericIndexInner::Mutable(_) => false,
             NumericIndexInner::Immutable(_) => false,
-            NumericIndexInner::Mmap(index) => index.is_on_disk(),
+            NumericIndexInner::OnDisk(index) => index.is_on_disk(),
         }
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
@@ -40,7 +40,7 @@ where
         match self {
             NumericIndexInner::Mutable(index) => index.wipe(),
             NumericIndexInner::Immutable(index) => index.wipe(),
-            NumericIndexInner::Mmap(index) => index.wipe(),
+            NumericIndexInner::OnDisk(index) => index.wipe(),
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -146,11 +146,13 @@ fn random_index(
     let mut index = index_builder.finalize().unwrap();
 
     if matches!(index_type, IndexType::RamMmap) {
-        let NumericIndexInner::Mmap(mmap_index) = index.inner else {
+        let NumericIndexInner::OnDisk(mmap_index) = index.inner else {
             panic!("Expected mmap index");
         };
         index = NumericIndex {
-            inner: NumericIndexInner::Immutable(ImmutableNumericIndex::open_mmap(mmap_index)),
+            inner: NumericIndexInner::Immutable(ImmutableNumericIndex::load_from_on_disk(
+                mmap_index,
+            )),
             _phantom: Default::default(),
         };
     }

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -13,7 +13,6 @@ use rstest::rstest;
 use serde_json::Value;
 use tempfile::{Builder, TempDir};
 
-use super::immutable_numeric_index::ImmutableNumericIndex;
 use super::*;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::numeric_point::Numericable;
@@ -112,13 +111,13 @@ fn open_index_from_disk(
     deleted: &BitSlice,
 ) -> NumericIndex<FloatPayloadType, FloatPayloadType> {
     match index_type {
-        IndexType::MutableGridstore => NumericIndex::new_gridstore(temp_dir.to_path_buf(), true)
+        IndexType::MutableGridstore => NumericIndex::new_mutable(temp_dir.to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::Mmap => NumericIndex::new_mmap(temp_dir, true, deleted)
+        IndexType::Mmap => NumericIndex::new_immutable(temp_dir, true, deleted)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => NumericIndex::new_mmap(temp_dir, false, deleted)
+        IndexType::RamMmap => NumericIndex::new_immutable(temp_dir, false, deleted)
             .unwrap()
             .unwrap(),
     }
@@ -143,19 +142,7 @@ fn random_index(
             .add_point(i as PointOffsetType, &values, &hw_counter)
             .unwrap();
     }
-    let mut index = index_builder.finalize().unwrap();
-
-    if matches!(index_type, IndexType::RamMmap) {
-        let NumericIndexInner::OnDisk(mmap_index) = index.inner else {
-            panic!("Expected mmap index");
-        };
-        index = NumericIndex {
-            inner: NumericIndexInner::Immutable(ImmutableNumericIndex::load_from_on_disk(
-                mmap_index,
-            )),
-            _phantom: Default::default(),
-        };
-    }
+    let index = index_builder.finalize().unwrap();
 
     (temp_dir, index)
 }

--- a/lib/segment/src/index/field_index/numeric_index/value_indexer.rs
+++ b/lib/segment/src/index/field_index/numeric_index/value_indexer.rs
@@ -30,7 +30,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, IntPayloadType> {
             NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
-            NumericIndexInner::Mmap(_) => Err(OperationError::service_error(
+            NumericIndexInner::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap numeric index",
             )),
         }
@@ -71,7 +71,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, DateTimePayloadType> {
             NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
-            NumericIndexInner::Mmap(_) => Err(OperationError::service_error(
+            NumericIndexInner::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap numeric index",
             )),
         }
@@ -108,7 +108,7 @@ impl ValueIndexer for NumericIndex<FloatPayloadType, FloatPayloadType> {
             NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
-            NumericIndexInner::Mmap(_) => Err(OperationError::service_error(
+            NumericIndexInner::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap numeric index",
             )),
         }
@@ -148,7 +148,7 @@ impl ValueIndexer for NumericIndex<UuidIntType, UuidPayloadType> {
             NumericIndexInner::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable numeric index",
             )),
-            NumericIndexInner::Mmap(_) => Err(OperationError::service_error(
+            NumericIndexInner::OnDisk(_) => Err(OperationError::service_error(
                 "Can't add values to mmap numeric index",
             )),
         }

--- a/lib/segment/src/index/field_index/numeric_index/value_indexer.rs
+++ b/lib/segment/src/index/field_index/numeric_index/value_indexer.rs
@@ -31,7 +31,7 @@ impl ValueIndexer for NumericIndex<IntPayloadType, IntPayloadType> {
                 "Can't add values to immutable numeric index",
             )),
             NumericIndexInner::OnDisk(_) => Err(OperationError::service_error(
-                "Can't add values to mmap numeric index",
+                "Can't add values to on-disk numeric index",
             )),
         }
     }

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -18,9 +18,7 @@ use common::defaults::log_load_timing;
 use fs_err as fs;
 
 use super::field_index::FieldIndex;
-use super::field_index::index_selector::{
-    IndexSelector, IndexSelectorGridstore, IndexSelectorMmap,
-};
+use super::field_index::index_selector::IndexSelector;
 use super::payload_config::{FullPayloadIndexType, PayloadFieldSchemaWithIndexType};
 use crate::common::operation_error::OperationResult;
 use crate::common::utils::IndexesMap;
@@ -33,8 +31,8 @@ use crate::vector_storage::VectorStorageEnum;
 
 #[derive(Debug)]
 enum StorageType {
-    GridstoreAppendable,
-    GridstoreNonAppendable,
+    Appendable,
+    NonAppendable,
 }
 
 /// `PayloadIndex` implementation, which actually uses index structures for providing faster search
@@ -204,9 +202,9 @@ impl StructPayloadIndex {
         };
 
         let storage_type = if is_appendable {
-            StorageType::GridstoreAppendable
+            StorageType::Appendable
         } else {
-            StorageType::GridstoreNonAppendable
+            StorageType::NonAppendable
         };
 
         let mut index = StructPayloadIndex {
@@ -276,27 +274,21 @@ impl StructPayloadIndex {
         let is_on_disk = payload_schema.is_on_disk();
 
         match &self.storage_type {
-            StorageType::GridstoreAppendable => {
-                IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
-            }
-            StorageType::GridstoreNonAppendable => IndexSelector::Mmap(IndexSelectorMmap {
+            StorageType::Appendable => IndexSelector::Appendable { dir: &self.path },
+            StorageType::NonAppendable => IndexSelector::NonAppendable {
                 dir: &self.path,
                 is_on_disk,
-            }),
+            },
         }
     }
 
     fn selector_with_type(&self, index_type: &FullPayloadIndexType) -> IndexSelector<'_> {
         match index_type.storage_type {
-            payload_config::StorageType::Gridstore => {
-                IndexSelector::Gridstore(IndexSelectorGridstore { dir: &self.path })
-            }
-            payload_config::StorageType::Mmap { is_on_disk } => {
-                IndexSelector::Mmap(IndexSelectorMmap {
-                    dir: &self.path,
-                    is_on_disk,
-                })
-            }
+            payload_config::StorageType::Gridstore => IndexSelector::Appendable { dir: &self.path },
+            payload_config::StorageType::Mmap { is_on_disk } => IndexSelector::NonAppendable {
+                dir: &self.path,
+                is_on_disk,
+            },
         }
     }
 

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -124,7 +124,7 @@ impl PayloadIndex for StructPayloadIndex {
             // existing files and reload the index in the new mode during
             // `build_index` instead of dropping and rebuilding from payload.
             SchemaTransition::OnlyOnDiskFlipped { .. }
-                if matches!(self.storage_type, StorageType::GridstoreNonAppendable) =>
+                if matches!(self.storage_type, StorageType::NonAppendable) =>
             {
                 Ok(false)
             }


### PR DESCRIPTION
A bunch of renames to standardize terms in indexes' enum variants

For the existing deployments (not taking read-only mode) we only want 3 possible variants:
- `Mutable`: used in appendable segments, or when there is no appropriate "optimized" version like for bool and null indexes
- `Immutable`: Same format as `OnDisk` but loaded in ram. 
- `OnDisk`: Same format as `Immutable` but served directly from universal-io.

Plus, now that we don't have rocksdb, we can get rid of the Gridstore postfix of variants and some methods.