### PR TITLE
test(id_tracker): failing tests for two correctness findings in #9249

### DIFF
--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -104,8 +104,52 @@ mod tests {
     use rand::SeedableRng as _;
     use rand::rngs::StdRng;
     use rstest::rstest;
+    use tempfile::Builder;
 
     use super::*;
+    use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
+
+    /// Review finding #1 (optimizer merge consequence): `for_each_unique_point`
+    /// is the merge primitive `segment_builder::update_from` uses to pick the
+    /// winning copy per external id when rolling segments together. It walks
+    /// `iter_from(None)` and keeps the highest version. For a shadowed point
+    /// (active head below the cutoff + deferred head above it, the result of an
+    /// in-place mutation), `iter_from` resolves the collision to the *active*
+    /// (older) slot and never yields the deferred head — so the merge keeps the
+    /// pre-mutation copy and the mutation is silently dropped on optimization.
+    ///
+    /// On `dev` this worked: a deferred write tombstoned the active, so the
+    /// single map pointed at the deferred head and the merge pulled the latest.
+    #[test]
+    fn for_each_unique_point_keeps_deferred_head_for_shadowed_point() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        // Appendable tracker with deferred cutoff = 5.
+        let mut tracker = MutableIdTracker::open(dir.path(), Some(5)).unwrap();
+        let p7 = PointIdType::NumId(7);
+
+        // ext 7: active@2 is the pre-mutation copy (version 5); deferred@9 is
+        // the latest in-place mutation (version 8). The active is shadowed.
+        tracker.set_link(p7, 2).unwrap();
+        tracker.set_internal_version(2, 5).unwrap();
+        tracker.set_link(p7, 9).unwrap();
+        tracker.set_internal_version(9, 8).unwrap();
+
+        let trackers = [tracker];
+        let mut merged = Vec::new();
+        for_each_unique_point(trackers.iter(), |m| {
+            merged.push((m.external_id, m.internal_id, m.version));
+        });
+
+        // The merge must carry the latest (deferred) copy so the mutation
+        // survives optimization. It instead yields the stale active copy
+        // (internal 2, version 5), silently dropping the version-8 mutation.
+        assert_eq!(
+            merged,
+            vec![(p7, 9, 8)],
+            "for_each_unique_point dropped the deferred (latest) copy of a \
+             shadowed point, keeping the pre-mutation active version",
+        );
+    }
 
     #[rstest]
     fn test_for_each_unique_point(#[values(0, 1, 5)] tracker_count: usize) {

--- a/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
@@ -755,3 +755,57 @@ fn test_store_versions_extends_without_set_len() {
     assert_eq!(versions[4], 0);
     assert_eq!(versions[5], 500);
 }
+
+/// Review finding (shadow durability): PR-B keeps a mutated point's active
+/// (visible) head alive and shadows it with the deferred head. But the
+/// persisted format is a single combined map, and `PointMappings::new` (the
+/// load entry point) cannot reconstruct a shadow — each ext is partitioned
+/// into exactly one track. The append-only change journal records only
+/// `Insert(ext, internal_id)`, so on reload the later deferred insert
+/// overwrites the active entry and the combined map collapses to
+/// deferred-only.
+///
+/// Result: after a plain mappings flush + reload (no WAL replay), the visible
+/// (active) head is gone — `VisibleOnly` readers, which saw the point live,
+/// no longer resolve it. This isolates the persistence layer; in the full
+/// system the active head is only restored if the deferred op is still in the
+/// WAL and gets re-applied, so durability hinges on flush-vs-WAL-truncate
+/// ordering.
+#[test]
+fn shadow_visible_head_survives_mapping_flush_reload() {
+    use common::types::DeferredBehavior;
+
+    let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let cutoff = Some(5 as PointOffsetType);
+    let p7 = PointIdType::NumId(7);
+
+    {
+        let mut id_tracker = MutableIdTracker::open(segment_dir.path(), cutoff).unwrap();
+        // Active head below the cutoff — the visible version.
+        id_tracker.set_link(p7, 2).unwrap();
+        id_tracker.set_internal_version(2, 1).unwrap();
+        // Deferred head above the cutoff (in-place mutation) shadows the active.
+        id_tracker.set_link(p7, 9).unwrap();
+        id_tracker.set_internal_version(9, 2).unwrap();
+
+        // Live: VisibleOnly readers still resolve the point to its active head.
+        assert_eq!(
+            id_tracker.internal_id_with_behavior(p7, DeferredBehavior::VisibleOnly),
+            Some(2),
+            "live: the visible (active) head should resolve",
+        );
+
+        id_tracker.mapping_flusher()().unwrap();
+        id_tracker.versions_flusher()().unwrap();
+    }
+
+    // Reload from disk only (no WAL replay).
+    let id_tracker = MutableIdTracker::open(segment_dir.path(), cutoff).unwrap();
+    assert_eq!(
+        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::VisibleOnly),
+        Some(2),
+        "reload: the visible (active) head was lost — the single-map on-disk \
+         format collapsed the shadow to deferred-only, so VisibleOnly readers \
+         no longer see a point that was live before the flush",
+    );
+}

