### PR TITLE
Fixed trait solver overflow in anonymize_collection_values_opt

### DIFF
--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -105,7 +105,7 @@ where
 {
     collection_opt
         .as_ref()
-        .map(|c| anonymize_collection_values(c))
+        .map(|c| anonymize_collection_values::<C, K, V>(c))
 }
 
 impl Anonymize for String {


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR fixes a Rust compiler overflow that can occur when compiling `qdrant-edge` as a dependency in a larger application -- in our case it is https://github.com/MindWorkAI/AI-Studio. The compiler runs fine on Windows x64. On macOS ARM, other dependencies such as `objc2` are needed. Then, the compiler overflows while resolving the generic parameters of `anonymize_collection_values`. The solution is, to apply the already-known generic parameters.