### PR TITLE
feat: live_reload for read-only quantized vectors

### DIFF
--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -426,6 +426,10 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         &self.encoded_vectors
     }
 
+    pub fn storage_mut(&mut self) -> &mut TStorage {
+        &mut self.encoded_vectors
+    }
+
     pub fn encode<'a>(
         orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<Storage = TStorage>,

--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -95,6 +95,10 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         &self.encoded_vectors
     }
 
+    pub fn storage_mut(&mut self) -> &mut TStorage {
+        &mut self.encoded_vectors
+    }
+
     /// Encode vector data
     ///
     /// # Arguments

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
@@ -1,0 +1,24 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
+
+impl<S: UniversalRead> LiveReload for QuantizedChunkedStorageRead<S> {
+    type Fs = <S as UniversalRead>::Fs;
+
+    /// Pick up quantized vectors a writer appended to the chunked backing.
+    fn live_reload(
+        &mut self,
+        fs: &Self::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.data
+            .live_reload(fs, deleted_points, new_points, hw_counter)
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/mod.rs
@@ -1,3 +1,4 @@
+mod live_reload;
 mod read_only;
 mod read_write;
 

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -4,9 +4,11 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, MmapFlusher};
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
@@ -39,6 +41,15 @@ impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.data.clear_cache()
+    }
+
+    /// Pick up quantized vectors a writer appended to the chunked backing.
+    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
+        // Chunk-open settings are stored on the reader; deletions/new points are
+        // not tracked for quantized, so empty deltas are passed through.
+        let empty = SortedSlice::new(&[]).unwrap();
+        self.data
+            .live_reload(fs, &empty, &empty, &HardwareCounterCell::disposable())
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -44,12 +44,15 @@ impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
     }
 
     /// Pick up quantized vectors a writer appended to the chunked backing.
-    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
-        // Chunk-open settings are stored on the reader; deletions/new points are
-        // not tracked for quantized, so empty deltas are passed through.
-        let empty = SortedSlice::new(&[]).unwrap();
+    pub fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
         self.data
-            .live_reload(fs, &empty, &empty, &HardwareCounterCell::disposable())
+            .live_reload(fs, deleted_points, new_points, hw_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -4,11 +4,9 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, MmapFlusher};
-use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
-use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
@@ -20,7 +18,7 @@ use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 /// so the mutable storage format can be loaded by the read-only quantized storage.
 #[derive(Debug)]
 pub struct QuantizedChunkedStorageRead<S: UniversalRead> {
-    data: ChunkedVectorsRead<u8, S>,
+    pub(super) data: ChunkedVectorsRead<u8, S>,
 }
 
 impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
