### PR TITLE
`is_on_disk` fix for Quantized Chunked Mmap Storage

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -92,7 +92,10 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
     }
 
     fn is_on_disk(&self) -> bool {
-        true
+        // Pin the storage type: changing `data`'s type breaks this annotation.
+        let data: &ChunkedVectors<u8, MmapFile> = &self.data;
+
+        data.is_on_disk()
     }
 
     fn vectors_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage.rs
@@ -92,10 +92,7 @@ impl quantization::EncodedStorage for QuantizedChunkedMmapStorage {
     }
 
     fn is_on_disk(&self) -> bool {
-        // Pin the storage type: changing `data`'s type breaks this annotation.
-        let data: &ChunkedVectors<u8, MmapFile> = &self.data;
-
-        data.is_on_disk()
+        self.data.is_on_disk()
     }
 
     fn vectors_count(&self) -> usize {


### PR DESCRIPTION
We currently unconditionally return `true` in the `is_on_disk` function for QuantizedChunkedMmapStorage, without respecting the underlying types `is_on_disk` value.
This PR fixes this by calling the underlying storage's `is_on_disk` function.