### PR TITLE
Read-only dense vector index

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/mod.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/mod.rs
@@ -3,7 +3,7 @@ mod tracker_enum;
 mod trait_def;
 
 #[allow(dead_code)]
-mod read_only_tracker_enum;
+pub mod read_only_tracker_enum;
 
 pub use point_mappings_ref::{PointMappingsGuard, PointMappingsRefEnum};
 pub use tracker_enum::IdTrackerEnum;

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -19,9 +19,13 @@ mod build;
 #[cfg(feature = "gpu")]
 mod gpu_build;
 mod old_index;
-mod search;
+#[allow(dead_code)]
+mod read_only;
+mod read_view;
 mod telemetry;
 mod vector_index_impl;
+
+use self::read_view::{HNSWIndexReadView, HNSWIndexReadViewEnum};
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";
@@ -154,5 +158,25 @@ impl HNSWIndex {
         } = self;
         graph.clear_cache()?;
         Ok(())
+    }
+
+    pub fn with_view<R>(&self, f: impl FnOnce(HNSWIndexReadViewEnum<'_>) -> R) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = HNSWIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors: quantized_vectors.as_ref(),
+                payload_index: payload_index_view,
+                config: &self.config,
+                graph: &self.graph,
+                searches_telemetry: &self.searches_telemetry,
+            };
+            f(read_view)
+        })
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -27,7 +27,7 @@ use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::VectorStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
+use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 /// Read-only, generic-over-storage counterpart of [`HNSWIndex`].
@@ -41,7 +41,7 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
-    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectorsRead<S>>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     config: HnswGraphConfig,
     path: PathBuf,
@@ -53,13 +53,13 @@ pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
 /// Read-only view over a [`ReadOnlyHNSWIndex`].
 ///
 /// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
-/// [`VectorStorageReadEnum`] / [`QuantizedVectorsRead`]), while the payload
+/// [`VectorStorageReadEnum`] / [`ReadOnlyQuantizedVectors`]), while the payload
 /// index view is still built over the in-memory enums of [`StructPayloadIndex`].
 type ReadView<'a, S> = HNSWIndexReadView<
     'a,
     ReadOnlyIdTrackerEnum<S>,
     VectorStorageReadEnum<S>,
-    QuantizedVectorsRead<S>,
+    ReadOnlyQuantizedVectors<S>,
     StructPayloadIndexReadView<
         'a,
         PayloadStorageEnum,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -19,12 +19,14 @@ use common::universal_io::UniversalRead;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::IdTrackerEnum;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::FieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
-use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
@@ -48,6 +50,25 @@ pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
     is_on_disk: bool,
 }
 
+/// Read-only view over a [`ReadOnlyHNSWIndex`].
+///
+/// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
+/// [`VectorStorageReadEnum`] / [`QuantizedVectorsRead`]), while the payload
+/// index view is still built over the in-memory enums of [`StructPayloadIndex`].
+type ReadView<'a, S> = HNSWIndexReadView<
+    'a,
+    ReadOnlyIdTrackerEnum<S>,
+    VectorStorageReadEnum<S>,
+    QuantizedVectorsRead<S>,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
+>;
+
 impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
     pub fn is_on_disk(&self) -> bool {
         self.is_on_disk
@@ -57,19 +78,7 @@ impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
     /// [`HNSWIndex::with_view`].
     ///
     /// [`HNSWIndex::with_view`]: super::super::HNSWIndex::with_view
-    pub fn with_view<R>(
-        &self,
-        f: impl FnOnce(
-            HNSWIndexReadView<
-                '_,
-                ReadOnlyIdTrackerEnum<S>,
-                VectorStorageReadEnum<S>,
-                PayloadStorageEnum,
-                FieldIndex,
-                QuantizedVectorsRead<S>,
-            >,
-        ) -> R,
-    ) -> R {
+    pub fn with_view<R>(&self, f: impl FnOnce(ReadView<'_, S>) -> R) -> R {
         let id_tracker = self.id_tracker.borrow();
         let vector_storage = self.vector_storage.borrow();
         let quantized_vectors = self.quantized_vectors.borrow();

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -1,0 +1,91 @@
+// NOTE: This module does NOT compile yet. It is the "naive reuse" version of the
+// read-only HNSW index that delegates search to the existing
+// [`HNSWIndexReadView`] search implementation. It is here to show the shape; two
+// things still block compilation:
+//   1. The view struct reuses the same `I`/`V` type params for both the
+//      standalone storages and the (always in-RAM) payload view, so building the
+//      view in `with_view` fails (`id_tracker` wants `ReadOnlyIdTrackerEnum<S>`,
+//      the payload view forces `IdTrackerEnum`).
+//   2. The search body builds scorers from the concrete `VectorStorageEnum` /
+//      `QuantizedVectors` (`new_raw_scorer`, `FilteredScorer::new`, ...), which
+//      do not accept `VectorStorageReadEnum<S>` / `QuantizedVectorsRead<S>`.
+mod read;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+
+use super::read_view::HNSWIndexReadView;
+use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::field_index::FieldIndex;
+use crate::index::hnsw_index::config::HnswGraphConfig;
+use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+/// Read-only, generic-over-storage counterpart of [`HNSWIndex`].
+///
+/// The graph itself stays a plain [`GraphLayers`] (it materializes into RAM or
+/// mmap on load via [`GraphLayers::load`] over a [`UniversalRead`] filesystem),
+/// so only the id tracker, vector storage and quantized vectors are
+/// parameterized by the backing storage `S`.
+///
+/// [`HNSWIndex`]: super::super::HNSWIndex
+pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
+    id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectorsRead<S>>>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    config: HnswGraphConfig,
+    path: PathBuf,
+    graph: GraphLayers,
+    searches_telemetry: HNSWSearchesTelemetry,
+    is_on_disk: bool,
+}
+
+impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
+    /// Borrow all backing storages and hand a read view to `f`, mirroring
+    /// [`HNSWIndex::with_view`].
+    ///
+    /// [`HNSWIndex::with_view`]: super::super::HNSWIndex::with_view
+    pub fn with_view<R>(
+        &self,
+        f: impl FnOnce(
+            HNSWIndexReadView<
+                '_,
+                ReadOnlyIdTrackerEnum<S>,
+                VectorStorageReadEnum<S>,
+                PayloadStorageEnum,
+                FieldIndex,
+                QuantizedVectorsRead<S>,
+            >,
+        ) -> R,
+    ) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = HNSWIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors: quantized_vectors.as_ref(),
+                payload_index: payload_index_view,
+                config: &self.config,
+                graph: &self.graph,
+                searches_telemetry: &self.searches_telemetry,
+            };
+            f(read_view)
+        })
+    }
+}

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -12,6 +12,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
 
 impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -12,7 +12,6 @@ use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::VectorStorageRead;
 
 impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 
-use super::HNSWIndex;
-use crate::common::operation_error::{OperationError, OperationResult};
+use super::ReadOnlyHNSWIndex;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::{VectorIndex, VectorIndexRead};
+use crate::data_types::vectors::QueryVector;
+use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
 
