### PR TITLE
[TQDT] Dense tq vector storage trait

### DIFF
--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -35,7 +35,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::{VectorStorage, VectorStorageRead};
+use crate::vector_storage::{DenseTQVectorStorage, VectorStorage, VectorStorageRead};
 
 // TurboQuant DataType (TQDT) always uses 4 bits without shift+scale error correction.
 const TQDT_BITS: TQBits = TQBits::Bits4;
@@ -170,5 +170,29 @@ impl VectorStorage for TurboVectorStorage {
     fn delete_vector(&mut self, _key: PointOffsetType) -> OperationResult<bool> {
         // TODO: set the bit in `self.deleted` and bump `self.deleted_count`.
         unimplemented!("TODO: flag a vector as deleted")
+    }
+}
+
+impl DenseTQVectorStorage for TurboVectorStorage {
+    fn vector_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn quantized_vector_size(&self) -> usize {
+        // TODO: bytes of one encoded vector from `self.quantizer`.
+        unimplemented!("TODO: encoded size of one vector")
+    }
+
+    fn get_dense_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.storage.get_quantized_vector(key)
+    }
+
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        // TODO: append the incoming encoded blobs and propagate deleted flags.
+        unimplemented!("TODO: copy encoded vectors from another TQ storage")
     }
 }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -272,6 +272,66 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: VectorStorageRead {
     ) -> OperationResult<Range<PointOffsetType>>;
 }
 
+pub trait DenseTQVectorStorage: VectorStorageRead {
+    /// Original dimension of the vector, without quantization applied.
+    fn vector_dim(&self) -> usize;
+
+    /// Size in bytes of the quantized vector.
+    fn quantized_vector_size(&self) -> usize;
+
+    /// Get the quantized vector by the given key
+    fn get_dense_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]>;
+
+    /// Add the given dense TQ vectors to the storage.
+    ///
+    /// # Returns
+    /// The range of point offsets that were added to the storage.
+    ///
+    /// If stopped, the operation returns a cancellation error.
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
+
+    /// Call `f` with the raw bytes of the vector if it exists.
+    ///
+    /// Uses `bytemuck::cast_slice` on the borrowed data — zero copy, zero allocation.
+    fn with_dense_tq_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        ((key as usize) < self.total_vector_count()).then(|| {
+            let dense_tq = self.get_dense_tq::<P>(key);
+            f(&dense_tq)
+        })
+    }
+
+    /// Get layout for a single vector
+    fn get_dense_tq_vector_layout(&self) -> OperationResult<Layout> {
+        Layout::array::<u8>(self.quantized_vector_size())
+            .map_err(|_| OperationError::service_error("Layout is too big"))
+    }
+
+    /// Run given function for each vector in the dense batch.
+    ///
+    /// Implementation can assume that the keys are consecutive
+    fn for_each_in_dense_tq_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        mut f: F,
+    ) {
+        for (idx, &key) in keys.iter().enumerate() {
+            f(idx, &self.get_dense_tq::<Random>(key));
+        }
+    }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.quantized_vector_size()
+    }
+}
+
 #[derive(Debug)]
 pub enum VectorStorageEnum {
     DenseVolatile(VolatileDenseVectorStorage<VectorElementType>),


### PR DESCRIPTION
This PR adds `DenseTQVectorStorage` trait, which is the TQ analogue of the `DenseVectorStorage` trait.