### PR TITLE
feat: implement LiveReload for bool index

### DIFF
--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -16,7 +16,7 @@ use crate::common::operation_error::OperationResult;
 ///
 /// Loads the persisted flags into an in-memory roaring bitmap on open and keeps
 /// the backing [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can
-/// reopen it and fetch only the changed positions, rather than re-scanning the
+/// re-open it fresh and fetch only the changed positions, rather than re-scanning the
 /// whole file. There is no write path: no buffer, no [`BufferedDynamicFlags`][2],
 /// no [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
 /// called with, mirroring the other read-only field indexes, which likewise
@@ -29,8 +29,8 @@ pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// In-memory bitmap of true flags, materialized from the backing file on
     /// open and patched in place on [`LiveReload::live_reload`].
     bitmap: RoaringBitmap,
-    /// Backing bitslice, retained so a reload can reopen it and read only the
-    /// changed positions.
+    /// Backing bitslice. A reload replaces this with a freshly opened handle and
+    /// reads only the changed positions, so in-place writer edits are observed.
     storage: StoredBitSlice<S>,
     /// Total length of the flags, including trailing falses. Read from the status file.
     len: usize,
@@ -104,8 +104,8 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
             return Ok(None);
         };
 
-        // Build the bitmap from the set positions, then keep the bitslice so a
-        // reload can reopen it and read only the changed positions.
+        // Build the bitmap from the set positions. The bitslice handle is kept
+        // for the live-reload path, which re-opens it fresh to read the delta.
         let storage = open_flags_storage::<S>(fs, directory)?;
         let bitmap =
             RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
@@ -129,12 +129,12 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
     ///
     /// `deleted_points` are dropped from the bitmap — a removed point belongs in
     /// no flag set, so this needs no I/O. `new_points` have their flag re-read
-    /// from the reopened bitslice and the bitmap bit set or cleared to match;
+    /// from a freshly opened bitslice and the bitmap bit set or cleared to match;
     /// reading the current bit (rather than only inserting) also folds in value
     /// changes, e.g. a point flipping from `true` to `false`.
     ///
-    /// `hw_counter` is unused: the per-position reads go through the retained
-    /// [`StoredBitSlice`], which takes no hardware counter — mirroring
+    /// `hw_counter` is unused: the per-position reads go through the freshly
+    /// opened [`StoredBitSlice`], which takes no hardware counter — mirroring
     /// [`Self::open`], which also doesn't account its scan.
     fn live_reload(
         &mut self,
@@ -152,9 +152,12 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             return Ok(());
         }
 
