### PR TITLE
feat: open dispatcher for VectorStorageReadEnum

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -24,8 +24,8 @@ use crate::vector_storage::{
     DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
-const VECTORS_DIR_PATH: &str = "vectors";
-const DELETED_DIR_PATH: &str = "deleted";
+pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Debug)]
 pub struct AppendableMmapDenseVectorStorage<T: PrimitiveVectorElement> {

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -181,7 +181,7 @@ pub fn open_dense_vector_storage_byte(
     Ok(VectorStorageEnum::DenseMemmapByte(Box::new(mmap_storage)))
 }
 
-fn open_dense_vector_storage_impl<T, S>(
+pub(crate) fn open_dense_vector_storage_impl<T, S>(
     fs: S::Fs,
     path: &Path,
     dim: usize,

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -1,24 +1,59 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::dense::appendable_dense_vector_storage::{
+    DELETED_DIR_PATH, VECTORS_DIR_PATH,
+};
 use crate::vector_storage::{VectorOffsetType, VectorStorageRead};
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
     vectors: ChunkedVectorsRead<T, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     distance: Distance,
-    deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStorage<T, S> {
+    /// Open the read-only counterpart of the appendable dense storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `populate` warms the vector chunks.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> OperationResult<Self> {
+        let vectors = ChunkedVectorsRead::open(
+            fs,
+            &path.join(VECTORS_DIR_PATH),
+            dim,
+            advice,
+            Some(populate),
+        )?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            deleted,
+            distance,
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
@@ -69,14 +104,98 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
+
+    /// Write vectors (deleting ~10%) through the writable appendable storage,
+    /// then reopen the same directory read-only and assert it mirrors the state.
+    #[test]
+    fn read_only_chunked_dense_round_trip() {
+        const POINT_COUNT: PointOffsetType = 2500; // spans more than one chunk
+        const DIM: usize = 128;
+
+        let dir = Builder::new().prefix("ro_dense").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw = HardwareCounterCell::disposable();
+
+        let vectors: Vec<DenseVector> = (0..POINT_COUNT)
+            .map(|_| {
+                std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                    .take(DIM)
+                    .collect()
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap();
+            for (id, vector) in vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            for id in 0..POINT_COUNT {
+                if rng.random_bool(0.1) {
+                    storage.delete_vector(id).unwrap();
+                    deleted_ids.push(id);
+                }
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlyChunkedDenseVectorStorage::<VectorElementType, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), Distance::Dot);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            assert_eq!(storage.is_deleted_vector(id), deleted_ids.contains(&id));
+
+            let got: DenseVector = storage
+                .get_vector::<Random>(id)
+                .to_owned()
+                .try_into()
+                .unwrap();
+            assert_eq!(got, vectors[id as usize], "vector {id} mismatch");
+        }
     }
 }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -30,9 +30,9 @@ use crate::vector_storage::{
     MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
-const VECTORS_DIR_PATH: &str = "vectors";
-const OFFSETS_DIR_PATH: &str = "offsets";
-const DELETED_DIR_PATH: &str = "deleted";
+pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
+pub(crate) const OFFSETS_DIR_PATH: &str = "offsets";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]

--- a/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
@@ -1,28 +1,68 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
-    MultivectorMmapOffset, flattened_to_multi_vector, read_multi_vector,
+    DELETED_DIR_PATH, MultivectorMmapOffset, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
+    flattened_to_multi_vector, read_multi_vector,
 };
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedMultiDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
     vectors: ChunkedVectorsRead<T, S>,
     offsets: ChunkedVectorsRead<MultivectorMmapOffset, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     distance: Distance,
-    deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    /// Open the read-only counterpart of the appendable multi-dense storage at
+    /// `path`, threading every file open through `fs`; reads the existing layout
+    /// but creates and writes nothing. `populate` warms the vector and offset
+    /// chunks.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        advice: AdviceSetting,
+        populate: bool,
+    ) -> OperationResult<Self> {
+        let vectors = ChunkedVectorsRead::open(
+            fs,
+            &path.join(VECTORS_DIR_PATH),
+            dim,
+            advice,
+            Some(populate),
+        )?;
+
+        // Offsets store one `MultivectorMmapOffset` element per point, so the
+        // chunked storage dimensionality is 1.
+        let offsets =
+            ChunkedVectorsRead::open(fs, &path.join(OFFSETS_DIR_PATH), 1, advice, Some(populate))?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            offsets,
+            deleted,
+            distance,
+        })
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
@@ -75,14 +115,113 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{
+        MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
+    };
+    use crate::types::MultiVectorConfig;
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_impl;
+
+    /// Write multivectors (deleting ~10%) through the writable appendable
+    /// storage, then reopen the same directory read-only and assert it mirrors
+    /// the state — including per-point multivector contents, which exercises the
+    /// offsets storage.
+    #[test]
+    fn read_only_chunked_multi_dense_round_trip() {
+        const POINT_COUNT: PointOffsetType = 1000;
+        const DIM: usize = 128;
+
+        let dir = Builder::new().prefix("ro_multi_dense").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw = HardwareCounterCell::disposable();
+
+        let multivectors: Vec<MultiDenseVectorInternal> = (0..POINT_COUNT)
+            .map(|_| {
+                let inner = rng.random_range(1..=4);
+                let vectors = std::iter::repeat_with(|| {
+                    std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                        .take(DIM)
+                        .collect()
+                })
+                .take(inner)
+                .collect::<Vec<Vec<VectorElementType>>>();
+                MultiDenseVectorInternal::try_from(vectors).unwrap()
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage =
+                open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                    dir.path(),
+                    DIM,
+                    Distance::Dot,
+                    MultiVectorConfig::default(),
+                    AdviceSetting::Global,
+                    false,
+                )
+                .unwrap();
+            for (id, multivec) in multivectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(multivec), &hw)
+                    .unwrap();
+            }
+            for id in 0..POINT_COUNT {
+                if rng.random_bool(0.1) {
+                    storage.delete_vector(id).unwrap();
+                    deleted_ids.push(id);
+                }
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), Distance::Dot);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            assert_eq!(storage.is_deleted_vector(id), deleted_ids.contains(&id));
+
+            let stored = storage.get_vector::<Random>(id);
+            let multi: TypedMultiDenseVectorRef<VectorElementType> =
+                stored.as_vec_ref().try_into().unwrap();
+            assert_eq!(
+                multi.to_owned(),
+                multivectors[id as usize],
+                "vector {id} mismatch",
+            );
+        }
     }
 }

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -1,13 +1,19 @@
+use std::path::Path;
+
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
+use common::mmap::{Advice, AdviceSetting};
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
-use crate::types::{Distance, VectorStorageDatatype};
+use crate::types::{Distance, VectorDataConfig, VectorStorageDatatype, VectorStorageType};
 use crate::vector_storage::VectorStorageRead;
