### PR TITLE
feat: add payload storage constructor

### DIFF
--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -3,26 +3,29 @@ use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
 
-/// Common live-reload surface shared by the read-only field-index variants.
+/// Common live-reload surface shared by the read-only, gridstore-backed stores —
+/// the read-only field-index variants and the read-only payload storage.
 ///
-/// A read-only index is opened over a [`UniversalRead`] backend while a writer
+/// A read-only store is opened over a [`UniversalRead`] backend while a writer
 /// keeps appending to the same files. `live_reload` refreshes the in-memory
 /// view to the current on-disk state without a full re-open. Implementers fall
-/// into two shapes:
+/// into a few shapes:
 ///
-/// - immutable mmap variants only re-apply the authoritative `deleted_points`
-///   to their in-memory deletion bitmap — `fs` and `new_points` are unused
-///   because no on-disk state changes after build;
-/// - appendable gridstore variants reload the backing storage through `fs`,
-///   drop `deleted_points` from the in-memory index, then ingest `new_points`
-///   from the refreshed storage view.
+/// - immutable mmap field-index variants only re-apply the authoritative
+///   `deleted_points` to their in-memory deletion bitmap — `fs` and
+///   `new_points` are unused because no on-disk state changes after build;
+/// - appendable gridstore field-index variants reload the backing storage
+///   through `fs`, drop `deleted_points` from the in-memory index, then ingest
+///   `new_points` from the refreshed storage view;
+/// - stores with no separate in-memory index (e.g. the payload storage) only
+///   reload the backing storage through `fs`; deletions and newly written
+///   points are served straight from the refreshed gridstore, so
+///   `deleted_points` / `new_points` are unused.
 ///
 /// `deleted_points` / `new_points` are supplied by the caller (typically the
 /// segment's id-tracker diff accumulated since the previous reload).
 ///
 /// [`UniversalRead`]: common::universal_io::UniversalRead
-// No in-crate implementer on the trait-only branch; the per-index impls land
-// on the sibling branches that fork from here.
 #[allow(dead_code)]
 pub(crate) trait LiveReload {
     /// Filesystem context (`S::Fs` of the backing [`UniversalRead`]) used to

--- a/lib/segment/src/common/mod.rs
+++ b/lib/segment/src/common/mod.rs
@@ -2,6 +2,7 @@ pub mod anonymize;
 pub mod buffered_update_bitslice;
 pub mod error_logging;
 pub mod flags;
+pub mod live_reload;
 pub mod macros;
 pub mod memory_usage;
 pub mod operation_error;

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -1,13 +1,12 @@
 mod lifecycle;
-mod live_reload;
 mod read_ops;
 
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 
 use common::universal_io::UniversalRead;
-pub(crate) use live_reload::LiveReload;
 
+pub(crate) use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::bool_index::ReadOnlyBoolIndex;
 use crate::index::field_index::full_text_index::read_only::ReadOnlyFullTextIndex;

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+use common::universal_io::{OkNotFound, UniversalRead};
+use gridstore::GridstoreReader;
+
+use super::ReadOnlyPayloadStorage;
+use crate::common::operation_error::OperationResult;
+use crate::payload_storage::mmap_payload_storage::storage_dir;
+use crate::types::Payload;
+
+impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
+    /// Open the payload storage read-only over the generic filesystem `fs` —
+    /// the read-only counterpart of [`MmapPayloadStorage::open_or_create`][1].
+    ///
+    /// Resolves the `payload_storage` sub-directory (matching the writable
+    /// storage's on-disk layout) and opens a [`GridstoreReader`] over it.
+    /// `Payload` values are read straight from the reader, so unlike the
+    /// read-only field indexes there is no in-memory index to rebuild. When
+    /// `populate` is set the pages are loaded eagerly, exactly as the writable
+    /// storage does; the flag is retained to answer
+    /// [`is_on_disk`](super::super::PayloadStorageRead::is_on_disk).
+    ///
+    /// Returns [`Ok(None)`] when the on-disk directory doesn't exist — the read
+    /// path never creates, mirroring the read-only field indexes.
+    ///
+    /// [1]: crate::payload_storage::mmap_payload_storage::MmapPayloadStorage::open_or_create
+    pub fn open(fs: &S::Fs, path: PathBuf, populate: bool) -> OperationResult<Option<Self>> {
+        let path = storage_dir(path);
+        let Some(storage) = GridstoreReader::<Payload, S>::open(fs, path).ok_not_found()? else {
+            // Files don't exist, cannot load
+            return Ok(None);
+        };
+
+        if populate {
+            storage.populate()?;
+        }
+
+        Ok(Some(Self { storage, populate }))
+    }
+}

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -20,9 +20,6 @@ impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
     /// storage does; the flag is retained to answer
     /// [`is_on_disk`](super::super::PayloadStorageRead::is_on_disk).
     ///
