### PR TITLE
[TQDT] Integration into VectorStorageEnum

### DIFF
--- a/lib/segment/src/data_types/named_vectors.rs
+++ b/lib/segment/src/data_types/named_vectors.rs
@@ -356,9 +356,9 @@ impl<'a> NamedVectors<'a> {
             Some(VectorStorageDatatype::Float16) => config
                 .distance
                 .preprocess_vector::<VectorElementTypeHalf>(dense_vector),
-            Some(VectorStorageDatatype::Turbo4) => {
-                unimplemented!("turbo4 datatype storage not yet wired up")
-            }
+            Some(VectorStorageDatatype::Turbo4) => config
+                .distance
+                .preprocess_vector::<VectorElementType>(dense_vector), // Turbo only needs normal preprocessing.
         }
     }
 }

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -483,6 +483,10 @@ impl GpuVectorStorage {
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(vector_storage) => {
                 Self::new_multi_f16(device, vector_storage.as_ref(), stopped)
             }
+            // TODO(TQDT): GPU f16 fallback
+            VectorStorageEnum::DenseTurbo(_) => Err(OperationError::from(
+                gpu::GpuError::NotSupported("Turbo4 vectors are not supported on GPU".to_string()),
+            )),
             VectorStorageEnum::EmptyDense(_) | VectorStorageEnum::EmptySparse(_) => {
                 Err(OperationError::service_error(
                     "Cannot create GPU vector storage for empty vector storage",

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -14,8 +14,9 @@ use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::CompactExtendedPointId;
 use crate::vector_storage::{
-    DenseVectorStorage, DenseVectorStorageRead, MultiVectorStorage, MultiVectorStorageRead,
-    SparseVectorStorage, SparseVectorStorageRead, VectorStorageEnum, VectorStorageRead,
+    DenseTQVectorStorage, DenseVectorStorage, DenseVectorStorageRead, MultiVectorStorage,
+    MultiVectorStorageRead, SparseVectorStorage, SparseVectorStorageRead, VectorStorageEnum,
+    VectorStorageRead,
 };
 
 /// Define location of the point source during segment construction.
@@ -104,6 +105,11 @@ pub(crate) fn merge_from<'a>(
         }
         VectorStorageEnum::DenseAppendableMemmapHalf(target) => {
             let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseTurbo(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_tq);
             let range = target.update_from(&mut reader, stopped);
             reader.finish(range)
         }
@@ -326,6 +332,7 @@ fn read_dense_f32(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
                 "Cannot merge vector storage: source is not a f32 dense storage",
@@ -373,6 +380,7 @@ fn read_dense_byte(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
@@ -420,6 +428,7 @@ fn read_dense_half(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
@@ -438,6 +447,53 @@ fn read_dense_half(
         VectorStorageEnum::DenseUring(_) | VectorStorageEnum::DenseUringByte(_) => {
             return Err(OperationError::service_error(
                 "Cannot merge vector storage: source is not a half dense storage",
+            ));
+        }
+    };
+    Ok((vector, deleted))
+}
+
+fn read_dense_tq(
+    source: &VectorStorageEnum,
+    key: PointOffsetType,
+) -> OperationResult<(Cow<'_, [u8]>, bool)> {
+    let deleted = source.is_deleted_vector(key);
+    let vector = match source {
+        VectorStorageEnum::DenseTurbo(v) => v.get_dense_tq::<Sequential>(key),
+        VectorStorageEnum::DenseVolatile(_)
+        | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseAppendableMemmap(_)
+        | VectorStorageEnum::DenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::SparseVolatile(_)
+        | VectorStorageEnum::SparseMmap(_)
+        | VectorStorageEnum::MultiDenseVolatile(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::EmptyDense(_)
+        | VectorStorageEnum::EmptySparse(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a turbo storage",
+            ));
+        }
+        #[cfg(test)]
+        VectorStorageEnum::DenseVolatileByte(_)
+        | VectorStorageEnum::DenseVolatileHalf(_)
+        | VectorStorageEnum::MultiDenseVolatileByte(_)
+        | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a turbo storage",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        VectorStorageEnum::DenseUring(_)
+        | VectorStorageEnum::DenseUringByte(_)
+        | VectorStorageEnum::DenseUringHalf(_) => {
+            return Err(OperationError::service_error(
+                "Cannot merge vector storage: source is not a turbo storage",
             ));
         }
     };
@@ -463,6 +519,7 @@ fn read_multi_f32(
         | VectorStorageEnum::SparseMmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
@@ -511,6 +568,7 @@ fn read_multi_byte(
         | VectorStorageEnum::MultiDenseVolatile(_)
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
@@ -558,6 +616,7 @@ fn read_multi_half(
         | VectorStorageEnum::MultiDenseVolatile(_)
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::EmptySparse(_) => {
             return Err(OperationError::service_error(
@@ -616,6 +675,7 @@ fn read_sparse(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+        | VectorStorageEnum::DenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_) => {
             return Err(OperationError::service_error(
                 "Cannot merge vector storage: source is not a sparse storage",

--- a/lib/segment/src/segment_constructor/segment_constructor_base.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base.rs
@@ -56,6 +56,7 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+use crate::vector_storage::turbo::open_turbo_vector_storage;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 pub const PAYLOAD_INDEX_PATH: &str = "payload_index";
@@ -123,9 +124,13 @@ fn open_mmap_vector_storage(
                 vector_config.distance,
                 populate,
             ),
-            VectorStorageDatatype::Turbo4 => {
-                unimplemented!("turbo4 datatype storage not yet wired up")
-            }
+            VectorStorageDatatype::Turbo4 => open_turbo_vector_storage(
+                vector_storage_path,
+                vector_config.size,
+                vector_config.distance,
+                populate,
+            )
+            .map(|s| VectorStorageEnum::DenseTurbo(Box::new(s))),
         }
     }
 }
@@ -389,7 +394,7 @@ pub(crate) fn create_sparse_vector_index(
             VectorIndexEnum::SparseCompressedMmapU8(SparseVectorIndex::open(args)?)
         }
         (_, VectorStorageDatatype::Turbo4) => {
-            unimplemented!("turbo4 datatype storage not yet wired up")
+            unreachable!("Sparse index incompatible with turbo. Validated at API level.")
         }
     };
 

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -68,6 +68,8 @@ impl MemoryReporter for VectorStorageEnum {
                 from_files_with_on_disk(v.files(), v.is_on_disk())
             }
 
+            VectorStorageEnum::DenseTurbo(v) => from_files_with_on_disk(v.files(), v.is_on_disk()),
+
             // Volatile sparse: in-memory
             VectorStorageEnum::SparseVolatile(v) => {
                 ComponentMemoryUsage::ram_only(v.size_of_available_vectors_in_bytes() as u64)

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -26,6 +26,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
     open_appendable_memmap_vector_storage_byte, open_appendable_memmap_vector_storage_full,
     open_appendable_memmap_vector_storage_half,
 };
+use crate::vector_storage::turbo::open_appendable_turbo_vector_storage;
 use crate::vector_storage::{
     MultiVectorStorage, MultiVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
     VectorStorageRead,
@@ -440,7 +441,8 @@ pub fn open_appendable_memmap_vector_storage(
             populate,
         ),
         VectorStorageDatatype::Turbo4 => {
-            unimplemented!("turbo4 datatype storage not yet wired up")
+            open_appendable_turbo_vector_storage(vector_storage_path, size, distance, populate)
+                .map(|s| VectorStorageEnum::DenseTurbo(Box::new(s)))
         }
     }
 }

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -29,7 +29,7 @@ fn fill_dense<T: PrimitiveVectorElement>(
     Ok(())
 }
 
-fn fill_turbo(
+pub(super) fn fill_turbo(
     storage: &mut impl DenseTQVectorStorage,
     count: usize,
     stopped: &AtomicBool,

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -4,7 +4,10 @@ use std::sync::atomic::AtomicBool;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::vector_storage_base::VectorStorageEnum;
-use super::{DenseVectorStorage, MultiVectorStorage, SparseVectorStorage, VectorStorageRead as _};
+use super::{
+    DenseTQVectorStorage, DenseVectorStorage, MultiVectorStorage, SparseVectorStorage,
+    VectorStorageRead as _,
+};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -21,6 +24,18 @@ fn fill_dense<T: PrimitiveVectorElement>(
 ) -> OperationResult<()> {
     let dim = storage.vector_dim();
     let placeholder: Cow<[T]> = Cow::Owned(vec![T::default(); dim]);
+    let mut iter = std::iter::repeat_n((placeholder, true), count);
+    storage.update_from(&mut iter, stopped)?;
+    Ok(())
+}
+
+fn fill_turbo(
+    storage: &mut impl DenseTQVectorStorage,
+    count: usize,
+    stopped: &AtomicBool,
+) -> OperationResult<()> {
+    let size = storage.quantized_vector_size();
+    let placeholder: Cow<[u8]> = Cow::Owned(vec![0u8; size]);
     let mut iter = std::iter::repeat_n((placeholder, true), count);
     storage.update_from(&mut iter, stopped)?;
     Ok(())
@@ -98,6 +113,8 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 fill_dense(&mut **v, count, &stopped)
             }
+
+            VectorStorageEnum::DenseTurbo(v) => fill_turbo(&mut **v, count, &stopped),
 
             VectorStorageEnum::MultiDenseVolatile(v) => fill_multi(v, count, &stopped),
             #[cfg(test)]

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
@@ -128,6 +128,9 @@ impl QuantizedVectors {
                 max_threads,
                 stopped,
             ),
+            VectorStorageEnum::DenseTurbo(_) => Err(OperationError::service_error(
+                "Cannot quantize a Turbo4 vector storage; it is already quantized",
+            )),
             VectorStorageEnum::SparseVolatile(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::SparseMmap(_) => Err(OperationError::WrongSparse),
             VectorStorageEnum::MultiDenseVolatile(v) => Self::create_multi_impl(

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -77,6 +77,7 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseAppendableMemmap(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapByte(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapHalf(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseTurbo(_) => unimplemented!("turbo4 scoring not yet wired up"),
         VectorStorageEnum::SparseVolatile(vs) => raw_sparse_scorer_volatile(query, vs, hc),
         VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, hc),
         VectorStorageEnum::MultiDenseVolatile(vs) => raw_multi_scorer_impl(query, vs, hc),

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -84,7 +84,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
             | VectorStorageEnum::DenseUringHalf(_) => unreachable!(),
             VectorStorageEnum::DenseAppendableMemmap(_)
             | VectorStorageEnum::DenseAppendableMemmapByte(_)
-            | VectorStorageEnum::DenseAppendableMemmapHalf(_) => unreachable!(),
+            | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+            | VectorStorageEnum::DenseTurbo(_) => unreachable!(),
             VectorStorageEnum::SparseMmap(_) => unreachable!(),
             #[cfg(test)]
             VectorStorageEnum::SparseVolatile(_) => unreachable!(),

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -8,10 +8,6 @@
 //! It intentionally implements only [`VectorStorageRead`] + [`VectorStorage`],
 //! **not** `DenseVectorStorage<T>`.
 
-// Scaffold: nothing constructs `TurboVectorStorage` yet. Remove once it is wired
-// into `VectorStorageEnum::DenseTurbo`.
-#![allow(dead_code)]
-
 mod turbo_encoded_vectors;
 
 use std::borrow::Cow;
@@ -116,6 +112,17 @@ impl TurboVectorStorage {
                 .map(|i| *i as f32)
                 .collect::<Vec<_>>(),
         ))
+    }
+}
+
+impl std::fmt::Debug for TurboVectorStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TurboVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("total_vector_count", &self.storage.vectors_count())
+            .field("deleted_count", &self.deleted_count)
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -344,6 +344,7 @@ mod tests {
 
     use super::*;
     use crate::data_types::vectors::DenseVector;
+    use crate::vector_storage::prefill_deleted::fill_turbo;
 
     /// Deterministic test vectors in `[-1, 1]`, seeded so that the storage and
     /// the independent oracle observe exactly the same inputs across runs.
@@ -914,6 +915,57 @@ mod tests {
             let mut offsets: Vec<PointOffsetType> = seen.iter().map(|(_, o, _)| *o).collect();
             offsets.sort_unstable();
             assert_eq!(offsets, (0..COUNT as PointOffsetType).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn deleted_placeholders_load_and_score_without_panic() {
+        const COUNT: usize = 4;
+        let stopped = AtomicBool::new(false);
+
+        for distance in [
+            Distance::Dot,
+            Distance::Cosine,
+            Distance::Euclid,
+            Distance::Manhattan,
+        ] {
+            for dim in [1, 127, 128] {
+                let dir = Builder::new()
+                    .prefix("turbo_placeholder")
+                    .tempdir()
+                    .unwrap();
+                let mut storage =
+                    open_appendable_turbo_vector_storage(dir.path(), dim, distance, true).unwrap();
+
+                // Append COUNT deleted placeholders, exactly as prefill does.
+                fill_turbo(&mut storage, COUNT, &stopped).unwrap();
+                assert_eq!(storage.total_vector_count(), COUNT);
+                assert_eq!(storage.deleted_vector_count(), COUNT);
+
+                // A real (normalized) query for the asymmetric path.
+                let query = make_vectors(dim, 1, 0x5EED)[0].clone();
+                let precomputed = storage.quantizer.precompute_query(&query);
+
+                for key in 0..COUNT as PointOffsetType {
+                    // Load: dequantize keeps the original dim and stays finite.
+                    let loaded = DenseVector::try_from(storage.get_vector::<Random>(key)).unwrap();
+                    assert_eq!(loaded.len(), dim);
+                    assert!(loaded.iter().all(|x| x.is_finite()));
+
+                    // Score the raw placeholder bytes on both paths: finite, no panic.
+                    let bytes = storage.get_quantized_vector(key);
+                    let sym = storage
+                        .quantizer
+                        .score_symmetric(bytes.as_ref(), bytes.as_ref());
+                    let asym = storage
+                        .quantizer
+                        .score_precomputed(&precomputed, bytes.as_ref());
+                    assert!(
+                        sym.is_finite() && asym.is_finite(),
+                        "placeholder score not finite (dim {dim}, {distance:?}): sym {sym}, asym {asym}",
+                    );
+                }
+            }
         }
     }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -309,9 +309,7 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
 
-    /// Call `f` with the raw bytes of the vector if it exists.
-    ///
-    /// Uses `bytemuck::cast_slice` on the borrowed data — zero copy, zero allocation.
+    /// Call `f` with the raw encoded bytes of the vector if it exists.
     fn with_dense_tq_bytes_opt<P: AccessPattern, R>(
         &self,
         key: PointOffsetType,
@@ -591,9 +589,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.with_dense_bytes_opt::<P, R>(key, f)
             }
-            // TQ-encoded bytes aren't f32-layout; the only consumer (HNSW `inline_storage`
-            // graph-links) is already gated off for Turbo by get_vector_layout() returning Err.
-            VectorStorageEnum::DenseTurbo(_) => None,
+            VectorStorageEnum::DenseTurbo(v) => v.with_dense_tq_bytes_opt::<P, R>(key, f),
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,
             VectorStorageEnum::MultiDenseVolatile(_) => None,
@@ -631,8 +627,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => return v.get_dense_vector_layout(),
-            // Quantized layout differs from f32; not exposed through the generic interface.
-            VectorStorageEnum::DenseTurbo(_) => {}
+            VectorStorageEnum::DenseTurbo(v) => return v.get_dense_tq_vector_layout(),
             VectorStorageEnum::SparseVolatile(_) => {}
             VectorStorageEnum::SparseMmap(_) => {}
             VectorStorageEnum::MultiDenseVolatile(_) => {}

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -21,6 +21,7 @@ use super::multi_dense::volatile_multi_dense_vector_storage::VolatileMultiDenseV
 use super::sparse::empty_sparse_vector_storage::EmptySparseVectorStorage;
 use super::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use super::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
+use super::turbo::TurboVectorStorage;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
@@ -364,6 +365,7 @@ pub enum VectorStorageEnum {
     DenseAppendableMemmap(Box<AppendableMmapDenseVectorStorage<VectorElementType>>),
     DenseAppendableMemmapByte(Box<AppendableMmapDenseVectorStorage<VectorElementTypeByte>>),
     DenseAppendableMemmapHalf(Box<AppendableMmapDenseVectorStorage<VectorElementTypeHalf>>),
+    DenseTurbo(Box<TurboVectorStorage>),
     SparseVolatile(VolatileSparseVectorStorage),
     SparseMmap(MmapSparseVectorStorage),
     MultiDenseVolatile(VolatileMultiDenseVectorStorage<VectorElementType>),
@@ -404,6 +406,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(_) => None,
             VectorStorageEnum::DenseAppendableMemmapByte(_) => None,
             VectorStorageEnum::DenseAppendableMemmapHalf(_) => None,
+            VectorStorageEnum::DenseTurbo(_) => None,
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,
             VectorStorageEnum::MultiDenseVolatile(s) => Some(s.multi_vector_config()),
@@ -454,6 +457,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
+            VectorStorageEnum::DenseTurbo(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
             VectorStorageEnum::SparseVolatile(_) => VectorInternal::from(SparseVector::default()),
             VectorStorageEnum::SparseMmap(_) => VectorInternal::from(SparseVector::default()),
             VectorStorageEnum::MultiDenseVolatile(v) => {
@@ -502,6 +506,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(vs) => vs.populate()?,
             VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.populate()?,
             VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.populate()?,
+            VectorStorageEnum::DenseTurbo(vs) => vs.populate()?,
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.populate()?,
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -539,6 +544,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseTurbo(vs) => vs.clear_cache()?,
             VectorStorageEnum::SparseVolatile(_) => {} // Can't populate as it is not mmap
             VectorStorageEnum::SparseMmap(vs) => vs.clear_cache()?,
             VectorStorageEnum::MultiDenseVolatile(_) => {} // Can't populate as it is not mmap
@@ -585,6 +591,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.with_dense_bytes_opt::<P, R>(key, f)
             }
+            // Encoded TQ bytes have a different layout than f32; the only caller
+            // (graph-links serialization) expects f32 bytes, so fall back to get_vector.
+            VectorStorageEnum::DenseTurbo(_) => None,
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,
             VectorStorageEnum::MultiDenseVolatile(_) => None,
@@ -622,6 +631,8 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => return v.get_dense_vector_layout(),
+            // Quantized layout differs from f32; not exposed through the generic interface.
+            VectorStorageEnum::DenseTurbo(_) => {}
             VectorStorageEnum::SparseVolatile(_) => {}
             VectorStorageEnum::SparseMmap(_) => {}
             VectorStorageEnum::MultiDenseVolatile(_) => {}
@@ -667,6 +678,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.size_of_available_vectors_in_bytes()
             }
+            VectorStorageEnum::DenseTurbo(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::SparseVolatile(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::SparseMmap(_v) => {
                 unreachable!(
@@ -713,6 +725,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.distance(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.distance(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.distance(),
+            VectorStorageEnum::DenseTurbo(v) => v.distance(),
             VectorStorageEnum::SparseVolatile(v) => v.distance(),
             VectorStorageEnum::SparseMmap(v) => v.distance(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.distance(),
@@ -749,6 +762,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.datatype(),
+            VectorStorageEnum::DenseTurbo(v) => v.datatype(),
             VectorStorageEnum::SparseVolatile(v) => v.datatype(),
             VectorStorageEnum::SparseMmap(v) => v.datatype(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.datatype(),
@@ -787,6 +801,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseTurbo(v) => v.is_on_disk(),
             VectorStorageEnum::SparseVolatile(v) => v.is_on_disk(),
             VectorStorageEnum::SparseMmap(v) => v.is_on_disk(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_on_disk(),
@@ -823,6 +838,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseTurbo(v) => v.total_vector_count(),
             VectorStorageEnum::SparseVolatile(v) => v.total_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.total_vector_count(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.total_vector_count(),
@@ -859,6 +875,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_vector::<P>(key),
+            VectorStorageEnum::DenseTurbo(v) => v.get_vector::<P>(key),
             VectorStorageEnum::SparseVolatile(v) => v.get_vector::<P>(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector::<P>(key),
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector::<P>(key),
@@ -903,6 +920,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.read_vectors::<P, U>(keys, callback)
             }
+            VectorStorageEnum::DenseTurbo(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::SparseVolatile(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::SparseMmap(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::MultiDenseVolatile(v) => v.read_vectors::<P, U>(keys, callback),
@@ -945,6 +963,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_vector_opt::<P>(key),
+            VectorStorageEnum::DenseTurbo(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::SparseVolatile(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::SparseMmap(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::MultiDenseVolatile(v) => v.get_vector_opt::<P>(key),
@@ -981,6 +1000,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseTurbo(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseVolatile(v) => v.is_deleted_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::MultiDenseVolatile(v) => v.is_deleted_vector(key),
@@ -1017,6 +1037,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseTurbo(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_count(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_count(),
@@ -1053,6 +1074,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseTurbo(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseVolatile(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::SparseMmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.deleted_vector_bitslice(),
@@ -1100,6 +1122,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.insert_vector(key, vector, hw_counter)
             }
+            VectorStorageEnum::DenseTurbo(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::SparseVolatile(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::SparseMmap(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::MultiDenseVolatile(v) => v.insert_vector(key, vector, hw_counter),
@@ -1146,6 +1169,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.flusher(),
+            VectorStorageEnum::DenseTurbo(v) => v.flusher(),
             VectorStorageEnum::SparseVolatile(v) => v.flusher(),
             VectorStorageEnum::SparseMmap(v) => v.flusher(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.flusher(),
@@ -1182,6 +1206,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.files(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.files(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.files(),
+            VectorStorageEnum::DenseTurbo(v) => v.files(),
             VectorStorageEnum::SparseVolatile(v) => v.files(),
             VectorStorageEnum::SparseMmap(v) => v.files(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.files(),
@@ -1218,6 +1243,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.immutable_files(),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.immutable_files(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.immutable_files(),
+            VectorStorageEnum::DenseTurbo(v) => v.immutable_files(),
             VectorStorageEnum::SparseVolatile(v) => v.immutable_files(),
             VectorStorageEnum::SparseMmap(v) => v.immutable_files(),
             VectorStorageEnum::MultiDenseVolatile(v) => v.immutable_files(),
@@ -1254,6 +1280,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmap(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseTurbo(v) => v.delete_vector(key),
             VectorStorageEnum::SparseVolatile(v) => v.delete_vector(key),
             VectorStorageEnum::SparseMmap(v) => v.delete_vector(key),
             VectorStorageEnum::MultiDenseVolatile(v) => v.delete_vector(key),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -591,8 +591,8 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
                 v.with_dense_bytes_opt::<P, R>(key, f)
             }
-            // Encoded TQ bytes have a different layout than f32; the only caller
-            // (graph-links serialization) expects f32 bytes, so fall back to get_vector.
+            // TQ-encoded bytes aren't f32-layout; the only consumer (HNSW `inline_storage`
+            // graph-links) is already gated off for Turbo by get_vector_layout() returning Err.
             VectorStorageEnum::DenseTurbo(_) => None,
             VectorStorageEnum::SparseVolatile(_) => None,
             VectorStorageEnum::SparseMmap(_) => None,


### PR DESCRIPTION
This PR integrates the recently added `TurboVectorStorage` into `VectorStorageEnum`, implementing `unimplemented!()` stubs.

Merging this enables basic CRUD operations with Turbo4 datatype.
Scoring is not part of this PR and is done in a separate PR.