### PR TITLE
fix: reject non-finite f32 vector values at the API boundary

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -342,7 +342,11 @@ mod tests {
 
     #[test]
     fn test_vector_struct_single_rejects_non_finite() {
-        assert!(VectorStruct::Single(vec![1.0, f32::NAN]).validate().is_err());
+        assert!(
+            VectorStruct::Single(vec![1.0, f32::NAN])
+                .validate()
+                .is_err()
+        );
         assert!(
             VectorStruct::Single(vec![f32::NEG_INFINITY])
                 .validate()

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -39,7 +39,7 @@ pub(crate) fn validate_non_empty_dense(vector: &[f32]) -> Result<(), ValidationE
     // incoming JSON f64 value exceeds f32::MAX and is silently overflowed to
     // +Inf by the deserializer. Storing such values corrupts distance metrics
     // and breaks HNSW ordering.
-    if vector.iter().any(|x| !x.is_finite()) {
+    if any_non_finite(vector) {
         let mut err = ValidationError::new("non_finite_value");
         err.message = Some(Cow::Borrowed(
             "vector values must be finite (no NaN or Inf); values exceeding the f32 range are not allowed",
@@ -49,6 +49,87 @@ pub(crate) fn validate_non_empty_dense(vector: &[f32]) -> Result<(), ValidationE
         return Err(errors);
     }
     Ok(())
+}
+
+fn any_non_finite(vector: &[f32]) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    if is_x86_feature_detected!("avx") {
+        return unsafe { any_non_finite_avx(vector) };
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    return unsafe { any_non_finite_neon(vector) };
+
+    #[cfg_attr(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        allow(unreachable_code)
+    )]
+    vector.iter().any(|v| !v.is_finite())
+}
+
+/// Checks 8 floats per iteration using 256-bit AVX registers.
+///
+/// Strips the sign bit and compares against +Inf using an ordered less-than.
+/// `_CMP_LT_OS` returns 0 for NaN lanes (ordered comparisons with NaN are false),
+/// so both NaN and ±Inf are correctly detected as non-finite.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx")]
+unsafe fn any_non_finite_avx(vector: &[f32]) -> bool {
+    use std::arch::x86_64::*;
+
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFF_FFFFi32));
+
+    let chunks = vector.chunks_exact(8);
+    let remainder = chunks.remainder();
+
+    for chunk in chunks {
+        // SAFETY: chunk is exactly 8 elements; _mm256_loadu_ps does not require alignment
+        let non_finite = unsafe {
+            let v = _mm256_loadu_ps(chunk.as_ptr());
+            let abs_v = _mm256_and_ps(v, abs_mask);
+            let is_finite = _mm256_cmp_ps::<_CMP_LT_OS>(abs_v, inf);
+            _mm256_movemask_ps(is_finite) != 0xFF
+        };
+        if non_finite {
+            return true;
+        }
+    }
+
+    remainder.iter().any(|v| !v.is_finite())
+}
+
+/// Checks 4 floats per iteration using 128-bit NEON registers.
+///
+/// A float is non-finite (Inf or NaN) iff its exponent bits are all 1s (0x7F80_0000).
+/// This bit-level check correctly handles NaN, which vcageq_f32 would miss because
+/// ordered comparisons with NaN always return false.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn any_non_finite_neon(vector: &[f32]) -> bool {
+    use std::arch::aarch64::*;
+
+    let exp_mask = vdupq_n_u32(0x7F80_0000u32);
+
+    let chunks = vector.chunks_exact(4);
+    let remainder = chunks.remainder();
+
+    for chunk in chunks {
+        // SAFETY: chunk is exactly 4 elements; vld1q_f32 does not require alignment
+        let non_finite = unsafe {
+            let v = vld1q_f32(chunk.as_ptr());
+            let bits = vreinterpretq_u32_f32(v);
+            let exp = vandq_u32(bits, exp_mask);
+            // Non-finite iff exponent bits == 0x7F80_0000
+            let is_non_finite = vceqq_u32(exp, exp_mask);
+            vmaxvq_u32(is_non_finite) != 0
+        };
+        if non_finite {
+            return true;
+        }
+    }
+
+    remainder.iter().any(|v| !v.is_finite())
 }
 
 pub(crate) fn validate_multi_dense_vector(m: &MultiDenseVector) -> Result<(), ValidationErrors> {
@@ -375,7 +456,7 @@ mod tests {
         let valid_bm25_config = serde_json::to_string(&json).unwrap();
         let options: DocumentOptions = serde_json::from_str(&valid_bm25_config).unwrap();
         // Bm25 option is used only for schema, actual deserialization will happen in specialized code
-        assert_matches!(options, DocumentOptions::Common(_));
+        assert!(matches!(options, DocumentOptions::Common(_)));
     }
 }
 

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -35,6 +35,27 @@ pub(crate) fn validate_non_empty_dense(vector: &[f32]) -> Result<(), ValidationE
         errors.add("vector", err);
         return Err(errors);
     }
