### PR TITLE
Bump dev version to 1.18.3-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "1.18.2-dev"
+version = "1.18.3-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.18.2-dev"
+version = "1.18.3-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.18.2-dev"
+version = "1.18.3-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.18.2-dev"
+version = "1.18.3-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.18.2-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.18.3-dev";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =


### PR DESCRIPTION
Bump the dev version after the [Qdrant 1.18.2](https://github.com/qdrant/qdrant/pull/9290) release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/9135>