### PR TITLE
feat: read-only sparse vector index for VectorIndexReadEnum

### DIFF
--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -2,14 +2,19 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::UniversalRead;
-use sparse::common::types::DimId;
+use common::universal_io::{MmapFile, UniversalRead};
+use half::f16;
+use sparse::common::types::{DimId, QuantizedU8};
+use sparse::index::inverted_index::InvertedIndex;
+use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
+use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
 use crate::index::hnsw_index::hnsw::read_only::ReadOnlyHNSWIndex;
 use crate::index::plain_vector_index::read_only::ReadOnlyPlainVectorIndex;
+use crate::index::sparse_index::sparse_vector_index::read_only::ReadOnlySparseVectorIndex;
 use crate::index::vector_index_base::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
@@ -22,20 +27,24 @@ use crate::types::{Filter, SearchParams};
 pub enum VectorIndexReadEnum<S: UniversalRead> {
     Plain(Box<ReadOnlyPlainVectorIndex<S>>),
     Hnsw(Box<ReadOnlyHNSWIndex<S>>),
-    // SparseCompressedImmutableRamF32(
-    //     Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedImmutableRam<f32>>>,
-    // ),
-    // SparseCompressedImmutableRamF16(
-    //     Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedImmutableRam<f16>>>,
-    // ),
-    // SparseCompressedImmutableRamU8(
-    //     Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedImmutableRam<QuantizedU8>>>,
-    // ),
-    // SparseCompressedMmapF32(Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedMmap<f32>>>),
-    // SparseCompressedMmapF16(Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedMmap<f16>>>),
-    // SparseCompressedMmapU8(
-    //     Box<ReadOnlySparseVectorIndex<InvertedIndexCompressedMmap<QuantizedU8>>>,
-    // ),
+    SparseCompressedImmutableRamF32(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedImmutableRam<f32>>>,
+    ),
+    SparseCompressedImmutableRamF16(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedImmutableRam<f16>>>,
+    ),
+    SparseCompressedImmutableRamU8(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedImmutableRam<QuantizedU8>>>,
+    ),
+    SparseCompressedMmapF32(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedMmap<f32, MmapFile>>>,
+    ),
+    SparseCompressedMmapF16(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedMmap<f16, MmapFile>>>,
+    ),
+    SparseCompressedMmapU8(
+        Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedMmap<QuantizedU8, MmapFile>>>,
+    ),
 }
 
 impl<S: UniversalRead> VectorIndexReadEnum<S> {
@@ -44,12 +53,12 @@ impl<S: UniversalRead> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => false,
             Self::Hnsw(index) => index.is_on_disk(),
-            //     Self::SparseCompressedImmutableRamF32(index) => index.is_on_disk(),
-            //     Self::SparseCompressedImmutableRamF16(index) => index.is_on_disk(),
-            //     Self::SparseCompressedImmutableRamU8(index) => index.is_on_disk(),
-            //     Self::SparseCompressedMmapF32(index) => index.is_on_disk(),
-            //     Self::SparseCompressedMmapF16(index) => index.is_on_disk(),
-            //     Self::SparseCompressedMmapU8(index) => index.is_on_disk(),
+            Self::SparseCompressedImmutableRamF32(index) => index.inverted_index().is_on_disk(),
+            Self::SparseCompressedImmutableRamF16(index) => index.inverted_index().is_on_disk(),
+            Self::SparseCompressedImmutableRamU8(index) => index.inverted_index().is_on_disk(),
+            Self::SparseCompressedMmapF32(index) => index.inverted_index().is_on_disk(),
+            Self::SparseCompressedMmapF16(index) => index.inverted_index().is_on_disk(),
+            Self::SparseCompressedMmapU8(index) => index.inverted_index().is_on_disk(),
         }
     }
 
@@ -57,12 +66,12 @@ impl<S: UniversalRead> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => {}
             Self::Hnsw(index) => index.populate()?,
-            //     Self::SparseCompressedImmutableRamF32(_) => {}
-            //     Self::SparseCompressedImmutableRamF16(_) => {}
-            //     Self::SparseCompressedImmutableRamU8(_) => {}
-            //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().populate()?,
-            //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().populate()?,
-            //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().populate()?,
+            Self::SparseCompressedImmutableRamF32(_) => {}
+            Self::SparseCompressedImmutableRamF16(_) => {}
+            Self::SparseCompressedImmutableRamU8(_) => {}
+            Self::SparseCompressedMmapF32(index) => index.inverted_index().populate()?,
+            Self::SparseCompressedMmapF16(index) => index.inverted_index().populate()?,
+            Self::SparseCompressedMmapU8(index) => index.inverted_index().populate()?,
         };
         Ok(())
     }
@@ -71,12 +80,12 @@ impl<S: UniversalRead> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => {}
             Self::Hnsw(index) => index.clear_cache()?,
