### PR TITLE
feat: make VectorIndexReadEnum usable for ReadSegment

### DIFF
--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -20,7 +20,7 @@ mod build;
 mod gpu_build;
 mod old_index;
 #[allow(dead_code)]
-mod read_only;
+pub mod read_only;
 mod read_view;
 mod telemetry;
 mod vector_index_impl;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -1,14 +1,3 @@
-// NOTE: This module does NOT compile yet. It is the "naive reuse" version of the
-// read-only HNSW index that delegates search to the existing
-// [`HNSWIndexReadView`] search implementation. It is here to show the shape; two
-// things still block compilation:
-//   1. The view struct reuses the same `I`/`V` type params for both the
-//      standalone storages and the (always in-RAM) payload view, so building the
-//      view in `with_view` fails (`id_tracker` wants `ReadOnlyIdTrackerEnum<S>`,
-//      the payload view forces `IdTrackerEnum`).
-//   2. The search body builds scorers from the concrete `VectorStorageEnum` /
-//      `QuantizedVectors` (`new_raw_scorer`, `FilteredScorer::new`, ...), which
-//      do not accept `VectorStorageReadEnum<S>` / `QuantizedVectorsRead<S>`.
 mod read;
 
 use std::path::PathBuf;
@@ -19,6 +8,7 @@ use common::universal_io::UniversalRead;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerEnum;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::FieldIndex;
@@ -72,6 +62,16 @@ type ReadView<'a, S> = HNSWIndexReadView<
 impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
     pub fn is_on_disk(&self) -> bool {
         self.is_on_disk
+    }
+
+    /// Read underlying graph data from disk into the disk cache.
+    pub fn populate(&self) -> OperationResult<()> {
+        self.graph.populate()
+    }
+
+    /// Drop the graph's disk cache.
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.graph.clear_cache()
     }
 
     /// Borrow all backing storages and hand a read view to `f`, mirroring

--- a/lib/segment/src/index/plain_vector_index/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/mod.rs
@@ -1,8 +1,7 @@
 mod lifecycle;
 mod read;
 
-#[allow(dead_code)]
-mod read_only;
+pub mod read_only;
 mod read_view;
 
 use std::sync::Arc;

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -1,3 +1,5 @@
+mod read;
+
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;

--- a/lib/segment/src/index/plain_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/read.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::universal_io::UniversalRead;
+use sparse::common::types::DimId;
+
+use super::ReadOnlyPlainVectorIndex;
+use crate::common::operation_error::OperationResult;
+use crate::common::operation_time_statistics::OperationDurationStatistics;
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::QueryVector;
+use crate::index::VectorIndexRead;
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+use crate::vector_storage::VectorStorageRead;
+
+impl<S: UniversalRead> VectorIndexRead for ReadOnlyPlainVectorIndex<S> {
+    fn search(
+        &self,
+        query_vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        self.with_view(|view| view.search(query_vectors, filter, top, params, query_context))
+    }
+
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        VectorIndexSearchesTelemetry {
+            index_name: None,
+            unfiltered_plain: self
+                .unfiltered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            filtered_plain: self
+                .filtered_searches_telemetry
+                .lock()
+                .get_statistics(detail),
+            unfiltered_hnsw: OperationDurationStatistics::default(),
+            filtered_small_cardinality: OperationDurationStatistics::default(),
+            filtered_large_cardinality: OperationDurationStatistics::default(),
+            filtered_exact: OperationDurationStatistics::default(),
+            filtered_sparse: Default::default(),
+            unfiltered_exact: OperationDurationStatistics::default(),
+            unfiltered_sparse: OperationDurationStatistics::default(),
+        }
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        0
+    }
+
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.vector_storage
+            .borrow()
+            .size_of_available_vectors_in_bytes()
+    }
+
+    fn fill_idf_statistics(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Plain (dense) index doesn't track IDF.
+        Ok(())
+    }
+
+    fn is_index(&self) -> bool {
+        false
+    }
+}

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -2,11 +2,14 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
+use crate::index::hnsw_index::hnsw::read_only::ReadOnlyHNSWIndex;
+use crate::index::plain_vector_index::read_only::ReadOnlyPlainVectorIndex;
 use crate::index::vector_index_base::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
