### PR TITLE
Stabilize WAL record ID preservation test

### DIFF
--- a/lib/wal/src/lib.rs
+++ b/lib/wal/src/lib.rs
@@ -1281,7 +1281,8 @@ mod test {
         };
 
         let mut wal = Wal::with_options(dir.path(), &options).unwrap();
-        let entries = EntryGenerator::new().take(entry_count).collect::<Vec<_>>();
+        // Fixed-size entries make the segment boundaries deterministic.
+        let entries = vec![vec![0; 32]; entry_count];
 
         for entry in &entries {
             wal.append(entry).unwrap();


### PR DESCRIPTION
Fixes #9181.

## Summary

Replace randomly sized WAL entries in `test_record_id_preserving` with fixed
32-byte entries. This makes the segment boundaries deterministic while
preserving the existing truncation and record-ID assertions.

The random fixture could leave the same number of retained closed segments
after both truncations, causing an assertion unrelated to WAL correctness to
fail.

## Validation

- `cargo test -p wal`
- `cargo clippy -p wal --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- 100 consecutive runs of `test::test_record_id_preserving`

## AI disclosure

- `[AI]` The fix is reviewed by AI for optimization.
