### PR TITLE
[UIO] condition checker: fallible checks

### DIFF
--- a/lib/common/common/src/iterator_ext/mod.rs
+++ b/lib/common/common/src/iterator_ext/mod.rs
@@ -73,6 +73,19 @@ pub trait IteratorExt: Iterator {
         })
         .unwrap_or(Ok(false))
     }
+
+    /// [`Iterator::filter()`] but for fallible predicates.
+    fn try_filter<F, E>(self, mut f: F) -> impl Iterator<Item = Result<Self::Item, E>>
+    where
+        F: FnMut(&Self::Item) -> Result<bool, E>,
+        Self: Sized,
+    {
+        self.filter_map(move |item| match f(&item) {
+            Ok(true) => Some(Ok(item)),
+            Ok(false) => None,
+            Err(e) => Some(Err(e)),
+        })
+    }
 }
 
 impl<I: Iterator> IteratorExt for I {}

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -78,7 +78,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
             let context = plain_index.filter_context(&filter, &hw_counter).unwrap();
             let filtered_sample = sample
                 .into_iter()
-                .filter(|id| context.check(*id))
+                .filter(|id| context.check(*id).unwrap())
                 .collect_vec();
             result_size += filtered_sample.len();
             query_count += 1;
@@ -101,7 +101,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
             let context = plain_index.filter_context(&filter, &hw_counter).unwrap();
             let filtered_sample = sample
                 .into_iter()
-                .filter(|id| context.check(*id))
+                .filter(|id| context.check(*id).unwrap())
                 .collect_vec();
             result_size += filtered_sample.len();
             query_count += 1;
@@ -117,7 +117,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
             let context = plain_index.filter_context(&filter, &hw_counter).unwrap();
             let filtered_sample = sample
                 .into_iter()
-                .filter(|id| context.check(*id))
+                .filter(|id| context.check(*id).unwrap())
                 .collect_vec();
             result_size += filtered_sample.len();
             query_count += 1;
@@ -177,7 +177,10 @@ fn conditional_struct_search_benchmark(c: &mut Criterion) {
                 .collect_vec();
             let filtered_count = struct_index.with_view(|v| {
                 let context = v.filter_context(&filter, &hw_counter).unwrap();
-                sample.into_iter().filter(|id| context.check(*id)).count()
+                sample
+                    .into_iter()
+                    .filter(|id| context.check(*id).unwrap())
+                    .count()
             });
             result_size += filtered_count;
             query_count += 1;

--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for ImmutableBoolIndex {
@@ -79,7 +79,7 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -19,7 +19,7 @@ use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::FieldCondition;
 
@@ -140,7 +140,7 @@ impl PayloadFieldIndexRead for BoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for MutableBoolIndex {
@@ -77,7 +77,7 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -12,7 +12,7 @@ use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, PayloadKeyType};
 
@@ -89,7 +89,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -29,7 +29,7 @@ use crate::common::operation_error::OperationResult;
 use crate::common::utils::MultiValue;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -268,7 +268,7 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
     idx: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -290,7 +290,7 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
         }) => {
             let is_true = *is_true;
             Some(Box::new(move |point_id: PointOffsetType| {
-                idx.check_values_any(point_id, is_true)
+                Ok(idx.check_values_any(point_id, is_true))
             }))
         }
         Match::Value(MatchValue {

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -14,7 +14,7 @@ use crate::index::field_index::geo_index::GeoIndexRead;
 use crate::index::field_index::null_index::NullIndexRead;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -101,7 +101,7 @@ impl PayloadFieldIndexRead for FieldIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         match self {
             FieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Read-only operations available on every payload field index.
@@ -56,7 +56,7 @@ pub trait PayloadFieldIndexRead {
         &'a self,
         _condition: &FieldCondition,
         _hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>>;
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>>;
 
     /// Index-aware check for conditions that need parameters held by
     /// the index (today: full-text tokenizers).

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -17,7 +17,7 @@ use crate::index::field_index::numeric_index::{
 use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -112,7 +112,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),

--- a/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`FullTextIndexRead`] method to the active
@@ -193,7 +193,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         read_ops::condition_checker(self, condition, hw_acc)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{
     FieldCondition, Match, MatchAny, MatchExcept, MatchPhrase, MatchText, MatchTextAny, MatchValue,
     PayloadKeyType,
@@ -180,7 +180,7 @@ impl PayloadFieldIndexRead for FullTextIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         condition_checker(self, condition, hw_acc)
     }
 
@@ -280,7 +280,7 @@ pub fn condition_checker<'a, T: FullTextIndexRead>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -319,12 +319,11 @@ pub fn condition_checker<'a, T: FullTextIndexRead>(
     }?;
 
     let Some(parsed_query) = query_opt else {
-        return Ok(Some(Box::new(|_| false)));
+        return Ok(Some(Box::new(|_| Ok(false))));
     };
 
-    Ok(Some(Box::new(move |point_id: PointOffsetType| {
-        // FIXME(uio): don't silently ignore errors. Log error? Update ConditionCheckerFn?
-        index.check_match(&parsed_query, point_id).unwrap_or(false)
+    Ok(Some(Box::new(move |point_id| {
+        index.check_match(&parsed_query, point_id)
     })))
 }
 

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -14,7 +14,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -144,7 +144,7 @@ impl PayloadFieldIndexRead for GeoIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`GeoIndexRead`] method to the active
@@ -243,7 +243,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -31,7 +31,7 @@ use crate::index::field_index::geo_hash::{
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -328,7 +328,7 @@ pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
     geo: &'a G,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -350,7 +350,6 @@ pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
             geo.check_values_any(point_id, &hw_counter, &|value| {
                 geo_radius.check_point(value)
             })
-            .unwrap_or(false) // TODO(uio): handle errors
         }));
     }
     if let Some(geo_bounding_box) = *geo_bounding_box {
@@ -358,7 +357,6 @@ pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
             geo.check_values_any(point_id, &hw_counter, &|value| {
                 geo_bounding_box.check_point(value)
             })
-            .unwrap_or(false) // TODO(uio): handle errors
         }));
     }
     if let Some(geo_polygon) = geo_polygon.as_ref() {
@@ -367,7 +365,6 @@ pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
             geo.check_values_any(point_id, &hw_counter, &|value| {
                 polygon_wrapper.check_point(value)
             })
-            .unwrap_or(false) // TODO(uio): handle errors
         }));
     }
     None

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/read_ops.rs
@@ -23,9 +23,10 @@ where
         idx: PointOffsetType,
         _hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
