### PR TITLE
feat: read-only open for ReadOnlySparseVectorStorage

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -24,8 +24,8 @@ use crate::vector_storage::{
     DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
-const VECTORS_DIR_PATH: &str = "vectors";
-const DELETED_DIR_PATH: &str = "deleted";
+pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Debug)]
 pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -1,24 +1,59 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::dense::appendable_dense_vector_storage::{
+    DELETED_DIR_PATH, VECTORS_DIR_PATH,
+};
 use crate::vector_storage::{VectorOffsetType, VectorStorageRead};
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
     vectors: ChunkedVectorsRead<T, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     distance: Distance,
-    deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStorage<T, S> {
+    /// Open the read-only counterpart of the appendable dense storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `populate` warms the vector chunks.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> OperationResult<Self> {
+        let vectors = ChunkedVectorsRead::open(
+            fs,
+            &path.join(VECTORS_DIR_PATH),
+            dim,
+            advice,
+            Some(populate),
+        )?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            deleted,
+            distance,
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
@@ -69,14 +104,98 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
+
+    /// Write vectors (deleting ~10%) through the writable appendable storage,
+    /// then reopen the same directory read-only and assert it mirrors the state.
+    #[test]
+    fn read_only_chunked_dense_round_trip() {
+        const POINT_COUNT: PointOffsetType = 2500; // spans more than one chunk
+        const DIM: usize = 128;
+
+        let dir = Builder::new().prefix("ro_dense").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw = HardwareCounterCell::disposable();
+
+        let vectors: Vec<DenseVector> = (0..POINT_COUNT)
+            .map(|_| {
+                std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                    .take(DIM)
+                    .collect()
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap();
+            for (id, vector) in vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            for id in 0..POINT_COUNT {
+                if rng.random_bool(0.1) {
+                    storage.delete_vector(id).unwrap();
+                    deleted_ids.push(id);
+                }
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlyChunkedDenseVectorStorage::<VectorElementType, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), Distance::Dot);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            assert_eq!(storage.is_deleted_vector(id), deleted_ids.contains(&id));
+
+            let got: DenseVector = storage
+                .get_vector::<Random>(id)
+                .to_owned()
+                .try_into()
+                .unwrap();
+            assert_eq!(got, vectors[id as usize], "vector {id} mismatch");
+        }
     }
 }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -30,9 +30,9 @@ use crate::vector_storage::{
     MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
-const VECTORS_DIR_PATH: &str = "vectors";
-const OFFSETS_DIR_PATH: &str = "offsets";
-const DELETED_DIR_PATH: &str = "deleted";
+pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
+pub(crate) const OFFSETS_DIR_PATH: &str = "offsets";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]

--- a/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
@@ -1,28 +1,68 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
-    MultivectorMmapOffset, flattened_to_multi_vector, read_multi_vector,
+    DELETED_DIR_PATH, MultivectorMmapOffset, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
+    flattened_to_multi_vector, read_multi_vector,
 };
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedMultiDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
     vectors: ChunkedVectorsRead<T, S>,
     offsets: ChunkedVectorsRead<MultivectorMmapOffset, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     distance: Distance,
-    deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    /// Open the read-only counterpart of the appendable multi-dense storage at
+    /// `path`, threading every file open through `fs`; reads the existing layout
+    /// but creates and writes nothing. `populate` warms the vector and offset
+    /// chunks.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> OperationResult<Self> {
+        let vectors = ChunkedVectorsRead::open(
+            fs,
+            &path.join(VECTORS_DIR_PATH),
+            dim,
+            advice,
+            Some(populate),
+        )?;
+
+        // Offsets store one `MultivectorMmapOffset` element per point, so the
+        // chunked storage dimensionality is 1.
+        let offsets =
+            ChunkedVectorsRead::open(fs, &path.join(OFFSETS_DIR_PATH), 1, advice, Some(populate))?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            offsets,
+            deleted,
+            distance,
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
@@ -75,14 +115,113 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{
+        MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
+    };
+    use crate::types::MultiVectorConfig;
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_impl;
+
+    /// Write multivectors (deleting ~10%) through the writable appendable
+    /// storage, then reopen the same directory read-only and assert it mirrors
+    /// the state — including per-point multivector contents, which exercises the
+    /// offsets storage.
+    #[test]
+    fn read_only_chunked_multi_dense_round_trip() {
+        const POINT_COUNT: PointOffsetType = 1000;
+        const DIM: usize = 128;
+
+        let dir = Builder::new().prefix("ro_multi_dense").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw = HardwareCounterCell::disposable();
+
+        let multivectors: Vec<MultiDenseVectorInternal> = (0..POINT_COUNT)
+            .map(|_| {
+                let inner = rng.random_range(1..=4);
+                let vectors = std::iter::repeat_with(|| {
+                    std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                        .take(DIM)
+                        .collect()
+                })
+                .take(inner)
+                .collect::<Vec<Vec<VectorElementType>>>();
+                MultiDenseVectorInternal::try_from(vectors).unwrap()
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage =
+                open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                    dir.path(),
+                    DIM,
+                    Distance::Dot,
+                    MultiVectorConfig::default(),
+                    AdviceSetting::Global,
+                    false,
+                )
+                .unwrap();
+            for (id, multivec) in multivectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(multivec), &hw)
+                    .unwrap();
+            }
+            for id in 0..POINT_COUNT {
+                if rng.random_bool(0.1) {
+                    storage.delete_vector(id).unwrap();
+                    deleted_ids.push(id);
+                }
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), Distance::Dot);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            assert_eq!(storage.is_deleted_vector(id), deleted_ids.contains(&id));
+
+            let stored = storage.get_vector::<Random>(id);
+            let multi: TypedMultiDenseVectorRef<VectorElementType> =
+                stored.as_vec_ref().try_into().unwrap();
+            assert_eq!(
+                multi.to_owned(),
+                multivectors[id as usize],
+                "vector {id} mismatch",
+            );
+        }
     }
 }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -23,8 +23,8 @@ use crate::types::VectorStorageDatatype;
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageRead};
 