-impl VectorIndexRead for HNSWIndex {
+impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(
         &self,
         vectors: &[&QueryVector],
@@ -23,6 +23,7 @@ impl VectorIndexRead for HNSWIndex {
         params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        // Reuses the shared search logic implemented on the read view.
         self.with_view(|view| view.search(vectors, filter, top, params, query_context))
     }
 
@@ -66,29 +67,5 @@ impl VectorIndexRead for HNSWIndex {
 
     fn is_index(&self) -> bool {
         true
-    }
-}
-
-impl VectorIndex for HNSWIndex {
-    fn files(&self) -> Vec<PathBuf> {
-        let mut files = self.graph.files(&self.path);
-        let config_path = HnswGraphConfig::get_config_path(&self.path);
-        if config_path.exists() {
-            files.push(config_path);
-        }
-        files
-    }
-
-    fn immutable_files(&self) -> Vec<PathBuf> {
-        self.files() // All HNSW index files are immutable 😎
-    }
-
-    fn update_vector(
-        &mut self,
-        _id: PointOffsetType,
-        _vector: Option<VectorRef>,
-        _hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        Err(OperationError::service_error("Cannot update HNSW index"))
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -53,7 +53,8 @@ impl HNSWIndexReadViewEnum<'_> {
                 // to do a plain search instead.
                 let plain_search = exact
                     || is_hnsw_disabled
-                    || self.vector_storage.available_vector_count() < self.config.full_scan_threshold;
+                    || self.vector_storage.available_vector_count()
+                        < self.config.full_scan_threshold;
 
                 // Do plain or graph search
                 if plain_search {
@@ -138,8 +139,9 @@ impl HNSWIndexReadViewEnum<'_> {
                 // The filter context's lifetime is tied to the payload view, which is already
                 // held by this read view.
                 let use_graph = {
-                    let filter_context =
-                        self.payload_index.filter_context(query_filter, &hw_counter)?;
+                    let filter_context = self
+                        .payload_index
+                        .filter_context(query_filter, &hw_counter)?;
                     sample_check_cardinality(
                         self.id_tracker
                             .sample_ids(Some(self.vector_storage.deleted_vector_bitslice())),

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -1,6 +1,6 @@
 use common::types::ScoredPointOffset;
 
-use super::HNSWIndexReadViewEnum;
+use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
 use crate::data_types::query_context::VectorQueryContext;
@@ -10,9 +10,16 @@ use crate::index::PayloadIndexRead;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::types::{Filter, QuantizationSearchParams, SearchParams};
-use crate::vector_storage::VectorStorageRead;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl HNSWIndexReadViewEnum<'_> {
+impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
+{
     pub(crate) fn search(
         &self,
         vectors: &[&QueryVector],

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -10,14 +10,14 @@ use crate::index::PayloadIndexRead;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::types::{Filter, QuantizationSearchParams, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
 impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
 where
     I: IdTrackerRead,
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
 {
     pub(crate) fn search(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -1,0 +1,166 @@
+use common::types::ScoredPointOffset;
+
+use super::HNSWIndexReadViewEnum;
+use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::ScopeDurationMeasurer;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::QueryVector;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::PayloadIndexRead;
+use crate::index::query_estimator::adjust_to_available_vectors;
+use crate::index::sample_estimation::sample_check_cardinality;
+use crate::types::{Filter, QuantizationSearchParams, SearchParams};
+use crate::vector_storage::VectorStorageRead;
+
+impl HNSWIndexReadViewEnum<'_> {
+    pub(crate) fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        if top == 0 {
+            return Ok(vec![vec![]; vectors.len()]);
+        }
+
+        // If neither `m` nor `payload_m` is set, HNSW doesn't have any links.
+        // And if so, we need to fall back to plain search (optionally, with quantization).
+
+        let is_hnsw_disabled = self.config.m == 0 && self.config.payload_m.unwrap_or(0) == 0;
+        let exact = params.is_some_and(|params| params.exact);
+
+        let exact_params = if exact {
+            params.map(|params| {
+                let mut params = *params;
+                params.quantization = Some(QuantizationSearchParams {
+                    ignore: true,
+                    rescore: Some(false),
+                    oversampling: None,
+                }); // disable quantization for exact search
+                params
+            })
+        } else {
+            None
+        };
+
+        match filter {
+            None => {
+                // Determine whether to do a plain or graph search, and pick search timer aggregator
+                // Because an HNSW graph is built, we'd normally always assume to search the graph.
+                // But because a lot of points may be deleted in this graph, it may just be faster
+                // to do a plain search instead.
+                let plain_search = exact
+                    || is_hnsw_disabled
+                    || self.vector_storage.available_vector_count() < self.config.full_scan_threshold;
+
+                // Do plain or graph search
+                if plain_search {
+                    let _timer = ScopeDurationMeasurer::new(if exact {
+                        &self.searches_telemetry.exact_unfiltered
+                    } else {
+                        &self.searches_telemetry.unfiltered_plain
+                    });
+
+                    let params_ref = if exact { exact_params.as_ref() } else { params };
+                    self.search_plain_unfiltered_batched(vectors, top, params_ref, query_context)
+                } else {
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_hnsw);
+                    self.search_vectors_with_graph(vectors, None, top, params, query_context)
+                }
+            }
+            Some(query_filter) => {
+                // depending on the amount of filtered-out points the optimal strategy could be
+                // - to retrieve possible points and score them after
+                // - to use HNSW index with filtering condition
+
+                // if exact search is requested, we should not use HNSW index
+                if exact || is_hnsw_disabled {
+                    let _timer = ScopeDurationMeasurer::new(if exact {
+                        &self.searches_telemetry.exact_filtered
+                    } else {
+                        &self.searches_telemetry.filtered_plain
+                    });
+
+                    let params_ref = if exact { exact_params.as_ref() } else { params };
+
+                    return self.search_vectors_plain(
+                        vectors,
+                        query_filter,
+                        top,
+                        params_ref,
+                        query_context,
+                    );
+                }
+
+                let available_vector_count = self.vector_storage.available_vector_count();
+
+                let hw_counter = query_context.hardware_counter();
+
+                let query_point_cardinality = self
+                    .payload_index
+                    .estimate_cardinality(query_filter, &hw_counter)?;
+                let query_cardinality = adjust_to_available_vectors(
+                    query_point_cardinality,
+                    available_vector_count,
+                    self.id_tracker.available_point_count(),
+                );
+
+                if query_cardinality.max < self.config.full_scan_threshold {
+                    // if cardinality is small - use plain index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.small_cardinality);
+                    return self.search_vectors_plain(
+                        vectors,
+                        query_filter,
+                        top,
+                        params,
+                        query_context,
+                    );
+                }
+
+                if query_cardinality.min > self.config.full_scan_threshold {
+                    // if cardinality is high enough - use HNSW index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+                    return self.search_vectors_with_graph(
+                        vectors,
+                        filter,
+                        top,
+                        params,
+                        query_context,
+                    );
+                }
+
+                // Fast cardinality estimation is not enough, do sample estimation of cardinality.
+                // The filter context's lifetime is tied to the payload view, which is already
+                // held by this read view.
+                let use_graph = {
+                    let filter_context =
+                        self.payload_index.filter_context(query_filter, &hw_counter)?;
+                    sample_check_cardinality(
+                        self.id_tracker
+                            .sample_ids(Some(self.vector_storage.deleted_vector_bitslice())),
+                        |idx| filter_context.check(idx),
+                        self.config.full_scan_threshold,
+                        available_vector_count, // Check cardinality among available vectors
+                    )
+                };
+
+                if use_graph {
+                    // if cardinality is high enough - use HNSW index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+                    self.search_vectors_with_graph(vectors, filter, top, params, query_context)
+                } else {
+                    // if cardinality is small - use plain index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.small_cardinality);
+                    self.search_vectors_plain(vectors, query_filter, top, params, query_context)
+                }
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -1,0 +1,45 @@
+mod dispatch;
+mod search;
+
+use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::index::hnsw_index::config::HnswGraphConfig;
+use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::payload_storage::PayloadStorageRead;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectors, QuantizedVectorsReadAccess,
+};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+
+pub struct HNSWIndexReadView<
+    'a,
+    I: IdTracker,
+    V: VectorStorageRead,
+    P: PayloadStorageRead,
+    F: FieldIndexRead,
+    Q: QuantizedVectorsReadAccess,
+> {
+    pub(crate) id_tracker: &'a I,
+    pub(crate) vector_storage: &'a V,
+    pub(crate) quantized_vectors: Option<&'a Q>,
+    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) config: &'a HnswGraphConfig,
+    pub(crate) graph: &'a GraphLayers,
+    pub(crate) searches_telemetry: &'a HNSWSearchesTelemetry,
+}
+
+/// Read-only view over an [`HNSWIndex`] backed by the in-memory
+/// [`IdTrackerEnum`] / [`VectorStorageEnum`] / [`PayloadStorageEnum`] enums.
+///
+/// [`HNSWIndex`]: super::super::HNSWIndex
+pub(crate) type HNSWIndexReadViewEnum<'a> = HNSWIndexReadView<
+    'a,
+    IdTrackerEnum,
+    VectorStorageEnum,
+    PayloadStorageEnum,
+    FieldIndex,
+    QuantizedVectors,
+>;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -9,9 +9,7 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::{
-    QuantizedVectors, QuantizedVectorsReadAccess,
-};
+use crate::vector_storage::quantized::quantized_vectors::{QuantizedVectors, QuantizedVectorsRead};
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 /// Read-only view over an HNSW index.
@@ -23,7 +21,7 @@ pub struct HNSWIndexReadView<
     'a,
     I: IdTrackerRead,
     V: VectorStorageRead,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
 > {
     pub(crate) id_tracker: &'a I,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -2,30 +2,34 @@ mod dispatch;
 mod search;
 
 use super::telemetry::HNSWSearchesTelemetry;
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
-use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::PayloadIndexRead;
+use crate::index::field_index::FieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
-use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsReadAccess,
 };
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
+/// Read-only view over an HNSW index.
+///
+/// The top-level id tracker / vector storage / quantized vectors are decoupled
+/// from the payload index view (`P`), so read-only backends can be combined with
+/// a payload index view built over different (e.g. still-mutable) backends.
 pub struct HNSWIndexReadView<
     'a,
-    I: IdTracker,
+    I: IdTrackerRead,
     V: VectorStorageRead,
-    P: PayloadStorageRead,
-    F: FieldIndexRead,
     Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
 > {
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storage: &'a V,
     pub(crate) quantized_vectors: Option<&'a Q>,
-    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) payload_index: P,
     pub(crate) config: &'a HnswGraphConfig,
     pub(crate) graph: &'a GraphLayers,
     pub(crate) searches_telemetry: &'a HNSWSearchesTelemetry,
@@ -39,7 +43,12 @@ pub(crate) type HNSWIndexReadViewEnum<'a> = HNSWIndexReadView<
     'a,
     IdTrackerEnum,
     VectorStorageEnum,
-    PayloadStorageEnum,
-    FieldIndex,
     QuantizedVectors,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
 >;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -17,7 +17,7 @@ use crate::index::vector_index_search_common::{
 };
 use crate::payload_storage::FilterContext;
 use crate::types::{ACORN_MAX_SELECTIVITY_DEFAULT, Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::query::DiscoverQuery;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
@@ -25,7 +25,7 @@ impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
 where
     I: IdTrackerRead,
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
 {
     pub(super) fn search_with_graph(
@@ -365,7 +365,7 @@ fn construct_search_scorer<'a, V, Q>(
 ) -> OperationResult<FilteredScorer<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
 {
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     FilteredScorer::new(
@@ -391,7 +391,7 @@ fn construct_batch_searcher<'a, V, Q>(
 ) -> OperationResult<BatchFilteredSearcher<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
 {
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     BatchFilteredSearcher::new(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cow::BoxCow;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
 
-use super::HNSWIndexReadViewEnum;
+use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
@@ -17,11 +17,17 @@ use crate::index::vector_index_search_common::{
 };
 use crate::payload_storage::FilterContext;
 use crate::types::{ACORN_MAX_SELECTIVITY_DEFAULT, Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
 use crate::vector_storage::query::DiscoverQuery;
-use crate::vector_storage::{VectorStorageEnum, VectorStorageRead, new_raw_scorer};
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl HNSWIndexReadViewEnum<'_> {
+impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
+{
     pub(super) fn search_with_graph(
         &self,
         vector: &QueryVector,
@@ -115,11 +121,9 @@ impl HNSWIndexReadViewEnum<'_> {
             };
 
             // Full vectors are "base vectors"
-            let base_scorer = new_raw_scorer(
-                vector.to_owned(),
-                self.vector_storage,
-                vector_query_context.hardware_counter(),
-            )?;
+            let base_scorer = self
+                .vector_storage
+                .build_raw_scorer(vector.to_owned(), vector_query_context.hardware_counter())?;
             let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
                 return Ok(None);
             };
@@ -350,15 +354,19 @@ impl HNSWIndexReadViewEnum<'_> {
     }
 }
 
-fn construct_search_scorer<'a>(
+fn construct_search_scorer<'a, V, Q>(
     vector: &QueryVector,
-    vector_storage: &'a VectorStorageEnum,
-    quantized_storage: Option<&'a QuantizedVectors>,
+    vector_storage: &'a V,
+    quantized_storage: Option<&'a Q>,
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
     filter_context: Option<Box<dyn FilterContext + 'a>>,
-) -> OperationResult<FilteredScorer<'a>> {
+) -> OperationResult<FilteredScorer<'a>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     FilteredScorer::new(
         vector.to_owned(),
@@ -371,16 +379,20 @@ fn construct_search_scorer<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn construct_batch_searcher<'a>(
+fn construct_batch_searcher<'a, V, Q>(
     vectors: &[&QueryVector],
-    vector_storage: &'a VectorStorageEnum,
-    quantized_storage: Option<&'a QuantizedVectors>,
+    vector_storage: &'a V,
+    quantized_storage: Option<&'a Q>,
     top: usize,
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
     filter_context: Option<Box<dyn FilterContext + 'a>>,
-) -> OperationResult<BatchFilteredSearcher<'a>> {
+) -> OperationResult<BatchFilteredSearcher<'a>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     BatchFilteredSearcher::new(
         vectors,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -65,8 +65,9 @@ impl HNSWIndexReadViewEnum<'_> {
             let selectivity = if available_vector_count == 0 {
                 1.0
             } else {
-                let query_point_cardinality =
-                    self.payload_index.estimate_cardinality(filter, &hw_counter)?;
+                let query_point_cardinality = self
+                    .payload_index
+                    .estimate_cardinality(filter, &hw_counter)?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
@@ -288,7 +289,9 @@ impl HNSWIndexReadViewEnum<'_> {
         let is_stopped = &vector_query_context.is_stopped();
 
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-        let query_cardinality = self.payload_index.estimate_cardinality(filter, hw_counter)?;
+        let query_cardinality = self
+            .payload_index
+            .estimate_cardinality(filter, hw_counter)?;
         let filtered_points: Vec<PointOffsetType> = self
             .payload_index
             .iter_filtered_points(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cow::BoxCow;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
 
-use super::HNSWIndex;
+use super::HNSWIndexReadViewEnum;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
@@ -21,7 +21,7 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::DiscoverQuery;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead, new_raw_scorer};
 
-impl HNSWIndex {
+impl HNSWIndexReadViewEnum<'_> {
     pub(super) fn search_with_graph(
         &self,
         vector: &QueryVector,
@@ -44,17 +44,12 @@ impl HNSWIndex {
 
         let is_stopped = vector_query_context.is_stopped();
 
-        let id_tracker = self.id_tracker.borrow();
-        let payload_index = self.payload_index.borrow();
-        let vector_storage = self.vector_storage.borrow();
-        let quantized_vectors = self.quantized_vectors.borrow();
-
         let deleted_points = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
 
         let hw_counter = vector_query_context.hardware_counter();
-        let oversampled_top = get_oversampled_top(quantized_vectors.as_ref(), params, top);
+        let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
 
         let mut algorithm = SearchAlgorithm::Hnsw;
         if acorn_enabled
@@ -66,16 +61,16 @@ impl HNSWIndex {
             // practice, such segments most likely to be picked by an optimizer
             // soon.
 
-            let available_vector_count = vector_storage.available_vector_count();
+            let available_vector_count = self.vector_storage.available_vector_count();
             let selectivity = if available_vector_count == 0 {
                 1.0
             } else {
                 let query_point_cardinality =
-                    payload_index.with_view(|v| v.estimate_cardinality(filter, &hw_counter))?;
+                    self.payload_index.estimate_cardinality(filter, &hw_counter)?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
-                    id_tracker.available_point_count(),
+                    self.id_tracker.available_point_count(),
                 );
                 query_cardinality.exp as f64 / available_vector_count as f64
             };
@@ -91,91 +86,87 @@ impl HNSWIndex {
                 SearchAlgorithm::Acorn => return Ok(None),
             }
             if !self.graph.has_inline_vectors()
-                || !is_quantized_search(quantized_vectors.as_ref(), params)
+                || !is_quantized_search(self.quantized_vectors, params)
             {
                 return Ok(None);
             }
-            let Some(quantized_vectors) = quantized_vectors.as_ref() else {
+            let Some(quantized_vectors) = self.quantized_vectors else {
                 return Ok(None);
             };
 
-            payload_index.with_view(|payload_index_view| {
-                // Quantized vectors are "link vectors"
-                let link_scorer_filtered = FilteredScorer::new(
-                    vector.to_owned(),
-                    &vector_storage,
-                    Some(quantized_vectors),
-                    filter
-                        .map(|f| {
-                            payload_index_view
-                                .filter_context(f, &hw_counter)
-                                .map(BoxCow::Owned)
-                        })
-                        .transpose()?,
-                    deleted_points,
-                    vector_query_context.hardware_counter(),
-                )?;
-                let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
-                    return Ok(None);
-                };
+            // Quantized vectors are "link vectors"
+            let link_scorer_filtered = FilteredScorer::new(
+                vector.to_owned(),
+                self.vector_storage,
+                Some(quantized_vectors),
+                filter
+                    .map(|f| {
+                        self.payload_index
+                            .filter_context(f, &hw_counter)
+                            .map(BoxCow::Owned)
+                    })
+                    .transpose()?,
+                deleted_points,
+                vector_query_context.hardware_counter(),
+            )?;
+            let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
+                return Ok(None);
+            };
 
-                // Full vectors are "base vectors"
-                let base_scorer = new_raw_scorer(
-                    vector.to_owned(),
-                    &vector_storage,
-                    vector_query_context.hardware_counter(),
-                )?;
-                let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
-                    return Ok(None);
-                };
+            // Full vectors are "base vectors"
+            let base_scorer = new_raw_scorer(
+                vector.to_owned(),
+                self.vector_storage,
+                vector_query_context.hardware_counter(),
+            )?;
+            let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
+                return Ok(None);
+            };
 
-                Ok(Some(self.graph.search_with_vectors(
-                    top,
-                    std::cmp::max(ef, oversampled_top),
-                    &link_scorer_filtered,
-                    &link_scorer_filtered_bytes,
-                    base_scorer_bytes,
-                    custom_entry_points,
-                    &vector_query_context.is_stopped(),
-                )?))
-            })
+            Ok(Some(self.graph.search_with_vectors(
+                top,
+                std::cmp::max(ef, oversampled_top),
+                &link_scorer_filtered,
+                &link_scorer_filtered_bytes,
+                base_scorer_bytes,
+                custom_entry_points,
+                &vector_query_context.is_stopped(),
+            )?))
         };
 
         let regular_search = || -> OperationResult<Vec<ScoredPointOffset>> {
-            payload_index.with_view(|payload_index_view| {
-                let filter_context = filter
-                    .map(|f| payload_index_view.filter_context(f, &hw_counter))
-                    .transpose()?;
-                let points_scorer = construct_search_scorer(
-                    vector,
-                    &vector_storage,
-                    quantized_vectors.as_ref(),
-                    deleted_points,
-                    params,
-                    vector_query_context.hardware_counter(),
-                    filter_context,
-                )?;
+            let filter_context = filter
+                .map(|f| self.payload_index.filter_context(f, &hw_counter))
+                .transpose()?;
+            let points_scorer = construct_search_scorer(
+                vector,
+                self.vector_storage,
+                self.quantized_vectors,
+                deleted_points,
+                params,
+                vector_query_context.hardware_counter(),
+                filter_context,
+            )?;
 
-                let search_result = self.graph.search(
-                    oversampled_top,
-                    ef,
-                    algorithm,
-                    points_scorer,
-                    custom_entry_points,
-                    &is_stopped,
-                )?;
+            let search_result = self.graph.search(
+                oversampled_top,
+                ef,
+                algorithm,
+                points_scorer,
+                custom_entry_points,
+                &is_stopped,
+            )?;
 
-                postprocess_search_result(
-                    search_result,
-                    id_tracker.deleted_point_bitslice(),
-                    &vector_storage,
-                    quantized_vectors.as_ref(),
-                    vector,
-                    params,
-                    top,
-                    vector_query_context.hardware_counter(),
-                )
-            })
+            postprocess_search_result(
+                search_result,
+                self.id_tracker.deleted_point_bitslice(),
+                self.vector_storage,
+                self.quantized_vectors,
+                vector,
+                params,
+                top,
+                vector_query_context.hardware_counter(),
+            )
         };
 
         // Try to use graph with vectors first.
@@ -224,21 +215,17 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let id_tracker = self.id_tracker.borrow();
-        let vector_storage = self.vector_storage.borrow();
-        let quantized_vectors = self.quantized_vectors.borrow();
-
         let deleted_points = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
 
         let is_stopped = vector_query_context.is_stopped();
-        let oversampled_top = get_oversampled_top(quantized_vectors.as_ref(), params, top);
+        let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
 
         let batch_filtered_searcher = construct_batch_searcher(
             query_vectors,
-            &vector_storage,
-            quantized_vectors.as_ref(),
+            self.vector_storage,
+            self.quantized_vectors,
             oversampled_top,
             deleted_points,
             params,
@@ -249,9 +236,9 @@ impl HNSWIndex {
         for (search_result, query_vector) in search_results.iter_mut().zip(query_vectors) {
             *search_result = postprocess_search_result(
                 std::mem::take(search_result),
-                id_tracker.deleted_point_bitslice(),
-                &vector_storage,
-                quantized_vectors.as_ref(),
+                self.id_tracker.deleted_point_bitslice(),
+                self.vector_storage,
+                self.quantized_vectors,
                 query_vector,
                 params,
                 top,
@@ -285,8 +272,7 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let id_tracker = self.id_tracker.borrow();
-        let ids_iterator = id_tracker.point_mappings().iter_internal();
+        let ids_iterator = self.id_tracker.point_mappings().iter_internal();
         self.search_plain_iterator_batched(vectors, ids_iterator, top, params, vector_query_context)
     }
 
@@ -301,11 +287,11 @@ impl HNSWIndex {
         let hw_counter = &vector_query_context.hardware_counter();
         let is_stopped = &vector_query_context.is_stopped();
 
-        let payload_index = self.payload_index.borrow();
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-        let filtered_points: Vec<PointOffsetType> = payload_index.with_view(|v| {
-            let query_cardinality = v.estimate_cardinality(filter, hw_counter)?;
-            v.iter_filtered_points(
+        let query_cardinality = self.payload_index.estimate_cardinality(filter, hw_counter)?;
+        let filtered_points: Vec<PointOffsetType> = self
+            .payload_index
+            .iter_filtered_points(
                 filter,
                 &query_cardinality,
                 hw_counter,
@@ -313,8 +299,7 @@ impl HNSWIndex {
                 // No deferred filtering here since it's HNSW index.
                 DeferredBehavior::WithDeferred,
             )
-            .map(|it| it.collect())
-        })?;
+            .map(|it| it.collect())?;
         self.search_plain_batched(
             vectors,
             filtered_points.into_iter(),

--- a/lib/segment/src/index/hnsw_index/hnsw/telemetry.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/telemetry.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 
 #[derive(Debug)]
-pub(super) struct HNSWSearchesTelemetry {
+pub(crate) struct HNSWSearchesTelemetry {
     pub(super) unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     pub(super) filtered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     pub(super) unfiltered_hnsw: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
@@ -13,6 +13,7 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::{VectorIndex, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
 
 impl VectorIndexRead for HNSWIndex {
     fn search(

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -13,7 +13,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::payload_storage::FilterContext;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
     RawScorer, RawScorerBuilder, VectorStorageRead, check_deleted_condition,
@@ -127,7 +127,7 @@ impl<'a> FilteredScorer<'a> {
     ) -> OperationResult<Self>
     where
         V: VectorStorageRead + RawScorerBuilder,
-        Q: QuantizedVectorsReadAccess,
+        Q: QuantizedVectorsRead,
     {
         let raw_scorer = match quantized_vectors {
             Some(quantized_vectors) => quantized_vectors.raw_scorer(query, hardware_counter)?,
@@ -154,7 +154,7 @@ impl<'a> FilteredScorer<'a> {
     ) -> OperationResult<Self>
     where
         V: VectorStorageRead + RawScorerBuilder,
-        Q: QuantizedVectorsReadAccess,
+        Q: QuantizedVectorsRead,
     {
         // This is a fallback function, which is used if quantized vector storage
         // is not capable of reconstructing the query vector.
@@ -296,7 +296,7 @@ impl<'a> BatchFilteredSearcher<'a> {
     ) -> OperationResult<Self>
     where
         V: VectorStorageRead + RawScorerBuilder,
-        Q: QuantizedVectorsReadAccess,
+        Q: QuantizedVectorsRead,
     {
         let scorer_batch = queries
             .iter()

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -13,11 +13,13 @@ use crate::data_types::vectors::QueryVector;
 use crate::payload_storage::FilterContext;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
-    RawScorer, VectorStorageEnum, VectorStorageRead, check_deleted_condition, new_raw_scorer,
+    RawScorer, RawScorerBuilder, VectorStorageRead, check_deleted_condition,
 };
+#[cfg(feature = "testing")]
+use crate::vector_storage::{VectorStorageEnum, new_raw_scorer};
 
 /// Scorers composition:
 ///
@@ -115,17 +117,21 @@ impl<'a> FilteredScorer<'a> {
     /// Create a new filtered scorer.
     ///
     /// If present, `quantized_vectors` will be used for scoring, otherwise `vectors` will be used.
-    pub fn new(
+    pub fn new<V, Q>(
         query: QueryVector,
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         let raw_scorer = match quantized_vectors {
             Some(quantized_vectors) => quantized_vectors.raw_scorer(query, hardware_counter)?,
-            None => new_raw_scorer(query, vectors, hardware_counter)?,
+            None => vectors.build_raw_scorer(query, hardware_counter)?,
         };
         Ok(FilteredScorer {
             raw_scorer,
@@ -138,14 +144,18 @@ impl<'a> FilteredScorer<'a> {
         })
     }
 
-    pub fn new_internal(
+    pub fn new_internal<V, Q>(
         point_id: PointOffsetType,
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         // This is a fallback function, which is used if quantized vector storage
         // is not capable of reconstructing the query vector.
         let original_query_fn = || {
@@ -161,7 +171,7 @@ impl<'a> FilteredScorer<'a> {
                 })?,
             None => {
                 let query = original_query_fn();
-                new_raw_scorer(query, vectors, hardware_counter)?
+                vectors.build_raw_scorer(query, hardware_counter)?
             }
         };
         Ok(FilteredScorer {
@@ -275,15 +285,19 @@ impl<'a> BatchFilteredSearcher<'a> {
     /// Create a new batch filtered searcher.
     ///
     /// If present, `quantized_vectors` will be used for scoring, otherwise `vectors` will be used.
-    pub fn new(
+    pub fn new<V, Q>(
         queries: &[&QueryVector],
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         top: usize,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         let scorer_batch = queries
             .iter()
             .map(|&query| {
@@ -293,7 +307,7 @@ impl<'a> BatchFilteredSearcher<'a> {
                     Some(quantized_vectors) => {
                         quantized_vectors.raw_scorer(query, hardware_counter)
                     }
-                    None => new_raw_scorer(query, vectors, hardware_counter),
+                    None => vectors.build_raw_scorer(query, hardware_counter),
                 };
                 let pq = FixedLengthPriorityQueue::new(top);
                 raw_scorer.map(|raw_scorer| BatchSearch { raw_scorer, pq })

--- a/lib/segment/src/index/plain_vector_index/lifecycle.rs
+++ b/lib/segment/src/index/plain_vector_index/lifecycle.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+
+use super::PlainVectorIndex;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::vectors::VectorRef;
+use crate::index::VectorIndex;
+use crate::vector_storage::{VectorStorage, VectorStorageRead};
+
+impl VectorIndex for PlainVectorIndex {
+    fn files(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn update_vector(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<VectorRef>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let mut vector_storage = self.vector_storage.borrow_mut();
+
+        if let Some(vector) = vector {
+            vector_storage.insert_vector(id, vector, hw_counter)?;
+
+            let mut quantized_vectors = self.quantized_vectors.borrow_mut();
+            if let Some(quantized_vectors) = quantized_vectors.as_mut() {
+                quantized_vectors.upsert_vector(id, vector, hw_counter)?;
+            }
+        } else {
+            if id as usize >= vector_storage.total_vector_count() {
+                debug_assert!(id as usize == vector_storage.total_vector_count());
+                // Vector doesn't exist in the storage
+                // Insert default vector to keep the sequence
+                let default_vector = vector_storage.default_vector();
+                vector_storage.insert_vector(id, VectorRef::from(&default_vector), hw_counter)?;
+            }
+            vector_storage.delete_vector(id)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/plain_vector_index/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/mod.rs
@@ -1,0 +1,41 @@
+mod lifecycle;
+mod read;
+
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use parking_lot::Mutex;
+
+use crate::common::operation_time_statistics::OperationDurationsAggregator;
+use crate::id_tracker::IdTrackerEnum;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::vector_storage::VectorStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+
+#[derive(Debug)]
+pub struct PlainVectorIndex {
+    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+    unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+impl PlainVectorIndex {
+    pub fn new(
+        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
+        quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    ) -> PlainVectorIndex {
+        PlainVectorIndex {
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            payload_index,
+            filtered_searches_telemetry: OperationDurationsAggregator::new(),
+            unfiltered_searches_telemetry: OperationDurationsAggregator::new(),
+        }
+    }
+}

--- a/lib/segment/src/index/plain_vector_index/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/mod.rs
@@ -12,10 +12,10 @@ use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 use crate::id_tracker::IdTrackerEnum;
-use crate::index::field_index::FieldIndex;
-use crate::index::plain_vector_index::read_view::PlainVectorIndexReadView;
+use crate::index::plain_vector_index::read_view::{
+    PlainVectorIndexReadView, PlainVectorIndexReadViewEnum,
+};
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
@@ -46,19 +46,7 @@ impl PlainVectorIndex {
         }
     }
 
-    pub fn with_view<R>(
-        &self,
-        f: impl FnOnce(
-            PlainVectorIndexReadView<
-                '_,
-                IdTrackerEnum,
-                VectorStorageEnum,
-                PayloadStorageEnum,
-                FieldIndex,
-                QuantizedVectors,
-            >,
-        ) -> R,
-    ) -> R {
+    pub fn with_view<R>(&self, f: impl FnOnce(PlainVectorIndexReadViewEnum<'_>) -> R) -> R {
         let payload_index = self.payload_index.borrow();
         let id_tracker = self.id_tracker.borrow();
         let vector_storage = self.vector_storage.borrow();

--- a/lib/segment/src/index/plain_vector_index/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/mod.rs
@@ -1,6 +1,10 @@
 mod lifecycle;
 mod read;
 
+#[allow(dead_code)]
+mod read_only;
+mod read_view;
+
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -8,7 +12,10 @@ use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 use crate::id_tracker::IdTrackerEnum;
+use crate::index::field_index::FieldIndex;
+use crate::index::plain_vector_index::read_view::PlainVectorIndexReadView;
 use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
@@ -37,5 +44,37 @@ impl PlainVectorIndex {
             filtered_searches_telemetry: OperationDurationsAggregator::new(),
             unfiltered_searches_telemetry: OperationDurationsAggregator::new(),
         }
+    }
+
+    pub fn with_view<R>(
+        &self,
+        f: impl FnOnce(
+            PlainVectorIndexReadView<
+                '_,
+                IdTrackerEnum,
+                VectorStorageEnum,
+                PayloadStorageEnum,
+                FieldIndex,
+            >,
+        ) -> R,
+    ) -> R {
+        let payload_index = self.payload_index.borrow();
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.clone();
+        let filtered_searches_telemetry = self.filtered_searches_telemetry.clone();
+        let unfiltered_searches_telemetry = self.unfiltered_searches_telemetry.clone();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = PlainVectorIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors,
+                payload_index: payload_index_view,
+                filtered_searches_telemetry,
+                unfiltered_searches_telemetry,
+            };
+            f(read_view)
+        })
     }
 }

--- a/lib/segment/src/index/plain_vector_index/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/mod.rs
@@ -55,13 +55,14 @@ impl PlainVectorIndex {
                 VectorStorageEnum,
                 PayloadStorageEnum,
                 FieldIndex,
+                QuantizedVectors,
             >,
         ) -> R,
     ) -> R {
         let payload_index = self.payload_index.borrow();
         let id_tracker = self.id_tracker.borrow();
         let vector_storage = self.vector_storage.borrow();
-        let quantized_vectors = self.quantized_vectors.clone();
+        let quantized_vectors = self.quantized_vectors.borrow();
         let filtered_searches_telemetry = self.filtered_searches_telemetry.clone();
         let unfiltered_searches_telemetry = self.unfiltered_searches_telemetry.clone();
 
@@ -69,7 +70,7 @@ impl PlainVectorIndex {
             let read_view = PlainVectorIndexReadView {
                 id_tracker: &*id_tracker,
                 vector_storage: &*vector_storage,
-                quantized_vectors,
+                quantized_vectors: quantized_vectors.as_ref(),
                 payload_index: payload_index_view,
                 filtered_searches_telemetry,
                 unfiltered_searches_telemetry,

--- a/lib/segment/src/index/plain_vector_index/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read.rs
@@ -12,6 +12,7 @@ use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
 
 impl PlainVectorIndex {
     pub fn is_small_enough_for_unindexed_search(

--- a/lib/segment/src/index/plain_vector_index/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read.rs
@@ -6,6 +6,7 @@ use sparse::common::types::DimId;
 
 use super::PlainVectorIndex;
 use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::OperationDurationStatistics;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
@@ -42,26 +43,46 @@ impl VectorIndexRead for PlainVectorIndex {
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        self.with_view(|view| view.get_telemetry_data(detail))
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: self
+                .unfiltered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            filtered_plain: self
+                .filtered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            unfiltered_hnsw: OperationDurationStatistics::default(),
+            filtered_small_cardinality: OperationDurationStatistics::default(),
+            filtered_large_cardinality: OperationDurationStatistics::default(),
+            filtered_exact: OperationDurationStatistics::default(),
+            filtered_sparse: Default::default(),
+            unfiltered_exact: OperationDurationStatistics::default(),
+            unfiltered_sparse: OperationDurationStatistics::default(),
+        }
     }
 
     fn indexed_vector_count(&self) -> usize {
-        self.with_view(|view| view.indexed_vector_count())
+        0
     }
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        self.with_view(|view| view.size_of_searchable_vectors_in_bytes())
+        self.vector_storage
+            .borrow()
+            .size_of_available_vectors_in_bytes()
     }
 
     fn fill_idf_statistics(
         &self,
-        idf: &mut HashMap<DimId, usize>,
-        hw_counter: &HardwareCounterCell,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
+        // Plain (dense) index doesn't track IDF.
+        Ok(())
     }
 
     fn is_index(&self) -> bool {
-        self.with_view(|view| view.is_index())
+        false
     }
 }

--- a/lib/segment/src/index/plain_vector_index/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read.rs
@@ -1,59 +1,28 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset, TelemetryDetail};
-use parking_lot::Mutex;
+use common::types::{DeferredBehavior, ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 
-use super::hnsw_index::point_scorer::BatchFilteredSearcher;
+use super::PlainVectorIndex;
 use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::{
-    OperationDurationStatistics, OperationDurationsAggregator, ScopeDurationMeasurer,
+    OperationDurationStatistics, ScopeDurationMeasurer,
 };
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
-use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::data_types::vectors::QueryVector;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
-use crate::index::{PayloadIndexRead, VectorIndex, VectorIndexRead};
+use crate::index::{PayloadIndexRead, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
-
-#[derive(Debug)]
-pub struct PlainVectorIndex {
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
-    unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
-}
+use crate::vector_storage::VectorStorageRead;
 
 impl PlainVectorIndex {
-    pub fn new(
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-        quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
-        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    ) -> PlainVectorIndex {
-        PlainVectorIndex {
-            id_tracker,
-            vector_storage,
-            quantized_vectors,
-            payload_index,
-            filtered_searches_telemetry: OperationDurationsAggregator::new(),
-            unfiltered_searches_telemetry: OperationDurationsAggregator::new(),
-        }
-    }
-
     pub fn is_small_enough_for_unindexed_search(
         &self,
         search_optimized_threshold_kb: usize,
@@ -211,40 +180,5 @@ impl VectorIndexRead for PlainVectorIndex {
 
     fn is_index(&self) -> bool {
         false
-    }
-}
-
-impl VectorIndex for PlainVectorIndex {
-    fn files(&self) -> Vec<PathBuf> {
-        vec![]
-    }
-
-    fn update_vector(
-        &mut self,
-        id: PointOffsetType,
-        vector: Option<VectorRef>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        let mut vector_storage = self.vector_storage.borrow_mut();
-
-        if let Some(vector) = vector {
-            vector_storage.insert_vector(id, vector, hw_counter)?;
-
-            let mut quantized_vectors = self.quantized_vectors.borrow_mut();
-            if let Some(quantized_vectors) = quantized_vectors.as_mut() {
-                quantized_vectors.upsert_vector(id, vector, hw_counter)?;
-            }
-        } else {
-            if id as usize >= vector_storage.total_vector_count() {
-                debug_assert!(id as usize == vector_storage.total_vector_count());
-                // Vector doesn't exist in the storage
-                // Insert default vector to keep the sequence
-                let default_vector = vector_storage.default_vector();
-                vector_storage.insert_vector(id, VectorRef::from(&default_vector), hw_counter)?;
-            }
-            vector_storage.delete_vector(id)?;
-        }
-
-        Ok(())
     }
 }

--- a/lib/segment/src/index/plain_vector_index/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read.rs
@@ -1,26 +1,16 @@
 use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, ScoredPointOffset, TelemetryDetail};
+use common::types::{ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 
 use super::PlainVectorIndex;
-use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
-use crate::common::operation_time_statistics::{
-    OperationDurationStatistics, ScopeDurationMeasurer,
-};
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
-use crate::id_tracker::IdTrackerRead;
-use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
-use crate::index::vector_index_search_common::{
-    get_oversampled_top, is_quantized_search, postprocess_search_result,
-};
-use crate::index::{PayloadIndexRead, VectorIndexRead};
+use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::VectorStorageRead;
 
 impl PlainVectorIndex {
     pub fn is_small_enough_for_unindexed_search(
@@ -29,27 +19,13 @@ impl PlainVectorIndex {
         filter: Option<&Filter>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool> {
-        let vector_storage = self.vector_storage.borrow();
-        let available_vector_count = vector_storage.available_vector_count();
-        if available_vector_count == 0 {
-            return Ok(true);
-        }
-
-        let vector_size_bytes =
-            vector_storage.size_of_available_vectors_in_bytes() / available_vector_count;
-        let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
-
-        if let Some(payload_filter) = filter {
-            let cardinality = self
-                .payload_index
-                .borrow()
-                .with_view(|v| v.estimate_cardinality(payload_filter, hw_counter))?;
-            let scan_size = vector_size_bytes.saturating_mul(cardinality.max);
-            Ok(scan_size <= indexing_threshold_bytes)
-        } else {
-            let vector_storage_size = vector_size_bytes.saturating_mul(available_vector_count);
-            Ok(vector_storage_size <= indexing_threshold_bytes)
-        }
+        self.with_view(|view| {
+            view.is_small_enough_for_unindexed_search(
+                search_optimized_threshold_kb,
+                filter,
+                hw_counter,
+            )
+        })
     }
 }
 
@@ -62,123 +38,30 @@ impl VectorIndexRead for PlainVectorIndex {
         params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let is_indexed_only = params.is_some_and(|p| p.indexed_only);
-        if is_indexed_only
-            && !self.is_small_enough_for_unindexed_search(
-                query_context.search_optimized_threshold_kb(),
-                filter,
-                &query_context.hardware_counter(),
-            )?
-        {
-            return Ok(vec![vec![]; query_vectors.len()]);
-        }
-        if top == 0 {
-            return Ok(vec![vec![]; query_vectors.len()]);
-        }
-
-        let is_stopped = query_context.is_stopped();
-
-        let hw_counter = query_context.hardware_counter();
-
-        let _timer = ScopeDurationMeasurer::new(if filter.is_some() {
-            &self.filtered_searches_telemetry
-        } else {
-            &self.unfiltered_searches_telemetry
-        });
-        let vector_storage = self.vector_storage.borrow();
-        let quantized_storage = self.quantized_vectors.borrow();
-        let id_tracker = self.id_tracker.borrow();
-        let deleted_points = query_context
-            .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
-        let quantization_enabled = is_quantized_search(quantized_storage.as_ref(), params);
-        let quantized_vectors = quantization_enabled
-            .then_some(quantized_storage.as_ref())
-            .flatten();
-        let oversampled_top = get_oversampled_top(quantized_storage.as_ref(), params, top);
-        let batch_searcher = BatchFilteredSearcher::new(
-            query_vectors,
-            &vector_storage,
-            quantized_vectors,
-            None,
-            oversampled_top,
-            deleted_points,
-            query_context.hardware_counter(),
-        )?;
-
-        let mut search_results = match filter {
-            Some(filter) => {
-                let filtered_ids_vec = self
-                    .payload_index
-                    .borrow()
-                    .with_view(|v| v.query_points(filter, &hw_counter, &is_stopped))?;
-                batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
-            }
-            None => {
-                let iter = id_tracker.point_mappings().filter_deferred_and_deleted(
-                    batch_searcher.iter_not_deleted(),
-                    DeferredBehavior::VisibleOnly,
-                );
-                batch_searcher.peek_top_iter(iter, &is_stopped)?
-            }
-        };
-
-        for (search_result, query_vector) in search_results.iter_mut().zip(query_vectors) {
-            *search_result = postprocess_search_result(
-                std::mem::take(search_result),
-                deleted_points,
-                &vector_storage,
-                quantized_storage.as_ref(),
-                query_vector,
-                params,
-                top,
-                query_context.hardware_counter(),
-            )?;
-        }
-        Ok(search_results)
+        self.with_view(|view| view.search(query_vectors, filter, top, params, query_context))
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        VectorIndexSearchesTelemetry {
-            index_name: None,
-            unfiltered_plain: self
-                .unfiltered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            filtered_plain: self
-                .filtered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            unfiltered_hnsw: OperationDurationStatistics::default(),
-            filtered_small_cardinality: OperationDurationStatistics::default(),
-            filtered_large_cardinality: OperationDurationStatistics::default(),
-            filtered_exact: OperationDurationStatistics::default(),
-            filtered_sparse: Default::default(),
-            unfiltered_exact: OperationDurationStatistics::default(),
-            unfiltered_sparse: OperationDurationStatistics::default(),
-        }
+        self.with_view(|view| view.get_telemetry_data(detail))
     }
 
     fn indexed_vector_count(&self) -> usize {
-        0
+        self.with_view(|view| view.indexed_vector_count())
     }
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        self.vector_storage
-            .borrow()
-            .size_of_available_vectors_in_bytes()
+        self.with_view(|view| view.size_of_searchable_vectors_in_bytes())
     }
 
     fn fill_idf_statistics(
         &self,
-        _idf: &mut HashMap<DimId, usize>,
-        _hw_counter: &HardwareCounterCell,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // Plain (dense) index doesn't track IDF.
-        Ok(())
+        self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
     }
 
     fn is_index(&self) -> bool {
-        false
+        self.with_view(|view| view.is_index())
     }
 }

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -7,13 +7,13 @@ use parking_lot::Mutex;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
-    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectorsRead<S>>>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -12,13 +12,13 @@ use crate::index::plain_vector_index::read_view::PlainVectorIndexReadView;
 use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::VectorStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
+use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
-    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectorsRead<S>>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
@@ -27,13 +27,13 @@ pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
 /// Read-only view over a [`ReadOnlyPlainVectorIndex`].
 ///
 /// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
-/// [`VectorStorageReadEnum`] / [`QuantizedVectorsRead`]), while the payload
+/// [`VectorStorageReadEnum`] / [`ReadOnlyQuantizedVectors`]), while the payload
 /// index view is still built over the in-memory enums of [`StructPayloadIndex`].
 type ReadView<'a, S> = PlainVectorIndexReadView<
     'a,
     ReadOnlyIdTrackerEnum<S>,
     VectorStorageReadEnum<S>,
-    QuantizedVectorsRead<S>,
+    ReadOnlyQuantizedVectors<S>,
     StructPayloadIndexReadView<
         'a,
         PayloadStorageEnum,

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -5,8 +5,13 @@ use common::universal_io::UniversalRead;
 use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
+use crate::id_tracker::IdTrackerEnum;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
-use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::field_index::FieldIndex;
+use crate::index::plain_vector_index::read_view::PlainVectorIndexReadView;
+use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
@@ -17,4 +22,46 @@ pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+/// Read-only view over a [`ReadOnlyPlainVectorIndex`].
+///
+/// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
+/// [`VectorStorageReadEnum`] / [`QuantizedVectorsRead`]), while the payload
+/// index view is still built over the in-memory enums of [`StructPayloadIndex`].
+type ReadView<'a, S> = PlainVectorIndexReadView<
+    'a,
+    ReadOnlyIdTrackerEnum<S>,
+    VectorStorageReadEnum<S>,
+    QuantizedVectorsRead<S>,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
+>;
+
+impl<S: UniversalRead> ReadOnlyPlainVectorIndex<S> {
+    pub fn with_view<R>(&self, f: impl FnOnce(ReadView<'_, S>) -> R) -> R {
+        let payload_index = self.payload_index.borrow();
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.borrow();
+        let filtered_searches_telemetry = self.filtered_searches_telemetry.clone();
+        let unfiltered_searches_telemetry = self.unfiltered_searches_telemetry.clone();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = PlainVectorIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors: quantized_vectors.as_ref(),
+                payload_index: payload_index_view,
+                filtered_searches_telemetry,
+                unfiltered_searches_telemetry,
+            };
+            f(read_view)
+        })
+    }
 }

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+use parking_lot::Mutex;
+
+use crate::common::operation_time_statistics::OperationDurationsAggregator;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
+    id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+    unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}

--- a/lib/segment/src/index/plain_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/mod.rs
@@ -10,9 +10,7 @@ use crate::index::PayloadIndexRead;
 use crate::index::field_index::FieldIndex;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::{
-    QuantizedVectors, QuantizedVectorsReadAccess,
-};
+use crate::vector_storage::quantized::quantized_vectors::{QuantizedVectors, QuantizedVectorsRead};
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 /// Read-only view over a plain vector index.
@@ -24,7 +22,7 @@ pub struct PlainVectorIndexReadView<
     'a,
     I: IdTrackerRead,
     V: VectorStorageRead,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
 > {
     pub(crate) id_tracker: &'a I,

--- a/lib/segment/src/index/plain_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/mod.rs
@@ -1,4 +1,4 @@
-mod vector_index_read;
+mod search;
 
 use std::sync::Arc;
 

--- a/lib/segment/src/index/plain_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/mod.rs
@@ -2,7 +2,6 @@ mod search;
 
 use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
 use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
@@ -11,7 +10,9 @@ use crate::index::field_index::{FieldIndex, FieldIndexRead};
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectors, QuantizedVectorsReadAccess,
+};
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 pub struct PlainVectorIndexReadView<
@@ -20,10 +21,11 @@ pub struct PlainVectorIndexReadView<
     V: VectorStorageRead,
     P: PayloadStorageRead,
     F: FieldIndexRead,
+    Q: QuantizedVectorsReadAccess,
 > {
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storage: &'a V,
-    pub(crate) quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>, // ToDo: make reference to generic, once available
+    pub(crate) quantized_vectors: Option<&'a Q>,
     pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
     pub(crate) filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     pub(crate) unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
@@ -33,5 +35,11 @@ pub struct PlainVectorIndexReadView<
 /// [`IdTrackerEnum`] / [`VectorStorageEnum`] / [`PayloadStorageEnum`] enums.
 ///
 /// [`PlainVectorIndex`]: super::PlainVectorIndex
-pub(crate) type PlainVectorIndexReadViewEnum<'a> =
-    PlainVectorIndexReadView<'a, IdTrackerEnum, VectorStorageEnum, PayloadStorageEnum, FieldIndex>;
+pub(crate) type PlainVectorIndexReadViewEnum<'a> = PlainVectorIndexReadView<
+    'a,
+    IdTrackerEnum,
+    VectorStorageEnum,
+    PayloadStorageEnum,
+    FieldIndex,
+    QuantizedVectors,
+>;

--- a/lib/segment/src/index/plain_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/mod.rs
@@ -5,28 +5,32 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
-use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::PayloadIndexRead;
+use crate::index::field_index::FieldIndex;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
-use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsReadAccess,
 };
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
+/// Read-only view over a plain vector index.
+///
+/// The top-level id tracker / vector storage / quantized vectors are decoupled
+/// from the payload index view (`P`), so read-only backends can be combined with
+/// a payload index view built over different (e.g. still-mutable) backends.
 pub struct PlainVectorIndexReadView<
     'a,
-    I: IdTracker,
+    I: IdTrackerRead,
     V: VectorStorageRead,
-    P: PayloadStorageRead,
-    F: FieldIndexRead,
     Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
 > {
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storage: &'a V,
     pub(crate) quantized_vectors: Option<&'a Q>,
-    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) payload_index: P,
     pub(crate) filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
     pub(crate) unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
 }
@@ -39,7 +43,12 @@ pub(crate) type PlainVectorIndexReadViewEnum<'a> = PlainVectorIndexReadView<
     'a,
     IdTrackerEnum,
     VectorStorageEnum,
-    PayloadStorageEnum,
-    FieldIndex,
     QuantizedVectors,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
 >;

--- a/lib/segment/src/index/plain_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/mod.rs
@@ -1,0 +1,37 @@
+mod vector_index_read;
+
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use parking_lot::Mutex;
+
+use crate::common::operation_time_statistics::OperationDurationsAggregator;
+use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::payload_storage::PayloadStorageRead;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+
+pub struct PlainVectorIndexReadView<
+    'a,
+    I: IdTracker,
+    V: VectorStorageRead,
+    P: PayloadStorageRead,
+    F: FieldIndexRead,
+> {
+    pub(crate) id_tracker: &'a I,
+    pub(crate) vector_storage: &'a V,
+    pub(crate) quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>, // ToDo: make reference to generic, once available
+    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) filtered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+    pub(crate) unfiltered_searches_telemetry: Arc<Mutex<OperationDurationsAggregator>>,
+}
+
+/// Read-only view over a [`PlainVectorIndex`] backed by the in-memory
+/// [`IdTrackerEnum`] / [`VectorStorageEnum`] / [`PayloadStorageEnum`] enums.
+///
+/// [`PlainVectorIndex`]: super::PlainVectorIndex
+pub(crate) type PlainVectorIndexReadViewEnum<'a> =
+    PlainVectorIndexReadView<'a, IdTrackerEnum, VectorStorageEnum, PayloadStorageEnum, FieldIndex>;

--- a/lib/segment/src/index/plain_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/search.rs
@@ -14,14 +14,14 @@ use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
 impl<'a, I, V, Q, P> PlainVectorIndexReadView<'a, I, V, Q, P>
 where
     I: IdTrackerRead,
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
 {
     pub fn is_small_enough_for_unindexed_search(

--- a/lib/segment/src/index/plain_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/search.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{DeferredBehavior, ScoredPointOffset};
 
-use super::PlainVectorIndexReadViewEnum;
+use super::PlainVectorIndexReadView;
 use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
@@ -14,9 +14,16 @@ use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::VectorStorageRead;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl PlainVectorIndexReadViewEnum<'_> {
+impl<'a, I, V, Q, P> PlainVectorIndexReadView<'a, I, V, Q, P>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
+{
     pub fn is_small_enough_for_unindexed_search(
         &self,
         search_optimized_threshold_kb: usize,

--- a/lib/segment/src/index/plain_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/search.rs
@@ -1,24 +1,18 @@
-use std::collections::HashMap;
-
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, ScoredPointOffset, TelemetryDetail};
-use sparse::common::types::DimId;
+use common::types::{DeferredBehavior, ScoredPointOffset};
 
 use super::PlainVectorIndexReadViewEnum;
 use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
-use crate::common::operation_time_statistics::{
-    OperationDurationStatistics, ScopeDurationMeasurer,
-};
+use crate::common::operation_time_statistics::ScopeDurationMeasurer;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
 use crate::id_tracker::IdTrackerRead;
+use crate::index::PayloadIndexRead;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
-use crate::index::{PayloadIndexRead, VectorIndexRead};
-use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 use crate::vector_storage::VectorStorageRead;
 
@@ -49,10 +43,8 @@ impl PlainVectorIndexReadViewEnum<'_> {
             Ok(vector_storage_size <= indexing_threshold_bytes)
         }
     }
-}
 
-impl VectorIndexRead for PlainVectorIndexReadViewEnum<'_> {
-    fn search(
+    pub fn search(
         &self,
         query_vectors: &[&QueryVector],
         filter: Option<&Filter>,
@@ -134,47 +126,5 @@ impl VectorIndexRead for PlainVectorIndexReadViewEnum<'_> {
             )?;
         }
         Ok(search_results)
-    }
-
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        VectorIndexSearchesTelemetry {
-            index_name: None,
-            unfiltered_plain: self
-                .unfiltered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            filtered_plain: self
-                .filtered_searches_telemetry
-                .lock()
-                .get_statistics(detail),
-            unfiltered_hnsw: OperationDurationStatistics::default(),
-            filtered_small_cardinality: OperationDurationStatistics::default(),
-            filtered_large_cardinality: OperationDurationStatistics::default(),
-            filtered_exact: OperationDurationStatistics::default(),
-            filtered_sparse: Default::default(),
-            unfiltered_exact: OperationDurationStatistics::default(),
-            unfiltered_sparse: OperationDurationStatistics::default(),
-        }
-    }
-
-    fn indexed_vector_count(&self) -> usize {
-        0
-    }
-
-    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        self.vector_storage.size_of_available_vectors_in_bytes()
-    }
-
-    fn fill_idf_statistics(
-        &self,
-        _idf: &mut HashMap<DimId, usize>,
-        _hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        // Plain (dense) index doesn't track IDF.
-        Ok(())
-    }
-
-    fn is_index(&self) -> bool {
-        false
     }
 }

--- a/lib/segment/src/index/plain_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/search.rs
@@ -75,15 +75,14 @@ impl PlainVectorIndexReadViewEnum<'_> {
         } else {
             &self.unfiltered_searches_telemetry
         });
-        let quantized_storage = self.quantized_vectors.borrow();
         let deleted_points = query_context
             .deleted_points()
             .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
-        let quantization_enabled = is_quantized_search(quantized_storage.as_ref(), params);
+        let quantization_enabled = is_quantized_search(self.quantized_vectors, params);
         let quantized_vectors = quantization_enabled
-            .then_some(quantized_storage.as_ref())
+            .then_some(self.quantized_vectors)
             .flatten();
-        let oversampled_top = get_oversampled_top(quantized_storage.as_ref(), params, top);
+        let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
         let batch_searcher = BatchFilteredSearcher::new(
             query_vectors,
             self.vector_storage,
@@ -118,7 +117,7 @@ impl PlainVectorIndexReadViewEnum<'_> {
                 std::mem::take(search_result),
                 deleted_points,
                 self.vector_storage,
-                quantized_storage.as_ref(),
+                self.quantized_vectors,
                 query_vector,
                 params,
                 top,

--- a/lib/segment/src/index/plain_vector_index/read_view/vector_index_read.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/vector_index_read.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::{DeferredBehavior, ScoredPointOffset, TelemetryDetail};
+use sparse::common::types::DimId;
+
+use super::PlainVectorIndexReadViewEnum;
+use crate::common::BYTES_IN_KB;
+use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::{
+    OperationDurationStatistics, ScopeDurationMeasurer,
+};
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::QueryVector;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
+use crate::index::vector_index_search_common::{
+    get_oversampled_top, is_quantized_search, postprocess_search_result,
+};
+use crate::index::{PayloadIndexRead, VectorIndexRead};
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
+
+impl PlainVectorIndexReadViewEnum<'_> {
+    pub fn is_small_enough_for_unindexed_search(
+        &self,
+        search_optimized_threshold_kb: usize,
+        filter: Option<&Filter>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        let available_vector_count = self.vector_storage.available_vector_count();
+        if available_vector_count == 0 {
+            return Ok(true);
+        }
+
+        let vector_size_bytes =
+            self.vector_storage.size_of_available_vectors_in_bytes() / available_vector_count;
+        let indexing_threshold_bytes = search_optimized_threshold_kb * BYTES_IN_KB;
+
+        if let Some(payload_filter) = filter {
+            let cardinality = self
+                .payload_index
+                .estimate_cardinality(payload_filter, hw_counter)?;
+            let scan_size = vector_size_bytes.saturating_mul(cardinality.max);
+            Ok(scan_size <= indexing_threshold_bytes)
+        } else {
+            let vector_storage_size = vector_size_bytes.saturating_mul(available_vector_count);
+            Ok(vector_storage_size <= indexing_threshold_bytes)
+        }
+    }
+}
+
+impl VectorIndexRead for PlainVectorIndexReadViewEnum<'_> {
+    fn search(
+        &self,
+        query_vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let is_indexed_only = params.is_some_and(|p| p.indexed_only);
+        if is_indexed_only
+            && !self.is_small_enough_for_unindexed_search(
+                query_context.search_optimized_threshold_kb(),
+                filter,
+                &query_context.hardware_counter(),
+            )?
+        {
+            return Ok(vec![vec![]; query_vectors.len()]);
+        }
+        if top == 0 {
+            return Ok(vec![vec![]; query_vectors.len()]);
+        }
+
+        let is_stopped = query_context.is_stopped();
+
+        let hw_counter = query_context.hardware_counter();
+
+        let _timer = ScopeDurationMeasurer::new(if filter.is_some() {
+            &self.filtered_searches_telemetry
+        } else {
+            &self.unfiltered_searches_telemetry
+        });
+        let quantized_storage = self.quantized_vectors.borrow();
+        let deleted_points = query_context
+            .deleted_points()
+            .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
+        let quantization_enabled = is_quantized_search(quantized_storage.as_ref(), params);
+        let quantized_vectors = quantization_enabled
+            .then_some(quantized_storage.as_ref())
+            .flatten();
+        let oversampled_top = get_oversampled_top(quantized_storage.as_ref(), params, top);
+        let batch_searcher = BatchFilteredSearcher::new(
+            query_vectors,
+            self.vector_storage,
+            quantized_vectors,
+            None,
+            oversampled_top,
+            deleted_points,
+            query_context.hardware_counter(),
+        )?;
+
+        let mut search_results = match filter {
+            Some(filter) => {
+                let filtered_ids_vec =
+                    self.payload_index
+                        .query_points(filter, &hw_counter, &is_stopped)?;
+                batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
+            }
+            None => {
+                let iter = self
+                    .id_tracker
+                    .point_mappings()
+                    .filter_deferred_and_deleted(
+                        batch_searcher.iter_not_deleted(),
+                        DeferredBehavior::VisibleOnly,
+                    );
+                batch_searcher.peek_top_iter(iter, &is_stopped)?
+            }
+        };
+
+        for (search_result, query_vector) in search_results.iter_mut().zip(query_vectors) {
+            *search_result = postprocess_search_result(
+                std::mem::take(search_result),
+                deleted_points,
+                self.vector_storage,
+                quantized_storage.as_ref(),
+                query_vector,
+                params,
+                top,
+                query_context.hardware_counter(),
+            )?;
+        }
+        Ok(search_results)
+    }
+
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: self
+                .unfiltered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            filtered_plain: self
+                .filtered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            unfiltered_hnsw: OperationDurationStatistics::default(),
+            filtered_small_cardinality: OperationDurationStatistics::default(),
+            filtered_large_cardinality: OperationDurationStatistics::default(),
+            filtered_exact: OperationDurationStatistics::default(),
+            filtered_sparse: Default::default(),
+            unfiltered_exact: OperationDurationStatistics::default(),
+            unfiltered_sparse: OperationDurationStatistics::default(),
+        }
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        0
+    }
+
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.vector_storage.size_of_available_vectors_in_bytes()
+    }
+
+    fn fill_idf_statistics(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Plain (dense) index doesn't track IDF.
+        Ok(())
+    }
+
+    fn is_index(&self) -> bool {
+        false
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
@@ -16,6 +16,7 @@ use crate::index::field_index::CardinalityEstimation;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::types::{DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, Filter};
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageRead, check_deleted_condition};
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -57,8 +58,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         let searcher = BatchFilteredSearcher::new(
             &[query_vector],
-            &vector_storage,
-            None,
+            &*vector_storage,
+            None::<&QuantizedVectors>,
             None,
             top,
             deleted_point_bitslice,

--- a/lib/segment/src/index/vector_index_search_common.rs
+++ b/lib/segment/src/index/vector_index_search_common.rs
@@ -9,10 +9,10 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{
     SearchParams, default_quantization_ignore_value, default_quantization_oversampling_value,
 };
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-pub fn is_quantized_search<Q: QuantizedVectorsReadAccess>(
+pub fn is_quantized_search<Q: QuantizedVectorsRead>(
     quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
 ) -> bool {
@@ -24,7 +24,7 @@ pub fn is_quantized_search<Q: QuantizedVectorsReadAccess>(
     quantized_storage.is_some() && !ignore_quantization && !exact
 }
 
-pub fn get_oversampled_top<Q: QuantizedVectorsReadAccess>(
+pub fn get_oversampled_top<Q: QuantizedVectorsRead>(
     quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
     top: usize,
@@ -57,7 +57,7 @@ pub fn postprocess_search_result<V, Q>(
 ) -> OperationResult<Vec<ScoredPointOffset>>
 where
     V: VectorStorageRead + RawScorerBuilder,
-    Q: QuantizedVectorsReadAccess,
+    Q: QuantizedVectorsRead,
 {
     let quantization_enabled = is_quantized_search(quantized_vectors, params);
 

--- a/lib/segment/src/index/vector_index_search_common.rs
+++ b/lib/segment/src/index/vector_index_search_common.rs
@@ -9,11 +9,11 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{
     SearchParams, default_quantization_ignore_value, default_quantization_oversampling_value,
 };
-use crate::vector_storage::VectorStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-pub fn is_quantized_search(
-    quantized_storage: Option<&QuantizedVectors>,
+pub fn is_quantized_search<Q: QuantizedVectorsReadAccess>(
+    quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
 ) -> bool {
     let ignore_quantization = params
@@ -24,8 +24,8 @@ pub fn is_quantized_search(
     quantized_storage.is_some() && !ignore_quantization && !exact
 }
 
-pub fn get_oversampled_top(
-    quantized_storage: Option<&QuantizedVectors>,
+pub fn get_oversampled_top<Q: QuantizedVectorsReadAccess>(
+    quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
     top: usize,
 ) -> usize {
@@ -45,16 +45,20 @@ pub fn get_oversampled_top(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn postprocess_search_result(
+pub fn postprocess_search_result<V, Q>(
     mut search_result: Vec<ScoredPointOffset>,
     point_deleted: &BitSlice,
-    vector_storage: &VectorStorageEnum,
-    quantized_vectors: Option<&QuantizedVectors>,
+    vector_storage: &V,
+    quantized_vectors: Option<&Q>,
     vector: &QueryVector,
     params: Option<&SearchParams>,
     top: usize,
     hardware_counter: HardwareCounterCell,
-) -> OperationResult<Vec<ScoredPointOffset>> {
+) -> OperationResult<Vec<ScoredPointOffset>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_vectors, params);
 
     let default_rescoring = quantized_vectors
@@ -70,7 +74,7 @@ pub fn postprocess_search_result(
         let mut scorer = FilteredScorer::new(
             vector.to_owned(),
             vector_storage,
-            None,
+            None::<&Q>,
             None,
             point_deleted,
             hardware_counter,

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -14,8 +14,8 @@ use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::CompactExtendedPointId;
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, MultiVectorStorage, MultiVectorStorageRead,
+    SparseVectorStorage, SparseVectorStorageRead, VectorStorageEnum, VectorStorageRead,
 };
 
 /// Define location of the point source during segment construction.

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -21,7 +21,8 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
@@ -77,7 +78,7 @@ impl<T: PrimitiveVectorElement> AppendableMmapDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> DenseVectorStorageRead<T> for AppendableMmapDenseVectorStorage<T> {
     fn vector_dim(&self) -> usize {
         self.vectors.dim()
     }
@@ -94,7 +95,9 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
     {
         self.vectors.for_each_in_batch(keys, callback);
     }
+}
 
+impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -116,6 +116,10 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorStorage<T> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -301,6 +301,10 @@ where
     T: PrimitiveVectorElement,
     S: UniversalRead,
 {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -22,7 +22,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 const VECTORS_PATH: &str = "matrix.dat";
@@ -210,7 +210,7 @@ where
     Ok(storage)
 }
 
-impl<T, S> DenseVectorStorage<T> for DenseVectorStorageImpl<T, S>
+impl<T, S> DenseVectorStorageRead<T> for DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
     S: UniversalRead,
@@ -231,7 +231,13 @@ where
         let mmap_store = self.vectors.as_ref().unwrap();
         mmap_store.for_each_in_batch(keys, f);
     }
+}
 
+impl<T, S> DenseVectorStorage<T> for DenseVectorStorageImpl<T, S>
+where
+    T: PrimitiveVectorElement,
+    S: UniversalRead,
+{
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -111,6 +111,11 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
 }
 
 impl VectorStorageRead for EmptyDenseVectorStorage {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        // All vectors are deleted, so there are no available vectors.
+        0
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::{
-    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 /// Placeholder vector storage that contains no data.
@@ -84,7 +84,7 @@ pub fn new_empty_dense_vector_storage(
     ))
 }
 
-impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
+impl DenseVectorStorageRead<VectorElementType> for EmptyDenseVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -96,7 +96,9 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
         // flag from `is_deleted_vector` keeps the placeholder from being read.
         Cow::Owned(vec![0.0; self.dim])
     }
+}
 
+impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
     fn update_from<'a>(
         &mut self,
         _other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -28,6 +28,10 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedDenseVectorStorage<T, S>
 {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
@@ -7,7 +9,21 @@ use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::{VectorOffsetType, VectorStorageRead};
+use crate::vector_storage::{DenseVectorStorageRead, VectorOffsetType, VectorStorageRead};
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
+    for ReadOnlyChunkedDenseVectorStorage<T, S>
+{
+    fn vector_dim(&self) -> usize {
+        self.vectors.dim()
+    }
+
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        self.vectors
+            .get::<P>(key as VectorOffsetType)
+            .expect("vector not found")
+    }
+}
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedDenseVectorStorage<T, S>

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -15,7 +15,8 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 /// In-memory vector storage that is volatile
@@ -75,7 +76,7 @@ impl<T: PrimitiveVectorElement> VolatileDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> DenseVectorStorageRead<T> for VolatileDenseVectorStorage<T> {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -83,7 +84,9 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
     }
+}
 
+impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -104,6 +104,10 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage<T> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 
 use crate::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent, MemoryReporter};
 use crate::vector_storage::vector_storage_base::{
-    DenseVectorStorageRead as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
-    VectorStorageRead as _,
+    VectorStorage as _, VectorStorageEnum, VectorStorageRead as _,
 };
 
 /// Determine the file storage intent for mmap-based vector storage.

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent, MemoryReporter};
 use crate::vector_storage::vector_storage_base::{
-    DenseVectorStorage as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
+    DenseVectorStorageRead as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
     VectorStorageRead as _,
 };
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -268,16 +268,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
         &self.multi_vector_config
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count() > 0 {
-            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
-            (total_size as u128 * self.available_vector_count() as u128
-                / self.total_vector_count() as u128) as usize
-        } else {
-            0
-        }
-    }
-
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,
@@ -297,6 +287,16 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVectorStorage<T> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count() > 0 {
+            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
+            (total_size as u128 * self.available_vector_count() as u128
+                / self.total_vector_count() as u128) as usize
+        } else {
+            0
+        }
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -27,7 +27,8 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
     open_appendable_memmap_vector_storage_half,
 };
 use crate::vector_storage::{
-    MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    MultiVectorStorage, MultiVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 pub(crate) const VECTORS_DIR_PATH: &str = "vectors";
@@ -209,7 +210,9 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> MultiVectorStorageRead<T>
+    for AppendableMmapMultiDenseVectorStorage<T>
+{
     fn vector_dim(&self) -> usize {
         self.vectors.dim()
     }
@@ -267,7 +270,9 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
+}
 
+impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,

--- a/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
@@ -7,7 +7,7 @@ use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::types::Distance;
+use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     DELETED_DIR_PATH, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
@@ -24,6 +24,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVecto
         path: &Path,
         dim: usize,
         distance: Distance,
+        multi_vector_config: MultiVectorConfig,
         advice: AdviceSetting,
         populate: bool,
     ) -> OperationResult<Self> {
@@ -47,6 +48,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVecto
             offsets,
             deleted,
             distance,
+            multi_vector_config,
         })
     }
 }

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -7,7 +7,7 @@ use common::universal_io::UniversalRead;
 use super::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::types::Distance;
+use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 
 mod lifecycle;
@@ -20,6 +20,7 @@ pub struct ReadOnlyChunkedMultiDenseVectorStorage<T: PrimitiveVectorElement, S: 
     /// Flags marking deleted vectors.
     deleted: InMemoryBitvecFlags,
     distance: Distance,
+    multi_vector_config: MultiVectorConfig,
 }
 
 pub fn iter_vectors<'a, P, T, U, S>(
@@ -132,6 +133,7 @@ mod tests {
             dir.path(),
             DIM,
             Distance::Dot,
+            MultiVectorConfig::default(),
             AdviceSetting::Global,
             false,
         )

--- a/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
@@ -12,6 +12,13 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
     flattened_to_multi_vector, read_multi_vector,
 };
 
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        // Total flattened element bytes across all stored multi-vectors.
+        self.vectors.len() * self.vectors.dim() * std::mem::size_of::<T>()
+    }
+}
+
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
 {

--- a/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
@@ -12,16 +12,14 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
     flattened_to_multi_vector, read_multi_vector,
 };
 
-impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
-    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
-        // Total flattened element bytes across all stored multi-vectors.
-        self.vectors.len() * self.vectors.dim() * std::mem::size_of::<T>()
-    }
-}
-
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
 {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        // Total flattened element bytes across all stored multi-vectors.
+        self.vectors.len() * self.vectors.dim() * std::mem::size_of::<T>()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
@@ -1,16 +1,74 @@
+use std::borrow::Cow;
+
 use common::bitvec::BitSlice;
-use common::generic_consts::AccessPattern;
+use common::generic_consts::{AccessPattern, Sequential};
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
-use crate::data_types::named_vectors::CowVector;
+use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::VectorStorageRead;
+use crate::data_types::vectors::TypedMultiDenseVectorRef;
+use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
     flattened_to_multi_vector, read_multi_vector,
 };
+use crate::vector_storage::{MultiVectorStorageRead, VectorOffsetType, VectorStorageRead};
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> MultiVectorStorageRead<T>
+    for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
+{
+    fn vector_dim(&self) -> usize {
+        self.vectors.dim()
+    }
+
+    fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T> {
+        self.get_multi_opt::<P>(key).expect("vector not found")
+    }
+
+    fn get_multi_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<CowMultiVector<'_, T>> {
+        read_multi_vector::<T, P, _>(&self.offsets, &self.vectors, key)
+    }
+
+    fn for_each_in_batch_multi<F>(&self, keys: &[PointOffsetType], mut callback: F)
+    where
+        F: FnMut(usize, TypedMultiDenseVectorRef<'_, T>),
+    {
+        let point_offsets = keys.iter().copied().enumerate();
+
+        let vectors =
+            super::iter_vectors::<Sequential, _, _, _>(&self.offsets, &self.vectors, point_offsets);
+
+        for (index, flattened) in vectors {
+            let vector = TypedMultiDenseVectorRef::new(&flattened, self.vector_dim());
+            callback(index, vector)
+        }
+    }
+
+    fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send {
+        (0..self.total_vector_count()).flat_map(move |key| {
+            let mmap_offset = self
+                .offsets
+                .get::<Sequential>(key as VectorOffsetType)
+                .unwrap()
+                .first()
+                .copied()
+                .unwrap();
+            (0..mmap_offset.count).map(move |i| {
+                self.vectors
+                    .get::<Sequential>((mmap_offset.offset + i) as VectorOffsetType)
+                    .unwrap()
+            })
+        })
+    }
+
+    fn multi_vector_config(&self) -> &MultiVectorConfig {
+        &self.multi_vector_config
+    }
+}
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -237,16 +237,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
         &self.multi_vector_config
     }
 
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count() > 0 {
-            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
-            (total_size as u128 * self.available_vector_count() as u128
-                / self.total_vector_count() as u128) as usize
-        } else {
-            0
-        }
-    }
-
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,
@@ -269,6 +259,16 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
 }
 
 impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileMultiDenseVectorStorage<T> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count() > 0 {
+            let total_size = self.vectors.len() * self.vector_dim() * std::mem::size_of::<T>();
+            (total_size as u128 * self.available_vector_count() as u128
+                / self.total_vector_count() as u128) as usize
+        } else {
+            0
+        }
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -17,7 +17,8 @@ use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
-    MultiVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    MultiVectorStorage, MultiVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 /// All fields are counting vectors and not dimensions.
@@ -196,7 +197,7 @@ impl<T: PrimitiveVectorElement> VolatileMultiDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> MultiVectorStorageRead<T> for VolatileMultiDenseVectorStorage<T> {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -236,7 +237,9 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
     fn multi_vector_config(&self) -> &MultiVectorConfig {
         &self.multi_vector_config
     }
+}
 
+impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -92,7 +92,7 @@ where
 /// so the [`QuantizedScorerBuilder`] wiring lives in a single place.
 ///
 /// [`QuantizedVectors`]: super::quantized_vectors::QuantizedVectors
-/// [`QuantizedVectorsRead`]: super::quantized_vectors::QuantizedVectorsRead
+/// [`QuantizedVectorsRead`]: super::quantized_vectors::ReadOnlyQuantizedVectors
 pub(in crate::vector_storage::quantized) fn build_quantized_raw_scorer<'a, Q>(
     storage: &'a Q,
     quantization_config: &'a QuantizationConfig,

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -86,6 +86,36 @@ where
     Ok(Box::new(RawScorerImpl { query_scorer }))
 }
 
+/// Build a query raw scorer over a quantized storage enum.
+///
+/// Shared by the read-write [`QuantizedVectors`] and read-only [`QuantizedVectorsRead`]
+/// so the [`QuantizedScorerBuilder`] wiring lives in a single place.
+///
+/// [`QuantizedVectors`]: super::quantized_vectors::QuantizedVectors
+/// [`QuantizedVectorsRead`]: super::quantized_vectors::QuantizedVectorsRead
+pub(in crate::vector_storage::quantized) fn build_quantized_raw_scorer<'a, Q>(
+    storage: &'a Q,
+    quantization_config: &'a QuantizationConfig,
+    distance: &'a Distance,
+    datatype: VectorStorageDatatype,
+    on_disk: bool,
+    query: QueryVector,
+    hardware_counter: HardwareCounterCell,
+) -> OperationResult<Box<dyn RawScorer + 'a>>
+where
+    Q: QuantizedScorerDispatch,
+{
+    QuantizedScorerBuilder::new(
+        quantization_config,
+        query,
+        distance,
+        datatype,
+        hardware_counter,
+        on_disk,
+    )
+    .build(storage)
+}
+
 pub(in crate::vector_storage::quantized) struct QuantizedScorerBuilder<'a> {
     quantization_config: &'a QuantizationConfig,
     query: QueryVector,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -4,6 +4,7 @@ mod config;
 mod create;
 mod load;
 mod pq;
+mod read_access;
 mod read_only;
 mod scalar;
 mod storage;
@@ -31,6 +32,7 @@ pub use self::config::{
     QUANTIZED_DATA_PATH, QUANTIZED_META_PATH, QUANTIZED_OFFSETS_PATH, QuantizedVectorsConfig,
     QuantizedVectorsStorageType,
 };
+pub use self::read_access::QuantizedVectorsReadAccess;
 pub use self::read_only::{QuantizedVectorStorageRead, QuantizedVectorsRead};
 pub use self::storage::QuantizedVectorStorage;
 use crate::common::operation_error::OperationResult;
@@ -43,7 +45,7 @@ use crate::types::{
 use crate::vector_storage::RawScorer;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
 use crate::vector_storage::quantized::quantized_scorer_builder::{
-    QuantizedScorerBuilder, QuantizedScorerDispatch,
+    QuantizedScorerDispatch, build_quantized_raw_scorer,
 };
 
 #[derive(Debug)]
@@ -65,15 +67,15 @@ impl QuantizedVectors {
         query: QueryVector,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-        QuantizedScorerBuilder::new(
+        build_quantized_raw_scorer(
+            &self.storage_impl,
             &self.config.quantization_config,
-            query,
             &self.distance,
             self.datatype,
-            hardware_counter,
             self.storage_impl.is_on_disk(),
+            query,
+            hardware_counter,
         )
-        .build(&self.storage_impl)
     }
 
     /// Build a raw scorer for the specified `point_id`.
@@ -278,6 +280,32 @@ impl QuantizedVectors {
 
     pub fn get_storage(&self) -> &QuantizedVectorStorage {
         &self.storage_impl
+    }
+}
+
+impl QuantizedVectorsReadAccess for QuantizedVectors {
+    fn config(&self) -> &QuantizedVectorsConfig {
+        self.config()
+    }
+
+    fn default_rescoring(&self) -> bool {
+        self.default_rescoring()
+    }
+
+    fn raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        self.raw_scorer(query, hardware_counter)
+    }
+
+    fn raw_internal_scorer<'a>(
+        &'a self,
+        point_id: PointOffsetType,
+        hardware_counter: HardwareCounterCell,
+    ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported> {
+        self.raw_internal_scorer(point_id, hardware_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -32,8 +32,8 @@ pub use self::config::{
     QUANTIZED_DATA_PATH, QUANTIZED_META_PATH, QUANTIZED_OFFSETS_PATH, QuantizedVectorsConfig,
     QuantizedVectorsStorageType,
 };
-pub use self::read_access::QuantizedVectorsReadAccess;
-pub use self::read_only::{QuantizedVectorStorageRead, QuantizedVectorsRead};
+pub use self::read_access::QuantizedVectorsRead;
+pub use self::read_only::{ReadOnlyQuantizedVectorStorage, ReadOnlyQuantizedVectors};
 pub use self::storage::QuantizedVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::QueryVector;
@@ -283,7 +283,7 @@ impl QuantizedVectors {
     }
 }
 
-impl QuantizedVectorsReadAccess for QuantizedVectors {
+impl QuantizedVectorsRead for QuantizedVectors {
     fn config(&self) -> &QuantizedVectorsConfig {
         self.config()
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_access.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_access.rs
@@ -1,0 +1,35 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+
+use super::QuantizedVectorsConfig;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::vectors::QueryVector;
+use crate::vector_storage::RawScorer;
+use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
+
+/// Shared read/scoring interface over quantized vectors.
+///
+/// Implemented by both the read-write [`QuantizedVectors`] and the read-only
+/// [`QuantizedVectorsRead`], so search code can be generic over the backend.
+///
+/// [`QuantizedVectors`]: super::QuantizedVectors
+/// [`QuantizedVectorsRead`]: super::QuantizedVectorsRead
+pub trait QuantizedVectorsReadAccess {
+    fn config(&self) -> &QuantizedVectorsConfig;
+
+    fn default_rescoring(&self) -> bool;
+
+    fn raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>>;
+
+    /// Build a raw scorer for the specified `point_id`.
+    /// If not supported, return [`InternalScorerUnsupported`] with the original `hardware_counter`.
+    fn raw_internal_scorer<'a>(
+        &'a self,
+        point_id: PointOffsetType,
+        hardware_counter: HardwareCounterCell,
+    ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported>;
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_access.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_access.rs
@@ -13,8 +13,8 @@ use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsu
 /// [`QuantizedVectorsRead`], so search code can be generic over the backend.
 ///
 /// [`QuantizedVectors`]: super::QuantizedVectors
-/// [`QuantizedVectorsRead`]: super::QuantizedVectorsRead
-pub trait QuantizedVectorsReadAccess {
+/// [`QuantizedVectorsRead`]: super::ReadOnlyQuantizedVectors
+pub trait QuantizedVectorsRead {
     fn config(&self) -> &QuantizedVectorsConfig;
 
     fn default_rescoring(&self) -> bool;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
@@ -6,8 +6,8 @@ use quantization::encoded_vectors_binary::EncodedVectorsBin;
 use quantization::encoded_vectors_tq::EncodedVectorsTQ;
 use quantization::encoded_vectors_u8::EncodedVectorsU8;
 
-use super::QuantizedVectorsRead;
-use super::storage::QuantizedVectorStorageRead;
+use super::ReadOnlyQuantizedVectors;
+use super::storage::ReadOnlyQuantizedVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
@@ -21,7 +21,7 @@ use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedStorageKind, QuantizedVectors, QuantizedVectorsConfig,
 };
 
-impl<S: UniversalRead> QuantizedVectorsRead<S> {
+impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     /// Open existing quantized vectors read-only through the [`UniversalRead`] backend `S`.
     ///
     /// Returns `Ok(None)` when no quantization config is present at `path`. Every read —
@@ -73,7 +73,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         path: &Path,
         config: &QuantizedVectorsConfig,
         on_disk_vector_storage: bool,
-    ) -> OperationResult<QuantizedVectorStorageRead<S>> {
+    ) -> OperationResult<ReadOnlyQuantizedVectorStorage<S>> {
         let data_path = QuantizedVectors::get_data_path(path, config.storage_type);
         let meta_path = QuantizedVectors::get_meta_path(path);
         let size = config.quantized_vector_size(false);
@@ -84,34 +84,34 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         let chunked = || QuantizedChunkedStorageRead::<S>::open(fs, &data_path, size);
 
         let storage = match config.storage_kind(on_disk_vector_storage)? {
-            QuantizedStorageKind::ScalarRam => QuantizedVectorStorageRead::ScalarRam(
+            QuantizedStorageKind::ScalarRam => ReadOnlyQuantizedVectorStorage::ScalarRam(
                 EncodedVectorsU8::load(fs, ram()?, &meta_path)?,
             ),
-            QuantizedStorageKind::ScalarMmap => QuantizedVectorStorageRead::ScalarMmap(
+            QuantizedStorageKind::ScalarMmap => ReadOnlyQuantizedVectorStorage::ScalarMmap(
                 EncodedVectorsU8::load(fs, mmap()?, &meta_path)?,
             ),
-            QuantizedStorageKind::PqRam => {
-                QuantizedVectorStorageRead::PQRam(EncodedVectorsPQ::load(fs, ram()?, &meta_path)?)
-            }
-            QuantizedStorageKind::PqMmap => {
-                QuantizedVectorStorageRead::PQMmap(EncodedVectorsPQ::load(fs, mmap()?, &meta_path)?)
-            }
-            QuantizedStorageKind::BinaryRam => QuantizedVectorStorageRead::BinaryRam(
+            QuantizedStorageKind::PqRam => ReadOnlyQuantizedVectorStorage::PQRam(
+                EncodedVectorsPQ::load(fs, ram()?, &meta_path)?,
+            ),
+            QuantizedStorageKind::PqMmap => ReadOnlyQuantizedVectorStorage::PQMmap(
+                EncodedVectorsPQ::load(fs, mmap()?, &meta_path)?,
+            ),
+            QuantizedStorageKind::BinaryRam => ReadOnlyQuantizedVectorStorage::BinaryRam(
                 EncodedVectorsBin::load(fs, ram()?, &meta_path)?,
             ),
-            QuantizedStorageKind::BinaryMmap => QuantizedVectorStorageRead::BinaryMmap(
+            QuantizedStorageKind::BinaryMmap => ReadOnlyQuantizedVectorStorage::BinaryMmap(
                 EncodedVectorsBin::load(fs, mmap()?, &meta_path)?,
             ),
-            QuantizedStorageKind::BinaryChunked => QuantizedVectorStorageRead::BinaryChunked(
+            QuantizedStorageKind::BinaryChunked => ReadOnlyQuantizedVectorStorage::BinaryChunked(
                 EncodedVectorsBin::load(fs, chunked()?, &meta_path)?,
             ),
-            QuantizedStorageKind::TqRam => {
-                QuantizedVectorStorageRead::TQRam(EncodedVectorsTQ::load(fs, ram()?, &meta_path)?)
-            }
-            QuantizedStorageKind::TqMmap => {
-                QuantizedVectorStorageRead::TQMmap(EncodedVectorsTQ::load(fs, mmap()?, &meta_path)?)
-            }
-            QuantizedStorageKind::TqChunked => QuantizedVectorStorageRead::TQChunked(
+            QuantizedStorageKind::TqRam => ReadOnlyQuantizedVectorStorage::TQRam(
+                EncodedVectorsTQ::load(fs, ram()?, &meta_path)?,
+            ),
+            QuantizedStorageKind::TqMmap => ReadOnlyQuantizedVectorStorage::TQMmap(
+                EncodedVectorsTQ::load(fs, mmap()?, &meta_path)?,
+            ),
+            QuantizedStorageKind::TqChunked => ReadOnlyQuantizedVectorStorage::TQChunked(
                 EncodedVectorsTQ::load(fs, chunked()?, &meta_path)?,
             ),
         };
@@ -124,7 +124,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         config: &QuantizedVectorsConfig,
         multivector_config: &MultiVectorConfig,
         on_disk_vector_storage: bool,
-    ) -> OperationResult<QuantizedVectorStorageRead<S>> {
+    ) -> OperationResult<ReadOnlyQuantizedVectorStorage<S>> {
         let data_path = QuantizedVectors::get_data_path(path, config.storage_type);
         let meta_path = QuantizedVectors::get_meta_path(path);
         let offsets_path = QuantizedVectors::get_offsets_path(path, config.storage_type);
@@ -143,7 +143,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         let storage = match config.storage_kind(on_disk_vector_storage)? {
             QuantizedStorageKind::ScalarRam => {
                 let inner = EncodedVectorsU8::load(fs, ram()?, &meta_path)?;
-                QuantizedVectorStorageRead::ScalarRamMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::ScalarRamMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     ram_offsets()?,
@@ -152,7 +152,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::ScalarMmap => {
                 let inner = EncodedVectorsU8::load(fs, mmap()?, &meta_path)?;
-                QuantizedVectorStorageRead::ScalarMmapMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     mmap_offsets()?,
@@ -161,7 +161,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::PqRam => {
                 let inner = EncodedVectorsPQ::load(fs, ram()?, &meta_path)?;
-                QuantizedVectorStorageRead::PQRamMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::PQRamMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     ram_offsets()?,
@@ -170,7 +170,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::PqMmap => {
                 let inner = EncodedVectorsPQ::load(fs, mmap()?, &meta_path)?;
-                QuantizedVectorStorageRead::PQMmapMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::PQMmapMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     mmap_offsets()?,
@@ -179,7 +179,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::BinaryRam => {
                 let inner = EncodedVectorsBin::load(fs, ram()?, &meta_path)?;
-                QuantizedVectorStorageRead::BinaryRamMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::BinaryRamMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     ram_offsets()?,
@@ -188,7 +188,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::BinaryMmap => {
                 let inner = EncodedVectorsBin::load(fs, mmap()?, &meta_path)?;
-                QuantizedVectorStorageRead::BinaryMmapMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     mmap_offsets()?,
@@ -197,16 +197,18 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::BinaryChunked => {
                 let inner = EncodedVectorsBin::load(fs, chunked()?, &meta_path)?;
-                QuantizedVectorStorageRead::BinaryChunkedMulti(QuantizedMultivectorStorage::new(
-                    dim,
-                    inner,
-                    chunked_offsets()?,
-                    *multivector_config,
-                ))
+                ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(
+                    QuantizedMultivectorStorage::new(
+                        dim,
+                        inner,
+                        chunked_offsets()?,
+                        *multivector_config,
+                    ),
+                )
             }
             QuantizedStorageKind::TqRam => {
                 let inner = EncodedVectorsTQ::load(fs, ram()?, &meta_path)?;
-                QuantizedVectorStorageRead::TQRamMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::TQRamMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     ram_offsets()?,
@@ -215,7 +217,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::TqMmap => {
                 let inner = EncodedVectorsTQ::load(fs, mmap()?, &meta_path)?;
-                QuantizedVectorStorageRead::TQMmapMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::TQMmapMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     mmap_offsets()?,
@@ -224,7 +226,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
             }
             QuantizedStorageKind::TqChunked => {
                 let inner = EncodedVectorsTQ::load(fs, chunked()?, &meta_path)?;
-                QuantizedVectorStorageRead::TQChunkedMulti(QuantizedMultivectorStorage::new(
+                ReadOnlyQuantizedVectorStorage::TQChunkedMulti(QuantizedMultivectorStorage::new(
                     dim,
                     inner,
                     chunked_offsets()?,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
@@ -11,7 +11,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, UniversalRead};
 
-pub use self::storage::QuantizedVectorStorageRead;
+pub use self::storage::ReadOnlyQuantizedVectorStorage;
 use super::{QUANTIZED_CONFIG_PATH, QuantizedVectorsConfig};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -22,7 +22,7 @@ use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsu
 use crate::vector_storage::quantized::quantized_scorer_builder::{
     QuantizedScorerDispatch, build_quantized_raw_scorer,
 };
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 
 /// Read-only counterpart of [`super::super::QuantizedVectors`].
 ///
@@ -30,17 +30,17 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAcc
 /// on-disk data (see [`Self::open`]) and exposes only read operations: it has no
 /// `create`/`upsert`/builder path and never writes to disk.
 #[derive(Debug)]
-pub struct QuantizedVectorsRead<S: UniversalRead = MmapFile> {
-    storage_impl: QuantizedVectorStorageRead<S>,
+pub struct ReadOnlyQuantizedVectors<S: UniversalRead = MmapFile> {
+    storage_impl: ReadOnlyQuantizedVectorStorage<S>,
     config: QuantizedVectorsConfig,
     path: PathBuf,
     distance: Distance,
     datatype: VectorStorageDatatype,
 }
 
-impl<S: UniversalRead> QuantizedVectorsRead<S> {
+impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     pub(super) fn new(
-        storage_impl: QuantizedVectorStorageRead<S>,
+        storage_impl: ReadOnlyQuantizedVectorStorage<S>,
         config: QuantizedVectorsConfig,
         path: PathBuf,
         distance: Distance,
@@ -59,7 +59,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         &self.config
     }
 
-    pub fn get_storage(&self) -> &QuantizedVectorStorageRead<S> {
+    pub fn get_storage(&self) -> &ReadOnlyQuantizedVectorStorage<S> {
         &self.storage_impl
     }
 
@@ -141,7 +141,7 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
     }
 }
 
-impl<S: UniversalRead> QuantizedVectorsReadAccess for QuantizedVectorsRead<S> {
+impl<S: UniversalRead> QuantizedVectorsRead for ReadOnlyQuantizedVectors<S> {
     fn config(&self) -> &QuantizedVectorsConfig {
         self.config()
     }
@@ -167,7 +167,7 @@ impl<S: UniversalRead> QuantizedVectorsReadAccess for QuantizedVectorsRead<S> {
     }
 }
 
-impl<S: UniversalRead> crate::common::memory_usage::MemoryReporter for QuantizedVectorsRead<S> {
+impl<S: UniversalRead> crate::common::memory_usage::MemoryReporter for ReadOnlyQuantizedVectors<S> {
     fn memory_usage(&self) -> crate::common::memory_usage::ComponentMemoryUsage {
         use crate::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent};
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
@@ -20,8 +20,9 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::RawScorer;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
 use crate::vector_storage::quantized::quantized_scorer_builder::{
-    QuantizedScorerBuilder, QuantizedScorerDispatch,
+    QuantizedScorerDispatch, build_quantized_raw_scorer,
 };
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
 
 /// Read-only counterpart of [`super::super::QuantizedVectors`].
 ///
@@ -79,15 +80,15 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
         query: QueryVector,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Box<dyn RawScorer + 'a>> {
-        QuantizedScorerBuilder::new(
+        build_quantized_raw_scorer(
+            &self.storage_impl,
             &self.config.quantization_config,
-            query,
             &self.distance,
             self.datatype,
-            hardware_counter,
             self.storage_impl.is_on_disk(),
+            query,
+            hardware_counter,
         )
-        .build(&self.storage_impl)
     }
 
     /// Build a raw scorer for the specified `point_id`.
@@ -137,6 +138,32 @@ impl<S: UniversalRead> QuantizedVectorsRead<S> {
     pub fn flusher(&self) -> Flusher {
         let flusher = self.storage_impl.flusher();
         Box::new(move || flusher().map_err(OperationError::from))
+    }
+}
+
+impl<S: UniversalRead> QuantizedVectorsReadAccess for QuantizedVectorsRead<S> {
+    fn config(&self) -> &QuantizedVectorsConfig {
+        self.config()
+    }
+
+    fn default_rescoring(&self) -> bool {
+        self.default_rescoring()
+    }
+
+    fn raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        self.raw_scorer(query, hardware_counter)
+    }
+
+    fn raw_internal_scorer<'a>(
+        &'a self,
+        point_id: PointOffsetType,
+        hardware_counter: HardwareCounterCell,
+    ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported> {
+        self.raw_internal_scorer(point_id, hardware_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -82,7 +82,7 @@ type TQChunkedMulti<S> = QuantizedMultivectorStorage<
 /// can read every on-disk layout: in-RAM (`*Ram`), read-only mmap (`*Mmap`) and the
 /// appendable chunked layout opened read-only (`*Chunked`, only produced by Binary
 /// and TurboQuant quantization).
-pub enum QuantizedVectorStorageRead<S: UniversalRead = MmapFile> {
+pub enum ReadOnlyQuantizedVectorStorage<S: UniversalRead = MmapFile> {
     ScalarRam(EncodedVectorsU8<QuantizedRamStorage>),
     ScalarMmap(EncodedVectorsU8<QuantizedStorage<S>>),
     PQRam(EncodedVectorsPQ<QuantizedRamStorage>),
@@ -105,96 +105,96 @@ pub enum QuantizedVectorStorageRead<S: UniversalRead = MmapFile> {
     TQChunkedMulti(TQChunkedMulti<S>),
 }
 
-impl<S: UniversalRead> fmt::Debug for QuantizedVectorStorageRead<S> {
+impl<S: UniversalRead> fmt::Debug for ReadOnlyQuantizedVectorStorage<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("QuantizedVectorStorageRead").finish()
     }
 }
 
-impl<S: UniversalRead> QuantizedVectorStorageRead<S> {
+impl<S: UniversalRead> ReadOnlyQuantizedVectorStorage<S> {
     pub fn is_on_disk(&self) -> bool {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::PQRam(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQRam(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::PQRamMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::PQMmapMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQRamMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQMmapMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQChunked(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => q.is_on_disk(),
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.is_on_disk(),
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.is_on_disk(),
         }
     }
 
     /// Heap memory used by this storage that is not tracked in files.
     pub fn heap_size_bytes(&self) -> usize {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::PQRam(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQRam(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::PQRamMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::PQMmapMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQRamMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQMmapMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQChunked(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => q.heap_size_bytes(),
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.heap_size_bytes(),
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.heap_size_bytes(),
         }
     }
 
     pub fn default_rescoring(&self) -> bool {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(_)
-            | QuantizedVectorStorageRead::ScalarMmap(_)
-            | QuantizedVectorStorageRead::PQRam(_)
-            | QuantizedVectorStorageRead::PQMmap(_)
-            | QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::ScalarMmapMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::PQMmapMulti(_) => false,
-            QuantizedVectorStorageRead::BinaryRam(_)
-            | QuantizedVectorStorageRead::BinaryMmap(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryChunked(_)
-            | QuantizedVectorStorageRead::BinaryChunkedMulti(_) => true,
-            QuantizedVectorStorageRead::TQRam(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmap(_)
+            | ReadOnlyQuantizedVectorStorage::PQRam(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmap(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmapMulti(_) => false,
+            ReadOnlyQuantizedVectorStorage::BinaryRam(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmap(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryChunked(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(_) => true,
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.get_metadata().bits)
             }
-            QuantizedVectorStorageRead::TQMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.get_metadata().bits)
             }
-            QuantizedVectorStorageRead::TQRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.storage().get_metadata().bits)
             }
-            QuantizedVectorStorageRead::TQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.storage().get_metadata().bits)
             }
-            QuantizedVectorStorageRead::TQChunked(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.get_metadata().bits)
             }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
                 QuantizedVectors::tq_bits_default_rescoring(q.storage().get_metadata().bits)
             }
         }
@@ -203,53 +203,55 @@ impl<S: UniversalRead> QuantizedVectorStorageRead<S> {
     /// Get layout for a single quantized vector (size in bytes and required alignment).
     pub fn get_quantized_vector_layout(&self) -> OperationResult<Layout> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::ScalarMmap(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::PQRam(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::PQMmap(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::BinaryRam(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::BinaryMmap(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::TQRam(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::TQMmap(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::BinaryChunked(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::TQChunked(q) => Ok(q.layout()),
-            QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::ScalarMmapMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::PQMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryMmapMulti(_)
-            | QuantizedVectorStorageRead::TQRamMulti(_)
-            | QuantizedVectorStorageRead::TQMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryChunkedMulti(_)
-            | QuantizedVectorStorageRead::TQChunkedMulti(_) => Err(OperationError::service_error(
-                "Cannot get quantized vector layout from multivector storage",
-            )),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => Ok(q.layout()),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQChunkedMulti(_) => {
+                Err(OperationError::service_error(
+                    "Cannot get quantized vector layout from multivector storage",
+                ))
+            }
         }
     }
 
     pub fn get_quantized_vector(&self, id: PointOffsetType) -> Cow<'_, [u8]> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::PQRam(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::PQMmap(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::TQRam(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::TQMmap(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::TQChunked(q) => q.get_quantized_vector(id),
-            QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::ScalarMmapMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::PQMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryMmapMulti(_)
-            | QuantizedVectorStorageRead::TQRamMulti(_)
-            | QuantizedVectorStorageRead::TQMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryChunkedMulti(_)
-            | QuantizedVectorStorageRead::TQChunkedMulti(_) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.get_quantized_vector(id),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQChunkedMulti(_) => {
                 panic!("Cannot get quantized vector from multivector storage");
             }
         }
@@ -257,91 +259,91 @@ impl<S: UniversalRead> QuantizedVectorStorageRead<S> {
 
     pub fn files(&self) -> Vec<PathBuf> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.files(),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.files(),
-            QuantizedVectorStorageRead::PQRam(q) => q.files(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.files(),
-            QuantizedVectorStorageRead::TQRam(q) => q.files(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.files(),
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => q.files(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => q.files(),
-            QuantizedVectorStorageRead::PQRamMulti(q) => q.files(),
-            QuantizedVectorStorageRead::PQMmapMulti(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => q.files(),
-            QuantizedVectorStorageRead::TQRamMulti(q) => q.files(),
-            QuantizedVectorStorageRead::TQMmapMulti(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.files(),
-            QuantizedVectorStorageRead::TQChunked(q) => q.files(),
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => q.files(),
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.files(),
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.files(),
         }
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::PQRam(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQRam(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::PQRamMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::PQMmapMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQRamMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQMmapMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQChunked(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => q.immutable_files(),
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.immutable_files(),
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.immutable_files(),
         }
     }
 
     pub fn populate(&self) -> OperationResult<()> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(_)
-            | QuantizedVectorStorageRead::PQRam(_)
-            | QuantizedVectorStorageRead::BinaryRam(_)
-            | QuantizedVectorStorageRead::TQRam(_)
-            | QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::TQRamMulti(_) => {} // already in RAM
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.storage().populate(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.storage().populate(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.storage().populate(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.storage().populate(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(_)
+            | ReadOnlyQuantizedVectorStorage::PQRam(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRam(_)
+            | ReadOnlyQuantizedVectorStorage::TQRam(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_) => {} // already in RAM
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.storage().populate(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.storage().populate(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.storage().populate(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.storage().populate(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => {
                 q.storage().storage().populate();
                 q.offsets_storage().populate()?;
             }
-            QuantizedVectorStorageRead::PQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => {
                 q.storage().storage().populate();
                 q.offsets_storage().populate()?;
             }
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => {
                 q.storage().storage().populate();
                 q.offsets_storage().populate()?;
             }
-            QuantizedVectorStorageRead::TQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => {
                 q.storage().storage().populate();
                 q.offsets_storage().populate()?;
             }
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.storage().populate()?,
-            QuantizedVectorStorageRead::TQChunked(q) => q.storage().populate()?,
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.storage().populate()?,
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.storage().populate()?,
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
                 q.storage().storage().populate()?;
                 q.offsets_storage().populate()?;
             }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
                 q.storage().storage().populate()?;
                 q.offsets_storage().populate()?;
             }
@@ -351,41 +353,41 @@ impl<S: UniversalRead> QuantizedVectorStorageRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(_)
-            | QuantizedVectorStorageRead::PQRam(_)
-            | QuantizedVectorStorageRead::BinaryRam(_)
-            | QuantizedVectorStorageRead::TQRam(_)
-            | QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::TQRamMulti(_) => {} // nothing to clear
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.storage().clear_cache(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.storage().clear_cache(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.storage().clear_cache(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.storage().clear_cache(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(_)
+            | ReadOnlyQuantizedVectorStorage::PQRam(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRam(_)
+            | ReadOnlyQuantizedVectorStorage::TQRam(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_) => {} // nothing to clear
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.storage().clear_cache(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.storage().clear_cache(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.storage().clear_cache(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.storage().clear_cache(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => {
                 q.storage().storage().clear_cache();
                 q.offsets_storage().clear_cache()?;
             }
-            QuantizedVectorStorageRead::PQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => {
                 q.storage().storage().clear_cache();
                 q.offsets_storage().clear_cache()?;
             }
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => {
                 q.storage().storage().clear_cache();
                 q.offsets_storage().clear_cache()?;
             }
-            QuantizedVectorStorageRead::TQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => {
                 q.storage().storage().clear_cache();
                 q.offsets_storage().clear_cache()?;
             }
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.storage().clear_cache()?,
-            QuantizedVectorStorageRead::TQChunked(q) => q.storage().clear_cache()?,
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.storage().clear_cache()?,
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.storage().clear_cache()?,
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
                 q.storage().storage().clear_cache()?;
                 q.offsets_storage().clear_cache()?;
             }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
                 q.storage().storage().clear_cache()?;
                 q.offsets_storage().clear_cache()?;
             }
@@ -395,31 +397,31 @@ impl<S: UniversalRead> QuantizedVectorStorageRead<S> {
 
     pub fn flusher(&self) -> MmapFlusher {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => q.flusher(),
-            QuantizedVectorStorageRead::ScalarMmap(q) => q.flusher(),
-            QuantizedVectorStorageRead::PQRam(q) => q.flusher(),
-            QuantizedVectorStorageRead::PQMmap(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryRam(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryMmap(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQRam(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQMmap(q) => q.flusher(),
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::PQRamMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::PQMmapMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQRamMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQMmapMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQChunked(q) => q.flusher(),
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => q.flusher(),
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.flusher(),
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.flusher(),
         }
     }
 }
 
-impl<S: UniversalRead> QuantizedScorerDispatch for QuantizedVectorStorageRead<S> {
+impl<S: UniversalRead> QuantizedScorerDispatch for ReadOnlyQuantizedVectorStorage<S> {
     fn build_metric_scorer<'a, TElement, TMetric>(
         &'a self,
         builder: QuantizedScorerBuilder<'a>,
@@ -429,64 +431,64 @@ impl<S: UniversalRead> QuantizedScorerDispatch for QuantizedVectorStorageRead<S>
         TMetric: Metric<TElement> + 'a,
     {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::ScalarMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::PQRam(q) => {
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::PQMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::BinaryRam(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::BinaryMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::TQRam(q) => {
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::TQMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::PQRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::PQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::TQRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::TQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::BinaryChunked(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::TQChunked(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => {
                 builder.new_quantized_scorer::<TElement, TMetric>(q)
             }
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
                 builder.new_multi_quantized_scorer::<TElement, TMetric, _, _>(q)
             }
         }
@@ -498,64 +500,64 @@ impl<S: UniversalRead> QuantizedScorerDispatch for QuantizedVectorStorageRead<S>
         hardware_counter: HardwareCounterCell,
     ) -> Result<Box<dyn RawScorer + 'a>, InternalScorerUnsupported> {
         match self {
-            QuantizedVectorStorageRead::ScalarRam(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::ScalarMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarMmap(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::PQRam(q) => {
+            ReadOnlyQuantizedVectorStorage::PQRam(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::PQMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmap(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryRam(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryRam(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmap(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQRam(q) => {
+            ReadOnlyQuantizedVectorStorage::TQRam(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQMmap(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmap(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::ScalarRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarRamMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::ScalarMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::PQRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQRamMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::PQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::PQMmapMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryRamMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQRamMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQRamMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQMmapMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQMmapMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryChunked(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQChunked(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => {
                 internal_raw_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
                 internal_raw_multi_scorer(point_id, q, hardware_counter)
             }
         }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -8,7 +8,7 @@ use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rstest::rstest;
 
-use super::QuantizedVectorsRead;
+use super::ReadOnlyQuantizedVectors;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{
@@ -79,7 +79,7 @@ fn turbo_config(always_ram: bool) -> QuantizationConfig {
     })
 }
 
-/// The read-only [`QuantizedVectorsRead`] opened over the same on-disk data must
+/// The read-only [`ReadOnlyQuantizedVectors`] opened over the same on-disk data must
 /// produce bit-identical scores to the read-write [`QuantizedVectors`].
 #[rstest]
 #[case::scalar_mmap(scalar_config(false), QuantizedVectorsStorageType::Immutable)]
@@ -113,7 +113,7 @@ fn read_only_matches_read_write(
     )
     .unwrap();
 
-    let ro = QuantizedVectorsRead::<MmapFile>::open(
+    let ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
         &MmapFs,
         quant_dir.path(),
         storage.distance(),
@@ -195,7 +195,7 @@ fn read_only_matches_read_write_multivector(
     )
     .unwrap();
 
-    let ro = QuantizedVectorsRead::<MmapFile>::open(
+    let ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
         &MmapFs,
         quant_dir.path(),
         storage.distance(),
@@ -231,7 +231,7 @@ fn read_only_matches_read_write_multivector(
 
 fn assert_internal_scorer_eq(
     rw: &QuantizedVectors,
-    ro: &QuantizedVectorsRead<MmapFile>,
+    ro: &ReadOnlyQuantizedVectors<MmapFile>,
     sample: &[PointOffsetType],
 ) {
     let pivot = sample[0];

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -10,7 +10,7 @@ use zerocopy::FromBytes;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{DenseVector, TypedDenseVector};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
+use crate::vector_storage::DenseVectorStorageRead;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -18,7 +18,7 @@ pub struct CustomQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > {
     vector_storage: &'a TVectorStorage,
@@ -32,7 +32,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TStoredQuery>
 {
@@ -76,7 +76,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > QueryScorer for CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TStoredQuery>
 {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -10,14 +10,14 @@ use zerocopy::FromBytes;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{TypedDenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
+use crate::vector_storage::DenseVectorStorageRead;
 use crate::vector_storage::query_scorer::QueryScorer;
 
 pub struct MetricQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
     query: TypedDenseVector<TElement>,
@@ -29,7 +29,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > MetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     pub fn new(
@@ -61,7 +61,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > QueryScorer for MetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     type TVector = [TElement];

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -12,7 +12,7 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
 use crate::spaces::metric::Metric;
-use crate::vector_storage::MultiVectorStorage;
+use crate::vector_storage::MultiVectorStorageRead;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -20,7 +20,7 @@ pub struct MultiCustomQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
 > {
     vector_storage: &'a TVectorStorage,
@@ -34,7 +34,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
 > MultiCustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TQuery>
 {
@@ -83,7 +83,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
 > MultiCustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TQuery>
 {
@@ -108,7 +108,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
     TQuery: Query<TypedMultiDenseVector<TElement>>,
 > QueryScorer for MultiCustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TQuery>
 {

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -12,14 +12,14 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
 };
 use crate::spaces::metric::Metric;
-use crate::vector_storage::MultiVectorStorage;
+use crate::vector_storage::MultiVectorStorageRead;
 use crate::vector_storage::query_scorer::QueryScorer;
 
 pub struct MultiMetricQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
     query: TypedMultiDenseVector<TElement>,
@@ -31,7 +31,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
 > MultiMetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     pub fn new(
@@ -86,7 +86,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
 > QueryScorer for MultiMetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     type TVector = TypedMultiDenseVector<TElement>;

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -5,13 +5,13 @@ use common::types::{PointOffsetType, ScoreType};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::{DimId, DimWeight};
 
-use crate::vector_storage::SparseVectorStorage;
+use crate::vector_storage::SparseVectorStorageRead;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
 pub struct SparseCustomQueryScorer<
     'a,
-    TVectorStorage: SparseVectorStorage,
+    TVectorStorage: SparseVectorStorageRead,
     TQuery: Query<SparseVector>,
 > {
     vector_storage: &'a TVectorStorage,
@@ -21,7 +21,7 @@ pub struct SparseCustomQueryScorer<
 
 impl<
     'a,
-    TVectorStorage: SparseVectorStorage,
+    TVectorStorage: SparseVectorStorageRead,
     TQuery: Query<SparseVector> + TransformInto<TQuery, SparseVector, SparseVector>,
 > SparseCustomQueryScorer<'a, TVectorStorage, TQuery>
 {
@@ -52,7 +52,7 @@ impl<
     }
 }
 
-impl<TVectorStorage: SparseVectorStorage, TQuery: Query<SparseVector>> QueryScorer
+impl<TVectorStorage: SparseVectorStorageRead, TQuery: Query<SparseVector>> QueryScorer
     for SparseCustomQueryScorer<'_, TVectorStorage, TQuery>
 {
     type TVector = SparseVector;

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -4,7 +4,7 @@ use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 use sparse::common::sparse_vector::SparseVector;
 
-use crate::vector_storage::SparseVectorStorage;
+use crate::vector_storage::SparseVectorStorageRead;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
 

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -12,7 +12,7 @@ use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::multi_custom_query_scorer::MultiCustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;
 use super::query_scorer::{QueryScorerBytes, QueryScorerBytesImpl};
-use super::{DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
+use super::{DenseVectorStorageRead, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
@@ -93,6 +93,30 @@ pub fn new_raw_scorer<'a>(
         }
         VectorStorageEnum::EmptyDense(vs) => raw_scorer_impl(query, vs, hc),
         VectorStorageEnum::EmptySparse(vs) => raw_sparse_scorer_impl(query, vs, hc),
+    }
+}
+
+/// Build a [`RawScorer`] for a query against this vector storage.
+///
+/// Implemented for the storage enums so scoring code can be generic over
+/// read-write ([`VectorStorageEnum`]) and read-only
+/// ([`VectorStorageReadEnum`](crate::vector_storage::read_only::VectorStorageReadEnum))
+/// backends.
+pub trait RawScorerBuilder {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>>;
+}
+
+impl RawScorerBuilder for VectorStorageEnum {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        new_raw_scorer(query, self, hardware_counter)
     }
 }
 
@@ -187,7 +211,7 @@ pub fn new_raw_scorer_for_test<'a>(
 pub fn raw_scorer_impl<
     'a,
     TElement: PrimitiveVectorElement,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
@@ -227,7 +251,7 @@ fn new_scorer_with_metric<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement> + 'a,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -12,7 +12,9 @@ use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::multi_custom_query_scorer::MultiCustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;
 use super::query_scorer::{QueryScorerBytes, QueryScorerBytesImpl};
-use super::{DenseVectorStorageRead, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
+use super::{
+    DenseVectorStorageRead, MultiVectorStorageRead, SparseVectorStorageRead, VectorStorageEnum,
+};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
@@ -142,7 +144,7 @@ pub fn raw_sparse_scorer_volatile<'a>(
     raw_scorer_from_query_scorer(query_scorer)
 }
 
-pub fn raw_sparse_scorer_impl<'a, TVectorStorage: SparseVectorStorage>(
+pub fn raw_sparse_scorer_impl<'a, TVectorStorage: SparseVectorStorageRead>(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
     hardware_counter: HardwareCounterCell,
@@ -324,7 +326,7 @@ pub fn raw_scorer_from_query_scorer<'a>(
 pub fn raw_multi_scorer_impl<
     'a,
     TElement: PrimitiveVectorElement,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
@@ -364,7 +366,7 @@ fn new_multi_scorer_with_metric<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement> + 'a,
-    TVectorStorage: MultiVectorStorage<TElement>,
+    TVectorStorage: MultiVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -40,21 +40,39 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
         };
 
         // Multivectors always use the appendable chunked layout.
-        if vector_config.multivector_config.is_some() {
+        if let Some(multivector_config) = vector_config.multivector_config {
             return Ok(Some(match datatype {
                 VectorStorageDatatype::Float32 => {
                     Self::MultiDenseChunked(Box::new(ReadOnlyChunkedMultiDenseVectorStorage::open(
-                        fs, path, dim, distance, advice, populate,
+                        fs,
+                        path,
+                        dim,
+                        distance,
+                        multivector_config,
+                        advice,
+                        populate,
                     )?))
                 }
                 VectorStorageDatatype::Uint8 => Self::MultiDenseChunkedByte(Box::new(
                     ReadOnlyChunkedMultiDenseVectorStorage::open(
-                        fs, path, dim, distance, advice, populate,
+                        fs,
+                        path,
+                        dim,
+                        distance,
+                        multivector_config,
+                        advice,
+                        populate,
                     )?,
                 )),
                 VectorStorageDatatype::Float16 => Self::MultiDenseChunkedHalf(Box::new(
                     ReadOnlyChunkedMultiDenseVectorStorage::open(
-                        fs, path, dim, distance, advice, populate,
+                        fs,
+                        path,
+                        dim,
+                        distance,
+                        multivector_config,
+                        advice,
+                        populate,
                     )?,
                 )),
                 VectorStorageDatatype::Turbo4 => {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -9,7 +9,7 @@ use crate::vector_storage::dense::dense_vector_storage::DenseVectorStorageImpl;
 use crate::vector_storage::dense::read_only::ReadOnlyChunkedDenseVectorStorage;
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
-use crate::vector_storage::{DenseVectorStorageRead, RawScorer, RawScorerBuilder, raw_scorer_impl};
+use crate::vector_storage::{RawScorer, RawScorerBuilder, raw_scorer_impl};
 
 mod lifecycle;
 mod read_ops;
@@ -29,30 +29,6 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
-}
-
-impl<S: UniversalRead> VectorStorageReadEnum<S> {
-    /// Size of all available (non-deleted) vectors in bytes.
-    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
-        match self {
-            VectorStorageReadEnum::Dense(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::DenseByte(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::DenseHalf(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::DenseChunked(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::DenseChunkedByte(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::DenseChunkedHalf(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::MultiDenseChunked(s) => s.size_of_available_vectors_in_bytes(),
-            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
-                s.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
-                s.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageReadEnum::Sparse(_) => {
-                unreachable!("Sparse storage does not know its total size, get from index instead")
-            }
-        }
-    }
 }
 
 impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -1,10 +1,15 @@
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::UniversalRead;
 
-use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{
+    QueryVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+};
 use crate::vector_storage::dense::dense_vector_storage::DenseVectorStorageImpl;
 use crate::vector_storage::dense::read_only::ReadOnlyChunkedDenseVectorStorage;
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
+use crate::vector_storage::{DenseVectorStorageRead, RawScorer, RawScorerBuilder, raw_scorer_impl};
 
 mod lifecycle;
 mod read_ops;
@@ -24,6 +29,65 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
+}
+
+impl<S: UniversalRead> VectorStorageReadEnum<S> {
+    /// Size of all available (non-deleted) vectors in bytes.
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::Sparse(_) => {
+                unreachable!("Sparse storage does not know its total size, get from index instead")
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        match self {
+            VectorStorageReadEnum::Dense(s) => raw_scorer_impl(query, s.as_ref(), hardware_counter),
+            VectorStorageReadEnum::DenseByte(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseHalf(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunked(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunkedByte(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunkedHalf(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            // Multi / sparse read-only storages don't yet implement the typed
+            // storage traits the query scorers are built from.
+            VectorStorageReadEnum::MultiDenseChunked(_)
+            | VectorStorageReadEnum::MultiDenseChunkedByte(_)
+            | VectorStorageReadEnum::MultiDenseChunkedHalf(_)
+            | VectorStorageReadEnum::Sparse(_) => Err(OperationError::service_error(
+                "raw scorer is not yet supported for read-only multi / sparse vector storage",
+            )),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::UniversalRead;
 
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{
     QueryVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
 };
@@ -9,7 +9,9 @@ use crate::vector_storage::dense::dense_vector_storage::DenseVectorStorageImpl;
 use crate::vector_storage::dense::read_only::ReadOnlyChunkedDenseVectorStorage;
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
-use crate::vector_storage::{RawScorer, RawScorerBuilder, raw_scorer_impl};
+use crate::vector_storage::{
+    RawScorer, RawScorerBuilder, raw_multi_scorer_impl, raw_scorer_impl, raw_sparse_scorer_impl,
+};
 
 mod lifecycle;
 mod read_ops;
@@ -54,14 +56,18 @@ impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::DenseChunkedHalf(s) => {
                 raw_scorer_impl(query, s.as_ref(), hardware_counter)
             }
-            // Multi / sparse read-only storages don't yet implement the typed
-            // storage traits the query scorers are built from.
-            VectorStorageReadEnum::MultiDenseChunked(_)
-            | VectorStorageReadEnum::MultiDenseChunkedByte(_)
-            | VectorStorageReadEnum::MultiDenseChunkedHalf(_)
-            | VectorStorageReadEnum::Sparse(_) => Err(OperationError::service_error(
-                "raw scorer is not yet supported for read-only multi / sparse vector storage",
-            )),
+            VectorStorageReadEnum::MultiDenseChunked(s) => {
+                raw_multi_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                raw_multi_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                raw_multi_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::Sparse(s) => {
+                raw_sparse_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -9,6 +9,25 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::VectorStorageRead;
 
 impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::Sparse(s) => s.size_of_available_vectors_in_bytes(),
+        }
+    }
+
     fn distance(&self) -> Distance {
         match self {
             VectorStorageReadEnum::Dense(s) => s.distance(),

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -16,7 +16,8 @@ use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
 use crate::vector_storage::{
-    SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    SparseVectorStorage, SparseVectorStorageRead, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 /// Placeholder sparse vector storage that contains no data.
@@ -51,7 +52,7 @@ pub fn new_empty_sparse_vector_storage(num_points: usize) -> VectorStorageEnum {
     VectorStorageEnum::EmptySparse(EmptySparseVectorStorage::new(num_points))
 }
 
-impl SparseVectorStorage for EmptySparseVectorStorage {
+impl SparseVectorStorageRead for EmptySparseVectorStorage {
     fn get_sparse<P: AccessPattern>(&self, _key: PointOffsetType) -> OperationResult<SparseVector> {
         Ok(SparseVector::default())
     }
@@ -73,7 +74,9 @@ impl SparseVectorStorage for EmptySparseVectorStorage {
     {
         Ok(())
     }
+}
 
+impl SparseVectorStorage for EmptySparseVectorStorage {
     fn update_from<'a>(
         &mut self,
         _other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -86,6 +86,10 @@ impl SparseVectorStorage for EmptySparseVectorStorage {
 }
 
 impl VectorStorageRead for EmptySparseVectorStorage {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        0
+    }
+
     fn distance(&self) -> Distance {
         SPARSE_VECTOR_DISTANCE
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -254,6 +254,10 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
 }
 
 impl VectorStorageRead for MmapSparseVectorStorage {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        unreachable!("Mmap sparse storage does not know its total size, get from index instead")
+    }
+
     fn distance(&self) -> crate::types::Distance {
         super::SPARSE_VECTOR_DISTANCE
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -21,7 +21,9 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::VectorStorageDatatype;
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
-use crate::vector_storage::{SparseVectorStorage, VectorStorage, VectorStorageRead};
+use crate::vector_storage::{
+    SparseVectorStorage, SparseVectorStorageRead, VectorStorage, VectorStorageRead,
+};
 
 pub(crate) const DELETED_DIRNAME: &str = "deleted";
 pub(crate) const STORAGE_DIRNAME: &str = "store";
@@ -187,7 +189,7 @@ impl MmapSparseVectorStorage {
     }
 }
 
-impl SparseVectorStorage for MmapSparseVectorStorage {
+impl SparseVectorStorageRead for MmapSparseVectorStorage {
     fn get_sparse<P: AccessPattern>(&self, key: PointOffsetType) -> OperationResult<SparseVector> {
         self.get_sparse_opt::<P>(key)?
             .ok_or_else(|| OperationError::service_error(format!("Key {key} not found")))
@@ -227,7 +229,9 @@ impl SparseVectorStorage for MmapSparseVectorStorage {
             HardwareCounterCell::disposable().vector_io_read(),
         )
     }
+}
 
+impl SparseVectorStorage for MmapSparseVectorStorage {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,

--- a/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
@@ -1,16 +1,58 @@
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::AccessPattern;
+use common::generic_consts::{AccessPattern, Random};
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::ReadOnlySparseVectorStorage;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
+use crate::vector_storage::{SparseVectorStorageRead, VectorStorageRead};
+
+impl<S: UniversalRead> SparseVectorStorageRead for ReadOnlySparseVectorStorage<S> {
+    fn get_sparse<P: AccessPattern>(&self, key: PointOffsetType) -> OperationResult<SparseVector> {
+        self.get_sparse_opt::<P>(key)?
+            .ok_or_else(|| OperationError::service_error(format!("Key {key} not found")))
+    }
+
+    fn get_sparse_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> OperationResult<Option<SparseVector>> {
+        self.storage
+            .get_value::<P>(key, &HardwareCounterCell::disposable())? // Vector storage read IO not measured
+            .map(SparseVector::try_from)
+            .transpose()
+    }
+
+    fn for_each_in_sparse_batch<F>(
+        &self,
+        keys: &[PointOffsetType],
+        mut callback: F,
+    ) -> OperationResult<()>
+    where
+        F: FnMut(usize, SparseVector),
+    {
+        let point_offsets = keys.iter().copied().enumerate();
+
+        let callback = |value_idx, _, sparse_vector| {
+            if let Some(sparse_vector) = sparse_vector {
+                callback(value_idx, SparseVector::try_from(sparse_vector)?);
+            }
+
+            Ok(())
+        };
+
+        self.storage.read_values::<Random, _, _>(
+            point_offsets,
+            callback,
+            HardwareCounterCell::disposable().vector_io_read(),
+        )
+    }
+}
 
 impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
     fn size_of_available_vectors_in_bytes(&self) -> usize {

--- a/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
@@ -13,6 +13,10 @@ use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
 
 impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        unreachable!("Sparse storage does not know its total size, get from index instead")
+    }
+
     fn distance(&self) -> Distance {
         SPARSE_VECTOR_DISTANCE
     }

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -88,16 +88,6 @@ impl VolatileSparseVectorStorage {
             *entry = vector.cloned();
         }
     }
-
-    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
-        if self.total_vector_count == 0 {
-            return 0;
-        }
-        let available_fraction =
-            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
-        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
-        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
-    }
 }
 
 impl SparseVectorStorage for VolatileSparseVectorStorage {
@@ -153,6 +143,16 @@ impl SparseVectorStorage for VolatileSparseVectorStorage {
 }
 
 impl VectorStorageRead for VolatileSparseVectorStorage {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count == 0 {
+            return 0;
+        }
+        let available_fraction =
+            (self.total_vector_count - self.deleted_count) as f32 / self.total_vector_count as f32;
+        let available_size = (self.total_sparse_size as f32 * available_fraction) as usize;
+        available_size * (std::mem::size_of::<DimWeight>() + std::mem::size_of::<DimId>())
+    }
+
     fn distance(&self) -> Distance {
         SPARSE_VECTOR_DISTANCE
     }

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -15,7 +15,8 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::{
-    SparseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    SparseVectorStorage, SparseVectorStorageRead, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
@@ -90,7 +91,7 @@ impl VolatileSparseVectorStorage {
     }
 }
 
-impl SparseVectorStorage for VolatileSparseVectorStorage {
+impl SparseVectorStorageRead for VolatileSparseVectorStorage {
     fn get_sparse<P: AccessPattern>(&self, key: PointOffsetType) -> OperationResult<SparseVector> {
         let vector = self
             .get_sparse_opt::<P>(key)?
@@ -122,7 +123,9 @@ impl SparseVectorStorage for VolatileSparseVectorStorage {
 
         Ok(())
     }
+}
 
+impl SparseVectorStorage for VolatileSparseVectorStorage {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, SparseVector>, bool)>,

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -15,6 +15,7 @@ use crate::types::Distance;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage_with_uring;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::vector_storage_base::VectorStorageRead;
 
 #[test]
@@ -96,7 +97,7 @@ fn test_random_score(
     let mut async_scorer = FilteredScorer::new(
         query,
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         deleted_points,
         HardwareCounterCell::new(),

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -240,7 +240,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
     let mut raw_scorer = FilteredScorer::new(
         query.clone(),
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         id_tracker.deleted_point_bitslice(),
         HardwareCounterCell::new(),
@@ -250,7 +250,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
     let searcher = BatchFilteredSearcher::new(
         &[&query],
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         2,
         id_tracker.deleted_point_bitslice(),

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -20,7 +20,7 @@ use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_full;
 use crate::vector_storage::multi_dense::volatile_multi_dense_vector_storage::new_volatile_multi_dense_vector_storage;
 use crate::vector_storage::{
-    DEFAULT_STOPPED, MultiVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DEFAULT_STOPPED, MultiVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 #[derive(Clone, Copy)]

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -69,12 +69,6 @@ pub struct TurboVectorStorage {
 }
 
 impl TurboVectorStorage {
-    /// Memory layout of a single encoded vector.
-    pub fn quantized_vector_layout(&self) -> OperationResult<Layout> {
-        // TODO: build from quantized_vector_size() with the encoding alignment.
-        unimplemented!("TODO: layout of one encoded vector")
-    }
-
     /// Raw encoded vector blob for one vector (no dequantization/lloyd lookup).
     pub fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
         self.storage.get_quantized_vector(key)

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -69,9 +69,10 @@ pub struct TurboVectorStorage {
 }
 
 impl TurboVectorStorage {
-    /// Bytes used by all available (non-deleted) vectors in their encoded form.
-    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.quantized_vector_size()
+    /// Memory layout of a single encoded vector.
+    pub fn quantized_vector_layout(&self) -> OperationResult<Layout> {
+        // TODO: build from quantized_vector_size() with the encoding alignment.
+        unimplemented!("TODO: layout of one encoded vector")
     }
 
     /// Raw encoded vector blob for one vector (no dequantization/lloyd lookup).
@@ -200,6 +201,10 @@ fn open_turbo_vector_storage_impl(
 }
 
 impl VectorStorageRead for TurboVectorStorage {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.quantized_vector_size()
+    }
+
     fn distance(&self) -> Distance {
         self.distance
     }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -162,22 +162,15 @@ pub trait VectorStorage: VectorStorageRead {
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool>;
 }
 
-pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
+/// Read-only access to a dense vector storage.
+///
+/// Everything needed to read and score dense vectors, without the ability to
+/// mutate. Implemented by read-only storages too, which cannot provide
+/// [`DenseVectorStorage::update_from`].
+pub trait DenseVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]>;
-
-    /// Add the given dense vectors to the storage.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>>;
 
     /// Call `f` with the raw bytes of the vector if it exists.
     ///
@@ -211,6 +204,20 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
+}
+
+pub trait DenseVectorStorage<T: PrimitiveVectorElement>: DenseVectorStorageRead<T> {
+    /// Add the given dense vectors to the storage.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 }
 
 pub trait SparseVectorStorage: VectorStorageRead {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -219,7 +219,10 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: DenseVectorStorageRead<
     ) -> OperationResult<Range<PointOffsetType>>;
 }
 
-pub trait SparseVectorStorage: VectorStorageRead {
+/// Read-only access to a sparse vector storage: everything needed to score
+/// queries, without the ability to mutate. Implemented by read-only storages
+/// too, which cannot provide [`SparseVectorStorage::update_from`].
+pub trait SparseVectorStorageRead: VectorStorageRead {
     fn get_sparse<P: AccessPattern>(&self, key: PointOffsetType) -> OperationResult<SparseVector>;
     fn get_sparse_opt<P: AccessPattern>(
         &self,
@@ -233,7 +236,9 @@ pub trait SparseVectorStorage: VectorStorageRead {
     ) -> OperationResult<()>
     where
         F: FnMut(usize, SparseVector);
+}
 
+pub trait SparseVectorStorage: SparseVectorStorageRead {
     /// Add the given sparse vectors to the storage.
     ///
     /// # Returns
@@ -247,7 +252,10 @@ pub trait SparseVectorStorage: VectorStorageRead {
     ) -> OperationResult<Range<PointOffsetType>>;
 }
 
-pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
+/// Read-only access to a multi-dense vector storage: everything needed to score
+/// queries, without the ability to mutate. Implemented by read-only storages
+/// too, which cannot provide [`MultiVectorStorage::update_from`].
+pub trait MultiVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_multi<P: AccessPattern>(&self, key: PointOffsetType) -> CowMultiVector<'_, T>;
@@ -262,7 +270,9 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
+}
 
+pub trait MultiVectorStorage<T: PrimitiveVectorElement>: MultiVectorStorageRead<T> {
     /// Add the given multi-dense vectors to the storage.
     ///
     /// # Returns

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -340,10 +340,6 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
             f(idx, &self.get_dense_tq::<Random>(key));
         }
     }
-
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.quantized_vector_size()
-    }
 }
 
 #[derive(Debug)]

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -134,6 +134,9 @@ pub trait VectorStorageRead {
     /// The size of this slice is not guaranteed. It may be smaller/larger than the number of
     /// vectors in this segment.
     fn deleted_vector_bitslice(&self) -> &BitSlice;
+
+    /// Size of all available (non-deleted) vectors in bytes.
+    fn size_of_available_vectors_in_bytes(&self) -> usize;
 }
 
 /// Trait for vector storage with mutating operations.
@@ -200,10 +203,6 @@ pub trait DenseVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
             f(idx, &self.get_dense::<Random>(key));
         }
     }
-
-    fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
-    }
 }
 
 pub trait DenseVectorStorage<T: PrimitiveVectorElement>: DenseVectorStorageRead<T> {
@@ -263,8 +262,6 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
-
-    fn size_of_available_vectors_in_bytes(&self) -> usize;
 
     /// Add the given multi-dense vectors to the storage.
     ///
@@ -478,56 +475,6 @@ impl VectorStorageEnum {
         }
     }
 
-    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.size_of_available_vectors_in_bytes(),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::SparseVolatile(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::SparseMmap(_v) => {
-                unreachable!(
-                    "Mmap sparse storage does not know its total size, get from index instead"
-                )
-            }
-            VectorStorageEnum::MultiDenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.size_of_available_vectors_in_bytes(),
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.size_of_available_vectors_in_bytes(),
-            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.size_of_available_vectors_in_bytes()
-            }
-            VectorStorageEnum::EmptyDense(_) => 0,
-            VectorStorageEnum::EmptySparse(_) => 0,
-        }
-    }
-
     pub fn populate(&self) -> OperationResult<()> {
         match self {
             VectorStorageEnum::DenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -689,6 +636,56 @@ impl VectorStorageEnum {
 }
 
 impl VectorStorageRead for VectorStorageEnum {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.size_of_available_vectors_in_bytes(),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::SparseVolatile(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::SparseMmap(_v) => {
+                unreachable!(
+                    "Mmap sparse storage does not know its total size, get from index instead"
+                )
+            }
+            VectorStorageEnum::MultiDenseVolatile(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.size_of_available_vectors_in_bytes(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageEnum::EmptyDense(_) => 0,
+            VectorStorageEnum::EmptySparse(_) => 0,
+        }
+    }
+
     fn distance(&self) -> Distance {
         match self {
             VectorStorageEnum::DenseVolatile(v) => v.distance(),


### PR DESCRIPTION
Groundwork for read-only vector indexes: factor the read paths of the plain and HNSW vector indexes into reusable borrowed read-views, and split the vector-storage traits into read/write halves so read-only storages can be scored. This branch combines the original plain read-view work with the `read-only-hnsw-index` work (merged in) and is rebased on latest `dev`.

> ⚠️ Contains intermediate WIP commits that don't individually compile (the read-only HNSW scaffold). The **branch tip compiles cleanly** — `cargo clippy --all-targets` and `cargo +nightly fmt --all --check` are green. Intended to be re-sliced into several independent PRs.

### Plain vector index read-view
- Split `plain_vector_index.rs` into a `plain_vector_index/` module: `mod.rs` (`PlainVectorIndex` + `new`/`with_view`), `read.rs` (thin `VectorIndexRead` delegation), `lifecycle.rs` (`VectorIndex` impl), `read_view/` (the borrowed view + its search).
- `PlainVectorIndexReadView`: a borrowed view holding the read guards up front. Type params are **decoupled** (`I: IdTrackerRead`, `V: VectorStorageRead`, `Q: QuantizedVectorsReadAccess`, `P: PayloadIndexRead`) so the payload-index view can be built over different (e.g. still-mutable) backends than the standalone storages.
- `search` / `is_small_enough_for_unindexed_search` live on the **generic view** (not the concrete enum alias), so `PlainVectorIndex` and `ReadOnlyPlainVectorIndex` share one implementation.

### HNSW read-view + read-only index
- Extract `HNSWIndex`'s read path into `HNSWIndexReadView` (`hnsw/read_view/{mod,search,dispatch}.rs`); `HNSWIndex::search` delegates via `with_view`.
- Add `ReadOnlyHNSWIndex<S>` + `with_view` + `VectorIndexRead` (`hnsw/read_only/`), reusing the same generic view search. The graph stays a plain `GraphLayers` loaded over a `UniversalRead` filesystem.

### `QuantizedVectorsReadAccess` trait
- New trait (own `read_access.rs`) implemented by both read-write `QuantizedVectors` and read-only `QuantizedVectorsRead<S>` (`config` / `default_rescoring` / `raw_scorer` / `raw_internal_scorer`); shared `raw_scorer` body extracted into a helper.

### Vector-storage trait splits (read vs write)
- Split `DenseVectorStorage`, `MultiVectorStorage`, and `SparseVectorStorage` each into a read-only supertrait (`DenseVectorStorageRead` / `MultiVectorStorageRead` / `SparseVectorStorageRead`, holding the scoring methods) plus the write-only `update_from`. Read-only storages implement the `*Read` half — they couldn't implement the originals because of `update_from`.
- Hoist `size_of_available_vectors_in_bytes` onto `VectorStorageRead` (was split across the typed traits / enum-inherent impls).

### Generic scoring over read & read-only storages
- New `RawScorerBuilder` trait (impl'd by `VectorStorageEnum` and `VectorStorageReadEnum<S>`); make `FilteredScorer`/`BatchFilteredSearcher` constructors, `postprocess_search_result`, `is_quantized_search`, `get_oversampled_top`, the dense/multi/sparse query scorers, and `raw_*_scorer_impl` generic over `VectorStorageRead` + `RawScorerBuilder` / `QuantizedVectorsReadAccess` / the `*Read` traits.
- `VectorStorageReadEnum::build_raw_scorer` scores **all** read-only dense, multi, and sparse variants — so read-only plain & HNSW search work end to end (no `service_error` stubs left).

### Misc
- Fix missing `std::ops::Range` / `std::sync::atomic::AtomicBool` imports in the `TurboVectorStorage` scaffold (uncompilable at branch base).

No behavior change for the existing read-write paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
