### PR TITLE
[UIO] Sorted offsets in `LiveReload`

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -39,6 +39,7 @@ pub mod save_on_disk;
 pub mod scope_tracker;
 pub mod small_uint;
 pub mod sort_utils;
+pub mod sorted_slice;
 pub mod stable_hash;
 pub mod storage_version;
 pub mod stored_bitslice;

--- a/lib/common/common/src/sorted_slice.rs
+++ b/lib/common/common/src/sorted_slice.rs
@@ -1,0 +1,53 @@
+use std::ops::{Deref, Range, RangeInclusive};
+
+pub struct SortedSlice<'a, T: PartialOrd>(&'a [T]);
+
+impl<'a, T: PartialOrd> SortedSlice<'a, T> {
+    pub fn new(slice: &'a [T]) -> Option<Self> {
+        if slice.is_sorted() {
+            Some(Self(slice))
+        } else {
+            None
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the slice is sorted.
+    pub unsafe fn new_unchecked(slice: &'a [T]) -> Self {
+        debug_assert!(slice.is_sorted());
+        Self(slice)
+    }
+}
+
+impl<'a, T: PartialOrd + Copy> SortedSlice<'a, T> {
+    pub fn get_range_inclusive(&self) -> Option<RangeInclusive<T>> {
+        let first = *self.first()?;
+        let last = *self.last()?;
+        Some(first..=last)
+    }
+}
+
+impl<'a> SortedSlice<'a, u32> {
+    pub fn range_u64(&self) -> Option<Range<u64>> {
+        let (start, end) = self.get_range_inclusive()?.into_inner();
+        Some(u64::from(start)..u64::from(end) + 1)
+    }
+}
+
+impl<T: PartialOrd> Deref for SortedSlice<'_, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, T: PartialOrd> IntoIterator for &'a SortedSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
+use common::sorted_slice::SortedSlice;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead};
@@ -139,8 +140,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         for &point in deleted_points {
@@ -152,17 +153,16 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
             return Ok(());
         }
 
-        // Reopen so points appended past the previous mapping become readable.
-        // The producer (the appendable id tracker) is append-only: a value
-        // change never overwrites an offset in place — it allocates a fresh
-        // offset (reported in `new_points`) and retires the displaced one (in
-        // `deleted_points`). So every `new_point` is a brand-new offset that was
-        // never in the bitmap: insert it when its bit is set, and otherwise
-        // leave it absent — no clear is needed.
+        // Live reload is append-only, so we only need to process the new range of
+        // the bitslice.
         self.storage.reopen()?;
-        for &point in new_points {
-            // Possible optimization: If new_points is sorted, we should be able to use read_bit_range and iter_ones on top of it
-            if self.storage.get_bit(u64::from(point))?.unwrap_or(false) {
+        if let Some(new_range) = new_points.range_u64() {
+            let start = new_range.start as usize;
+            let bitslice = self.storage.read_bit_range(new_range)?;
+            for point in bitslice
+                .iter_ones()
+                .map(|idx| (idx + start) as PointOffsetType)
+            {
                 self.bitmap.insert(point);
             }
         }

--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
@@ -37,8 +38,8 @@ pub(crate) trait LiveReload {
     fn live_reload(
         &mut self,
         fs: &Self::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -13,8 +14,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyBoolIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // Reload each flag set's bitmap from the changed points only.
@@ -26,11 +27,16 @@ impl<S: UniversalRead> LiveReload for ReadOnlyBoolIndex<S> {
             .live_reload(fs, deleted_points, new_points, hw_counter)?;
 
         // Refresh the derived counts from the reloaded bitmaps, as `open` does.
+        //
+        // possible opt: update this using deleted_points and new_points separately,
+        //               so we only process the delta
         self.indexed_count =
             self.storage
                 .trues_flags
                 .get_bitmap()
                 .union_len(self.storage.falses_flags.get_bitmap()) as usize;
+
+        // possible opt: track num_trues within `RoaringFlags`.
         self.trues_count = self.storage.trues_flags.count_trues();
         self.falses_count = self.storage.falses_flags.count_trues();
 

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -70,6 +70,7 @@ impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
 mod tests {
     use common::counter::hardware_accumulator::HwMeasurementAcc;
     use common::counter::hardware_counter::HardwareCounterCell;
+    use common::sorted_slice::SortedSlice;
     use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
     use itertools::Itertools as _;
     use serde_json::json;
@@ -213,7 +214,12 @@ mod tests {
         index.flusher()().unwrap();
 
         reloaded
-            .live_reload(&fs, &[1, 2], &[6, 7, 1100], &hw_counter)
+            .live_reload(
+                &fs,
+                &SortedSlice::new(&[1, 2]).unwrap(),
+                &SortedSlice::new(&[6, 7, 1100]).unwrap(),
+                &hw_counter,
+            )
             .unwrap();
 
         let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())

--- a/lib/segment/src/index/field_index/full_text_index/mmap_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mmap_text_index/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -12,8 +13,8 @@ impl<S: UniversalRead> LiveReload for MmapFullTextIndex<S> {
     fn live_reload(
         &mut self,
         _fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        _new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // Immutable on-disk state: only the in-memory deletion bitmap is

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -1,5 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::Sequential;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -17,8 +18,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
@@ -32,10 +33,13 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
 
         self.storage
             .view()
-            .read_values::<Random, _, OperationError>(
-                new_points.iter().copied().enumerate(),
+            .read_values::<Sequential, _, OperationError>(
+                new_points.iter().map(|&id| ((), id)),
                 |_, point_offset, maybe_value: Option<Vec<u8>>| {
-                    let value = maybe_value.unwrap_or_default();
+                    let Some(value) = maybe_value else {
+                        debug_assert!(false, "This should be unreachable");
+                        return Ok(());
+                    };
                     // The stored document is already tokenized, so we replay the
                     // post-tokenization half of `MutableFullTextIndex::add_many`:
                     // register the tokens, then index them (plus the ordered

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -1,5 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::Sequential;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -14,8 +15,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
@@ -28,8 +29,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoIndex<S> {
 
         self.storage
             .view()
-            .read_values::<Random, _, OperationError>(
-                new_points.iter().copied().enumerate(),
+            .read_values::<Sequential, _, OperationError>(
+                new_points.iter().map(|&id| ((), id)),
                 |_, point_offset, maybe_values: Option<Vec<RawGeoPoint>>| {
                     let geo_points = maybe_values
                         .unwrap_or_default()

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -12,8 +13,8 @@ impl<S: UniversalRead> LiveReload for OnDiskGeoIndex<S> {
     fn live_reload(
         &mut self,
         _fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        _new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // No on-disk state changes on reload: this index is immutable, so only

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
@@ -1,5 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::Sequential;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 use gridstore::Blob;
@@ -19,8 +20,8 @@ where
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
@@ -33,8 +34,8 @@ where
 
         self.storage
             .view()
-            .read_values::<Random, _, GridstoreError>(
-                new_points.iter().copied().enumerate(),
+            .read_values::<Sequential, _, GridstoreError>(
+                new_points.iter().map(|&id| ((), id)),
                 |_, point_offset, maybe_values: Option<Vec<_>>| {
                     let values = maybe_values.unwrap_or_default();
                     in_memory_index.add_many_to_map(point_offset, values);

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
@@ -1,5 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::persisted_hashmap::Key;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -18,8 +19,8 @@ where
     fn live_reload(
         &mut self,
         _fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        _new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // No on-disk state is changing when we live-reload, as

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -12,8 +13,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // Reload each flag set's bitmap from the changed points only.
@@ -26,8 +27,9 @@ impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
 
         // total_point_count only grows, to cover appended offsets.
         self.total_point_count = new_points
-            .iter()
-            .fold(self.total_point_count, |max, &id| max.max(id as usize + 1));
+            .last()
+            .map(|&id| id as usize + 1)
+            .unwrap_or(self.total_point_count);
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
@@ -63,6 +63,7 @@ impl<S: UniversalRead> ReadOnlyNullIndex<S> {
 #[cfg(test)]
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
+    use common::sorted_slice::SortedSlice;
     use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
     use itertools::Itertools as _;
     use serde_json::{Value, json};
@@ -212,7 +213,12 @@ mod tests {
         let total = 5;
 
         reloaded
-            .live_reload(&fs, &[1], &[2, 4], &hw_counter)
+            .live_reload(
+                &fs,
+                &SortedSlice::new(&[1]).unwrap(),
+                &SortedSlice::new(&[2, 4]).unwrap(),
+                &hw_counter,
+            )
             .unwrap();
 
         let fresh = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), total)

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
@@ -1,5 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::Sequential;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 use gridstore::Blob;
@@ -21,8 +22,8 @@ where
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
@@ -35,8 +36,8 @@ where
 
         self.storage
             .view()
-            .read_values::<Random, _, GridstoreError>(
-                new_points.iter().copied().enumerate(),
+            .read_values::<Sequential, _, GridstoreError>(
+                new_points.iter().map(|&id| ((), id)),
                 |_, point_offset, maybe_values: Option<Vec<T>>| {
                     let values = maybe_values.unwrap_or_default();
                     in_memory_index.add_many_to_list(point_offset, values);

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -17,8 +18,8 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     fn live_reload(
         &mut self,
         _fs: &S::Fs,
-        deleted_points: &[PointOffsetType],
-        _new_points: &[PointOffsetType],
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         // No on-disk state changes on reload: this index is immutable, so only

--- a/lib/segment/src/payload_storage/read_only/live_reload.rs
+++ b/lib/segment/src/payload_storage/read_only/live_reload.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
@@ -12,8 +13,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyPayloadStorage<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        _deleted_points: &[PointOffsetType],
-        _new_points: &[PointOffsetType],
+        _deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         Ok(self.storage.live_reload(fs)?)


### PR DESCRIPTION
Adds a `SortedSlice` wrapper for making sure a slice is sorted. Then uses it across `LiveReload` trait, and applies a few optimizations.