### PR TITLE
Fix invertion in delete_vector (appendable mmap storages)

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -215,7 +215,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStora
     }
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.set_deleted(key, true))
+        Ok(!self.set_deleted(key, true))
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -405,7 +405,7 @@ impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapMultiDenseVector
     }
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.set_deleted(key, true))
+        Ok(!self.set_deleted(key, true))
     }
 }
 

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -47,7 +47,8 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         .enumerate()
         .filter(|(_, d)| *d)
         .for_each(|(i, _)| {
-            storage.delete_vector(i as PointOffsetType).unwrap();
+            let was_deleted = storage.delete_vector(i as PointOffsetType).unwrap();
+            assert!(was_deleted, "deleting a live vector must return true");
         });
     assert_eq!(
         storage.deleted_vector_count(),
@@ -75,8 +76,14 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     assert_eq!(closest[2].idx, 4);
 
     // Delete 1, redelete 2
-    storage.delete_vector(1 as PointOffsetType).unwrap();
-    storage.delete_vector(2 as PointOffsetType).unwrap();
+    assert!(
+        storage.delete_vector(1 as PointOffsetType).unwrap(),
+        "deleting a live vector must return true"
+    );
+    assert!(
+        !storage.delete_vector(2 as PointOffsetType).unwrap(),
+        "redeleting a deleted vector must return false"
+    );
     assert_eq!(
         storage.deleted_vector_count(),
         3,
@@ -102,8 +109,8 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
     assert_eq!(closest[1].idx, 0);
 
     // Delete all
-    storage.delete_vector(0 as PointOffsetType).unwrap();
-    storage.delete_vector(4 as PointOffsetType).unwrap();
+    assert!(storage.delete_vector(0 as PointOffsetType).unwrap());
+    assert!(storage.delete_vector(4 as PointOffsetType).unwrap());
     assert_eq!(
         storage.deleted_vector_count(),
         5,

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -114,7 +114,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
         .enumerate()
         .filter(|(_, d)| *d)
         .for_each(|(i, _)| {
-            storage.delete_vector(i as PointOffsetType).unwrap();
+            let was_deleted = storage.delete_vector(i as PointOffsetType).unwrap();
+            assert!(was_deleted, "deleting a live vector must return true");
         });
     assert_eq!(
         storage.deleted_vector_count(),
@@ -140,8 +141,14 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     assert_eq!(closest[2].idx, 0);
 
     // Delete 1, redelete 2
-    storage.delete_vector(1 as PointOffsetType).unwrap();
-    storage.delete_vector(2 as PointOffsetType).unwrap();
+    assert!(
+        storage.delete_vector(1 as PointOffsetType).unwrap(),
+        "deleting a live vector must return true"
+    );
+    assert!(
+        !storage.delete_vector(2 as PointOffsetType).unwrap(),
+        "redeleting a deleted vector must return false"
+    );
     assert_eq!(
         storage.deleted_vector_count(),
         3,
@@ -166,8 +173,8 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
     assert_eq!(closest[1].idx, 0);
 
     // Delete all
-    storage.delete_vector(0 as PointOffsetType).unwrap();
-    storage.delete_vector(4 as PointOffsetType).unwrap();
+    assert!(storage.delete_vector(0 as PointOffsetType).unwrap());
+    assert!(storage.delete_vector(4 as PointOffsetType).unwrap());
     assert_eq!(
         storage.deleted_vector_count(),
         5,

--- a/tests/openapi/test_shard_snapshot.py
+++ b/tests/openapi/test_shard_snapshot.py
@@ -38,6 +38,55 @@ def test_recover_partial_snapshot_rejects_malformed_checksum(collection_name):
     )
 
 
+def test_delete_vector_advances_partial_snapshot_manifest(collection_name):
+    # Pin the vector storage tracker to a known version with a vector update.
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={"points": [{"id": 1, "vector": [1.0, 2.0, 3.0, 4.0]}]},
+    )
+    assert response.ok
+
+    # Delete the default named vector of another point; this mutates the
+    # vector storage's deleted-flags file.
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/vectors/delete',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={"points": [1], "vector": [""]},
+    )
+    assert response.ok
+    delete_op = response.json()['result']['operation_id']
+
+    # Sanity: the vector is gone locally.
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1},
+    )
+    assert response.ok
+    assert '' not in (response.json()['result']['vector'] or {})
+
+    # The manifest must stamp the mutated vector storage files with the delete
+    # op version; a stale version makes partial snapshot recovery skip the
+    # changed deleted-flags file and resurrect the vector on the replica.
+    response = requests.get(
+        f"{QDRANT_HOST}/collections/{collection_name}/shards/0/snapshot/partial/manifest",
+        headers=qdrant_host_headers(),
+    )
+    assert response.ok
+    vector_file_versions = [
+        version
+        for segment in response.json()['result'].values()
+        for path, version in segment['file_versions'].items()
+        if path.startswith('vector_storage/') and version is not None
+    ]
+    assert max(vector_file_versions) >= delete_op
+
+
 def test_shard_snapshot_operations(http_server, collection_name):
     (srv_dir, srv_url) = http_server
 


### PR DESCRIPTION
 Fix inverted `delete_vector()` return value in appendable mmap storages.

`AppendableMmapDenseVectorStorage` and `AppendableMmapMultiDenseVectorStorage` returned the **previous deleted state** from `delete_vector()`, while the trait contract (and every other storage) says "true if the vector was deleted by this call". Both appendable variants had the negation missing. (For reference the [same `delete_vector()` implementation](https://github.com/qdrant/qdrant/blob/dev/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs#L130) in another storage that is [negated](https://github.com/qdrant/qdrant/blob/6788391a4e32a16fe0cbf206b13e93855e4b5af7/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs#L376) in the trait impl)

Since `Segment::delete_vector` uses that bool to decide whether to bump the version tracker, a fresh named-vector delete never bumped it. Partial snapshot manifests then reported the storage files as unchanged, so a replica catching up via partial snapshot recovery would skip the updated deleted-flags file and keep the vector alive, while its point version says the delete was applied, so the WAL never replays it.


Regular full snapshots and snapshot-based transfers are **unaffected** (they always copy everything), and the deleted flag itself was always written correctly, only the returned bool was wrong.