-use crate::vector_storage::dense::dense_vector_storage::DenseVectorStorageImpl;
+use crate::vector_storage::dense::dense_vector_storage::{
+    DenseVectorStorageImpl, open_dense_vector_storage_impl,
+};
 use crate::vector_storage::dense::read_only::chunked_vector_storage::ReadOnlyChunkedDenseVectorStorage;
 use crate::vector_storage::multi_dense::read_only::chunked_vector_storage::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::sparse_vector_storage::ReadOnlySparseVectorStorage;
@@ -27,6 +33,120 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
+}
+
+impl<S: UniversalRead> VectorStorageReadEnum<S> {
+    /// Open the read-only counterpart of a dense vector storage from its
+    /// `VectorDataConfig`, mirroring `open_vector_storage`. Sparse storages are
+    /// opened separately via `ReadOnlySparseVectorStorage::open`.
+    #[allow(dead_code)] // pending: read-only segment constructor will use this
+    pub fn open(
+        fs: &S::Fs,
+        vector_config: &VectorDataConfig,
+        path: &Path,
+    ) -> OperationResult<Option<Self>>
+    where
+        S::Fs: Clone,
+    {
+        let dim = vector_config.size;
+        let distance = vector_config.distance;
+        let datatype = vector_config.datatype.unwrap_or_default();
+
+        let (advice, populate, chunked) = match vector_config.storage_type {
+            VectorStorageType::Mmap => (AdviceSetting::Global, false, false),
+            VectorStorageType::InRamMmap => (AdviceSetting::from(Advice::Normal), true, false),
+            VectorStorageType::ChunkedMmap => (AdviceSetting::Global, false, true),
+            VectorStorageType::InRamChunkedMmap => {
+                (AdviceSetting::from(Advice::Normal), true, true)
+            }
+            // No on-disk data to open for these storage types: no-op.
+            VectorStorageType::Memory | VectorStorageType::Empty => return Ok(None),
+        };
+
+        // Multivectors always use the appendable chunked layout.
+        if vector_config.multivector_config.is_some() {
+            return Ok(Some(match datatype {
+                VectorStorageDatatype::Float32 => {
+                    Self::MultiDenseChunked(Box::new(ReadOnlyChunkedMultiDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?))
+                }
+                VectorStorageDatatype::Uint8 => Self::MultiDenseChunkedByte(Box::new(
+                    ReadOnlyChunkedMultiDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?,
+                )),
+                VectorStorageDatatype::Float16 => Self::MultiDenseChunkedHalf(Box::new(
+                    ReadOnlyChunkedMultiDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?,
+                )),
+                VectorStorageDatatype::Turbo4 => {
+                    return Err(OperationError::service_error(
+                        "Turbo4 datatype storage is not yet supported",
+                    ));
+                }
+            }));
+        }
+
+        // chunked-mmap is appendable; plain mmap is the immutable storage.
+        Ok(Some(if chunked {
+            match datatype {
+                VectorStorageDatatype::Float32 => {
+                    Self::DenseChunked(Box::new(ReadOnlyChunkedDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?))
+                }
+                VectorStorageDatatype::Uint8 => {
+                    Self::DenseChunkedByte(Box::new(ReadOnlyChunkedDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?))
+                }
+                VectorStorageDatatype::Float16 => {
+                    Self::DenseChunkedHalf(Box::new(ReadOnlyChunkedDenseVectorStorage::open(
+                        fs, path, dim, distance, advice, populate,
+                    )?))
+                }
+                VectorStorageDatatype::Turbo4 => {
+                    return Err(OperationError::service_error(
+                        "Turbo4 datatype storage is not yet supported",
+                    ));
+                }
+            }
+        } else {
+            match datatype {
+                VectorStorageDatatype::Float32 => {
+                    Self::Dense(Box::new(open_dense_vector_storage_impl::<
+                        VectorElementType,
+                        S,
+                    >(
+                        fs.clone(), path, dim, distance, populate
+                    )?))
+                }
+                VectorStorageDatatype::Uint8 => {
+                    Self::DenseByte(Box::new(open_dense_vector_storage_impl::<
+                        VectorElementTypeByte,
+                        S,
+                    >(
+                        fs.clone(), path, dim, distance, populate
+                    )?))
+                }
+                VectorStorageDatatype::Float16 => {
+                    Self::DenseHalf(Box::new(open_dense_vector_storage_impl::<
+                        VectorElementTypeHalf,
+                        S,
+                    >(
+                        fs.clone(), path, dim, distance, populate
+                    )?))
+                }
+                VectorStorageDatatype::Turbo4 => {
+                    return Err(OperationError::service_error(
+                        "Turbo4 datatype storage is not yet supported",
+                    ));
+                }
+            }
+        }))
+    }
 }
 
 impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
