### PR TITLE
feat: implement LiveReload for read-only roaring flags

### DIFF
--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
@@ -8,23 +9,30 @@ use roaring::RoaringBitmap;
 
 use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, status_file};
 use super::roaring_flags::RoaringFlagsRead;
+use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 /// Read-only counterpart of [`RoaringFlags`][1].
 ///
-/// Loads the persisted flags into an in-memory roaring bitmap on open. No
-/// write path: there is no buffer, no [`BufferedDynamicFlags`][2], no
-/// [`DynamicStoredFlags`][3]. After construction nothing on the struct
-/// depends on the storage backend — `S` only appears on [`Self::open`],
-/// so consumers don't have to thread the backend type through the index
-/// stack just to hold an in-memory bitmap.
+/// Loads the persisted flags into an in-memory roaring bitmap on open and keeps
+/// the backing [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can
+/// reopen it and fetch only the changed positions, rather than re-scanning the
+/// whole file. There is no write path: no buffer, no [`BufferedDynamicFlags`][2],
+/// no [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
+/// called with, mirroring the other read-only field indexes, which likewise
+/// hold their backing storage across reloads.
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::buffered_dynamic_flags::BufferedDynamicFlags
 /// [3]: super::dynamic_stored_flags::DynamicStoredFlags
-pub struct ReadOnlyRoaringFlags {
-    /// In-memory bitmap of true flags, materialized from the backing file on open.
+pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
+    /// In-memory bitmap of true flags, materialized from the backing file on
+    /// open and patched in place on [`LiveReload::live_reload`].
     bitmap: RoaringBitmap,
+
+    /// Backing bitslice, retained so a reload can reopen it and read only the
+    /// changed positions.
+    storage: StoredBitSlice<S>,
 
     /// Total length of the flags, including trailing falses. Read from the status file.
     len: usize,
@@ -32,9 +40,56 @@ pub struct ReadOnlyRoaringFlags {
     directory: PathBuf,
 }
 
-impl ReadOnlyRoaringFlags {
+/// Read-only open options shared by every file this storage maps: never
+/// writable, lazily paged under the global mmap advice, nothing populated up
+/// front. `OpenOptions` has no general constructor by design (callers spell the
+/// knobs out), so this one value keeps the read path's opens identical.
+const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
+    writeable: false,
+    need_sequential: false,
+    populate: Populate::No,
+    advice: AdviceSetting::Global,
+};
+
+/// Read the logical flag length from the status struct, opened read-only.
+///
+/// `StoredStruct` is write-bound, so the read goes through the read-only
+/// `TypedStorage`. Returns `Ok(None)` when the status file is absent — the flag
+/// directory doesn't exist — matching the read path's never-create contract.
+fn read_status_len<S: UniversalRead>(
+    fs: &S::Fs,
+    directory: &Path,
+) -> OperationResult<Option<usize>> {
+    let Some(status) = TypedStorage::<S, DynamicFlagsStatus>::open(
+        fs,
+        status_file(directory),
+        READ_ONLY_OPTIONS,
+        Default::default(),
+    )
+    .ok_not_found()?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(status.read_whole()?[0].len()))
+}
+
+/// Open the flags bitslice read-only. Shared by `open` (full scan into a fresh
+/// bitmap) and `live_reload` (delta reads of the changed positions).
+fn open_flags_storage<S: UniversalRead>(
+    fs: &S::Fs,
+    directory: &Path,
+) -> OperationResult<StoredBitSlice<S>> {
+    Ok(StoredBitSlice::<S>::open(
+        fs,
+        directory.join(FLAGS_FILE),
+        READ_ONLY_OPTIONS,
+        Default::default(),
+    )?)
+}
+
+impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
     /// Open persisted flags read-only and materialize them into an in-memory
-    /// roaring bitmap.
+    /// roaring bitmap, retaining the bitslice handle for [`LiveReload`].
     ///
     /// Read-only counterpart of [`RoaringFlags::new`][1]: every file is opened
     /// through `fs` non-writable, nothing is created and nothing is written.