-    /// Returns [`Ok(None)`] when the on-disk directory doesn't exist — the read
-    /// path never creates, mirroring the read-only field indexes.
-    ///
     /// [1]: crate::payload_storage::mmap_payload_storage::MmapPayloadStorage::open_or_create
     pub fn open(fs: &S::Fs, path: PathBuf, populate: bool) -> OperationResult<Self> {
         let path = storage_dir(path);

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::universal_io::{OkNotFound, UniversalRead};
+use common::universal_io::UniversalRead;
 use gridstore::GridstoreReader;
 
 use super::ReadOnlyPayloadStorage;
@@ -24,17 +24,14 @@ impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
     /// path never creates, mirroring the read-only field indexes.
     ///
     /// [1]: crate::payload_storage::mmap_payload_storage::MmapPayloadStorage::open_or_create
-    pub fn open(fs: &S::Fs, path: PathBuf, populate: bool) -> OperationResult<Option<Self>> {
+    pub fn open(fs: &S::Fs, path: PathBuf, populate: bool) -> OperationResult<Self> {
         let path = storage_dir(path);
-        let Some(storage) = GridstoreReader::<Payload, S>::open(fs, path).ok_not_found()? else {
-            // Files don't exist, cannot load
-            return Ok(None);
-        };
+        let storage = GridstoreReader::<Payload, S>::open(fs, path)?;
 
         if populate {
             storage.populate()?;
         }
 
-        Ok(Some(Self { storage, populate }))
+        Ok(Self { storage, populate })
     }
 }

--- a/lib/segment/src/payload_storage/read_only/live_reload.rs
+++ b/lib/segment/src/payload_storage/read_only/live_reload.rs
@@ -1,0 +1,21 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyPayloadStorage;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyPayloadStorage<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        _deleted_points: &[PointOffsetType],
+        _new_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Ok(self.storage.live_reload(fs)?)
+    }
+}

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -60,9 +60,7 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
         let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> =
-            ReadOnlyPayloadStorage::open(&fs, dir.path().to_path_buf(), populate)
-                .unwrap()
-                .unwrap();
+            ReadOnlyPayloadStorage::open(&fs, dir.path().to_path_buf(), populate).unwrap();
 
         assert_eq!(storage.is_on_disk(), !populate);
         for i in 0..5 {
@@ -70,21 +68,5 @@ mod tests {
         }
         // An unwritten point reads back as an empty payload.
         assert_eq!(storage.get(99, &hw_counter).unwrap(), payload_json! {});
-    }
-
-    /// Opening over a directory that was never written returns `Ok(None)` — the
-    /// read path never creates.
-    #[test]
-    fn read_only_payload_storage_missing_dir_is_none() {
-        let dir = TempDir::with_prefix("read_only_payload_missing").unwrap();
-        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
-        let fs = RoFs::from_context(Default::default()).unwrap();
-        let opened = ReadOnlyPayloadStorage::<ReadOnly<MmapFile>>::open(
-            &fs,
-            dir.path().to_path_buf(),
-            false,
-        )
-        .unwrap();
-        assert!(opened.is_none());
     }
 }

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -1,4 +1,5 @@
 mod lifecycle;
+mod live_reload;
 mod payload_storage_read;
 
 use common::universal_io::UniversalRead;

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -1,3 +1,4 @@
+mod lifecycle;
 mod payload_storage_read;
 
 use common::universal_io::UniversalRead;
