### PR TITLE
feat: read-only open for ReadOnlyChunkedDenseVectorStorage

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -24,8 +24,8 @@ use crate::vector_storage::{
     DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
-const VECTORS_DIR_PATH: &str = "vectors";
-const DELETED_DIR_PATH: &str = "deleted";
+pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Debug)]
 pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -1,24 +1,59 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::dense::appendable_dense_vector_storage::{
+    DELETED_DIR_PATH, VECTORS_DIR_PATH,
+};
 use crate::vector_storage::{VectorOffsetType, VectorStorageRead};
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
     vectors: ChunkedVectorsRead<T, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     distance: Distance,
-    deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStorage<T, S> {
+    /// Open the read-only counterpart of the appendable dense storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `populate` warms the vector chunks.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> OperationResult<Self> {
+        let vectors = ChunkedVectorsRead::open(
+            fs,
+            &path.join(VECTORS_DIR_PATH),
+            dim,
+            advice,
+            Some(populate),
+        )?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            deleted,
+            distance,
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
@@ -69,14 +104,98 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
+
+    /// Write vectors (deleting ~10%) through the writable appendable storage,
+    /// then reopen the same directory read-only and assert it mirrors the state.
+    #[test]
+    fn read_only_chunked_dense_round_trip() {
+        const POINT_COUNT: PointOffsetType = 2500; // spans more than one chunk
+        const DIM: usize = 128;
+
+        let dir = Builder::new().prefix("ro_dense").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw = HardwareCounterCell::disposable();
+
+        let vectors: Vec<DenseVector> = (0..POINT_COUNT)
+            .map(|_| {
+                std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                    .take(DIM)
+                    .collect()
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap();
+            for (id, vector) in vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            for id in 0..POINT_COUNT {
+                if rng.random_bool(0.1) {
+                    storage.delete_vector(id).unwrap();
+                    deleted_ids.push(id);
+                }
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlyChunkedDenseVectorStorage::<VectorElementType, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), Distance::Dot);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            assert_eq!(storage.is_deleted_vector(id), deleted_ids.contains(&id));
+
+            let got: DenseVector = storage
+                .get_vector::<Random>(id)
+                .to_owned()
+                .try_into()
+                .unwrap();
+            assert_eq!(got, vectors[id as usize], "vector {id} mismatch");
+        }
     }
 }


### PR DESCRIPTION
Part of #9241 — read-only vector storage `open` constructors. Stacked on #9333.

Adds `ReadOnlyChunkedDenseVectorStorage::open`, the read-only counterpart of `open_appendable_memmap_vector_storage_impl`: opens the chunked `vectors/` directory via `ChunkedVectorsRead::open` and materializes the `deleted/` flags into a `InMemoryBitvecFlags`, threading every file open through the `UniversalRead` backend without writing anything.

Shares the `vectors/` / `deleted/` directory names with the writable storage (`pub(crate)`). Covered by a write→reopen-read-only round-trip test.