-        self.point_to_values
-            .check_values_any(idx, |v| check_fn(v.borrow()))
+    ) -> OperationResult<bool> {
+        Ok(self
+            .point_to_values
+            .check_values_any(idx, |v| check_fn(v.borrow())))
     }
 
     fn get_values<'a>(

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/in_memory.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/in_memory.rs
@@ -112,11 +112,12 @@ where
         idx: PointOffsetType,
         _hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
-        self.point_to_values
+    ) -> OperationResult<bool> {
+        Ok(self
+            .point_to_values
             .get(idx as usize)
             .map(|values| values.iter().any(|v| check_fn(v.borrow())))
-            .unwrap_or(false)
+            .unwrap_or(false))
     }
 
     fn get_values<'a>(

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/read_ops.rs
@@ -20,7 +20,7 @@ where
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.in_memory_index
             .check_values_any(idx, hw_counter, check_fn)
     }

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_ops.rs
@@ -19,7 +19,7 @@ where
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.in_memory_index
             .check_values_any(idx, hw_counter, check_fn)
     }

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
@@ -23,7 +23,7 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for OnDisk
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         let hw_counter = ConditionedCounter::always(hw_counter);
 
         // Measure self.deleted access.
@@ -38,14 +38,12 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> MapIndexRead<N> for OnDisk
             .is_some_and(|b| b);
 
         if is_deleted {
-            return false;
+            return Ok(false);
         }
 
-        // FIXME: don't silently ignore errors. Log error? Update ConditionCheckerFn?
         self.storage
             .point_to_values
             .check_values_any(idx, |v| check_fn(v), &hw_counter)
-            .unwrap_or(false)
     }
 
     fn get_values<'a>(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
