### PR TITLE
fix(api): map PreconditionFailed to HTTP 412 instead of 500

### DIFF
--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -251,7 +251,7 @@ impl ResponseError for HttpError {
             StorageError::AlreadyExists { .. } => http::StatusCode::CONFLICT,
             StorageError::ChecksumMismatch { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::Forbidden { .. } => http::StatusCode::FORBIDDEN,
-            StorageError::PreconditionFailed { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
+            StorageError::PreconditionFailed { .. } => http::StatusCode::PRECONDITION_FAILED,
             StorageError::InferenceError { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::RateLimitExceeded { .. } => http::StatusCode::TOO_MANY_REQUESTS,
             StorageError::ShardUnavailable { .. } => http::StatusCode::SERVICE_UNAVAILABLE,
@@ -275,5 +275,20 @@ impl From<CollectionError> for HttpError {
 impl From<std::io::Error> for HttpError {
     fn from(err: std::io::Error) -> Self {
         HttpError(err.into()) // TODO: Is this good enough?.. 🤔
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::http;
+
+    use super::*;
+
+    #[test]
+    fn precondition_failed_maps_to_412() {
+        let err = HttpError(StorageError::PreconditionFailed {
+            description: "collection not in expected state".to_string(),
+        });
+        assert_eq!(err.status_code(), http::StatusCode::PRECONDITION_FAILED);
     }
 }


### PR DESCRIPTION
## Summary

`StorageError::PreconditionFailed` is returned when the system is not in the expected state to perform an operation — e.g. when a point upsert supplies vector names that do not match the collection schema. The gRPC path already maps this variant to `tonic::Code::FailedPrecondition` ([conversions.rs](lib/storage/src/content_manager/conversions.rs)), but the REST/actix path was returning `500 INTERNAL_SERVER_ERROR`.

## Before

```rust
StorageError::PreconditionFailed { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
```

A `PreconditionFailed` error surfaced to REST clients as `500`, making a caller-side precondition violation (client sent the wrong input) indistinguishable from a server-side fault.

## After

```rust
StorageError::PreconditionFailed { .. } => http::StatusCode::PRECONDITION_FAILED,
```

REST and gRPC clients now receive consistent, semantically correct responses for the same error. `412 Precondition Failed` is the HTTP equivalent of gRPC `FailedPrecondition` and correctly signals that the request cannot be fulfilled given the current state of the resource.

## Impact

- **No behaviour change for correctly-formed requests.**
- Clients that previously retried on `500` for a `PreconditionFailed` condition should now see `412` and can handle it as a non-retryable, request-level error.
- Aligns REST error semantics with the gRPC contract already in place.

## Test plan

Unit test in `src/actix/helpers.rs`:
```
#[test]
fn precondition_failed_maps_to_412() {
    let err = HttpError(StorageError::PreconditionFailed { description: "..." });
    assert_eq!(err.status_code(), http::StatusCode::PRECONDITION_FAILED);
}
```

---

## Contributing with AI

This fix was developed with the assistance of an AI coding assistant. The root cause analysis (gRPC ↔ REST status code divergence) and the patch were verified against the codebase before submission.