-            //     Self::SparseCompressedImmutableRamF32(_) => {}
-            //     Self::SparseCompressedImmutableRamF16(_) => {}
-            //     Self::SparseCompressedImmutableRamU8(_) => {}
-            //     Self::SparseCompressedMmapF32(index) => index.inner().inverted_index().clear_cache()?,
-            //     Self::SparseCompressedMmapF16(index) => index.inner().inverted_index().clear_cache()?,
-            //     Self::SparseCompressedMmapU8(index) => index.inner().inverted_index().clear_cache()?,
+            Self::SparseCompressedImmutableRamF32(_) => {}
+            Self::SparseCompressedImmutableRamF16(_) => {}
+            Self::SparseCompressedImmutableRamU8(_) => {}
+            Self::SparseCompressedMmapF32(index) => index.inverted_index().clear_cache()?,
+            Self::SparseCompressedMmapF16(index) => index.inverted_index().clear_cache()?,
+            Self::SparseCompressedMmapU8(index) => index.inverted_index().clear_cache()?,
         };
         Ok(())
     }
@@ -94,24 +103,24 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.search(vectors, filter, top, params, query_context),
             Self::Hnsw(index) => index.search(vectors, filter, top, params, query_context),
-            //     Self::SparseCompressedImmutableRamF32(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
-            //     Self::SparseCompressedImmutableRamF16(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
-            //     Self::SparseCompressedImmutableRamU8(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
-            //     Self::SparseCompressedMmapF32(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
-            //     Self::SparseCompressedMmapF16(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
-            //     Self::SparseCompressedMmapU8(index) => {
-            //         index.search(vectors, filter, top, params, query_context)
-            //     }
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            Self::SparseCompressedMmapF32(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            Self::SparseCompressedMmapF16(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
+            Self::SparseCompressedMmapU8(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
         }
     }
 
@@ -119,12 +128,12 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.get_telemetry_data(detail),
             Self::Hnsw(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedImmutableRamF32(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedImmutableRamF16(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedImmutableRamU8(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
-            //     Self::SparseCompressedMmapU8(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedImmutableRamF32(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedImmutableRamF16(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedImmutableRamU8(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedMmapF32(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedMmapF16(index) => index.get_telemetry_data(detail),
+            Self::SparseCompressedMmapU8(index) => index.get_telemetry_data(detail),
         }
     }
 
@@ -132,12 +141,12 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.indexed_vector_count(),
             Self::Hnsw(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
-            //     Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapF32(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapF16(index) => index.indexed_vector_count(),
+            Self::SparseCompressedMmapU8(index) => index.indexed_vector_count(),
         }
     }
 
@@ -145,18 +154,18 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::Hnsw(index) => index.size_of_searchable_vectors_in_bytes(),
-            //     Self::SparseCompressedImmutableRamF32(index) => {
-            //         index.size_of_searchable_vectors_in_bytes()
-            //     }
-            //     Self::SparseCompressedImmutableRamF16(index) => {
-            //         index.size_of_searchable_vectors_in_bytes()
-            //     }
-            //     Self::SparseCompressedImmutableRamU8(index) => {
-            //         index.size_of_searchable_vectors_in_bytes()
-            //     }
-            //     Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
-            //     Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
-            //     Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.size_of_searchable_vectors_in_bytes()
+            }
+            Self::SparseCompressedMmapF32(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedMmapF16(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseCompressedMmapU8(index) => index.size_of_searchable_vectors_in_bytes(),
         }
     }
 
@@ -168,18 +177,18 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.fill_idf_statistics(idf, hw_counter),
             Self::Hnsw(index) => index.fill_idf_statistics(idf, hw_counter),
-            //     Self::SparseCompressedImmutableRamF32(index) => {
-            //         index.fill_idf_statistics(idf, hw_counter)
-            //     }
-            //     Self::SparseCompressedImmutableRamF16(index) => {
-            //         index.fill_idf_statistics(idf, hw_counter)
-            //     }
-            //     Self::SparseCompressedImmutableRamU8(index) => {
-            //         index.fill_idf_statistics(idf, hw_counter)
-            //     }
-            //     Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
-            //     Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
-            //     Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.fill_idf_statistics(idf, hw_counter)
+            }
+            Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
+            Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
         }
     }
 
@@ -187,12 +196,12 @@ impl<S: UniversalRead> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.is_index(),
             Self::Hnsw(index) => index.is_index(),