@@ -77,7 +77,7 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -119,7 +119,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -244,7 +244,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<IntPayloadType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
@@ -78,7 +78,7 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -120,7 +120,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -247,7 +247,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<str> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -22,7 +22,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
@@ -81,7 +81,7 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -123,7 +123,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -303,7 +303,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<UuidIntType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
@@ -26,7 +26,7 @@ where
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         match self {
             ReadOnlyMapIndex::Appendable(index) => {
                 index.check_values_any(idx, hw_counter, check_fn)

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -29,7 +29,7 @@ pub trait MapIndexRead<N: MapIndexKey + ?Sized> {
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool;
+    ) -> OperationResult<bool>;
 
     fn get_values<'a>(
         &'a self,
@@ -205,7 +205,7 @@ where
         idx: PointOffsetType,
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         match self {
             MapIndex::Mutable(index) => index.check_values_any(idx, hw_counter, check_fn),
             MapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for ImmutableNullIndex {
@@ -72,7 +72,7 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -17,7 +17,7 @@ use super::{PayloadFieldIndex, PayloadFieldIndexRead};
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::FieldCondition;
 
 pub enum NullIndex {
@@ -134,7 +134,7 @@ impl PayloadFieldIndexRead for NullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for MutableNullIndex {
@@ -68,7 +68,7 @@ impl PayloadFieldIndexRead for MutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
@@ -68,7 +68,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_ops.rs
@@ -25,7 +25,7 @@ use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::FieldCondition;
 
@@ -225,7 +225,7 @@ pub(super) fn condition_checker<'a, N: NullIndexRead>(
     null_index: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>> {
+) -> Option<Box<dyn ConditionChecker + 'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -242,12 +242,12 @@ pub(super) fn condition_checker<'a, N: NullIndexRead>(
 
     if let Some(is_empty) = *is_empty {
         return Some(Box::new(move |point_id: PointOffsetType| {
-            null_index.values_is_empty(point_id) == is_empty
+            Ok(null_index.values_is_empty(point_id) == is_empty)
         }));
     }
     if let Some(is_null) = *is_null {
         return Some(Box::new(move |point_id: PointOffsetType| {
-            null_index.values_is_null(point_id) == is_null
+            Ok(null_index.values_is_null(point_id) == is_null)
         }));
     }
     None

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -27,7 +27,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::utils::check_boundaries;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{
     FieldCondition, Match, MatchValue, PayloadKeyType, Range, RangeInterface, ValueVariants,
 };
@@ -304,7 +304,7 @@ pub(super) fn condition_checker<'a, T, I>(
     index: &'a I,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<ConditionCheckerFn<'a>>
+) -> Option<Box<dyn ConditionChecker + 'a>>
 where
     T: Encodable + Numericable + StoredValue + Send + Sync + Default,
     I: NumericIndexRead<T>,
@@ -339,11 +339,11 @@ where
 
     let hw_counter = hw_acc.get_counter_cell();
     Some(Box::new(move |point_id: PointOffsetType| {
-        index.check_values_any(
+        Ok(index.check_values_any(
             point_id,
             |value| typed_range.check_range(*value),
             &hw_counter,
-        )
+        ))
     }))
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -20,7 +20,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, P, S: UniversalRead>
@@ -129,7 +129,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_ops.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, Range, RangeInterface};
 
 pub trait StreamRange<T> {
@@ -86,7 +86,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, S: UniversalRead>
@@ -60,7 +60,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(query::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
@@ -28,7 +28,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, RangeInterface};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> PayloadFieldIndex
@@ -95,7 +95,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<ConditionCheckerFn<'a>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
         Ok(query::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -1,18 +1,19 @@
 use common::types::PointOffsetType;
 
+use crate::common::operation_error::OperationResult;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::visited_pool::VisitedListHandle;
-use crate::payload_storage::FilterContext;
 
 pub struct BuildConditionChecker<'a> {
     pub filter_list: &'a VisitedListHandle<'a>,
     pub current_point: PointOffsetType,
 }
 
-impl FilterContext for BuildConditionChecker<'_> {
-    fn check(&self, point_id: PointOffsetType) -> bool {
+impl ConditionChecker for BuildConditionChecker<'_> {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         if point_id == self.current_point {
-            return false; // Do not match current point while inserting it (second time)
+            return Ok(false); // Do not match current point while inserting it (second time)
         }
-        self.filter_list.check(point_id)
+        Ok(self.filter_list.check(point_id))
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -18,8 +18,8 @@ use crate::index::hnsw_index::gpu::gpu_insert_context::GpuInsertContext;
 use crate::index::hnsw_index::gpu::gpu_vector_storage::GpuVectorStorage;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::visited_pool::VisitedListHandle;
-use crate::payload_storage::FilterContext;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
@@ -89,10 +89,11 @@ pub(super) fn build_filtered_graph_on_gpu(
         1,
         |block_point_id| -> OperationResult<_> {
             let hardware_counter = HardwareCounterCell::disposable();
-            let block_condition_checker: Box<dyn FilterContext> = Box::new(BuildConditionChecker {
-                filter_list: block_filter_list,
-                current_point: block_point_id,
-            });
+            let block_condition_checker: Box<dyn ConditionChecker> =
+                Box::new(BuildConditionChecker {
+                    filter_list: block_filter_list,
+                    current_point: block_point_id,
+                });
             FilteredScorer::new_internal(
                 block_point_id,
                 vector_storage,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -155,7 +155,7 @@ where
                         |idx| filter_context.check(idx),
                         self.config.full_scan_threshold,
                         available_vector_count, // Check cardinality among available vectors
-                    )
+                    )?
                 };
 
                 if use_graph {

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -12,10 +12,10 @@ use crate::index::PayloadIndexRead;
 use crate::index::hnsw_index::graph_layers::{GraphLayersWithVectors, SearchAlgorithm};
 use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
 use crate::index::query_estimator::adjust_to_available_vectors;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
-use crate::payload_storage::FilterContext;
 use crate::types::{ACORN_MAX_SELECTIVITY_DEFAULT, Filter, SearchParams};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::query::DiscoverQuery;
@@ -361,7 +361,7 @@ fn construct_search_scorer<'a, V, Q>(
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
-    filter_context: Option<Box<dyn FilterContext + 'a>>,
+    filter_context: Option<Box<dyn ConditionChecker + 'a>>,
 ) -> OperationResult<FilteredScorer<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,
@@ -387,7 +387,7 @@ fn construct_batch_searcher<'a, V, Q>(
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
-    filter_context: Option<Box<dyn FilterContext + 'a>>,
+    filter_context: Option<Box<dyn ConditionChecker + 'a>>,
 ) -> OperationResult<BatchFilteredSearcher<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 
 use crate::common::operation_error::{OperationResult, check_process_stopped};
 use crate::data_types::vectors::QueryVector;
-use crate::payload_storage::FilterContext;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
@@ -31,7 +31,7 @@ use crate::vector_storage::{VectorStorageEnum, new_raw_scorer};
 /// ┌─────────────────┐ ┌───────────────┐   ┌────────────────┐ ┌─┤ - Euclidean │
 /// │ RawScorer ◄─────┼─┤ QueryScorer ◄─┼───│ Metric ◄───────┼─┘ └─────────────┘
 /// │                 │ └───────────────┘   │                │    - Vector Distance
-/// │ FilterContext   │  - Access patterns  │ Query  ◄───────┼─┐
+/// │ ConditionChecker│  - Access patterns  │ Query  ◄───────┼─┐
 /// │                 │                     │                │ │  Query
 /// │ deleted_points  │                     │ TVectorStorage │ │ ┌──────────────────┐
 /// │ deleted_vectors │                     └────────────────┘ └─┤ - RecoQuery      │
@@ -49,7 +49,7 @@ use crate::vector_storage::{VectorStorageEnum, new_raw_scorer};
 ///  ┌─────────────────┐  ┌───────────────┐
 ///  │ [RawScorer] ◄───┼──┤ QueryScorer ◄─┼── (ditto)
 ///  │                 │  └───────────────┘
-///  │ FilterContext   │
+///  │ ConditionChecker│
 ///  └─────────────────┘
 /// ```
 pub struct FilteredScorer<'a> {
@@ -60,7 +60,7 @@ pub struct FilteredScorer<'a> {
 }
 
 pub struct ScorerFilters<'a> {
-    filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+    filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
     /// Point deleted flags should be explicitly present as `false`
     /// for each existing point in the segment.
     /// If there are no flags for some points, they are considered deleted.
@@ -78,7 +78,7 @@ impl<'a> ScorerFilters<'a> {
             && self
                 .filter_context
                 .as_ref()
-                .is_none_or(|f| f.check(point_id))
+                .is_none_or(|f| f.check_infallible(point_id))
     }
 
     fn as_borrowed(&'a self) -> Self {
@@ -121,7 +121,7 @@ impl<'a> FilteredScorer<'a> {
         query: QueryVector,
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Self>
@@ -148,7 +148,7 @@ impl<'a> FilteredScorer<'a> {
         point_id: PointOffsetType,
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Self>
@@ -289,7 +289,7 @@ impl<'a> BatchFilteredSearcher<'a> {
         queries: &[&QueryVector],
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn FilterContext + 'a>>,
+        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
         top: usize,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,

--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -4,6 +4,7 @@ mod key_encoding;
 mod memory_reporter;
 pub mod payload_config;
 mod payload_index_base;
+#[cfg(feature = "testing")]
 pub mod plain_payload_index;
 pub mod plain_vector_index;
 pub mod query_estimator;

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -15,8 +15,8 @@ use super::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::json_path::JsonPath;
-use crate::payload_storage::FilterContext;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
@@ -75,7 +75,7 @@ pub trait PayloadIndexRead {
         &'a self,
         filter: &'a Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn FilterContext + 'a>>;
+    ) -> OperationResult<Box<dyn ConditionChecker + 'a>>;
 
     /// Look up a numeric index for the given payload key, if one exists.
     ///

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -21,11 +21,12 @@ use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, FacetIndex, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
-use crate::payload_storage::{ConditionCheckerSS, FilterContext};
+use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
@@ -34,7 +35,7 @@ use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadK
 /// Used for small segments, which are easier to keep simple for faster updates,
 /// rather than spend time for index re-building
 pub struct PlainPayloadIndex {
-    condition_checker: Arc<ConditionCheckerSS>,
+    condition_checker: Arc<SimpleConditionChecker>,
     id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     config: PayloadConfig,
     path: PathBuf,
@@ -51,7 +52,7 @@ impl PlainPayloadIndex {
     }
 
     pub fn open(
-        condition_checker: Arc<ConditionCheckerSS>,
+        condition_checker: Arc<SimpleConditionChecker>,
         id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
         path: &Path,
     ) -> OperationResult<Self> {
@@ -117,10 +118,10 @@ impl PayloadIndexRead for PlainPayloadIndex {
         let id_tracker = self.id_tracker.borrow();
         let point_mappings = id_tracker.point_mappings();
         let all_points_iter = point_mappings.iter_internal_visible();
-        Ok(all_points_iter
+        all_points_iter
             .stop_if(is_stopped)
-            .filter(|id| filter_context.check(*id))
-            .collect())
+            .try_filter(|id| filter_context.check(*id))
+            .collect()
     }
 
     fn indexed_points(&self, _field: PayloadKeyTypeRef) -> usize {
@@ -131,7 +132,7 @@ impl PayloadIndexRead for PlainPayloadIndex {
         &'a self,
         filter: &'a Filter,
         _: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn FilterContext + 'a>> {
+    ) -> OperationResult<Box<dyn ConditionChecker + 'a>> {
         Ok(Box::new(PlainFilterContext {
             filter,
             condition_checker: self.condition_checker.clone(),
@@ -216,8 +217,8 @@ impl PayloadIndexRead for PlainPayloadIndex {
             .point_mappings()
             .iter_internal_with_behavior(deferred_behavior)
             .stop_if(is_stopped)
-            .filter(|id| filter_context.check(*id))
-            .collect();
+            .try_filter(|id| filter_context.check(*id))
+            .collect::<OperationResult<_>>()?;
         Ok(matched.into_iter())
     }
 }
@@ -330,12 +331,12 @@ impl PayloadIndex for PlainPayloadIndex {
 }
 
 pub struct PlainFilterContext<'a> {
-    condition_checker: Arc<ConditionCheckerSS>,
+    condition_checker: Arc<SimpleConditionChecker>,
     filter: &'a Filter,
 }
 
-impl FilterContext for PlainFilterContext<'_> {
-    fn check(&self, point_id: PointOffsetType) -> bool {
-        self.condition_checker.check(point_id, self.filter)
+impl ConditionChecker for PlainFilterContext<'_> {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(self.condition_checker.check(point_id, self.filter))
     }
 }

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -1,3 +1,4 @@
+use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
@@ -55,31 +56,31 @@ impl ConditionChecker for OptimizedFilter<'_> {
         } = self;
 
         // `should`: at least one matches.
-        if let Some(conditions) = should {
-            let mut matched = false;
-            for condition in conditions {
-                if condition.check(point_id)? {
-                    matched = true;
-                    break;
-                }
-            }
-            if !matched {
-                return Ok(false);
-            }
+        if let Some(conditions) = should
+            && !conditions
+                .iter()
+                .try_any(|condition| condition.check(point_id))?
+        {
+            return Ok(false);
         }
 
         // `min_should`: at least `min_count` match.
         if let Some(min_should) = min_should {
+            let OptimizedMinShould {
+                conditions,
+                min_count,
+            } = min_should;
             let mut matched = 0;
-            for condition in &min_should.conditions {
+
+            for condition in conditions {
                 if condition.check(point_id)? {
                     matched += 1;
-                    if matched == min_should.min_count {
+                    if matched == *min_count {
                         break;
                     }
                 }
             }
-            if matched < min_should.min_count {
+            if matched < *min_count {
                 return Ok(false);
             }
         }

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -1,11 +1,30 @@
 use common::types::PointOffsetType;
 
-use crate::payload_storage::FilterContext;
+use crate::common::operation_error::OperationResult;
 
-pub type ConditionCheckerFn<'a> = Box<dyn Fn(PointOffsetType) -> bool + 'a>;
+/// A check that tests whether points satisfy a condition.
+pub trait ConditionChecker {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool>;
+
+    /// Same as [`Self::check`] but without [`OperationResult`].
+    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
+        // This method is a workaround to keep the performance on-par.
+        // It's faster to do `.unwrap_or(false)` *inside* the trait method
+        // because the compiler can't inline `&dyn Trait` methods.
+        //
+        // TODO(uio): remove this method and handle errors properly.
+        self.check(point_id).unwrap_or(false)
+    }
+}
+
+impl<F: Fn(PointOffsetType) -> OperationResult<bool>> ConditionChecker for F {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        self(point_id)
+    }
+}
 
 pub enum OptimizedCondition<'a> {
-    Checker(ConditionCheckerFn<'a>),
+    Checker(Box<dyn ConditionChecker + 'a>),
     /// Nested filter
     Filter(OptimizedFilter<'a>),
 }
@@ -26,64 +45,79 @@ pub struct OptimizedFilter<'a> {
     pub must_not: Option<Vec<OptimizedCondition<'a>>>,
 }
 
-impl FilterContext for OptimizedFilter<'_> {
-    fn check(&self, point_id: PointOffsetType) -> bool {
-        check_optimized_filter(self, point_id)
+impl ConditionChecker for OptimizedFilter<'_> {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        let OptimizedFilter {
+            should,
+            min_should,
+            must,
+            must_not,
+        } = self;
+
+        // `should`: at least one matches.
+        if let Some(conditions) = should {
+            let mut matched = false;
+            for condition in conditions {
+                if condition.check(point_id)? {
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                return Ok(false);
+            }
+        }
+
+        // `min_should`: at least `min_count` match.
+        if let Some(min_should) = min_should {
+            let mut matched = 0;
+            for condition in &min_should.conditions {
+                if condition.check(point_id)? {
+                    matched += 1;
+                    if matched == min_should.min_count {
+                        break;
+                    }
+                }
+            }
+            if matched < min_should.min_count {
+                return Ok(false);
+            }
+        }
+
+        // `must`: all match.
+        if let Some(conditions) = must {
+            for condition in conditions {
+                if !condition.check(point_id)? {
+                    return Ok(false);
+                }
+            }
+        }
+
+        // `must_not`: none match.
+        if let Some(conditions) = must_not {
+            for condition in conditions {
+                if condition.check(point_id)? {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
     }
 }
 
-pub fn check_optimized_filter(filter: &OptimizedFilter, point_id: PointOffsetType) -> bool {
-    check_should(&filter.should, point_id)
-        && check_min_should(&filter.min_should, point_id)
-        && check_must(&filter.must, point_id)
-        && check_must_not(&filter.must_not, point_id)
-}
-
-pub fn check_condition(condition: &OptimizedCondition, point_id: PointOffsetType) -> bool {
-    match condition {
-        OptimizedCondition::Filter(filter) => check_optimized_filter(filter, point_id),
-        OptimizedCondition::Checker(checker) => checker(point_id),
-    }
-}
-
-fn check_should(should: &Option<Vec<OptimizedCondition>>, point_id: PointOffsetType) -> bool {
-    let check = |condition| check_condition(condition, point_id);
-    match should {
-        None => true,
-        Some(conditions) => conditions.iter().any(check),
-    }
-}
-
-fn check_min_should(min_should: &Option<OptimizedMinShould>, point_id: PointOffsetType) -> bool {
-    let check = |condition| check_condition(condition, point_id);
-    match min_should {
-        None => true,
-        Some(OptimizedMinShould {
-            conditions,
-            min_count,
-        }) => {
-            conditions
-                .iter()
-                .filter(|cond| check(cond))
-                .take(*min_count)
-                .count()
-                == *min_count
+impl ConditionChecker for OptimizedCondition<'_> {
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        match self {
+            OptimizedCondition::Filter(filter) => filter.check(point_id),
+            OptimizedCondition::Checker(checker) => checker.check(point_id),
         }
     }
-}
 
-fn check_must(must: &Option<Vec<OptimizedCondition>>, point_id: PointOffsetType) -> bool {
-    let check = |condition| check_condition(condition, point_id);
-    match must {
-        None => true,
-        Some(conditions) => conditions.iter().all(check),
-    }
-}
-
-fn check_must_not(must: &Option<Vec<OptimizedCondition>>, point_id: PointOffsetType) -> bool {
-    let check = |condition| !check_condition(condition, point_id);
-    match must {
-        None => true,
-        Some(conditions) => conditions.iter().all(check),
+    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            OptimizedCondition::Filter(filter) => filter.check_infallible(point_id),
+            OptimizedCondition::Checker(checker) => checker.check_infallible(point_id),
+        }
     }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -11,7 +11,7 @@ use super::parsed_formula::{
 };
 use super::value_retriever::VariableRetrieverFn;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::query_optimization::optimized_filter::{OptimizedCondition, check_condition};
+use crate::index::query_optimization::optimized_filter::{ConditionChecker, OptimizedCondition};
 use crate::json_path::JsonPath;
 use crate::types::{DateTimePayloadType, GeoPoint};
 
@@ -114,7 +114,7 @@ impl FormulaScorer<'_> {
                     })
                 }
                 VariableId::Condition(id) => {
-                    let value = check_condition(&self.condition_checkers[*id], point_id);
+                    let value = self.condition_checkers[*id].check(point_id)?;
                     let score = if value { 1.0 } else { 0.0 };
                     Ok(score)
                 }
@@ -399,8 +399,8 @@ mod tests {
             );
 
             let condition_checkers = vec![
-                OptimizedCondition::Checker(Box::new(|_| true)),
-                OptimizedCondition::Checker(Box::new(|_| false)),
+                OptimizedCondition::Checker(Box::new(|_| Ok(true))),
+                OptimizedCondition::Checker(Box::new(|_| Ok(false))),
             ];
 
             FormulaScorer {

--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -1,5 +1,7 @@
 use common::types::PointOffsetType;
 
+use crate::common::operation_error::OperationResult;
+
 const MAX_ESTIMATED_POINTS: usize = 1000;
 
 /// Returns (expected cardinality ± confidence interval at 0.99)
@@ -19,17 +21,17 @@ fn confidence_agresti_coull_interval(trials: usize, positive: usize, total: usiz
 /// Iteratively samples points until the decision could be made with confidence
 pub fn sample_check_cardinality(
     sample_points: impl Iterator<Item = PointOffsetType>,
-    checker: impl Fn(PointOffsetType) -> bool,
+    checker: impl Fn(PointOffsetType) -> OperationResult<bool>,
     threshold: usize,
     total_points: usize,
-) -> bool {
+) -> OperationResult<bool> {
     let mut matched_points = 0;
     let mut total_checked = 0;
 
     let mut exp = 0;
     let mut interval;
     for idx in sample_points.take(MAX_ESTIMATED_POINTS) {
-        matched_points += usize::from(checker(idx));
+        matched_points += usize::from(checker(idx)?);
         total_checked += 1;
 
         let estimation =
@@ -38,15 +40,15 @@ pub fn sample_check_cardinality(
         interval = estimation.1;
 
         if exp - interval > threshold as i64 {
-            return true;
+            return Ok(true);
         }
 
         if exp + interval < threshold as i64 {
-            return false;
+            return Ok(false);
         }
     }
 
-    exp > threshold as i64
+    Ok(exp > threshold as i64)
 }
 
 #[cfg(test)]
@@ -81,10 +83,11 @@ mod tests {
     fn test_sample_check_cardinality() {
         let res = sample_check_cardinality(
             vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_iter(),
-            |idx| idx % 2 == 0,
+            |idx| Ok(idx % 2 == 0),
             10_000,
             100_000,
-        );
+        )
+        .unwrap();
 
         assert!(res)
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -268,7 +268,7 @@ where
             Some(filter) => {
                 let filter_context = self.payload_index.filter_context(filter, &hw_counter)?;
                 let matches_filter_condition = |idx: PointOffsetType| -> bool {
-                    not_deleted_condition(idx) && filter_context.check(idx)
+                    not_deleted_condition(idx) && filter_context.check_infallible(idx)
                 };
                 Ok(search_context.search(&matches_filter_condition))
             }

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -9,7 +9,7 @@ use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndexRead;
-use crate::index::query_optimization::optimized_filter::ConditionCheckerFn;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
@@ -33,23 +33,18 @@ where
         payload_provider: PayloadProvider<S>,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<ConditionCheckerFn<'b>> {
+    ) -> OperationResult<Box<dyn ConditionChecker + 'b>> {
         let id_tracker = self.id_tracker;
         let field_indexes = self.field_indexes;
         Ok(match condition {
-            Condition::Field(field_condition) => {
-                field_condition_checker(
-                    field_indexes,
-                    &field_condition.key,
-                    hw_counter,
-                    field_condition,
-                    payload_provider,
-                    |payload, hw| {
-                        check_field_condition(field_condition, &payload, field_indexes, hw)
-                            .unwrap(/* TODO(uio): handle errors */)
-                    },
-                )?
-            }
+            Condition::Field(field_condition) => field_condition_checker(
+                field_indexes,
+                &field_condition.key,
+                hw_counter,
+                field_condition,
+                payload_provider,
+                |payload, hw| check_field_condition(field_condition, &payload, field_indexes, hw),
+            )?,
             // is_empty / is_null are served by NullIndex via
             // `condition_checker`. NullIndex is built alongside every
             // index from #6088 (released in v1.13.5) onwards, so the
@@ -66,7 +61,7 @@ where
                     hw_counter,
                     &FieldCondition::new_is_empty(key.clone(), true),
                     payload_provider,
-                    |payload, _| check_is_empty_condition(is_empty, &payload),
+                    |payload, _| Ok(check_is_empty_condition(is_empty, &payload)),
                 )?
             }
 
@@ -78,7 +73,7 @@ where
                     hw_counter,
                     &FieldCondition::new_is_null(key.clone(), true),
                     payload_provider,
-                    |payload, _| check_is_null_condition(is_null, &payload),
+                    |payload, _| Ok(check_is_null_condition(is_null, &payload)),
                 )?
             }
             // ToDo: It might be possible to make this condition faster by using `VisitedPool` instead of HashSet
@@ -90,15 +85,17 @@ where
                         id_tracker.internal_id_with_behavior(*external_id, deferred_behavior)
                     })
                     .collect();
-                Box::new(move |point_id| segment_ids.contains(&point_id))
+                Box::new(move |point_id| Ok(segment_ids.contains(&point_id)))
             }
             Condition::HasVector(has_vector) => {
                 if let Some(vector_storage) =
                     self.vector_storages.get(&has_vector.has_vector).cloned()
                 {
-                    Box::new(move |point_id| !vector_storage.borrow().is_deleted_vector(point_id))
+                    Box::new(move |point_id| {
+                        Ok(!vector_storage.borrow().is_deleted_vector(point_id))
+                    })
                 } else {
-                    Box::new(|_point_id| false)
+                    Box::new(|_point_id| Ok(false))
                 }
             }
             Condition::Nested(nested) => {
@@ -147,11 +144,11 @@ where
                                         &hw,
                                     ) {
                                         // If at least one nested object matches, return true
-                                        return true;
+                                        return Ok(true);
                                     }
                                 }
                             }
-                            false
+                            Ok(false)
                         },
                         &hw,
                     )
@@ -167,7 +164,7 @@ where
                     })
                     .collect();
 
-                Box::new(move |internal_id| segment_ids.contains(&internal_id))
+                Box::new(move |internal_id| Ok(segment_ids.contains(&internal_id)))
             }
             Condition::Filter(_) => unreachable!(),
         })
@@ -180,8 +177,8 @@ fn field_condition_checker<'a>(
     hw_counter: &HardwareCounterCell,
     field_condition: &FieldCondition,
     payload_provider: PayloadProvider<impl PayloadStorageRead + 'a>,
-    check: impl Fn(OwnedPayloadRef, &HardwareCounterCell) -> bool + 'a,
-) -> OperationResult<ConditionCheckerFn<'a>> {
+    check: impl Fn(OwnedPayloadRef, &HardwareCounterCell) -> OperationResult<bool> + 'a,
+) -> OperationResult<Box<dyn ConditionChecker + 'a>> {
     // 1. Find first index that can check condition.
     if let Some(indexes) = field_indexes.get(key) {
         for index in indexes {

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -18,11 +18,12 @@ use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition,
 };
 use crate::index::query_estimator::estimate_filter;
+use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::json_path::JsonPath;
-use crate::payload_storage::{FilterContext, PayloadStorageRead};
+use crate::payload_storage::PayloadStorageRead;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
     Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
@@ -169,7 +170,7 @@ where
             // Worst case: query expected to return few matches, but index can't be used
             let matched_points = full_scan_iterator
                 .stop_if(is_stopped)
-                .filter(move |i| optimized_filter.check(*i));
+                .filter(move |i| optimized_filter.check_infallible(*i));
 
             Ok(EitherVariant::A(matched_points))
         } else {
@@ -211,7 +212,8 @@ where
                     let optimized_filter =
                         self.optimized_filter(filter, deferred_behavior, hw_counter)?;
                     let iter = joined_primary_iterator.filter(move |&id| {
-                        !visited_list.check_and_update_visited(id) && optimized_filter.check(id)
+                        !visited_list.check_and_update_visited(id)
+                            && optimized_filter.check_infallible(id)
                     });
                     EitherVariant::C(iter)
                 });
