### PR TITLE
fix(api): validate geo polygon in gRPC FieldCondition

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -281,10 +281,18 @@ impl Validate for grpc::FieldCondition {
                 "match",
                 ValidationError::new("At least one field condition must be specified"),
             );
-            Err(errors)
-        } else {
-            Ok(())
+            return Err(errors);
         }
+
+        // Recurse into the geo polygon's own validator. Otherwise FieldCondition
+        // only checks that some field is set, so a malformed polygon (empty,
+        // fewer than 4 points, or an unclosed exterior/interior) is accepted here
+        // and later panics when the geo index processes it.
+        if let Some(geo_polygon) = geo_polygon {
+            geo_polygon.validate()?;
+        }
+
+        Ok(())
     }
 }
 
@@ -757,6 +765,45 @@ mod tests {
             good_polygon.validate().is_ok(),
             "good polygon should not error on validation"
         );
+    }
+
+    #[test]
+    fn test_field_condition_validates_geo_polygon() {
+        use crate::grpc::qdrant::FieldCondition;
+
+        // FieldCondition::validate only checks that at least one field is set; it
+        // must also reject a malformed geo polygon, otherwise the invalid shape
+        // reaches the geo index and panics. An empty exterior is invalid.
+        let bad = FieldCondition {
+            key: "location".into(),
+            geo_polygon: Some(GeoPolygon {
+                exterior: Some(GeoLineString { points: vec![] }),
+                interiors: vec![],
+            }),
+            ..Default::default()
+        };
+        assert!(
+            bad.validate().is_err(),
+            "field condition with an empty polygon exterior should error"
+        );
+
+        // A well-formed polygon still passes.
+        let good = FieldCondition {
+            key: "location".into(),
+            geo_polygon: Some(GeoPolygon {
+                exterior: Some(GeoLineString {
+                    points: vec![
+                        GeoPoint { lat: 1., lon: 1. },
+                        GeoPoint { lat: 2., lon: 2. },
+                        GeoPoint { lat: 3., lon: 3. },
+                        GeoPoint { lat: 1., lon: 1. },
+                    ],
+                }),
+                interiors: vec![],
+            }),
+            ..Default::default()
+        };
+        assert!(good.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`impl Validate for grpc::FieldCondition` only checks that at least one condition field is set — it never validates the contents of a `geo_polygon`. A `FieldCondition` carrying a malformed polygon (empty exterior, fewer than 4 points, or an unclosed exterior/interior ring) therefore passes validation, and the invalid shape later reaches the geo index and panics.

`grpc::GeoPolygon` already has a `Validate` impl that rejects these shapes (it is exercised by the existing `test_geo_polygon`); `FieldCondition` simply never called it. The fix recurses into it.

## Before

`FieldCondition::validate` (lib/api/src/grpc/validate.rs) computes `all_fields_none` and returns `Ok(())` whenever any field is set, without inspecting the geo conditions. So a request like `FieldCondition { geo_polygon: Some(GeoPolygon { exterior: Some(GeoLineString { points: vec![] }), .. }), .. }` is accepted, and the malformed shape later panics when the geo index processes it.

## After

After the `all_fields_none` check, the validator recurses into the polygon's own validator:

```rust
if let Some(geo_polygon) = geo_polygon {
    geo_polygon.validate()?;
}
```

Malformed polygons are rejected with a clean validation error before reaching the index. Valid polygons, and conditions without a polygon, are unaffected.

## Impact

- Fixes a remotely triggerable panic reachable from a single gRPC request carrying a malformed `geo_polygon` field condition (a filter on an indexed geo field).
- No behavior change for valid input; no public API or schema change.

## Test plan

- New unit test `test_field_condition_validates_geo_polygon` (lib/api/src/grpc/validate.rs): a `FieldCondition` with an empty polygon exterior is rejected (RED on pre-fix code, which returned `Ok`), while a well-formed polygon still passes.
- Validated locally on the `x86_64-pc-windows-gnu` toolchain: `cargo test -p api` passes (18 tests), `cargo clippy -p api` is clean, and `cargo fmt --all -- --check` is clean on stable and nightly. CI re-runs the full matrix.

## Contributing with AI

This change was AI-assisted: it was surfaced by a code audit of qdrant's gRPC input-validation paths (the same audit behind #9308) and fixed by wiring up the polygon validator that `FieldCondition` already had but did not call. The diff and this description were reviewed and edited by me.