-            //     Self::SparseCompressedImmutableRamF32(index) => index.is_index(),
-            //     Self::SparseCompressedImmutableRamF16(index) => index.is_index(),
-            //     Self::SparseCompressedImmutableRamU8(index) => index.is_index(),
-            //     Self::SparseCompressedMmapF32(index) => index.is_index(),
-            //     Self::SparseCompressedMmapF16(index) => index.is_index(),
-            //     Self::SparseCompressedMmapU8(index) => index.is_index(),
+            Self::SparseCompressedImmutableRamF32(index) => index.is_index(),
+            Self::SparseCompressedImmutableRamF16(index) => index.is_index(),
+            Self::SparseCompressedImmutableRamU8(index) => index.is_index(),
+            Self::SparseCompressedMmapF32(index) => index.is_index(),
+            Self::SparseCompressedMmapF16(index) => index.is_index(),
+            Self::SparseCompressedMmapU8(index) => index.is_index(),
         }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -14,6 +14,7 @@ use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 
+use self::read_view::{SparseVectorIndexReadView, SparseVectorIndexReadViewEnum};
 use super::indices_tracker::IndicesTracker;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
@@ -22,8 +23,10 @@ use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
-mod search;
+mod read_view;
 mod vector_index_impl;
+
+pub mod read_only;
 
 #[derive(Debug)]
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
@@ -215,6 +218,34 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
 
     pub fn inverted_index(&self) -> &TInvertedIndex {
         &self.inverted_index
+    }
+
+    /// Borrow all backing storages and hand a read view to `f`.
+    ///
+    /// Mirrors the dense indexes: the shared search logic lives on
+    /// [`SparseVectorIndexReadView`], so both this mutable index and the
+    /// read-only counterpart drive the exact same code.
+    pub fn with_view<R>(
+        &self,
+        f: impl FnOnce(SparseVectorIndexReadViewEnum<'_, TInvertedIndex>) -> R,
+    ) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = SparseVectorIndexReadView {
+                config: self.config,
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                payload_index: payload_index_view,
+                inverted_index: &self.inverted_index,
+                searches_telemetry: &self.searches_telemetry,
+                indices_tracker: &self.indices_tracker,
+                search_scratch_pool: &self.search_scratch_pool,
+            };
+            f(read_view)
+        })
     }
 
     /// Returns the maximum number of results that can be returned by the index for a given sparse vector

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -7,16 +7,15 @@ use common::universal_io::UniversalRead;
 use sparse::SearchScratchPool;
 use sparse::index::inverted_index::InvertedIndex;
 
-use crate::id_tracker::IdTrackerEnum;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
-use crate::index::field_index::FieldIndex;
+use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::sparse_index::indices_tracker::IndicesTracker;
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
 use crate::index::sparse_index::sparse_vector_index::read_view::SparseVectorIndexReadView;
-use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
-use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::vector_storage::VectorStorageEnum;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
+use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 /// Read-only, generic-over-storage counterpart of [`SparseVectorIndex`].
@@ -30,28 +29,24 @@ pub struct ReadOnlySparseVectorIndex<S: UniversalRead, TInvertedIndex: InvertedI
     config: SparseIndexConfig,
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
     inverted_index: TInvertedIndex,
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,
     search_scratch_pool: SearchScratchPool,
 }
 
-/// Read-only view over a [`ReadOnlySparseVectorIndex`].
-///
-/// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
-/// [`VectorStorageReadEnum`]), while the payload index view is still built over
-/// the in-memory enums of [`StructPayloadIndex`].
+/// Read-only view over a [`ReadOnlySparseVectorIndex`]: all backends are read-only.
 type ReadView<'a, S, TInvertedIndex> = SparseVectorIndexReadView<
     'a,
     ReadOnlyIdTrackerEnum<S>,
     VectorStorageReadEnum<S>,
     StructPayloadIndexReadView<
         'a,
-        PayloadStorageEnum,
-        IdTrackerEnum,
-        VectorStorageEnum,
-        FieldIndex,
+        ReadOnlyPayloadStorage<S>,
+        ReadOnlyIdTrackerEnum<S>,
+        VectorStorageReadEnum<S>,
+        ReadOnlyFieldIndex<S>,
     >,
     TInvertedIndex,
 >;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -1,0 +1,87 @@
