### PR TITLE
fix: preserve empty min_should filter semantics

### DIFF
--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -76,7 +76,6 @@ where
                 conditions,
                 min_count,
             }) = filter.min_should.as_ref()
-                && !conditions.is_empty()
             {
                 let (optimized_conditions, estimation) = self.optimize_min_should(
                     conditions,

--- a/lib/segment/tests/integration/filtering_context_check.rs
+++ b/lib/segment/tests/integration/filtering_context_check.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicBool;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use itertools::Itertools;
@@ -8,6 +10,7 @@ use segment::fixtures::payload_context_fixture::{
 };
 use segment::fixtures::payload_fixtures::random_filter;
 use segment::index::PayloadIndexRead;
+use segment::types::{Filter, MinShould};
 use tempfile::Builder;
 
 const NUM_POINTS: usize = 2000;
@@ -39,5 +42,49 @@ fn test_filtering_context_consistency() {
                 .collect_vec()
         });
         assert_eq!(plain_result, struct_result, "filter: {filter:#?}");
+    }
+}
+
+#[test]
+fn test_empty_min_should_filtering_context_consistency() {
+    const NUM_TEST_POINTS: usize = 10;
+
+    let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+    let plain_index = create_plain_payload_index(dir.path(), NUM_TEST_POINTS, 42);
+    let struct_index = create_struct_payload_index(dir.path(), NUM_TEST_POINTS, 42);
+    let hw_counter = HardwareCounterCell::new();
+    let is_stopped = AtomicBool::new(false);
+
+    for (min_count, expected_count) in [(0, NUM_TEST_POINTS), (1, 0)] {
+        let filter = Filter::new_min_should(MinShould {
+            conditions: vec![],
+            min_count,
+        });
+
+        let plain_filter_context = plain_index.filter_context(&filter, &hw_counter).unwrap();
+        let plain_result = (0..NUM_TEST_POINTS)
+            .filter(|point_id| plain_filter_context.check(*point_id as PointOffsetType))
+            .collect_vec();
+
+        let struct_result = struct_index.with_view(|view| {
+            let struct_filter_context = view.filter_context(&filter, &hw_counter).unwrap();
+            (0..NUM_TEST_POINTS)
+                .filter(|point_id| struct_filter_context.check(*point_id as PointOffsetType))
+                .collect_vec()
+        });
+
+        assert_eq!(plain_result.len(), expected_count);
+        assert_eq!(plain_result, struct_result);
+
+        let plain_points = plain_index
+            .query_points(&filter, &hw_counter, &is_stopped)
+            .unwrap();
+        let struct_points = struct_index.with_view(|view| {
+            view.query_points(&filter, &hw_counter, &is_stopped)
+                .unwrap()
+        });
+
+        assert_eq!(plain_points.len(), expected_count);
+        assert_eq!(plain_points, struct_points);
     }
 }


### PR DESCRIPTION
Fixes #9369.

## Summary

- Empty `min_should` clauses were removed during filter optimization.
- This changed `min_count > 0` from match-none to match-all.
- The change preserves the clause so the optimized and plain filtering paths have identical semantics.

## Testing

- Regression coverage for `min_count = 0` and `min_count = 1`
- `cargo test -p segment --lib`
- `cargo test -p segment --test integration`
- `cargo clippy -p segment --lib --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`

## AI disclosure
Code reviewed by AI for any possible optimization.