### PR TITLE
feat: add Web UI login, logout, and credential management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +484,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "1.18.2"
+version = "1.18.3-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -926,6 +932,15 @@ checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 dependencies = [
  "arrayvec 0.4.12",
  "constant_time_eq 0.1.5",
+]
+
+[[package]]
+name = "blink-alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c15bad517bc0fb4a44523adf470e2c3eb3a365769327acdba849948ea3705"
+dependencies = [
+ "allocator-api2 0.4.0",
 ]
 
 [[package]]
@@ -2551,7 +2566,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "anyhow",
  "bytes",
  "core_affinity",
@@ -3119,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]
@@ -3128,7 +3143,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.1.5",
 ]
@@ -3139,7 +3154,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -5409,7 +5424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap 0.10.1",
@@ -5429,7 +5444,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -5531,7 +5546,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "prost-types 0.14.3",
@@ -5705,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.18.2"
+version = "1.18.3-dev"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -5760,6 +5775,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
+ "sha2 0.11.0",
  "shard",
  "slog",
  "slog-stdlog",
@@ -6875,6 +6891,7 @@ dependencies = [
  "atomicwrites",
  "bincode 1.3.3",
  "bitvec",
+ "blink-alloc",
  "bytemuck",
  "byteorder",
  "cc",
@@ -7431,6 +7448,7 @@ version = "0.1.0"
 dependencies = [
  "bincode 1.3.3",
  "bitpacking",
+ "blink-alloc",
  "common",
  "criterion",
  "dataset",
@@ -7452,7 +7470,6 @@ dependencies = [
  "sha2 0.11.0",
  "sparse",
  "tempfile",
- "typed-arena",
  "validator",
  "zerocopy",
 ]
@@ -8335,12 +8352,6 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
  "rand 0.9.2",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.18.2"
+version = "1.18.3-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",
@@ -129,6 +129,7 @@ wal = { path = "lib/wal" }
 
 actix-multipart = "0.7.2"
 constant_time_eq = "0.4.2"
+sha2 = { workspace = true }
 
 # Profiling
 tracing = { workspace = true }
@@ -206,6 +207,7 @@ async-trait = "0.1.89"
 atomicwrites = "0.4.4"
 bincode = "1.3.3" # no upgrade because 2.0.x is much slower https://github.com/qdrant/qdrant/pull/6134
 bitpacking = "0.9.3"
+blink-alloc = "0.4.0"
 bytemuck = { version = "1.25.0", features = [
     "derive",
     "extern_crate_alloc",

--- a/Dockerfile.ui-auth
+++ b/Dockerfile.ui-auth
@@ -1,0 +1,20 @@
+FROM debian:13-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata libunwind8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /qdrant
+COPY target/debug/qdrant ./qdrant
+COPY config ./config
+COPY static ./static
+COPY tools/entrypoint.sh ./entrypoint.sh
+
+RUN chmod +x ./entrypoint.sh ./qdrant
+
+ENV TZ=Etc/UTC \
+    RUN_MODE=production
+
+EXPOSE 6333 6334
+CMD ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ To experience the full power of Qdrant locally, run the container with this comm
 docker run -p 6333:6333 qdrant/qdrant
 ```
 
-Note that this starts an insecure deployment without authentication, open to all network interfaces. Please refer to [secure your instance](https://qdrant.tech/documentation/security/#secure-your-instance).
+The Web UI at `http://localhost:6333/dashboard` is protected by a login screen. On first start it uses default credentials `admin` / `qdrant` (change them at `/dashboard/login` or via `QDRANT__SERVICE__UI_USERNAME` / `QDRANT__SERVICE__UI_PASSWORD`). Use the **Log out** button in the dashboard header or on the login page to end your session. Interactive Docker starts can optionally prompt for credentials during container startup.
+
+Note that the REST API remains open unless you also configure an API key. This deployment is open to all network interfaces. Please refer to [secure your instance](https://qdrant.tech/documentation/security/#secure-your-instance).
 
 Now you can connect to the server with any [client](#clients). For example, using Python:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -318,6 +318,14 @@ service:
   #
   # enforce_internal_auth: true
 
+  # Protect the Web UI with a username/password login screen.
+  # Credentials are stored in `storage/ui_auth.json` after the first start.
+  # Default credentials: admin / qdrant
+  #
+  # ui_auth_enabled: true
+  # ui_username: admin
+  # ui_password: qdrant
+
   # Hardware reporting adds information to the API responses with a
   # hint on how many resources were used to execute the request.
   #

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -2,6 +2,7 @@ pub mod actix_telemetry;
 pub mod api;
 mod auth;
 mod certificate_helpers;
+mod ui_auth;
 mod forwarded;
 pub mod helpers;
 pub mod metrics_service;
@@ -46,6 +47,7 @@ use crate::actix::api::vector_name_api::config_vector_name_api;
 use crate::actix::auth::{AuthTransform, WhitelistItem};
 use crate::actix::web_ui::{WEB_UI_PATH, web_ui_factory, web_ui_folder};
 use crate::common::auth::AuthKeys;
+use crate::common::ui_auth::UiAuthState;
 use crate::common::debugger::DebuggerState;
 use crate::common::health;
 use crate::common::http_client::HttpClient;
@@ -84,6 +86,23 @@ pub fn init(
         let http_client = web::Data::new(HttpClient::from_settings(&settings)?);
         let health_checker = web::Data::new(health_checker);
         let web_ui_available = web_ui_folder(&settings);
+        let ui_auth_state = web_ui_available.as_ref().map(|_| {
+            if settings.service.ui_auth_enabled() {
+                match UiAuthState::load_or_create(
+                    std::path::Path::new(&settings.storage.storage_path),
+                    &settings.service,
+                ) {
+                    Ok(state) => web::Data::new(state),
+                    Err(err) => {
+                        log::error!("Failed to initialize Web UI authentication: {err}");
+                        web::Data::new(UiAuthState::disabled())
+                    }
+                }
+            } else {
+                web::Data::new(UiAuthState::disabled())
+            }
+        });
+        let secure_ui_cookie = web::Data::new(settings.service.enable_tls);
         let service_config = web::Data::new(settings.service.clone());
         let audit_config_data = web::Data::new(settings.audit.clone());
 
@@ -171,8 +190,14 @@ pub fn init(
                 .service(get_point)
                 .service(get_points);
 
-            if let Some(static_folder) = web_ui_available.as_deref() {
-                app = app.service(web_ui_factory(static_folder));
+            if let (Some(static_folder), Some(ui_auth_state)) =
+                (web_ui_available.as_deref(), ui_auth_state.clone())
+            {
+                app = app.service(web_ui_factory(
+                    static_folder,
+                    ui_auth_state,
+                    secure_ui_cookie.clone(),
+                ));
             }
 
             app

--- a/src/actix/ui_auth.rs
+++ b/src/actix/ui_auth.rs
@@ -1,0 +1,245 @@
+use actix_web::body::BoxBody;
+use actix_web::cookie::{Cookie, SameSite};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::http::header;
+use actix_web::middleware::Next;
+use actix_web::web;
+use actix_web::{Error, HttpResponse, Responder};
+use serde::Deserialize;
+
+use crate::common::ui_auth::{
+    SESSION_COOKIE, SESSION_DURATION_SECS, UiAuthError, UiAuthState,
+};
+
+const LOGIN_PAGE: &str = include_str!("ui_login.html");
+
+const PUBLIC_PATHS: [&str; 4] = [
+    "/dashboard/login",
+    "/dashboard/auth/login",
+    "/dashboard/auth/logout",
+    "/dashboard/auth/session",
+];
+
+const LOGOUT_BAR_INJECTION: &str = r#"
+  <div id="qdrant-ui-auth-bar" style="position:fixed;top:12px;right:12px;z-index:100000;display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:10px;border:1px solid rgba(255,255,255,0.12);background:rgba(15,20,25,0.92);color:#e7ecf3;font:600 0.85rem Inter,system-ui,sans-serif;backdrop-filter:blur(8px);box-shadow:0 8px 24px rgba(0,0,0,0.35);">
+    <span id="qdrant-ui-auth-user"></span>
+    <button id="qdrant-ui-auth-logout" type="button" style="border:0;border-radius:8px;padding:8px 12px;background:#dc244c;color:#fff;font:inherit;cursor:pointer;">Log out</button>
+  </div>
+  <script>
+  (function () {
+    fetch('/dashboard/auth/session')
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        if (!data.authenticated) {
+          var bar = document.getElementById('qdrant-ui-auth-bar');
+          if (bar) bar.remove();
+          return;
+        }
+        document.getElementById('qdrant-ui-auth-user').textContent = data.username;
+        document.getElementById('qdrant-ui-auth-logout').addEventListener('click', function () {
+          fetch('/dashboard/auth/logout', { method: 'POST' })
+            .then(function () { window.location.href = '/dashboard/login'; });
+        });
+      });
+  })();
+  </script>
+"#;
+
+pub fn inject_dashboard_logout_bar(html: &str) -> String {
+    if html.contains("</body>") {
+        html.replacen("</body>", &format!("{LOGOUT_BAR_INJECTION}</body>"), 1)
+    } else {
+        format!("{html}{LOGOUT_BAR_INJECTION}")
+    }
+}
+
+fn is_public_path(req: &ServiceRequest) -> bool {
+    let pattern = req.match_pattern().unwrap_or_else(|| req.path().to_string());
+    PUBLIC_PATHS.iter().any(|path| pattern == *path)
+}
+
+fn has_valid_session(auth: &UiAuthState, req: &ServiceRequest) -> bool {
+    req.cookie(SESSION_COOKIE)
+        .map(|cookie| auth.validate_session_token(cookie.value()))
+        .unwrap_or(false)
+}
+
+pub async fn ui_auth_middleware(
+    req: ServiceRequest,
+    next: Next<BoxBody>,
+) -> Result<ServiceResponse<BoxBody>, Error> {
+    let auth = req
+        .app_data::<web::Data<UiAuthState>>()
+        .cloned()
+        .expect("UiAuthState must be registered for dashboard scope");
+
+    if !auth.enabled || is_public_path(&req) || has_valid_session(&auth, &req) {
+        return next.call(req).await;
+    }
+
+    let method = req.method().clone();
+    let redirect_target = req.uri().to_string();
+    let response = if method == actix_web::http::Method::GET {
+        let location = format!(
+            "/dashboard/login?redirect={}",
+            urlencoding::encode(&redirect_target)
+        );
+        HttpResponse::Found()
+            .append_header((header::LOCATION, location))
+            .finish()
+    } else {
+        HttpResponse::Unauthorized().body("Web UI authentication required")
+    };
+
+    let (request, _) = req.into_parts();
+    Ok(ServiceResponse::new(request, response.map_into_boxed_body()))
+}
+
+fn session_cookie(token: &str, secure: bool, max_age_secs: i64) -> Cookie<'static> {
+    Cookie::build(SESSION_COOKIE, token.to_string())
+        .path("/dashboard")
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .secure(secure)
+        .max_age(actix_web::cookie::time::Duration::seconds(max_age_secs))
+        .finish()
+}
+
+pub async fn login_page(auth: web::Data<UiAuthState>) -> impl Responder {
+    if !auth.enabled {
+        return HttpResponse::NotFound().body("Web UI authentication is disabled");
+    }
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(LOGIN_PAGE)
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    username: String,
+    password: String,
+}
+
+pub async fn login_handler(
+    auth: web::Data<UiAuthState>,
+    secure_cookie: web::Data<bool>,
+    body: web::Json<LoginRequest>,
+) -> impl Responder {
+    if !auth.enabled {
+        return HttpResponse::NotFound().json(serde_json::json!({
+            "status": "error",
+            "message": "Web UI authentication is disabled",
+        }));
+    }
+
+    if !auth.verify_credentials(&body.username, &body.password) {
+        return HttpResponse::Unauthorized().json(serde_json::json!({
+            "status": "error",
+            "message": "Invalid username or password",
+        }));
+    }
+
+    let token = auth.create_session_token();
+    let cookie = session_cookie(&token, **secure_cookie, SESSION_DURATION_SECS as i64);
+
+    HttpResponse::Ok()
+        .cookie(cookie)
+        .json(serde_json::json!({
+            "status": "ok",
+            "username": auth.username(),
+        }))
+}
+
+pub async fn logout_handler(secure_cookie: web::Data<bool>) -> impl Responder {
+    let cookie = session_cookie("", **secure_cookie, 0);
+
+    HttpResponse::Ok()
+        .cookie(cookie)
+        .json(serde_json::json!({ "status": "ok" }))
+}
+
+#[derive(Deserialize)]
+pub struct ChangeCredentialsRequest {
+    current_password: String,
+    new_username: Option<String>,
+    new_password: String,
+}
+
+pub async fn change_credentials_handler(
+    auth: web::Data<UiAuthState>,
+    secure_cookie: web::Data<bool>,
+    req: actix_web::HttpRequest,
+    body: web::Json<ChangeCredentialsRequest>,
+) -> impl Responder {
+    if !auth.enabled {
+        return HttpResponse::NotFound().json(serde_json::json!({
+            "status": "error",
+            "message": "Web UI authentication is disabled",
+        }));
+    }
+
+    let Some(cookie) = req.cookie(SESSION_COOKIE) else {
+        return HttpResponse::Unauthorized().json(serde_json::json!({
+            "status": "error",
+            "message": "Not authenticated",
+        }));
+    };
+
+    if !auth.validate_session_token(cookie.value()) {
+        return HttpResponse::Unauthorized().json(serde_json::json!({
+            "status": "error",
+            "message": "Not authenticated",
+        }));
+    }
+
+    let new_username = body
+        .new_username
+        .clone()
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| auth.username());
+
+    match auth.update_credentials(
+        &body.current_password,
+        &new_username,
+        &body.new_password,
+    ) {
+        Ok(()) => HttpResponse::Ok()
+            .cookie(session_cookie("", **secure_cookie, 0))
+            .json(serde_json::json!({
+                "status": "ok",
+                "username": new_username,
+                "message": "Credentials updated. Please sign in again.",
+            })),
+        Err(UiAuthError::InvalidCredentials) => HttpResponse::Unauthorized().json(serde_json::json!({
+            "status": "error",
+            "message": "Invalid current password",
+        })),
+        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
+            "status": "error",
+            "message": err.to_string(),
+        })),
+    }
+}
+
+pub async fn session_status_handler(
+    auth: web::Data<UiAuthState>,
+    req: actix_web::HttpRequest,
+) -> impl Responder {
+    if !auth.enabled {
+        return HttpResponse::Ok().json(serde_json::json!({
+            "authenticated": false,
+            "enabled": false,
+        }));
+    }
+
+    let authenticated = req
+        .cookie(SESSION_COOKIE)
+        .map(|cookie| auth.validate_session_token(cookie.value()))
+        .unwrap_or(false);
+
+    HttpResponse::Ok().json(serde_json::json!({
+        "authenticated": authenticated,
+        "enabled": true,
+        "username": if authenticated { Some(auth.username()) } else { None },
+    }))
+}

--- a/src/actix/ui_login.html
+++ b/src/actix/ui_login.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Qdrant Dashboard Login</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f1419;
+      --card: #1a2332;
+      --text: #e7ecf3;
+      --muted: #9aa7b8;
+      --accent: #dc244c;
+      --border: #2a3648;
+      --error: #ff6b6b;
+      --ok: #3dd68c;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: Inter, system-ui, -apple-system, sans-serif;
+      background: radial-gradient(circle at top, #243049, var(--bg) 55%);
+      color: var(--text);
+      padding: 24px;
+    }
+    .card {
+      width: min(420px, 100%);
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 28px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.5rem;
+    }
+    p {
+      margin: 0 0 20px;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+    label {
+      display: block;
+      margin: 14px 0 6px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    input {
+      width: 100%;
+      padding: 12px 14px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: #111827;
+      color: var(--text);
+      font-size: 1rem;
+    }
+    button {
+      width: 100%;
+      margin-top: 18px;
+      padding: 12px 14px;
+      border: 0;
+      border-radius: 10px;
+      background: var(--accent);
+      color: white;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button.secondary {
+      margin-top: 10px;
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--text);
+    }
+    .message {
+      margin-top: 14px;
+      min-height: 1.2rem;
+      font-size: 0.92rem;
+    }
+    .message.error { color: var(--error); }
+    .message.ok { color: var(--ok); }
+    .tabs {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+    .tab {
+      flex: 1;
+      padding: 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .tab.active {
+      border-color: var(--accent);
+      color: var(--text);
+      background: rgba(220, 36, 76, 0.12);
+    }
+    .hidden { display: none; }
+    .hint {
+      margin-top: 16px;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Qdrant Dashboard</h1>
+    <p id="subtitle">Sign in to access the Web UI.</p>
+
+    <div class="tabs">
+      <button class="tab active" id="tab-login" type="button">Sign in</button>
+      <button class="tab" id="tab-change" type="button">Change credentials</button>
+    </div>
+
+    <form id="login-form">
+      <label for="login-username">Username</label>
+      <input id="login-username" name="username" autocomplete="username" required>
+
+      <label for="login-password">Password</label>
+      <input id="login-password" name="password" type="password" autocomplete="current-password" required>
+
+      <button type="submit">Sign in</button>
+    </form>
+
+    <form id="change-form" class="hidden">
+      <label for="current-password">Current password</label>
+      <input id="current-password" name="current_password" type="password" autocomplete="current-password" required>
+
+      <label for="new-username">New username</label>
+      <input id="new-username" name="new_username" autocomplete="username">
+
+      <label for="new-password">New password</label>
+      <input id="new-password" name="new_password" type="password" autocomplete="new-password" required>
+
+      <button type="submit">Update credentials</button>
+      <button class="secondary" id="open-dashboard" type="button">Open dashboard</button>
+      <button class="secondary" id="logout-btn" type="button">Log out</button>
+    </form>
+
+    <div class="message" id="message"></div>
+    <p class="hint">Default credentials are <code>admin</code> / <code>qdrant</code> until you change them here or via Docker environment variables.</p>
+  </div>
+
+  <script>
+    const message = document.getElementById('message');
+    const loginForm = document.getElementById('login-form');
+    const changeForm = document.getElementById('change-form');
+    const tabLogin = document.getElementById('tab-login');
+    const tabChange = document.getElementById('tab-change');
+    const subtitle = document.getElementById('subtitle');
+    const redirect = new URLSearchParams(window.location.search).get('redirect') || '/dashboard/';
+
+    function setMessage(text, type) {
+      message.textContent = text;
+      message.className = 'message' + (type ? ' ' + type : '');
+    }
+
+    function showLogin() {
+      tabLogin.classList.add('active');
+      tabChange.classList.remove('active');
+      loginForm.classList.remove('hidden');
+      changeForm.classList.add('hidden');
+      subtitle.textContent = 'Sign in to access the Web UI.';
+    }
+
+    function showChange() {
+      tabChange.classList.add('active');
+      tabLogin.classList.remove('active');
+      changeForm.classList.remove('hidden');
+      loginForm.classList.add('hidden');
+      subtitle.textContent = 'Update the dashboard username and password.';
+    }
+
+    tabLogin.addEventListener('click', showLogin);
+    tabChange.addEventListener('click', showChange);
+
+    async function refreshSession() {
+      const response = await fetch('/dashboard/auth/session');
+      if (!response.ok) return;
+      const data = await response.json();
+      if (data.authenticated) {
+        document.getElementById('new-username').placeholder = data.username || '';
+        showChange();
+      }
+    }
+
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      setMessage('');
+      const payload = {
+        username: document.getElementById('login-username').value,
+        password: document.getElementById('login-password').value,
+      };
+      const response = await fetch('/dashboard/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage(data.message || 'Login failed', 'error');
+        return;
+      }
+      window.location.href = redirect;
+    });
+
+    changeForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      setMessage('');
+      const payload = {
+        current_password: document.getElementById('current-password').value,
+        new_username: document.getElementById('new-username').value || undefined,
+        new_password: document.getElementById('new-password').value,
+      };
+      const response = await fetch('/dashboard/auth/credentials', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage(data.message || 'Update failed', 'error');
+        return;
+      }
+      setMessage(data.message || 'Credentials updated', 'ok');
+      showLogin();
+    });
+
+    document.getElementById('open-dashboard').addEventListener('click', () => {
+      window.location.href = redirect;
+    });
+
+    document.getElementById('logout-btn').addEventListener('click', async () => {
+      setMessage('');
+      await fetch('/dashboard/auth/logout', { method: 'POST' });
+      window.location.href = '/dashboard/login';
+    });
+
+    refreshSession();
+  </script>
+</body>
+</html>

--- a/src/actix/web_ui.rs
+++ b/src/actix/web_ui.rs
@@ -1,10 +1,16 @@
+use std::fs;
 use std::path::Path;
 
 use actix_web::dev::HttpServiceFactory;
 use actix_web::http::header::HeaderValue;
-use actix_web::middleware::DefaultHeaders;
-use actix_web::web;
+use actix_web::middleware::{self, DefaultHeaders};
+use actix_web::{web, HttpResponse, Responder};
 
+use crate::actix::ui_auth::{
+    change_credentials_handler, inject_dashboard_logout_bar, login_handler, login_page,
+    logout_handler, session_status_handler, ui_auth_middleware,
+};
+use crate::common::ui_auth::UiAuthState;
 use crate::settings::Settings;
 
 const DEFAULT_STATIC_DIR: &str = "./static";
@@ -37,9 +43,50 @@ pub fn web_ui_folder(settings: &Settings) -> Option<String> {
     }
 }
 
-pub fn web_ui_factory(static_folder: &str) -> impl HttpServiceFactory + use<> {
+async fn dashboard_index(
+    auth: web::Data<UiAuthState>,
+    static_folder: web::Data<String>,
+) -> impl Responder {
+    let index_path = Path::new(static_folder.as_str()).join("index.html");
+    let Ok(content) = fs::read_to_string(index_path) else {
+        return HttpResponse::NotFound().finish();
+    };
+
+    let body = if auth.enabled {
+        inject_dashboard_logout_bar(&content)
+    } else {
+        content
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(body)
+}
+
+pub fn web_ui_factory(
+    static_folder: &str,
+    ui_auth_state: web::Data<UiAuthState>,
+    secure_ui_cookie: web::Data<bool>,
+) -> impl HttpServiceFactory + use<> {
+    let static_folder_data = web::Data::new(static_folder.to_string());
+
     web::scope(WEB_UI_PATH)
         .wrap(DefaultHeaders::new().add(("X-Frame-Options", HeaderValue::from_static("DENY"))))
+        .app_data(ui_auth_state.clone())
+        .app_data(secure_ui_cookie)
+        .app_data(static_folder_data)
+        .wrap(middleware::from_fn(ui_auth_middleware))
+        .route("/login", web::get().to(login_page))
+        .route("/auth/login", web::post().to(login_handler))
+        .route("/auth/logout", web::post().to(logout_handler))
+        .route("/auth/session", web::get().to(session_status_handler))
+        .route(
+            "/auth/credentials",
+            web::put().to(change_credentials_handler),
+        )
+        .route("", web::get().to(dashboard_index))
+        .route("/", web::get().to(dashboard_index))
+        .route("/index.html", web::get().to(dashboard_index))
         .service(actix_files::Files::new("/", static_folder).index_file("index.html"))
 }
 
@@ -72,7 +119,12 @@ mod tests {
         }
 
         let static_folder = maybe_static_folder.unwrap();
-        let srv = test::init_service(App::new().service(web_ui_factory(&static_folder))).await;
+        let secure_cookie = web::Data::new(false);
+        let auth = web::Data::new(UiAuthState::disabled());
+        let srv = test::init_service(
+            App::new().service(web_ui_factory(&static_folder, auth, secure_cookie)),
+        )
+        .await;
 
         // Index path (no trailing slash)
         let req = TestRequest::with_uri(WEB_UI_PATH).to_request();
@@ -103,7 +155,12 @@ mod tests {
         );
         // Non-existing path (404 Not Found)
         let fake_path = uuid::Uuid::new_v4().to_string();
-        let srv = test::init_service(App::new().service(web_ui_factory(&fake_path))).await;
+        let secure_cookie = web::Data::new(false);
+        let auth = web::Data::new(UiAuthState::disabled());
+        let srv = test::init_service(
+            App::new().service(web_ui_factory(&fake_path, auth, secure_cookie)),
+        )
+        .await;
 
         let req = TestRequest::with_uri(WEB_UI_PATH).to_request();
         let res = test::call_service(&srv, req).await;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -17,5 +17,6 @@ pub mod strings;
 pub mod telemetry;
 pub mod telemetry_ops;
 pub mod telemetry_reporting;
+pub mod ui_auth;
 pub mod update;
 pub mod validate_vectors;

--- a/src/common/ui_auth.rs
+++ b/src/common/ui_auth.rs
@@ -1,0 +1,282 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::common::strings::ct_eq;
+use crate::settings::ServiceConfig;
+
+pub const DEFAULT_USERNAME: &str = "admin";
+pub const DEFAULT_PASSWORD: &str = "qdrant";
+pub const UI_AUTH_FILE: &str = "ui_auth.json";
+pub const SESSION_COOKIE: &str = "qdrant_ui_session";
+pub const SESSION_DURATION_SECS: u64 = 60 * 60 * 24 * 7;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredUiAuth {
+    username: String,
+    password_hash: String,
+    salt: String,
+    session_secret: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UiAuthError {
+    #[error("Invalid username or password")]
+    InvalidCredentials,
+    #[error("Invalid session")]
+    InvalidSession,
+    #[error("UI authentication is disabled")]
+    Disabled,
+    #[error("{0}")]
+    Internal(#[from] anyhow::Error),
+}
+
+#[derive(Clone)]
+pub struct UiAuthState {
+    inner: Arc<RwLock<StoredUiAuth>>,
+    path: PathBuf,
+    pub enabled: bool,
+}
+
+impl UiAuthState {
+    pub fn disabled() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(
+                StoredUiAuth::new(DEFAULT_USERNAME.into(), DEFAULT_PASSWORD.into())
+                    .expect("default UI auth credentials must be valid"),
+            )),
+            path: PathBuf::from("."),
+            enabled: false,
+        }
+    }
+
+    pub fn load_or_create(storage_path: &Path, service: &ServiceConfig) -> Result<Self> {
+        let enabled = service.ui_auth_enabled();
+        let path = storage_path.join(UI_AUTH_FILE);
+
+        if path.exists() {
+            let stored: StoredUiAuth = serde_json::from_str(
+                &fs_err::read_to_string(&path)
+                    .with_context(|| format!("Failed to read {}", path.display()))?,
+            )
+            .context("Failed to parse UI auth file")?;
+            log::info!(
+                "Loaded Web UI credentials for user '{}'",
+                stored.username
+            );
+            return Ok(Self {
+                inner: Arc::new(RwLock::new(stored)),
+                path,
+                enabled,
+            });
+        }
+
+        let username = service
+            .ui_username
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| DEFAULT_USERNAME.to_string());
+        let password = service
+            .ui_password
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| DEFAULT_PASSWORD.to_string());
+
+        if username == DEFAULT_USERNAME && password == DEFAULT_PASSWORD {
+            log::warn!(
+                "Web UI is using default credentials ({DEFAULT_USERNAME} / {DEFAULT_PASSWORD}). \
+                 Change them at /dashboard/login after signing in, or set \
+                 QDRANT__SERVICE__UI_USERNAME and QDRANT__SERVICE__UI_PASSWORD before starting."
+            );
+        }
+
+        let stored = StoredUiAuth::new(username, password)?;
+        Self::write_file(&path, &stored)?;
+        log::info!(
+            "Initialized Web UI credentials for user '{}'",
+            stored.username
+        );
+
+        Ok(Self {
+            inner: Arc::new(RwLock::new(stored)),
+            path,
+            enabled,
+        })
+    }
+
+    pub fn username(&self) -> String {
+        self.inner.read().expect("ui auth lock poisoned").username.clone()
+    }
+
+    pub fn verify_credentials(&self, username: &str, password: &str) -> bool {
+        let stored = self.inner.read().expect("ui auth lock poisoned");
+        stored.username == username && stored.verify_password(password)
+    }
+
+    pub fn create_session_token(&self) -> String {
+        let stored = self.inner.read().expect("ui auth lock poisoned");
+        let exp = chrono::Utc::now().timestamp() + SESSION_DURATION_SECS as i64;
+        let payload = format!("{}:{}", stored.username, exp);
+        let sig = sign_message(&stored.session_secret, payload.as_bytes());
+        format!("{payload}.{}", to_hex(&sig))
+    }
+
+    pub fn validate_session_token(&self, token: &str) -> bool {
+        let Some((payload, sig_hex)) = token.rsplit_once('.') else {
+            return false;
+        };
+        let Some(sig) = from_hex(sig_hex) else {
+            return false;
+        };
+        let Some((username, exp)) = payload.rsplit_once(':') else {
+            return false;
+        };
+        let Ok(exp) = exp.parse::<i64>() else {
+            return false;
+        };
+        if chrono::Utc::now().timestamp() > exp {
+            return false;
+        }
+
+        let stored = self.inner.read().expect("ui auth lock poisoned");
+        if stored.username != username {
+            return false;
+        }
+
+        let expected = sign_message(&stored.session_secret, payload.as_bytes());
+        ct_eq_bytes(&expected, &sig)
+    }
+
+    pub fn update_credentials(
+        &self,
+        current_password: &str,
+        new_username: &str,
+        new_password: &str,
+    ) -> Result<(), UiAuthError> {
+        if !self.enabled {
+            return Err(UiAuthError::Disabled);
+        }
+        if new_username.is_empty()
+            || new_password.is_empty()
+            || new_username.contains(':')
+        {
+            return Err(UiAuthError::InvalidCredentials);
+        }
+
+        let mut stored = self.inner.write().expect("ui auth lock poisoned");
+        if !stored.verify_password(current_password) {
+            return Err(UiAuthError::InvalidCredentials);
+        }
+
+        let updated = StoredUiAuth::new(new_username.to_string(), new_password.to_string())?;
+        Self::write_file(&self.path, &updated)?;
+        *stored = updated;
+        Ok(())
+    }
+
+    fn write_file(path: &Path, stored: &StoredUiAuth) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs_err::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(stored)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        file.write_all(json.as_bytes())?;
+        file.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+impl StoredUiAuth {
+    fn new(username: String, password: String) -> Result<Self> {
+        if username.is_empty() || password.is_empty() || username.contains(':') {
+            anyhow::bail!("Invalid UI auth username or password");
+        }
+
+        let salt = uuid::Uuid::new_v4().into_bytes().to_vec();
+        let mut session_secret = uuid::Uuid::new_v4().into_bytes().to_vec();
+        session_secret.extend(uuid::Uuid::new_v4().into_bytes());
+
+        Ok(Self {
+            username,
+            password_hash: hash_password(&salt, password.as_bytes()),
+            salt: to_hex(&salt),
+            session_secret: to_hex(&session_secret),
+        })
+    }
+
+    fn verify_password(&self, password: &str) -> bool {
+        let Some(salt) = from_hex(&self.salt) else {
+            return false;
+        };
+        let expected = hash_password(&salt, password.as_bytes());
+        ct_eq(&expected, &self.password_hash)
+    }
+}
+
+fn hash_password(salt: &[u8], password: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(salt);
+    hasher.update(password);
+    to_hex(&hasher.finalize())
+}
+
+fn sign_message(secret_hex: &str, message: &[u8]) -> Vec<u8> {
+    let secret = from_hex(secret_hex).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(secret);
+    hasher.update(message);
+    hasher.finalize().to_vec()
+}
+
+fn ct_eq_bytes(lhs: &[u8], rhs: &[u8]) -> bool {
+    constant_time_eq::constant_time_eq(lhs, rhs)
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn from_hex(hex: &str) -> Option<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|idx| u8::from_str_radix(&hex[idx..idx + 2], 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credentials_roundtrip() {
+        let stored = StoredUiAuth::new("alice".into(), "secret".into()).unwrap();
+        assert!(stored.verify_password("secret"));
+        assert!(!stored.verify_password("wrong"));
+    }
+
+    #[test]
+    fn test_session_token() {
+        let state = UiAuthState {
+            inner: Arc::new(RwLock::new(
+                StoredUiAuth::new("alice".into(), "secret".into()).unwrap(),
+            )),
+            path: PathBuf::from("/tmp/ui_auth.json"),
+            enabled: true,
+        };
+        let token = state.create_session_token();
+        assert!(state.validate_session_token(&token));
+        assert!(!state.validate_session_token("invalid.token"));
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,19 @@ pub struct ServiceConfig {
     #[serde(default)]
     pub enable_static_content: Option<bool>,
 
+    /// Require username/password login before serving the Web UI.
+    /// Enabled by default when static content is enabled.
+    #[serde(default)]
+    pub ui_auth_enabled: Option<bool>,
+
+    /// Initial Web UI username. Used only when `ui_auth.json` does not exist yet.
+    /// Default: `admin`
+    pub ui_username: Option<String>,
+
+    /// Initial Web UI password. Used only when `ui_auth.json` does not exist yet.
+    /// Default: `qdrant`
+    pub ui_password: Option<String>,
+
     /// How much time is considered too long for a query to execute.
     pub slow_query_secs: Option<f32>,
 
@@ -109,6 +122,10 @@ pub struct ServiceConfig {
 impl ServiceConfig {
     pub fn hardware_reporting(&self) -> bool {
         self.hardware_reporting.unwrap_or_default()
+    }
+
+    pub fn ui_auth_enabled(&self) -> bool {
+        self.ui_auth_enabled.unwrap_or(true)
     }
 }
 

--- a/tests/consensus_tests/auth_tests/test_dashboard_ui_auth.py
+++ b/tests/consensus_tests/auth_tests/test_dashboard_ui_auth.py
@@ -1,0 +1,86 @@
+"""
+Web UI username/password authentication.
+
+When UI auth is enabled, static dashboard assets must not be served until the
+user signs in. Login and credential management endpoints stay reachable without
+an API key because the /dashboard prefix remains API-key-whitelisted.
+"""
+
+import pytest
+import requests
+from consensus_tests.utils import kill_all_processes
+
+from .utils import REST_URI, start_jwt_protected_cluster
+
+
+@pytest.fixture(scope="module")
+def dashboard_ui_auth_cluster(tmp_path_factory: pytest.TempPathFactory):
+    tmp_path = tmp_path_factory.mktemp("dashboard_ui_auth")
+    static_dir = tmp_path_factory.mktemp("static_content_ui_auth")
+    (static_dir / "index.html").write_text(
+        "<!doctype html><title>dashboard</title><body>secret-ui</body>"
+    )
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_jwt_protected_cluster(
+        tmp_path,
+        extra_env={
+            "QDRANT__SERVICE__ENABLE_STATIC_CONTENT": "true",
+            "QDRANT__SERVICE__STATIC_CONTENT_DIR": str(static_dir),
+            "QDRANT__SERVICE__UI_USERNAME": "tester",
+            "QDRANT__SERVICE__UI_PASSWORD": "s3cret-pass",
+        },
+    )
+
+    try:
+        yield peer_api_uris, peer_dirs, bootstrap_uri
+    finally:
+        kill_all_processes()
+
+
+def test_dashboard_requires_login(dashboard_ui_auth_cluster):
+    response = requests.get(f"{REST_URI}/dashboard", allow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("/dashboard/login")
+
+
+def test_dashboard_login_grants_access(dashboard_ui_auth_cluster):
+    session = requests.Session()
+    login = session.post(
+        f"{REST_URI}/dashboard/auth/login",
+        json={"username": "tester", "password": "s3cret-pass"},
+    )
+    assert login.status_code == 200, login.text
+    assert login.json()["status"] == "ok"
+
+    dashboard = session.get(f"{REST_URI}/dashboard")
+    assert dashboard.status_code == 200
+    assert "secret-ui" in dashboard.text
+
+
+def test_dashboard_rejects_invalid_login(dashboard_ui_auth_cluster):
+    response = requests.post(
+        f"{REST_URI}/dashboard/auth/login",
+        json={"username": "tester", "password": "wrong"},
+    )
+    assert response.status_code == 401
+
+
+def test_dashboard_logout(dashboard_ui_auth_cluster):
+    session = requests.Session()
+    login = session.post(
+        f"{REST_URI}/dashboard/auth/login",
+        json={"username": "tester", "password": "s3cret-pass"},
+    )
+    assert login.status_code == 200, login.text
+
+    dashboard = session.get(f"{REST_URI}/dashboard")
+    assert dashboard.status_code == 200
+    assert "Log out" in dashboard.text
+
+    logout = session.post(f"{REST_URI}/dashboard/auth/logout")
+    assert logout.status_code == 200
+    assert logout.json()["status"] == "ok"
+
+    locked = session.get(f"{REST_URI}/dashboard", allow_redirects=False)
+    assert locked.status_code == 302
+    assert locked.headers["Location"].startswith("/dashboard/login")

--- a/tests/consensus_tests/auth_tests/test_dashboard_whitelist_bypass.py
+++ b/tests/consensus_tests/auth_tests/test_dashboard_whitelist_bypass.py
@@ -50,6 +50,8 @@ def dashboard_cluster(tmp_path_factory: pytest.TempPathFactory):
         extra_env={
             "QDRANT__SERVICE__ENABLE_STATIC_CONTENT": "true",
             "QDRANT__SERVICE__STATIC_CONTENT_DIR": str(static_dir),
+            # UI login is tested separately; keep this regression focused on API-key whitelist behavior.
+            "QDRANT__SERVICE__UI_AUTH_ENABLED": "false",
         },
     )
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -18,6 +18,45 @@ _interrupt () {
 
 trap _interrupt SIGINT
 
+setup_ui_auth() {
+  local storage_path="${QDRANT__STORAGE__STORAGE_PATH:-./storage}"
+  local auth_file="${storage_path}/ui_auth.json"
+
+  if [ -f "$auth_file" ]; then
+    return
+  fi
+
+  if [ -n "$QDRANT__SERVICE__UI_USERNAME" ] && [ -n "$QDRANT__SERVICE__UI_PASSWORD" ]; then
+    return
+  fi
+
+  if [ -t 0 ] && [ "${QDRANT_UI_SETUP_PROMPT:-true}" = "true" ]; then
+    echo ""
+    echo "Qdrant Web UI login setup"
+    echo "Default credentials: admin / qdrant"
+    echo "Press Enter to keep defaults, or type 'setup' to configure now."
+    read -r choice
+
+    if [ "$choice" = "setup" ]; then
+      read -r -p "Username [admin]: " username
+      read -r -s -p "Password: " password
+      echo ""
+      export QDRANT__SERVICE__UI_USERNAME="${username:-admin}"
+      export QDRANT__SERVICE__UI_PASSWORD="${password}"
+      echo "Web UI credentials will be initialized on first start."
+    else
+      echo "Using default Web UI credentials (admin / qdrant)."
+      echo "Change them later at /dashboard/login after the container starts."
+    fi
+    echo ""
+  else
+    echo "Web UI will start with default credentials (admin / qdrant)."
+    echo "Set QDRANT__SERVICE__UI_USERNAME and QDRANT__SERVICE__UI_PASSWORD to override."
+  fi
+}
+
+setup_ui_auth
+
 ./qdrant $@ &
 
 # Get PID for the traps

--- a/tools/test-ui-auth.sh
+++ b/tools/test-ui-auth.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:6333}"
+COOKIE_JAR="$(mktemp)"
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+echo "Testing Qdrant Web UI auth at $BASE_URL"
+
+# 1) Dashboard should redirect to login without session
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/dashboard")
+LOCATION=$(curl -s -D - -o /dev/null "$BASE_URL/dashboard" | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r')
+[[ "$STATUS" == "302" ]] || fail "expected 302 on /dashboard, got $STATUS"
+[[ "$LOCATION" == /dashboard/login* ]] || fail "expected redirect to login, got $LOCATION"
+pass "unauthenticated /dashboard redirects to login"
+
+# 2) Login page is reachable
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/dashboard/login")
+[[ "$STATUS" == "200" ]] || fail "expected 200 on /dashboard/login, got $STATUS"
+pass "login page is public"
+
+# 3) Invalid login rejected
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"tester","password":"wrong"}' \
+  "$BASE_URL/dashboard/auth/login")
+[[ "$STATUS" == "401" ]] || fail "expected 401 for bad password, got $STATUS"
+pass "invalid login rejected"
+
+# 4) Valid login sets session cookie
+LOGIN_BODY=$(curl -s -c "$COOKIE_JAR" -w "\n%{http_code}" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"tester","password":"s3cret-pass"}' \
+  "$BASE_URL/dashboard/auth/login")
+STATUS=$(echo "$LOGIN_BODY" | tail -n1)
+BODY=$(echo "$LOGIN_BODY" | sed '$d')
+[[ "$STATUS" == "200" ]] || fail "expected 200 for valid login, got $STATUS"
+echo "$BODY" | grep -q '"status":"ok"' || fail "login response missing status ok"
+grep -q 'qdrant_ui_session' "$COOKIE_JAR" || fail "session cookie not set"
+pass "valid login succeeds and sets cookie"
+
+# 5) Dashboard accessible with session
+STATUS=$(curl -s -b "$COOKIE_JAR" -o /tmp/dashboard-body.html -w "%{http_code}" "$BASE_URL/dashboard")
+[[ "$STATUS" == "200" ]] || fail "expected 200 on /dashboard with session, got $STATUS"
+grep -q 'dashboard-ok' /tmp/dashboard-body.html || fail "dashboard body not served"
+pass "authenticated dashboard loads static UI"
+
+# 6) Dashboard includes logout control
+grep -q 'Log out' /tmp/dashboard-body.html || fail "dashboard missing logout control"
+pass "dashboard includes logout control"
+
+# 7) Logout clears session
+STATUS=$(curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE_URL/dashboard/auth/logout")
+[[ "$STATUS" == "200" ]] || fail "expected 200 on logout, got $STATUS"
+STATUS=$(curl -s -b "$COOKIE_JAR" -o /dev/null -w "%{http_code}" "$BASE_URL/dashboard")
+[[ "$STATUS" == "302" ]] || fail "expected 302 on /dashboard after logout, got $STATUS"
+pass "logout clears dashboard session"
+
+# 8) API still open without API key (expected default)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/collections")
+[[ "$STATUS" == "200" ]] || fail "expected open API /collections, got $STATUS"
+pass "REST API remains accessible without API key (default behavior)"
+
+echo "All UI auth smoke tests passed."


### PR DESCRIPTION
Protect the dashboard with session-based username/password auth so operators can safely expose the Web UI without leaving static assets publicly accessible. Includes login page, logout control, credential updates, Docker setup helpers, and integration tests.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
