### PR TITLE
Fix test build ReadOnlyChunkedMultiDenseVectorStorage

### DIFF
--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -205,6 +205,7 @@ mod tests {
                 dir.path(),
                 DIM,
                 Distance::Dot,
+                MultiVectorConfig::default(),
                 AdviceSetting::Global,
                 false,
             )


### PR DESCRIPTION
Fix dev build.

```
error[E0061]: this function takes 7 arguments but 6 arguments were supplied
   --> lib/segment/src/vector_storage/multi_dense/read_only/mod.rs:203:13
    |
203 |             ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
208 |                 AdviceSetting::Global,
    |                 --------------------- argument #5 of type `types::MultiVectorConfig` is missing
    |
note: associated function defined here
   --> lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs:22:12
    |
 22 |     pub fn open(
    |            ^^^^
...
 27 |         multi_vector_config: MultiVectorConfig,
    |         --------------------------------------
help: provide the argument
    |
203 |             ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
...
207 |                 Distance::Dot,
208 ~                 /* types::MultiVectorConfig */,
209 ~                 AdviceSetting::Global,
    |

For more information about this error, try `rustc --explain E0061`.
```