@@ -46,58 +101,82 @@ impl ReadOnlyRoaringFlags {
     /// file is absent), matching the read path's never-create contract.
     ///
     /// [1]: super::roaring_flags::RoaringFlags::new
-    pub fn open<S: UniversalRead>(fs: &S::Fs, directory: &Path) -> OperationResult<Option<Self>> {
-        // Logical length: read the status struct directly. `StoredStruct` is
-        // write-bound, so go through the read-only `TypedStorage`. A missing
-        // status file means the index isn't present, so map not-found to `None`.
-        let status_path = status_file(directory);
-        let Some(status) = TypedStorage::<S, DynamicFlagsStatus>::open(
-            fs,
-            &status_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate: Populate::No,
-                advice: AdviceSetting::Global,
-            },
-            Default::default(),
-        )
-        .ok_not_found()?
-        else {
+    pub fn open(fs: &S::Fs, directory: &Path) -> OperationResult<Option<Self>> {
+        // A missing status file means the index isn't present on disk.
+        let Some(len) = read_status_len::<S>(fs, directory)? else {
             return Ok(None);
         };
-        let len = status.read_whole()?[0].len();
 
-        // Set positions: open the flags file and build the bitmap. The
-        // `StoredBitSlice` is dropped at the end of this function — the
-        // bitmap is the only state we keep.
-        let flags_path = directory.join(FLAGS_FILE);
-        let flags_storage = StoredBitSlice::<S>::open(
-            fs,
-            &flags_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate: Populate::No,
-                advice: AdviceSetting::Global,
-            },
-            Default::default(),
-        )?;
-
-        let bitmap = RoaringBitmap::from_sorted_iter(
-            flags_storage.iter_ones()?.map(|i| i as PointOffsetType),
-        )
-        .expect("iter_ones iterates in sorted order");
+        // Build the bitmap from the set positions, then keep the bitslice so a
+        // reload can reopen it and read only the changed positions.
+        let storage = open_flags_storage::<S>(fs, directory)?;
+        let bitmap =
+            RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
+                .expect("iter_ones iterates in sorted order");
 
         Ok(Some(Self {
             bitmap,
+            storage,
             len,
             directory: directory.to_path_buf(),
         }))
     }
 }
 
-impl RoaringFlagsRead for ReadOnlyRoaringFlags {
+impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
+    type Fs = S::Fs;
+
+    /// Refresh the in-memory bitmap to the current on-disk state by fetching
+    /// only the delta, instead of re-scanning every set position like
+    /// [`Self::open`].
+    ///
+    /// `deleted_points` are dropped from the bitmap — a removed point belongs in
+    /// no flag set, so this needs no I/O. `new_points` have their flag re-read
+    /// from the reopened bitslice and the bitmap bit set or cleared to match;
+    /// reading the current bit (rather than only inserting) also folds in value
+    /// changes, e.g. a point flipping from `true` to `false`.
+    ///
+    /// `hw_counter` is unused: the per-position reads go through the retained
+    /// [`StoredBitSlice`], which takes no hardware counter — mirroring
+    /// [`Self::open`], which also doesn't account its scan.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &[PointOffsetType],
+        new_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for &point in deleted_points {
+            self.bitmap.remove(point);
+        }
+
+        // Nothing appended → no on-disk delta to fetch, skip all I/O.
+        if new_points.is_empty() {
+            return Ok(());
+        }
+
+        // Reopen to pick up the writer's appended data, then read only the
+        // changed positions.
+        self.storage.reopen()?;
+        for &point in new_points {
+            if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
+                self.bitmap.insert(point);
+            } else {
+                self.bitmap.remove(point);
+            }
+        }
+
+        // The logical length grows as points are appended; refresh it so
+        // length-driven readers (the null index's `iter_falses`) stay correct.
+        if let Some(len) = read_status_len::<S>(fs, &self.directory)? {
+            self.len = len;
+        }
+
+        Ok(())
+    }
+}
+
+impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
     fn len(&self) -> usize {
         self.len
     }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -156,6 +156,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
         // changed positions.
         self.storage.reopen()?;
         for &point in new_points {
+            // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
             }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -29,14 +29,11 @@ pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// In-memory bitmap of true flags, materialized from the backing file on
     /// open and patched in place on [`LiveReload::live_reload`].
     bitmap: RoaringBitmap,
-
     /// Backing bitslice, retained so a reload can reopen it and read only the
     /// changed positions.
     storage: StoredBitSlice<S>,
-
     /// Total length of the flags, including trailing falses. Read from the status file.
     len: usize,
-
     directory: PathBuf,
 }
 
