### PR TITLE
[TQDT] Define `update_from` for each vector storage trait

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -12,8 +12,8 @@ use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::id_tracker::IdTrackerRead;
 use segment::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use segment::types::Distance;
+use segment::vector_storage::DEFAULT_STOPPED;
 use segment::vector_storage::dense::dense_vector_storage::open_dense_vector_storage;
-use segment::vector_storage::{DEFAULT_STOPPED, VectorStorage};
 use tempfile::Builder;
 
 #[cfg(not(target_os = "windows"))]

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -94,6 +94,24 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
     {
         self.vectors.for_each_in_batch(keys, callback);
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.vectors.len() as PointOffsetType;
+        let disposed_hw = HardwareCounterCell::disposable(); // This function is only used for internal operations.
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = T::slice_from_float_cow(other_vector);
+            let new_id = self.vectors.push(other_vector.as_ref(), &disposed_hw)?;
+            self.set_deleted(new_id as PointOffsetType, other_deleted);
+        }
+        let end_index = self.vectors.len() as PointOffsetType;
+        Ok(start_index..end_index)
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorStorage<T> {
@@ -167,24 +185,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
             .insert(key as VectorOffsetType, vector.as_ref(), hw_counter)?;
         self.set_deleted(key, false);
         Ok(())
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.vectors.len() as PointOffsetType;
-        let disposed_hw = HardwareCounterCell::disposable(); // This function is only used for internal operations.
-        for (other_vector, other_deleted) in other_vectors {
-            check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
-            let new_id = self.vectors.push(other_vector.as_ref(), &disposed_hw)?;
-            self.set_deleted(new_id as PointOffsetType, other_deleted);
-        }
-        let end_index = self.vectors.len() as PointOffsetType;
-        Ok(start_index..end_index)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -16,7 +16,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::VectorRef;
+use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 #[cfg(target_os = "linux")]
 use crate::vector_storage::common::get_async_scorer;
@@ -231,6 +231,63 @@ where
         let mmap_store = self.vectors.as_ref().unwrap();
         mmap_store.for_each_in_batch(keys, f);
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let dim = self.vector_dim();
+        let start_index = self.vectors.as_ref().unwrap().num_vectors as PointOffsetType;
+        let mut end_index = start_index;
+
+        // Extend vectors file, write other vectors into it
+        let mut vectors_file = BufWriter::new(open_append(&self.vectors_path)?);
+        let mut deleted_ids = vec![];
+        for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
+            check_process_stopped(stopped)?;
+            let vector = T::slice_from_float_cow(other_vector);
+            // Safety: T implements zerocopy::IntoBytes.
+            #[expect(deprecated, reason = "legacy code")]
+            let raw_bites = unsafe { mmap::transmute_to_u8_slice(vector.as_ref()) };
+            vectors_file.write_all(raw_bites)?;
+            end_index += 1;
+
+            // Remember deleted IDs so we can propagate deletions later
+            if other_deleted {
+                deleted_ids.push(start_index as PointOffsetType + offset as PointOffsetType);
+            }
+        }
+
+        // Explicitly fsync file contents to ensure durability
+        vectors_file.flush()?;
+        vectors_file
+            .into_inner()
+            .map_err(io::IntoInnerError::into_error)?
+            .sync_data()?;
+
+        // Load store with updated files
+        self.vectors.replace(ImmutableDenseVectors::open(
+            &self.fs,
+            &self.vectors_path,
+            &self.deleted_path,
+            dim,
+            false, // No need to populate
+        )?);
+
+        // Flush deleted flags into store
+        // We must do that in the updated store, and cannot do it in the previous loop. That is
+        // because the file backing delete storage must be resized, and for that we'd need to know
+        // the exact number of vectors beforehand. When opening the store it is done automatically.
+        let store = self.vectors.as_mut().unwrap();
+        for id in deleted_ids {
+            check_process_stopped(stopped)?;
+            store.delete(id);
+        }
+        store.flusher()()?;
+
+        Ok(start_index..end_index)
+    }
 }
 
 impl<T, S> VectorStorageRead for DenseVectorStorageImpl<T, S>