@@ -5,7 +6,85 @@ use gridstore::GridstoreReader;
 
 use crate::types::Payload;
 
+/// Read-only counterpart to [`super::mmap_payload_storage::MmapPayloadStorage`].
+///
+/// Backed by a [`GridstoreReader`] over generic [`UniversalRead`] instead of a
+/// writable [`gridstore::Gridstore`]. Unlike the read-only field indexes there
+/// is no in-memory index to rebuild: [`Payload`] values are read straight from
+/// the reader, so [`PayloadStorageRead`](super::PayloadStorageRead) forwards
+/// directly to it. Opened via [`Self::open`] (see [`lifecycle`]); provides no
+/// mutation surface.
 pub struct ReadOnlyPayloadStorage<S: UniversalRead> {
     storage: GridstoreReader<Payload, S>,
     populate: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
+    use rstest::rstest;
+    use tempfile::TempDir;
+
+    use super::ReadOnlyPayloadStorage;
+    use crate::payload_json;
+    use crate::payload_storage::mmap_payload_storage::MmapPayloadStorage;
+    use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
+
+    /// Write payloads through the writable mmap storage, then reopen the same
+    /// files read-only through the write-enforced `ReadOnly<MmapFile>` backend
+    /// and assert the reader returns what was written.
+    #[rstest]
+    fn read_only_payload_storage_round_trip(#[values(false, true)] populate: bool) {
+        let dir = TempDir::with_prefix("read_only_payload").unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let payload = payload_json! {
+            "a": "some text",
+            "n": 42,
+        };
+
+        {
+            let mut storage =
+                MmapPayloadStorage::open_or_create(dir.path().to_path_buf(), false).unwrap();
+            for i in 0..5 {
+                storage.set(i, &payload, &hw_counter).unwrap();
+            }
+            // Flush so the reader observes the data on disk.
+            storage.flusher()().unwrap();
+        }
+
+        // `S = ReadOnly<MmapFile>` → the write-enforced backend (every open
+        // asserted non-writable), usable because the gridstore reader opens
+        // read-only.
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+        let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> =
+            ReadOnlyPayloadStorage::open(&fs, dir.path().to_path_buf(), populate)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(storage.is_on_disk(), !populate);
+        for i in 0..5 {
+            assert_eq!(storage.get(i, &hw_counter).unwrap(), payload);
+        }
+        // An unwritten point reads back as an empty payload.
+        assert_eq!(storage.get(99, &hw_counter).unwrap(), payload_json! {});
+    }
+
+    /// Opening over a directory that was never written returns `Ok(None)` — the
+    /// read path never creates.
+    #[test]
+    fn read_only_payload_storage_missing_dir_is_none() {
+        let dir = TempDir::with_prefix("read_only_payload_missing").unwrap();
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+        let opened = ReadOnlyPayloadStorage::<ReadOnly<MmapFile>>::open(
+            &fs,
+            dir.path().to_path_buf(),
+            false,
+        )
+        .unwrap();
+        assert!(opened.is_none());
+    }
 }


### PR DESCRIPTION
### Summary

Adds a read-only `open` constructor for `ReadOnlyPayloadStorage`, the read-only counterpart of `MmapPayloadStorage::open_or_create`.

- `ReadOnlyPayloadStorage::open(fs, path, populate)` resolves the `payload_storage` sub-directory (matching the writable on-disk layout) and opens a `GridstoreReader` over the generic `fs`. Unlike the read-only field indexes there is no in-memory index to rebuild — `Payload` values are read straight from the reader.
- Returns `Ok(None)` when the directory doesn't exist — the read path never creates.
- `populate` eagerly loads the pages (same as the writable storage) and is retained to answer `is_on_disk`.
- Adds tests: a round-trip (write via writable mmap storage, reopen read-only over the write-enforced `ReadOnly<MmapFile>` backend) and a missing-directory case.

> Stacked on #9314 (which moves the `LiveReload` trait into `common`); the base will move to `dev` once that merges.

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
