### PR TITLE
Bump version to 1.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.18.1"
+version = "1.18.2"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.18.1"
+version = "1.18.2"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.18.1";
+pub const QDRANT_VERSION_STRING: &str = "1.18.2";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =

--- a/tools/missed_cherry_picks.sh
+++ b/tools/missed_cherry_picks.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Ignore all commits upto and including this commit hash on dev
-IGNORE_UPTO=4bca939259ddf07c1fb12c699cb6c94e98fa0843
+IGNORE_UPTO=899e2e34a5bb36050e1c4863c6739477226d7961
 
 # Fetch latest branch info from remote
 git fetch -q origin master


### PR DESCRIPTION
Bump Qdrant to version 1.18.2.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/9134>