### PR TITLE
WIP: read-only HNSW index

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -19,9 +19,13 @@ mod build;
 #[cfg(feature = "gpu")]
 mod gpu_build;
 mod old_index;
-mod search;
+#[allow(dead_code)]
+mod read_only;
+mod read_view;
 mod telemetry;
 mod vector_index_impl;
+
+use self::read_view::{HNSWIndexReadView, HNSWIndexReadViewEnum};
 
 const HNSW_USE_HEURISTIC: bool = true;
 const FINISH_MAIN_GRAPH_LOG_MESSAGE: &str = "Finish main graph in time";
@@ -154,5 +158,25 @@ impl HNSWIndex {
         } = self;
         graph.clear_cache()?;
         Ok(())
+    }
+
+    pub fn with_view<R>(&self, f: impl FnOnce(HNSWIndexReadViewEnum<'_>) -> R) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = HNSWIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors: quantized_vectors.as_ref(),
+                payload_index: payload_index_view,
+                config: &self.config,
+                graph: &self.graph,
+                searches_telemetry: &self.searches_telemetry,
+            };
+            f(read_view)
+        })
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -19,12 +19,14 @@ use common::universal_io::UniversalRead;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::IdTrackerEnum;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::FieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
-use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
@@ -48,6 +50,25 @@ pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
     is_on_disk: bool,
 }
 
+/// Read-only view over a [`ReadOnlyHNSWIndex`].
+///
+/// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
+/// [`VectorStorageReadEnum`] / [`QuantizedVectorsRead`]), while the payload
+/// index view is still built over the in-memory enums of [`StructPayloadIndex`].
+type ReadView<'a, S> = HNSWIndexReadView<
+    'a,
+    ReadOnlyIdTrackerEnum<S>,
+    VectorStorageReadEnum<S>,
+    QuantizedVectorsRead<S>,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
+>;
+
 impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
     pub fn is_on_disk(&self) -> bool {
         self.is_on_disk
@@ -57,19 +78,7 @@ impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
     /// [`HNSWIndex::with_view`].
     ///
     /// [`HNSWIndex::with_view`]: super::super::HNSWIndex::with_view
-    pub fn with_view<R>(
-        &self,
-        f: impl FnOnce(
-            HNSWIndexReadView<
-                '_,
-                ReadOnlyIdTrackerEnum<S>,
-                VectorStorageReadEnum<S>,
-                PayloadStorageEnum,
-                FieldIndex,
-                QuantizedVectorsRead<S>,
-            >,
-        ) -> R,
-    ) -> R {
+    pub fn with_view<R>(&self, f: impl FnOnce(ReadView<'_, S>) -> R) -> R {
         let id_tracker = self.id_tracker.borrow();
         let vector_storage = self.vector_storage.borrow();
         let quantized_vectors = self.quantized_vectors.borrow();

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -1,0 +1,91 @@
+// NOTE: This module does NOT compile yet. It is the "naive reuse" version of the
+// read-only HNSW index that delegates search to the existing
+// [`HNSWIndexReadView`] search implementation. It is here to show the shape; two
+// things still block compilation:
+//   1. The view struct reuses the same `I`/`V` type params for both the
+//      standalone storages and the (always in-RAM) payload view, so building the
+//      view in `with_view` fails (`id_tracker` wants `ReadOnlyIdTrackerEnum<S>`,
+//      the payload view forces `IdTrackerEnum`).
+//   2. The search body builds scorers from the concrete `VectorStorageEnum` /
+//      `QuantizedVectors` (`new_raw_scorer`, `FilteredScorer::new`, ...), which
+//      do not accept `VectorStorageReadEnum<S>` / `QuantizedVectorsRead<S>`.
+mod read;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+
+use super::read_view::HNSWIndexReadView;
+use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::field_index::FieldIndex;
+use crate::index::hnsw_index::config::HnswGraphConfig;
+use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::struct_payload_index::StructPayloadIndex;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+/// Read-only, generic-over-storage counterpart of [`HNSWIndex`].
+///
+/// The graph itself stays a plain [`GraphLayers`] (it materializes into RAM or
+/// mmap on load via [`GraphLayers::load`] over a [`UniversalRead`] filesystem),
+/// so only the id tracker, vector storage and quantized vectors are
+/// parameterized by the backing storage `S`.
+///
+/// [`HNSWIndex`]: super::super::HNSWIndex
+pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
+    id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectorsRead<S>>>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    config: HnswGraphConfig,
+    path: PathBuf,
+    graph: GraphLayers,
+    searches_telemetry: HNSWSearchesTelemetry,
+    is_on_disk: bool,
+}
+
+impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
+    pub fn is_on_disk(&self) -> bool {
+        self.is_on_disk
+    }
+
+    /// Borrow all backing storages and hand a read view to `f`, mirroring
+    /// [`HNSWIndex::with_view`].
+    ///
+    /// [`HNSWIndex::with_view`]: super::super::HNSWIndex::with_view
+    pub fn with_view<R>(
+        &self,
+        f: impl FnOnce(
+            HNSWIndexReadView<
+                '_,
+                ReadOnlyIdTrackerEnum<S>,
+                VectorStorageReadEnum<S>,
+                PayloadStorageEnum,
+                FieldIndex,
+                QuantizedVectorsRead<S>,
+            >,
+        ) -> R,
+    ) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let quantized_vectors = self.quantized_vectors.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = HNSWIndexReadView {
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                quantized_vectors: quantized_vectors.as_ref(),
+                payload_index: payload_index_view,
+                config: &self.config,
+                graph: &self.graph,
+                searches_telemetry: &self.searches_telemetry,
+            };
+            f(read_view)
+        })
+    }
+}

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -12,7 +12,6 @@ use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::VectorStorageRead;
 
 impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 
-use super::HNSWIndex;
-use crate::common::operation_error::{OperationError, OperationResult};
+use super::ReadOnlyHNSWIndex;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorRef};
-use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::{VectorIndex, VectorIndexRead};
+use crate::data_types::vectors::QueryVector;
+use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
 
