### PR TITLE
fix(api): reject empty multi-vector in flattened vectors_count path

### DIFF
--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -15,6 +15,12 @@ fn convert_to_plain_multi_vector(
     data: Vec<f32>,
     vectors_count: usize,
 ) -> Result<MultiDenseVector, OperationError> {
+    if vectors_count == 0 || data.is_empty() {
+        return Err(OperationError::validation_error(format!(
+            "Empty multi-vector data with vectors count: {vectors_count}"
+        )));
+    }
+
     let dim = data.len() / vectors_count;
     if dim * vectors_count != data.len() {
         return Err(OperationError::validation_error(format!(

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -302,6 +302,14 @@ pub fn validate_multi_vector_len(
         return Err(errors);
     }
 
+    if flatten_dense_vector.is_empty() {
+        let mut errors = ValidationErrors::default();
+        let mut err = ValidationError::new("empty_multi_vector");
+        err.add_param(Cow::from("message"), &"multi vector must not be empty");
+        errors.add("data", err);
+        return Err(errors);
+    }
+
     let dense_vector_len = flatten_dense_vector.len();
     if dense_vector_len >= MAX_MULTIVECTOR_FLATTENED_LEN {
         let mut errors = ValidationErrors::default();
@@ -327,6 +335,17 @@ pub fn validate_multi_vector_len(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_multi_vector_len_rejects_empty_data() {
+        // Regression: empty flattened data with a positive vectors_count must be
+        // rejected. Previously this returned Ok (0.is_multiple_of(N) == true), and
+        // the value then reached convert_to_plain_multi_vector, which builds
+        // chunks(dim) with dim == 0 and panics on the gRPC upsert path.
+        assert!(validate_multi_vector_len(2, &[]).is_err());
+        // A non-empty, consistent multivector still validates.
+        assert!(validate_multi_vector_len(2, &[1.0, 2.0, 3.0, 4.0]).is_ok());
+    }
 
     #[test]
     fn test_validate_range_generic() {


### PR DESCRIPTION
## Summary

A malformed gRPC `Upsert` can crash the server. Using the deprecated `vectors_count` field on a vector with empty flattened `data` makes `validate_multi_vector_len` return `Ok`, after which the value reaches `convert_to_plain_multi_vector` and panics on `itertools`' `chunks(0)`.

This PR adds the missing empty-data guard to the validator (mirroring the existing sibling validator), plus a small defense-in-depth guard at the conversion sink so the same panic cannot be reached via the internal node-to-node `sync` RPC, where validation is log-only.

This completes the empty-vector hardening from #9070 ("Fix empty vector panic", issue #9045), which covered the REST side only and did not touch the gRPC flattened `vectors_count` path. Follows the same tightly-scoped `fix(api)` validation vein as my prior #9271 and #9302.

## Before

`validate_multi_vector_len(N, &[])` with `N > 0` returned `Ok`:
- `vectors_count != 0` passes;
- empty `flatten_dense_vector` (len 0) clears the size check;
- `0.is_multiple_of(N)` is `true`, so it takes the `Ok` branch.

The unvalidated value then flows through the deprecated path: `grpc::Vector::validate` -> `validate_multi_vector_len(*vectors_count, data)` (`lib/api/src/grpc/validate.rs`, the only production caller) -> `convert_to_plain_multi_vector` (`lib/api/src/conversions/vectors.rs`): `dim = data.len() / vectors_count = 0`, the divisibility check `dim * vectors_count != data.len()` (`0 == 0`) passes, then `data.into_iter().chunks(0)` panics (itertools asserts the chunk size is non-zero — an unconditional `assert!`, so this reproduces in release builds).

The public gRPC upsert hard-validates (`validate(request.get_ref())?`), returning `invalid_argument` only once the validator rejects — which it did not for empty data. Separately, the internal node-to-node `sync` RPC uses `validate_and_log`, which only logs a warning and never rejects, and `SyncPoints.points` has no validation rule in `lib/api/build.rs`; that path reaches the same `convert_to_plain_multi_vector` sink and would still panic.

## After

- `validate_multi_vector_len` rejects empty `flatten_dense_vector` with an `empty_multi_vector` error, placed right after the `vectors_count == 0` check and before the length math. This mirrors the existing sibling `validate_multi_vector_by_length` in error shape and message, and reuses the already-imported `Cow`.
- `convert_to_plain_multi_vector` returns a clean `OperationError::validation_error` when `vectors_count == 0 || data.is_empty()`, before computing `dim`. This brings it in line with the already-guarded sibling `TypedMultiDenseVector::try_from_flatten` and closes the internal `sync` path.

Legitimate input is unaffected: a valid flattened multivector via `vectors_count` always has non-empty `data` (empty data implies `dim == 0`, never a valid multivector), so no valid request is newly rejected.

## Impact

- Fixes a remotely triggerable panic / DoS on the public gRPC `Upsert` / `UpdateVectors` / `UpdateBatch` endpoints (single malformed request, deprecated `vectors_count` field).
- Also closes the same panic on the internal node-to-node `sync` RPC, hardening cluster-to-cluster traffic.
- No behavior change for valid vectors; no public API change; no schema change.

## Test plan

- New unit regression test `test_validate_multi_vector_len_rejects_empty_data` (`lib/common/common/src/validation.rs`): asserts `validate_multi_vector_len(2, &[])` is `Err` (RED on pre-fix code, where it returned `Ok`) and that valid input `(2, &[1.0, 2.0, 3.0, 4.0])` stays `Ok`.
- Full unit test suites of both changed crates pass locally (`common`: 155 tests, `api`: 17 tests), `cargo clippy` is clean on both, and `cargo fmt --all -- --check` is clean on stable and nightly. CI re-runs the full compile/test/clippy matrix and the integration tests on the canonical targets.
- Follow-up (left out to keep the diff tight): an end-to-end negative case in `tests/basic_multivector_grpc_test.sh` — an `Upsert` with `"data": []` and `"vectors_count": 2` — would additionally assert the server returns a clean validation error rather than dropping the connection, matching the bar from #9070.

## Contributing with AI

This change was AI-assisted. It was surfaced by a code audit of qdrant' s gRPC input-validation paths and fixed by mirroring the sibling `validate_multi_vector_by_length` guard and the maintainer' s recent empty-vector fix (#9070). The diff and this description were reviewed and edited by me.