### PR TITLE
feat: live reload payload storage

### DIFF
--- a/lib/segment/src/payload_storage/read_only/live_reload.rs
+++ b/lib/segment/src/payload_storage/read_only/live_reload.rs
@@ -1,0 +1,21 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyPayloadStorage;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyPayloadStorage<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        _deleted_points: &[PointOffsetType],
+        _new_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Ok(self.storage.live_reload(fs)?)
+    }
+}

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -1,4 +1,5 @@
 mod lifecycle;
+mod live_reload;
 mod payload_storage_read;
 
 use common::universal_io::UniversalRead;


### PR DESCRIPTION
### Summary

Implements the `LiveReload` trait for `ReadOnlyPayloadStorage` (the read-only payload storage added in #9315).

- There is no separate in-memory index to patch — payloads are served straight from the gridstore — so reloading the backing reader is the whole reload: newly appended payloads become readable, and the reloaded id-tracker reflects deletions (point liveness is the id-tracker's concern, not this storage's).
- `deleted_points` / `new_points` / `hw_counter` are therefore unused.

> Stacked on #9315 → #9314; the base will move to `dev` once those merge.

---

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
