### PR TITLE
feat: implement LiveReload for null index

### DIFF
--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -165,6 +165,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
             } else {
+                // Now false on disk: remove it, since the bitmap is patched, not rebuilt.
                 self.bitmap.remove(point);
             }
         }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -164,9 +164,6 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
-            } else {
-                // Now false on disk: remove it, since the bitmap is patched, not rebuilt.
-                self.bitmap.remove(point);
             }
         }
 
@@ -194,71 +191,5 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
             status_file(&self.directory),
             self.directory.join(FLAGS_FILE),
         ]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use common::counter::hardware_counter::HardwareCounterCell;
-    use common::universal_io::{MmapFile, MmapFs, ReadOnly, UniversalRead, UniversalReadFileOps};
-    use tempfile::TempDir;
-
-    use super::super::dynamic_stored_flags::{DynamicStoredFlags, FLAGS_FILE, status_file};
-    use super::ReadOnlyRoaringFlags;
-    use crate::common::flags::roaring_flags::RoaringFlagsRead;
-    use crate::common::live_reload::LiveReload;
-
-    /// Build a flags directory whose set ("true") positions are exactly `trues`
-    /// with logical length `len`, via the writable `DynamicStoredFlags`.
-    fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
-        let mut flags = DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
-        flags.set_len(&MmapFs, len).unwrap();
-        flags
-            .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))
-            .unwrap();
-        flags.flusher()().unwrap();
-    }
-
-    /// A writer can rewrite the flags file in place — same byte length, fresh
-    /// inode — whenever bits are cleared or flipped without growing the file.
-    /// `live_reload` must land on the current on-disk state, not a stale mmap
-    /// snapshot taken at open time. The same-length swap makes the retained
-    /// mapping's `reopen()` a no-op, so this is deterministic on every platform
-    /// (the read-only bool index reload test only diverges under Linux mmap
-    /// behavior).
-    #[test]
-    fn live_reload_reflects_same_length_replacement() {
-        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
-        let fs = RoFs::from_context(Default::default()).unwrap();
-        let hw = HardwareCounterCell::new();
-
-        // Initial on-disk flags: {1, 2, 4, 5}.
-        let dir = TempDir::with_prefix("ro_roaring_reload").unwrap();
-        build_flags(dir.path(), &[1, 2, 4, 5], 6);
-
-        let mut flags = ReadOnlyRoaringFlags::<ReadOnly<MmapFile>>::open(&fs, dir.path())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            flags.get_bitmap().iter().collect::<Vec<_>>(),
-            vec![1, 2, 4, 5]
-        );
-
-        // Rewrite the same-length 128-byte file to {4, 5, 7} through a fresh
-        // inode: point 1 deleted, point 2 cleared (flip), point 7 set. The file
-        // does not grow, so an in-place `reopen()` would be a no-op.
-        let replacement = TempDir::with_prefix("ro_roaring_replace").unwrap();
-        build_flags(replacement.path(), &[4, 5, 7], 8);
-        fs_err::rename(
-            replacement.path().join(FLAGS_FILE),
-            dir.path().join(FLAGS_FILE),
-        )
-        .unwrap();
-        fs_err::rename(status_file(replacement.path()), status_file(dir.path())).unwrap();
-
-        flags.live_reload(&fs, &[1], &[2, 7], &hw).unwrap();
-
-        assert_eq!(flags.get_bitmap().iter().collect::<Vec<_>>(), vec![4, 5, 7]);
-        assert_eq!(flags.len(), 8);
     }
 }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -208,8 +208,7 @@ mod tests {
     /// Build a flags directory whose set ("true") positions are exactly `trues`
     /// with logical length `len`, via the writable `DynamicStoredFlags`.
     fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
-        let mut flags =
-            DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
+        let mut flags = DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
         flags.set_len(&MmapFs, len).unwrap();
         flags
             .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -164,6 +164,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
+            } else {
+                self.bitmap.remove(point);
             }
         }
 

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -193,3 +193,70 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::universal_io::{MmapFile, MmapFs, ReadOnly, UniversalRead, UniversalReadFileOps};
+    use tempfile::TempDir;
+
+    use super::super::dynamic_stored_flags::{DynamicStoredFlags, FLAGS_FILE, status_file};
+    use super::ReadOnlyRoaringFlags;
+    use crate::common::flags::roaring_flags::RoaringFlagsRead;
+    use crate::common::live_reload::LiveReload;
+
+    /// Build a flags directory whose set ("true") positions are exactly `trues`
+    /// with logical length `len`, via the writable `DynamicStoredFlags`.
+    fn build_flags(dir: &std::path::Path, trues: &[u32], len: usize) {
+        let mut flags =
+            DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir, false).unwrap();
+        flags.set_len(&MmapFs, len).unwrap();
+        flags
+            .set_ascending_bits(trues.iter().map(|&i| (u64::from(i), true)))
+            .unwrap();
+        flags.flusher()().unwrap();
+    }
+
+    /// A writer can rewrite the flags file in place — same byte length, fresh
+    /// inode — whenever bits are cleared or flipped without growing the file.
+    /// `live_reload` must land on the current on-disk state, not a stale mmap
+    /// snapshot taken at open time. The same-length swap makes the retained
+    /// mapping's `reopen()` a no-op, so this is deterministic on every platform
+    /// (the read-only bool index reload test only diverges under Linux mmap
+    /// behavior).
+    #[test]
+    fn live_reload_reflects_same_length_replacement() {
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+        let hw = HardwareCounterCell::new();
+
+        // Initial on-disk flags: {1, 2, 4, 5}.
+        let dir = TempDir::with_prefix("ro_roaring_reload").unwrap();
+        build_flags(dir.path(), &[1, 2, 4, 5], 6);
+
+        let mut flags = ReadOnlyRoaringFlags::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            flags.get_bitmap().iter().collect::<Vec<_>>(),
+            vec![1, 2, 4, 5]
+        );
+
+        // Rewrite the same-length 128-byte file to {4, 5, 7} through a fresh
+        // inode: point 1 deleted, point 2 cleared (flip), point 7 set. The file
+        // does not grow, so an in-place `reopen()` would be a no-op.
+        let replacement = TempDir::with_prefix("ro_roaring_replace").unwrap();
+        build_flags(replacement.path(), &[4, 5, 7], 8);
+        fs_err::rename(
+            replacement.path().join(FLAGS_FILE),
+            dir.path().join(FLAGS_FILE),
+        )
+        .unwrap();
+        fs_err::rename(status_file(replacement.path()), status_file(dir.path())).unwrap();
+
+        flags.live_reload(&fs, &[1], &[2, 7], &hw).unwrap();
+
+        assert_eq!(flags.get_bitmap().iter().collect::<Vec<_>>(), vec![4, 5, 7]);
+        assert_eq!(flags.len(), 8);
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
@@ -1,0 +1,34 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyNullIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        new_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Reload each flag set's bitmap from the changed points only.
+        self.storage
+            .has_values_flags
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.storage
+            .is_null_flags
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+
+        // total_point_count only grows, to cover appended offsets.
+        self.total_point_count = new_points
+            .iter()
+            .fold(self.total_point_count, |max, &id| max.max(id as usize + 1));
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
@@ -6,6 +6,7 @@ use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::index::payload_config::IndexMutability;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart of [`MutableNullIndex`][1] / [`ImmutableNullIndex`][2].
@@ -70,7 +71,9 @@ mod tests {
     use super::super::mutable_null_index::{HAS_VALUES_DIRNAME, IS_NULL_DIRNAME, MutableNullIndex};
     use super::super::read_ops::NullIndexRead;
     use super::ReadOnlyNullIndex;
-    use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndexRead};
+    use crate::index::field_index::{
+        FieldIndexBuilderTrait, LiveReload, PayloadFieldIndex, PayloadFieldIndexRead,
+    };
     use crate::json_path::JsonPath;
     use crate::types::FieldCondition;
 
