### PR TITLE
Sparse: use blink-alloc instead of typed-arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6966,6 +6966,7 @@ dependencies = [
  "atomicwrites",
  "bincode 1.3.3",
  "bitvec",
+ "blink-alloc",
  "bytemuck",
  "byteorder",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +932,15 @@ checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 dependencies = [
  "arrayvec 0.4.12",
  "constant_time_eq 0.1.5",
+]
+
+[[package]]
+name = "blink-alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c15bad517bc0fb4a44523adf470e2c3eb3a365769327acdba849948ea3705"
+dependencies = [
+ "allocator-api2 0.4.0",
 ]
 
 [[package]]
@@ -2551,7 +2566,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "anyhow",
  "bytes",
  "core_affinity",
@@ -3143,7 +3158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]
@@ -3152,7 +3167,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.1.5",
 ]
@@ -3163,7 +3178,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -5482,7 +5497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap 0.10.1",
@@ -5502,7 +5517,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -5604,7 +5619,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "prost-types 0.14.3",
@@ -7510,6 +7525,7 @@ version = "0.1.0"
 dependencies = [
  "bincode 1.3.3",
  "bitpacking",
+ "blink-alloc",
  "common",
  "criterion",
  "dataset",
@@ -7531,7 +7547,6 @@ dependencies = [
  "sha2 0.11.0",
  "sparse",
  "tempfile",
- "typed-arena",
  "validator",
  "zerocopy",
 ]
@@ -8383,12 +8398,6 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
  "rand 0.9.2",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ async-trait = "0.1.89"
 atomicwrites = "0.4.4"
 bincode = "1.3.3" # no upgrade because 2.0.x is much slower https://github.com/qdrant/qdrant/pull/6134
 bitpacking = "0.9.3"
+blink-alloc = "0.4.0"
 bytemuck = { version = "1.25.0", features = [
     "derive",
     "extern_crate_alloc",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = { workspace = true }
 pprof = { workspace = true }
 
 [dependencies]
+blink-alloc = { workspace = true }
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }
 fs-err = { workspace = true }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -227,14 +227,14 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let hw_counter = HardwareCounterCell::disposable();
 
         let mut unique_record_ids = std::collections::HashSet::new();
-        let mut arena = sparse::SearchScratchArena::new_slow();
+        let mut arena = blink_alloc::Blink::new();
         for dim_id in &query_vector.indices {
             if let Some(dim_id) = self.indices_tracker.remap_index(*dim_id) {
                 let posting_list_iter = self.inverted_index.get(dim_id, &arena, &hw_counter)?;
                 for element in posting_list_iter.into_std_iter() {
                     unique_record_ids.insert(element.record_id);
                 }
-                arena.gc();
+                arena.reset();
             }
         }
         Ok(unique_record_ids.len())

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -171,7 +171,7 @@ fn check_index_storage_consistency<T: InvertedIndex>(sparse_vector_index: &Spars
             .iter()
             .zip(remapped_vector.values.iter())
         {
-            let arena = sparse::SearchScratchArena::new_slow();
+            let arena = blink_alloc::Blink::new();
             let posting_list = sparse_vector_index
                 .inverted_index()
                 .get(*dim_id, &arena, &hw_counter)

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -16,6 +16,7 @@ testing = ["common/testing"]
 
 [dependencies]
 bitpacking = { workspace = true }
+blink-alloc = { workspace = true }
 gridstore = { path = "../gridstore" }
 bincode = { workspace = true }
 common = { path = "../common/common" }
@@ -33,7 +34,6 @@ itertools = { workspace = true }
 parking_lot = { workspace = true }
 log = { workspace = true }
 zerocopy = { workspace = true }
-typed-arena = "2.0.2"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Result};
@@ -8,7 +9,6 @@ use common::universal_io::{MmapFs, Result};
 use super::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use super::inverted_index_ram::InvertedIndexRam;
 use super::{InvertedIndex, out_of_bounds};
-use crate::SearchScratchArena;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset, Weight};
 use crate::index::compressed_posting_list::{
@@ -44,11 +44,11 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
 
         let hw_counter = HardwareCounterCell::disposable();
 
-        let mut arena = SearchScratchArena::new_slow();
+        let mut arena = Blink::new();
         for i in 0..mmap_inverted_index.file_header.posting_count as DimId {
             let posting_list = mmap_inverted_index.get(i, &arena, &hw_counter)?;
             inverted_index.postings.push(posting_list.to_owned());
-            arena.gc();
+            arena.reset();
         }
 
         mmap_inverted_index.clear_cache()?;
@@ -64,7 +64,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
     fn get<'a>(
         &'a self,
         id: DimOffset,
-        _arena: &'a SearchScratchArena,
+        _arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell, // Ignored for in-ram index
     ) -> Result<Self::Iter<'a>> {
         Ok(self.get(id, hw_counter)?.iter())

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 
+use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::ext::aligned_vec::ACow;
 use common::fs::{atomic_save_json, read_json};
@@ -20,7 +21,6 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use super::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
 use super::{INDEX_FILE_NAME, corrupted_index, out_of_bounds};
-use crate::SearchScratchArena;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset, Weight};
 use crate::index::compressed_posting_list::{
@@ -121,7 +121,7 @@ where
     fn get<'a>(
         &'a self,
         id: DimOffset,
-        arena: &'a SearchScratchArena,
+        arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
     ) -> Result<CompressedPostingListIterator<'a, W>> {
         Ok(self.get(id, arena, hw_counter)?.iter())
@@ -202,7 +202,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
     pub fn get<'a>(
         &'a self,
         id: DimId,
-        arena: &'a SearchScratchArena,
+        arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
     ) -> Result<CompressedPostingListView<'a, W>> {
         let (header, remainders_end) = self.read_posting_header(id, hw_counter)?;