@@ -186,5 +306,211 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_bitslice(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::generic_consts::Random;
+    use common::mmap::AdviceSetting;
+    use common::universal_io::{MmapFile, MmapFs};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::{
+        DenseVector, MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorRef,
+    };
+    use crate::types::{Indexes, MultiVectorConfig};
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
+    use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage;
+    use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+    use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_impl;
+
+    const DIM: usize = 16;
+
+    fn dense_config(
+        storage_type: VectorStorageType,
+        multivector_config: Option<MultiVectorConfig>,
+    ) -> VectorDataConfig {
+        VectorDataConfig {
+            size: DIM,
+            distance: Distance::Dot,
+            storage_type,
+            index: Indexes::Plain {},
+            quantization_config: None,
+            multivector_config,
+            datatype: Some(VectorStorageDatatype::Float32),
+        }
+    }
+
+    fn rand_vec(rng: &mut StdRng) -> DenseVector {
+        std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+            .take(DIM)
+            .collect()
+    }
+
+    /// `Memory` and `Empty` storage types are a no-op: nothing to open read-only.
+    #[test]
+    fn open_memory_and_empty_are_noop() {
+        let dir = Builder::new().prefix("disp_noop").tempdir().unwrap();
+        for storage_type in [VectorStorageType::Memory, VectorStorageType::Empty] {
+            let opened = VectorStorageReadEnum::<MmapFile>::open(
+                &MmapFs,
+                &dense_config(storage_type, None),
+                dir.path(),
+            )
+            .unwrap();
+            assert!(opened.is_none(), "{storage_type:?} should be a no-op");
+        }
+    }
+
+    /// `ChunkedMmap` single-dense routes to the chunked read-only storage.
+    #[test]
+    fn open_routes_chunked_mmap_to_dense_chunked() {
+        let dir = Builder::new().prefix("disp_chunked").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(1);
+        let hw = HardwareCounterCell::disposable();
+        let vectors: Vec<DenseVector> = (0..300).map(|_| rand_vec(&mut rng)).collect();
+
+        {
+            let mut storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap();
+            for (id, vector) in vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &dense_config(VectorStorageType::ChunkedMmap, None),
+            dir.path(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(matches!(storage, VectorStorageReadEnum::DenseChunked(_)));
+        assert_eq!(storage.total_vector_count(), vectors.len());
+        let got: DenseVector = storage
+            .get_vector::<Random>(7)
+            .to_owned()
+            .try_into()
+            .unwrap();
+        assert_eq!(got, vectors[7]);
+    }
+
+    /// `Mmap` single-dense config routes to the immutable `DenseVectorStorageImpl`.
+    #[test]
+    fn open_routes_mmap_to_dense() {
+        let dir = Builder::new().prefix("disp_mmap").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(2);
+        let hw = HardwareCounterCell::disposable();
+        let vectors: Vec<DenseVector> = (0..3).map(|_| rand_vec(&mut rng)).collect();
+
+        {
+            // The immutable mmap storage is built by copying from another storage.
+            let mut storage =
+                open_dense_vector_storage(dir.path(), DIM, Distance::Dot, false).unwrap();
+            let mut staging = new_volatile_dense_vector_storage(DIM, Distance::Dot);
+            for (id, vector) in vectors.iter().enumerate() {
+                staging
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            let mut iter = (0..vectors.len() as PointOffsetType).map(|i| {
+                (
+                    staging.get_vector::<Random>(i),
+                    staging.is_deleted_vector(i),
+                )
+            });
+            storage.update_from(&mut iter, &Default::default()).unwrap();
+            storage.flusher()().unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &dense_config(VectorStorageType::Mmap, None),
+            dir.path(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(matches!(storage, VectorStorageReadEnum::Dense(_)));
+        assert_eq!(storage.total_vector_count(), vectors.len());
+        let got: DenseVector = storage
+            .get_vector::<Random>(1)
+            .to_owned()
+            .try_into()
+            .unwrap();
+        assert_eq!(got, vectors[1]);
+    }
+
+    /// A multivector config routes to the chunked multi-dense read-only storage.
+    #[test]
+    fn open_routes_multivector_to_multi_dense_chunked() {
+        let dir = Builder::new().prefix("disp_multi").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(3);
+        let hw = HardwareCounterCell::disposable();
+        let multis: Vec<MultiDenseVectorInternal> = (0..200)
+            .map(|_| {
+                let inner = rng.random_range(1..=3);
+                let vectors = std::iter::repeat_with(|| rand_vec(&mut rng))
+                    .take(inner)
+                    .collect::<Vec<_>>();
+                MultiDenseVectorInternal::try_from(vectors).unwrap()
+            })
+            .collect();
+
+        {
+            let mut storage =
+                open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                    dir.path(),
+                    DIM,
+                    Distance::Dot,
+                    MultiVectorConfig::default(),
+                    AdviceSetting::Global,
+                    false,
+                )
+                .unwrap();
+            for (id, multivec) in multis.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(multivec), &hw)
+                    .unwrap();
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &dense_config(
+                VectorStorageType::ChunkedMmap,
+                Some(MultiVectorConfig::default()),
+            ),
+            dir.path(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(matches!(
+            storage,
+            VectorStorageReadEnum::MultiDenseChunked(_)
+        ));
+        assert_eq!(storage.total_vector_count(), multis.len());
+        let stored = storage.get_vector::<Random>(5);
+        let multi: TypedMultiDenseVectorRef<VectorElementType> =
+            stored.as_vec_ref().try_into().unwrap();
+        assert_eq!(multi.to_owned(), multis[5]);
     }
 }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -23,8 +23,8 @@ use crate::types::VectorStorageDatatype;
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageRead};
 
-const DELETED_DIRNAME: &str = "deleted";
-const STORAGE_DIRNAME: &str = "store";
+pub(crate) const DELETED_DIRNAME: &str = "deleted";
+pub(crate) const STORAGE_DIRNAME: &str = "store";
 
 /// Memory-mapped mutable sparse vector storage.
 #[derive(Debug)]

--- a/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/sparse_vector_storage.rs
@@ -1,4 +1,6 @@
-use common::bitvec::{BitSlice, BitVec};
+use std::path::Path;
+
+use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
@@ -6,23 +8,53 @@ use common::universal_io::UniversalRead;
 use gridstore::GridstoreReader;
 use sparse::common::sparse_vector::SparseVector;
 
-use crate::common::operation_error::OperationResult;
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
+use crate::vector_storage::sparse::mmap_sparse_vector_storage::{DELETED_DIRNAME, STORAGE_DIRNAME};
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 
 #[derive(Debug)]
 pub struct ReadOnlySparseVectorStorage<S: UniversalRead> {
     storage: GridstoreReader<StoredSparseVector, S>,
-    /// Flags marking deleted vectors
-    ///
-    /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
-    /// depend on its length.
-    deleted: BitVec,
-    deleted_count: usize,
+    /// Flags marking deleted vectors.
+    deleted: InMemoryBitvecFlags,
     next_point_offset: usize,
+}
+
+impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
+    /// Open the read-only counterpart of the mmap sparse storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `next_point_offset` is reconstructed like the
+    /// writable storage on reopen: the highest deleted id or the Gridstore
+    /// pointer count, whichever is larger.
+    #[allow(dead_code)] // pending: read-only vector storage enum will use this
+    pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
+        let storage =
+            GridstoreReader::<StoredSparseVector, S>::open(fs, path.join(STORAGE_DIRNAME))
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to open read-only sparse vector storage: {err}"
+                    ))
+                })?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIRNAME))?;
+
+        let next_point_offset = deleted
+            .as_bitslice()
+            .last_one()
+            .max(Some(storage.max_point_offset() as usize))
+            .unwrap_or_default();
+
+        Ok(Self {
+            storage,
+            deleted,
+            next_point_offset,
+        })
+    }
 }
 
 impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
