### PR TITLE
fix(shard): use saturating_add for query limit + offset to avoid overflow

### DIFF
--- a/lib/shard/src/query/planned_query.rs
+++ b/lib/shard/src/query/planned_query.rs
@@ -127,8 +127,10 @@ impl PlannedQuery {
             params,
         } = request;
 
-        // Adjust limit so that we have enough results when we cut off the offset at a higher level
-        let limit = limit + offset;
+        // Adjust limit so that we have enough results when we cut off the offset at a higher level.
+        // Use saturating_add so an unbounded user-supplied limit/offset cannot overflow
+        // (debug panic / release wraparound to a tiny limit) — it clamps to usize::MAX instead.
+        let limit = limit.saturating_add(offset);
 
         // Adjust with_vector based on the root query variant
         let with_vector = match &query {

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -127,6 +127,34 @@ fn test_try_from_double_rescore() {
 }
 
 #[test]
+fn test_try_from_limit_offset_saturates_on_overflow() {
+    // Regression: folding `offset` into the fetch `limit` must saturate instead
+    // of overflowing. With limit = usize::MAX and offset > 0, the previous
+    // `limit + offset` panicked in debug (overflow check) and wrapped to a tiny
+    // value in release; `saturating_add` clamps it to usize::MAX.
+    let dummy_vector = vec![1.0, 2.0, 3.0];
+    let request = ShardQueryRequest {
+        prefetches: vec![], // No prefetch
+        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
+            VectorInternal::Dense(dummy_vector),
+            "full",
+        )))),
+        filter: None,
+        score_threshold: None,
+        limit: usize::MAX,
+        offset: 10,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+
+    let planned_query = PlannedQuery::try_from(vec![request]).unwrap();
+
+    assert_eq!(planned_query.searches.len(), 1);
+    assert_eq!(planned_query.searches[0].limit, usize::MAX);
+}
+
+#[test]
 fn test_try_from_no_prefetch() {
     let dummy_vector = vec![1.0, 2.0, 3.0];
     let request = ShardQueryRequest {


### PR DESCRIPTION
## Summary

`PlannedQuery::add` folds the query `offset` into the fetch `limit` so that enough candidates are retrieved before the offset is applied at a higher level. It does this with a plain `usize` addition over user-supplied values:

```rust
let limit = limit + offset;
```

With a large `limit`/`offset`, `limit + offset` overflows — a panic in debug builds (overflow checks are on, including CI) and a silent wraparound to a tiny limit in release. This PR clamps it with `saturating_add`.

## Before

In `lib/shard/src/query/planned_query.rs`, `PlannedQuery::add` computes `let limit = limit + offset;`. For a no-prefetch query with `limit = usize::MAX` and `offset > 0`, planning panics (debug) or folds into a wrapped, far-too-small fetch limit (release).

## After

```rust
let limit = limit.saturating_add(offset);
```

An over-large limit/offset is clamped to `usize::MAX`, matching the saturating arithmetic already used elsewhere in the codebase. No behavior change for normal-sized queries.

## Impact

- Removes an overflow on the query-planning path reachable from user-supplied `limit`/`offset` (debug panic / release wrong fetch size). No API or schema change.

## Test plan

- New regression test `test_try_from_limit_offset_saturates_on_overflow` (`lib/shard/src/query/tests.rs`): a no-prefetch query with `limit = usize::MAX`, `offset = 10` plans a single search whose fetch limit is `usize::MAX` (RED on the previous code: debug overflow panic / release wraparound; GREEN after).
- Validated locally: `cargo test -p shard` (74 lib tests pass), `cargo clippy -p shard` clean, `cargo fmt --all -- --check` clean on stable and nightly. CI re-runs the full matrix.

## Contributing with AI

This change was AI-assisted: it was surfaced by a code audit of overflow/arithmetic on user-supplied query parameters and verified against the existing `saturating_add`/`saturating_sub` idioms in the codebase. The diff and this description were reviewed and edited by me.