### PR TITLE
feat: add in-memory bitvec flags

### DIFF
--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -1,0 +1,177 @@
+use std::path::Path;
+
+use common::bitvec::{BitSlice, BitVec};
+use common::mmap::AdviceSetting;
+use common::stored_bitslice::StoredBitSlice;
+use common::types::PointOffsetType;
+use common::universal_io::{OpenOptions, Populate, TypedStorage, UniversalRead};
+
+use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, status_file};
+use crate::common::operation_error::{OperationError, OperationResult};
+
+/// In-memory counterpart of `BitvecFlags`: persisted flags materialized into an
+/// owned `BitVec`, no write path.
+///
+/// Only consumer is the vector storages' `deleted` set, where the live-reload
+/// delta is authoritative (deleted offsets set, appended offsets live so absent).
+/// So unlike `ReadOnlyRoaringFlags` it keeps no file handle and never reopens —
+/// the owned bitvec is the whole state.
+#[derive(Debug)]
+#[allow(dead_code)] // pending: read-only vector storages will hold `deleted` as this
+pub struct InMemoryBitvecFlags {
+    /// Flags, materialized on open and patched in place on live-reload.
+    bitvec: BitVec,
+    /// Set-flag count, kept in sync with `bitvec`.
+    count: usize,
+}
+
+/// Read-only mmap options: never writable, lazily paged, nothing populated.
+const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
+    writeable: false,
+    need_sequential: false,
+    populate: Populate::No,
+    advice: AdviceSetting::Global,
+};
+
+#[allow(dead_code)] // pending: read-only vector storages will use these
+impl InMemoryBitvecFlags {
+    /// Open persisted flags read-only into an owned `BitVec`; creates and writes
+    /// nothing. The flags file is padded past the logical length (held in the
+    /// status file), so the bitvec is truncated to it and `count` is exact.
+    pub fn open<S: UniversalRead>(fs: &S::Fs, directory: &Path) -> OperationResult<Self> {
+        // Length via TypedStorage; StoredStruct is write-bound.
+        let status = TypedStorage::<S, DynamicFlagsStatus>::open(
+            fs,
+            status_file(directory),
+            READ_ONLY_OPTIONS,
+            Default::default(),
+        )?;
+        let len = status
+            .read_whole()?
+            .first()
+            .map_or(0, DynamicFlagsStatus::len);
+
+        let flags_path = directory.join(FLAGS_FILE);
+        let flags =
+            StoredBitSlice::<S>::open(fs, &flags_path, READ_ONLY_OPTIONS, Default::default())?;
+        let bits = flags.read_all()?;
+        let bitvec = bits.get(..len).map(BitVec::from_bitslice).ok_or_else(|| {
+            OperationError::service_error(format!(
+                "Flags file {} holds fewer than {len} bits",
+                flags_path.display(),
+            ))
+        })?;
+        let count = bitvec.count_ones();
+
+        Ok(Self { bitvec, count })
+    }
+
+    /// Whether the flag at `key` is set; out-of-range keys read as unset.
+    pub fn get(&self, key: PointOffsetType) -> bool {
+        self.bitvec.get(key as usize).is_some_and(|bit| *bit)
+    }
+
+    /// Number of set flags.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Set flags as a `BitSlice`.
+    pub fn as_bitslice(&self) -> &BitSlice {
+        self.bitvec.as_bitslice()
+    }
+
+    /// Set `points`, growing as needed and keeping `count` in sync. Folds a
+    /// live-reload deletion delta; live offsets aren't passed (they read unset).
+    pub fn insert_all(&mut self, points: &[PointOffsetType]) {
+        for &point in points {
+            let index = point as usize;
+            if index >= self.bitvec.len() {
+                self.bitvec.resize(index + 1, false);
+            }
+            if !self.bitvec.replace(index, true) {
+                self.count += 1;
+            }
+        }
+    }
+}
+
+#[allow(clippy::default_constructed_unit_structs)]
+#[duplicate::duplicate_item(
+    tests_mod       S               Fs              cfg_predicate;
+    [tests_mmap]    [MmapFile]      [MmapFs]        [cfg(all())];
+    [tests_uring]   [IoUringFile]   [IoUringFs]     [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
+#[cfg(test)]
+mod tests_mod {
+    use std::iter;
+
+    #[cfg_predicate]
+    use common::universal_io::{Fs, S};
+    use rand::prelude::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
+
+    /// Persist `flags` via the writable storage so the read-only path can open it.
+    fn persist(fs: &Fs, dir: &Path, flags: &[bool]) {
+        let mut dynamic_flags = DynamicStoredFlags::<S>::open(fs, dir, false).unwrap();
+        dynamic_flags.set_len(fs, flags.len()).unwrap();
+        flags
+            .iter()
+            .enumerate()
+            .filter(|(_, flag)| **flag)
+            .for_each(|(i, _)| assert!(!dynamic_flags.set(i, true).unwrap()));
+        dynamic_flags.flusher()().unwrap();
+    }
+
+    #[test]
+    fn open_materializes_persisted_flags() {
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let num_flags = 5003; // Prime number, not byte aligned
+        let mut rng = StdRng::seed_from_u64(42);
+        let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
+
+        persist(&Fs::default(), dir.path(), &random_flags);
+
+        let flags = InMemoryBitvecFlags::open::<S>(&Fs::default(), dir.path()).unwrap();
+
+        let expected_count = random_flags.iter().filter(|flag| **flag).count();
+        assert_eq!(flags.count(), expected_count);
+        for (i, &flag) in random_flags.iter().enumerate() {
+            assert_eq!(flags.get(i as PointOffsetType), flag);
+        }
+    }
+
+    #[test]
+    fn insert_all_folds_deletion_delta() {
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let num_flags = 1000;
+        let mut rng = StdRng::seed_from_u64(7);
+        let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
+
+        persist(&Fs::default(), dir.path(), &random_flags);
+        let mut flags = InMemoryBitvecFlags::open::<S>(&Fs::default(), dir.path()).unwrap();
+        let base_count = flags.count();
+
+        // One offset already set, one unset in range, one past the end (grows).
+        let already_set = random_flags.iter().position(|flag| *flag).unwrap();
+        let unset = random_flags.iter().position(|flag| !*flag).unwrap();
+        let beyond = num_flags as PointOffsetType + 5;
+        flags.insert_all(&[
+            already_set as PointOffsetType,
+            unset as PointOffsetType,
+            beyond,
+        ]);
+
+        // Only the two newly-set offsets bump the count.
+        assert_eq!(flags.count(), base_count + 2);
+        assert!(flags.get(already_set as PointOffsetType));
+        assert!(flags.get(unset as PointOffsetType));
+        assert!(flags.get(beyond));
+        assert!(!flags.get(beyond + 1));
+    }
+}

--- a/lib/segment/src/common/flags/mod.rs
+++ b/lib/segment/src/common/flags/mod.rs
@@ -5,10 +5,12 @@
 //! - `buffered_dynamic_flags`: Builds on top of `dynamic_mmap_flags` to provide buffered writes.
 //! - `bitvec_flags`: `buffered_dynamic_flags` with in-memory bitvec for reads.
 //! - `roaring_flags`: `buffered_dynamic_flags` with in-memory roaring bitmap for reads.
+//! - `in_memory_bitvec_flags`: in-memory counterpart of `bitvec_flags`, bound to `UniversalRead`.
 //! - `read_only_roaring_flags`: read-only counterpart of `roaring_flags`, bound to `UniversalRead`.
 
 pub mod bitvec_flags;
 mod buffered_dynamic_flags;
 pub mod dynamic_stored_flags;
+pub mod in_memory_bitvec_flags;
 pub mod read_only_roaring_flags;
 pub mod roaring_flags;


### PR DESCRIPTION
Part of #9241 — read-only vector storage `open` constructors.

Adds `InMemoryBitvecFlags`, the in-memory counterpart of `BitvecFlags`. It materializes the persisted dynamic flags (`status.dat` + `flags_a.dat`) into an owned `BitVec` over any `UniversalRead` backend, without creating, resizing or migrating files the way the writable `open` does. The bitvec is truncated to the logical length, so `count` returns the true flag count.

It exposes `get` / `count` / `as_bitslice` for reads, and `insert_all` to fold a live-reload deletion delta in place (set offsets, grow as needed, keep `count` in sync). Unlike `ReadOnlyRoaringFlags` it keeps no backing `StoredBitSlice` handle and never reopens on reload: its only consumer is the vector storages' `deleted` set, whose delta is authoritative (deleted offsets are set; appended offsets are live, so absent), needing no disk read.

The shared writable `dynamic_stored_flags.rs` is left untouched.

Prep PR — the `BitVec` analogue of `ReadOnlyRoaringFlags`. Read-only vector storages will hold their `deleted` as this (replacing a bare `BitVec`), mirroring the writable side holding `BitvecFlags`.

