### PR TITLE
Fix empty min_should with non-zero min_count matching everything

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9894,7 +9894,7 @@
           "min_count": {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 1
           }
         }
       },

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -319,6 +319,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("Condition.condition_one_of", ""),
             ("Filter.min_should", ""),
             ("MinShould.conditions", ""),
+            ("MinShould.min_count", "range(min = 1, message = \"min_count must be greater than 0\")"),
             ("PointStruct.vectors", ""),
             ("Vectors.vectors_options", ""),
             ("NamedVectors.vectors", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -151,6 +151,7 @@ pub struct MinShould {
     #[validate(nested)]
     pub conditions: ::prost::alloc::vec::Vec<Condition>,
     #[prost(uint64, tag = "2")]
+    #[validate(range(min = 1, message = "min_count must be greater than 0"))]
     pub min_count: u64,
 }
 #[derive(validator::Validate)]

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -72,11 +72,17 @@ where
             } else {
                 None
             },
+            // Drop `min_should` to `None` (match-all) only when it's a pure
+            // no-op: an empty condition list with `min_count == 0`. An empty
+            // list with `min_count > 0` is unsatisfiable (match-none) and must
+            // be kept -- dropping it silently degrades match-none into match-all
+            // (issue #9369). A non-empty list is always kept so `check_min_should`
+            // can compare the matched count against `min_count`.
             min_should: if let Some(MinShould {
                 conditions,
                 min_count,
             }) = filter.min_should.as_ref()
-                && !conditions.is_empty()
+                && (!conditions.is_empty() || *min_count > 0)
             {
                 let (optimized_conditions, estimation) = self.optimize_min_should(
                     conditions,

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -72,12 +72,9 @@ where
             } else {
                 None
             },
-            // Drop `min_should` to `None` (match-all) only when it's a pure
-            // no-op: an empty condition list with `min_count == 0`. An empty
-            // list with `min_count > 0` is unsatisfiable (match-none) and must
-            // be kept -- dropping it silently degrades match-none into match-all
-            // (issue #9369). A non-empty list is always kept so `check_min_should`
-            // can compare the matched count against `min_count`.
+            // Keep an empty `min_should` when `min_count > 0`: it's
+            // unsatisfiable (match-none), and dropping it would match all
+            // (issue #9369). Only the no-op (empty, `min_count == 0`) is dropped.
             min_should: if let Some(MinShould {
                 conditions,
                 min_count,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3845,6 +3845,10 @@ pub struct WithPayload {
 pub struct MinShould {
     #[validate(nested)]
     pub conditions: Vec<Condition>,
+    // Require `min_count > 0`. An empty condition list with `min_count == 0`
+    // matches every point, which is a footgun; reject it at the API boundary.
+    // See <https://github.com/qdrant/qdrant/pull/9401>.
+    #[validate(range(min = 1, message = "min_count must be greater than 0"))]
     pub min_count: usize,
 }
 
@@ -4941,6 +4945,25 @@ mod tests {
             }
             _ => panic!("Condition expected"),
         }
+    }
+
+    #[test]
+    fn test_min_should_min_count_validation() {
+        // `min_count == 0` is rejected: it is meaningless and a footgun, as an
+        // empty condition list with `min_count == 0` matches every point.
+        // See <https://github.com/qdrant/qdrant/pull/9401>.
+        let invalid = Filter::new_min_should(MinShould {
+            conditions: vec![],
+            min_count: 0,
+        });
+        assert!(invalid.validate().is_err());
+
+        // `min_count >= 1` is accepted.
+        let valid = Filter::new_min_should(MinShould {
+            conditions: vec![],
+            min_count: 1,
+        });
+        assert!(valid.validate().is_ok());
     }
 
     #[test]

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -44,8 +44,9 @@ use segment::types::PayloadSchemaType::{Integer, Keyword};
 use segment::types::{
     AnyVariants, Condition, Distance, FieldCondition, Filter, GeoBoundingBox, GeoLineString,
     GeoPoint, GeoPolygon, GeoRadius, HnswConfig, HnswGlobalConfig, Indexes, IsEmptyCondition,
-    Match, Payload, PayloadField, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
-    Range, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType, WithPayload,
+    Match, MinShould, Payload, PayloadField, PayloadFieldSchema, PayloadSchemaParams,
+    PayloadSchemaType, Range, SegmentConfig, ValueVariants, VectorDataConfig, VectorStorageType,
+    WithPayload,
 };
 use segment::utils::scored_point_ties::ScoredPointTies;
 use tempfile::{Builder, TempDir};
@@ -585,6 +586,7 @@ fn test_read_operations() -> Result<()> {
 
     for test_fn in [
         test_is_empty_conditions,
+        test_empty_min_should,
         test_integer_index_types,
         test_cardinality_estimation,
         test_struct_payload_index,
@@ -670,6 +672,71 @@ fn test_is_empty_conditions(test_segments: &TestSegments) -> Result<()> {
         (estimation_struct.exp as f64 - real_number as f64).abs()
             <= (estimation_plain.exp as f64 - real_number as f64).abs()
     );
+
+    Ok(())
+}
+
+/// Regression test for <https://github.com/qdrant/qdrant/issues/9369>.
+///
+/// `min_should` matches points satisfying at least `min_count` of the given
+/// conditions. With an empty condition list this means:
+///
+/// * `min_count == 0` is trivially satisfied -> match all points.
+/// * `min_count > 0` is impossible to satisfy -> match no points.
+///
+/// The optimized (indexed) filter path used to drop an empty `min_should`
+/// clause entirely, turning the unsatisfiable case into a match-all. Verify the
+/// optimized (`struct`/`mmap`) paths agree with the non-optimized (`plain`) one.
+fn test_empty_min_should(test_segments: &TestSegments) -> Result<()> {
+    let hw_counter = HardwareCounterCell::new();
+    let is_stopped = AtomicBool::new(false);
+
+    let query = |segment: &Segment, filter: &Filter| {
+        segment
+            .payload_index
+            .borrow()
+            .with_view(|v| v.query_points(filter, &hw_counter, &is_stopped))
+            .unwrap()
+    };
+
+    let segments = [
+        ("plain", &test_segments.plain_segment),
+        ("struct", &test_segments.struct_segment),
+        ("mmap", &test_segments.mmap_segment),
+    ];
+
+    // Empty conditions with `min_count > 0` is unsatisfiable: match nothing.
+    let unsatisfiable = Filter::new_min_should(MinShould {
+        conditions: vec![],
+        min_count: 1,
+    });
+    for (name, segment) in segments {
+        let result = query(segment, &unsatisfiable);
+        ensure!(
+            result.is_empty(),
+            "{name} segment matched {} points for unsatisfiable min_should",
+            result.len(),
+        );
+    }
+
+    // Empty conditions with `min_count == 0` is trivially satisfied: match all,
+    // exactly like an empty filter would.
+    let match_all = Filter::new_min_should(MinShould {
+        conditions: vec![],
+        min_count: 0,
+    });
+    for (name, segment) in segments {
+        let result = query(segment, &match_all);
+        let unfiltered = query(segment, &Filter::default());
+        ensure!(
+            !unfiltered.is_empty(),
+            "{name} segment has no points to match",
+        );
+        ensure!(
+            result == unfiltered,
+            "{name} segment match-all min_should disagrees with empty filter",
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/9369>

An empty match any filter with `min_count > 0` matches everything. Instead it should match nothing as we cannot satisfy the `min_count` clause.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