@@ -213,7 +213,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         )?;
         let data = match data_bytes {
             ACow::Borrowed(b) => b,
-            ACow::Owned(avec) => arena.alloc(avec),
+            ACow::Owned(avec) => arena.put(avec),
         };
 
         let ids_len = header.ids_len as usize;
@@ -396,10 +396,10 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
 
     fn calculate_total_sparse_size(&self, hw_counter: &HardwareCounterCell) -> Result<usize> {
         let mut total = 0;
-        let mut arena = SearchScratchArena::new_slow();
+        let mut arena = Blink::new();
         for id in 0..self.file_header.posting_count as DimId {
             total += self.get(id, &arena, hw_counter)?.store_size().total;
-            arena.gc();
+            arena.reset();
         }
         Ok(total)
     }
@@ -429,7 +429,7 @@ mod tests {
         inverted_index_mmap: &InvertedIndexCompressedMmap<W, S>,
     ) {
         let hw_counter = HardwareCounterCell::new();
-        let arena = SearchScratchArena::new_slow();
+        let arena = Blink::new();
         for id in 0..inverted_index_ram.postings.len() as DimId {
             let posting_list_ram = inverted_index_ram
                 .postings
@@ -508,7 +508,7 @@ mod tests {
 
         compare_indexes(&inverted_index_ram, &index);
 
-        let arena = SearchScratchArena::new_slow();
+        let arena = Blink::new();
         assert!(index.get(0, &arena, &hw_counter).unwrap().is_empty()); // the first entry is always empty as dimension ids start at 1
         assert_eq!(index.get(1, &arena, &hw_counter).unwrap().len(), 9);
         assert_eq!(index.get(2, &arena, &hw_counter).unwrap().len(), 4);

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
@@ -59,7 +60,7 @@ impl InvertedIndex for InvertedIndexRam {
     fn get<'a>(
         &'a self,
         id: DimOffset,
-        _arena: &'a crate::SearchScratchArena,
+        _arena: &'a Blink,
         _hw_counter: &'a HardwareCounterCell,
     ) -> Result<PostingListIterator<'a>> {
         Ok(self.get(id)?.iter())

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
+use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{Result, UniversalIoError};
 
 use super::posting_list_common::PostingListIter;
-use crate::SearchScratchArena;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::DimOffset;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
@@ -43,7 +43,7 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     fn get<'a>(
         &'a self,
         id: DimOffset,
-        arena: &'a SearchScratchArena,
+        arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
     ) -> Result<Self::Iter<'a>>;
 

--- a/lib/sparse/src/lib.rs
+++ b/lib/sparse/src/lib.rs
@@ -2,4 +2,4 @@ pub mod common;
 pub mod index;
 pub(crate) mod search_scratch;
 
-pub use search_scratch::{SearchScratch, SearchScratchArena, SearchScratchPool};
+pub use search_scratch::{SearchScratch, SearchScratchPool};

--- a/lib/sparse/src/search_scratch.rs
+++ b/lib/sparse/src/search_scratch.rs
@@ -1,11 +1,18 @@
+use std::fmt::Debug;
+
 use blink_alloc::Blink;
 use common::defaults::POOL_KEEP_LIMIT;
 use common::types::ScoreType;
 use parking_lot::Mutex;
 
-#[derive(Debug)]
 pub struct SearchScratchPool {
-    pool: Mutex<Vec<SearchScratchScores>>,
+    pool: Mutex<Vec<(SearchScratchScores, Blink)>>,
+}
+
+impl Debug for SearchScratchPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SearchScratchPool").finish_non_exhaustive()
+    }
 }
 
 impl SearchScratchPool {
@@ -18,11 +25,11 @@ impl SearchScratchPool {
 
     /// Take a single [`SearchScratch`] from the pool.
     pub fn get(&self) -> SearchScratch<'_> {
-        let scores = self.pool.lock().pop().unwrap_or_default();
+        let (scores, arena) = self.pool.lock().pop().unwrap_or_default();
         SearchScratch {
             pool: self,
             scores,
-            arena: Blink::new(),
+            arena,
         }
     }
 }