@@ -229,7 +231,8 @@ where
                     i.cpu_counter()
                 })
                 .filter(move |&id| {
-                    !visited_list.check_and_update_visited(id) && optimized_filter.check(id)
+                    !visited_list.check_and_update_visited(id)
+                        && optimized_filter.check_infallible(id)
                 });
 
             Ok(EitherVariant::D(iter))
@@ -253,7 +256,7 @@ where
         &'b self,
         filter: &'b Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn FilterContext + 'b>> {
+    ) -> OperationResult<Box<dyn ConditionChecker + 'b>> {
         Ok(Box::new(self.optimized_filter(
             filter,
             DeferredBehavior::VisibleOnly,

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
-use crate::types::{Filter, OwnedPayloadRef, Payload};
+use crate::types::{OwnedPayloadRef, Payload};
 
 /// Read-only trait for payload data storage.
 ///
@@ -122,16 +122,3 @@ pub trait PayloadStorage: PayloadStorageRead {
         Vec::new()
     }
 }
-
-pub trait ConditionChecker {
-    /// Check if point satisfies filter condition. Return true if satisfies
-    fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool;
-}
-
-pub trait FilterContext {
-    /// Check if point satisfies filter condition. Return true if satisfies
-    fn check(&self, point_id: PointOffsetType) -> bool;
-}
-
-pub type PayloadStorageSS = dyn PayloadStorage + Sync + Send;
-pub type ConditionCheckerSS = dyn ConditionChecker + Sync + Send;

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -13,9 +13,9 @@ use crate::common::operation_error::OperationResult;
 use crate::common::utils::{IndexesMap, check_is_empty, check_is_null};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::field_index::FieldIndexRead;
+use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::condition_checker::ValueChecker;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::payload_storage::{ConditionChecker, PayloadStorageRead};
 use crate::types::{
     Condition, FieldCondition, Filter, IsEmptyCondition, IsNullCondition, MinShould,
     OwnedPayloadRef, Payload, PayloadContainer, PayloadKeyType, VectorNameBuf,
@@ -270,8 +270,8 @@ impl SimpleConditionChecker {
 }
 
 #[cfg(feature = "testing")]
-impl ConditionChecker for SimpleConditionChecker {
-    fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool {
+impl SimpleConditionChecker {
+    pub fn check(&self, point_id: PointOffsetType, query: &Filter) -> bool {
         let hw_counter = HardwareCounterCell::new(); // No measurements needed as this is only for test!
 
         let payload_storage_guard = self.payload_storage.borrow();

--- a/lib/segment/src/segment/read_view/facet.rs
+++ b/lib/segment/src/segment/read_view/facet.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType};
 use itertools::Itertools;
 
@@ -106,8 +107,8 @@ where
                     let count = iter
                         .dedup()
                         .take_while(|&point_id| point_id < max_id)
-                        .filter(|&point_id| context.check(point_id))
-                        .count();
+                        .try_filter(|&point_id| context.check(point_id))
+                        .process_results(|it| it.count())?;
 
                     if count > 0 {
                         hits.insert(value.to_owned(), count);

--- a/lib/segment/src/segment/read_view/order_by.rs
+++ b/lib/segment/src/segment/read_view/order_by.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType};
-use itertools::Either;
+use itertools::{Either, Itertools};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::order_by::{Direction, OrderBy, OrderValue};
@@ -123,27 +123,26 @@ where
         };
 
         let filtered_iter = match filter {
-            None => Either::Left(directed_range_iter),
+            None => Either::Left(directed_range_iter.map(Ok)),
             Some(filter) => {
                 let filter_context = self.payload_index.filter_context(filter, hw_counter)?;
 
                 Either::Right(
                     directed_range_iter
-                        .filter(move |(_, internal_id)| filter_context.check(*internal_id)),
+                        .try_filter(move |(_, internal_id)| filter_context.check(*internal_id)),
                 )
             }
         };
 
-        let reads = filtered_iter
-            .stop_if(is_stopped)
-            .filter_map(|(value, internal_id)| {
+        filtered_iter.stop_if(is_stopped).process_results(|it| {
+            it.filter_map(|(value, internal_id)| {
                 self.id_tracker
                     .external_id(internal_id)
                     .map(|external_id| (value, external_id))
             })
             .take(limit.unwrap_or(usize::MAX))
-            .collect();
-        Ok(reads)
+            .collect()
+        })
     }
 
     pub fn read_ordered_filtered<'a>(

--- a/lib/segment/src/segment/read_view/sampling.rs
+++ b/lib/segment/src/segment/read_view/sampling.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::DeferredBehavior;
+use itertools::Itertools;
 use rand::seq::{IteratorRandom, SliceRandom};
 
 use crate::common::operation_error::OperationResult;
@@ -64,15 +65,14 @@ where
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<PointIdType>> {
         let filter_context = self.payload_index.filter_context(condition, hw_counter)?;
-        Ok(self
-            .id_tracker
+        self.id_tracker
             .point_mappings()
             .iter_random_visible()
             .stop_if(is_stopped)
-            .filter(move |(_, internal_id)| filter_context.check(*internal_id))
-            .map(|(external_id, _)| external_id)
+            .try_filter(move |(_, internal_id)| filter_context.check(*internal_id))
+            .map_ok(|(external_id, _)| external_id)
             .take(limit)
-            .collect())
+            .collect()
     }
 
     pub fn read_random_filtered(

--- a/lib/segment/src/segment/read_view/scroll.rs
+++ b/lib/segment/src/segment/read_view/scroll.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::iterator_ext::IteratorExt;
 use common::types::DeferredBehavior;
+use itertools::Itertools;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
@@ -115,15 +116,14 @@ where
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<Vec<PointIdType>> {
         let filter_context = self.payload_index.filter_context(condition, hw_counter)?;
-        Ok(self
-            .id_tracker
+        self.id_tracker
             .point_mappings()
             .iter_from_with_behavior(offset, deferred_behavior)
             .stop_if(is_stopped)
-            .filter(move |(_, internal_id)| filter_context.check(*internal_id))
-            .map(|(external_id, _)| external_id)
+            .try_filter(move |(_, internal_id)| filter_context.check(*internal_id))
+            .map_ok(|(external_id, _)| external_id)
             .take(limit.unwrap_or(usize::MAX))
-            .collect())
+            .collect()
     }
 
     pub fn read_filtered<'a>(

--- a/lib/segment/tests/integration/filtering_context_check.rs
+++ b/lib/segment/tests/integration/filtering_context_check.rs
@@ -29,13 +29,13 @@ fn test_filtering_context_consistency() {
 
         let plain_context = plain_index.filter_context(&filter, &hw_counter).unwrap();
         let plain_result = (0..NUM_POINTS)
-            .filter(|point_id| plain_context.check(*point_id as PointOffsetType))
+            .filter(|point_id| plain_context.check(*point_id as PointOffsetType).unwrap())
             .collect_vec();
 
         let struct_result = struct_index.with_view(|v| {
             let struct_context = v.filter_context(&filter, &hw_counter).unwrap();
             (0..NUM_POINTS)
-                .filter(|point_id| struct_context.check(*point_id as PointOffsetType))
+                .filter(|point_id| struct_context.check(*point_id as PointOffsetType).unwrap())
                 .collect_vec()
         });
         assert_eq!(plain_result, struct_result, "filter: {filter:#?}");

--- a/lib/segment/tests/integration/nested_filtering_test.rs
+++ b/lib/segment/tests/integration/nested_filtering_test.rs
@@ -150,7 +150,7 @@ fn test_filtering_context_consistency() {
                 .unwrap();
             let filter_context = v.filter_context(&nested_filter_0, &hw_counter).unwrap();
             let check_res0: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType).unwrap())
                 .collect();
             (res0, check_res0)
         });
@@ -191,7 +191,7 @@ fn test_filtering_context_consistency() {
                 .unwrap();
             let filter_context = v.filter_context(&nested_filter_1, &hw_counter).unwrap();
             let check_res1: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType).unwrap())
                 .collect();
             (res1, check_res1)
         });
@@ -229,7 +229,7 @@ fn test_filtering_context_consistency() {
                 .unwrap();
             let filter_context = v.filter_context(&nested_filter_2, &hw_counter).unwrap();
             let check_res2: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType).unwrap())
                 .collect();
             (res2, check_res2)
         });