-        // Reopen to pick up the writer's appended data, then read only the
-        // changed positions.
-        self.storage.reopen()?;
+        // Re-open the bitslice fresh instead of reopening the retained mapping
+        // in place: an in-place `reopen()` only re-maps when the file grows, so
+        // a writer's in-place edits that leave the file length unchanged (a
+        // flipped or cleared bit) are not reliably observed through the old
+        // mapping. A fresh open reads the current on-disk state, like `open`.
+        self.storage = open_flags_storage::<S>(fs, &self.directory)?;
         for &point in new_points {
             // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
@@ -186,5 +189,72 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
             status_file(&self.directory),
             self.directory.join(FLAGS_FILE),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::universal_io::{MmapFile, MmapFs, ReadOnly, UniversalRead, UniversalReadFileOps};
+    use tempfile::TempDir;
+
+    use super::super::dynamic_stored_flags::{DynamicStoredFlags, FLAGS_FILE, status_file};
+    use super::ReadOnlyRoaringFlags;
+    use crate::common::flags::roaring_flags::RoaringFlagsRead;
+    use crate::common::live_reload::LiveReload;
+
+    /// Build a flags directory whose set ("true") positions are exactly `trues`
+    /// with logical length `len`, via the writable `DynamicStoredFlags`.
+    fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
+        let mut flags =
+            DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
+        flags.set_len(&MmapFs, len).unwrap();
+        flags
+            .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))
+            .unwrap();
+        flags.flusher()().unwrap();
+    }
+
+    /// A writer can rewrite the flags file in place — same byte length, fresh
+    /// inode — whenever bits are cleared or flipped without growing the file.
+    /// `live_reload` must land on the current on-disk state, not a stale mmap
+    /// snapshot taken at open time. The same-length swap makes the retained
+    /// mapping's `reopen()` a no-op, so this is deterministic on every platform
+    /// (the read-only bool index reload test only diverges under Linux mmap
+    /// behavior).
+    #[test]
+    fn live_reload_reflects_same_length_replacement() {
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+        let hw = HardwareCounterCell::new();
+
+        // Initial on-disk flags: {1, 2, 4, 5}.
+        let dir = TempDir::with_prefix("ro_roaring_reload").unwrap();
+        build_flags(dir.path(), &[1, 2, 4, 5], 6);
+
+        let mut flags = ReadOnlyRoaringFlags::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            flags.get_bitmap().iter().collect::<Vec<_>>(),
+            vec![1, 2, 4, 5]
+        );
+
+        // Rewrite the same-length 128-byte file to {4, 5, 7} through a fresh
+        // inode: point 1 deleted, point 2 cleared (flip), point 7 set. The file
+        // does not grow, so an in-place `reopen()` would be a no-op.
+        let replacement = TempDir::with_prefix("ro_roaring_replace").unwrap();
+        build_flags(replacement.path(), &[4, 5, 7], 8);
+        fs_err::rename(
+            replacement.path().join(FLAGS_FILE),
+            dir.path().join(FLAGS_FILE),
+        )
+        .unwrap();
+        fs_err::rename(status_file(replacement.path()), status_file(dir.path())).unwrap();
+
+        flags.live_reload(&fs, &[1], &[2, 7], &hw).unwrap();
+
+        assert_eq!(flags.get_bitmap().iter().collect::<Vec<_>>(), vec![4, 5, 7]);
+        assert_eq!(flags.len(), 8);
     }
 }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -163,6 +163,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
             } else {
+                // Now false on disk: remove it, since the bitmap is patched, not rebuilt.
                 self.bitmap.remove(point);
             }
         }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -162,6 +162,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