-const DELETED_DIRNAME: &str = "deleted";
-const STORAGE_DIRNAME: &str = "store";
+pub(crate) const DELETED_DIRNAME: &str = "deleted";
+pub(crate) const STORAGE_DIRNAME: &str = "store";
 
 /// Memory-mapped mutable sparse vector storage.
 #[derive(Debug)]

--- a/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
@@ -1,4 +1,6 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
@@ -6,23 +8,53 @@ use common::universal_io::UniversalRead;
 use gridstore::GridstoreReader;
 use sparse::common::sparse_vector::SparseVector;
 
-use crate::common::operation_error::OperationResult;
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
+use crate::vector_storage::sparse::mmap_sparse_vector_storage::{DELETED_DIRNAME, STORAGE_DIRNAME};
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 
 #[derive(Debug)]
 pub struct ReadOnlySparseVectorStorage<S: UniversalRead> {
     storage: GridstoreReader<StoredSparseVector, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
-    deleted_count: usize,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     next_point_offset: usize,
+}
+
+impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
+    /// Open the read-only counterpart of the mmap sparse storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `next_point_offset` is reconstructed like the
+    /// writable storage on reopen: the highest deleted id or the Gridstore
+    /// pointer count, whichever is larger.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
+        let storage =
+            GridstoreReader::<StoredSparseVector, S>::open(fs, path.join(STORAGE_DIRNAME))
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to open read-only sparse vector storage: {err}"
+                    ))
+                })?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIRNAME))?;
+
+        let next_point_offset = deleted
+            .as_bitslice()
+            .last_one()
+            .max(Some(storage.max_point_offset() as usize))
+            .unwrap_or_default();
+
+        Ok(Self {
+            storage,
+            deleted,
+            next_point_offset,
+        })
+    }
 }
 
 impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
@@ -82,14 +114,89 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::VectorRef;
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+
+    /// Write sparse vectors (deleting some) through the writable mmap storage,
+    /// then reopen the same directory read-only and assert it mirrors the state,
+    /// including per-point sparse contents and the reconstructed point count.
+    #[test]
+    fn read_only_sparse_round_trip() {
+        const POINT_COUNT: PointOffsetType = 500;
+
+        let dir = Builder::new().prefix("ro_sparse").tempdir().unwrap();
+        let hw = HardwareCounterCell::disposable();
+
+        let sparse_vectors: Vec<SparseVector> = (0..POINT_COUNT)
+            .map(|id| {
+                let value = id as f32;
+                SparseVector {
+                    indices: vec![1, 5, 9],
+                    values: vec![value + 0.1, value + 0.2, value + 0.3],
+                }
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+            for (id, vector) in sparse_vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            for id in (0..POINT_COUNT).step_by(7) {
+                storage.delete_vector(id).unwrap();
+                deleted_ids.push(id);
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), SPARSE_VECTOR_DISTANCE);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            let deleted = deleted_ids.contains(&id);
+            assert_eq!(storage.is_deleted_vector(id), deleted);
+
+            // Deleting a sparse vector reclaims its Gridstore entry, so only
+            // live points still carry their contents.
+            if deleted {
+                continue;
+            }
+
+            match storage.get_vector::<Random>(id) {
+                CowVector::Sparse(got) => {
+                    assert_eq!(got.indices, sparse_vectors[id as usize].indices);
+                    assert_eq!(got.values, sparse_vectors[id as usize].values);
+                }
+                CowVector::Dense(_) | CowVector::MultiDense(_) => {
+                    panic!("expected sparse vector for point {id}")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Part of #9241 — read-only vector storage `open` constructors. Stacked on #9335.

Adds `ReadOnlySparseVectorStorage::open`, the read-only counterpart of `MmapSparseVectorStorage::open`: opens the Gridstore `store/` directory via `GridstoreReader::open` and materializes the `deleted/` flags into a `InMemoryBitvecFlags`, threading every file open through the `UniversalRead` backend without writing anything. `next_point_offset` is reconstructed the same way the writable storage does on reopen (highest deleted id or the Gridstore pointer count).

Shares the `store/` / `deleted/` directory names with the writable storage (`pub(crate)`). Covered by a round-trip test — deleted sparse vectors release their Gridstore entry, so only live points are content-checked.