@@ -277,7 +277,7 @@ fn test_filtering_context_consistency() {
                 .unwrap();
             let filter_context = v.filter_context(&nested_filter_3, &hw_counter).unwrap();
             let check_res3: Vec<_> = (0..NUM_POINTS as PointOffsetType)
-                .filter(|point_id| filter_context.check(*point_id as PointOffsetType))
+                .filter(|point_id| filter_context.check(*point_id as PointOffsetType).unwrap())
                 .collect();
             (res3, check_res3)
         });

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -759,7 +759,7 @@ fn test_cardinality_estimation(test_segments: &TestSegments) -> Result<()> {
             .borrow()
             .point_mappings()
             .iter_internal()
-            .filter(|x| filter_context.check(*x))
+            .filter(|x| filter_context.check(*x).unwrap())
             .collect_vec()
             .len()
     });
@@ -824,7 +824,7 @@ fn test_root_nested_array_filter_cardinality_estimation() {
             .borrow()
             .point_mappings()
             .iter_internal()
-            .filter(|x| filter_context.check(*x))
+            .filter(|x| filter_context.check(*x).unwrap())
             .collect_vec()
             .len()
     });
@@ -895,7 +895,7 @@ fn test_nesting_nested_array_filter_cardinality_estimation() {
             .borrow()
             .point_mappings()
             .iter_internal()
-            .filter(|x| filter_context.check(*x))
+            .filter(|x| filter_context.check(*x).unwrap())
             .collect_vec()
             .len()
     });
