### PR TITLE
fix: validate hnsw_ef search parameter

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9895,7 +9895,7 @@
             "description": "Params relevant to HNSW index Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search.",
             "type": "integer",
             "format": "uint",
-            "minimum": 0,
+            "minimum": 1,
             "nullable": true
           },
           "exact": {

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -275,6 +275,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("SearchPointGroups.group_size", "range(min = 1)"),
             ("SearchPointGroups.limit", "range(min = 1)"),
             ("SearchPointGroups.timeout", "range(min = 1)"),
+            ("SearchParams.hnsw_ef", "range(min = 1)"),
             ("SearchParams.quantization", ""),
             ("SearchParams.acorn", ""),
             ("QuantizationSearchParams.oversampling", "range(min = 1.0)"),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5646,6 +5646,7 @@ pub struct SearchParams {
     /// Params relevant to HNSW index. Size of the beam in a beam-search.
     /// Larger the value - more accurate the result, more time required for search.
     #[prost(uint64, optional, tag = "1")]
+    #[validate(range(min = 1))]
     pub hnsw_ef: ::core::option::Option<u64>,
     /// Search without approximation. If set to true, search may run long but with exact results.
     #[prost(bool, optional, tag = "2")]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -591,6 +591,7 @@ pub struct SearchParams {
     /// Params relevant to HNSW index
     /// Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1))]
     pub hnsw_ef: Option<usize>,
 
     /// Search without approximation. If set to true, search may run long but with exact results.
@@ -4141,9 +4142,27 @@ mod tests {
     use itertools::Itertools;
     use rstest::rstest;
     use serde_json;
+    use validator::Validate;
 
     use super::test_utils::build_polygon_with_interiors;
     use super::*;
+
+    #[test]
+    fn test_search_params_rejects_zero_hnsw_ef() {
+        let params = SearchParams {
+            hnsw_ef: Some(0),
+            ..Default::default()
+        };
+
+        let err = params.validate().unwrap_err().to_string();
+        assert!(err.contains("hnsw_ef"), "error was: {err}");
+
+        let params = SearchParams {
+            hnsw_ef: Some(1),
+            ..Default::default()
+        };
+        params.validate().unwrap();
+    }
 
     #[test]
     #[ignore]

--- a/tests/openapi/test_validation.py
+++ b/tests/openapi/test_validation.py
@@ -53,6 +53,24 @@ def test_validation_body_param(collection_name):
     assert 'hnsw_config.ef_construct' in response.json()["status"]["error"]
 
 
+def test_validation_search_hnsw_ef_zero(collection_name):
+    # HNSW search ef must be a positive beam size.
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/search',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3,
+            "params": {"hnsw_ef": 0},
+        }
+    )
+    assert not response.ok
+    error = response.json()["status"]["error"]
+    assert 'Validation error' in error
+    assert 'hnsw_ef' in error
+
+
 def test_validation_query_param(collection_name):
     # Illegal URL parameters must trigger a validation error
     response = request_with_validation(


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

Fixes #9017 by rejecting `hnsw_ef=0` during request/model validation.

This validates `SearchParams.hnsw_ef` directly with `#[validate(range(min = 1))]`, so invalid values are rejected before search execution. The same validation is wired for the generated gRPC API model.

There is an existing draft PR, #9136, that approaches this through strict-mode verification. I opened this as an alternative because strict-mode verification only runs when strict mode is enabled for the collection, while #9017 describes `hnsw_ef=0` as invalid request input in general.

## Tests

```bash
cargo test -p segment --lib --jobs 2 test_search_params_rejects_zero_hnsw_ef
QDRANT_HOST=http://localhost:6335 uv --project tests run pytest tests/openapi/test_validation.py -k hnsw_ef -q
```