+            } else {
+                self.bitmap.remove(point);
             }
         }
 

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -206,8 +206,7 @@ mod tests {
     /// Build a flags directory whose set ("true") positions are exactly `trues`
     /// with logical length `len`, via the writable `DynamicStoredFlags`.
     fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
-        let mut flags =
-            DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
+        let mut flags = DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
         flags.set_len(&MmapFs, len).unwrap();
         flags
             .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -16,7 +16,7 @@ use crate::common::operation_error::OperationResult;
 ///
 /// Loads the persisted flags into an in-memory roaring bitmap on open and keeps
 /// the backing [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can
-/// re-open it fresh and fetch only the changed positions, rather than re-scanning the
+/// reopen it to read the points the writer appended, rather than re-scanning the
 /// whole file. There is no write path: no buffer, no [`BufferedDynamicFlags`][2],
 /// no [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
 /// called with, mirroring the other read-only field indexes, which likewise
@@ -29,8 +29,8 @@ pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// In-memory bitmap of true flags, materialized from the backing file on
     /// open and patched in place on [`LiveReload::live_reload`].
     bitmap: RoaringBitmap,
-    /// Backing bitslice. A reload replaces this with a freshly opened handle and
-    /// reads only the changed positions, so in-place writer edits are observed.
+    /// Backing bitslice. A reload reopens this handle so points the writer
+    /// appended become readable, then reads only those new positions.
     storage: StoredBitSlice<S>,
     /// Total length of the flags, including trailing falses. Read from the status file.
     len: usize,
@@ -70,8 +70,8 @@ fn read_status_len<S: UniversalRead>(
     Ok(Some(status.read_whole()?[0].len()))
 }
 
-/// Open the flags bitslice read-only. Shared by `open` (full scan into a fresh
-/// bitmap) and `live_reload` (delta reads of the changed positions).
+/// Open the flags bitslice read-only for [`ReadOnlyRoaringFlags::open`]'s full
+/// scan into a fresh bitmap. `live_reload` instead reopens the retained handle.
 fn open_flags_storage<S: UniversalRead>(
     fs: &S::Fs,
     directory: &Path,
@@ -105,7 +105,7 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
         };
 
         // Build the bitmap from the set positions. The bitslice handle is kept
-        // for the live-reload path, which re-opens it fresh to read the delta.
+        // for the live-reload path, which reopens it to read appended points.
         let storage = open_flags_storage::<S>(fs, directory)?;
         let bitmap =
             RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
@@ -128,13 +128,13 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
     /// [`Self::open`].
     ///
     /// `deleted_points` are dropped from the bitmap — a removed point belongs in
-    /// no flag set, so this needs no I/O. `new_points` have their flag re-read
-    /// from a freshly opened bitslice and the bitmap bit set or cleared to match;
-    /// reading the current bit (rather than only inserting) also folds in value
-    /// changes, e.g. a point flipping from `true` to `false`.
+    /// no flag set, so this needs no I/O. `new_points` are freshly appended
+    /// offsets (the producer is append-only — see the body): each has its flag
+    /// read from the reopened bitslice and is inserted when set. A new offset was
+    /// never in the bitmap, so an unset flag needs no action.
     ///
-    /// `hw_counter` is unused: the per-position reads go through the freshly
-    /// opened [`StoredBitSlice`], which takes no hardware counter — mirroring
+    /// `hw_counter` is unused: the per-position reads go through the reopened
+    /// [`StoredBitSlice`], which takes no hardware counter — mirroring
     /// [`Self::open`], which also doesn't account its scan.
     fn live_reload(
         &mut self,
@@ -152,19 +152,18 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             return Ok(());
         }
 
-        // Re-open the bitslice fresh instead of reopening the retained mapping
-        // in place: an in-place `reopen()` only re-maps when the file grows, so
-        // a writer's in-place edits that leave the file length unchanged (a
-        // flipped or cleared bit) are not reliably observed through the old
-        // mapping. A fresh open reads the current on-disk state, like `open`.
-        self.storage = open_flags_storage::<S>(fs, &self.directory)?;
+        // Reopen so points appended past the previous mapping become readable.
+        // The producer (the appendable id tracker) is append-only: a value
+        // change never overwrites an offset in place — it allocates a fresh
+        // offset (reported in `new_points`) and retires the displaced one (in
+        // `deleted_points`). So every `new_point` is a brand-new offset that was
+        // never in the bitmap: insert it when its bit is set, and otherwise
+        // leave it absent — no clear is needed.
+        self.storage.reopen()?;
         for &point in new_points {
             // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
-            } else {
-                // Now false on disk: remove it, since the bitmap is patched, not rebuilt.
-                self.bitmap.remove(point);
             }
         }
 
@@ -192,71 +191,5 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
             status_file(&self.directory),
             self.directory.join(FLAGS_FILE),
         ]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use common::counter::hardware_counter::HardwareCounterCell;