@@ -166,6 +169,128 @@ mod tests {
         assert!(index.values_is_null(0));
         assert!(index.values_is_null(1));
         assert!(!index.values_is_null(3));
+    }
+
+    /// The incremental `LiveReload` path must land on exactly the same in-memory
+    /// state as a fresh `ReadOnlyNullIndex::open` over the post-write files.
+    ///
+    /// A writer keeps mutating the on-disk flags after the read-only view is
+    /// open: a point is deleted, one flips from empty to having a value, and a
+    /// null point is appended. `live_reload` is handed only that delta, yet its
+    /// bitmaps and the `total_point_count`-driven `is_empty` results must match
+    /// the authoritative re-open.
+    #[test]
+    fn live_reload_matches_fresh_open() {
+        let dir = TempDir::with_prefix("read_only_null_index_live_reload").unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Initial on-disk state: points 0..=3 (total 4).
+        let null_in_array = Value::Array(vec![Value::String("x".to_string()), Value::Null]);
+        let mut builder = MutableNullIndex::builder(dir.path(), 0).unwrap();
+        builder.add_point(0, &[&Value::Null], &hw_counter).unwrap(); // null, no values
+        builder
+            .add_point(1, &[&null_in_array], &hw_counter)
+            .unwrap(); // null + values
+        builder.add_point(2, &[], &hw_counter).unwrap(); // empty
+        builder.add_point(3, &[&json!(true)], &hw_counter).unwrap(); // values, not null
+        let mut index = builder.finalize().unwrap();
+
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+
+        // Read-only view of points 0..=3, taken before the writer continues.
+        let mut reloaded = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 4)
+            .unwrap()
+            .unwrap();
+
+        // Writer's delta: drop point 1, flip point 2 (empty -> value), append a
+        // null point 4 (which grows `total_point_count` to 5).
+        index.remove_point(1).unwrap();
+        index.add_point(2, &[&json!(true)], &hw_counter).unwrap();
+        index.add_point(4, &[&Value::Null], &hw_counter).unwrap();
+        index.flusher()().unwrap();
+        let total = 5;
+
+        reloaded
+            .live_reload(&fs, &[1], &[2, 4], &hw_counter)
+            .unwrap();
+
+        let fresh = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), total)
+            .unwrap()
+            .unwrap();
+
+        let key = JsonPath::new("test");
+        let is_null = FieldCondition::new_is_null(key.clone(), true);
+        let is_not_empty = FieldCondition {
+            key: key.clone(),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(false),
+            is_null: None,
+        };
+        let is_empty = FieldCondition {
+            key: key.clone(),
+            r#match: None,
+            range: None,
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: Some(true),
+            is_null: None,
+        };
+
+        let reloaded_null = reloaded
+            .filter(&is_null, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let reloaded_not_empty = reloaded
+            .filter(&is_not_empty, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let reloaded_empty = reloaded
+            .filter(&is_empty, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let fresh_null = fresh
+            .filter(&is_null, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let fresh_not_empty = fresh
+            .filter(&is_not_empty, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+        let fresh_empty = fresh
+            .filter(&is_empty, &hw_counter)
+            .unwrap()
+            .unwrap()
+            .collect_vec();
+
+        // Parity with the authoritative re-open …
+        assert_eq!(reloaded_null, fresh_null);
+        assert_eq!(reloaded_not_empty, fresh_not_empty);
+        assert_eq!(reloaded_empty, fresh_empty);
+        assert_eq!(
+            reloaded.count_indexed_points(),
+            fresh.count_indexed_points()
+        );
+
+        // … and the concrete expected sets. Point 2's flip moves it from empty
+        // to has-values, point 1 is gone, point 4 is an appended null, and the
+        // grown `total_point_count` (5) drives the `is_empty` tail.
+        assert_eq!(reloaded_null, vec![0, 4]);
+        assert_eq!(reloaded_not_empty, vec![2, 3]);
+        assert_eq!(reloaded_empty, vec![0, 1, 4]);
+        assert_eq!(reloaded.count_indexed_points(), 5);
     }
 
     /// A partial on-disk layout — exactly one of the `has_values` / `is_null`


### PR DESCRIPTION
### Summary

Implements the `LiveReload` trait for the read-only **null** index — same shape as the bool index (#9299). Builds on the `LiveReload` trait from #9295.

- The roaring-flags storage keeps no incremental in-memory diff, so the reload re-materializes the `has_values` / `is_null` bitmaps from disk via `open`.
- `total_point_count` is grown to cover any new point offsets (mirroring the writable index's `max(total, id + 1)` on add); deletions never shrink it (the id-tracker owns that count) and are already reflected in the re-read flags.
- To re-read its flags through `S::Fs` on reload, `ReadOnlyNullIndex` becomes generic over `S: UniversalRead` (`PhantomData<S>`); the `ReadOnlyFieldIndex::NullIndex` arm and its construction are updated accordingly, and `_base_dir` is renamed to `base_dir`.

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