+mod read;
+
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+use sparse::SearchScratchPool;
+use sparse::index::inverted_index::InvertedIndex;
+
+use crate::id_tracker::IdTrackerEnum;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::field_index::FieldIndex;
+use crate::index::sparse_index::indices_tracker::IndicesTracker;
+use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
+use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
+use crate::index::sparse_index::sparse_vector_index::read_view::SparseVectorIndexReadView;
+use crate::index::struct_payload_index::{StructPayloadIndex, StructPayloadIndexReadView};
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::VectorStorageEnum;
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+/// Read-only, generic-over-storage counterpart of [`SparseVectorIndex`].
+///
+/// The id tracker and vector storage are parameterized by the backing storage
+/// `S`, while the inverted index (`TInvertedIndex`) is whichever persisted layout
+/// was loaded — an immutable-ram or an `S`-backed mmap variant.
+///
+/// [`SparseVectorIndex`]: super::SparseVectorIndex
+pub struct ReadOnlySparseVectorIndex<S: UniversalRead, TInvertedIndex: InvertedIndex> {
+    config: SparseIndexConfig,
+    id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+    vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
+    inverted_index: TInvertedIndex,
+    searches_telemetry: SparseSearchesTelemetry,
+    indices_tracker: IndicesTracker,
+    search_scratch_pool: SearchScratchPool,
+}
+
+/// Read-only view over a [`ReadOnlySparseVectorIndex`].
+///
+/// The top-level backends are read-only ([`ReadOnlyIdTrackerEnum`] /
+/// [`VectorStorageReadEnum`]), while the payload index view is still built over
+/// the in-memory enums of [`StructPayloadIndex`].
+type ReadView<'a, S, TInvertedIndex> = SparseVectorIndexReadView<
+    'a,
+    ReadOnlyIdTrackerEnum<S>,
+    VectorStorageReadEnum<S>,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
+    TInvertedIndex,
+>;
+
+impl<S: UniversalRead, TInvertedIndex: InvertedIndex> ReadOnlySparseVectorIndex<S, TInvertedIndex> {
+    pub fn inverted_index(&self) -> &TInvertedIndex {
+        &self.inverted_index
+    }
+
+    /// Borrow all backing storages and hand a read view to `f`, mirroring
+    /// [`SparseVectorIndex::with_view`].
+    ///
+    /// [`SparseVectorIndex::with_view`]: super::SparseVectorIndex::with_view
+    pub fn with_view<R>(&self, f: impl FnOnce(ReadView<'_, S, TInvertedIndex>) -> R) -> R {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let payload_index = self.payload_index.borrow();
+
+        payload_index.with_view(|payload_index_view| {
+            let read_view = SparseVectorIndexReadView {
+                config: self.config,
+                id_tracker: &*id_tracker,
+                vector_storage: &*vector_storage,
+                payload_index: payload_index_view,
+                inverted_index: &self.inverted_index,
+                searches_telemetry: &self.searches_telemetry,
+                indices_tracker: &self.indices_tracker,
+                search_scratch_pool: &self.search_scratch_pool,
+            };
+            f(read_view)
+        })
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::universal_io::UniversalRead;
+use sparse::common::types::DimId;
+use sparse::index::inverted_index::InvertedIndex;
+
+use super::ReadOnlySparseVectorIndex;
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
+use crate::data_types::query_context::VectorQueryContext;
+use crate::data_types::vectors::{QueryVector, VectorInternal};
+use crate::index::VectorIndexRead;
+use crate::telemetry::VectorIndexSearchesTelemetry;
+use crate::types::{Filter, SearchParams};
+use crate::vector_storage::query::TransformInto;
+
+impl<S: UniversalRead, TInvertedIndex: InvertedIndex> VectorIndexRead
+    for ReadOnlySparseVectorIndex<S, TInvertedIndex>
+{
+    fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        _params: Option<&SearchParams>,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        self.with_view(|view| {
+            let mut results = Vec::with_capacity(vectors.len());
+            let mut prefiltered_points = None;
+
+            for vector in vectors {
+                check_process_stopped(&query_context.is_stopped())?;
+
+                let search_results = if query_context.is_require_idf() {
+                    let vector = (*vector).clone().transform(|mut vector| {
+                        match &mut vector {
+                            VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
+                                return Err(OperationError::WrongSparse);
+                            }
+                            VectorInternal::Sparse(sparse) => {
+                                query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
+                            }
+                        }
+
+                        Ok(vector)
+                    })?;
+
+                    view.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
+                } else {
+                    view.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
+                };
+
+                results.push(search_results);
+            }
+            Ok(results)
+        })
+    }
+
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        self.searches_telemetry.get_telemetry_data(detail)
+    }
+
+    fn indexed_vector_count(&self) -> usize {
+        self.inverted_index.vector_count()
+    }
+
+    fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.inverted_index.total_sparse_vectors_size()
+    }
+
+    /// Update statistics for idf-dot similarity.
+    fn fill_idf_statistics(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let iter = idf.iter_mut().filter_map(|(dim_id, count)| {
+            let offset = self.indices_tracker.remap_index(*dim_id)?;
+            Some((count, offset))
+        });
+        self.inverted_index
+            .posting_list_len_batch(iter, hw_counter, |count, len| {
+                *count += len;
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    fn is_index(&self) -> bool {
+        true
+    }
+}

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
@@ -7,13 +7,12 @@ use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
 
 use super::ReadOnlySparseVectorIndex;
-use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorInternal};
+use crate::data_types::vectors::QueryVector;
 use crate::index::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::query::TransformInto;
 
 impl<S: UniversalRead, TInvertedIndex: InvertedIndex> VectorIndexRead
     for ReadOnlySparseVectorIndex<S, TInvertedIndex>
@@ -26,66 +25,27 @@ impl<S: UniversalRead, TInvertedIndex: InvertedIndex> VectorIndexRead
         _params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        self.with_view(|view| {
-            let mut results = Vec::with_capacity(vectors.len());
-            let mut prefiltered_points = None;
-
-            for vector in vectors {
-                check_process_stopped(&query_context.is_stopped())?;
-
-                let search_results = if query_context.is_require_idf() {
-                    let vector = (*vector).clone().transform(|mut vector| {
-                        match &mut vector {
-                            VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
-                                return Err(OperationError::WrongSparse);
-                            }
-                            VectorInternal::Sparse(sparse) => {
-                                query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
-                            }
-                        }
-
-                        Ok(vector)
-                    })?;
-
-                    view.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
-                } else {
-                    view.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
-                };
-
-                results.push(search_results);
-            }
-            Ok(results)
-        })
+        self.with_view(|view| view.search(vectors, filter, top, query_context))
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        self.searches_telemetry.get_telemetry_data(detail)
+        self.with_view(|view| view.get_telemetry_data(detail))
     }
 
     fn indexed_vector_count(&self) -> usize {
-        self.inverted_index.vector_count()
+        self.with_view(|view| view.indexed_vector_count())
     }
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        self.inverted_index.total_sparse_vectors_size()
+        self.with_view(|view| view.size_of_searchable_vectors_in_bytes())
     }
 