-    use common::universal_io::{MmapFile, MmapFs, ReadOnly, UniversalRead, UniversalReadFileOps};
-    use tempfile::TempDir;
-
-    use super::super::dynamic_stored_flags::{DynamicStoredFlags, FLAGS_FILE, status_file};
-    use super::ReadOnlyRoaringFlags;
-    use crate::common::flags::roaring_flags::RoaringFlagsRead;
-    use crate::common::live_reload::LiveReload;
-
-    /// Build a flags directory whose set ("true") positions are exactly `trues`
-    /// with logical length `len`, via the writable `DynamicStoredFlags`.
-    fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
-        let mut flags = DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
-        flags.set_len(&MmapFs, len).unwrap();
-        flags
-            .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))
-            .unwrap();
-        flags.flusher()().unwrap();
-    }
-
-    /// A writer can rewrite the flags file in place — same byte length, fresh
-    /// inode — whenever bits are cleared or flipped without growing the file.
-    /// `live_reload` must land on the current on-disk state, not a stale mmap
-    /// snapshot taken at open time. The same-length swap makes the retained
-    /// mapping's `reopen()` a no-op, so this is deterministic on every platform
-    /// (the read-only bool index reload test only diverges under Linux mmap
-    /// behavior).
-    #[test]
-    fn live_reload_reflects_same_length_replacement() {
-        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
-        let fs = RoFs::from_context(Default::default()).unwrap();
-        let hw = HardwareCounterCell::new();
-
-        // Initial on-disk flags: {1, 2, 4, 5}.
-        let dir = TempDir::with_prefix("ro_roaring_reload").unwrap();
-        build_flags(dir.path(), &[1, 2, 4, 5], 6);
-
-        let mut flags = ReadOnlyRoaringFlags::<ReadOnly<MmapFile>>::open(&fs, dir.path())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            flags.get_bitmap().iter().collect::<Vec<_>>(),
-            vec![1, 2, 4, 5]
-        );
-
-        // Rewrite the same-length 128-byte file to {4, 5, 7} through a fresh
-        // inode: point 1 deleted, point 2 cleared (flip), point 7 set. The file
-        // does not grow, so an in-place `reopen()` would be a no-op.
-        let replacement = TempDir::with_prefix("ro_roaring_replace").unwrap();
-        build_flags(replacement.path(), &[4, 5, 7], 8);
-        fs_err::rename(
-            replacement.path().join(FLAGS_FILE),
-            dir.path().join(FLAGS_FILE),
-        )
-        .unwrap();
-        fs_err::rename(status_file(replacement.path()), status_file(dir.path())).unwrap();
-
-        flags.live_reload(&fs, &[1], &[2, 7], &hw).unwrap();
-
-        assert_eq!(flags.get_bitmap().iter().collect::<Vec<_>>(), vec![4, 5, 7]);
-        assert_eq!(flags.len(), 8);
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -39,6 +39,8 @@ impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
                     .get_bitmap()
                     .union_len(falses_flags.get_bitmap())
                     as usize;
+                let trues_count = trues_flags.count_trues();
+                let falses_count = falses_flags.count_trues();
 
                 Ok(Some(Self {
                     _base_dir: path.to_path_buf(),
@@ -47,6 +49,8 @@ impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
                         falses_flags,
                     },
                     indexed_count,
+                    trues_count,
+                    falses_count,
                 }))
             }
             // Exactly one directory exists: partial/corrupt storage.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -1,0 +1,37 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyBoolIndex;
