### PR TITLE
[TQDT] Vector storage update from without CowVector

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -6,14 +6,13 @@ use atomic_refcell::AtomicRefCell;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::RngExt;
 use rand::distr::StandardUniform;
-use segment::data_types::named_vectors::CowVector;
 use segment::data_types::vectors::{DenseVector, QueryVector};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::id_tracker::IdTrackerRead;
 use segment::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use segment::types::Distance;
-use segment::vector_storage::DEFAULT_STOPPED;
 use segment::vector_storage::dense::dense_vector_storage::open_dense_vector_storage;
+use segment::vector_storage::{DEFAULT_STOPPED, DenseVectorStorage, VectorStorageEnum};
 use tempfile::Builder;
 
 #[cfg(not(target_os = "windows"))]
@@ -49,12 +48,16 @@ fn benchmark<const IO_URING: bool, const VECTORS: usize, const BATCH: usize>(c: 
 
     let mut vectors = (0..VECTORS).map(|_| {
         let vector = random_vector(DIM);
-        (CowVector::from(vector), false)
+        (std::borrow::Cow::Owned(vector), false)
     });
 
-    storage
-        .update_from(&mut vectors, &AtomicBool::from(false))
-        .expect("vector storage populated");
+    let result = match &mut storage {
+        VectorStorageEnum::DenseMemmap(v) => v.update_from(&mut vectors, &AtomicBool::from(false)),
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(v) => v.update_from(&mut vectors, &AtomicBool::from(false)),
+        _ => panic!("unexpected dense vector storage variant"),
+    };
+    result.expect("vector storage populated");
 
     let id_tracker = Arc::new(AtomicRefCell::new(create_id_tracker_fixture(VECTORS)));
     let id_tracker = id_tracker.borrow();

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -1,6 +1,5 @@
 use std::array;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -52,9 +51,9 @@ fn benchmark<const IO_URING: bool, const VECTORS: usize, const BATCH: usize>(c: 
     });
 
     let result = match &mut storage {
-        VectorStorageEnum::DenseMemmap(v) => v.update_from(&mut vectors, &AtomicBool::from(false)),
+        VectorStorageEnum::DenseMemmap(v) => v.update_from(&mut vectors, &DEFAULT_STOPPED),
         #[cfg(target_os = "linux")]
-        VectorStorageEnum::DenseUring(v) => v.update_from(&mut vectors, &AtomicBool::from(false)),
+        VectorStorageEnum::DenseUring(v) => v.update_from(&mut vectors, &DEFAULT_STOPPED),
         _ => panic!("unexpected dense vector storage variant"),
     };
     result.expect("vector storage populated");

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -149,15 +149,13 @@ pub(crate) fn merge_from<'a>(
             let range = target.update_from(&mut reader, stopped);
             reader.finish(range)
         }
+        // Empty storages are read-only placeholders: their `update_from` always
+        // errors, so there is no source vector to read and no reader to build.
         VectorStorageEnum::EmptyDense(target) => {
-            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
-            let range = target.update_from(&mut reader, stopped);
-            reader.finish(range)
+            target.update_from(&mut std::iter::empty(), stopped)
         }
         VectorStorageEnum::EmptySparse(target) => {
-            let mut reader = BatchedReader::new(points, sources, read_sparse);
-            let range = target.update_from(&mut reader, stopped);
-            reader.finish(range)
+            target.update_from(&mut std::iter::empty(), stopped)
         }
     }
 }

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -1,20 +1,25 @@
+use std::borrow::Cow;
 use std::cmp::min;
-use std::iter::Iterator;
+use std::ops::Range;
+use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
-use atomic_refcell::AtomicRef;
 use common::generic_consts::Sequential;
 use common::small_uint::U24;
 use common::types::PointOffsetType;
+use sparse::common::sparse_vector::SparseVector;
 
-use crate::data_types::named_vectors::CowVector;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::named_vectors::CowMultiVector;
+use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::CompactExtendedPointId;
-use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
-
-const BATCH_SIZE: usize = 256;
+use crate::vector_storage::{
+    DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum,
+    VectorStorageRead,
+};
 
 /// Define location of the point source during segment construction.
