### PR TITLE
feat: live_reload for read-only sparse vector storage

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -205,6 +205,7 @@ mod tests {
                 dir.path(),
                 DIM,
                 Distance::Dot,
+                MultiVectorConfig::default(),
                 AdviceSetting::Global,
                 false,
             )

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -1,0 +1,35 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlySparseVectorStorage;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Reload the Gridstore, apply `deleted_points`, and recompute
+    /// `next_point_offset`; appended points come from the Gridstore, so
+    /// `new_points` is unused.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.live_reload(fs)?;
+        self.deleted.insert_all(deleted_points);
+
+        self.next_point_offset = self
+            .deleted
+            .as_bitslice()
+            .last_one()
+            .max(Some(self.storage.max_point_offset() as usize))
+            .unwrap_or_default();
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -5,6 +5,7 @@ use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 #[derive(Debug)]
@@ -19,12 +20,14 @@ pub struct ReadOnlySparseVectorStorage<S: UniversalRead> {
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::generic_consts::Random;
+    use common::sorted_slice::SortedSlice;
     use common::types::PointOffsetType;
     use common::universal_io::{MmapFile, MmapFs};
     use sparse::common::sparse_vector::SparseVector;
     use tempfile::Builder;
 
     use super::*;
+    use crate::common::live_reload::LiveReload;
     use crate::data_types::named_vectors::CowVector;
     use crate::data_types::vectors::VectorRef;
     use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
@@ -92,5 +95,73 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// After `live_reload`, the read-only view reflects appends and deletions.
+    #[test]
+    fn live_reload_picks_up_appends_and_deletions() {
+        let dir = Builder::new().prefix("ro_sparse_reload").tempdir().unwrap();
+        let hw = HardwareCounterCell::disposable();
+
+        fn make(id: usize) -> SparseVector {
+            SparseVector {
+                indices: vec![1, 5, 9],
+                values: vec![id as f32 + 0.1, id as f32 + 0.2, id as f32 + 0.3],
+            }
+        }
+        let first: Vec<SparseVector> = (0..150).map(make).collect();
+        let second: Vec<SparseVector> = (150..250).map(make).collect();
+
+        let mut writer = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+        for (id, vector) in first.iter().enumerate() {
+            writer
+                .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                .unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let mut reader =
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+        assert_eq!(reader.total_vector_count(), first.len());
+
+        for (offset, vector) in second.iter().enumerate() {
+            writer
+                .insert_vector(
+                    (first.len() + offset) as PointOffsetType,
+                    VectorRef::from(vector),
+                    &hw,
+                )
+                .unwrap();
+        }
+        let deleted_ids: Vec<PointOffsetType> = vec![2, 80, 149];
+        for &id in &deleted_ids {
+            writer.delete_vector(id).unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let new_ids: Vec<PointOffsetType> = (first.len()..first.len() + second.len())
+            .map(|offset| offset as PointOffsetType)
+            .collect();
+        reader
+            .live_reload(
+                &MmapFs,
+                &SortedSlice::new(&deleted_ids).unwrap(),
+                &SortedSlice::new(&new_ids).unwrap(),
+                &hw,
+            )
+            .unwrap();
+
+        assert_eq!(reader.total_vector_count(), first.len() + second.len());
+        assert_eq!(reader.deleted_vector_count(), deleted_ids.len());
+
+        // The appended vector is visible; deleted ones are flagged.
+        match reader.get_vector::<Random>(first.len() as PointOffsetType) {
+            CowVector::Sparse(got) => assert_eq!(got.values, second[0].values),
+            CowVector::Dense(_) | CowVector::MultiDense(_) => panic!("expected sparse vector"),
+        }
+        for &id in &deleted_ids {
+            assert!(reader.is_deleted_vector(id));
+        }
+        assert!(!reader.is_deleted_vector(0));
     }
 }


### PR DESCRIPTION
Part of #9241 — read-only vector-storage live-reload. Stacked on #9342.

Implements `LiveReload` for `ReadOnlySparseVectorStorage`: reload the Gridstore (picking up appended vectors), apply the authoritative `deleted_points` to the deletion bitvec, and recompute `next_point_offset` the same way `open` does. New points are served from the refreshed Gridstore.