### PR TITLE
feat: implement LiveReload for geo index

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/live_reload.rs
@@ -1,0 +1,28 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::StoredGeoMapIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for StoredGeoMapIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        _new_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // No on-disk state changes on reload: this index is immutable, so only
+        // the in-memory deletion bitvec is patched. `fs` / `new_points` are
+        // unused because nothing is appended after build.
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/mmap_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mmap_geo_index/mod.rs
@@ -10,6 +10,7 @@ use crate::index::field_index::on_disk_point_to_values::OnDiskPointToValues;
 use crate::types::GeoPoint;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub(super) const DELETED_PATH: &str = "deleted.bin";

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
@@ -177,7 +177,7 @@ impl InMemoryGeoMapIndex {
     ///
     /// [1]: super::MutableGeoMapIndex::open_gridstore
     /// [2]: super::read_only::ReadOnlyAppendableGeoMapIndex::open
-    pub fn ingest_raw_points(
+    pub fn ingest(
         &mut self,
         idx: PointOffsetType,
         values: Vec<RawGeoPoint>,

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
@@ -53,7 +53,7 @@ impl MutableGeoMapIndex {
         store
             .iter::<_, OperationError>(
                 |idx, values: Vec<RawGeoPoint>| {
-                    in_memory_index.ingest_raw_points(idx, values)?;
+                    in_memory_index.ingest(idx, values)?;
                     Ok(true)
                 },
                 hw_counter_ref,

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -39,7 +39,7 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoMapIndex<S> {
             .iter::<_, OperationError>(
                 storage.max_point_offset(),
                 |idx, values: Vec<RawGeoPoint>| {
-                    in_memory_index.ingest_raw_points(idx, values)?;
+                    in_memory_index.ingest(idx, values)?;
                     Ok(true)
                 },
                 // Same counter the writable `open_gridstore` load uses; this is

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -28,13 +28,10 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoMapIndex<S> {
 
         self.storage
             .view()
-            .for_each_in_batch::<Random, _, OperationError>(
-                new_points,
-                |idx, maybe_values: Option<Vec<RawGeoPoint>>| {
-                    let Some(values) = maybe_values else {
-                        return Ok(());
-                    };
-                    let point_offset = new_points[idx];
+            .read_values::<Random, _, OperationError>(
+                new_points.iter().copied().enumerate(),
+                |_, point_offset, maybe_values: Option<Vec<RawGeoPoint>>| {
+                    let values = maybe_values.unwrap_or_default();
                     in_memory_index.ingest(point_offset, values)?;
                     Ok(())
                 },

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -35,7 +35,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoMapIndex<S> {
                         return Ok(());
                     };
                     let point_offset = new_points[idx];
-                    in_memory_index.ingest_raw_points(point_offset, values)?;
+                    in_memory_index.ingest(point_offset, values)?;
                     Ok(())
                 },
                 hw_counter.payload_index_io_read_counter(),

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -1,0 +1,46 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyAppendableGeoMapIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::LiveReload;
+use crate::types::RawGeoPoint;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoMapIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        new_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.live_reload(fs)?;
+
+        let in_memory_index = &mut self.in_memory_index;
+
+        for deleted_point in deleted_points {
+            in_memory_index.remove_point(*deleted_point)?;
+        }
+
+        self.storage
+            .view()
+            .for_each_in_batch::<Random, _, OperationError>(
+                new_points,
+                |idx, maybe_values: Option<Vec<RawGeoPoint>>| {
+                    let Some(values) = maybe_values else {
+                        return Ok(());
+                    };
+                    let point_offset = new_points[idx];
+                    in_memory_index.ingest_raw_points(point_offset, values)?;
+                    Ok(())
+                },
+                hw_counter.payload_index_io_read_counter(),
+            )?;
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
@@ -5,6 +5,7 @@ use super::inner::InMemoryGeoMapIndex;
 use crate::types::RawGeoPoint;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart to [`super::MutableGeoMapIndex`].


### PR DESCRIPTION
### Summary

Implements the `LiveReload` trait for the read-only **geo** index variants, so an open read-only index can refresh to the current on-disk state without a full re-open while a writer keeps appending to the same files. Builds on the `LiveReload` trait from #9295.

- **`ReadOnlyAppendableGeoMapIndex`** (gridstore-backed): reloads the backing storage, drops `deleted_points` from the in-memory index, then ingests `new_points` from the refreshed gridstore view (batched read).
- **`StoredGeoMapIndex`** (immutable mmap): on-disk state never changes after build, so only the in-memory deletion bitvec is patched; `fs` / `new_points` are unused.
- Renames `InMemoryGeoMapIndex::ingest_raw_points` → `ingest` for naming consistency with the other indexes, and updates the existing callers (writable + read-only gridstore load).

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