@@ -41,18 +39,6 @@ impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.data.clear_cache()
-    }
-
-    /// Pick up quantized vectors a writer appended to the chunked backing.
-    pub fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        self.data
-            .live_reload(fs, deleted_points, new_points, hw_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
@@ -1,0 +1,24 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::MultivectorOffsetsStorageChunkedRead;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for MultivectorOffsetsStorageChunkedRead<S> {
+    type Fs = <S as UniversalRead>::Fs;
+
+    /// Pick up offsets a writer appended to the chunked backing.
+    fn live_reload(
+        &mut self,
+        fs: &Self::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.data
+            .live_reload(fs, deleted_points, new_points, hw_counter)
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/mod.rs
@@ -14,6 +14,7 @@ use smallvec::SmallVec;
 use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType};
 use crate::types::{MultiVectorComparator, MultiVectorConfig};
 
+mod live_reload;
 mod offsets;
 
 pub use offsets::{

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/mod.rs
@@ -97,8 +97,16 @@ where
         &self.quantized_storage
     }
 
+    pub fn storage_mut(&mut self) -> &mut QuantizedStorage {
+        &mut self.quantized_storage
+    }
+
     pub fn offsets_storage(&self) -> &TMultivectorOffsetsStorage {
         &self.offsets
+    }
+
+    pub fn offsets_storage_mut(&mut self) -> &mut TMultivectorOffsetsStorage {
+        &mut self.offsets
     }
 
     pub fn new(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
     MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalWrite,
@@ -12,6 +13,7 @@ use fs_err as fs;
 use memmap2::MmapMut;
 
 use super::{MultivectorOffset, MultivectorOffsetsStorage};
+use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::{ChunkedVectors, ChunkedVectorsRead};
@@ -386,6 +388,15 @@ impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.data.clear_cache()
+    }
+
+    /// Pick up offsets a writer appended to the chunked backing.
+    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
+        // Chunk-open settings are stored on the reader; deletions/new points are
+        // not tracked for offsets, so empty deltas are passed through.
+        let empty = SortedSlice::new(&[]).unwrap();
+        self.data
+            .live_reload(fs, &empty, &empty, &HardwareCounterCell::disposable())
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
-use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
     MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalWrite,
@@ -13,7 +12,6 @@ use fs_err as fs;
 use memmap2::MmapMut;
 
 use super::{MultivectorOffset, MultivectorOffsetsStorage};
-use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::{ChunkedVectors, ChunkedVectorsRead};
@@ -373,7 +371,7 @@ impl<S: UniversalWrite + Send + 'static> MultivectorOffsetsStorage
 /// Read-only counterpart of [`MultivectorOffsetsStorageChunked`], generic over
 /// the [`UniversalRead`] backend `S`.
 pub struct MultivectorOffsetsStorageChunkedRead<S: UniversalRead> {
-    data: ChunkedVectorsRead<MultivectorOffset, S>,
+    pub(super) data: ChunkedVectorsRead<MultivectorOffset, S>,
 }
 
 impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
@@ -388,18 +386,6 @@ impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.data.clear_cache()
-    }
-
-    /// Pick up offsets a writer appended to the chunked backing.
-    pub fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        self.data
-            .live_reload(fs, deleted_points, new_points, hw_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -391,12 +391,15 @@ impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
     }
 
     /// Pick up offsets a writer appended to the chunked backing.
-    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
-        // Chunk-open settings are stored on the reader; deletions/new points are
-        // not tracked for offsets, so empty deltas are passed through.
-        let empty = SortedSlice::new(&[]).unwrap();
+    pub fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
         self.data
-            .live_reload(fs, &empty, &empty, &HardwareCounterCell::disposable())
+            .live_reload(fs, deleted_points, new_points, hw_counter)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -27,7 +27,7 @@ use crate::vector_storage::{RawScorer, RawScorerImpl, raw_scorer_from_query_scor
 /// Per-variant scorer dispatch for a quantized storage enum.
 ///
 /// Implemented by both the read-write [`QuantizedVectorStorage`] and the
-/// read-only `QuantizedVectorStorageRead<S>` enums. Keeping the datatype/distance
+/// read-only `ReadOnlyQuantizedVectorStorage<S>` enums. Keeping the datatype/distance
 /// and per-query dispatch in [`QuantizedScorerBuilder`] (shared) and only the
 /// per-variant `match` here avoids duplicating the scorer construction logic.
 pub(in crate::vector_storage::quantized) trait QuantizedScorerDispatch {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -3,11 +3,11 @@ use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
-use super::QuantizedVectorsRead;
+use super::{ReadOnlyQuantizedVectorStorage, ReadOnlyQuantizedVectors};
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
-impl<S: UniversalRead> LiveReload for QuantizedVectorsRead<S> {
+impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
     type Fs = S::Fs;
 
     /// Reload appended quantized vectors from disk (chunked layouts only).
@@ -20,5 +20,68 @@ impl<S: UniversalRead> LiveReload for QuantizedVectorsRead<S> {
     ) -> OperationResult<()> {
         self.storage_impl
             .live_reload(fs, deleted_points, new_points, hw_counter)
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
+    /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't
+    /// tracked here — they live in the raw vector storage.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyQuantizedVectorStorage::ScalarRam(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmap(_)
+            | ReadOnlyQuantizedVectorStorage::PQRam(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmap(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRam(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmap(_)
+            | ReadOnlyQuantizedVectorStorage::TQRam(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmap(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmapMulti(_) => {}
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => {
+                q.storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?
+            }
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => {
+                q.storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?
+            }
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
+                q.storage_mut().storage_mut().live_reload(
+                    fs,
+                    deleted_points,
+                    new_points,
+                    hw_counter,
+                )?;
+                q.offsets_storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
+            }
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
+                q.storage_mut().storage_mut().live_reload(
+                    fs,
+                    deleted_points,
+                    new_points,
+                    hw_counter,
+                )?;
+                q.offsets_storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
+            }
+        }
+        Ok(())
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -1,0 +1,25 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::QuantizedVectorsRead;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for QuantizedVectorsRead<S> {
+    type Fs = S::Fs;
+
+    /// Reload appended quantized vectors from disk (chunked layouts only).
+    /// Quantized tracks no deletions, so `deleted_points` is unused; appended
+    /// vectors come from disk, so `new_points` is unused too.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        _deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage_impl.live_reload(fs)
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -11,15 +11,14 @@ impl<S: UniversalRead> LiveReload for QuantizedVectorsRead<S> {
     type Fs = S::Fs;
 
     /// Reload appended quantized vectors from disk (chunked layouts only).
-    /// Quantized tracks no deletions, so `deleted_points` is unused; appended
-    /// vectors come from disk, so `new_points` is unused too.
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        _deleted_points: &SortedSlice<'_, PointOffsetType>,
-        _new_points: &SortedSlice<'_, PointOffsetType>,
-        _hw_counter: &HardwareCounterCell,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        self.storage_impl.live_reload(fs)
+        self.storage_impl
+            .live_reload(fs, deleted_points, new_points, hw_counter)
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/mod.rs
@@ -1,4 +1,5 @@
 mod lifecycle;
+mod live_reload;
 mod storage;
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::MmapFlusher;
-use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, UniversalRead};
 use quantization::encoded_vectors_binary::EncodedVectorsBin;
@@ -15,7 +14,6 @@ use quantization::{EncodedVectors, EncodedVectorsPQ};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::index::field_index::LiveReload;
 use crate::spaces::metric::Metric;
 use crate::vector_storage::RawScorer;
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
@@ -109,7 +107,7 @@ pub enum ReadOnlyQuantizedVectorStorage<S: UniversalRead = MmapFile> {
 
 impl<S: UniversalRead> fmt::Debug for ReadOnlyQuantizedVectorStorage<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("QuantizedVectorStorageRead").finish()
+        f.debug_tuple("ReadOnlyQuantizedVectorStorage").finish()
     }
 }
 
@@ -420,65 +418,6 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectorStorage<S> {
             ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => q.flusher(),
             ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.flusher(),
         }
-    }
-
-    /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
-    /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't
-    /// tracked here — they live in the raw vector storage.
-    pub fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        match self {
-            QuantizedVectorStorageRead::ScalarRam(_)
-            | QuantizedVectorStorageRead::ScalarMmap(_)
-            | QuantizedVectorStorageRead::PQRam(_)
-            | QuantizedVectorStorageRead::PQMmap(_)
-            | QuantizedVectorStorageRead::BinaryRam(_)
-            | QuantizedVectorStorageRead::BinaryMmap(_)
-            | QuantizedVectorStorageRead::TQRam(_)
-            | QuantizedVectorStorageRead::TQMmap(_)
-            | QuantizedVectorStorageRead::ScalarRamMulti(_)
-            | QuantizedVectorStorageRead::ScalarMmapMulti(_)
-            | QuantizedVectorStorageRead::PQRamMulti(_)
-            | QuantizedVectorStorageRead::PQMmapMulti(_)
-            | QuantizedVectorStorageRead::BinaryRamMulti(_)
-            | QuantizedVectorStorageRead::BinaryMmapMulti(_)
-            | QuantizedVectorStorageRead::TQRamMulti(_)
-            | QuantizedVectorStorageRead::TQMmapMulti(_) => {}
-            QuantizedVectorStorageRead::BinaryChunked(q) => {
-                q.storage_mut()
-                    .live_reload(fs, deleted_points, new_points, hw_counter)?
-            }
-            QuantizedVectorStorageRead::TQChunked(q) => {
-                q.storage_mut()
-                    .live_reload(fs, deleted_points, new_points, hw_counter)?
-            }
-            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
-                q.storage_mut().storage_mut().live_reload(
-                    fs,
-                    deleted_points,
-                    new_points,
-                    hw_counter,
-                )?;
-                q.offsets_storage_mut()
-                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
-            }
-            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
-                q.storage_mut().storage_mut().live_reload(
-                    fs,
-                    deleted_points,
-                    new_points,
-                    hw_counter,
-                )?;
-                q.offsets_storage_mut()
-                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
-            }
-        }
-        Ok(())
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -419,6 +419,41 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectorStorage<S> {
             ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => q.flusher(),
         }
     }
+
+    /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
+    /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't
+    /// tracked here — they live in the raw vector storage.
+    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
+        match self {
+            QuantizedVectorStorageRead::ScalarRam(_)
+            | QuantizedVectorStorageRead::ScalarMmap(_)
+            | QuantizedVectorStorageRead::PQRam(_)
+            | QuantizedVectorStorageRead::PQMmap(_)
+            | QuantizedVectorStorageRead::BinaryRam(_)
+            | QuantizedVectorStorageRead::BinaryMmap(_)
+            | QuantizedVectorStorageRead::TQRam(_)
+            | QuantizedVectorStorageRead::TQMmap(_)
+            | QuantizedVectorStorageRead::ScalarRamMulti(_)
+            | QuantizedVectorStorageRead::ScalarMmapMulti(_)
+            | QuantizedVectorStorageRead::PQRamMulti(_)
+            | QuantizedVectorStorageRead::PQMmapMulti(_)
+            | QuantizedVectorStorageRead::BinaryRamMulti(_)
+            | QuantizedVectorStorageRead::BinaryMmapMulti(_)
+            | QuantizedVectorStorageRead::TQRamMulti(_)
+            | QuantizedVectorStorageRead::TQMmapMulti(_) => {}
+            QuantizedVectorStorageRead::BinaryChunked(q) => q.storage_mut().live_reload(fs)?,
+            QuantizedVectorStorageRead::TQChunked(q) => q.storage_mut().live_reload(fs)?,
+            QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
+                q.storage_mut().storage_mut().live_reload(fs)?;
+                q.offsets_storage_mut().live_reload(fs)?;
+            }
+            QuantizedVectorStorageRead::TQChunkedMulti(q) => {
+                q.storage_mut().storage_mut().live_reload(fs)?;
+                q.offsets_storage_mut().live_reload(fs)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<S: UniversalRead> QuantizedScorerDispatch for ReadOnlyQuantizedVectorStorage<S> {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -15,6 +15,7 @@ use quantization::{EncodedVectors, EncodedVectorsPQ};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::index::field_index::LiveReload;
 use crate::spaces::metric::Metric;
 use crate::vector_storage::RawScorer;
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::MmapFlusher;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, UniversalRead};
 use quantization::encoded_vectors_binary::EncodedVectorsBin;
@@ -423,7 +424,13 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectorStorage<S> {
     /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
     /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't
     /// tracked here — they live in the raw vector storage.
-    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<()> {
+    pub fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
         match self {
             QuantizedVectorStorageRead::ScalarRam(_)
             | QuantizedVectorStorageRead::ScalarMmap(_)
@@ -441,15 +448,33 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectorStorage<S> {
             | QuantizedVectorStorageRead::BinaryMmapMulti(_)
             | QuantizedVectorStorageRead::TQRamMulti(_)
             | QuantizedVectorStorageRead::TQMmapMulti(_) => {}
-            QuantizedVectorStorageRead::BinaryChunked(q) => q.storage_mut().live_reload(fs)?,
-            QuantizedVectorStorageRead::TQChunked(q) => q.storage_mut().live_reload(fs)?,
+            QuantizedVectorStorageRead::BinaryChunked(q) => {
+                q.storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?
+            }
+            QuantizedVectorStorageRead::TQChunked(q) => {
+                q.storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?
+            }
             QuantizedVectorStorageRead::BinaryChunkedMulti(q) => {
-                q.storage_mut().storage_mut().live_reload(fs)?;
-                q.offsets_storage_mut().live_reload(fs)?;
+                q.storage_mut().storage_mut().live_reload(
+                    fs,
+                    deleted_points,
+                    new_points,
+                    hw_counter,
+                )?;
+                q.offsets_storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
             }
             QuantizedVectorStorageRead::TQChunkedMulti(q) => {
-                q.storage_mut().storage_mut().live_reload(fs)?;
-                q.offsets_storage_mut().live_reload(fs)?;
+                q.storage_mut().storage_mut().live_reload(
+                    fs,
+                    deleted_points,
+                    new_points,
+                    hw_counter,
+                )?;
+                q.offsets_storage_mut()
+                    .live_reload(fs, deleted_points, new_points, hw_counter)?;
             }
         }
         Ok(())

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -10,6 +10,7 @@ use rand::{RngExt, SeedableRng};
 use rstest::rstest;
 
 use super::ReadOnlyQuantizedVectors;
+use crate::common::live_reload::LiveReload;
 use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::segment_constructor::batched_reader::merge_from_single_source;
 use crate::types::{
@@ -279,7 +280,7 @@ fn live_reload_chunked_preserves_scores() {
     )
     .unwrap();
 
-    let mut ro = QuantizedVectorsRead::<MmapFile>::open(
+    let mut ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
         &MmapFs,
         quant_dir.path(),
         storage.distance(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, MmapFs};
 use rand::rngs::StdRng;
@@ -251,4 +252,64 @@ fn assert_internal_scorer_eq(
         (Err(_), Err(_)) => {}
         _ => panic!("read-only and read-write internal scorer support diverged"),
     }
+}
+
+/// `live_reload` on a chunked quantized storage reopens its backing without
+/// disturbing the data: scores match before and after. There is no public append
+/// API to drive growth here; the chunked reload primitive is covered by
+/// `ChunkedVectorsRead`'s own tests.
+#[test]
+fn live_reload_chunked_preserves_scores() {
+    let dir = tempfile::Builder::new().prefix("src").tempdir().unwrap();
+    let quant_dir = tempfile::Builder::new().prefix("quant").tempdir().unwrap();
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    let storage = build_on_disk_storage(dir.path(), &mut rng);
+    let on_disk = storage.is_on_disk();
+
+    // Binary quantization with the mutable storage type produces the chunked
+    // (appendable) layout — the only one `live_reload` acts on.
+    QuantizedVectors::create(
+        &storage,
+        &binary_config(false),
+        QuantizedVectorsStorageType::Mutable,
+        quant_dir.path(),
+        1,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
+
+    let mut ro = QuantizedVectorsRead::<MmapFile>::open(
+        &MmapFs,
+        quant_dir.path(),
+        storage.distance(),
+        storage.datatype(),
+        None,
+        on_disk,
+    )
+    .unwrap()
+    .expect("quantization config exists");
+
+    let sample: Vec<PointOffsetType> = (0..NUM_POINTS as PointOffsetType).step_by(7).collect();
+    let query = QueryVector::Nearest(storage.get_vector::<Random>(0).to_owned());
+
+    let before: Vec<_> = {
+        let scorer = ro
+            .raw_scorer(query.clone(), HardwareCounterCell::disposable())
+            .unwrap();
+        sample.iter().map(|&id| scorer.score_point(id)).collect()
+    };
+
+    let empty = SortedSlice::new(&[]).unwrap();
+    ro.live_reload(&MmapFs, &empty, &empty, &HardwareCounterCell::disposable())
+        .unwrap();
+
+    let after: Vec<_> = {
+        let scorer = ro
+            .raw_scorer(query, HardwareCounterCell::disposable())
+            .unwrap();
+        sample.iter().map(|&id| scorer.score_point(id)).collect()
+    };
+
+    assert_eq!(before, after);
 }


### PR DESCRIPTION
Part of #9241 — live-reload for read-only vector storage.

Implements `LiveReload` for the read-only quantized vectors (`QuantizedVectorsRead`). Quantized tracks no deletions (those live in the raw vector storage), and only the chunked (appendable) layouts grow — so the reload picks up appended quantized vectors via the chunked backing and is a no-op for the immutable RAM/mmap layouts. `deleted_points`/`new_points` are therefore unused.

- `EncodedVectorsBin` / `EncodedVectorsTQ` (quantization crate): add `storage_mut()`, the `&mut` counterpart of `storage()`, so the read-only quantized storage can reach its backing to reload it.
- `QuantizedChunkedStorageRead` / `MultivectorOffsetsStorageChunkedRead`: `live_reload` delegating to `ChunkedVectorsRead::live_reload`.
- `QuantizedMultivectorStorage`: `storage_mut()` / `offsets_storage_mut()`.
- `QuantizedVectorStorageRead::live_reload`: dispatch — chunked variants reload, RAM/mmap no-op (mirrors `populate`).
- `QuantizedVectorsRead`: `impl LiveReload`, delegating to the storage.

Based on #9342 for the `ChunkedVectorsRead::live_reload` primitive. There is no public append API for the writable quantized storage, so the test asserts the chunked reload preserves the storage (scores match before/after); the growth path itself is covered by `ChunkedVectorsRead`'s tests.
