### PR TITLE
refactor: move LiveReload trait to common module

### DIFF
--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -3,26 +3,29 @@ use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
 
-/// Common live-reload surface shared by the read-only field-index variants.
+/// Common live-reload surface shared by the read-only, gridstore-backed stores —
+/// the read-only field-index variants and the read-only payload storage.
 ///
-/// A read-only index is opened over a [`UniversalRead`] backend while a writer
+/// A read-only store is opened over a [`UniversalRead`] backend while a writer
 /// keeps appending to the same files. `live_reload` refreshes the in-memory
 /// view to the current on-disk state without a full re-open. Implementers fall
-/// into two shapes:
+/// into a few shapes:
 ///
-/// - immutable mmap variants only re-apply the authoritative `deleted_points`
-///   to their in-memory deletion bitmap — `fs` and `new_points` are unused
-///   because no on-disk state changes after build;
-/// - appendable gridstore variants reload the backing storage through `fs`,
-///   drop `deleted_points` from the in-memory index, then ingest `new_points`
-///   from the refreshed storage view.
+/// - immutable mmap field-index variants only re-apply the authoritative
+///   `deleted_points` to their in-memory deletion bitmap — `fs` and
+///   `new_points` are unused because no on-disk state changes after build;
+/// - appendable gridstore field-index variants reload the backing storage
+///   through `fs`, drop `deleted_points` from the in-memory index, then ingest
+///   `new_points` from the refreshed storage view;
+/// - stores with no separate in-memory index (e.g. the payload storage) only
+///   reload the backing storage through `fs`; deletions and newly written
+///   points are served straight from the refreshed gridstore, so
+///   `deleted_points` / `new_points` are unused.
 ///
 /// `deleted_points` / `new_points` are supplied by the caller (typically the
 /// segment's id-tracker diff accumulated since the previous reload).
 ///
 /// [`UniversalRead`]: common::universal_io::UniversalRead
-// No in-crate implementer on the trait-only branch; the per-index impls land
-// on the sibling branches that fork from here.
 #[allow(dead_code)]
 pub(crate) trait LiveReload {
     /// Filesystem context (`S::Fs` of the backing [`UniversalRead`]) used to

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -2,6 +2,7 @@ pub mod anonymize;
 pub mod buffered_update_bitslice;
 pub mod error_logging;
 pub mod flags;
+pub mod live_reload;
 pub mod macros;
 pub mod memory_usage;
 pub mod operation_error;

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -1,13 +1,12 @@
 mod lifecycle;
-mod live_reload;
 mod read_ops;
 
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 
 use common::universal_io::UniversalRead;
-pub(crate) use live_reload::LiveReload;
 
+pub(crate) use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::bool_index::ReadOnlyBoolIndex;
 use crate::index::field_index::full_text_index::read_only::ReadOnlyFullTextIndex;


### PR DESCRIPTION
### Summary

Relocates the `LiveReload` trait out of the field-index tree into a shared module, so non-field-index read-only stores can implement it too — specifically the upcoming read-only payload storage (#9315 / #9316).

- Moves the trait from `index/field_index/field_index_base/read_only/live_reload.rs` to a new `common/live_reload.rs` (registered in `common/mod.rs`).
- The field-index module now re-exports it from `crate::common::live_reload::LiveReload`, so existing `use` paths through `field_index` keep working.
- Expands the doc comment to cover a third implementer shape alongside the immutable-mmap and appendable-gridstore field indexes: stores with no separate in-memory index (e.g. the payload storage) that only reload the backing storage through `fs`, with `deleted_points` / `new_points` unused.

Pure relocation — no behavior change. Once this merges, the read-only field-index live-reload PRs (#9297, #9298, #9299, #9300, #9313) get rebased to import the trait from `common`.

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