-pub struct PointData {
+pub(crate) struct PointData {
     pub external_id: CompactExtendedPointId,
     /// [`CompactExtendedPointId`] is 17 bytes, we reduce
     /// `segment_index` to 3 bytes to avoid paddings and align nicely.
@@ -24,55 +29,222 @@ pub struct PointData {
     pub ordering: u64,
 }
 
-/// Batched iterator over points to insert.
-/// This structure should read `BATCH_SIZE` points into a buffer,
-/// and then iterate over them.
-pub struct BatchedVectorReader<'a> {
-    points_to_insert: &'a [PointData],
-    source_vector_storages: &'a [AtomicRef<'a, VectorStorageEnum>],
-    buffer: Vec<(CowVector<'a>, bool)>,
+/// Append `points` (read from `sources`) into `target`, copying each vector in
+/// its native representation — no `f32` round-trip, no dequantization.
+///
+/// Every source must be the same vector kind and element type as `target` (the
+/// storage type is fixed by the collection config, so this holds within one
+/// merge); a source of a different kind/element type yields a service error.
+pub(crate) fn merge_from<'a>(
+    target: &mut VectorStorageEnum,
+    points: &'a [PointData],
+    sources: &'a [&'a VectorStorageEnum],
+    stopped: &AtomicBool,
+) -> OperationResult<Range<PointOffsetType>> {
+    match target {
+        VectorStorageEnum::DenseVolatile(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseMemmap(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseMemmapByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseMemmapHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUringByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUringHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseAppendableMemmap(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseAppendableMemmapByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseAppendableMemmapHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::SparseVolatile(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_sparse);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::SparseMmap(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_sparse);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::MultiDenseVolatile(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(test)]
+        VectorStorageEnum::MultiDenseVolatileByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        #[cfg(test)]
+        VectorStorageEnum::MultiDenseVolatileHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::MultiDenseAppendableMemmap(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::MultiDenseAppendableMemmapByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::MultiDenseAppendableMemmapHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_multi_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::EmptyDense(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::EmptySparse(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_sparse);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+    }
+}
+
+/// Test-only helper: merge `count` points (offsets `0..count`) from a single
+/// `source` storage into `target` via [`merge_from`].
+#[cfg(test)]
+pub(crate) fn merge_from_single_source(
+    target: &mut VectorStorageEnum,
+    source: &VectorStorageEnum,
+    count: PointOffsetType,
+) -> OperationResult<Range<PointOffsetType>> {
+    use crate::types::PointIdType;
+
+    let points: Vec<PointData> = (0..count)
+        .map(|internal_id| PointData {
+            external_id: CompactExtendedPointId::from(PointIdType::NumId(u64::from(internal_id))),
+            segment_index: U24::new_wrapped(0),
+            internal_id,
+            version: 0,
+            ordering: 0,
+        })
+        .collect();
+    let sources = [source];
+    merge_from(target, &points, &sources, &AtomicBool::default())
+}
+
+// --- internal merge machinery -------------------------------------------------
+
+const BATCH_SIZE: usize = 256;
+
+/// Reads a point's vector (in the native representation `V`) and its deleted
+/// flag from a source storage. One reader per kind/element-type — all source
+/// variants of that kind are accepted, so e.g. a volatile source can feed an
+/// mmap target without an f32 round-trip. A source of the wrong kind/element
+/// type yields a service error.
+type ReadFn<'a, V> = fn(&'a VectorStorageEnum, PointOffsetType) -> OperationResult<(V, bool)>;
+
+/// Batched iterator over points to insert, reading each source vector in its
+/// **native** representation `V` — no `f32` round-trip.
+///
+/// Reads `BATCH_SIZE` points into a buffer (grouped by source segment for read
+/// locality) and then iterates over them. A read error is captured in `error`
+/// and ends iteration; the caller retrieves it via [`BatchedReader::finish`].
+struct BatchedReader<'a, V> {
+    points: &'a [PointData],
+    sources: &'a [&'a VectorStorageEnum],
+    read: ReadFn<'a, V>,
+    buffer: Vec<Option<(V, bool)>>,
     seg_to_points_buffer: AHashMap<U24, Vec<(&'a PointData, usize)>>,
+    /// First read error encountered, if any. Set => iteration stops.
+    error: Option<OperationError>,
     /// Global position of the iterator.
-    /// From 0 to `points_to_insert.len()`.
+    /// From 0 to `points.len()`.
     position: usize,
 }
 
-impl<'a> BatchedVectorReader<'a> {
-    pub fn new(
-        points_to_insert: &'a [PointData],
-        source_vector_storages: &'a [AtomicRef<'a, VectorStorageEnum>],
-    ) -> BatchedVectorReader<'a> {
-        // We need to allocate the buffer with the size of the batch,
-        // but we don't know the size of the vectors.
-        // So we use a placeholder vector with size 0.
-        let buffer = vec![(CowVector::default(), false); BATCH_SIZE];
+impl<'a, V> BatchedReader<'a, V> {
+    fn new(
+        points: &'a [PointData],
+        sources: &'a [&'a VectorStorageEnum],
+        read: ReadFn<'a, V>,
+    ) -> BatchedReader<'a, V> {
+        // We don't know the vector type's size, so pre-size the buffer with
+        // empty slots and fill them per batch.
+        let buffer = (0..BATCH_SIZE).map(|_| None).collect();
 
-        BatchedVectorReader {
-            points_to_insert,
-            source_vector_storages,
+        BatchedReader {
+            points,
+            sources,
+            read,
             buffer,
             seg_to_points_buffer: AHashMap::default(),
+            error: None,
             position: 0,
         }
     }
 
-    /// Fills the buffer with the next batch of points.
-    ///
-    /// Reading of a single point looks like this:
-    ///
-    /// ```text
-    ///  let source_vector_storage = &source_vector_storages[point_data.segment_index.get() as usize];
-    ///  let vec = source_vector_storage.get_vector(point_data.internal_id);
-    ///  let vector_deleted = source_vector_storage.is_deleted_vector(point_data.internal_id);
-    ///  (vec, vector_deleted)
-    /// ```
-    fn refill_buffer(&mut self) {
+    /// Fills the buffer with the next batch of points, stopping at the first
+    /// read error.
+    fn refill_buffer(&mut self) -> OperationResult<()> {
         let start_pos = self.position;
-        let end_pos = min(self.position + BATCH_SIZE, self.points_to_insert.len());
+        let end_pos = min(self.position + BATCH_SIZE, self.points.len());
 
         // Read by segments, as we want to localize reads as much as possible.
         for pos in start_pos..end_pos {
-            let point_data = &self.points_to_insert[pos];
+            let point_data = &self.points[pos];
             let offset_in_batch = pos - start_pos;
 
             self.seg_to_points_buffer
@@ -82,36 +254,415 @@ impl<'a> BatchedVectorReader<'a> {
         }
 
         for (segment_index, points) in self.seg_to_points_buffer.drain() {
-            let source_vector_storage = &self.source_vector_storages[segment_index.get() as usize];
+            let source = self.sources[segment_index.get() as usize];
             for (point_data, offset_in_batch) in points {
-                let vec = source_vector_storage.get_vector::<Sequential>(point_data.internal_id);
-                let vector_deleted =
-                    source_vector_storage.is_deleted_vector(point_data.internal_id);
-                self.buffer[offset_in_batch] = (vec, vector_deleted);
+                self.buffer[offset_in_batch] = Some((self.read)(source, point_data.internal_id)?);
             }
         }
+
+        Ok(())
     }
 
-    fn refill_buffer_if_needed(&mut self) {
-        if self.position.is_multiple_of(BATCH_SIZE) {
-            self.refill_buffer();
+    /// Combine `update_from`'s result with any error captured while reading.
+    ///
+    /// A read error makes the source iterator end early, so `update_from`
+    /// returns `Ok` with a partial range — this surfaces the real error.
+    fn finish(
+        self,
+        range: OperationResult<Range<PointOffsetType>>,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        match self.error {
+            Some(error) => Err(error),
+            None => range,
         }
     }
 }
 
-impl<'a> Iterator for BatchedVectorReader<'a> {
-    type Item = (CowVector<'a>, bool);
+impl<'a, V> Iterator for BatchedReader<'a, V> {
+    type Item = (V, bool);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.position >= self.points_to_insert.len() {
+        if self.error.is_some() || self.position >= self.points.len() {
             return None;
         }
 
-        self.refill_buffer_if_needed();
+        if self.position.is_multiple_of(BATCH_SIZE)
+            && let Err(error) = self.refill_buffer()
+        {
+            self.error = Some(error);
+            return None;
+        }
 
-        let item = self.buffer[self.position % BATCH_SIZE].clone();
+        let item = self.buffer[self.position % BATCH_SIZE]
+            .take()
+            .expect("buffer slot must be filled for a valid position");
         self.position += 1;
 
         Some(item)
+    }
+}
+
+// Native source readers, one per (kind, element type). All variants of the same
+// kind/element type are accepted; a source of any other kind/element type is a
+// merge between incompatible storages and yields a service error.
+
+fn read_dense_f32(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(Cow<'_, [VectorElementType]>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        VectorStorageEnum::DenseVolatile(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseMemmap(v) => v.get_dense::<Sequential>(key),
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseAppendableMemmap(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::EmptyDense(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUringByte(_) | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_dense_byte(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(Cow<'_, [VectorElementTypeByte]>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseMemmapByte(v) => v.get_dense::<Sequential>(key),
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUringByte(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_) | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_dense_half(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(Cow<'_, [VectorElementTypeHalf]>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileHalf(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseMemmapHalf(v) => v.get_dense::<Sequential>(key),
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUringHalf(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_) | VectorStorageEnum::DenseUringByte(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_multi_f32(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(CowMultiVector<'_, VectorElementType>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        VectorStorageEnum::MultiDenseVolatile(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 multi-dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 multi-dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_)
+        | VectorStorageEnum::DenseUringByte(_)
+        | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a f32 multi-dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_multi_byte(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(CowMultiVector<'_, VectorElementTypeByte>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        #[cfg(test)]
+        VectorStorageEnum::MultiDenseVolatileByte(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte multi-dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte multi-dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_)
+        | VectorStorageEnum::DenseUringByte(_)
+        | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a byte multi-dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_multi_half(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(CowMultiVector<'_, VectorElementTypeHalf>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        #[cfg(test)]
+        VectorStorageEnum::MultiDenseVolatileHalf(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.get_multi::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half multi-dense storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half multi-dense storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_)
+        | VectorStorageEnum::DenseUringByte(_)
+        | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a half multi-dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_sparse(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(Cow<'_, SparseVector>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        // A deleted/absent vector reads as `None`; the placeholder is fine
+        // since the deleted flag is carried separately. Real read errors
+        // propagate via `?`.
+        VectorStorageEnum::SparseVolatile(v) => v
+            .get_sparse_opt::<Sequential>(key)?
+            .map(Cow::Owned)
+            .unwrap_or_default(),
+        VectorStorageEnum::SparseMmap(v) => v
+            .get_sparse_opt::<Sequential>(key)?
+            .map(Cow::Owned)
+            .unwrap_or_default(),
+        VectorStorageEnum::EmptySparse(v) => v
+            .get_sparse_opt::<Sequential>(key)?
+            .map(Cow::Owned)
+            .unwrap_or_default(),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a sparse storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a sparse storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_)
+        | VectorStorageEnum::DenseUringByte(_)
+        | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a sparse storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Distance;
+    use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+    use crate::vector_storage::sparse::volatile_sparse_vector_storage::new_volatile_sparse_vector_storage;
+
+    /// Merging storages of different kinds (here sparse into dense) is rejected
+    /// with a service error rather than panicking.
+    #[test]
+    fn merge_rejects_incompatible_storage_kinds() {
+        let mut dense_target = new_volatile_dense_vector_storage(4, Distance::Dot);
+        let sparse_source = new_volatile_sparse_vector_storage();
+
+        let result = merge_from_single_source(&mut dense_target, &sparse_source, 1);
+
+        assert!(
+            result.is_err(),
+            "merging a sparse source into a dense target must error, got {result:?}"
+        );
     }
 }

--- a/lib/segment/src/segment_constructor/mod.rs
+++ b/lib/segment/src/segment_constructor/mod.rs
@@ -1,4 +1,4 @@
-mod batched_reader;
+pub(crate) mod batched_reader;
 pub mod segment_builder;
 mod segment_constructor_base;
 #[cfg(any(test, feature = "testing"))]

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -43,7 +43,7 @@ use crate::index::{PayloadIndex, PayloadIndexRead, VectorIndexEnum};
 use crate::payload_storage::PayloadStorage;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::segment::{Segment, SegmentVersion};
-use crate::segment_constructor::batched_reader::{BatchedVectorReader, PointData};
+use crate::segment_constructor::batched_reader::{PointData, merge_from};
 use crate::segment_constructor::{
     VectorIndexBuildArgs, VectorIndexOpenArgs, build_vector_index, load_segment,
 };
@@ -385,12 +385,14 @@ impl SegmentBuilder {
                 })
                 .collect::<Result<Vec<_>, OperationError>>()?;
 
-            let mut vectors_iter: BatchedVectorReader =
-                BatchedVectorReader::new(&points_to_insert, &other_vector_storages);
-
-            let internal_range = vector_data
-                .vector_storage
-                .update_from(&mut vectors_iter, stopped)?;
+            let source_refs: Vec<&VectorStorageEnum> =
+                other_vector_storages.iter().map(|s| &**s).collect();
+            let internal_range = merge_from(
+                &mut vector_data.vector_storage,
+                &points_to_insert,
+                &source_refs,
+                stopped,
+            )?;
 
             if new_internal_range != internal_range {
                 debug_assert!(

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -246,6 +246,7 @@ where
         let mut deleted_ids = vec![];
         for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
             check_process_stopped(stopped)?;
+            // Vectors are already in the storage's element type — write as-is.
             // Safety: T implements zerocopy::IntoBytes.
             #[expect(deprecated, reason = "legacy code")]
             let raw_bites = unsafe { mmap::transmute_to_u8_slice(other_vector.as_ref()) };
@@ -421,6 +422,7 @@ mod tests {
     use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
     use crate::id_tracker::{IdTracker, IdTrackerRead};
     use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
+    use crate::segment_constructor::batched_reader::merge_from_single_source;
     use crate::types::{PointIdType, QuantizationConfig, ScalarQuantizationConfig};
     use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
     use crate::vector_storage::quantized::quantized_vectors::{
@@ -466,13 +468,7 @@ mod tests {
                     .insert_vector(2, points[2].as_slice().into(), &hw_counter)
                     .unwrap();
             }
-            let mut iter = (0..3).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, 3).unwrap();
         }
 
         assert_eq!(storage.total_vector_count(), 3);
@@ -494,13 +490,7 @@ mod tests {
                     .insert_vector(4, points[4].as_slice().into(), &hw_counter)
                     .unwrap();
             }
-            let mut iter = (0..2).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, 2).unwrap();
         }
 
         assert_eq!(storage.total_vector_count(), 5);
@@ -570,13 +560,8 @@ mod tests {
                         .unwrap();
                 });
             }
-            let mut iter = (0..points.len()).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, points.len() as PointOffsetType)
+                .unwrap();
         }
 
         assert_eq!(storage.total_vector_count(), 5);
@@ -700,13 +685,8 @@ mod tests {
                     }
                 });
             }
-            let mut iter = (0..points.len()).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, points.len() as PointOffsetType)
+                .unwrap();
         }
 
         assert_eq!(
@@ -771,13 +751,8 @@ mod tests {
                         .unwrap();
                 }
             }
-            let mut iter = (0..points.len()).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, points.len() as PointOffsetType)
+                .unwrap();
         }
 
         let vector = vec![-1.0, -1.0, -1.0, -1.0];
@@ -843,13 +818,8 @@ mod tests {
                         .unwrap();
                 }
             }
-            let mut iter = (0..points.len()).map(|i| {
-                let i = i as PointOffsetType;
-                let vector = storage2.get_vector::<Random>(i);
-                let deleted = storage2.is_deleted_vector(i);
-                (vector, deleted)
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &storage2, points.len() as PointOffsetType)
+                .unwrap();
         }
 
         let config: QuantizationConfig = ScalarQuantizationConfig {

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -1,9 +1,53 @@
+use std::borrow::Cow;
 use std::sync::atomic::AtomicBool;
 
-use super::VectorStorageRead as _;
+use sparse::common::sparse_vector::SparseVector;
+
 use super::vector_storage_base::VectorStorageEnum;
+use super::{DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageRead as _};
 use crate::common::operation_error::OperationResult;
-use crate::data_types::named_vectors::CowVector;
+use crate::data_types::named_vectors::CowMultiVector;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::TypedMultiDenseVector;
+
+// Append `count` deleted placeholders in the storage's own element type. The
+// placeholder content is irrelevant — every entry is flagged deleted — so we
+// just use zero vectors of the right dimension.
+
+fn fill_dense<T: PrimitiveVectorElement>(
+    storage: &mut impl DenseVectorStorage<T>,
+    count: usize,
+    stopped: &AtomicBool,
+) -> OperationResult<()> {
+    let dim = storage.vector_dim();
+    let placeholder: Cow<[T]> = Cow::Owned(vec![T::default(); dim]);
+    let mut iter = std::iter::repeat_n((placeholder, true), count);
+    storage.update_from(&mut iter, stopped)?;
+    Ok(())
+}
+
+fn fill_multi<T: PrimitiveVectorElement>(
+    storage: &mut impl MultiVectorStorage<T>,
+    count: usize,
+    stopped: &AtomicBool,
+) -> OperationResult<()> {
+    let dim = storage.vector_dim();
+    let placeholder = CowMultiVector::Owned(TypedMultiDenseVector::<T>::placeholder(dim));
+    let mut iter = std::iter::repeat_n((placeholder, true), count);
+    storage.update_from(&mut iter, stopped)?;
+    Ok(())
+}
+
+fn fill_sparse(
+    storage: &mut impl SparseVectorStorage,
+    count: usize,
+    stopped: &AtomicBool,
+) -> OperationResult<()> {
+    let placeholder = Cow::Owned(SparseVector::default());
+    let mut iter = std::iter::repeat_n((placeholder, true), count);
+    storage.update_from(&mut iter, stopped)?;
+    Ok(())
+}
 
 impl VectorStorageEnum {
     /// Ensure the storage has at least `num_points` entries, with any newly
@@ -17,59 +61,61 @@ impl VectorStorageEnum {
             return Ok(());
         }
 
-        let entries_to_add = num_points - self.total_vector_count();
+        let count = num_points - self.total_vector_count();
+        let stopped = AtomicBool::new(false);
 
         match self {
             // Empty storages can adjust their size directly.
             VectorStorageEnum::EmptyDense(v) => {
                 v.set_num_points(num_points);
-                return Ok(());
+                Ok(())
             }
             VectorStorageEnum::EmptySparse(v) => {
                 v.set_num_points(num_points);
-                return Ok(());
+                Ok(())
             }
 
-            // All other storages need to be extended via update_from.
-            // We just need to know which default vector to use.
-            VectorStorageEnum::DenseVolatile(_)
-            | VectorStorageEnum::DenseMemmap(_)
-            | VectorStorageEnum::DenseMemmapByte(_)
-            | VectorStorageEnum::DenseMemmapHalf(_)
-            | VectorStorageEnum::DenseAppendableMemmap(_)
-            | VectorStorageEnum::DenseAppendableMemmapByte(_)
-            | VectorStorageEnum::DenseAppendableMemmapHalf(_)
-            | VectorStorageEnum::MultiDenseVolatile(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmap(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => {}
-
+            VectorStorageEnum::DenseVolatile(v) => fill_dense(v, count, &stopped),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(_)
-            | VectorStorageEnum::DenseVolatileHalf(_)
-            | VectorStorageEnum::MultiDenseVolatileByte(_)
-            | VectorStorageEnum::MultiDenseVolatileHalf(_) => {}
+            VectorStorageEnum::DenseVolatileByte(v) => fill_dense(v, count, &stopped),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => fill_dense(v, count, &stopped),
+            VectorStorageEnum::DenseMemmap(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseMemmapByte(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseMemmapHalf(v) => fill_dense(&mut **v, count, &stopped),
 
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(_)
-            | VectorStorageEnum::DenseUringByte(_)
-            | VectorStorageEnum::DenseUringHalf(_) => {}
+            VectorStorageEnum::DenseUring(v) => fill_dense(&mut **v, count, &stopped),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => fill_dense(&mut **v, count, &stopped),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => fill_dense(&mut **v, count, &stopped),
 
-            VectorStorageEnum::SparseVolatile(_) | VectorStorageEnum::SparseMmap(_) => {
-                let stopped = AtomicBool::new(false);
-                let mut iter =
-                    std::iter::repeat_n((CowVector::default_sparse(), true), entries_to_add);
-                self.update_from(&mut iter, &stopped)?;
-                return Ok(());
+            VectorStorageEnum::DenseAppendableMemmap(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                fill_dense(&mut **v, count, &stopped)
             }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                fill_dense(&mut **v, count, &stopped)
+            }
+
+            VectorStorageEnum::MultiDenseVolatile(v) => fill_multi(v, count, &stopped),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => fill_multi(v, count, &stopped),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => fill_multi(v, count, &stopped),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                fill_multi(&mut **v, count, &stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                fill_multi(&mut **v, count, &stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                fill_multi(&mut **v, count, &stopped)
+            }
+
+            VectorStorageEnum::SparseVolatile(v) => fill_sparse(v, count, &stopped),
+            VectorStorageEnum::SparseMmap(v) => fill_sparse(v, count, &stopped),
         }
-
-        // Dense / multi-dense: fill with zero vectors of the appropriate dimension.
-        let default_vector = CowVector::from(self.default_vector());
-        let stopped = AtomicBool::new(false);
-        let mut iter = std::iter::repeat_n((default_vector, true), entries_to_add);
-        self.update_from(&mut iter, &stopped)?;
-
-        Ok(())
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -10,6 +10,7 @@ use rstest::rstest;
 
 use super::QuantizedVectorsRead;
 use crate::data_types::vectors::{QueryVector, VectorRef};
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{
     BinaryQuantizationConfig, Distance, ProductQuantizationConfig, QuantizationConfig,
     ScalarQuantizationConfig, TurboQuantQuantizationConfig,
@@ -39,11 +40,7 @@ fn build_on_disk_storage(dir: &std::path::Path, rng: &mut StdRng) -> VectorStora
     }
 
     let mut storage = open_dense_vector_storage(dir, DIMS, DISTANCE, false).unwrap();
-    let mut iter = (0..NUM_POINTS as PointOffsetType)
-        .map(|i| (raw.get_vector::<Random>(i), raw.is_deleted_vector(i)));
-    storage
-        .update_from(&mut iter, &AtomicBool::new(false))
-        .unwrap();
+    merge_from_single_source(&mut storage, &raw, NUM_POINTS as PointOffsetType).unwrap();
     storage
 }
 

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -41,6 +41,7 @@ mod tests {
     use crate::data_types::vectors::{
         DenseVector, MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorRef,
     };
+    use crate::segment_constructor::batched_reader::merge_from_single_source;
     use crate::types::{
         Distance, Indexes, MultiVectorConfig, VectorDataConfig, VectorStorageDatatype,
         VectorStorageType,
@@ -150,13 +151,8 @@ mod tests {
                     .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
                     .unwrap();
             }
-            let mut iter = (0..vectors.len() as PointOffsetType).map(|i| {
-                (
-                    staging.get_vector::<Random>(i),
-                    staging.is_deleted_vector(i),
-                )
-            });
-            storage.update_from(&mut iter, &Default::default()).unwrap();
+            merge_from_single_source(&mut storage, &staging, vectors.len() as PointOffsetType)
+                .unwrap();
             storage.flusher()().unwrap();
         }
 

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -1,6 +1,5 @@
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::SeedableRng as _;
@@ -11,6 +10,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::Distance;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage_with_uring;
@@ -64,13 +64,7 @@ fn test_async_raw_scorer(
         insert_random_vectors(&mut rng, dim, &mut volatile_storage, points)?;
         delete_random_vectors(&mut rng, &mut volatile_storage, &mut id_tracker, delete)?;
 
-        let mut iter = (0..points).map(|i| {
-            let i = i as PointOffsetType;
-            let vec = volatile_storage.get_vector::<Random>(i);
-            let deleted = volatile_storage.is_deleted_vector(i);
-            (vec, deleted)
-        });
-        storage.update_from(&mut iter, &Default::default())?;
+        merge_from_single_source(&mut storage, &volatile_storage, points as PointOffsetType)?;
     }
 
     for _ in 0..score {

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::AtomicBool;
 use std::{error, result};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use itertools::Itertools;
 use rand::rngs::StdRng;
@@ -18,6 +17,7 @@ use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::fixtures::query_fixtures::QueryVariant;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{
     BinaryQuantizationConfig, Distance, ProductQuantizationConfig, QuantizationConfig,
     ScalarQuantizationConfig,
@@ -144,13 +144,11 @@ fn scoring_equivalency(
 
     let mut other_storage = other_storage(other_dir.path());
 
-    let mut iter = (0..NUM_POINTS).map(|i| {
-        let i = i as PointOffsetType;
-        let vec = raw_storage.get_vector::<Random>(i);
-        let deleted = raw_storage.is_deleted_vector(i);
-        (vec, deleted)
-    });
-    other_storage.update_from(&mut iter, &Default::default())?;
+    merge_from_single_source(
+        &mut other_storage,
+        &raw_storage,
+        NUM_POINTS as PointOffsetType,
+    )?;
 
     let quant_dir = tempfile::Builder::new().prefix("quant-storage").tempdir()?;
     let quantized_vectors = if let Some(config) = &quant_config {

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use itertools::Itertools;
@@ -11,6 +10,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::id_tracker::{IdTracker, IdTrackerRead};
 use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{Distance, PointIdType, QuantizationConfig, ScalarQuantizationConfig};
 use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_full;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
@@ -152,13 +152,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
                 }
             });
         }
-        let mut iter = (0..points.len()).map(|i| {
-            let i = i as PointOffsetType;
-            let vec = storage2.get_vector::<Random>(i);
-            let deleted = storage2.is_deleted_vector(i);
-            (vec, deleted)
-        });
-        storage.update_from(&mut iter, &Default::default()).unwrap();
+        merge_from_single_source(storage, &storage2, points.len() as PointOffsetType).unwrap();
     }
 
     assert_eq!(

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -14,6 +14,7 @@ use crate::data_types::vectors::{
 use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_full;
@@ -218,13 +219,7 @@ fn do_test_update_from_delete_points(
                 }
             });
         }
-        let mut iter = (0..points.len()).map(|i| {
-            let i = i as PointOffsetType;
-            let vec = storage2.get_vector::<Random>(i);
-            let deleted = storage2.is_deleted_vector(i);
-            (vec, deleted)
-        });
-        storage.update_from(&mut iter, &Default::default()).unwrap();
+        merge_from_single_source(storage, &storage2, points.len() as PointOffsetType).unwrap();
     }
 
     assert_eq!(

--- a/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_sparse_vector_storage.rs
@@ -11,6 +11,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
+use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::vector_storage::query::RecoQuery;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::new_volatile_sparse_vector_storage;
@@ -139,13 +140,7 @@ fn do_test_update_from_delete_points(storage: &mut VectorStorageEnum) {
             }
         });
 
-        let mut iter = (0..points.len()).map(|i| {
-            let i = i as PointOffsetType;
-            let vec = storage2.get_vector::<Random>(i);
-            let deleted = storage2.is_deleted_vector(i);
-            (vec, deleted)
-        });
-        storage.update_from(&mut iter, &Default::default()).unwrap();
+        merge_from_single_source(storage, &storage2, points.len() as PointOffsetType).unwrap();
     }
 
     assert_eq!(

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -173,6 +173,9 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     /// The range of point offsets that were added to the storage.
     ///
     /// If stopped, the operation returns a cancellation error.
+    ///
+    /// Vectors are in the storage's own element type `T` — no f32 round-trip.
+    /// Used by the same-type merge path (`merge_from`).
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
@@ -259,7 +262,10 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     fn size_of_available_vectors_in_bytes(&self) -> usize;
 
-    /// Add the given multi-dense vectors to the storage.
+    /// Append the given multi-dense vectors to the storage.
+    ///
+    /// Vectors are in the storage's own element type `T` — no f32 round-trip.
+    /// Used by the same-type merge path (`merge_from`).
     ///
     /// # Returns
     /// The range of point offsets that were added to the storage.
@@ -995,141 +1001,6 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::EmptyDense(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::EmptySparse(v) => v.deleted_vector_bitslice(),
-        }
-    }
-}
-
-/// Unwrap a generic [`CowVector`] into a dense slice in the storage's element
-/// type `T` for [`DenseVectorStorage`], converting from f32 if needed.
-///
-/// Receiving a non-dense vector here is a logic error: the merge path always
-/// feeds a storage with vectors of its own kind.
-fn unwrap_dense<T: PrimitiveVectorElement>(
-    (vector, deleted): (CowVector<'_>, bool),
-) -> (Cow<'_, [T]>, bool) {
-    match vector {
-        CowVector::Dense(v) => (T::slice_from_float_cow(v), deleted),
-        CowVector::Sparse(_) | CowVector::MultiDense(_) => {
-            unreachable!("dense vector storage received a non-dense vector")
-        }
-    }
-}
-
-/// Unwrap a generic [`CowVector`] into a sparse vector for [`SparseVectorStorage`].
-fn unwrap_sparse((vector, deleted): (CowVector<'_>, bool)) -> (Cow<'_, SparseVector>, bool) {
-    match vector {
-        CowVector::Sparse(v) => (v, deleted),
-        CowVector::Dense(_) | CowVector::MultiDense(_) => {
-            unreachable!("sparse vector storage received a non-sparse vector")
-        }
-    }
-}
-
-/// Unwrap a generic [`CowVector`] into a multi-dense vector in the storage's
-/// element type `T` for [`MultiVectorStorage`], converting from f32 if needed.
-fn unwrap_multi<T: PrimitiveVectorElement>(
-    (vector, deleted): (CowVector<'_>, bool),
-) -> (CowMultiVector<'_, T>, bool) {
-    match vector {
-        CowVector::MultiDense(v) => (T::from_float_multivector(v), deleted),
-        CowVector::Dense(_) | CowVector::Sparse(_) => {
-            unreachable!("multi-dense vector storage received a non-multi-dense vector")
-        }
-    }
-}
-
-impl VectorStorageEnum {
-    /// Add the given vectors to the storage.
-    ///
-    /// Dispatches to the kind-specific [`DenseVectorStorage::update_from`],
-    /// [`SparseVectorStorage::update_from`] or [`MultiVectorStorage::update_from`],
-    /// unwrapping the generic [`CowVector`] into the concrete vector kind.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    pub fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::DenseMemmap(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::DenseMemmapByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::DenseMemmapHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::SparseVolatile(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
-            }
-            VectorStorageEnum::SparseMmap(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
-            }
-            VectorStorageEnum::MultiDenseVolatile(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
-            }
-            VectorStorageEnum::EmptyDense(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
-            }
-            VectorStorageEnum::EmptySparse(v) => {
-                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
-            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -173,9 +173,6 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     /// The range of point offsets that were added to the storage.
     ///
     /// If stopped, the operation returns a cancellation error.
-    ///
-    /// Vectors are in the storage's own element type `T` — no f32 round-trip.
-    /// Used by the same-type merge path (`merge_from`).
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
@@ -262,10 +259,7 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     fn size_of_available_vectors_in_bytes(&self) -> usize;
 
-    /// Append the given multi-dense vectors to the storage.
-    ///
-    /// Vectors are in the storage's own element type `T` — no f32 round-trip.
-    /// Used by the same-type merge path (`merge_from`).
+    /// Add the given multi-dense vectors to the storage.
     ///
     /// # Returns
     /// The range of point offsets that were added to the storage.


### PR DESCRIPTION
Part 3 of `update_from` refactor, first PR: https://github.com/qdrant/qdrant/pull/9357

Before TQ as a data type implementation, we have to avoid CowVector usage in `VectorStorageEnum::update_from` since it's too expensive to perform forward and back rotatiotions. Moreover, rotation may potentially accumulate an f32 error while tons of rotations.

This PR uses `update_from` from base vector storage trait into individual ones: `DenseVectorStorage`/`SparseVectorStorage`/`MultiVectorStorage`