### PR TITLE
feat: live reload fulltext index

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index/live_reload.rs
@@ -1,0 +1,28 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::MmapFullTextIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for MmapFullTextIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        _new_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Immutable on-disk state: only the in-memory deletion bitmap is
+        // patched (mirrors the other immutable leaves). `fs` / `new_points`
+        // are unused because nothing is appended after build.
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index/mod.rs
@@ -9,6 +9,7 @@ use super::tokenizers::Tokenizer;
 use crate::data_types::index::TextIndexParams;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct MmapFullTextIndex<S: UniversalRead = MmapFile> {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -1,0 +1,68 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyAppendableFullTextIndex;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::full_text_index::FullTextIndex;
+use crate::index::field_index::full_text_index::inverted_index::{
+    Document, InvertedIndex, TokenSet,
+};
+
+impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        new_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.live_reload(fs)?;
+
+        // Pulled out before the `&mut self.inner` borrow taken below.
+        let phrase_matching = self.inner.config.phrase_matching.unwrap_or_default();
+        let inner = &mut self.inner;
+
+        for &deleted_point in deleted_points {
+            inner.inverted_index.remove(deleted_point);
+        }
+
+        self.storage
+            .view()
+            .for_each_in_batch::<Random, _, OperationError>(
+                new_points,
+                |idx, maybe_value: Option<Vec<u8>>| {
+                    let Some(value) = maybe_value else {
+                        return Ok(());
+                    };
+                    let point_offset = new_points[idx];
+                    // The stored document is already tokenized, so we replay the
+                    // post-tokenization half of `MutableFullTextIndex::add_many`:
+                    // register the tokens, then index them (plus the ordered
+                    // document when phrase matching is enabled).
+                    let str_tokens = FullTextIndex::deserialize_document(&value)?;
+                    let tokens = inner.inverted_index.register_tokens(str_tokens);
+                    if phrase_matching {
+                        inner.inverted_index.index_document(
+                            point_offset,
+                            Document::new(tokens.clone()),
+                            hw_counter,
+                        )?;
+                    }
+                    inner.inverted_index.index_tokens(
+                        point_offset,
+                        TokenSet::from_iter(tokens),
+                        hw_counter,
+                    )?;
+                    Ok(())
+                },
+                hw_counter.payload_index_io_read_counter(),
+            )?;
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -23,7 +23,6 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
 
-        // Pulled out before the `&mut self.inner` borrow taken below.
         let phrase_matching = self.inner.config.phrase_matching.unwrap_or_default();
         let inner = &mut self.inner;
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/mod.rs
@@ -4,6 +4,7 @@ use gridstore::GridstoreReader;
 use super::inner::MutableFullTextIndexInner;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart to [`super::MutableFullTextIndex`].


### PR DESCRIPTION
### Summary

Implements the `LiveReload` trait for the read-only **full-text** index variants, so an open read-only index can refresh to the current on-disk state without a full re-open while a writer keeps appending to the same files. Builds on the `LiveReload` trait from #9295.

- **`ReadOnlyAppendableFullTextIndex`** (gridstore-backed): reloads the backing storage, removes `deleted_points` from the inverted index, then replays the post-tokenization half of `MutableFullTextIndex::add_many` for each new point — the stored document is already tokenized, so it registers the tokens, indexes the ordered document when phrase matching is enabled, and indexes the token set.
- **`MmapFullTextIndex`** (immutable): on-disk state never changes after build, so only the in-memory deletion bitmap is patched; `fs` / `new_points` are unused.

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