+    // Reject values that are non-finite (NaN, ±Inf). This can happen when an
+    // incoming JSON f64 value exceeds f32::MAX and is silently overflowed to
+    // +Inf by the deserializer. Storing such values corrupts distance metrics
+    // and breaks HNSW ordering.
+    if vector.iter().any(|x| !x.is_finite()) {
+        let mut err = ValidationError::new("non_finite_value");
+        err.message = Some(Cow::Borrowed(
+            "vector values must be finite (no NaN or Inf); values exceeding the f32 range are not allowed",
+        ));
+        let mut errors = ValidationErrors::new();
+        errors.add("vector", err);
+        return Err(errors);
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_multi_dense_vector(m: &MultiDenseVector) -> Result<(), ValidationErrors> {
+    validate_multi_vector(m)?;
+    for vec in m {
+        validate_non_empty_dense(vec)?;
+    }
     Ok(())
 }
 
@@ -66,7 +87,7 @@ impl Validate for Vector {
         match self {
             Vector::Dense(v) => validate_non_empty_dense(v),
             Vector::Sparse(v) => v.validate(),
-            Vector::MultiDense(m) => validate_multi_vector(m),
+            Vector::MultiDense(m) => validate_multi_dense_vector(m),
             Vector::Document(_) => Ok(()),
             Vector::Image(_) => Ok(()),
             Vector::Object(_) => Ok(()),
@@ -147,7 +168,7 @@ impl Validate for VectorStruct {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             VectorStruct::Single(v) => validate_non_empty_dense(v),
-            VectorStruct::MultiDense(v) => validate_multi_vector(v),
+            VectorStruct::MultiDense(v) => validate_multi_dense_vector(v),
             VectorStruct::Named(v) => common::validation::validate_iter(v.values()),
             VectorStruct::Document(_) => Ok(()),
             VectorStruct::Image(_) => Ok(()),

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -314,8 +314,6 @@ pub enum DocumentOptions {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches;
-
     use validator::Validate as _;
 
     use super::*;

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -316,7 +316,53 @@ pub enum DocumentOptions {
 mod tests {
     use std::assert_matches;
 
+    use validator::Validate as _;
+
     use super::*;
+
+    #[test]
+    fn test_validate_non_empty_dense_rejects_nan() {
+        assert!(validate_non_empty_dense(&[1.0, f32::NAN, 3.0]).is_err());
+    }
+
+    #[test]
+    fn test_validate_non_empty_dense_rejects_inf() {
+        assert!(validate_non_empty_dense(&[1.0, f32::INFINITY, 3.0]).is_err());
+        assert!(validate_non_empty_dense(&[f32::NEG_INFINITY, 2.0]).is_err());
+    }
+
+    #[test]
+    fn test_validate_non_empty_dense_accepts_finite() {
+        assert!(validate_non_empty_dense(&[1.0, -2.5, 3.0]).is_ok());
+    }
+
+    #[test]
+    fn test_vector_dense_rejects_non_finite() {
+        assert!(Vector::Dense(vec![1.0, f32::NAN]).validate().is_err());
+        assert!(Vector::Dense(vec![f32::INFINITY]).validate().is_err());
+    }
+
+    #[test]
+    fn test_vector_struct_single_rejects_non_finite() {
+        assert!(VectorStruct::Single(vec![1.0, f32::NAN]).validate().is_err());
+        assert!(
+            VectorStruct::Single(vec![f32::NEG_INFINITY])
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_vector_struct_multi_dense_rejects_non_finite() {
+        let multi = vec![vec![1.0, f32::NAN], vec![2.0, 3.0]];
+        assert!(VectorStruct::MultiDense(multi).validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_multi_dense_rejects_non_finite() {
+        let multi = vec![vec![f32::INFINITY, 1.0], vec![2.0, 3.0]];
+        assert!(validate_multi_dense_vector(&multi).is_err());
+    }
 
     #[test]
     fn test_document_options_should_deserialize_into_common() {

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -340,18 +340,34 @@ mod tests {
 
     #[test]
     fn vector_input_dense_rejects_nan() {
-        assert!(VectorInput::DenseVector(vec![1.0, f32::NAN]).validate().is_err());
+        assert!(
+            VectorInput::DenseVector(vec![1.0, f32::NAN])
+                .validate()
+                .is_err()
+        );
     }
 
     #[test]
     fn vector_input_dense_rejects_inf() {
-        assert!(VectorInput::DenseVector(vec![f32::INFINITY, 1.0]).validate().is_err());
-        assert!(VectorInput::DenseVector(vec![f32::NEG_INFINITY]).validate().is_err());
+        assert!(
+            VectorInput::DenseVector(vec![f32::INFINITY, 1.0])
+                .validate()
+                .is_err()
+        );
+        assert!(
+            VectorInput::DenseVector(vec![f32::NEG_INFINITY])
+                .validate()
+                .is_err()
+        );
     }
 
     #[test]
     fn vector_input_dense_accepts_finite() {
-        assert!(VectorInput::DenseVector(vec![1.0, -2.5, 3.0]).validate().is_ok());
+        assert!(
+            VectorInput::DenseVector(vec![1.0, -2.5, 3.0])
+                .validate()
+                .is_ok()
+        );
     }
 
     #[test]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -4,7 +4,7 @@ use common::validation::validate_multi_vector;
 use segment::index::query_optimization::rescore_formula::parsed_formula::VariableId;
 use validator::{Validate, ValidationError, ValidationErrors};
 
-use super::schema::validate_non_empty_dense;
+use super::schema::{validate_multi_dense_vector, validate_non_empty_dense};
 use super::{
     Batch, BatchVectorStruct, ContextInput, Expression, FormulaQuery, Fusion, NamedVectorStruct,
     PointVectors, Query, QueryInterface, RecommendInput, RelevanceFeedbackInput, Sample,
@@ -52,9 +52,9 @@ impl Validate for VectorInput {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             VectorInput::Id(_id) => Ok(()),
-            VectorInput::DenseVector(_dense) => Ok(()),
+            VectorInput::DenseVector(dense) => validate_non_empty_dense(dense),
             VectorInput::SparseVector(sparse) => sparse.validate(),
-            VectorInput::MultiDenseVector(multi) => validate_multi_vector(multi),
+            VectorInput::MultiDenseVector(multi) => validate_multi_dense_vector(multi),
             VectorInput::Document(doc) => doc.validate(),
             VectorInput::Image(image) => image.validate(),
             VectorInput::Object(obj) => obj.validate(),

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -337,4 +337,26 @@ mod tests {
 
         assert!(query.validate().is_ok());
     }
+
+    #[test]
+    fn vector_input_dense_rejects_nan() {
+        assert!(VectorInput::DenseVector(vec![1.0, f32::NAN]).validate().is_err());
+    }
+
+    #[test]
+    fn vector_input_dense_rejects_inf() {
+        assert!(VectorInput::DenseVector(vec![f32::INFINITY, 1.0]).validate().is_err());
+        assert!(VectorInput::DenseVector(vec![f32::NEG_INFINITY]).validate().is_err());
+    }
+
+    #[test]
+    fn vector_input_dense_accepts_finite() {
+        assert!(VectorInput::DenseVector(vec![1.0, -2.5, 3.0]).validate().is_ok());
+    }
+
+    #[test]
+    fn vector_input_multi_dense_rejects_non_finite() {
+        let multi = vec![vec![1.0, f32::NAN], vec![2.0, 3.0]];
+        assert!(VectorInput::MultiDenseVector(multi).validate().is_err());
+    }
 }

--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -219,7 +219,7 @@ pub fn measure_component(
 
     for entry in files {
         let ComponentFileEntry { path, intent } = &entry;
-        if let Ok(meta) = std::fs::metadata(path) {
+        if let Ok(meta) = fs_err::metadata(path) {
             disk_bytes += meta.len();
             if *intent == FileStorageIntent::Cached {
                 expected_cache_bytes += meta.len();

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -386,6 +386,23 @@ mod tests {
     }
 
     #[test]
+    fn test_reject_nan_values() {
+        let with_nan = SparseVector::new(vec![1, 2, 3], vec![1.0, f32::NAN, 3.0]);
+        assert!(with_nan.is_err());
+        let err = with_nan.unwrap_err();
+        assert!(err.field_errors().contains_key("values"));
+    }
+
+    #[test]
+    fn test_reject_inf_values() {
+        let with_inf = SparseVector::new(vec![1, 2, 3], vec![1.0, f32::INFINITY, 3.0]);
+        assert!(with_inf.is_err());
+
+        let with_neg_inf = SparseVector::new(vec![1, 2], vec![f32::NEG_INFINITY, 2.0]);
+        assert!(with_neg_inf.is_err());
+    }
+
+    #[test]
     fn sorting_test() {
         let mut not_sorted = SparseVector::new(vec![1, 3, 2], vec![1.0, 2.0, 3.0]).unwrap();
         assert!(!not_sorted.is_sorted());

--- a/lib/sparse/src/common/sparse_vector.rs
+++ b/lib/sparse/src/common/sparse_vector.rs
@@ -314,6 +314,14 @@ pub fn validate_sparse_vector_impl<T: Clone + Eq + Hash>(
     if indices.iter().unique().count() != indices.len() {
         errors.add("indices", ValidationError::new("must be unique"));
     }
+    if values.iter().any(|x| !x.is_finite()) {
+        errors.add(
+            "values",
+            ValidationError::new(
+                "vector values must be finite (no NaN or Inf); values exceeding the f32 range are not allowed",
+            ),
+        );
+    }
 
     if errors.is_empty() {
         Ok(())


### PR DESCRIPTION
## Problem 
The REST API accepts vector payloads containing extreme f64 values (e.g. sys.float_info.max ≈ 1.79×10³⁰⁸) without validation. When deserialized into Vec<f32>, values exceeding f32::MAX (~3.4×10³⁸) silently overflow to +Inf. This causes two downstream failures:

NaN scores: computing cosine/dot-product distance against a +Inf vector yields NaN, which serializes as "score": null in the response
HNSW corruption: NaN distances break strict-weak ordering in the HNSW priority queue, causing the poisoned node to hijack Top-1 results for unrelated queries

## Fix
Add is_finite() checks at the API validation boundary, before vectors reach storage or indexing:

Extended validate_non_empty_dense to reject any non-finite f32 value (NaN, ±Inf)
Added validate_multi_dense_vector helper that checks values (not just structure) for MultiDense variants in both Vector and VectorStruct
Fixed VectorInput::DenseVector and VectorInput::MultiDenseVector which previously skipped value validation entirely
Added finite-value check to validate_sparse_vector_impl for the same class of overflow in sparse vectors
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
