### PR TITLE
Enable the `single_file_mmap_vector_storage` flag by default

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12642,8 +12642,8 @@
             "type": "boolean"
           },
           "single_file_mmap_vector_storage": {
-            "description": "Use single-file mmap in-ram vector storage (InRamMmap)\n\nEnabled by default in Qdrant 1.17.1+",
-            "default": false,
+            "description": "Use single-file mmap in-ram vector storage (InRamMmap)\n\nEnabled by default in Qdrant 1.18.3+",
+            "default": true,
             "type": "boolean"
           },
           "async_payload_storage": {

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -26,7 +26,7 @@ pub struct FeatureFlags {
 
     /// Use single-file mmap in-ram vector storage (InRamMmap)
     ///
-    /// Enabled by default in Qdrant 1.17.1+
+    /// Enabled by default in Qdrant 1.18.2+
     pub single_file_mmap_vector_storage: bool,
 
     /// Use io_uring-based payload storage implementation.
@@ -39,7 +39,7 @@ impl Default for FeatureFlags {
             all: false,
             incremental_hnsw_building: true,
             appendable_quantization: true,
-            single_file_mmap_vector_storage: false,
+            single_file_mmap_vector_storage: true,
             async_payload_storage: false,
         }
     }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -26,7 +26,7 @@ pub struct FeatureFlags {
 
     /// Use single-file mmap in-ram vector storage (InRamMmap)
     ///
-    /// Enabled by default in Qdrant 1.18.2+
+    /// Enabled by default in Qdrant 1.18.3+
     pub single_file_mmap_vector_storage: bool,
 
     /// Use io_uring-based payload storage implementation.

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -245,14 +245,16 @@ pub trait SegmentOptimizer: Sync {
                         if common::flags::feature_flags().single_file_mmap_vector_storage {
                             config.storage_type = VectorStorageType::InRamMmap;
                         }
-                    } // on_disk=false wins, do nothing
+                        // on_disk=false wins, do nothing
+                    }
                     None => {
                         if threshold_is_on_disk {
+                            // Mmap threshold wins
                             config.storage_type = VectorStorageType::Mmap
                         } else if common::flags::feature_flags().single_file_mmap_vector_storage {
                             config.storage_type = VectorStorageType::InRamMmap;
                         }
-                    } // Mmap threshold wins
+                    }
                 }
 
                 // If we explicitly configure on_disk, but the segment storage type uses something

--- a/tests/e2e_tests/test_strict_mode_disk.py
+++ b/tests/e2e_tests/test_strict_mode_disk.py
@@ -30,21 +30,25 @@ from e2e_tests.models import QdrantContainerConfig
 
 # 200 MB tmpfs: needs to comfortably fit Qdrant's default WAL buffer
 # (which is multiple tens of MB) plus the segment data we'll write, while
-# being small enough that ~50% trips after a moderate amount of data.
+# being small enough that the threshold trips after a moderate amount of data.
 TMPFS_BYTES = 200 * 1024 * 1024
 
 # Shrink WAL so it doesn't dominate the small tmpfs (Qdrant's default WAL
 # buffer alone would fill a sub-100 MB tmpfs at collection-creation time).
 WAL_CAPACITY_MB = 1
 
-DISK_PERCENT_THRESHOLD = 50
+# InRamMmap is compact and optimization keeps reclaiming disk, so the tmpfs only
+# fills to ~30-45%; 20% trips reliably and still recovers below after a drop.
+DISK_PERCENT_THRESHOLD = 20
 
 VECTOR_DIM = 128
 BATCH_SIZE = 200
 COLLECTION_NAME = "strict_mode_disk_test"
 RECOVERY_COLLECTION_NAME = "strict_mode_disk_recovery"
 
-MAX_INSERT_BATCHES = 400
+# Generous ceiling; the gate usually trips by ~300. The loop breaks on trip, so
+# the headroom is free and just absorbs variance in the check's 5s cache lag.
+MAX_INSERT_BATCHES = 600
 
 RECOVERY_TIMEOUT_SECS = 60
 

--- a/tests/e2e_tests/test_strict_mode_memory.py
+++ b/tests/e2e_tests/test_strict_mode_memory.py
@@ -11,7 +11,8 @@ Scenario:
    threshold well below the container cap.
 3. Upsert batches of sparse vectors with random indices drawn from a very
    large id space until an upsert is rejected with the memory strict-mode
-   error (process RSS crossed the configured percentage).
+   error (process RSS crossed the configured percentage). Inserts are paced so
+   the 5s-cached memory reader trips the gate before the cap OOM-kills us.
 4. Delete a significant chunk of points. Deletes must not be gated by the
    memory check — otherwise there would be no way to recover.
 5. Retry inserts with a generous timeout. jemalloc may hold freed pages for
@@ -50,7 +51,14 @@ SPARSE_ID_SPACE = 2_000_000
 # Non-zeros per sparse vector. Larger = more heap pressure per point.
 NNZ_PER_VECTOR = 512
 
-BATCH_SIZE = 500
+# Small batches: the gate reads memory through a 5s cache, so back-to-back
+# batches slip through stale; keep each from overshooting the cap.
+BATCH_SIZE = 100
+
+# The gate re-samples memory only every 5s; without pacing, inserts OOM the
+# container before it trips. Slow growth so it trips cleanly near the threshold.
+INSERT_PACING_SECS = 1.5
+
 COLLECTION_NAME = "strict_mode_memory_test"
 
 # Upper bound on how many batches we'll try before declaring "threshold never
@@ -166,6 +174,8 @@ class TestStrictModeMemory:
             err = _try_upsert(client, batch)
             if err is None:
                 inserted_ids.extend(p.id for p in batch)
+                # Let the 5s-cached memory reader refresh so the gate can trip.
+                time.sleep(INSERT_PACING_SECS)
                 continue
 
             if _is_memory_rejection(err):


### PR DESCRIPTION
Enables the `single_file_mmap_vector_storage` flag by default. It was supposed to be enabled by default since 1.17.1+ but it wasn't. This now enables it.

It disables chunking mmaps and uses a single file for storage by default.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