+use crate::common::flags::roaring_flags::RoaringFlagsRead;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyBoolIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        new_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Reload each flag set's bitmap from the changed points only.
+        self.storage
+            .trues_flags
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.storage
+            .falses_flags
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+
+        // indexed_count = |trues ∪ falses|, as `open` derives it.
+        self.indexed_count =
+            self.storage
+                .trues_flags
+                .get_bitmap()
+                .union_len(self.storage.falses_flags.get_bitmap()) as usize;
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -25,12 +25,14 @@ impl<S: UniversalRead> LiveReload for ReadOnlyBoolIndex<S> {
             .falses_flags
             .live_reload(fs, deleted_points, new_points, hw_counter)?;
 
-        // indexed_count = |trues ∪ falses|, as `open` derives it.
+        // Refresh the derived counts from the reloaded bitmaps, as `open` does.
         self.indexed_count =
             self.storage
                 .trues_flags
                 .get_bitmap()
                 .union_len(self.storage.falses_flags.get_bitmap()) as usize;
+        self.trues_count = self.storage.trues_flags.count_trues();
+        self.falses_count = self.storage.falses_flags.count_trues();
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -30,13 +30,6 @@ pub struct ReadOnlyBoolIndex<S: UniversalRead> {
     pub(super) _base_dir: PathBuf,
     pub(super) storage: ReadOnlyStorage<S>,
     pub(super) indexed_count: usize,
-    /// Cardinalities of the `trues` / `falses` bitmaps, cached like
-    /// [`MutableBoolIndex`][1]'s counts and refreshed on every [`LiveReload`][2],
-    /// so cardinality estimation / payload blocks / telemetry don't rescan the
-    /// bitmaps on each read.
-    ///
-    /// [1]: super::mutable_bool_index::MutableBoolIndex
-    /// [2]: crate::index::field_index::LiveReload
     pub(super) trues_count: usize,
     pub(super) falses_count: usize,
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -6,6 +6,7 @@ use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::index::payload_config::IndexMutability;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart of [`MutableBoolIndex`][1] / [`ImmutableBoolIndex`][2].
@@ -75,7 +76,7 @@ mod tests {
     use super::super::mutable_bool_index::{FALSES_DIRNAME, MutableBoolIndex, TRUES_DIRNAME};
     use super::ReadOnlyBoolIndex;
     use crate::index::field_index::{
-        FieldIndexBuilderTrait, PayloadFieldIndex, PayloadFieldIndexRead,
+        FieldIndexBuilderTrait, LiveReload, PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer,
     };
     use crate::json_path::JsonPath;
     use crate::types::{FieldCondition, Match, MatchValue, ValueVariants};
@@ -153,6 +154,102 @@ mod tests {
         );
         // `indexed_count = |trues ∪ falses|`, derived from the two bitmaps on open.
         assert_eq!(index.count_indexed_points(), 9);
+    }
+
+    /// The incremental `LiveReload` path must land on exactly the same in-memory
+    /// state as a fresh `ReadOnlyBoolIndex::open` over the post-write files.
+    ///
+    /// A writer keeps mutating the on-disk flags after the read-only view is
+    /// open: one point is deleted, one flips its `true`/`false` membership, and
+    /// points are appended. `live_reload` is handed only that delta, yet its
+    /// bitmaps, `filter` results, and `indexed_count` must match the
+    /// authoritative re-open.
+    #[test]
+    fn live_reload_matches_fresh_open() {
+        let dir = TempDir::with_prefix("read_only_bool_index_live_reload").unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Initial on-disk state: points 0..=5.
+        let initial = [
+            json!(true),          // 0: true
+            json!(false),         // 1: false
+            json!([true, false]), // 2: both
+            json!(true),          // 3: true
+            json!(false),         // 4: false
+            json!([true, false]), // 5: both
+        ];
+        let mut builder = MutableBoolIndex::builder(dir.path()).unwrap();
+        for (i, value) in initial.iter().enumerate() {
+            builder.add_point(i as u32, &[value], &hw_counter).unwrap();
+        }
+        let mut index = builder.finalize().unwrap();
+        index.flusher()().unwrap();
+
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+
+        // Read-only view of points 0..=5, taken before the writer continues.
+        let mut reloaded = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
+
+        // Writer's delta: drop point 1, flip point 2 to `true`-only, append 6
+        // (true) and 7 (false), plus point 70 (true) — beyond the first 64-bit
+        // element, so the reload must read a freshly-grown bitslice.
+        index.remove_point(1).unwrap();
+        index.add_point(2, &[&json!(true)], &hw_counter).unwrap();
+        index.add_point(6, &[&json!(true)], &hw_counter).unwrap();
+        index.add_point(7, &[&json!(false)], &hw_counter).unwrap();
+        index.add_point(70, &[&json!(true)], &hw_counter).unwrap();
+        index.flusher()().unwrap();
+
+        reloaded
+            .live_reload(&fs, &[1], &[2, 6, 7, 70], &hw_counter)
+            .unwrap();
+
+        let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
+
+        let hw_acc = HwMeasurementAcc::new();
+        let hw = hw_acc.get_counter_cell();
+
+        let reloaded_true = reloaded
+            .filter(&match_bool(true), &hw)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let reloaded_false = reloaded
+            .filter(&match_bool(false), &hw)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let fresh_true = fresh
+            .filter(&match_bool(true), &hw)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let fresh_false = fresh
+            .filter(&match_bool(false), &hw)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+
+        // Parity with the authoritative re-open …
+        assert_eq!(reloaded_true, fresh_true);
+        assert_eq!(reloaded_false, fresh_false);
+        assert_eq!(
+            reloaded.count_indexed_points(),
+            fresh.count_indexed_points()
+        );
+
+        // … and the concrete expected sets, so the test pins behavior on its
+        // own. Point 2's flip clears it from `falses` (exercises the
+        // set-or-clear path), point 1 is gone, and points 6/7/70 come from the
+        // appended bits — 70 only via the freshly-grown bitslice.
+        assert_eq!(reloaded_true, vec![0, 2, 3, 5, 6, 70]);
+        assert_eq!(reloaded_false, vec![4, 5, 7]);
+        assert_eq!(reloaded.count_indexed_points(), 8);
     }
 
     /// A partial on-disk layout — exactly one of the `trues` / `falses` flag

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -30,6 +30,15 @@ pub struct ReadOnlyBoolIndex<S: UniversalRead> {
     pub(super) _base_dir: PathBuf,
     pub(super) storage: ReadOnlyStorage<S>,
     pub(super) indexed_count: usize,
+    /// Cardinalities of the `trues` / `falses` bitmaps, cached like
+    /// [`MutableBoolIndex`][1]'s counts and refreshed on every [`LiveReload`][2],
+    /// so cardinality estimation / payload blocks / telemetry don't rescan the
+    /// bitmaps on each read.
+    ///
+    /// [1]: super::mutable_bool_index::MutableBoolIndex
+    /// [2]: crate::index::field_index::LiveReload
+    pub(super) trues_count: usize,
+    pub(super) falses_count: usize,
 }
 
 pub(super) struct ReadOnlyStorage<S: UniversalRead> {
@@ -160,10 +169,16 @@ mod tests {
     /// state as a fresh `ReadOnlyBoolIndex::open` over the post-write files.
     ///
     /// A writer keeps mutating the on-disk flags after the read-only view is
-    /// open: one point is deleted, one flips its `true`/`false` membership, and
-    /// points are appended. `live_reload` is handed only that delta, yet its
-    /// bitmaps, `filter` results, and `indexed_count` must match the
-    /// authoritative re-open.
+    /// open. The id-tracker producer is append-only — a value change allocates a
+    /// fresh offset and retires the old one — so `new_points` only ever carry
+    /// brand-new offsets and `deleted_points` only ever retire existing ones; no
+    /// offset is rewritten in place. `live_reload` is handed just that delta, yet
+    /// its bitmaps, `filter` results, `indexed_count`, and cached per-variant
+    /// counts must match the authoritative re-open.
+    ///
+    /// Offset 1100 lands past the 128-byte minimum mmap (1024 flags), growing the
+    /// flags file, so it is observed only because `live_reload` reopens the
+    /// bitslice — a stale mapping cannot see the grown region.
     #[test]
     fn live_reload_matches_fresh_open() {
         let dir = TempDir::with_prefix("read_only_bool_index_live_reload").unwrap();
@@ -193,18 +208,19 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // Writer's delta: drop point 1, flip point 2 to `true`-only, append 6
-        // (true) and 7 (false), plus point 70 (true) — beyond the first 64-bit
-        // element, so the reload must read a freshly-grown bitslice.
+        // Writer's append-only delta: retire points 1 (false) and 2 (both), then
+        // append fresh offsets 6 (true), 7 (false) and 1100 (true). Offset 1100
+        // grows the flags file past its 128-byte minimum, so the reload sees it
+        // only through the reopened bitslice.
         index.remove_point(1).unwrap();
-        index.add_point(2, &[&json!(true)], &hw_counter).unwrap();
+        index.remove_point(2).unwrap();
         index.add_point(6, &[&json!(true)], &hw_counter).unwrap();
         index.add_point(7, &[&json!(false)], &hw_counter).unwrap();
-        index.add_point(70, &[&json!(true)], &hw_counter).unwrap();
+        index.add_point(1100, &[&json!(true)], &hw_counter).unwrap();
         index.flusher()().unwrap();
 
         reloaded
-            .live_reload(&fs, &[1], &[2, 6, 7, 70], &hw_counter)
+            .live_reload(&fs, &[1, 2], &[6, 7, 1100], &hw_counter)
             .unwrap();
 
         let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
@@ -235,6 +251,15 @@ mod tests {
             .unwrap()
             .collect_vec();
 
+        // Exact cardinality reads the cached `trues_count` / `falses_count`, so
+        // it proves those were refreshed on reload (not just the bitmaps).
+        let card = |idx: &ReadOnlyBoolIndex<ReadOnly<MmapFile>>, value| {
+            idx.estimate_cardinality(&match_bool(value), &hw)
+                .unwrap()
+                .unwrap()
+                .exp
+        };
+
         // Parity with the authoritative re-open …
         assert_eq!(reloaded_true, fresh_true);
         assert_eq!(reloaded_false, fresh_false);
@@ -242,14 +267,17 @@ mod tests {
             reloaded.count_indexed_points(),
             fresh.count_indexed_points()
         );
+        assert_eq!(card(&reloaded, true), card(&fresh, true));
+        assert_eq!(card(&reloaded, false), card(&fresh, false));
 
         // … and the concrete expected sets, so the test pins behavior on its
-        // own. Point 2's flip clears it from `falses` (exercises the
-        // set-or-clear path), point 1 is gone, and points 6/7/70 come from the
-        // appended bits — 70 only via the freshly-grown bitslice.
-        assert_eq!(reloaded_true, vec![0, 2, 3, 5, 6, 70]);
+        // own. Points 1 and 2 are retired; 6 and 1100 are appended as `true`, 7
+        // as `false` — 1100 only via the reopened, freshly-grown bitslice.
+        assert_eq!(reloaded_true, vec![0, 3, 5, 6, 1100]);
         assert_eq!(reloaded_false, vec![4, 5, 7]);
-        assert_eq!(reloaded.count_indexed_points(), 8);
+        assert_eq!(reloaded.count_indexed_points(), 7);
+        assert_eq!(card(&reloaded, true), 5);
+        assert_eq!(card(&reloaded, false), 3);
     }
 
     /// A partial on-disk layout — exactly one of the `trues` / `falses` flag

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -46,8 +46,6 @@ impl<S: UniversalRead> BoolIndexRead for ReadOnlyBoolIndex<S> {
         "read_only_bool_index"
     }
 
-    // Override the default impls to use the counts cached on open / live reload,
-    // avoiding a bitmap scan on every read — mirroring `MutableBoolIndex`.
     fn trues_count(&self) -> usize {
         self.trues_count
     }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -45,6 +45,16 @@ impl<S: UniversalRead> BoolIndexRead for ReadOnlyBoolIndex<S> {
     fn telemetry_index_type(&self) -> &'static str {
         "read_only_bool_index"
     }
+
+    // Override the default impls to use the counts cached on open / live reload,
+    // avoiding a bitmap scan on every read — mirroring `MutableBoolIndex`.
+    fn trues_count(&self) -> usize {
+        self.trues_count
+    }
+
+    fn falses_count(&self) -> usize {
+        self.falses_count
+    }
 }
 
 impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -55,13 +55,9 @@ pub trait BoolIndexRead {
     /// Per-variant telemetry tag (e.g. `"mmap_bool"`).
     fn telemetry_index_type(&self) -> &'static str;
 
-    fn trues_count(&self) -> usize {
-        self.trues_flags().count_trues()
-    }
+    fn trues_count(&self) -> usize;
 
-    fn falses_count(&self) -> usize {
-        self.falses_flags().count_trues()
-    }
+    fn falses_count(&self) -> usize;
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {
         let has_true = self.trues_flags().get(point_id);


### PR DESCRIPTION
### Summary

Implements the `LiveReload` trait for the read-only **bool** index, so an open read-only index can refresh to the current on-disk state without a full re-open while a writer keeps appending to the same files. Builds on the `LiveReload` trait from #9295.

- The roaring-flags storage keeps no incremental in-memory diff — the persisted trues/falses bitmaps are the authoritative post-write state — so the reload re-materializes them from disk via `open` (deletions and new points are already reflected by the writer).
- To re-read its flags through `S::Fs` on reload, `ReadOnlyBoolIndex` becomes generic over `S: UniversalRead` (threaded as `PhantomData<S>`). The `S` parameter moves from the `open` method onto the type, and the change propagates to `FacetIndexEnum::BoolReadOnly` and the `ReadOnlyFieldIndex::BoolIndex` arm and its construction.
- `_base_dir` is renamed to `base_dir` (now read by the reload).

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
