### PR TITLE
fix(api): validate shard snapshot upload checksum

### DIFF
--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -507,7 +507,7 @@ async fn upload_shard_snapshot(
     early_auth: ActixAccessManage,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
-    query: web::Query<SnapshotUploadingParam>,
+    query: valid::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
 ) -> impl Responder {
     let ActixAccessManage { auth, multipass } = early_auth;
@@ -675,7 +675,7 @@ async fn recover_partial_snapshot(
     early_auth: ActixAccessManage,
     dispatcher: web::Data<Dispatcher>,
     path: valid::Path<CollectionShardPath>,
-    query: web::Query<SnapshotUploadingParam>,
+    query: valid::Query<SnapshotUploadingParam>,
     MultipartForm(form): MultipartForm<SnapshottingForm>,
 ) -> impl Responder {
     let ActixAccessManage { auth, multipass } = early_auth;

--- a/tests/openapi/test_shard_snapshot.py
+++ b/tests/openapi/test_shard_snapshot.py
@@ -15,6 +15,29 @@ def setup(on_disk_vectors, collection_name):
     drop_collection(collection_name=collection_name)
 
 
+def assert_malformed_checksum_rejected_before_upload(endpoint):
+    response = requests.post(
+        f"{QDRANT_HOST}{endpoint}",
+        params={'checksum': 'abc'},
+        files={'snapshot': ('snapshot.tar', b'not a snapshot', 'application/octet-stream')},
+        headers=qdrant_host_headers(),
+    )
+    assert response.status_code == 422
+    assert 'invalid_sha256_hash' in response.text
+
+
+def test_upload_shard_snapshot_rejects_malformed_checksum(collection_name):
+    assert_malformed_checksum_rejected_before_upload(
+        f"/collections/{collection_name}/shards/0/snapshots/upload",
+    )
+
+
+def test_recover_partial_snapshot_rejects_malformed_checksum(collection_name):
+    assert_malformed_checksum_rejected_before_upload(
+        f"/collections/{collection_name}/shards/0/snapshot/partial/recover",
+    )
+
+
 def test_shard_snapshot_operations(http_server, collection_name):
     (srv_dir, srv_url) = http_server
 


### PR DESCRIPTION
## Summary
- validate shard snapshot upload and partial recover query parameters with actix-web-validator
- make malformed shard snapshot upload checksums fail before multipart recovery handling
- add OpenAPI regressions for malformed checksum on both shard upload endpoints

## Testing
- cargo +nightly fmt --manifest-path qdrant\Cargo.toml --all -- --check
- python -m py_compile qdrant\tests\openapi\test_shard_snapshot.py

I could not run the full OpenAPI snapshot test locally because it requires a running Qdrant test server.

## AI assistance disclosure
This patch was prepared with assistance from OpenAI Codex. I used it to inspect the snapshot upload validation paths, make the focused change, and draft the regression tests; I reviewed the final diff and ran the checks listed above.