### PR TITLE
edge: use `cargo metadata` instead of parsing Cargo.toml

### DIFF
--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -13,6 +13,7 @@ Amalgamation
 # ///
 
 import functools
+import json
 import os.path
 import re
 import shutil
@@ -56,7 +57,7 @@ def main() -> None:
     root_manifest = tomlkit.loads(
         Path(REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
     )
-    packages = all_file_dependencies(REPO_ROOT / "lib/edge")
+    packages = gather_packages()
 
     shutil.rmtree(AMALGAMATION, ignore_errors=True)
 
@@ -249,14 +250,11 @@ def gather_dependencies(
         for name, spec in root_manifest["workspace"]["dependencies"].items()
     }
 
-    excluded = set()
-
     def add_specs(path: tuple[str, ...], specs: dict) -> None:
         dest = None
         for name, spec in specs.items():
             spec = {"version": spec} if isinstance(spec, str) else spec
-            if name in EXCLUDED_DEPENDENCIES:
-                excluded.add(name)
+            if name in EXCLUDED_DEPENDENCIES or name in PACKAGES_TO_INCLUDE:
                 continue
             if "path" in spec or spec.get("optional") is True:
                 continue
@@ -306,28 +304,21 @@ def substitute(paths: Path | Iterable[Path], *replacements: tuple[str, str]) -> 
         assert seen, f"Pattern {pattern!r} not found"
 
 
-def all_file_dependencies(root: Path) -> dict[str, tuple[Path, tomlkit.TOMLDocument]]:
-    """Recursively collect Cargo.toml files for all dependencies.
-    Returns mapping package_name -> (path_to_package, manifest).
-    """
-    seen: set[Path] = {root}
-    stack = [root]
-    result: dict[str, tuple[Path, tomlkit.TOMLDocument]] = {}
+def gather_packages() -> dict[str, tuple[Path, tomlkit.TOMLDocument]]:
+    cargo_metadata = json.loads(
+        subprocess.check_output(
+            ["cargo", "metadata", "--format-version=1"], cwd=REPO_ROOT
+        )
+    )
+    meta_packages = {pkg["name"]: pkg for pkg in cargo_metadata["packages"]}
 
-    while stack:
-        path = stack.pop()
-        manifest = tomlkit.loads((path / "Cargo.toml").read_text(encoding="utf-8"))
-        name = manifest["package"]["name"]
-        if name in PACKAGES_TO_INCLUDE:
-            result[manifest["package"]["name"]] = (path, manifest)
-        for spec in manifest["dependencies"].values():
-            if isinstance(spec, dict) and isinstance(spec.get("path"), str):
-                dep = Path(os.path.normpath(path / spec["path"]))
-                if dep not in seen:
-                    seen.add(dep)
-                    stack.append(dep)
-
-    return dict(sorted(result.items()))
+    packages = []
+    for name in PACKAGES_TO_INCLUDE:
+        assert name in meta_packages, f"Package {name!r} not found in cargo metadata"
+        path = Path(meta_packages[name]["manifest_path"]).parent
+        manifest = tomlkit.loads((path / "Cargo.toml").read_text(encoding="utf8"))
+        packages.append((name, (path, manifest)))
+    return dict(sorted(packages))
 
 
 if __name__ == "__main__":

--- a/lib/edge/publish/ast-grep-rules.yaml
+++ b/lib/edge/publish/ast-grep-rules.yaml
@@ -7,8 +7,10 @@
 id: self-crate
 language: rust
 rule:
-  kind: crate
-  not: { inside: { kind: visibility_modifier } } # Don't fix `crate` in `pub(crate)`.
+  all:
+    - kind: crate
+    - not: { inside: { kind: visibility_modifier } } # `pub(crate)`
+    - not: { inside: { kind: extern_crate_declaration } } # `extern crate blah;`
 fix: crate::%PACKAGE%
 ---
 id: self-crate-in-macro-rules


### PR DESCRIPTION
This PR updates how `lib/edge/publish/amalgamate.py` works.

Previously: manually traverse workspace packages and parse their `Cargo.toml`.
In this PR: use `cargo metadata` to find package locations. It will provide locations both for workspace packages, and for cached dependencies.

Why: it should simplify using our non-crates.io forks as dependencies. (at least for simple packages without feature gates or build scripts)

With this change it's possible to add non-workspace crates into amalgamation. E.g., if we decide to fork/patch `tempfile`, we can add it into `PACKAGES_TO_INCLUDE` list, like so:
```diff
 PACKAGES_TO_INCLUDE = [
     # Crates from this workspace
     "bm25", "common", "edge", "gridstore", "posting_list",
     "quantization", "segment", "shard", "sparse", "wal",
+    # External dependencies
+    "tempfile",
 ]
```

(we should still prefer contributing changes upstream; but this change would simplify/unblock usage in the meantime)