### PR TITLE
fix(gridstore): honor pending pointer-unset in batched reads

### DIFF
--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1388,6 +1388,49 @@ fn test_for_each_in_batch_congruent_with_get_value() {
     }
 }
 
+/// Regression: a value that is persisted on disk and then deleted in memory (a pending
+/// pointer-unset that hasn't been flushed) must read back as absent through *both* the single
+/// `get_value` path and the batched `read_values` path. The batched tracker lookup used to skip
+/// the `pending.current == None` case and fall through to the stale persisted pointer, so
+/// `read_values` resurrected the old value while `get_value` correctly reported it gone.
+#[test]
+fn test_batch_read_honors_pending_unset_of_flushed_value() {
+    let (_dir, mut storage) = empty_storage();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_write = hw_counter.ref_payload_io_write_counter();
+
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    // Write and FLUSH so the pointer is persisted on disk.
+    let payload = random_payload(rng, 3);
+    storage.put_value(0, &payload, hw_write).unwrap();
+    storage.flusher()().unwrap();
+
+    // Delete WITHOUT flushing: leaves a pending pointer-unset (`current == None`) over a
+    // persisted pointer — the exact precondition the batched read must respect.
+    storage.delete_value(0).unwrap();
+
+    let single = storage.get_value::<Random>(0, &hw_counter).unwrap();
+    assert_eq!(single, None, "single get must see the pending delete");
+
+    let mut batch = vec![Some(Payload::default())];
+    storage
+        .read_values::<Random, _, GridstoreError>(
+            std::iter::once((0usize, 0u32)),
+            |idx, _, value| {
+                batch[idx] = value;
+                Ok(())
+            },
+            hw_counter.payload_io_read_counter(),
+        )
+        .unwrap();
+    assert_eq!(
+        batch[0], None,
+        "batched read must also see the pending delete, not the stale persisted value",
+    );
+}
+
 /// Opening a [`GridstoreReader`] must not require a writable backend: a reader
 /// only reads. Backing it with the write-enforced `ReadOnly<MmapFile>` (which
 /// `debug_assert!`s every open is non-writable) only succeeds if the reader

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1414,7 +1414,7 @@ fn test_batch_read_honors_pending_unset_of_flushed_value() {
     let single = storage.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(single, None, "single get must see the pending delete");
 
-    let mut batch = vec![Some(Payload::default())];
+    let mut batch = [Some(Payload::default())];
     storage
         .read_values::<Random, _, GridstoreError>(
             std::iter::once((0usize, 0u32)),

--- a/lib/gridstore/src/tracker.rs
+++ b/lib/gridstore/src/tracker.rs
@@ -403,10 +403,15 @@ impl<S: UniversalRead> Tracker<S> {
             if let Some(pending) = self.pending_updates.get(&point_offset) {
                 debug_assert!(!pending.is_empty(), "pending updates must not be empty");
 
-                if let Some(pointer) = pending.current {
-                    pointers.borrow_mut().valid.push((user_data, pointer));
-                    return None;
+                // Honor the pending update either way: `Some` is the in-memory pointer, `None`
+                // is a pending unset. Falling through to the persisted pointer on `None` would
+                // resurrect the stale on-disk value (see `get`, which returns `pending.current`
+                // directly).
+                match pending.current {
+                    Some(pointer) => pointers.borrow_mut().valid.push((user_data, pointer)),
+                    None => pointers.borrow_mut().empty.push(user_data),
                 }
+                return None;
             }
 
             let byte_offset = header_size + item_size * point_offset as usize;


### PR DESCRIPTION
## Problem

`Tracker::get_batch` only handled the `Some` arm of a point's pending pointer update. When a point had a pending pointer-**unset** (`current == None`) over a value that was already flushed to disk, the batched lookup fell through to the **stale persisted pointer**, so `read_values` resurrected the deleted value — while the single-read `get` / `get_value` correctly reported it gone.

This silently split the two payload read paths:

- `retrieve`-by-id → `read_payloads` (batched) → `get_batch` → **stale value**
- `scroll` / filter / `payload()` → `get_value` → `get` (single) → **correct empty**

It surfaced as a payload mismatch after a filter-driven clear: a point cleared by `ClearPayloadByFilter` was still returned with its old payload by `retrieve`-by-id, even though `scroll` and the field index agreed it was gone.

## Fix

In `get_batch`, honor the pending update either way — `Some(ptr)` → `valid`, `None` → `empty` — mirroring `get`.

## Test

Adds `test_batch_read_honors_pending_unset_of_flushed_value`: put + flush, then delete without flushing, and assert the single and batched read paths agree (both absent). It fails without the fix and passes with it. The pre-existing `test_for_each_in_batch_congruent_with_get_value` missed this because it only deleted never-flushed points (no stale persisted pointer).