### PR TITLE
fix(segment): use saturating_sub in geo-polygon interior cardinality estimation

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -277,13 +277,19 @@ pub(super) fn estimate_cardinality<G: GeoMapIndexRead + ?Sized>(
 
         for interior in &interior_hashes {
             let interior_estimation = geo.match_cardinality(interior, hw_counter)?;
-            exterior_estimation.min = max(0, exterior_estimation.min - interior_estimation.max);
+            exterior_estimation.min = exterior_estimation
+                .min
+                .saturating_sub(interior_estimation.max);
             exterior_estimation.max = max(
                 exterior_estimation.min,
-                exterior_estimation.max - interior_estimation.min,
+                exterior_estimation
+                    .max
+                    .saturating_sub(interior_estimation.min),
             );
             exterior_estimation.exp = max(
-                exterior_estimation.exp - interior_estimation.exp,
+                exterior_estimation
+                    .exp
+                    .saturating_sub(interior_estimation.exp),
                 exterior_estimation.min,
             );
         }

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -216,6 +216,69 @@ fn radius_to_polygon(circle: &GeoRadius) -> GeoPolygon {
     ])
 }
 
+/// Regression: a geo-polygon whose interior ring matches more points than its
+/// exterior ring must not underflow the cardinality estimate. `estimate_cardinality`
+/// subtracted `usize`s wrapped in a no-op `max(0, ..)`, so when an interior estimate
+/// exceeded the exterior estimate the subtraction underflowed (debug panic / release
+/// wrap to ~usize::MAX, corrupting query planning).
+#[rstest]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
+fn test_polygon_interior_exceeds_exterior_cardinality(#[case] index_type: IndexType) {
+    let (mut builder, _temp_dir, _db) = create_builder(index_type);
+
+    // A single indexed point in New York.
+    builder
+        .add_point(
+            0,
+            &[&json!([{ "lon": NYC.lon, "lat": NYC.lat }])],
+            &HardwareCounterCell::new(),
+        )
+        .unwrap();
+    let index = builder.finalize().unwrap();
+
+    // Exterior ring over Europe (does not contain the point); interior ring around
+    // New York (contains the point). The interior cardinality estimate therefore
+    // exceeds the exterior one, which previously underflowed `exterior.min - interior.max`.
+    let polygon = GeoPolygon {
+        exterior: GeoLineString {
+            points: vec![
+                GeoPoint::new_unchecked(2.0, 51.0),
+                GeoPoint::new_unchecked(2.0, 60.0),
+                GeoPoint::new_unchecked(20.0, 60.0),
+                GeoPoint::new_unchecked(20.0, 51.0),
+                GeoPoint::new_unchecked(2.0, 51.0),
+            ],
+        },
+        interiors: Some(vec![GeoLineString {
+            points: vec![
+                GeoPoint::new_unchecked(-74.5, 40.0),
+                GeoPoint::new_unchecked(-74.5, 41.5),
+                GeoPoint::new_unchecked(-73.0, 41.5),
+                GeoPoint::new_unchecked(-73.0, 40.0),
+                GeoPoint::new_unchecked(-74.5, 40.0),
+            ],
+        }]),
+    };
+
+    let hw_counter = HardwareCounterCell::new();
+    let card = index
+        .estimate_cardinality(&condition_for_geo_polygon("test", polygon), &hw_counter)
+        .unwrap()
+        .unwrap();
+
+    // No underflow: a self-consistent estimate bounded by the single indexed point.
+    assert!(card.min <= card.exp, "min {} > exp {}", card.min, card.exp);
+    assert!(card.exp <= card.max, "exp {} > max {}", card.exp, card.max);
+    assert!(
+        card.max <= index.points_count(),
+        "max {} exceeds total points {}",
+        card.max,
+        index.points_count(),
+    );
+}
+
 #[rstest]
 #[case(IndexType::Mutable)]
 #[case(IndexType::OnDisk)]


### PR DESCRIPTION
## Summary

`estimate_cardinality` for a geo-polygon subtracts each interior ring's cardinality estimate from the exterior estimate. The three subtractions are plain `usize` subtractions wrapped in `max(0, ..)`, which is a no-op for unsigned integers — the subtraction is evaluated first and underflows when an interior estimate exceeds the corresponding exterior estimate (a debug panic; a wrap to ~`usize::MAX` in release that corrupts query planning).

## Before

In `lib/segment/src/index/field_index/geo_index/read_ops.rs`, the geo-polygon branch of `estimate_cardinality`:

```rust
exterior_estimation.min = max(0, exterior_estimation.min - interior_estimation.max);
exterior_estimation.max = max(exterior_estimation.min, exterior_estimation.max - interior_estimation.min);
exterior_estimation.exp = max(exterior_estimation.exp - interior_estimation.exp, exterior_estimation.min);
```

`max(0, a - b)` evaluates `a - b` first; for `usize` this underflows when `b > a` (e.g. an interior ring over a denser region than the exterior boundary). Debug builds (overflow checks on, as in CI) panic; release wraps to a near-`usize::MAX` cardinality that corrupts query planning.

## After

Use `saturating_sub` for each subtraction (keeping the meaningful outer `max(.., exterior_estimation.min)` clamps), matching `match_cardinality` in the same file (`sum.saturating_sub(point_duplications)`) and the other cardinality estimators in the tree.

## Impact

- Removes an underflow on the geo-polygon cardinality-estimation path reachable from a filter with an interior (exclusion) ring. No behavior change when no underflow occurs; no API or schema change.

## Test plan

- New regression test `test_polygon_interior_exceeds_exterior_cardinality` (`lib/segment/src/index/field_index/geo_index/tests.rs`, all three index variants): a single indexed point, an exterior ring that does not contain it, and an interior ring that does, so the interior estimate exceeds the exterior one. RED on the previous code: all three cases panic with `attempt to subtract with overflow` at `read_ops.rs:280`. GREEN after the fix.
- Validated locally: `cargo test -p segment --features testing` (new test passes; RED->GREEN verified by running before and after the fix), `cargo clippy -p segment` clean, `cargo fmt --all -- --check` clean on stable and nightly. CI re-runs the full matrix.

## Contributing with AI

This change was AI-assisted: it was surfaced by an audit for unchecked arithmetic on estimator paths and verified against the existing `saturating_sub` idiom in the same file. The diff and this description were reviewed and edited by me; the RED->GREEN behavior was confirmed by running the test before and after the fix locally.