@@ -1443,7 +1443,7 @@ fn test_any_matcher_cardinality_estimation(test_segments: &TestSegments) -> Resu
             .borrow()
             .point_mappings()
             .iter_internal()
-            .filter(|x| filter_context.check(*x))
+            .filter(|x| filter_context.check(*x).unwrap())
             .collect_vec()
             .len()
     });


### PR DESCRIPTION
Goal: error propagation and batching in `ConditionCheckerFn` (#8630).
Continuation of #9404.

This pr makes adds `ConditionChecker` trait instead of using `dyn Fn`.

```diff
     fn condition_checker(
         &self,
-    ) -> OperationResult<Option<Box<dyn Fn(PointOffsetType) -> bool>>> {
+    ) -> OperationResult<Option<Box<dyn ConditionChecker>>> {
```

This trait provides both fallible and infallible checks.

```rust
/// A check that tests whether points satisfy a condition.
pub trait ConditionChecker {
    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool>;

    /// Same as [`Self::check`] but without [`OperationResult`].
    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
        // This method is a workaround to keep the performance on-par.
        // It's faster to do `.unwrap_or(false)` *inside* the trait method
        // because the compiler can't inline `&dyn Trait` methods.
        //
        // TODO(uio): remove this method and handle errors properly.
        self.check(point_id).unwrap_or(false)
    }
}
```

In subsequent PRs I plan to remove `check_infallible` and provide fallible+batched method.