@@ -82,14 +114,89 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.deleted.get(key as usize).is_some_and(|bit| *bit)
+        self.deleted.get(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.deleted_count
+        self.deleted.count()
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::generic_consts::Random;
+    use common::universal_io::{MmapFile, MmapFs};
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::data_types::vectors::VectorRef;
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+
+    /// Write sparse vectors (deleting some) through the writable mmap storage,
+    /// then reopen the same directory read-only and assert it mirrors the state,
+    /// including per-point sparse contents and the reconstructed point count.
+    #[test]
+    fn read_only_sparse_round_trip() {
+        const POINT_COUNT: PointOffsetType = 500;
+
+        let dir = Builder::new().prefix("ro_sparse").tempdir().unwrap();
+        let hw = HardwareCounterCell::disposable();
+
+        let sparse_vectors: Vec<SparseVector> = (0..POINT_COUNT)
+            .map(|id| {
+                let value = id as f32;
+                SparseVector {
+                    indices: vec![1, 5, 9],
+                    values: vec![value + 0.1, value + 0.2, value + 0.3],
+                }
+            })
+            .collect();
+
+        let mut deleted_ids = Vec::new();
+        {
+            let mut storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+            for (id, vector) in sparse_vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            for id in (0..POINT_COUNT).step_by(7) {
+                storage.delete_vector(id).unwrap();
+                deleted_ids.push(id);
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let storage = ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        assert_eq!(storage.distance(), SPARSE_VECTOR_DISTANCE);
+        assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
+
+        for id in 0..POINT_COUNT {
+            let deleted = deleted_ids.contains(&id);
+            assert_eq!(storage.is_deleted_vector(id), deleted);
+
+            // Deleting a sparse vector reclaims its Gridstore entry, so only
+            // live points still carry their contents.
+            if deleted {
+                continue;
+            }
+
+            match storage.get_vector::<Random>(id) {
+                CowVector::Sparse(got) => {
+                    assert_eq!(got.indices, sparse_vectors[id as usize].indices);
+                    assert_eq!(got.values, sparse_vectors[id as usize].values);
+                }
+                CowVector::Dense(_) | CowVector::MultiDense(_) => {
+                    panic!("expected sparse vector for point {id}")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Part of #9241 — read-only vector storage `open` constructors. Stacked on #9336.

Adds `VectorStorageReadEnum::open`, the read-only counterpart of `open_vector_storage`: routes a `VectorDataConfig` to the matching read-only variant. The storage type selects the on-disk layout (`Mmap` → immutable `DenseVectorStorageImpl`, `ChunkedMmap` → appendable chunked storage), the datatype selects the element type, and a multivector config routes to the chunked multi-dense storage (mmap multivectors are appendable-only). `advice`/`populate` are derived from the storage type exactly as the writable path does.

`open_dense_vector_storage_impl` is exposed `pub(crate)` so the dispatcher can build the immutable `Dense*` variants. Sparse storage keeps its own `ReadOnlySparseVectorStorage::open` (#9336) and is wrapped at the call site, mirroring the writable side's separate sparse path.

Tests assert each config routes to the expected variant and round-trips.