### PR TITLE
deduplicate ingestion method for `InMemoryGeoIndex`

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/builders.rs
+++ b/lib/segment/src/index/field_index/geo_index/builders.rs
@@ -37,7 +37,7 @@ impl FieldIndexBuilderTrait for GeoMapIndexMmapBuilder {
             .flat_map(|value| <GeoMapIndex as ValueIndexer>::get_values(value))
             .collect::<Vec<_>>();
         self.in_memory_index
-            .add_many_geo_points(id, &values, hw_counter)
+            .add_many_geo_points(id, values, hw_counter)
     }
 
     fn finalize(self) -> OperationResult<Self::FieldIndexType> {

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
@@ -10,7 +10,7 @@ use super::super::read_ops::GeoMapIndexRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::geo_hash::{GeoHash, encode_max_precision};
 use crate::index::payload_config::StorageType;
-use crate::types::{GeoPoint, RawGeoPoint};
+use crate::types::GeoPoint;
 
 /// In-memory state shared by [`super::MutableGeoMapIndex`] and
 /// [`super::read_only::ReadOnlyAppendableGeoMapIndex`].
@@ -116,39 +116,37 @@ impl InMemoryGeoMapIndex {
         Ok(())
     }
 
+    /// Assign these geo points to the point offset.
     pub fn add_many_geo_points(
         &mut self,
         idx: PointOffsetType,
-        values: &[GeoPoint],
+        geo_points: Vec<GeoPoint>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        if values.is_empty() {
+        if geo_points.is_empty() {
             return Ok(());
         }
-
-        if self.point_to_values.len() <= idx as usize {
-            // That's a smart reallocation
-            self.point_to_values.resize_with(idx as usize + 1, Vec::new);
-        }
-
-        self.point_to_values[idx as usize] = values.to_vec();
-
-        let mut geo_hashes = vec![];
 
         let mut hw_cell_wb = hw_counter
             .payload_index_io_write_counter()
             .write_back_counter();
 
-        for added_point in values {
-            let added_geo_hash: GeoHash =
-                encode_max_precision(added_point.lon.0, added_point.lat.0).map_err(|e| {
+        let geo_hashes = geo_points
+            .iter()
+            .map(|geo_point| {
+                hw_cell_wb.incr_delta(size_of_val(geo_point));
+                encode_max_precision(geo_point.lon.0, geo_point.lat.0).map_err(|e| {
                     OperationError::service_error(format!("Malformed geo points: {e}"))
-                })?;
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
-            hw_cell_wb.incr_delta(size_of_val(&added_geo_hash));
-
-            geo_hashes.push(added_geo_hash);
+        if self.point_to_values.len() <= idx as usize {
+            self.point_to_values.resize_with(idx as usize + 1, Vec::new);
         }
+
+        let num_geo_points = geo_points.len();
+        self.point_to_values[idx as usize] = geo_points;
 
         for &geo_hash in &geo_hashes {
             self.points_map.entry(geo_hash).or_default().insert(idx);
@@ -157,61 +155,11 @@ impl InMemoryGeoMapIndex {
         }
 
         hw_cell_wb.incr_delta(geo_hashes.len() * size_of::<PointOffsetType>());
-
         self.increment_hash_point_counts(&geo_hashes);
 
-        self.points_values_count += values.len();
+        self.points_values_count += num_geo_points;
         self.points_count += 1;
-        self.max_values_per_point = self.max_values_per_point.max(values.len());
-        Ok(())
-    }
-
-    /// Ingest one point's persisted geo values (as read back from Gridstore)
-    /// into the in-memory maps.
-    ///
-    /// Shared by the writable [`MutableGeoMapIndex::open_gridstore`][1] load
-    /// path and the read-only [`ReadOnlyAppendableGeoMapIndex::open`][2]: both
-    /// iterate their backend (`Gridstore` / `GridstoreReader`) and feed each
-    /// stored `(idx, Vec<RawGeoPoint>)` here, so the geohash-bucket
-    /// reconstruction lives in exactly one place.
-    ///
-    /// [1]: super::MutableGeoMapIndex::open_gridstore
-    /// [2]: super::read_only::ReadOnlyAppendableGeoMapIndex::open
-    pub fn ingest(
-        &mut self,
-        idx: PointOffsetType,
-        values: Vec<RawGeoPoint>,
-    ) -> OperationResult<()> {
-        let geo_points = values.into_iter().map(GeoPoint::from).collect::<Vec<_>>();
-        let geo_hashes = geo_points
-            .iter()
-            .map(|geo_point| {
-                encode_max_precision(geo_point.lon.0, geo_point.lat.0).map_err(|e| {
-                    OperationError::service_error(format!("Malformed geo points: {e}"))
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        for geo_point in geo_points {
-            if self.point_to_values.len() <= idx as usize {
-                self.point_to_values.resize_with(idx as usize + 1, Vec::new);
-            }
-
-            if self.point_to_values[idx as usize].is_empty() {
-                self.points_count += 1;
-            }
-
-            self.point_to_values[idx as usize].push(geo_point);
-            self.points_values_count += 1;
-        }
-
-        self.max_values_per_point = self.max_values_per_point.max(geo_hashes.len());
-        self.increment_hash_point_counts(&geo_hashes);
-        for geo_hash in geo_hashes {
-            self.increment_hash_value_counts(geo_hash);
-            self.points_map.entry(geo_hash).or_default().insert(idx);
-        }
-
+        self.max_values_per_point = self.max_values_per_point.max(num_geo_points);
         Ok(())
     }
 

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
@@ -53,7 +53,8 @@ impl MutableGeoMapIndex {
         store
             .iter::<_, OperationError>(
                 |idx, values: Vec<RawGeoPoint>| {
-                    in_memory_index.ingest(idx, values)?;
+                    let geo_points = values.into_iter().map(GeoPoint::from).collect::<Vec<_>>();
+                    in_memory_index.add_many_geo_points(idx, geo_points, &hw_counter)?;
                     Ok(true)
                 },
                 hw_counter_ref,
@@ -111,7 +112,7 @@ impl MutableGeoMapIndex {
     pub fn add_many_geo_points(
         &mut self,
         idx: PointOffsetType,
-        values: &[GeoPoint],
+        values: Vec<GeoPoint>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // Update persisted storage

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -7,7 +7,7 @@ use gridstore::GridstoreReader;
 use super::super::inner::InMemoryGeoMapIndex;
 use super::ReadOnlyAppendableGeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::types::RawGeoPoint;
+use crate::types::{GeoPoint, RawGeoPoint};
 
 impl<S: UniversalRead> ReadOnlyAppendableGeoMapIndex<S> {
     /// Open the appendable (Gridstore) geo index read-only, threading every
@@ -39,7 +39,8 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoMapIndex<S> {
             .iter::<_, OperationError>(
                 storage.max_point_offset(),
                 |idx, values: Vec<RawGeoPoint>| {
-                    in_memory_index.ingest(idx, values)?;
+                    let geo_points = values.into_iter().map(GeoPoint::from).collect::<Vec<_>>();
+                    in_memory_index.add_many_geo_points(idx, geo_points, &hw_counter)?;
                     Ok(true)
                 },
                 // Same counter the writable `open_gridstore` load uses; this is

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -6,7 +6,7 @@ use common::universal_io::UniversalRead;
 use super::ReadOnlyAppendableGeoMapIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::LiveReload;
-use crate::types::RawGeoPoint;
+use crate::types::{GeoPoint, RawGeoPoint};
 
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoMapIndex<S> {
     type Fs = S::Fs;
@@ -31,8 +31,12 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoMapIndex<S> {
             .read_values::<Random, _, OperationError>(
                 new_points.iter().copied().enumerate(),
                 |_, point_offset, maybe_values: Option<Vec<RawGeoPoint>>| {
-                    let values = maybe_values.unwrap_or_default();
-                    in_memory_index.ingest(point_offset, values)?;
+                    let geo_points = maybe_values
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(GeoPoint::from)
+                        .collect::<Vec<_>>();
+                    in_memory_index.add_many_geo_points(point_offset, geo_points, hw_counter)?;
                     Ok(())
                 },
                 hw_counter.payload_index_io_read_counter(),

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
@@ -50,17 +50,17 @@ mod tests {
                 .unwrap();
             // point 0: Berlin, 1 value
             mutable
-                .add_many_geo_points(0, &[GeoPoint::new_unchecked(13.41, 52.52)], &hw_counter)
+                .add_many_geo_points(0, vec![GeoPoint::new_unchecked(13.41, 52.52)], &hw_counter)
                 .unwrap();
             // point 1: Paris, 1 value
             mutable
-                .add_many_geo_points(1, &[GeoPoint::new_unchecked(2.35, 48.85)], &hw_counter)
+                .add_many_geo_points(1, vec![GeoPoint::new_unchecked(2.35, 48.85)], &hw_counter)
                 .unwrap();
             // point 2: two values
             mutable
                 .add_many_geo_points(
                     2,
-                    &[
+                    vec![
                         GeoPoint::new_unchecked(1.0, 1.0),
                         GeoPoint::new_unchecked(2.0, 2.0),
                     ],

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -28,7 +28,7 @@ impl ValueIndexer for GeoMapIndex {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
-            GeoMapIndex::Mutable(index) => index.add_many_geo_points(id, &values, hw_counter),
+            GeoMapIndex::Mutable(index) => index.add_many_geo_points(id, values, hw_counter),
             GeoMapIndex::Immutable(_) => Err(OperationError::service_error(
                 "Can't add values to immutable geo index",
             )),

--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -105,15 +105,15 @@ mod tests {
                 .unwrap()
                 .unwrap();
             mutable
-                .add_many_geo_points(0, &[GeoPoint::new_unchecked(13.41, 52.52)], &hw_counter)
+                .add_many_geo_points(0, vec![GeoPoint::new_unchecked(13.41, 52.52)], &hw_counter)
                 .unwrap();
             mutable
-                .add_many_geo_points(1, &[GeoPoint::new_unchecked(2.35, 48.85)], &hw_counter)
+                .add_many_geo_points(1, vec![GeoPoint::new_unchecked(2.35, 48.85)], &hw_counter)
                 .unwrap();
             mutable
                 .add_many_geo_points(
                     2,
-                    &[
+                    vec![
                         GeoPoint::new_unchecked(1.0, 1.0),
                         GeoPoint::new_unchecked(2.0, 2.0),
                     ],


### PR DESCRIPTION
We have two sibling methods for ingesting in in-memory geo index. 

The only difference is that one takes `RawGeoPoint` and the other one `GeoPoint`, and the original one can take a hw counter, which can be easily ignored.

This PR deduplicates them.