### PR TITLE
Fix red CI on dev

### DIFF
--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -16,9 +16,7 @@ mod turbo_encoded_vectors;
 
 use std::alloc::Layout;
 use std::borrow::Cow;
-use std::ops::Range;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -128,15 +126,6 @@ impl VectorStorage for TurboVectorStorage {
     ) -> OperationResult<()> {
         // TODO: encode the f32 vector via `self.encoded.upsert_vector` (live insert).
         unimplemented!("TODO: encode and insert a single vector")
-    }
-
-    fn update_from<'a>(
-        &mut self,
-        _other_vectors: &'a mut impl Iterator<Item = (CowVector<'a>, bool)>,
-        _stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>> {
-        // TODO: encode each incoming f32 vector and propagate deleted flags.
-        unimplemented!("TODO: encode vectors from another storage (optimize)")
     }
 
     fn flusher(&self) -> Flusher {


### PR DESCRIPTION
We just merged both https://github.com/qdrant/qdrant/pull/9357 and https://github.com/qdrant/qdrant/pull/9326

CI fails now because the second PR contained a trait function impl, which was earlier removed in #9357. CI didn't re-run after merging the first PR, so it was not caught. This PR fixes CI by removing the function impl introduced in #9326.