--- a/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
@@ -800,6 +800,12 @@ fn shadow_visible_head_survives_mapping_flush_reload() {
             "live: the visible (active) head should resolve",
         );
 
+        assert_eq!(
+            id_tracker.internal_id_with_behavior(p7, DeferredBehavior::WithDeferred),
+            Some(9),
+            "live: the visible (active) head should resolve",
+        );
+
         id_tracker.mapping_flusher()().unwrap();
         id_tracker.versions_flusher()().unwrap();
     }
@@ -810,25 +816,15 @@ fn shadow_visible_head_survives_mapping_flush_reload() {
     // The mapping collapsed to deferred-only: the combined map kept only the
     // last-written head (9), so a plain lookup resolves the deferred slot.
     assert_eq!(
-        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::WithDeferred),
-        Some(9)
+        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::VisibleOnly),
+        Some(2)
     );
     assert_eq!(
         id_tracker.internal_id_with_behavior(p7, DeferredBehavior::WithDeferred),
         Some(9),
     );
     // Torn state: the active slot survived as a live orphan in the inverse map
-    // (a VisibleOnly scroll would still surface this stale copy)...
+    // (a VisibleOnly scroll would still surface this stale copy)
     assert_eq!(id_tracker.external_id(2), Some(p7));
     assert!(!id_tracker.is_deleted_point(2));
-
-    // ...but the active forward entry is gone, so by-id VisibleOnly resolution
-    // that returned Some(2) live now returns None. The PR-B visible head did
-    // not survive the flush+reload — a live-vs-reload divergence.
-    assert_eq!(
-        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::VisibleOnly),
-        Some(2),
-        "reload: the visible (active) head was lost — the single-map on-disk \
-         format collapsed the shadow to deferred-only",
-    );
 }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
@@ -757,7 +757,8 @@ fn test_store_versions_extends_without_set_len() {
 }
 
 /// Review finding (shadow durability): PR-B keeps a mutated point's active
-/// (visible) head alive and shadows it with the deferred head. But the
+/// (visible) head alive and shadows it with the deferred head, so a
+/// deferred-mutated point stays visible to `VisibleOnly` readers. But the
 /// persisted format is a single combined map, and `PointMappings::new` (the
 /// load entry point) cannot reconstruct a shadow — each ext is partitioned
 /// into exactly one track. The append-only change journal records only
@@ -765,12 +766,16 @@ fn test_store_versions_extends_without_set_len() {
 /// overwrites the active entry and the combined map collapses to
 /// deferred-only.
 ///
-/// Result: after a plain mappings flush + reload (no WAL replay), the visible
-/// (active) head is gone — `VisibleOnly` readers, which saw the point live,
-/// no longer resolve it. This isolates the persistence layer; in the full
-/// system the active head is only restored if the deferred op is still in the
-/// WAL and gets re-applied, so durability hinges on flush-vs-WAL-truncate
-/// ordering.
+/// This is a live-vs-reload divergence the PR introduces: on `dev` a deferred
+/// write tombstones the active, so the point is `None` for `VisibleOnly` both
+/// live and after reload (consistent). Here it is `Some(2)` live but `None`
+/// after a plain mappings flush + reload. The reload state is also *torn*: the
+/// active slot survives as a live orphan in the inverse map (so a `VisibleOnly`
+/// scroll still surfaces the stale copy), while by-id resolution is broken.
+///
+/// The test isolates the persistence layer (no WAL replay); in the full system
+/// the active head is only restored if the deferred op is still in the WAL and
+/// gets re-applied, so durability hinges on flush-vs-WAL-truncate ordering.
 #[test]
 fn shadow_visible_head_survives_mapping_flush_reload() {
     use common::types::DeferredBehavior;
@@ -801,11 +806,29 @@ fn shadow_visible_head_survives_mapping_flush_reload() {
 
     // Reload from disk only (no WAL replay).
     let id_tracker = MutableIdTracker::open(segment_dir.path(), cutoff).unwrap();
+
+    // The mapping collapsed to deferred-only: the combined map kept only the
+    // last-written head (9), so a plain lookup resolves the deferred slot.
+    assert_eq!(
+        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::WithDeferred),
+        Some(9)
+    );
+    assert_eq!(
+        id_tracker.internal_id_with_behavior(p7, DeferredBehavior::WithDeferred),
+        Some(9),
+    );
+    // Torn state: the active slot survived as a live orphan in the inverse map
+    // (a VisibleOnly scroll would still surface this stale copy)...
+    assert_eq!(id_tracker.external_id(2), Some(p7));
+    assert!(!id_tracker.is_deleted_point(2));
+
+    // ...but the active forward entry is gone, so by-id VisibleOnly resolution
+    // that returned Some(2) live now returns None. The PR-B visible head did
+    // not survive the flush+reload — a live-vs-reload divergence.
     assert_eq!(
         id_tracker.internal_id_with_behavior(p7, DeferredBehavior::VisibleOnly),
         Some(2),
         "reload: the visible (active) head was lost — the single-map on-disk \
-         format collapsed the shadow to deferred-only, so VisibleOnly readers \
-         no longer see a point that was live before the flush",
+         format collapsed the shadow to deferred-only",
     );
 }

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -988,4 +988,51 @@ mod set_link_shadow_tests {
             None
         );
     }
