### PR TITLE
fix(common): don't fsync read-only file handles on Windows (#9132)

### DIFF
--- a/lib/common/common/src/fs/sync.rs
+++ b/lib/common/common/src/fs/sync.rs
@@ -7,6 +7,10 @@ use fs_err::File;
 /// Commits filesystem caches for the given directory.
 ///
 /// On Linux, it commits the entire filesystem containing the directory.
+///
+/// On non-unix platforms (e.g. Windows) this is a no-op: we can neither `fsync`
+/// a read-only file handle (`FlushFileBuffers` requires write access and fails
+/// with `ERROR_ACCESS_DENIED`) nor a directory handle. See #9132.
 pub fn bulk_sync_dir(dir: &Path) -> io::Result<()> {
     // Matches all platforms that have `nix::unistd::syncfs` function.
     // https://github.com/nix-rust/nix/blob/v0.30.1/src/unistd.rs#L1679
@@ -21,29 +25,28 @@ pub fn bulk_sync_dir(dir: &Path) -> io::Result<()> {
         Err(e) => log::warn!("syncfs failed for {}: {e}", dir.display()),
     }
 
-    // Fallback
-    sync_dir_with_fsync(dir)
+    // Fallback for the remaining unix platforms (e.g. macOS, *BSD).
+    #[cfg(unix)]
+    sync_dir_with_fsync(dir)?;
+
+    // Nothing to sync on non-unix platforms (see the doc comment above).
+    #[cfg(not(unix))]
+    let _ = dir;
+
+    Ok(())
 }
 
 /// Calls `fsync` recursively.
+#[cfg(unix)]
 fn sync_dir_with_fsync(dir: &Path) -> io::Result<()> {
     for entry in fs_err::read_dir(dir)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
             sync_dir_with_fsync(&entry.path())?;
         } else {
-            // `File::open` opens the file read-only. On Windows `sync_all()`
-            // lowers to `FlushFileBuffers`, which requires a handle with write
-            // access and returns ERROR_ACCESS_DENIED (os error 5) for read-only
-            // handles — breaking snapshot restore (#9132). POSIX `fsync` accepts
-            // any descriptor. The directory `sync_all` below is already
-            // `#[cfg(unix)]`-gated for the same reason; gate the per-file sync to
-            // match, so non-unix targets skip it instead of erroring.
-            #[cfg(unix)]
             File::open(entry.path())?.sync_all()?;
         }
     }
-    #[cfg(unix)]
     File::open(dir)?.sync_all()?;
     Ok(())
 }
@@ -58,9 +61,9 @@ mod tests {
     #[test]
     fn bulk_sync_dir_succeeds() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("applied_seq.json"), b"{}").unwrap();
-        std::fs::create_dir(dir.path().join("sub")).unwrap();
-        std::fs::write(dir.path().join("sub").join("data"), b"x").unwrap();
+        fs_err::write(dir.path().join("applied_seq.json"), b"{}").unwrap();
+        fs_err::create_dir(dir.path().join("sub")).unwrap();
+        fs_err::write(dir.path().join("sub").join("data"), b"x").unwrap();
         bulk_sync_dir(dir.path()).unwrap();
     }
 }

--- a/lib/common/common/src/fs/sync.rs
+++ b/lib/common/common/src/fs/sync.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::path::Path;
 
+#[cfg(unix)]
 use fs_err::File;
 
 /// Commits filesystem caches for the given directory.
@@ -31,10 +32,35 @@ fn sync_dir_with_fsync(dir: &Path) -> io::Result<()> {
         if entry.file_type()?.is_dir() {
             sync_dir_with_fsync(&entry.path())?;
         } else {
+            // `File::open` opens the file read-only. On Windows `sync_all()`
+            // lowers to `FlushFileBuffers`, which requires a handle with write
+            // access and returns ERROR_ACCESS_DENIED (os error 5) for read-only
+            // handles — breaking snapshot restore (#9132). POSIX `fsync` accepts
+            // any descriptor. The directory `sync_all` below is already
+            // `#[cfg(unix)]`-gated for the same reason; gate the per-file sync to
+            // match, so non-unix targets skip it instead of erroring.
+            #[cfg(unix)]
             File::open(entry.path())?.sync_all()?;
         }
     }
     #[cfg(unix)]
     File::open(dir)?.sync_all()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for #9132: syncing files opened read-only failed on
+    /// Windows with `ERROR_ACCESS_DENIED (os error 5)`. `bulk_sync_dir` must
+    /// succeed on every platform for a freshly written directory tree.
+    #[test]
+    fn bulk_sync_dir_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("applied_seq.json"), b"{}").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub").join("data"), b"x").unwrap();
+        bulk_sync_dir(dir.path()).unwrap();
+    }
 }


### PR DESCRIPTION
**What**
On Windows, restoring a collection snapshot fails with:
`Service internal error: failed to sync file ...\applied_seq.json: Access is denied. (os error 5)`

**Why**
`sync_dir_with_fsync` (lib/common/common/src/fs/sync.rs) opens every file with
`File::open` (read-only) and calls `sync_all()`. On Windows `sync_all()` maps to
`FlushFileBuffers`, which requires a handle with **write** access and returns
`ERROR_ACCESS_DENIED (os error 5)` on a read-only handle. POSIX `fsync()` accepts any
descriptor, so this only breaks on Windows. The directory `sync_all` right below is
already `#[cfg(unix)]`-gated for the same reason, only the per-file one was missing it.

**Fix**
Gate the per-file `sync_all` with `#[cfg(unix)]` (matching the directory sync) and gate
the `use fs_err::File;` import so it isn't unused on Windows. Adds a regression test.
Non-unix targets skip the per-file fsync instead of erroring.

Alternative considered: on `not(unix)`, open the file with `write(true)` before
`sync_all()` to keep per-file durability on Windows. I chose the gate for consistency with
the existing directory sync, happy to switch if you'd prefer to keep the flush.

**Verification (Windows)**
Standalone repro of `sync_dir_with_fsync` (same `fs_err::File::sync_all`), same compiler,
only the guard differs:
  (a) without fix -> failed to sync file ...\applied_seq.json: Access is denied. (os error 5)
  (b) with fix    -> OK
In-tree test (rustc 1.96): `test fs::sync::tests::bulk_sync_dir_succeeds ... ok`
Direct Win32: FlushFileBuffers read-only -> GetLastError()=5 ; read-write -> TRUE

Note: this fixes snapshot **restore**. Snapshot **creation** can still hit a separate
Windows issue (`fs::rename` of a memory-mapped segment dir in `safe_delete_with_suffix`);
happy to open a follow-up.

Fixes #9132

## All Submissions

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## New Feature Submissions

* [x] Does your submission pass tests?
* [x] Have you formatted your code locally using `cargo +nightly fmt --all` prior to submission?
* [x] Have you checked your code using `cargo clippy --workspace --all-features`?, ran `cargo clippy -p common` clean locally; the full `--workspace --all-features` is Linux-only (needs protoc/clang/libunwind) and runs on CI.

## Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?