### PR TITLE
fix(segment): start recreated named vector from a clean slate

### DIFF
--- a/lib/segment/src/segment/tests/test_vector_name_ops.rs
+++ b/lib/segment/src/segment/tests/test_vector_name_ops.rs
@@ -16,7 +16,9 @@ use crate::entry::entry_point::{
 };
 use crate::segment::Segment;
 use crate::segment_constructor::segment_builder::SegmentBuilder;
-use crate::segment_constructor::{build_segment, load_segment};
+use crate::segment_constructor::{
+    build_segment, get_vector_index_path, get_vector_storage_path, load_segment,
+};
 use crate::types::{
     Distance, HnswGlobalConfig, Indexes, SegmentConfig, VectorDataConfig, VectorStorageType,
 };
@@ -439,6 +441,110 @@ fn test_persistence_after_create_with_data() {
             "point {i} should have default vector after reload"
         );
     }
+}
+
+/// Recursively copy a directory tree (test helper).
+fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) {
+    fs_err::create_dir_all(dst).unwrap();
+    for entry in fs_err::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_all(&entry.path(), &dst_path);
+        } else {
+            fs_err::copy(entry.path(), &dst_path).unwrap();
+        }
+    }
+}
+
+/// Regression test for vector-data resurrection across a `DeleteVectorName` /
+/// `CreateVectorName` cycle.
+///
+/// `delete_vector_name` removes the vector's storage directory, but that
+/// removal is best-effort: it logs a warning and continues on failure (and a
+/// crash mid-delete leaves the directory too), so it can still be on disk after
+/// the delete. We reproduce that outcome deterministically: snapshot the
+/// storage (and index) directory, delete the name, then restore the snapshot
+/// before recreating, standing in for files the delete did not remove.
+///
+/// When the name is recreated, `create_vector_name` must start from a clean
+/// slate. Otherwise it reopens the stale files and a point that was never
+/// re-upserted silently regains its old vector after reload.
+fn check_recreate_does_not_resurrect(
+    config: VectorNameConfig,
+    build_value: impl Fn() -> crate::data_types::vectors::VectorInternal,
+) {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let backup = Builder::new().prefix("stale_backup").tempdir().unwrap();
+    let mut segment = build_appendable_segment_with_data(dir.path());
+    let hw = hw();
+
+    let new_point = (NUM_POINTS as u64 + 1).into();
+
+    // Create "v2", write a point carrying v2 data, then persist it to disk.
+    segment.create_vector_name(100, "v2", &config).unwrap();
+    let mut vectors = NamedVectors::default();
+    vectors.insert(DEFAULT_VECTOR_NAME.to_owned(), vec![9.0f32; DIM].into());
+    vectors.insert("v2".to_owned(), build_value());
+    segment.upsert_point(101, new_point, vectors, &hw).unwrap();
+    segment.flush(true).unwrap();
+
+    // Snapshot the on-disk storage/index, so we can restore them after the
+    // delete — simulating an in-flight flush writing them back behind the
+    // delete's `remove_dir_all`.
+    let segment_path = segment.data_path();
+    let storage_path = get_vector_storage_path(&segment_path, "v2");
+    let index_path = get_vector_index_path(&segment_path, "v2");
+    let storage_backup = backup.path().join("storage");
+    let index_backup = backup.path().join("index");
+    copy_dir_all(&storage_path, &storage_backup);
+    if index_path.exists() {
+        copy_dir_all(&index_path, &index_backup);
+    }
+
+    segment.delete_vector_name(102, "v2").unwrap();
+
+    // The stale files reappear on disk after the delete removed them.
+    copy_dir_all(&storage_backup, &storage_path);
+    if index_backup.exists() {
+        copy_dir_all(&index_backup, &index_path);
+    }
+
+    // Recreate the same name — must produce an empty vector, not reopen stale data.
+    segment.create_vector_name(103, "v2", &config).unwrap();
+
+    let v2 = segment.vector("v2", new_point, &hw).unwrap();
+    assert!(
+        v2.is_none(),
+        "recreated vector resurrected stale data in memory"
+    );
+
+    // The clean slate must also survive a reload.
+    let segment_uuid = segment.uuid;
+    segment.flush(true).unwrap();
+    drop(segment);
+
+    let stopped = AtomicBool::new(false);
+    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped).unwrap();
+    let v2 = loaded.vector("v2", new_point, &hw).unwrap();
+    assert!(
+        v2.is_none(),
+        "recreated vector resurrected stale data after reload"
+    );
+}
+
+#[test]
+fn test_recreate_dense_vector_name_does_not_resurrect_stale_data() {
+    check_recreate_does_not_resurrect(dense_vector_name_config(8), || vec![3.0f32; 8].into());
+}
+
+#[test]
+fn test_recreate_sparse_vector_name_does_not_resurrect_stale_data() {
+    check_recreate_does_not_resurrect(sparse_vector_name_config(), || {
+        SparseVector::new(vec![1, 29], vec![0.25, 0.5])
+            .unwrap()
+            .into()
+    });
 }
 
 #[test]

--- a/lib/segment/src/segment/vector_name_ops.rs
+++ b/lib/segment/src/segment/vector_name_ops.rs
@@ -36,6 +36,22 @@ impl Segment {
             return Ok(false);
         }
 
+        // Start from a clean slate. A prior `delete_vector_name` removes the
+        // storage/index directories, but that removal is best-effort: it logs a
+        // warning and continues on failure (and a crash mid-delete leaves them
+        // too), so the directories can still be on disk. If we reopened those
+        // stale files here, the recreated vector would resurrect data from
+        // points that were never re-upserted (visible after a reload). Remove
+        // any leftovers first.
+        let storage_path = get_vector_storage_path(&self.segment_path, vector_name);
+        let index_path = get_vector_index_path(&self.segment_path, vector_name);
+        if storage_path.exists() {
+            fs_err::remove_dir_all(&storage_path)?;
+        }
+        if index_path.exists() {
+            fs_err::remove_dir_all(&index_path)?;
+        }
+
         match config {
             VectorNameConfig::Dense(wrapper) => {
                 let internal = wrapper.dense.to_internal(false);


### PR DESCRIPTION
## Problem

A point had its `m` (multi-dense) and `s` (sparse) vectors deleted, then recreated (`DeleteVectorName` / `CreateVectorName`). It was never re-upserted in between. 

After a restart, it silently regained those vectors, with their old pre-delete values.

## Root cause

`delete_vector_name` removes the vector's storage and index directories. That removal is best-effort. It logs a warning and continues on failure. 

A crash mid-delete leaves them too. So the directories can still be on disk after a delete.

On recreate, `create_vector_name` reopened whatever was on disk. 

`open_vector_storage` reuses existing files. `prefill_deleted_entries` only pads missing tail entries.

 Neither clears existing vectors. So the recreated name inherited the stale data, which then survived reload.

## Fix

`create_vector_name_impl` now wipes any leftover storage and index directories before opening.

 A recreated name always starts empty. It does not matter whether the earlier delete fully removed them.

 The change is surgical and storage-type-agnostic (dense, multi-dense, sparse).

## Tests

Two deterministic regression tests (dense + sparse) in `test_vector_name_ops.rs`. The flow:

1. Flush.
2. Snapshot the storage/index dir.
3. `delete_vector_name`.
4. Restore the snapshot. This stands in for leftovers the delete did not remove.
5. `create_vector_name`.
6. Assert the never-re-upserted point has no vector, in memory and after reload.

Both fail on the pre-fix code and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