@@ -161,8 +158,6 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
         for &point in new_points {
             if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
                 self.bitmap.insert(point);
-            } else {
-                self.bitmap.remove(point);
             }
         }
 

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -8,7 +8,7 @@ use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 
-impl ReadOnlyBoolIndex {
+impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
     /// Open a read-only bool index at `path`, threading every file open through
     /// the filesystem handle `fs`.
     ///
@@ -25,11 +25,11 @@ impl ReadOnlyBoolIndex {
     /// index that would drop the persisted postings of the present half.
     ///
     /// [1]: super::super::mutable_bool_index::MutableBoolIndex::open
-    pub fn open<S: UniversalRead>(fs: &S::Fs, path: &Path) -> OperationResult<Option<Self>> {
+    pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Option<Self>> {
         // Open both directories first so a partial layout can be distinguished
         // from a genuinely absent index, regardless of which half is missing.
-        let trues_flags = ReadOnlyRoaringFlags::open::<S>(fs, &path.join(TRUES_DIRNAME))?;
-        let falses_flags = ReadOnlyRoaringFlags::open::<S>(fs, &path.join(FALSES_DIRNAME))?;
+        let trues_flags = ReadOnlyRoaringFlags::<S>::open(fs, &path.join(TRUES_DIRNAME))?;
+        let falses_flags = ReadOnlyRoaringFlags::<S>::open(fs, &path.join(FALSES_DIRNAME))?;
 
         match (trues_flags, falses_flags) {
             // Neither directory exists: the index isn't present on disk.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use common::universal_io::UniversalRead;
+
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::index::payload_config::IndexMutability;
 
@@ -14,27 +16,29 @@ mod read_ops;
 /// condition checker / faceting) is shared with the writable variants via
 /// [`BoolIndexRead`][4].
 ///
-/// The backend type only appears on [`Self::open`]; once the bitmaps are in
-/// memory the struct is backend-agnostic.
+/// Each [`ReadOnlyRoaringFlags`] retains its backend `S` so a [`LiveReload`][5]
+/// can reopen the bitslice and apply only the changed positions, instead of
+/// re-materializing the bitmaps from scratch.
 ///
 /// [1]: super::mutable_bool_index::MutableBoolIndex
 /// [2]: super::immutable_bool_index::ImmutableBoolIndex
 /// [3]: common::universal_io::UniversalRead
 /// [4]: super::read_ops::BoolIndexRead
-pub struct ReadOnlyBoolIndex {
+/// [5]: crate::index::field_index::LiveReload
+pub struct ReadOnlyBoolIndex<S: UniversalRead> {
     pub(super) _base_dir: PathBuf,
-    pub(super) storage: ReadOnlyStorage,
+    pub(super) storage: ReadOnlyStorage<S>,
     pub(super) indexed_count: usize,
 }
 
-pub(super) struct ReadOnlyStorage {
+pub(super) struct ReadOnlyStorage<S: UniversalRead> {
     /// Points which have at least one `true` value
-    pub(super) trues_flags: ReadOnlyRoaringFlags,
+    pub(super) trues_flags: ReadOnlyRoaringFlags<S>,
     /// Points which have at least one `false` value
-    pub(super) falses_flags: ReadOnlyRoaringFlags,
+    pub(super) falses_flags: ReadOnlyRoaringFlags<S>,
 }
 
-impl ReadOnlyBoolIndex {
+impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
     /// Reports the on-disk format's mutability, mirroring
     /// [`BoolIndex::get_mutability_type`][1].
     ///
@@ -124,7 +128,7 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
 
-        let index = ReadOnlyBoolIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path())
+        let index = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
             .unwrap()
             .unwrap();
 
@@ -173,11 +177,11 @@ mod tests {
         // `trues` present, `falses` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(FALSES_DIRNAME)).unwrap();
-        assert!(ReadOnlyBoolIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path()).is_err());
+        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
 
         // `falses` present, `trues` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
-        assert!(ReadOnlyBoolIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path()).is_err());
+        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 
 use super::super::read_ops::{self, BoolIndexRead};
 use super::ReadOnlyBoolIndex;
@@ -15,7 +16,7 @@ use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, PayloadKeyType};
 
-impl ReadOnlyBoolIndex {
+impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
     /// Produce a closure that maps a point id to its indexed bool
     /// values as JSON `Value`s. Used by `ReadOnlyFieldIndex::value_retriever`.
     pub fn value_retriever<'a>(
@@ -26,8 +27,8 @@ impl ReadOnlyBoolIndex {
     }
 }
 
-impl BoolIndexRead for ReadOnlyBoolIndex {
-    type Flags = ReadOnlyRoaringFlags;
+impl<S: UniversalRead> BoolIndexRead for ReadOnlyBoolIndex<S> {
+    type Flags = ReadOnlyRoaringFlags<S>;
 
     fn trues_flags(&self) -> &Self::Flags {
         &self.storage.trues_flags
@@ -46,7 +47,7 @@ impl BoolIndexRead for ReadOnlyBoolIndex {
     }
 }
 
-impl PayloadFieldIndexRead for ReadOnlyBoolIndex {
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_count()
     }
@@ -88,7 +89,7 @@ impl PayloadFieldIndexRead for ReadOnlyBoolIndex {
 /// Faceting over the read-only bool index mirrors the `FacetIndex` impl for
 /// `BoolIndex`: every method delegates to a [`BoolIndexRead`] default, so the
 /// body is identical — only the `Self` type differs.
-impl FacetIndex for ReadOnlyBoolIndex {
+impl<S: UniversalRead> FacetIndex for ReadOnlyBoolIndex<S> {
     fn for_points_values(
         &self,
         points: impl Iterator<Item = PointOffsetType>,

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -73,10 +73,11 @@ pub trait FacetIndex {
 
 /// Borrowed view over any concrete index that can produce facet counts.
 ///
-/// The `S: UniversalRead` parameter is consumed only by the map-based
-/// `*ReadOnly` variants (`ReadOnlyMapIndex<N, S>`); appendable / in-memory
-/// variants (`Keyword`, `Int`, `Uuid`, `Bool`) and `ReadOnlyBoolIndex` ignore
-/// it. The default `S = MmapFile` keeps the common construction path
+/// The `S: UniversalRead` parameter is consumed by the map-based `*ReadOnly`
+/// variants (`ReadOnlyMapIndex<N, S>`) and threaded as a phantom by
+/// `ReadOnlyBoolIndex<S>` (so it can re-read its flags through `S::Fs` on
+/// live-reload); the in-memory variants (`Keyword`, `Int`, `Uuid`, `Bool`)
+/// ignore it. The default `S = MmapFile` keeps the common construction path
 /// (`FieldIndex::as_facet_index`) free of turbofish.
 pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
     Keyword(&'a MapIndex<str>),
@@ -93,7 +94,7 @@ pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
     #[allow(dead_code)]
     UuidReadOnly(&'a ReadOnlyMapIndex<UuidIntType, S>),
     #[allow(dead_code)]
-    BoolReadOnly(&'a ReadOnlyBoolIndex),
+    BoolReadOnly(&'a ReadOnlyBoolIndex<S>),
 }
 
 impl<'a, S: UniversalRead> FacetIndex for FacetIndexEnum<'a, S> {

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -199,10 +199,10 @@ impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
             // serves both modes (neither consumes the immutable-only
             // `is_on_disk` / `deleted_points`).
             PayloadIndexType::BoolIndex => {
-                ReadOnlyBoolIndex::open::<S>(fs, &bool_dir(dir, field))?.map(Self::BoolIndex)
+                ReadOnlyBoolIndex::<S>::open(fs, &bool_dir(dir, field))?.map(Self::BoolIndex)
             }
             PayloadIndexType::NullIndex => {
-                ReadOnlyNullIndex::open::<S>(fs, &null_dir(dir, field), total_point_count)?
+                ReadOnlyNullIndex::<S>::open(fs, &null_dir(dir, field), total_point_count)?
                     .map(Self::NullIndex)
             }
         };

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -33,10 +33,10 @@ pub enum ReadOnlyFieldIndex<S: UniversalRead> {
     FloatIndex(ReadOnlyNumericIndex<FloatPayloadType, FloatPayloadType, S>),
     GeoIndex(ReadOnlyGeoMapIndex<S>),
     FullTextIndex(ReadOnlyFullTextIndex<S>),
-    BoolIndex(ReadOnlyBoolIndex),
+    BoolIndex(ReadOnlyBoolIndex<S>),
     UuidIndex(ReadOnlyNumericIndex<UuidIntType, UuidPayloadType, S>),
     UuidMapIndex(ReadOnlyMapIndex<UuidIntType, S>),
-    NullIndex(ReadOnlyNullIndex),
+    NullIndex(ReadOnlyNullIndex<S>),
 }
 
 /// Mirrors [`impl Debug for FieldIndex`][1] one-for-one: each arm prints

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
@@ -7,7 +7,7 @@ use super::{ReadOnlyNullIndex, ReadOnlyStorage};
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 
-impl ReadOnlyNullIndex {
+impl<S: UniversalRead> ReadOnlyNullIndex<S> {
     /// Open a read-only null index at `path`, threading every file open through
     /// the filesystem handle `fs`.
     ///
@@ -24,15 +24,15 @@ impl ReadOnlyNullIndex {
     /// index that would drop the persisted postings of the present half.
     ///
     /// [1]: super::super::mutable_null_index::MutableNullIndex::open
-    pub fn open<S: UniversalRead>(
+    pub fn open(
         fs: &S::Fs,
         path: &Path,
         total_point_count: usize,
     ) -> OperationResult<Option<Self>> {
         // Open both directories first so a partial layout can be distinguished
         // from a genuinely absent index, regardless of which half is missing.
-        let has_values_flags = ReadOnlyRoaringFlags::open::<S>(fs, &path.join(HAS_VALUES_DIRNAME))?;
-        let is_null_flags = ReadOnlyRoaringFlags::open::<S>(fs, &path.join(IS_NULL_DIRNAME))?;
+        let has_values_flags = ReadOnlyRoaringFlags::<S>::open(fs, &path.join(HAS_VALUES_DIRNAME))?;
+        let is_null_flags = ReadOnlyRoaringFlags::<S>::open(fs, &path.join(IS_NULL_DIRNAME))?;
 
         match (has_values_flags, is_null_flags) {
             // Neither directory exists: the index isn't present on disk.

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use common::universal_io::UniversalRead;
+
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::index::payload_config::IndexMutability;
 
@@ -13,27 +15,29 @@ mod read_ops;
 /// no write path. Query logic (filter / cardinality / condition checker) is
 /// shared with the writable variant via the [`NullIndexRead`][4] trait.
 ///
-/// The backend type only appears on [`Self::open`]; once the bitmaps are in
-/// memory the struct is backend-agnostic.
+/// Each [`ReadOnlyRoaringFlags`] retains its backend `S` so a [`LiveReload`][5]
+/// can reopen the bitslice and apply only the changed positions on reload,
+/// instead of re-materializing the bitmaps from scratch.
 ///
 /// [1]: super::mutable_null_index::MutableNullIndex
 /// [2]: super::immutable_null_index::ImmutableNullIndex
 /// [3]: common::universal_io::UniversalRead
 /// [4]: super::read_ops::NullIndexRead
-pub struct ReadOnlyNullIndex {
+/// [5]: crate::index::field_index::LiveReload
+pub struct ReadOnlyNullIndex<S: UniversalRead> {
     pub(super) _base_dir: PathBuf,
-    pub(super) storage: ReadOnlyStorage,
+    pub(super) storage: ReadOnlyStorage<S>,
     pub(super) total_point_count: usize,
 }
 
-pub(super) struct ReadOnlyStorage {
+pub(super) struct ReadOnlyStorage<S: UniversalRead> {
     /// Points which have at least one value
-    pub(super) has_values_flags: ReadOnlyRoaringFlags,
+    pub(super) has_values_flags: ReadOnlyRoaringFlags<S>,
     /// Points which have null values
-    pub(super) is_null_flags: ReadOnlyRoaringFlags,
+    pub(super) is_null_flags: ReadOnlyRoaringFlags<S>,
 }
 
-impl ReadOnlyNullIndex {
+impl<S: UniversalRead> ReadOnlyNullIndex<S> {
     /// Reports the on-disk format's mutability, mirroring
     /// [`NullIndex::get_mutability_type`][1].
     ///
@@ -95,7 +99,7 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
 
-        let index = ReadOnlyNullIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path(), total)
+        let index = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), total)
             .unwrap()
             .unwrap();
 
@@ -185,11 +189,11 @@ mod tests {
         // `has_values` present, `is_null` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(IS_NULL_DIRNAME)).unwrap();
-        assert!(ReadOnlyNullIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path(), 1).is_err());
+        assert!(ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 1).is_err());
 
         // `is_null` present, `has_values` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(HAS_VALUES_DIRNAME)).unwrap();
-        assert!(ReadOnlyNullIndex::open::<ReadOnly<MmapFile>>(&fs, dir.path(), 1).is_err());
+        assert!(ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 1).is_err());
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
 
 use super::super::read_ops::{self, NullIndexRead};
 use super::ReadOnlyNullIndex;
@@ -12,8 +13,8 @@ use crate::index::field_index::{
 use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
 use crate::types::{FieldCondition, PayloadKeyType};
 
-impl NullIndexRead for ReadOnlyNullIndex {
-    type Flags = ReadOnlyRoaringFlags;
+impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
+    type Flags = ReadOnlyRoaringFlags<S>;
 
     fn has_values_flags(&self) -> &Self::Flags {
         &self.storage.has_values_flags
@@ -32,7 +33,7 @@ impl NullIndexRead for ReadOnlyNullIndex {
     }
 }
 
-impl PayloadFieldIndexRead for ReadOnlyNullIndex {
+impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points_count()
     }


### PR DESCRIPTION
Make `ReadOnlyRoaringFlags<S>` implement the shared LiveReload trait (open retains the `StoredBitSlice`; `reopen + read` only the changed positions on reload), threading the backend `S` through the read-only bool/null index structs, the field-index enum and the facet enum. The per-index reload impls live in the bool/null branches stacked on top.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
