### PR TITLE
[TQDT] Veсtor storage `update_from` with element type

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -97,15 +97,13 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
 
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
         let disposed_hw = HardwareCounterCell::disposable(); // This function is only used for internal operations.
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(other_vector);
             let new_id = self.vectors.push(other_vector.as_ref(), &disposed_hw)?;
             self.set_deleted(new_id as PointOffsetType, other_deleted);
         }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -16,7 +16,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 #[cfg(target_os = "linux")]
 use crate::vector_storage::common::get_async_scorer;
@@ -234,7 +234,7 @@ where
 
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
@@ -246,10 +246,9 @@ where
         let mut deleted_ids = vec![];
         for (offset, (other_vector, other_deleted)) in other_vectors.enumerate() {
             check_process_stopped(stopped)?;
-            let vector = T::slice_from_float_cow(other_vector);
             // Safety: T implements zerocopy::IntoBytes.
             #[expect(deprecated, reason = "legacy code")]
-            let raw_bites = unsafe { mmap::transmute_to_u8_slice(vector.as_ref()) };
+            let raw_bites = unsafe { mmap::transmute_to_u8_slice(other_vector.as_ref()) };
             vectors_file.write_all(raw_bites)?;
             end_index += 1;
 

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -86,14 +86,12 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
 
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors.len() as PointOffsetType;
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = T::slice_from_float_cow(other_vector);
             let new_id = self.vectors.push(other_vector.as_ref())? as PointOffsetType;
             self.set_deleted(new_id, other_deleted);
         }

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -125,6 +125,63 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
         previous
     }
 
+    /// Insert a multi-vector already in the storage's element type `T`.
+    ///
+    /// Leaves the deleted flag cleared; callers that need it set should call
+    /// [`Self::set_deleted`] afterwards.
+    fn insert_multi_native(
+        &mut self,
+        key: PointOffsetType,
+        multi_vector: TypedMultiDenseVectorRef<T>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        assert_eq!(multi_vector.dim, self.vectors.dim());
+        let multivector_size_in_bytes = std::mem::size_of_val(multi_vector.flattened_vectors);
+        let max_vector_size_bytes = self.vectors.max_vector_size_bytes();
+        if multivector_size_in_bytes >= max_vector_size_bytes {
+            return Err(OperationError::service_error(format!(
+                "Cannot insert multi vector of size {multivector_size_in_bytes} to the mmap vector storage.\
+                 It's too large, maximum size is {max_vector_size_bytes}."
+            )));
+        }
+
+        let mut offset = self
+            .offsets
+            .get::<Random>(key as VectorOffsetType)
+            .map(|x| x.first().copied().unwrap_or_default())
+            .unwrap_or_default();
+
+        if multi_vector.vectors_count() > offset.capacity as usize {
+            // append vector to the end
+            let mut new_key = self.vectors.len();
+            let chunk_left_keys = self.vectors.get_remaining_chunk_keys(new_key);
+            if multi_vector.vectors_count() > chunk_left_keys {
+                new_key += chunk_left_keys;
+            }
+
+            offset = MultivectorMmapOffset {
+                offset: new_key as PointOffsetType,
+                count: multi_vector.vectors_count() as PointOffsetType,
+                capacity: multi_vector.vectors_count() as PointOffsetType,
+            };
+        } else {
+            // use existing place to insert vector
+            offset.count = multi_vector.vectors_count() as PointOffsetType;
+        }
+
+        self.vectors.insert_many(
+            offset.offset as VectorOffsetType,
+            multi_vector.flattened_vectors,
+            multi_vector.vectors_count(),
+            hw_counter,
+        )?;
+        self.offsets
+            .insert(key as VectorOffsetType, &[offset], hw_counter)?;
+        self.set_deleted(key, false);
+
+        Ok(())
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
@@ -223,17 +280,15 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for AppendableMmapMultiDen
 
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.offsets.len() as PointOffsetType;
         let disposed_hw_counter = HardwareCounterCell::disposable(); // Internal operation
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = VectorRef::MultiDense(other_vector.as_ref());
             let new_id = self.offsets.len() as PointOffsetType;
-            self.insert_vector(new_id, other_vector, &disposed_hw_counter)?;
+            self.insert_multi_native(new_id, other_vector.as_ref(), &disposed_hw_counter)?;
             self.set_deleted(new_id, other_deleted);
         }
         let end_index = self.offsets.len() as PointOffsetType;