@@ -315,63 +372,6 @@ where
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         panic!("Can't directly update vector in mmap storage")
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let dim = self.vector_dim();
-        let start_index = self.vectors.as_ref().unwrap().num_vectors as PointOffsetType;
-        let mut end_index = start_index;
-
-        // Extend vectors file, write other vectors into it
-        let mut vectors_file = BufWriter::new(open_append(&self.vectors_path)?);
-        let mut deleted_ids = vec![];
-        for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
-            check_process_stopped(stopped)?;
-            let vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
-            // Safety: T implements zerocopy::IntoBytes.
-            #[expect(deprecated, reason = "legacy code")]
-            let raw_bites = unsafe { mmap::transmute_to_u8_slice(vector.as_ref()) };
-            vectors_file.write_all(raw_bites)?;
-            end_index += 1;
-
-            // Remember deleted IDs so we can propagate deletions later
-            if other_deleted {
-                deleted_ids.push(start_index as PointOffsetType + offset as PointOffsetType);
-            }
-        }
-
-        // Explicitly fsync file contents to ensure durability
-        vectors_file.flush()?;
-        vectors_file
-            .into_inner()
-            .map_err(io::IntoInnerError::into_error)?
-            .sync_data()?;
-
-        // Load store with updated files
-        self.vectors.replace(ImmutableDenseVectors::open(
-            &self.fs,
-            &self.vectors_path,
-            &self.deleted_path,
-            dim,
-            false, // No need to populate
-        )?);
-
-        // Flush deleted flags into store
-        // We must do that in the updated store, and cannot do it in the previous loop. That is
-        // because the file backing delete storage must be resized, and for that we'd need to know
-        // the exact number of vectors beforehand. When opening the store it is done automatically.
-        let store = self.vectors.as_mut().unwrap();
-        for id in deleted_ids {
-            check_process_stopped(stopped)?;
-            store.delete(id);
-        }
-        store.flusher()()?;
-
-        Ok(start_index..end_index)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -96,6 +96,16 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
         // flag from `is_deleted_vector` keeps the placeholder from being read.
         Cow::Owned(vec![0.0; self.dim])
     }
