### PR TITLE
[TQDT] Basic structure for `TurboVectorStorage`

### DIFF
--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -10,6 +10,7 @@ pub mod query_scorer;
 pub mod raw_scorer;
 pub mod read_only;
 pub mod sparse;
+pub mod turbo;
 mod vector_storage_base;
 pub mod volatile_chunked_vectors;
 

--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -1,10 +1,10 @@
-mod quantized_chunked_mmap_storage;
+pub(crate) mod quantized_chunked_mmap_storage;
 mod quantized_custom_query_scorer;
 mod quantized_multi_custom_query_scorer;
 mod quantized_multi_query_scorer;
 pub mod quantized_multivector_storage;
 pub mod quantized_query_scorer;
-mod quantized_ram_storage;
+pub(crate) mod quantized_ram_storage;
 mod quantized_scorer_builder;
-mod quantized_storage;
+pub(crate) mod quantized_storage;
 pub mod quantized_vectors;

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -1,0 +1,164 @@
+//! TurboQuant-backed dense vector storage.
+//!
+//! [`TurboVectorStorage`] is a *primary* dense storage that keeps only the
+//! TurboQuant (TQ) encoded vectors plus its own deletion state — as opposed to
+//! the secondary `QuantizedVectorStorage` layer that sits beside a
+//! full-precision storage.
+//!
+//! It intentionally implements only [`VectorStorageRead`] + [`VectorStorage`],
+//! **not** `DenseVectorStorage<T>`.
+
+// Scaffold: nothing constructs `TurboVectorStorage` yet. Remove once it is wired
+// into `VectorStorageEnum::DenseTurbo`.
+#![allow(dead_code)]
+
+mod turbo_encoded_vectors;
+
+use std::alloc::Layout;
+use std::borrow::Cow;
+use std::ops::Range;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+
+use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
+use common::mmap::MmapBitSlice;
+use common::types::PointOffsetType;
+use quantization::turboquant::quantization::TurboQuantizer;
+use quantization::turboquant::{TQBits, TQMode};
+
+use self::turbo_encoded_vectors::TurboEncodedVectorStorage;
+use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::named_vectors::CowVector;
+use crate::data_types::vectors::VectorRef;
+use crate::types::{Distance, VectorStorageDatatype};
+use crate::vector_storage::{VectorStorage, VectorStorageRead};
+
+// TurboQuant DataType (TQDT) always uses 4 bits without shift+scale error correction.
+const TQDT_BITS: TQBits = TQBits::Bits4;
+const TQDT_MODE: TQMode = TQMode::Normal;
+
+/// Vector storage for TurboQuant encoded vectors.
+pub struct TurboVectorStorage {
+    /// Raw quantized storage over one of the three backends.
+    storage: TurboEncodedVectorStorage,
+
+    /// Quantizer used to de/quantize.
+    quantizer: TurboQuantizer,
+
+    /// Memory-mapped deletion flags (`deleted.dat`).
+    deleted: MmapBitSlice,
+    /// Number of vectors currently flagged as deleted.
+    deleted_count: usize,
+
+    /// Distance used for scoring / query preprocessing.
+    distance: Distance,
+    /// Original (un-padded) vector dimensionality.
+    dim: usize,
+    /// Path to the `deleted.dat` flags file.
+    deleted_path: PathBuf,
+}
+
+impl TurboVectorStorage {
+    /// Bytes used by all available (non-deleted) vectors in their encoded form.
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        // TODO: available_vector_count() * quantizer.quantized_size().
+        unimplemented!("TODO: encoded size of available vectors")
+    }
+
+    /// Memory layout of a single encoded vector.
+    pub fn quantized_vector_layout(&self) -> OperationResult<Layout> {
+        // TODO: build from quantized_vector_size() with the encoding alignment.
+        unimplemented!("TODO: layout of one encoded vector")
+    }
+
+    /// Raw encoded vector blob for one vector (no dequantization/lloyd lookup).
+    pub fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.storage.get_quantized_vector(key)
+    }
+}
+
+impl VectorStorageRead for TurboVectorStorage {
+    fn distance(&self) -> Distance {
+        self.distance
+    }
+
+    fn datatype(&self) -> VectorStorageDatatype {
+        unimplemented!("TODO: datatype of TurboVectorStorage not yet decided")
+    }
+
+    fn is_on_disk(&self) -> bool {
+        self.storage.is_on_disk()
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.storage.vectors_count()
+    }
+
+    fn get_vector<P: AccessPattern>(&self, _key: PointOffsetType) -> CowVector<'_> {
+        // TODO: dequantize the encoded blob into `dim` f32 -> CowVector::Dense.
+        unimplemented!("TODO: dequantize encoded vector to f32")
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, _key: PointOffsetType) -> Option<CowVector<'_>> {
+        // TODO: as get_vector, returning None when the key is out of range.
+        unimplemented!("TODO: dequantize encoded vector to f32 (optional)")
+    }
+
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        &self.deleted
+    }
+}
+
+impl VectorStorage for TurboVectorStorage {
+    fn insert_vector(
+        &mut self,
+        _key: PointOffsetType,
+        _vector: VectorRef,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // TODO: encode the f32 vector via `self.encoded.upsert_vector` (live insert).
+        unimplemented!("TODO: encode and insert a single vector")
+    }
+
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        // TODO: encode each incoming f32 vector and propagate deleted flags.
+        unimplemented!("TODO: encode vectors from another storage (optimize)")
+    }
+
+    fn flusher(&self) -> Flusher {
+        // TODO: combine `self.encoded.flusher()` and `self.deleted.flusher()`.
+        unimplemented!("TODO: flush encoded storage + deleted flags")
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        // Encoded blob + quantized.meta.json + the mutable deleted.dat flags.
+        let mut files = self.storage.files();
+        files.push(self.deleted_path.clone());
+        files
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        // Encoded blob + meta are immutable; deleted.dat is not.
+        self.storage.immutable_files()
+    }
+
+    fn delete_vector(&mut self, _key: PointOffsetType) -> OperationResult<bool> {
+        // TODO: set the bit in `self.deleted` and bump `self.deleted_count`.
+        unimplemented!("TODO: flag a vector as deleted")
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -23,13 +23,14 @@ use std::sync::atomic::AtomicBool;
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
-use common::mmap::MmapBitSlice;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
 use quantization::turboquant::quantization::TurboQuantizer;
 use quantization::turboquant::{TQBits, TQMode};
 
 use self::turbo_encoded_vectors::TurboEncodedVectorStorage;
 use crate::common::Flusher;
+use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
@@ -48,8 +49,8 @@ pub struct TurboVectorStorage {
     /// Quantizer used to de/quantize.
     quantizer: TurboQuantizer,
 
-    /// Memory-mapped deletion flags (`deleted.dat`).
-    deleted: MmapBitSlice,
+    /// Persisted flags marking which vectors are soft-deleted.
+    deleted: BitvecFlags<MmapFile>,
     /// Number of vectors currently flagged as deleted.
     deleted_count: usize,
 
@@ -57,8 +58,6 @@ pub struct TurboVectorStorage {
     distance: Distance,
     /// Original (un-padded) vector dimensionality.
     dim: usize,
-    /// Path to the `deleted.dat` flags file.
-    deleted_path: PathBuf,
 }
 
 impl TurboVectorStorage {
@@ -108,7 +107,7 @@ impl VectorStorageRead for TurboVectorStorage {
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).map(|b| *b).unwrap_or(false)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
@@ -116,7 +115,7 @@ impl VectorStorageRead for TurboVectorStorage {
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
-        &self.deleted
+        self.deleted.get_bitslice()
     }
 }
 
@@ -146,9 +145,9 @@ impl VectorStorage for TurboVectorStorage {
     }
 
     fn files(&self) -> Vec<PathBuf> {
-        // Encoded blob + quantized.meta.json + the mutable deleted.dat flags.
+        // Encoded blob + quantized.meta.json + the mutable deleted flags.
         let mut files = self.storage.files();
-        files.push(self.deleted_path.clone());
+        files.extend(self.deleted.files());
         files
     }
 

--- a/lib/segment/src/vector_storage/turbo/turbo_encoded_vectors.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_encoded_vectors.rs
@@ -1,0 +1,70 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use common::mmap::MmapFlusher;
+use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
+use quantization::EncodedStorage;
+
+use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedMmapStorage;
+use crate::vector_storage::quantized::quantized_ram_storage::QuantizedRamStorage;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+
+/// Raw quantized storage backend for the TurboQuant-encoded bytes.
+pub(super) enum TurboEncodedVectorStorage {
+    /// In-memory encoded vectors.
+    Ram(QuantizedRamStorage),
+    /// Single mem-mapped file of encoded vectors.
+    Mmap(QuantizedStorage<MmapFile>),
+    /// Chunked mem-mapped encoded vectors (appendable).
+    ChunkedMmap(QuantizedChunkedMmapStorage),
+}
+
+impl TurboEncodedVectorStorage {
+    /// Raw encoded blob for one vector (no dequantization).
+    pub(super) fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        match self {
+            Self::Ram(s) => s.get_vector_data(key),
+            Self::Mmap(s) => s.get_vector_data(key),
+            Self::ChunkedMmap(s) => s.get_vector_data(key),
+        }
+    }
+
+    /// Number of encoded vectors (including soft-deleted).
+    pub(super) fn vectors_count(&self) -> usize {
+        match self {
+            Self::Ram(s) => s.vectors_count(),
+            Self::Mmap(s) => s.vectors_count(),
+            Self::ChunkedMmap(s) => s.vectors_count(),
+        }
+    }
+
+    pub(super) fn is_on_disk(&self) -> bool {
+        unimplemented!("TurboEncodedVectorStorage::is_on_disk")
+    }
+
+    /// All on-disk files backing the encoded vectors.
+    pub(super) fn files(&self) -> Vec<PathBuf> {
+        match self {
+            Self::Ram(s) => s.files(),
+            Self::Mmap(s) => s.files(),
+            Self::ChunkedMmap(s) => s.files(),
+        }
+    }
+
+    pub(super) fn immutable_files(&self) -> Vec<PathBuf> {
+        match self {
+            Self::Ram(s) => s.immutable_files(),
+            Self::Mmap(s) => s.immutable_files(),
+            Self::ChunkedMmap(s) => s.immutable_files(),
+        }
+    }
+
+    pub(super) fn flusher(&self) -> MmapFlusher {
+        match self {
+            Self::Ram(s) => s.flusher(),
+            Self::Mmap(s) => s.flusher(),
+            Self::ChunkedMmap(s) => s.flusher(),
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new vector storage type `TurboVectorStorage`, which is the basic foundation for the TurboQuant as a datatype implementation.
It currently is dead code since the implementation into the existing code will be done in a separate PR.