+
+    /// Review finding #1: `iter_from_with_behavior(WithDeferred)` must surface
+    /// the deferred (latest) internal id for a shadowed ext, the same way
+    /// `internal_id_with_behavior` and `iter_internal_with_behavior` already do.
+    /// It currently delegates to `iter_from`, whose merge resolves the
+    /// active/deferred collision to the *active* (stale) head — so consumers
+    /// that use the yielded internal id (optimizer merge via
+    /// `for_each_unique_point`, `filtered_read_by_id_stream`) observe the
+    /// pre-mutation version.
+    #[test]
+    fn iter_from_with_behavior_with_deferred_yields_latest_head() {
+        use common::types::DeferredBehavior;
+
+        // Cutoff = 5. ext 7: active@2, deferred@9 (active shadowed).
+        let mut m = fresh_mapping(Some(5));
+        m.set_link(ext(7), 2);
+        m.set_link(ext(7), 9);
+
+        // The point-lookup sibling agrees the latest head is the deferred slot.
+        assert_eq!(
+            m.internal_id_with_behavior(&ext(7), DeferredBehavior::WithDeferred),
+            Some(9),
+        );
+        // The internal-id iteration sibling also yields only the deferred slot
+        // (the shadowed active is skipped).
+        let via_internal: Vec<_> = m
+            .iter_internal_with_behavior(DeferredBehavior::WithDeferred)
+            .collect();
+        assert_eq!(
+            via_internal,
+            vec![9],
+            "iter_internal_with_behavior(WithDeferred) yields the deferred head",
+        );
+
+        // iter_from_with_behavior(WithDeferred) must agree: one yield per ext,
+        // carrying the latest (deferred) internal id.
+        let via_from: Vec<_> = m
+            .iter_from_with_behavior(None, DeferredBehavior::WithDeferred)
+            .collect();
+        assert_eq!(
+            via_from,
+            vec![(ext(7), 9)],
+            "iter_from_with_behavior(WithDeferred) must surface the deferred \
+             (latest) internal id, consistent with internal_id_with_behavior and \
+             iter_internal_with_behavior; it instead yields the stale active slot 2",
+        );
+    }
 }


### PR DESCRIPTION
Stacked on #9249 (`deferred-pr-d-counters`) to pin two correctness findings from review as red tests. **Intentionally failing — not for merge as-is.**

### 1. `iter_from` resolves active/deferred shadow collisions to the stale *active* head

`iter_from_with_behavior(WithDeferred)` delegates to `iter_from`, whose merge keeps the **active** (pre-mutation) internal id on a shadow collision — while its siblings `internal_id_with_behavior` and `iter_internal_with_behavior` correctly return the **deferred** (latest) head. Consumers that use the yielded internal id then observe the stale version.

- `point_mappings.rs :: iter_from_with_behavior_with_deferred_yields_latest_head` — unit: yields `(7, 2)`, expected `(7, 9)`.
- `mod.rs :: for_each_unique_point_keeps_deferred_head_for_shadowed_point` — the optimizer merge primitive yields `(7, internal 2, v5)` and drops the `v8` mutation; expected `(7, internal 9, v8)`. This is the data-loss-on-optimize consequence.

### 2. The shadow (visible-head) invariant isn't durable across reload

PR-B keeps a mutated point's active head visible. But the on-disk single combined map can't represent a shadow, so a mappings flush + reload collapses it to deferred-only and the visible head is lost — `Some(2)` live → `None` after reload (`dev` is consistently `None`). The reloaded state is also torn (active slot survives as a live orphan in the inverse map). Restoration then depends entirely on WAL replay, i.e. flush-vs-WAL-truncate ordering.

- `mutable_id_tracker/tests.rs :: shadow_visible_head_survives_mapping_flush_reload`

### Run

```
cargo test -p segment --lib -- iter_from_with_behavior shadow_visible_head for_each_unique_point
```

All three fail deterministically (no randomness / `HashMap` in these paths; `BTreeMap` + `merge_join_by` throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)