+
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        Err(OperationError::service_error(
+            "Cannot update empty vector storage",
+        ))
+    }
 }
 
 impl VectorStorageRead for EmptyDenseVectorStorage {
@@ -146,16 +156,6 @@ impl VectorStorage for EmptyDenseVectorStorage {
     ) -> OperationResult<()> {
         Err(OperationError::service_error(
             "Cannot insert into empty vector storage",
-        ))
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        _other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        _stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        Err(OperationError::service_error(
-            "Cannot update empty vector storage",
         ))
     }
 

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -83,6 +83,23 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.vectors.len() as PointOffsetType;
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = T::slice_from_float_cow(other_vector);
+            let new_id = self.vectors.push(other_vector.as_ref())? as PointOffsetType;
+            self.set_deleted(new_id, other_deleted);
+        }
+        let end_index = self.vectors.len() as PointOffsetType;
+        Ok(start_index..end_index)
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage<T> {
@@ -140,23 +157,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileDenseVectorStorage<T> 
             .insert(key as VectorOffsetType, vector.as_ref())?;
         self.set_deleted(key, false);
         Ok(())
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.vectors.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_vectors {
-            check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(Cow::try_from(other_vector)?);
-            let new_id = self.vectors.push(other_vector.as_ref())? as PointOffsetType;
-            self.set_deleted(new_id, other_deleted);
-        }
-        let end_index = self.vectors.len() as PointOffsetType;
-        Ok(start_index..end_index)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -220,6 +220,25 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
             0
         }
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.offsets.len() as PointOffsetType;
+        let disposed_hw_counter = HardwareCounterCell::disposable(); // Internal operation
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = VectorRef::MultiDense(other_vector.as_ref());
+            let new_id = self.offsets.len() as PointOffsetType;
+            self.insert_vector(new_id, other_vector, &disposed_hw_counter)?;
+            self.set_deleted(new_id, other_deleted);
+        }
+        let end_index = self.offsets.len() as PointOffsetType;
+        Ok(start_index..end_index)
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVectorStorage<T> {
@@ -341,25 +360,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
         self.set_deleted(key, false);
 
         Ok(())
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.offsets.len() as PointOffsetType;
-        let disposed_hw_counter = HardwareCounterCell::disposable(); // Internal operation
-        for (other_vector, other_deleted) in other_vectors {
-            check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector: VectorRef = other_vector.as_vec_ref();
-            let new_id = self.offsets.len() as PointOffsetType;
-            self.insert_vector(new_id, other_vector, &disposed_hw_counter)?;
-            self.set_deleted(new_id, other_deleted);
-        }
-        let end_index = self.offsets.len() as PointOffsetType;
-        Ok(start_index..end_index)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -236,6 +236,28 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
             0
         }
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.vectors_metadata.len() as PointOffsetType;
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = VectorRef::MultiDense(other_vector.as_ref());
+            let new_id = self.vectors_metadata.len() as PointOffsetType;
+            self.insert_vector_impl(
+                new_id,
+                other_vector,
+                other_deleted,
+                &HardwareCounterCell::disposable(), // This function is only used by internal operations
+            )?;
+        }
+        let end_index = self.vectors_metadata.len() as PointOffsetType;
+        Ok(start_index..end_index)
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileMultiDenseVectorStorage<T> {
@@ -286,28 +308,6 @@ impl<T: PrimitiveVectorElement> VectorStorage for VolatileMultiDenseVectorStorag
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.insert_vector_impl(key, vector, false, hw_counter)
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.vectors_metadata.len() as PointOffsetType;
-        for (other_vector, other_deleted) in other_vectors {
-            check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector: VectorRef = other_vector.as_vec_ref();
-            let new_id = self.vectors_metadata.len() as PointOffsetType;
-            self.insert_vector_impl(
-                new_id,
-                other_vector,
-                other_deleted,
-                &HardwareCounterCell::disposable(), // This function is only used by internal operations
-            )?;
-        }
-        let end_index = self.vectors_metadata.len() as PointOffsetType;
-        Ok(start_index..end_index)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::AtomicBool;
 
+use super::VectorStorageRead as _;
 use super::vector_storage_base::VectorStorageEnum;
-use super::{VectorStorage as _, VectorStorageRead as _};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -72,6 +73,16 @@ impl SparseVectorStorage for EmptySparseVectorStorage {
     {
         Ok(())
     }
+
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        Err(OperationError::service_error(
+            "Cannot update empty sparse vector storage",
+        ))
+    }
 }
 
 impl VectorStorageRead for EmptySparseVectorStorage {
@@ -122,16 +133,6 @@ impl VectorStorage for EmptySparseVectorStorage {
     ) -> OperationResult<()> {
         Err(OperationError::service_error(
             "Cannot insert into empty sparse vector storage",
-        ))
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        _other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        _stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        Err(OperationError::service_error(
-            "Cannot update empty sparse vector storage",
         ))
     }
 

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -226,6 +227,30 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
             HardwareCounterCell::disposable().vector_io_read(),
         )
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let hw_counter = HardwareCounterCell::disposable(); // This function is only used for internal operations. No need to measure.
+        let start_index = self.next_point_offset as PointOffsetType;
+        for (other_vector, other_deleted) in other_vectors.stop_if(stopped) {
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = other_vector.as_ref();
+            let new_id = self.next_point_offset as PointOffsetType;
+            self.next_point_offset += 1;
+            self.set_deleted(new_id, other_deleted);
+
+            let vector = (!other_deleted).then_some(other_vector);
+            self.update_stored(new_id, vector, &hw_counter)?;
+        }
+
+        // return cancelled error if stopped
+        check_process_stopped(stopped)?;
+
+        Ok(start_index..self.next_point_offset as PointOffsetType)
+    }
 }
 
 impl VectorStorageRead for MmapSparseVectorStorage {
@@ -309,30 +334,6 @@ impl VectorStorage for MmapSparseVectorStorage {
         self.set_deleted(key, false);
         self.update_stored(key, Some(vector), hw_counter)?;
         Ok(())
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let hw_counter = HardwareCounterCell::disposable(); // This function is only used for internal operations. No need to measure.
-        let start_index = self.next_point_offset as PointOffsetType;
-        for (other_vector, other_deleted) in other_vectors.stop_if(stopped) {
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = other_vector.as_vec_ref().try_into()?;
-            let new_id = self.next_point_offset as PointOffsetType;
-            self.next_point_offset += 1;
-            self.set_deleted(new_id, other_deleted);
-
-            let vector = (!other_deleted).then_some(other_vector);
-            self.update_stored(new_id, vector, &hw_counter)?;
-        }
-
-        // return cancelled error if stopped
-        check_process_stopped(stopped)?;
-
-        Ok(start_index..self.next_point_offset as PointOffsetType)
     }
 
     fn flusher(&self) -> crate::common::Flusher {

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 
@@ -131,6 +132,24 @@ impl SparseVectorStorage for VolatileSparseVectorStorage {
 
         Ok(())
     }
+
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        let start_index = self.total_vector_count as PointOffsetType;
+        for (other_vector, other_deleted) in other_vectors {
+            check_process_stopped(stopped)?;
+            // Do not perform preprocessing - vectors should be already processed
+            let other_vector = other_vector.as_ref();
+            let new_id = self.total_vector_count as PointOffsetType;
+            self.total_vector_count += 1;
+            self.set_deleted(new_id, other_deleted);
+            self.update_stored(new_id, other_deleted, Some(other_vector));
+        }
+        Ok(start_index..self.total_vector_count as PointOffsetType)
+    }
 }
 
 impl VectorStorageRead for VolatileSparseVectorStorage {
@@ -192,24 +211,6 @@ impl VectorStorage for VolatileSparseVectorStorage {
         self.set_deleted(key, false);
         self.update_stored(key, false, Some(vector));
         Ok(())
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        let start_index = self.total_vector_count as PointOffsetType;
-        for (other_vector, other_deleted) in other_vectors {
-            check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = other_vector.as_vec_ref().try_into()?;
-            let new_id = self.total_vector_count as PointOffsetType;
-            self.total_vector_count += 1;
-            self.set_deleted(new_id, other_deleted);
-            self.update_stored(new_id, other_deleted, Some(other_vector));
-        }
-        Ok(start_index..self.total_vector_count as PointOffsetType)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -15,7 +15,7 @@ use crate::types::Distance;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage_with_uring;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
-use crate::vector_storage::vector_storage_base::{VectorStorage, VectorStorageRead};
+use crate::vector_storage::vector_storage_base::VectorStorageRead;
 
 #[test]
 fn async_raw_scorer_cosine() -> Result<()> {

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -29,7 +29,7 @@ use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_de
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsStorageType,
 };
-use crate::vector_storage::vector_storage_base::{VectorStorage, VectorStorageRead};
+use crate::vector_storage::vector_storage_base::VectorStorageRead;
 
 const DIMS: usize = 128;
 const NUM_POINTS: usize = 600;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -148,18 +148,6 @@ pub trait VectorStorage: VectorStorageRead {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 
-    /// Add the given vectors to the storage.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>>;
-
     fn flusher(&self) -> Flusher;
 
     fn files(&self) -> Vec<PathBuf>;
@@ -178,6 +166,21 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]>;
+
+    /// Add the given dense vectors to the storage.
+    ///
+    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
+    /// with a narrower element type convert them on insert.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 
     /// Call `f` with the raw bytes of the vector if it exists.
     ///
@@ -227,6 +230,18 @@ pub trait SparseVectorStorage: VectorStorageRead {
     ) -> OperationResult<()>
     where
         F: FnMut(usize, SparseVector);
+
+    /// Add the given sparse vectors to the storage.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
@@ -246,6 +261,21 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn multi_vector_config(&self) -> &MultiVectorConfig;
 
     fn size_of_available_vectors_in_bytes(&self) -> usize;
+
+    /// Add the given multi-dense vectors to the storage.
+    ///
+    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
+    /// with a narrower element type convert them on insert.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 }
 
 #[derive(Debug)]
@@ -975,6 +1005,137 @@ impl VectorStorageRead for VectorStorageEnum {
     }
 }
 
+/// Unwrap a generic [`CowVector`] into a dense slice for [`DenseVectorStorage`].
+///
+/// Receiving a non-dense vector here is a logic error: the merge path always
+/// feeds a storage with vectors of its own kind.
+fn unwrap_dense((vector, deleted): (CowVector<'_>, bool)) -> (Cow<'_, [VectorElementType]>, bool) {
+    match vector {
+        CowVector::Dense(v) => (v, deleted),
+        CowVector::Sparse(_) | CowVector::MultiDense(_) => {
+            unreachable!("dense vector storage received a non-dense vector")
+        }
+    }
+}
+
+/// Unwrap a generic [`CowVector`] into a sparse vector for [`SparseVectorStorage`].
+fn unwrap_sparse((vector, deleted): (CowVector<'_>, bool)) -> (Cow<'_, SparseVector>, bool) {
+    match vector {
+        CowVector::Sparse(v) => (v, deleted),
+        CowVector::Dense(_) | CowVector::MultiDense(_) => {
+            unreachable!("sparse vector storage received a non-sparse vector")
+        }
+    }
+}
+
+/// Unwrap a generic [`CowVector`] into a multi-dense vector for [`MultiVectorStorage`].
+fn unwrap_multi(
+    (vector, deleted): (CowVector<'_>, bool),
+) -> (CowMultiVector<'_, VectorElementType>, bool) {
+    match vector {
+        CowVector::MultiDense(v) => (v, deleted),
+        CowVector::Dense(_) | CowVector::Sparse(_) => {
+            unreachable!("multi-dense vector storage received a non-multi-dense vector")
+        }
+    }
+}
+
+impl VectorStorageEnum {
+    /// Add the given vectors to the storage.
+    ///
+    /// Dispatches to the kind-specific [`DenseVectorStorage::update_from`],
+    /// [`SparseVectorStorage::update_from`] or [`MultiVectorStorage::update_from`],
+    /// unwrapping the generic [`CowVector`] into the concrete vector kind.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    pub fn update_from<'a>(
+        &mut self,
+        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::DenseMemmap(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::DenseMemmapByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::DenseMemmapHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::SparseVolatile(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
+            }
+            VectorStorageEnum::SparseMmap(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
+            }
+            VectorStorageEnum::MultiDenseVolatile(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_multi), stopped)
+            }
+            VectorStorageEnum::EmptyDense(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_dense), stopped)
+            }
+            VectorStorageEnum::EmptySparse(v) => {
+                v.update_from(&mut other_vectors.map(unwrap_sparse), stopped)
+            }
+        }
+    }
+}
+
 impl VectorStorage for VectorStorageEnum {
     fn insert_vector(
         &mut self,
@@ -1028,56 +1189,6 @@ impl VectorStorage for VectorStorageEnum {
             }
             VectorStorageEnum::EmptyDense(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::EmptySparse(v) => v.insert_vector(key, vector, hw_counter),
-        }
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.update_from(other_vectors, stopped),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.update_from(other_vectors, stopped),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::DenseMemmap(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::DenseMemmapByte(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.update_from(other_vectors, stopped),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.update_from(other_vectors, stopped),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.update_from(other_vectors, stopped),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.update_from(other_vectors, stopped),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.update_from(other_vectors, stopped)
-            }
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.update_from(other_vectors, stopped)
-            }
-            VectorStorageEnum::SparseVolatile(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::SparseMmap(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::MultiDenseVolatile(v) => v.update_from(other_vectors, stopped),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.update_from(other_vectors, stopped),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
-                v.update_from(other_vectors, stopped)
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.update_from(other_vectors, stopped)
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.update_from(other_vectors, stopped)
-            }
-            VectorStorageEnum::EmptyDense(v) => v.update_from(other_vectors, stopped),
-            VectorStorageEnum::EmptySparse(v) => v.update_from(other_vectors, stopped),
         }
     }
 


### PR DESCRIPTION
First step in `update_from` refactor for TQDT.
This PP moves `VectorStorage::update_from` into `DenseVectorStorage`, `SparseVectorStorage`, `MultiVectorStorage` without specific type (it's a next step of changes). It allows to use TQ version of `update_from` without conversion into `CowVector`.