-    /// Update statistics for idf-dot similarity.
     fn fill_idf_statistics(
         &self,
         idf: &mut HashMap<DimId, usize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        let iter = idf.iter_mut().filter_map(|(dim_id, count)| {
-            let offset = self.indices_tracker.remap_index(*dim_id)?;
-            Some((count, offset))
-        });
-        self.inverted_index
-            .posting_list_len_batch(iter, hw_counter, |count, len| {
-                *count += len;
-                Ok(())
-            })?;
-        Ok(())
+        self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
@@ -1,0 +1,54 @@
+mod search;
+
+use sparse::SearchScratchPool;
+use sparse::index::inverted_index::InvertedIndex;
+
+use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::PayloadIndexRead;
+use crate::index::field_index::FieldIndex;
+use crate::index::sparse_index::indices_tracker::IndicesTracker;
+use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
+use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
+use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+
+/// Read-only view over a sparse vector index.
+///
+/// The top-level id tracker / vector storage / inverted index are decoupled from
+/// the payload index view (`P`), so read-only backends can be combined with a
+/// payload index view built over different (e.g. still-mutable) backends.
+pub struct SparseVectorIndexReadView<'a, I, V, P, TInvertedIndex>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead,
+    P: PayloadIndexRead,
+    TInvertedIndex: InvertedIndex,
+{
+    pub(crate) config: SparseIndexConfig,
+    pub(crate) id_tracker: &'a I,
+    pub(crate) vector_storage: &'a V,
+    pub(crate) payload_index: P,
+    pub(crate) inverted_index: &'a TInvertedIndex,
+    pub(crate) searches_telemetry: &'a SparseSearchesTelemetry,
+    pub(crate) indices_tracker: &'a IndicesTracker,
+    pub(crate) search_scratch_pool: &'a SearchScratchPool,
+}
+
+/// Read-only view over a [`SparseVectorIndex`] backed by the in-memory
+/// [`IdTrackerEnum`] / [`VectorStorageEnum`] / [`PayloadStorageEnum`] enums.
+///
+/// [`SparseVectorIndex`]: super::SparseVectorIndex
+pub(crate) type SparseVectorIndexReadViewEnum<'a, TInvertedIndex> = SparseVectorIndexReadView<
+    'a,
+    IdTrackerEnum,
+    VectorStorageEnum,
+    StructPayloadIndexReadView<
+        'a,
+        PayloadStorageEnum,
+        IdTrackerEnum,
+        VectorStorageEnum,
+        FieldIndex,
+    >,
+    TInvertedIndex,
+>;

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -5,7 +5,7 @@ use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::search_context::SearchContext;
 
-use super::SparseVectorIndex;
+use super::SparseVectorIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
 use crate::data_types::query_context::VectorQueryContext;
@@ -17,30 +17,33 @@ use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::types::{DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, Filter};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorageRead, check_deleted_condition};
+use crate::vector_storage::{RawScorerBuilder, VectorStorageRead, check_deleted_condition};
 
-impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
-    pub(super) fn get_query_cardinality(
+impl<I, V, P, TInvertedIndex> SparseVectorIndexReadView<'_, I, V, P, TInvertedIndex>
+where
+    I: IdTrackerRead,
+    V: VectorStorageRead + RawScorerBuilder,
+    P: PayloadIndexRead,
+    TInvertedIndex: InvertedIndex,
+{
+    fn get_query_cardinality(
         &self,
         filter: &Filter,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<CardinalityEstimation> {
-        let vector_storage = self.vector_storage.borrow();
-        let id_tracker = self.id_tracker.borrow();
-        let available_vector_count = vector_storage.available_vector_count();
+        let available_vector_count = self.vector_storage.available_vector_count();
         let query_point_cardinality = self
             .payload_index
-            .borrow()
-            .with_view(|v| v.estimate_cardinality(filter, hw_counter))?;
+            .estimate_cardinality(filter, hw_counter)?;
         Ok(adjust_to_available_vectors(
             query_point_cardinality,
             available_vector_count,
-            id_tracker.available_point_count(),
+            self.id_tracker.available_point_count(),
         ))
     }
 
     // Search using raw scorer
-    pub(super) fn search_scored(
+    fn search_scored(
         &self,
         query_vector: &QueryVector,
         filter: Option<&Filter>,
@@ -48,17 +51,15 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         prefiltered_points: &mut Option<Vec<PointOffsetType>>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        let vector_storage = self.vector_storage.borrow();
-        let id_tracker = self.id_tracker.borrow();
         let deleted_point_bitslice = vector_query_context
             .deleted_points()
-            .unwrap_or(id_tracker.deleted_point_bitslice());
+            .unwrap_or(self.id_tracker.deleted_point_bitslice());
 
         let is_stopped = vector_query_context.is_stopped();
 
         let searcher = BatchFilteredSearcher::new(
             &[query_vector],
-            &*vector_storage,
+            self.vector_storage,
             None::<&QuantizedVectors>,
             None,
             top,
@@ -72,10 +73,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                     // `prefiltered_points` always contains visible points only so we don't need additional filtering here.
                     Some(filtered_points) => filtered_points.iter().copied(),
                     None => {
-                        let filtered_points = self
-                            .payload_index
-                            .borrow()
-                            .with_view(|v| v.query_points(filter, &hw_counter, &is_stopped))?;
+                        let filtered_points =
+                            self.payload_index
+                                .query_points(filter, &hw_counter, &is_stopped)?;
                         *prefiltered_points = Some(filtered_points);
                         prefiltered_points.as_ref().unwrap().iter().copied()
                     }
@@ -83,10 +83,13 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 searcher.peek_top_iter(filtered_points, &is_stopped)?
             }
             None => {
-                let iter = id_tracker.point_mappings().filter_deferred_and_deleted(
-                    searcher.iter_not_deleted(),
-                    DeferredBehavior::VisibleOnly,
-                );
+                let iter = self
+                    .id_tracker
+                    .point_mappings()
+                    .filter_deferred_and_deleted(
+                        searcher.iter_not_deleted(),
+                        DeferredBehavior::VisibleOnly,
+                    );
                 searcher.peek_top_iter(iter, &is_stopped)?
             }
         };
@@ -102,15 +105,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         prefiltered_points: &mut Option<Vec<PointOffsetType>>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        let vector_storage = self.vector_storage.borrow();
-        let id_tracker = self.id_tracker.borrow();
-
         let is_stopped = vector_query_context.is_stopped();
 
         let deleted_point_bitslice = vector_query_context
             .deleted_points()
-            .unwrap_or(id_tracker.deleted_point_bitslice());
-        let deleted_vectors = vector_storage.deleted_vector_bitslice();
+            .unwrap_or(self.id_tracker.deleted_point_bitslice());
+        let deleted_vectors = self.vector_storage.deleted_vector_bitslice();
 
         let hw_counter = vector_query_context.hardware_counter();
 
@@ -120,10 +120,9 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             // so no additional filtering is required in that case.
             Some(filtered_points) => filtered_points.iter(),
             None => {
-                let filtered_points = self
-                    .payload_index
-                    .borrow()
-                    .with_view(|v| v.query_points(filter, &hw_counter, &is_stopped))?;
+                let filtered_points =
+                    self.payload_index
+                        .query_points(filter, &hw_counter, &is_stopped)?;
                 *prefiltered_points = Some(filtered_points);
                 prefiltered_points.as_ref().unwrap().iter()
             }
@@ -145,7 +144,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let mut search_context = SearchContext::new(
             sparse_vector,
             top,
-            &self.inverted_index,
+            self.inverted_index,
             &mut scratch,
             &is_stopped,
             &hw_counter,
@@ -155,19 +154,17 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 
     // search using sparse vector inverted index
-    pub(super) fn search_sparse(
+    fn search_sparse(
         &self,
         sparse_vector: &SparseVector,
         filter: Option<&Filter>,
         top: usize,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<ScoredPointOffset>> {
-        let vector_storage = self.vector_storage.borrow();
-        let id_tracker = self.id_tracker.borrow();
         let deleted_point_bitslice = vector_query_context
             .deleted_points()
-            .unwrap_or(id_tracker.deleted_point_bitslice());
-        let deleted_vectors = vector_storage.deleted_vector_bitslice();
+            .unwrap_or(self.id_tracker.deleted_point_bitslice());
+        let deleted_vectors = self.vector_storage.deleted_vector_bitslice();
 
         let not_deleted_condition = |idx: PointOffsetType| -> bool {
             check_deleted_condition(idx, deleted_vectors, deleted_point_bitslice)
@@ -188,20 +185,20 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         let mut search_context = SearchContext::new(
             sparse_vector,
             top,
-            &self.inverted_index,
+            self.inverted_index,
             &mut scratch,
             &is_stopped,
             &hw_counter,
         )?;
 
         match filter {
-            Some(filter) => self.payload_index.borrow().with_view(|v| {
-                let filter_context = v.filter_context(filter, &hw_counter)?;
+            Some(filter) => {
+                let filter_context = self.payload_index.filter_context(filter, &hw_counter)?;
                 let matches_filter_condition = |idx: PointOffsetType| -> bool {
                     not_deleted_condition(idx) && filter_context.check(idx)
                 };
                 Ok(search_context.search(&matches_filter_condition))
-            }),
+            }
             None => Ok(search_context.search(&not_deleted_condition)),
         }
     }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -1,22 +1,27 @@
+use std::collections::HashMap;
+
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
+use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use itertools::Itertools;
 use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::search_context::SearchContext;
 
 use super::SparseVectorIndexReadView;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::common::operation_time_statistics::ScopeDurationMeasurer;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::QueryVector;
+use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use crate::index::query_estimator::adjust_to_available_vectors;
+use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, Filter};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::query::TransformInto;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead, check_deleted_condition};
 
 impl<I, V, P, TInvertedIndex> SparseVectorIndexReadView<'_, I, V, P, TInvertedIndex>
@@ -26,6 +31,74 @@ where
     P: PayloadIndexRead,
     TInvertedIndex: InvertedIndex,
 {
+    /// Search a batch of query vectors, remapping idf weights when required.
+    pub fn search(
+        &self,
+        vectors: &[&QueryVector],
+        filter: Option<&Filter>,
+        top: usize,
+        query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let mut results = Vec::with_capacity(vectors.len());
+        let mut prefiltered_points = None;
+
+        for vector in vectors {
+            check_process_stopped(&query_context.is_stopped())?;
+
+            let search_results = if query_context.is_require_idf() {
+                let vector = (*vector).clone().transform(|mut vector| {
+                    match &mut vector {
+                        VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
+                            return Err(OperationError::WrongSparse);
+                        }
+                        VectorInternal::Sparse(sparse) => {
+                            query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
+                        }
+                    }
+
+                    Ok(vector)
+                })?;
+
+                self.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
+            } else {
+                self.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
+            };
+
+            results.push(search_results);
+        }
+        Ok(results)
+    }
+
+    pub fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
+        self.searches_telemetry.get_telemetry_data(detail)
+    }
+
+    pub fn indexed_vector_count(&self) -> usize {
+        self.inverted_index.vector_count()
+    }
+
+    pub fn size_of_searchable_vectors_in_bytes(&self) -> usize {
+        self.inverted_index.total_sparse_vectors_size()
+    }
+
+    /// Update statistics for idf-dot similarity.
+    pub fn fill_idf_statistics(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let iter = idf.iter_mut().filter_map(|(dim_id, count)| {
+            let offset = self.indices_tracker.remap_index(*dim_id)?;
+            Some((count, offset))
+        });
+        self.inverted_index
+            .posting_list_len_batch(iter, hw_counter, |count, len| {
+                *count += len;
+                Ok(())
+            })?;
+        Ok(())
+    }
+
     fn get_query_cardinality(
         &self,
         filter: &Filter,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
@@ -23,6 +23,33 @@ use crate::types::{Filter, SearchParams};
 use crate::vector_storage::query::TransformInto;
 use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
+impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
+    /// Plain (full-scan) sparse search over a set of pre-filtered points.
+    ///
+    /// Thin wrapper that drives the shared [`SparseVectorIndexReadView`]; kept on
+    /// the index for benches and other direct callers.
+    ///
+    /// [`SparseVectorIndexReadView`]: super::read_view::SparseVectorIndexReadView
+    pub fn search_plain(
+        &self,
+        sparse_vector: &SparseVector,
+        filter: &Filter,
+        top: usize,
+        prefiltered_points: &mut Option<Vec<PointOffsetType>>,
+        vector_query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<ScoredPointOffset>> {
+        self.with_view(|view| {
+            view.search_plain(
+                sparse_vector,
+                filter,
+                top,
+                prefiltered_points,
+                vector_query_context,
+            )
+        })
+    }
+}
+
 impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInvertedIndex> {
     fn search(
         &self,
@@ -32,34 +59,36 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
         _params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let mut results = Vec::with_capacity(vectors.len());
-        let mut prefiltered_points = None;
+        self.with_view(|view| {
+            let mut results = Vec::with_capacity(vectors.len());
+            let mut prefiltered_points = None;
 
-        for vector in vectors {
-            check_process_stopped(&query_context.is_stopped())?;
+            for vector in vectors {
+                check_process_stopped(&query_context.is_stopped())?;
 
-            let search_results = if query_context.is_require_idf() {
-                let vector = (*vector).clone().transform(|mut vector| {
-                    match &mut vector {
-                        VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
-                            return Err(OperationError::WrongSparse);
+                let search_results = if query_context.is_require_idf() {
+                    let vector = (*vector).clone().transform(|mut vector| {
+                        match &mut vector {
+                            VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
+                                return Err(OperationError::WrongSparse);
+                            }
+                            VectorInternal::Sparse(sparse) => {
+                                query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
+                            }
                         }
-                        VectorInternal::Sparse(sparse) => {
-                            query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
-                        }
-                    }
 
-                    Ok(vector)
-                })?;
+                        Ok(vector)
+                    })?;
 
-                self.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
-            } else {
-                self.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
-            };
+                    view.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
+                } else {
+                    view.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
+                };
 
-            results.push(search_results);
-        }
-        Ok(results)
+                results.push(search_results);
+            }
+            Ok(results)
+        })
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
@@ -10,17 +10,16 @@ use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
 
 use super::SparseVectorIndex;
-use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::query_context::VectorQueryContext;
-use crate::data_types::vectors::{QueryVector, VectorInternal, VectorRef};
+use crate::data_types::vectors::{QueryVector, VectorRef};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::sparse_index::indices_tracker::IndicesTracker;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::index::{VectorIndex, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
-use crate::vector_storage::query::TransformInto;
 use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -59,66 +58,27 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
         _params: Option<&SearchParams>,
         query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        self.with_view(|view| {
-            let mut results = Vec::with_capacity(vectors.len());
-            let mut prefiltered_points = None;
-
-            for vector in vectors {
-                check_process_stopped(&query_context.is_stopped())?;
-
-                let search_results = if query_context.is_require_idf() {
-                    let vector = (*vector).clone().transform(|mut vector| {
-                        match &mut vector {
-                            VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
-                                return Err(OperationError::WrongSparse);
-                            }
-                            VectorInternal::Sparse(sparse) => {
-                                query_context.remap_idf_weights(&sparse.indices, &mut sparse.values)
-                            }
-                        }
-
-                        Ok(vector)
-                    })?;
-
-                    view.search_query(&vector, filter, top, &mut prefiltered_points, query_context)?
-                } else {
-                    view.search_query(vector, filter, top, &mut prefiltered_points, query_context)?
-                };
-
-                results.push(search_results);
-            }
-            Ok(results)
-        })
+        self.with_view(|view| view.search(vectors, filter, top, query_context))
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> VectorIndexSearchesTelemetry {
-        self.searches_telemetry.get_telemetry_data(detail)
+        self.with_view(|view| view.get_telemetry_data(detail))
     }
 
     fn indexed_vector_count(&self) -> usize {
-        self.inverted_index.vector_count()
+        self.with_view(|view| view.indexed_vector_count())
     }
 
     fn size_of_searchable_vectors_in_bytes(&self) -> usize {
-        self.inverted_index.total_sparse_vectors_size()
+        self.with_view(|view| view.size_of_searchable_vectors_in_bytes())
     }
 
-    /// Update statistics for idf-dot similarity.
     fn fill_idf_statistics(
         &self,
         idf: &mut HashMap<DimId, usize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        let iter = idf.iter_mut().filter_map(|(dim_id, count)| {
-            let offset = self.indices_tracker.remap_index(*dim_id)?;
-            Some((count, offset))
-        });
-        self.inverted_index
-            .posting_list_len_batch(iter, hw_counter, |count, len| {
-                *count += len;
-                Ok(())
-            })?;
-        Ok(())
+        self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
     }
 
     fn is_index(&self) -> bool {


### PR DESCRIPTION
Adds `ReadOnlySparseVectorIndex` and wires the 6 persisted sparse variants into `VectorIndexReadEnum`. Search logic is extracted into a generic `SparseVectorIndexReadView` so the mutable index and the read-only one share one code path.