-impl VectorIndexRead for HNSWIndex {
+impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(
         &self,
         vectors: &[&QueryVector],
@@ -23,6 +23,7 @@ impl VectorIndexRead for HNSWIndex {
         params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        // Reuses the shared search logic implemented on the read view.
         self.with_view(|view| view.search(vectors, filter, top, params, query_context))
     }
 
@@ -66,29 +67,5 @@ impl VectorIndexRead for HNSWIndex {
 
     fn is_index(&self) -> bool {
         true
-    }
-}
-
-impl VectorIndex for HNSWIndex {
-    fn files(&self) -> Vec<PathBuf> {
-        let mut files = self.graph.files(&self.path);
-        let config_path = HnswGraphConfig::get_config_path(&self.path);
-        if config_path.exists() {
-            files.push(config_path);
-        }
-        files
-    }
-
-    fn immutable_files(&self) -> Vec<PathBuf> {
-        self.files() // All HNSW index files are immutable 😎
-    }
-
-    fn update_vector(
-        &mut self,
-        _id: PointOffsetType,
-        _vector: Option<VectorRef>,
-        _hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        Err(OperationError::service_error("Cannot update HNSW index"))
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -53,7 +53,8 @@ impl HNSWIndexReadViewEnum<'_> {
                 // to do a plain search instead.
                 let plain_search = exact
                     || is_hnsw_disabled
-                    || self.vector_storage.available_vector_count() < self.config.full_scan_threshold;
+                    || self.vector_storage.available_vector_count()
+                        < self.config.full_scan_threshold;
 
                 // Do plain or graph search
                 if plain_search {
@@ -138,8 +139,9 @@ impl HNSWIndexReadViewEnum<'_> {
                 // The filter context's lifetime is tied to the payload view, which is already
                 // held by this read view.
                 let use_graph = {
-                    let filter_context =
-                        self.payload_index.filter_context(query_filter, &hw_counter)?;
+                    let filter_context = self
+                        .payload_index
+                        .filter_context(query_filter, &hw_counter)?;
                     sample_check_cardinality(
                         self.id_tracker
                             .sample_ids(Some(self.vector_storage.deleted_vector_bitslice())),

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -1,6 +1,6 @@
 use common::types::ScoredPointOffset;
 
-use super::HNSWIndexReadViewEnum;
+use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
 use crate::data_types::query_context::VectorQueryContext;
@@ -10,9 +10,16 @@ use crate::index::PayloadIndexRead;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::sample_estimation::sample_check_cardinality;
 use crate::types::{Filter, QuantizationSearchParams, SearchParams};
-use crate::vector_storage::VectorStorageRead;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl HNSWIndexReadViewEnum<'_> {
+impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
+{
     pub(crate) fn search(
         &self,
         vectors: &[&QueryVector],

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -1,0 +1,166 @@
+use common::types::ScoredPointOffset;
+
+use super::HNSWIndexReadViewEnum;
+use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::ScopeDurationMeasurer;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::QueryVector;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::PayloadIndexRead;
+use crate::index::query_estimator::adjust_to_available_vectors;
+use crate::index::sample_estimation::sample_check_cardinality;
+use crate::types::{Filter, QuantizationSearchParams, SearchParams};
+use crate::vector_storage::VectorStorageRead;
+
+impl HNSWIndexReadViewEnum<'_> {
+    pub(crate) fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        if top == 0 {
+            return Ok(vec![vec![]; vectors.len()]);
+        }
+
+        // If neither `m` nor `payload_m` is set, HNSW doesn't have any links.
+        // And if so, we need to fall back to plain search (optionally, with quantization).
+
+        let is_hnsw_disabled = self.config.m == 0 && self.config.payload_m.unwrap_or(0) == 0;
+        let exact = params.is_some_and(|params| params.exact);
+
+        let exact_params = if exact {
+            params.map(|params| {
+                let mut params = *params;
+                params.quantization = Some(QuantizationSearchParams {
+                    ignore: true,
+                    rescore: Some(false),
+                    oversampling: None,
+                }); // disable quantization for exact search
+                params
+            })
+        } else {
+            None
+        };
+
+        match filter {
+            None => {
+                // Determine whether to do a plain or graph search, and pick search timer aggregator
+                // Because an HNSW graph is built, we'd normally always assume to search the graph.
+                // But because a lot of points may be deleted in this graph, it may just be faster
+                // to do a plain search instead.
+                let plain_search = exact
+                    || is_hnsw_disabled
+                    || self.vector_storage.available_vector_count() < self.config.full_scan_threshold;
+
+                // Do plain or graph search
+                if plain_search {
+                    let _timer = ScopeDurationMeasurer::new(if exact {
+                        &self.searches_telemetry.exact_unfiltered
+                    } else {
+                        &self.searches_telemetry.unfiltered_plain
+                    });
+
+                    let params_ref = if exact { exact_params.as_ref() } else { params };
+                    self.search_plain_unfiltered_batched(vectors, top, params_ref, query_context)
+                } else {
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.unfiltered_hnsw);
+                    self.search_vectors_with_graph(vectors, None, top, params, query_context)
+                }
+            }
+            Some(query_filter) => {
+                // depending on the amount of filtered-out points the optimal strategy could be
+                // - to retrieve possible points and score them after
+                // - to use HNSW index with filtering condition
+
+                // if exact search is requested, we should not use HNSW index
+                if exact || is_hnsw_disabled {
+                    let _timer = ScopeDurationMeasurer::new(if exact {
+                        &self.searches_telemetry.exact_filtered
+                    } else {
+                        &self.searches_telemetry.filtered_plain
+                    });
+
+                    let params_ref = if exact { exact_params.as_ref() } else { params };
+
+                    return self.search_vectors_plain(
+                        vectors,
+                        query_filter,
+                        top,
+                        params_ref,
+                        query_context,
+                    );
+                }
+
+                let available_vector_count = self.vector_storage.available_vector_count();
+
+                let hw_counter = query_context.hardware_counter();
+
+                let query_point_cardinality = self
+                    .payload_index
+                    .estimate_cardinality(query_filter, &hw_counter)?;
+                let query_cardinality = adjust_to_available_vectors(
+                    query_point_cardinality,
+                    available_vector_count,
+                    self.id_tracker.available_point_count(),
+                );
+
+                if query_cardinality.max < self.config.full_scan_threshold {
+                    // if cardinality is small - use plain index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.small_cardinality);
+                    return self.search_vectors_plain(
+                        vectors,
+                        query_filter,
+                        top,
+                        params,
+                        query_context,
+                    );
+                }
+
+                if query_cardinality.min > self.config.full_scan_threshold {
+                    // if cardinality is high enough - use HNSW index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+                    return self.search_vectors_with_graph(
+                        vectors,
+                        filter,
+                        top,
+                        params,
+                        query_context,
+                    );
+                }
+
+                // Fast cardinality estimation is not enough, do sample estimation of cardinality.
+                // The filter context's lifetime is tied to the payload view, which is already
+                // held by this read view.
+                let use_graph = {
+                    let filter_context =
+                        self.payload_index.filter_context(query_filter, &hw_counter)?;
+                    sample_check_cardinality(
+                        self.id_tracker
+                            .sample_ids(Some(self.vector_storage.deleted_vector_bitslice())),
+                        |idx| filter_context.check(idx),
+                        self.config.full_scan_threshold,
+                        available_vector_count, // Check cardinality among available vectors
+                    )
+                };
+
+                if use_graph {
+                    // if cardinality is high enough - use HNSW index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.large_cardinality);
+                    self.search_vectors_with_graph(vectors, filter, top, params, query_context)
+                } else {
+                    // if cardinality is small - use plain index
+                    let _timer =
+                        ScopeDurationMeasurer::new(&self.searches_telemetry.small_cardinality);
+                    self.search_vectors_plain(vectors, query_filter, top, params, query_context)
+                }
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -1,0 +1,45 @@
+mod dispatch;
+mod search;
+
+use super::telemetry::HNSWSearchesTelemetry;
+use crate::id_tracker::{IdTracker, IdTrackerEnum};
+use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::index::hnsw_index::config::HnswGraphConfig;
+use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::payload_storage::PayloadStorageRead;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectors, QuantizedVectorsReadAccess,
+};
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+
+pub struct HNSWIndexReadView<
+    'a,
+    I: IdTracker,
+    V: VectorStorageRead,
+    P: PayloadStorageRead,
+    F: FieldIndexRead,
+    Q: QuantizedVectorsReadAccess,
+> {
+    pub(crate) id_tracker: &'a I,
+    pub(crate) vector_storage: &'a V,
+    pub(crate) quantized_vectors: Option<&'a Q>,
+    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) config: &'a HnswGraphConfig,
+    pub(crate) graph: &'a GraphLayers,
+    pub(crate) searches_telemetry: &'a HNSWSearchesTelemetry,
+}
+
+/// Read-only view over an [`HNSWIndex`] backed by the in-memory
+/// [`IdTrackerEnum`] / [`VectorStorageEnum`] / [`PayloadStorageEnum`] enums.
+///
+/// [`HNSWIndex`]: super::super::HNSWIndex
+pub(crate) type HNSWIndexReadViewEnum<'a> = HNSWIndexReadView<
+    'a,
+    IdTrackerEnum,
+    VectorStorageEnum,
+    PayloadStorageEnum,
+    FieldIndex,
+    QuantizedVectors,
+>;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -2,30 +2,34 @@ mod dispatch;
 mod search;
 
 use super::telemetry::HNSWSearchesTelemetry;
-use crate::id_tracker::{IdTracker, IdTrackerEnum};
-use crate::index::field_index::{FieldIndex, FieldIndexRead};
+use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::PayloadIndexRead;
+use crate::index::field_index::FieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
-use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsReadAccess,
 };
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
+/// Read-only view over an HNSW index.
+///
+/// The top-level id tracker / vector storage / quantized vectors are decoupled
+/// from the payload index view (`P`), so read-only backends can be combined with
+/// a payload index view built over different (e.g. still-mutable) backends.
 pub struct HNSWIndexReadView<
     'a,
-    I: IdTracker,
+    I: IdTrackerRead,
     V: VectorStorageRead,
-    P: PayloadStorageRead,
-    F: FieldIndexRead,
     Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
 > {
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storage: &'a V,
     pub(crate) quantized_vectors: Option<&'a Q>,
-    pub(crate) payload_index: StructPayloadIndexReadView<'a, P, I, V, F>,
+    pub(crate) payload_index: P,
     pub(crate) config: &'a HnswGraphConfig,
     pub(crate) graph: &'a GraphLayers,
     pub(crate) searches_telemetry: &'a HNSWSearchesTelemetry,
@@ -39,7 +43,12 @@ pub(crate) type HNSWIndexReadViewEnum<'a> = HNSWIndexReadView<
     'a,
     IdTrackerEnum,
     VectorStorageEnum,
-    PayloadStorageEnum,
-    FieldIndex,
     QuantizedVectors,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
 >;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cow::BoxCow;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
 
-use super::HNSWIndexReadViewEnum;
+use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
@@ -17,11 +17,17 @@ use crate::index::vector_index_search_common::{
 };
 use crate::payload_storage::FilterContext;
 use crate::types::{ACORN_MAX_SELECTIVITY_DEFAULT, Filter, SearchParams};
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
 use crate::vector_storage::query::DiscoverQuery;
-use crate::vector_storage::{VectorStorageEnum, VectorStorageRead, new_raw_scorer};
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl HNSWIndexReadViewEnum<'_> {
+impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+    P: PayloadIndexRead,
+{
     pub(super) fn search_with_graph(
         &self,
         vector: &QueryVector,
@@ -115,11 +121,9 @@ impl HNSWIndexReadViewEnum<'_> {
             };
 
             // Full vectors are "base vectors"
-            let base_scorer = new_raw_scorer(
-                vector.to_owned(),
-                self.vector_storage,
-                vector_query_context.hardware_counter(),
-            )?;
+            let base_scorer = self
+                .vector_storage
+                .build_raw_scorer(vector.to_owned(), vector_query_context.hardware_counter())?;
             let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
                 return Ok(None);
             };
@@ -350,15 +354,19 @@ impl HNSWIndexReadViewEnum<'_> {
     }
 }
 
-fn construct_search_scorer<'a>(
+fn construct_search_scorer<'a, V, Q>(
     vector: &QueryVector,
-    vector_storage: &'a VectorStorageEnum,
-    quantized_storage: Option<&'a QuantizedVectors>,
+    vector_storage: &'a V,
+    quantized_storage: Option<&'a Q>,
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
     filter_context: Option<Box<dyn FilterContext + 'a>>,
-) -> OperationResult<FilteredScorer<'a>> {
+) -> OperationResult<FilteredScorer<'a>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     FilteredScorer::new(
         vector.to_owned(),
@@ -371,16 +379,20 @@ fn construct_search_scorer<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn construct_batch_searcher<'a>(
+fn construct_batch_searcher<'a, V, Q>(
     vectors: &[&QueryVector],
-    vector_storage: &'a VectorStorageEnum,
-    quantized_storage: Option<&'a QuantizedVectors>,
+    vector_storage: &'a V,
+    quantized_storage: Option<&'a Q>,
     top: usize,
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
     filter_context: Option<Box<dyn FilterContext + 'a>>,
-) -> OperationResult<BatchFilteredSearcher<'a>> {
+) -> OperationResult<BatchFilteredSearcher<'a>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_storage, params);
     BatchFilteredSearcher::new(
         vectors,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -65,8 +65,9 @@ impl HNSWIndexReadViewEnum<'_> {
             let selectivity = if available_vector_count == 0 {
                 1.0
             } else {
-                let query_point_cardinality =
-                    self.payload_index.estimate_cardinality(filter, &hw_counter)?;
+                let query_point_cardinality = self
+                    .payload_index
+                    .estimate_cardinality(filter, &hw_counter)?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
@@ -288,7 +289,9 @@ impl HNSWIndexReadViewEnum<'_> {
         let is_stopped = &vector_query_context.is_stopped();
 
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-        let query_cardinality = self.payload_index.estimate_cardinality(filter, hw_counter)?;
+        let query_cardinality = self
+            .payload_index
+            .estimate_cardinality(filter, hw_counter)?;
         let filtered_points: Vec<PointOffsetType> = self
             .payload_index
             .iter_filtered_points(

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::cow::BoxCow;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
 
-use super::HNSWIndex;
+use super::HNSWIndexReadViewEnum;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
@@ -21,7 +21,7 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::query::DiscoverQuery;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead, new_raw_scorer};
 
-impl HNSWIndex {
+impl HNSWIndexReadViewEnum<'_> {
     pub(super) fn search_with_graph(
         &self,
         vector: &QueryVector,
@@ -44,17 +44,12 @@ impl HNSWIndex {
 
         let is_stopped = vector_query_context.is_stopped();
 
-        let id_tracker = self.id_tracker.borrow();
-        let payload_index = self.payload_index.borrow();
-        let vector_storage = self.vector_storage.borrow();
-        let quantized_vectors = self.quantized_vectors.borrow();
-
         let deleted_points = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
 
         let hw_counter = vector_query_context.hardware_counter();
-        let oversampled_top = get_oversampled_top(quantized_vectors.as_ref(), params, top);
+        let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
 
         let mut algorithm = SearchAlgorithm::Hnsw;
         if acorn_enabled
@@ -66,16 +61,16 @@ impl HNSWIndex {
             // practice, such segments most likely to be picked by an optimizer
             // soon.
 
-            let available_vector_count = vector_storage.available_vector_count();
+            let available_vector_count = self.vector_storage.available_vector_count();
             let selectivity = if available_vector_count == 0 {
                 1.0
             } else {
                 let query_point_cardinality =
-                    payload_index.with_view(|v| v.estimate_cardinality(filter, &hw_counter))?;
+                    self.payload_index.estimate_cardinality(filter, &hw_counter)?;
                 let query_cardinality = adjust_to_available_vectors(
                     query_point_cardinality,
                     available_vector_count,
-                    id_tracker.available_point_count(),
+                    self.id_tracker.available_point_count(),
                 );
                 query_cardinality.exp as f64 / available_vector_count as f64
             };
@@ -91,91 +86,87 @@ impl HNSWIndex {
                 SearchAlgorithm::Acorn => return Ok(None),
             }
             if !self.graph.has_inline_vectors()
-                || !is_quantized_search(quantized_vectors.as_ref(), params)
+                || !is_quantized_search(self.quantized_vectors, params)
             {
                 return Ok(None);
             }
-            let Some(quantized_vectors) = quantized_vectors.as_ref() else {
+            let Some(quantized_vectors) = self.quantized_vectors else {
                 return Ok(None);
             };
 
-            payload_index.with_view(|payload_index_view| {
-                // Quantized vectors are "link vectors"
-                let link_scorer_filtered = FilteredScorer::new(
-                    vector.to_owned(),
-                    &vector_storage,
-                    Some(quantized_vectors),
-                    filter
-                        .map(|f| {
-                            payload_index_view
-                                .filter_context(f, &hw_counter)
-                                .map(BoxCow::Owned)
-                        })
-                        .transpose()?,
-                    deleted_points,
-                    vector_query_context.hardware_counter(),
-                )?;
-                let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
-                    return Ok(None);
-                };
+            // Quantized vectors are "link vectors"
+            let link_scorer_filtered = FilteredScorer::new(
+                vector.to_owned(),
+                self.vector_storage,
+                Some(quantized_vectors),
+                filter
+                    .map(|f| {
+                        self.payload_index
+                            .filter_context(f, &hw_counter)
+                            .map(BoxCow::Owned)
+                    })
+                    .transpose()?,
+                deleted_points,
+                vector_query_context.hardware_counter(),
+            )?;
+            let Some(link_scorer_filtered_bytes) = link_scorer_filtered.scorer_bytes() else {
+                return Ok(None);
+            };
 
-                // Full vectors are "base vectors"
-                let base_scorer = new_raw_scorer(
-                    vector.to_owned(),
-                    &vector_storage,
-                    vector_query_context.hardware_counter(),
-                )?;
-                let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
-                    return Ok(None);
-                };
+            // Full vectors are "base vectors"
+            let base_scorer = new_raw_scorer(
+                vector.to_owned(),
+                self.vector_storage,
+                vector_query_context.hardware_counter(),
+            )?;
+            let Some(base_scorer_bytes) = base_scorer.scorer_bytes() else {
+                return Ok(None);
+            };
 
-                Ok(Some(self.graph.search_with_vectors(
-                    top,
-                    std::cmp::max(ef, oversampled_top),
-                    &link_scorer_filtered,
-                    &link_scorer_filtered_bytes,
-                    base_scorer_bytes,
-                    custom_entry_points,
-                    &vector_query_context.is_stopped(),
-                )?))
-            })
+            Ok(Some(self.graph.search_with_vectors(
+                top,
+                std::cmp::max(ef, oversampled_top),
+                &link_scorer_filtered,
+                &link_scorer_filtered_bytes,
+                base_scorer_bytes,
+                custom_entry_points,
+                &vector_query_context.is_stopped(),
+            )?))
         };
 
         let regular_search = || -> OperationResult<Vec<ScoredPointOffset>> {
-            payload_index.with_view(|payload_index_view| {
-                let filter_context = filter
-                    .map(|f| payload_index_view.filter_context(f, &hw_counter))
-                    .transpose()?;
-                let points_scorer = construct_search_scorer(
-                    vector,
-                    &vector_storage,
-                    quantized_vectors.as_ref(),
-                    deleted_points,
-                    params,
-                    vector_query_context.hardware_counter(),
-                    filter_context,
-                )?;
+            let filter_context = filter
+                .map(|f| self.payload_index.filter_context(f, &hw_counter))
+                .transpose()?;
+            let points_scorer = construct_search_scorer(
+                vector,
+                self.vector_storage,
+                self.quantized_vectors,
+                deleted_points,
+                params,
+                vector_query_context.hardware_counter(),
+                filter_context,
+            )?;
 
-                let search_result = self.graph.search(
-                    oversampled_top,
-                    ef,
-                    algorithm,
-                    points_scorer,
-                    custom_entry_points,
-                    &is_stopped,
-                )?;
+            let search_result = self.graph.search(
+                oversampled_top,
+                ef,
+                algorithm,
+                points_scorer,
+                custom_entry_points,
+                &is_stopped,
+            )?;
 
-                postprocess_search_result(
-                    search_result,
-                    id_tracker.deleted_point_bitslice(),
-                    &vector_storage,
-                    quantized_vectors.as_ref(),
-                    vector,
-                    params,
-                    top,
-                    vector_query_context.hardware_counter(),
-                )
-            })
+            postprocess_search_result(
+                search_result,
+                self.id_tracker.deleted_point_bitslice(),
+                self.vector_storage,
+                self.quantized_vectors,
+                vector,
+                params,
+                top,
+                vector_query_context.hardware_counter(),
+            )
         };
 
         // Try to use graph with vectors first.
@@ -224,21 +215,17 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let id_tracker = self.id_tracker.borrow();
-        let vector_storage = self.vector_storage.borrow();
-        let quantized_vectors = self.quantized_vectors.borrow();
-
         let deleted_points = vector_query_context
             .deleted_points()
-            .unwrap_or_else(|| id_tracker.deleted_point_bitslice());
+            .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
 
         let is_stopped = vector_query_context.is_stopped();
-        let oversampled_top = get_oversampled_top(quantized_vectors.as_ref(), params, top);
+        let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
 
         let batch_filtered_searcher = construct_batch_searcher(
             query_vectors,
-            &vector_storage,
-            quantized_vectors.as_ref(),
+            self.vector_storage,
+            self.quantized_vectors,
             oversampled_top,
             deleted_points,
             params,
@@ -249,9 +236,9 @@ impl HNSWIndex {
         for (search_result, query_vector) in search_results.iter_mut().zip(query_vectors) {
             *search_result = postprocess_search_result(
                 std::mem::take(search_result),
-                id_tracker.deleted_point_bitslice(),
-                &vector_storage,
-                quantized_vectors.as_ref(),
+                self.id_tracker.deleted_point_bitslice(),
+                self.vector_storage,
+                self.quantized_vectors,
                 query_vector,
                 params,
                 top,
@@ -285,8 +272,7 @@ impl HNSWIndex {
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let id_tracker = self.id_tracker.borrow();
-        let ids_iterator = id_tracker.point_mappings().iter_internal();
+        let ids_iterator = self.id_tracker.point_mappings().iter_internal();
         self.search_plain_iterator_batched(vectors, ids_iterator, top, params, vector_query_context)
     }
 
@@ -301,11 +287,11 @@ impl HNSWIndex {
         let hw_counter = &vector_query_context.hardware_counter();
         let is_stopped = &vector_query_context.is_stopped();
 
-        let payload_index = self.payload_index.borrow();
         // Assume query is already estimated to be small enough so we can iterate over all matched ids
-        let filtered_points: Vec<PointOffsetType> = payload_index.with_view(|v| {
-            let query_cardinality = v.estimate_cardinality(filter, hw_counter)?;
-            v.iter_filtered_points(
+        let query_cardinality = self.payload_index.estimate_cardinality(filter, hw_counter)?;
+        let filtered_points: Vec<PointOffsetType> = self
+            .payload_index
+            .iter_filtered_points(
                 filter,
                 &query_cardinality,
                 hw_counter,
@@ -313,8 +299,7 @@ impl HNSWIndex {
                 // No deferred filtering here since it's HNSW index.
                 DeferredBehavior::WithDeferred,
             )
-            .map(|it| it.collect())
-        })?;
+            .map(|it| it.collect())?;
         self.search_plain_batched(
             vectors,
             filtered_points.into_iter(),

--- a/lib/segment/src/index/hnsw_index/hnsw/telemetry.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/telemetry.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 
 #[derive(Debug)]
-pub(super) struct HNSWSearchesTelemetry {
+pub(crate) struct HNSWSearchesTelemetry {
     pub(super) unfiltered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     pub(super) filtered_plain: Arc<Mutex<OperationDurationsAggregator>>,
     pub(super) unfiltered_hnsw: Arc<Mutex<OperationDurationsAggregator>>,

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -13,11 +13,13 @@ use crate::data_types::vectors::QueryVector;
 use crate::payload_storage::FilterContext;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 use crate::vector_storage::{
-    RawScorer, VectorStorageEnum, VectorStorageRead, check_deleted_condition, new_raw_scorer,
+    RawScorer, RawScorerBuilder, VectorStorageRead, check_deleted_condition,
 };
+#[cfg(feature = "testing")]
+use crate::vector_storage::{VectorStorageEnum, new_raw_scorer};
 
 /// Scorers composition:
 ///
@@ -115,17 +117,21 @@ impl<'a> FilteredScorer<'a> {
     /// Create a new filtered scorer.
     ///
     /// If present, `quantized_vectors` will be used for scoring, otherwise `vectors` will be used.
-    pub fn new(
+    pub fn new<V, Q>(
         query: QueryVector,
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         let raw_scorer = match quantized_vectors {
             Some(quantized_vectors) => quantized_vectors.raw_scorer(query, hardware_counter)?,
-            None => new_raw_scorer(query, vectors, hardware_counter)?,
+            None => vectors.build_raw_scorer(query, hardware_counter)?,
         };
         Ok(FilteredScorer {
             raw_scorer,
@@ -138,14 +144,18 @@ impl<'a> FilteredScorer<'a> {
         })
     }
 
-    pub fn new_internal(
+    pub fn new_internal<V, Q>(
         point_id: PointOffsetType,
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         // This is a fallback function, which is used if quantized vector storage
         // is not capable of reconstructing the query vector.
         let original_query_fn = || {
@@ -161,7 +171,7 @@ impl<'a> FilteredScorer<'a> {
                 })?,
             None => {
                 let query = original_query_fn();
-                new_raw_scorer(query, vectors, hardware_counter)?
+                vectors.build_raw_scorer(query, hardware_counter)?
             }
         };
         Ok(FilteredScorer {
@@ -275,15 +285,19 @@ impl<'a> BatchFilteredSearcher<'a> {
     /// Create a new batch filtered searcher.
     ///
     /// If present, `quantized_vectors` will be used for scoring, otherwise `vectors` will be used.
-    pub fn new(
+    pub fn new<V, Q>(
         queries: &[&QueryVector],
-        vectors: &'a VectorStorageEnum,
-        quantized_vectors: Option<&'a QuantizedVectors>,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
         filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
         top: usize,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
-    ) -> OperationResult<Self> {
+    ) -> OperationResult<Self>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsReadAccess,
+    {
         let scorer_batch = queries
             .iter()
             .map(|&query| {
@@ -293,7 +307,7 @@ impl<'a> BatchFilteredSearcher<'a> {
                     Some(quantized_vectors) => {
                         quantized_vectors.raw_scorer(query, hardware_counter)
                     }
-                    None => new_raw_scorer(query, vectors, hardware_counter),
+                    None => vectors.build_raw_scorer(query, hardware_counter),
                 };
                 let pq = FixedLengthPriorityQueue::new(top);
                 raw_scorer.map(|raw_scorer| BatchSearch { raw_scorer, pq })

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/search.rs
@@ -16,6 +16,7 @@ use crate::index::field_index::CardinalityEstimation;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::types::{DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, Filter};
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageRead, check_deleted_condition};
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -57,8 +58,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
         let searcher = BatchFilteredSearcher::new(
             &[query_vector],
-            &vector_storage,
-            None,
+            &*vector_storage,
+            None::<&QuantizedVectors>,
             None,
             top,
             deleted_point_bitslice,

--- a/lib/segment/src/index/vector_index_search_common.rs
+++ b/lib/segment/src/index/vector_index_search_common.rs
@@ -9,11 +9,11 @@ use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::types::{
     SearchParams, default_quantization_ignore_value, default_quantization_oversampling_value,
 };
-use crate::vector_storage::VectorStorageEnum;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsReadAccess;
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-pub fn is_quantized_search(
-    quantized_storage: Option<&QuantizedVectors>,
+pub fn is_quantized_search<Q: QuantizedVectorsReadAccess>(
+    quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
 ) -> bool {
     let ignore_quantization = params
@@ -24,8 +24,8 @@ pub fn is_quantized_search(
     quantized_storage.is_some() && !ignore_quantization && !exact
 }
 
-pub fn get_oversampled_top(
-    quantized_storage: Option<&QuantizedVectors>,
+pub fn get_oversampled_top<Q: QuantizedVectorsReadAccess>(
+    quantized_storage: Option<&Q>,
     params: Option<&SearchParams>,
     top: usize,
 ) -> usize {
@@ -45,16 +45,20 @@ pub fn get_oversampled_top(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn postprocess_search_result(
+pub fn postprocess_search_result<V, Q>(
     mut search_result: Vec<ScoredPointOffset>,
     point_deleted: &BitSlice,
-    vector_storage: &VectorStorageEnum,
-    quantized_vectors: Option<&QuantizedVectors>,
+    vector_storage: &V,
+    quantized_vectors: Option<&Q>,
     vector: &QueryVector,
     params: Option<&SearchParams>,
     top: usize,
     hardware_counter: HardwareCounterCell,
-) -> OperationResult<Vec<ScoredPointOffset>> {
+) -> OperationResult<Vec<ScoredPointOffset>>
+where
+    V: VectorStorageRead + RawScorerBuilder,
+    Q: QuantizedVectorsReadAccess,
+{
     let quantization_enabled = is_quantized_search(quantized_vectors, params);
 
     let default_rescoring = quantized_vectors
@@ -70,7 +74,7 @@ pub fn postprocess_search_result(
         let mut scorer = FilteredScorer::new(
             vector.to_owned(),
             vector_storage,
-            None,
+            None::<&Q>,
             None,
             point_deleted,
             hardware_counter,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -21,7 +21,8 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 const VECTORS_DIR_PATH: &str = "vectors";
@@ -77,7 +78,7 @@ impl<T: PrimitiveVectorElement> AppendableMmapDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> DenseVectorStorageRead<T> for AppendableMmapDenseVectorStorage<T> {
     fn vector_dim(&self) -> usize {
         self.vectors.dim()
     }
@@ -94,7 +95,9 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVec
     {
         self.vectors.for_each_in_batch(keys, callback);
     }
+}
 
+impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for AppendableMmapDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -22,7 +22,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::common::get_async_scorer;
 use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 const VECTORS_PATH: &str = "matrix.dat";
@@ -210,7 +210,7 @@ where
     Ok(storage)
 }
 
-impl<T, S> DenseVectorStorage<T> for DenseVectorStorageImpl<T, S>
+impl<T, S> DenseVectorStorageRead<T> for DenseVectorStorageImpl<T, S>
 where
     T: PrimitiveVectorElement,
     S: UniversalRead,
@@ -231,7 +231,13 @@ where
         let mmap_store = self.vectors.as_ref().unwrap();
         mmap_store.for_each_in_batch(keys, f);
     }
+}
 
+impl<T, S> DenseVectorStorage<T> for DenseVectorStorageImpl<T, S>
+where
+    T: PrimitiveVectorElement,
+    S: UniversalRead,
+{
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -14,7 +14,7 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::{
-    DenseVectorStorage, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
 };
 
 /// Placeholder vector storage that contains no data.
@@ -84,7 +84,7 @@ pub fn new_empty_dense_vector_storage(
     ))
 }
 
-impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
+impl DenseVectorStorageRead<VectorElementType> for EmptyDenseVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -96,7 +96,9 @@ impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
         // flag from `is_deleted_vector` keeps the placeholder from being read.
         Cow::Owned(vec![0.0; self.dim])
     }
+}
 
+impl DenseVectorStorage<VectorElementType> for EmptyDenseVectorStorage {
     fn update_from<'a>(
         &mut self,
         _other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,

--- a/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/chunked_vector_storage.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use common::bitvec::{BitSlice, BitVec};
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
@@ -7,7 +9,7 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
-use crate::vector_storage::{VectorOffsetType, VectorStorageRead};
+use crate::vector_storage::{DenseVectorStorageRead, VectorOffsetType, VectorStorageRead};
 
 #[derive(Debug)]
 pub struct ReadOnlyChunkedDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
@@ -19,6 +21,20 @@ pub struct ReadOnlyChunkedDenseVectorStorage<T: PrimitiveVectorElement, S: Unive
     deleted: BitVec,
     distance: Distance,
     deleted_count: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
+    for ReadOnlyChunkedDenseVectorStorage<T, S>
+{
+    fn vector_dim(&self) -> usize {
+        self.vectors.dim()
+    }
+
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        self.vectors
+            .get::<P>(key as VectorOffsetType)
+            .expect("vector not found")
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -15,7 +15,8 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
-    DenseVectorStorage, VectorOffsetType, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 /// In-memory vector storage that is volatile
@@ -75,7 +76,7 @@ impl<T: PrimitiveVectorElement> VolatileDenseVectorStorage<T> {
     }
 }
 
-impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorStorage<T> {
+impl<T: PrimitiveVectorElement> DenseVectorStorageRead<T> for VolatileDenseVectorStorage<T> {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -83,7 +84,9 @@ impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorSto
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
     }
+}
 
+impl<T: PrimitiveVectorElement> DenseVectorStorage<T> for VolatileDenseVectorStorage<T> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent, MemoryReporter};
 use crate::vector_storage::vector_storage_base::{
-    DenseVectorStorage as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
+    DenseVectorStorageRead as _, MultiVectorStorage as _, VectorStorage as _, VectorStorageEnum,
     VectorStorageRead as _,
 };
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/chunked_vector_storage.rs
@@ -25,6 +25,13 @@ pub struct ReadOnlyChunkedMultiDenseVectorStorage<T: PrimitiveVectorElement, S: 
     deleted_count: usize,
 }
 
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        // Total flattened element bytes across all stored multi-vectors.
+        self.vectors.len() * self.vectors.dim() * std::mem::size_of::<T>()
+    }
+}
+
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
 {

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -10,7 +10,7 @@ use zerocopy::FromBytes;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{DenseVector, TypedDenseVector};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
+use crate::vector_storage::DenseVectorStorageRead;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -18,7 +18,7 @@ pub struct CustomQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > {
     vector_storage: &'a TVectorStorage,
@@ -32,7 +32,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > CustomQueryScorer<'a, TElement, TMetric, TVectorStorage, TStoredQuery>
 {
@@ -76,7 +76,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > QueryScorer for CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TStoredQuery>
 {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -10,14 +10,14 @@ use zerocopy::FromBytes;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{TypedDenseVector, VectorElementType};
 use crate::spaces::metric::Metric;
-use crate::vector_storage::DenseVectorStorage;
+use crate::vector_storage::DenseVectorStorageRead;
 use crate::vector_storage::query_scorer::QueryScorer;
 
 pub struct MetricQueryScorer<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > {
     vector_storage: &'a TVectorStorage,
     query: TypedDenseVector<TElement>,
@@ -29,7 +29,7 @@ impl<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > MetricQueryScorer<'a, TElement, TMetric, TVectorStorage>
 {
     pub fn new(
@@ -61,7 +61,7 @@ impl<
 impl<
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement>,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 > QueryScorer for MetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
     type TVector = [TElement];

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -12,7 +12,7 @@ use super::query_scorer::custom_query_scorer::CustomQueryScorer;
 use super::query_scorer::multi_custom_query_scorer::MultiCustomQueryScorer;
 use super::query_scorer::sparse_custom_query_scorer::SparseCustomQueryScorer;
 use super::query_scorer::{QueryScorerBytes, QueryScorerBytesImpl};
-use super::{DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
+use super::{DenseVectorStorageRead, MultiVectorStorage, SparseVectorStorage, VectorStorageEnum};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
@@ -93,6 +93,30 @@ pub fn new_raw_scorer<'a>(
         }
         VectorStorageEnum::EmptyDense(vs) => raw_scorer_impl(query, vs, hc),
         VectorStorageEnum::EmptySparse(vs) => raw_sparse_scorer_impl(query, vs, hc),
+    }
+}
+
+/// Build a [`RawScorer`] for a query against this vector storage.
+///
+/// Implemented for the storage enums so scoring code can be generic over
+/// read-write ([`VectorStorageEnum`]) and read-only
+/// ([`VectorStorageReadEnum`](crate::vector_storage::read_only::VectorStorageReadEnum))
+/// backends.
+pub trait RawScorerBuilder {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>>;
+}
+
+impl RawScorerBuilder for VectorStorageEnum {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        new_raw_scorer(query, self, hardware_counter)
     }
 }
 
@@ -187,7 +211,7 @@ pub fn new_raw_scorer_for_test<'a>(
 pub fn raw_scorer_impl<
     'a,
     TElement: PrimitiveVectorElement,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,
@@ -227,7 +251,7 @@ fn new_scorer_with_metric<
     'a,
     TElement: PrimitiveVectorElement,
     TMetric: Metric<TElement> + 'a,
-    TVectorStorage: DenseVectorStorage<TElement>,
+    TVectorStorage: DenseVectorStorageRead<TElement>,
 >(
     query: QueryVector,
     vector_storage: &'a TVectorStorage,

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -1,16 +1,22 @@
 use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
-use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::data_types::vectors::{
+    QueryVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+};
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::dense::dense_vector_storage::DenseVectorStorageImpl;
 use crate::vector_storage::dense::read_only::chunked_vector_storage::ReadOnlyChunkedDenseVectorStorage;
 use crate::vector_storage::multi_dense::read_only::chunked_vector_storage::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::sparse_vector_storage::ReadOnlySparseVectorStorage;
+use crate::vector_storage::{
+    DenseVectorStorageRead, RawScorer, RawScorerBuilder, VectorStorageRead, raw_scorer_impl,
+};
 
 /// Read-only counterpart of [`super::super::VectorStorageEnum`].
 ///
@@ -185,6 +191,65 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_bitslice(),
+        }
+    }
+}
+
+impl<S: UniversalRead> VectorStorageReadEnum<S> {
+    /// Size of all available (non-deleted) vectors in bytes.
+    pub fn size_of_available_vectors_in_bytes(&self) -> usize {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedByte(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseChunkedHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunked(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::Sparse(_) => {
+                unreachable!("Sparse storage does not know its total size, get from index instead")
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
+    fn build_raw_scorer<'a>(
+        &'a self,
+        query: QueryVector,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>> {
+        match self {
+            VectorStorageReadEnum::Dense(s) => raw_scorer_impl(query, s.as_ref(), hardware_counter),
+            VectorStorageReadEnum::DenseByte(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseHalf(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunked(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunkedByte(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseChunkedHalf(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            // Multi / sparse read-only storages don't yet implement the typed
+            // storage traits the query scorers are built from.
+            VectorStorageReadEnum::MultiDenseChunked(_)
+            | VectorStorageReadEnum::MultiDenseChunkedByte(_)
+            | VectorStorageReadEnum::MultiDenseChunkedHalf(_)
+            | VectorStorageReadEnum::Sparse(_) => Err(OperationError::service_error(
+                "raw scorer is not yet supported for read-only multi / sparse vector storage",
+            )),
         }
     }
 }

--- a/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
+++ b/lib/segment/src/vector_storage/tests/async_raw_scorer.rs
@@ -15,6 +15,7 @@ use crate::types::Distance;
 use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage_with_uring;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::vector_storage_base::VectorStorageRead;
 
 #[test]
@@ -102,7 +103,7 @@ fn test_random_score(
     let mut async_scorer = FilteredScorer::new(
         query,
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         deleted_points,
         HardwareCounterCell::new(),

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -246,7 +246,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
     let mut raw_scorer = FilteredScorer::new(
         query.clone(),
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         id_tracker.deleted_point_bitslice(),
         HardwareCounterCell::new(),
@@ -256,7 +256,7 @@ fn do_test_score_points(storage: &mut VectorStorageEnum) {
     let searcher = BatchFilteredSearcher::new(
         &[&query],
         storage,
-        None,
+        None::<&QuantizedVectors>,
         None,
         2,
         id_tracker.deleted_point_bitslice(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -162,25 +162,15 @@ pub trait VectorStorage: VectorStorageRead {
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool>;
 }
 
-pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
+/// Read-only access to a dense vector storage.
+///
+/// Everything needed to read and score dense vectors, without the ability to
+/// mutate. Implemented by read-only storages too, which cannot provide
+/// [`DenseVectorStorage::update_from`].
+pub trait DenseVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
     fn vector_dim(&self) -> usize;
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]>;
-
-    /// Add the given dense vectors to the storage.
-    ///
-    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
-    /// with a narrower element type convert them on insert.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>>;
 
     /// Call `f` with the raw bytes of the vector if it exists.
     ///
@@ -214,6 +204,23 @@ pub trait DenseVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
     }
+}
+
+pub trait DenseVectorStorage<T: PrimitiveVectorElement>: DenseVectorStorageRead<T> {
+    /// Add the given dense vectors to the storage.
+    ///
+    /// Incoming vectors are always in [`VectorElementType`] (`f32`); storages
+    /// with a narrower element type convert them on insert.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [VectorElementType]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 }
 
 pub trait SparseVectorStorage: VectorStorageRead {


### PR DESCRIPTION
> **WIP / does not compile yet.** Stacked on top of `read-only-vector-index` (plain-index read-only work). Opened as a draft to share the shape and the remaining blockers.

## What this does

Mirrors the `plain_vector_index` read-only structure for HNSW.

**Refactor (compiles, behavior-preserving):**
- Extract `HNSWIndex`'s read logic into a reusable `HNSWIndexReadView` under `hnsw/read_view/` (`mod` + `search` + `dispatch`); `HNSWIndex::search` now delegates via `with_view`.
- `HNSWIndexReadView` follows the refactored `PlainVectorIndexReadView` shape: bounds `I: IdTrackerRead` (not `IdTracker`) and takes the payload index view as its own decoupled `P: PayloadIndexRead` param instead of reusing `I`/`V`.

**Scaffold (intentionally does NOT compile):**
- `ReadOnlyHNSWIndex<S>` + `with_view` + an `impl VectorIndexRead` in `hnsw/read_only/` that naively reuses the shared view `search`.

The decoupled view fixed the two type-param blockers (`with_view` type-checks for the read-only backends). Two things still block compilation:

1. `search` is implemented only on the concrete in-RAM `HNSWIndexReadViewEnum`. Reusing it for read-only storages needs the scorer constructors (`new_raw_scorer` / `FilteredScorer::new` / `BatchFilteredSearcher::new` / `postprocess_search_result`) generalized over `VectorStorageRead` — there's no raw-scorer path over `VectorStorageReadEnum<S>` yet. (The `dyn`-erased graph-search code stays untouched.)
2. `size_of_searchable_vectors_in_bytes` has no `VectorStorageRead` source (the method lives on `DenseVectorStorage`/`MultiVectorStorage`).

Note: the plain index has the same two gaps unsolved (its `search` is also concrete-alias-only), so the scorer generalization is shared follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)