@@ -53,11 +60,14 @@ impl Drop for SearchScratch<'_> {
         let SearchScratch {
             pool: SearchScratchPool { pool },
             scores,
-            arena: _,
+            arena,
         } = self;
         let mut pool = pool.lock();
         if pool.len() < *POOL_KEEP_LIMIT {
-            pool.push(std::mem::take(scores));
+            let scores = std::mem::take(scores);
+            let mut arena = std::mem::take(arena);
+            arena.reset();
+            pool.push((scores, arena));
         }
     }
 }

--- a/lib/sparse/src/search_scratch.rs
+++ b/lib/sparse/src/search_scratch.rs
@@ -1,8 +1,7 @@
+use blink_alloc::Blink;
 use common::defaults::POOL_KEEP_LIMIT;
-use common::ext::aligned_vec::{AVec, RuntimeAlign};
 use common::types::ScoreType;
 use parking_lot::Mutex;
-use typed_arena::Arena;
 
 #[derive(Debug)]
 pub struct SearchScratchPool {
@@ -23,7 +22,7 @@ impl SearchScratchPool {
         SearchScratch {
             pool: self,
             scores,
-            arena: SearchScratchArena::new_slow(),
+            arena: Blink::new(),
         }
     }
 }
@@ -35,7 +34,7 @@ pub struct SearchScratch<'a> {
     /// Used for batched scoring.
     pub(crate) scores: SearchScratchScores,
     /// Used to own/store posting list bytes while reading them from the file.
-    pub(crate) arena: SearchScratchArena,
+    pub(crate) arena: Blink,
 }
 
 impl SearchScratch<'_> {
@@ -60,43 +59,5 @@ impl Drop for SearchScratch<'_> {
         if pool.len() < *POOL_KEEP_LIMIT {
             pool.push(std::mem::take(scores));
         }
-    }
-}
-
-/// Hacky wrapper around [`Arena`] with [`Self::gc`] method.
-///
-/// TODO: get rid of this struct once [`Arena`] gets `clear()` method, and use
-/// type alias instead.
-/// https://github.com/thomcc/rust-typed-arena/issues/64
-// pub type SearchScratchArena = Arena<AVec<u8, RuntimeAlign>>;
-pub struct SearchScratchArena(Arena<AVec<u8, RuntimeAlign>>);
-
-impl SearchScratchArena {
-    /// Same as [`Arena::new`].
-    /// Renamed to `new_slow` to point out that [`Arena::new`] allocates.
-    pub fn new_slow() -> SearchScratchArena {
-        SearchScratchArena(Arena::new())
-    }
-
-    /// Free memory if the arena got too big.
-    /// Poor's man version of `Arena::clear()`.
-    pub fn gc(&mut self) {
-        // Too small => frequent reallocations
-        // Too big => memory bloat
-        const ARBITRARY_LIMIT: usize = 256;
-        if self.0.len() > ARBITRARY_LIMIT {
-            self.0 = Arena::new();
-        }
-
-        for vec in self.0.iter_mut() {
-            *vec = AVec::new(1);
-        }
-    }
-}
-
-impl std::ops::Deref for SearchScratchArena {
-    type Target = Arena<AVec<u8, RuntimeAlign>>;
-    fn deref(&self) -> &Arena<AVec<u8, RuntimeAlign>> {
-        &self.0
     }
 }


### PR DESCRIPTION
Use [`blink_alloc::Blink`](https://docs.rs/blink-alloc/latest/blink_alloc/struct.Blink.html) instead of [`typed_arena::Arena`](https://docs.rs/typed-arena/2.0.2/typed_arena/struct.Arena.html).

Also, put the arena into the pool as suggested in https://github.com/qdrant/qdrant/pull/9144#discussion_r3325299867

# Alternatives

## Why not `typed_arena`

- Limited to only one type.
- `Arena::new()` allocates.[^1]
- Doesn't have the `reset()` method.[^1]

## Why not [`rodeo`](https://docs.rs/rodeo/0.2.1/rodeo/struct.Rodeo.html)

- Doesn't have the `reset()` method.[^1]
- Not that popular.

## Why not [`bumpalo`](https://docs.rs/bumpalo/3.20.3/bumpalo/)

[Doesn't run drop](https://docs.rs/bumpalo/3.20.3/bumpalo/#deallocation-en-masse-but-no-drop).

The documentation suggest using [`bumpalo::boxed::Box<T>`](https://docs.rs/bumpalo/latest/bumpalo/boxed/struct.Box.html), but it's not applicable to our case without heavy refactoring.

Initially, I did that refactoring in https://github.com/qdrant/qdrant/commit/aff40496e92b3f89136f15ed1833cd419dc244f4 (was part of #9144, but not merged). See refactored `CompressedPostingListIterator` that holds new structure `CompressedPostingListCow` which is either borrowed, or owned + self-referential.

But it was ugly, so I dismissed that approach and went with a simpler approach -- transfer the ownership of `ACow` to the arena, then don't bother dealing with the ownership.
https://github.com/qdrant/qdrant/blob/90fa97e4abe5880587de4cf7dd0b9c08ed4682ca/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs#L214-L217

Using `bumpalo::boxed::Box<T>` would require dealing of ownership of that `Box` again, which defeats the point of using the arena.

[^1]: Tho it's trivial to fix and propose to upstream.