@@ -16,10 +19,9 @@ use crate::types::{Filter, SearchParams};
 /// Wraps each read-capable index type with its read-only newtype. The mutable
 /// RAM sparse index is intentionally absent because it has no persisted
 /// read-only representation.
-#[derive(Debug)]
-pub enum VectorIndexReadEnum {
-    // Plain(Box<ReadOnlyPlainVectorIndex>),
-    // Hnsw(Box<ReadOnlyHNSWIndex>),
+pub enum VectorIndexReadEnum<S: UniversalRead> {
+    Plain(Box<ReadOnlyPlainVectorIndex<S>>),
+    Hnsw(Box<ReadOnlyHNSWIndex<S>>),
     // SparseCompressedImmutableRamF32(
     //     Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>>,
     // ),
@@ -36,179 +38,161 @@ pub enum VectorIndexReadEnum {
     // ),
 }
 
-impl VectorIndexReadEnum {
+impl<S: UniversalRead> VectorIndexReadEnum<S> {
     /// Returns true if underlying index files are configured to stay on disk.
     pub fn is_on_disk(&self) -> bool {
-        // match self {
-        //     Self::Plain(_) => false,
-        //     Self::Hnsw(index) => index.is_on_disk(),
-        //     Self::SparseCompressedImmutableRamF32(index) => index.is_on_disk(),
-        //     Self::SparseCompressedImmutableRamF16(index) => index.is_on_disk(),
-        //     Self::SparseCompressedImmutableRamU8(index) => index.is_on_disk(),
-        //     Self::SparseCompressedMmapF32(index) => index.is_on_disk(),
-        //     Self::SparseCompressedMmapF16(index) => index.is_on_disk(),
-        //     Self::SparseCompressedMmapU8(index) => index.is_on_disk(),
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(_) => false,
+            Self::Hnsw(index) => index.is_on_disk(),
+            //     Self::SparseCompressedImmutableRamF32(index) => index.is_on_disk(),
+            //     Self::SparseCompressedImmutableRamF16(index) => index.is_on_disk(),
+            //     Self::SparseCompressedImmutableRamU8(index) => index.is_on_disk(),
+            //     Self::SparseCompressedMmapF32(index) => index.is_on_disk(),
+            //     Self::SparseCompressedMmapF16(index) => index.is_on_disk(),
+            //     Self::SparseCompressedMmapU8(index) => index.is_on_disk(),
+        }
     }
 
     pub fn populate(&self) -> OperationResult<()> {
-        // match self {
-        //     Self::Plain(_) => {}
-        //     Self::Hnsw(index) => index.populate()?,
-        //     Self::SparseCompressedImmutableRamF32(_) => {}
-        //     Self::SparseCompressedImmutableRamF16(_) => {}
-        //     Self::SparseCompressedImmutableRamU8(_) => {}
-        //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().populate()?,
-        //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().populate()?,
-        //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().populate()?,
-        // };
-        // Ok(())
-
-        todo!()
+        match self {
+            Self::Plain(_) => {}
+            Self::Hnsw(index) => index.populate()?,
+            //     Self::SparseCompressedImmutableRamF32(_) => {}
+            //     Self::SparseCompressedImmutableRamF16(_) => {}
+            //     Self::SparseCompressedImmutableRamU8(_) => {}
+            //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().populate()?,
+            //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().populate()?,
+            //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().populate()?,
+        };
+        Ok(())
     }
 
     pub fn clear_cache(&self) -> OperationResult<()> {
-        // match self {
-        //     Self::Plain(_) => {}
-        //     Self::Hnsw(index) => index.clear_cache()?,
-        //     Self::SparseCompressedImmutableRamF32(_) => {}
-        //     Self::SparseCompressedImmutableRamF16(_) => {}
-        //     Self::SparseCompressedImmutableRamU8(_) => {}
-        //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().clear_cache()?,
-        //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().clear_cache()?,
-        //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().clear_cache()?,
-        // };
-        // Ok(())
-
-        todo!()
+        match self {
+            Self::Plain(_) => {}
+            Self::Hnsw(index) => index.clear_cache()?,
+            //     Self::SparseCompressedImmutableRamF32(_) => {}
+            //     Self::SparseCompressedImmutableRamF16(_) => {}
+            //     Self::SparseCompressedImmutableRamU8(_) => {}
+            //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().clear_cache()?,
+            //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().clear_cache()?,
+            //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().clear_cache()?,
+        };
+        Ok(())
     }
 }
 
-impl VectorIndexRead for VectorIndexReadEnum {
+impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
     fn search(
         &self,
-        _vectors: &[&QueryVector],
-        _filter: Option<&Filter>,
-        _top: usize,
-        _params: Option<&SearchParams>,
-        _query_context: &VectorQueryContext,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        // match self {
-        //     Self::Plain(index) => index.search(vectors, filter, top, params, query_context),
-        //     Self::Hnsw(index) => index.search(vectors, filter, top, params, query_context),
-        //     Self::SparseCompressedImmutableRamF32(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        //     Self::SparseCompressedImmutableRamF16(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        //     Self::SparseCompressedImmutableRamU8(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        //     Self::SparseCompressedMmapF32(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        //     Self::SparseCompressedMmapF16(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        //     Self::SparseCompressedMmapU8(index) => {
-        //         index.search(vectors, filter, top, params, query_context)
-        //     }
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(index) => index.search(vectors, filter, top, params, query_context),
+            Self::Hnsw(index) => index.search(vectors, filter, top, params, query_context),
+            //     Self::SparseCompressedImmutableRamF32(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+            //     Self::SparseCompressedImmutableRamF16(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+            //     Self::SparseCompressedImmutableRamU8(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+            //     Self::SparseCompressedMmapF32(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+            //     Self::SparseCompressedMmapF16(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+            //     Self::SparseCompressedMmapU8(index) => {
+            //         index.search(vectors, filter, top, params, query_context)
+            //     }
+        }
     }
 
-    fn get_telemetry_data(&self, _detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        // match self {
-        //     Self::Plain(index) => index.get_telemetry_data(detail),
-        //     Self::Hnsw(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedImmutableRamF32(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedImmutableRamF16(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedImmutableRamU8(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
-        //     Self::SparseCompressedMmapU8(index) => index.get_telemetry_data(detail),
-        // }
-
-        todo!()
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        match self {
+            Self::Plain(index) => index.get_telemetry_data(detail),
+            Self::Hnsw(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedImmutableRamF32(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedImmutableRamF16(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedImmutableRamU8(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
+            //     Self::SparseCompressedMmapU8(index) => index.get_telemetry_data(detail),
+        }
     }
 
     fn indexed_vector_count(&self) -> usize {
-        // match self {
-        //     Self::Plain(index) => index.indexed_vector_count(),
-        //     Self::Hnsw(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
-        //     Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(index) => index.indexed_vector_count(),
+            Self::Hnsw(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
+            //     Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
+        }
     }
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        // match self {
-        //     Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
-        //     Self::Hnsw(index) => index.size_of_searchable_vectors_in_bytes(),
-        //     Self::SparseCompressedImmutableRamF32(index) => {
-        //         index.size_of_searchable_vectors_in_bytes()
-        //     }
-        //     Self::SparseCompressedImmutableRamF16(index) => {
-        //         index.size_of_searchable_vectors_in_bytes()
-        //     }
-        //     Self::SparseCompressedImmutableRamU8(index) => {
-        //         index.size_of_searchable_vectors_in_bytes()
-        //     }
-        //     Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
-        //     Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
-        //     Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::Hnsw(index) => index.size_of_searchable_vectors_in_bytes(),
+            //     Self::SparseCompressedImmutableRamF32(index) => {
+            //         index.size_of_searchable_vectors_in_bytes()
+            //     }
+            //     Self::SparseCompressedImmutableRamF16(index) => {
+            //         index.size_of_searchable_vectors_in_bytes()
+            //     }
+            //     Self::SparseCompressedImmutableRamU8(index) => {
+            //         index.size_of_searchable_vectors_in_bytes()
+            //     }
+            //     Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
+            //     Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
+            //     Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
+        }
     }
 
     fn fill_idf_statistics(
         &self,
-        _idf: &mut HashMap<DimId, usize>,
-        _hw_counter: &HardwareCounterCell,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // match self {
-        //     Self::Plain(index) => index.fill_idf_statistics(idf, hw_counter),
-        //     Self::Hnsw(index) => index.fill_idf_statistics(idf, hw_counter),
-        //     Self::SparseCompressedImmutableRamF32(index) => {
-        //         index.fill_idf_statistics(idf, hw_counter)
-        //     }
-        //     Self::SparseCompressedImmutableRamF16(index) => {
-        //         index.fill_idf_statistics(idf, hw_counter)
-        //     }
-        //     Self::SparseCompressedImmutableRamU8(index) => {
-        //         index.fill_idf_statistics(idf, hw_counter)
-        //     }
-        //     Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
-        //     Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
-        //     Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::Hnsw(index) => index.fill_idf_statistics(idf, hw_counter),
+            //     Self::SparseCompressedImmutableRamF32(index) => {
+            //         index.fill_idf_statistics(idf, hw_counter)
+            //     }
+            //     Self::SparseCompressedImmutableRamF16(index) => {
+            //         index.fill_idf_statistics(idf, hw_counter)
+            //     }
+            //     Self::SparseCompressedImmutableRamU8(index) => {
+            //         index.fill_idf_statistics(idf, hw_counter)
+            //     }
+            //     Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
+            //     Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
+            //     Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
+        }
     }
 
     fn is_index(&self) -> bool {
-        // match self {
-        //     Self::Plain(index) => index.is_index(),
-        //     Self::Hnsw(index) => index.is_index(),
-        //     Self::SparseCompressedImmutableRamF32(index) => index.is_index(),
-        //     Self::SparseCompressedImmutableRamF16(index) => index.is_index(),
-        //     Self::SparseCompressedImmutableRamU8(index) => index.is_index(),
-        //     Self::SparseCompressedMmapF32(index) => index.is_index(),
-        //     Self::SparseCompressedMmapF16(index) => index.is_index(),
-        //     Self::SparseCompressedMmapU8(index) => index.is_index(),
-        // }
-
-        todo!()
+        match self {
+            Self::Plain(index) => index.is_index(),
+            Self::Hnsw(index) => index.is_index(),
+            //     Self::SparseCompressedImmutableRamF32(index) => index.is_index(),
+            //     Self::SparseCompressedImmutableRamF16(index) => index.is_index(),
+            //     Self::SparseCompressedImmutableRamU8(index) => index.is_index(),
+            //     Self::SparseCompressedMmapF32(index) => index.is_index(),
+            //     Self::SparseCompressedMmapF16(index) => index.is_index(),
+            //     Self::SparseCompressedMmapU8(index) => index.is_index(),
+        }
     }
 }

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -45,14 +45,14 @@ pub struct ReadOnlySegment<S: UniversalRead> {
 }
 
 pub struct ReadOnlyVectorData<S: UniversalRead> {
-    pub vector_index: Arc<AtomicRefCell<VectorIndexReadEnum>>, // ToDo: pass <S>
+    pub vector_index: Arc<AtomicRefCell<VectorIndexReadEnum<S>>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     pub quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
 }
 
 impl<S: UniversalRead> VectorDataRead for ReadOnlyVectorData<S> {
     type IndexRef<'a>
-        = AtomicRef<'a, VectorIndexReadEnum>
+        = AtomicRef<'a, VectorIndexReadEnum<S>>
     where
         Self: 'a;
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -205,6 +205,7 @@ mod tests {
                 dir.path(),
                 DIM,
                 Distance::Dot,
+                MultiVectorConfig::default(),
                 AdviceSetting::Global,
                 false,
             )


### PR DESCRIPTION
Makes `VectorIndexReadEnum` generic over the backing storage `S` and wires the Plain + Hnsw variants so `ReadOnlySegment` compiles — adds the missing `VectorIndexRead` impl for `ReadOnlyPlainVectorIndex` and `populate`/`clear_cache` on `ReadOnlyHNSWIndex`. Stacks on #9398.