@@ -314,52 +369,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
     ) -> OperationResult<()> {
         let multi_vector: TypedMultiDenseVectorRef<VectorElementType> = vector.try_into()?;
         let multi_vector = T::from_float_multivector(CowMultiVector::Borrowed(multi_vector));
-        let multi_vector = multi_vector.as_vec_ref();
-        assert_eq!(multi_vector.dim, self.vectors.dim());
-        let multivector_size_in_bytes = std::mem::size_of_val(multi_vector.flattened_vectors);
-        let max_vector_size_bytes = self.vectors.max_vector_size_bytes();
-        if multivector_size_in_bytes >= max_vector_size_bytes {
-            return Err(OperationError::service_error(format!(
-                "Cannot insert multi vector of size {multivector_size_in_bytes} to the mmap vector storage.\
-                 It's too large, maximum size is {max_vector_size_bytes}."
-            )));
-        }
-
-        let mut offset = self
-            .offsets
-            .get::<Random>(key as VectorOffsetType)
-            .map(|x| x.first().copied().unwrap_or_default())
-            .unwrap_or_default();
-
-        if multi_vector.vectors_count() > offset.capacity as usize {
-            // append vector to the end
-            let mut new_key = self.vectors.len();
-            let chunk_left_keys = self.vectors.get_remaining_chunk_keys(new_key);
-            if multi_vector.vectors_count() > chunk_left_keys {
-                new_key += chunk_left_keys;
-            }
-
-            offset = MultivectorMmapOffset {
-                offset: new_key as PointOffsetType,
-                count: multi_vector.vectors_count() as PointOffsetType,
-                capacity: multi_vector.vectors_count() as PointOffsetType,
-            };
-        } else {
-            // use existing place to insert vector
-            offset.count = multi_vector.vectors_count() as PointOffsetType;
-        }
-
-        self.vectors.insert_many(
-            offset.offset as VectorOffsetType,
-            multi_vector.flattened_vectors,
-            multi_vector.vectors_count(),
-            hw_counter,
-        )?;
-        self.offsets
-            .insert(key as VectorOffsetType, &[offset], hw_counter)?;
-        self.set_deleted(key, false);
-
-        Ok(())
+        self.insert_multi_native(key, multi_vector.as_ref(), hw_counter)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -129,11 +129,21 @@ impl<T: PrimitiveVectorElement> VolatileMultiDenseVectorStorage<T> {
         key: PointOffsetType,
         vector: VectorRef,
         is_deleted: bool,
-        _hw_counter: &HardwareCounterCell,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let multi_vector: TypedMultiDenseVectorRef<VectorElementType> = vector.try_into()?;
         let multi_vector = T::from_float_multivector(CowMultiVector::Borrowed(multi_vector));
-        let multi_vector = multi_vector.as_vec_ref();
+        self.insert_multi_native(key, multi_vector.as_ref(), is_deleted, hw_counter)
+    }
+
+    /// Insert a multi-vector already in the storage's element type `T`.
+    fn insert_multi_native(
+        &mut self,
+        key: PointOffsetType,
+        multi_vector: TypedMultiDenseVectorRef<T>,
+        is_deleted: bool,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
         assert_eq!(multi_vector.dim, self.dim);
         let multivector_size_in_bytes = std::mem::size_of_val(multi_vector.flattened_vectors);
         if multivector_size_in_bytes >= CHUNK_SIZE {
@@ -239,18 +249,16 @@ impl<T: PrimitiveVectorElement> MultiVectorStorage<T> for VolatileMultiDenseVect
 
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let start_index = self.vectors_metadata.len() as PointOffsetType;
         for (other_vector, other_deleted) in other_vectors {
             check_process_stopped(stopped)?;
-            // Do not perform preprocessing - vectors should be already processed
-            let other_vector = VectorRef::MultiDense(other_vector.as_ref());
             let new_id = self.vectors_metadata.len() as PointOffsetType;
-            self.insert_vector_impl(
+            self.insert_multi_native(
                 new_id,
-                other_vector,
+                other_vector.as_ref(),
                 other_deleted,
                 &HardwareCounterCell::disposable(), // This function is only used by internal operations
             )?;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -169,16 +169,13 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     /// Add the given dense vectors to the storage.
     ///
-    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
-    /// with a narrower element type convert them on insert.
-    ///
     /// # Returns
     /// The range of point offsets that were added to the storage.
     ///
     /// If stopped, the operation returns a cancellation error.
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 
@@ -264,16 +261,13 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
 
     /// Add the given multi-dense vectors to the storage.
     ///
-    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
-    /// with a narrower element type convert them on insert.
-    ///
     /// # Returns
     /// The range of point offsets that were added to the storage.
     ///
     /// If stopped, the operation returns a cancellation error.
     fn update_from<'a>(
         &mut self,
-        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, VectorElementType>, bool)>,
+        other_vectors: &mut impl Iterator<Item = (CowMultiVector<'a, T>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 }
@@ -1005,13 +999,16 @@ impl VectorStorageRead for VectorStorageEnum {
     }
 }
 
-/// Unwrap a generic [`CowVector`] into a dense slice for [`DenseVectorStorage`].
+/// Unwrap a generic [`CowVector`] into a dense slice in the storage's element
+/// type `T` for [`DenseVectorStorage`], converting from f32 if needed.
 ///
 /// Receiving a non-dense vector here is a logic error: the merge path always
 /// feeds a storage with vectors of its own kind.
-fn unwrap_dense((vector, deleted): (CowVector<'_>, bool)) -> (Cow<'_, [VectorElementType]>, bool) {
+fn unwrap_dense<T: PrimitiveVectorElement>(
+    (vector, deleted): (CowVector<'_>, bool),
+) -> (Cow<'_, [T]>, bool) {
     match vector {
-        CowVector::Dense(v) => (v, deleted),
+        CowVector::Dense(v) => (T::slice_from_float_cow(v), deleted),
         CowVector::Sparse(_) | CowVector::MultiDense(_) => {
             unreachable!("dense vector storage received a non-dense vector")
         }
@@ -1028,12 +1025,13 @@ fn unwrap_sparse((vector, deleted): (CowVector<'_>, bool)) -> (Cow<'_, SparseVec
     }
 }
 
-/// Unwrap a generic [`CowVector`] into a multi-dense vector for [`MultiVectorStorage`].
-fn unwrap_multi(
+/// Unwrap a generic [`CowVector`] into a multi-dense vector in the storage's
+/// element type `T` for [`MultiVectorStorage`], converting from f32 if needed.
+fn unwrap_multi<T: PrimitiveVectorElement>(
     (vector, deleted): (CowVector<'_>, bool),
-) -> (CowMultiVector<'_, VectorElementType>, bool) {
+) -> (CowMultiVector<'_, T>, bool) {
     match vector {
-        CowVector::MultiDense(v) => (v, deleted),
+        CowVector::MultiDense(v) => (T::from_float_multivector(v), deleted),
         CowVector::Dense(_) | CowVector::Sparse(_) => {
             unreachable!("multi-dense vector storage received a non-multi-dense vector")
         }


### PR DESCRIPTION
Continue https://github.com/qdrant/qdrant/pull/9357
This PR removes float conversion in `update_from` implementations