### PR TITLE
fix(segment): apply Create/DeleteVectorName on WAL replay regardless of segment version

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -678,7 +678,10 @@ impl NonAppendableSegmentEntry for Segment {
         vector_name: &VectorName,
         vector_config: &VectorNameConfig,
     ) -> OperationResult<bool> {
-        self.handle_segment_version_and_failure(op_num, |segment| {
+        // Schema op: must run even on stale (low-`op_num`) replay so a segment that lacks this
+        // vector gets its storage (re)created, otherwise later replayed upserts referencing it
+        // are declined and their points are lost. `create_vector_name_impl` is idempotent.
+        self.handle_segment_schema_op_and_failure(op_num, |segment| {
             segment.create_vector_name_impl(op_num, vector_name, vector_config)
         })
     }
@@ -688,7 +691,9 @@ impl NonAppendableSegmentEntry for Segment {
         op_num: SeqNumberType,
         vector_name: &VectorName,
     ) -> OperationResult<bool> {
-        self.handle_segment_version_and_failure(op_num, |segment| {
+        // Schema op: mirror of `create_vector_name`, must run on stale replay so the deletion is
+        // reconstructed in lockstep with the create. `delete_vector_name_impl` is idempotent.
+        self.handle_segment_schema_op_and_failure(op_num, |segment| {
             segment.delete_vector_name_impl(op_num, vector_name)
         })
     }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -297,6 +297,37 @@ impl Segment {
     where
         F: FnOnce(&mut Segment) -> OperationResult<bool>,
     {
+        self.handle_segment_op_and_failure(op_num, true, operation)
+    }
+
+    /// Variant of [`Self::handle_segment_version_and_failure`] that runs the operation even when
+    /// `op_num` is below the segment version, instead of skipping it as already-applied.
+    ///
+    /// For idempotent structural schema operations (create/delete vector storage): the segment
+    /// version is a point-data high-water mark and does not imply a schema op was applied to this
+    /// segment. Version-skipping a replayed `CreateVectorName` leaves a segment without a vector
+    /// that later replayed upserts reference, so those upserts are wrongly declined with "Not
+    /// existing vector name" and their points are lost. The underlying `*_impl` are idempotent.
+    pub(super) fn handle_segment_schema_op_and_failure<F>(
+        &mut self,
+        op_num: SeqNumberType,
+        operation: F,
+    ) -> OperationResult<bool>
+    where
+        F: FnOnce(&mut Segment) -> OperationResult<bool>,
+    {
+        self.handle_segment_op_and_failure(op_num, false, operation)
+    }
+
+    fn handle_segment_op_and_failure<F>(
+        &mut self,
+        op_num: SeqNumberType,
+        skip_stale: bool,
+        operation: F,
+    ) -> OperationResult<bool>
+    where
+        F: FnOnce(&mut Segment) -> OperationResult<bool>,
+    {
         if let Some(SegmentFailedState {
             version: failed_version,
             point_id: _failed_point_id,
@@ -312,7 +343,7 @@ impl Segment {
             } // else: Re-try operation
         }
 
-        let res = self.handle_segment_version(op_num, operation);
+        let res = self.handle_segment_version(op_num, skip_stale, operation);
 
         if let Some(error) = get_service_error(&res) {
             // ToDo: Recover previous segment state
@@ -406,13 +437,14 @@ impl Segment {
     fn handle_segment_version<F>(
         &mut self,
         op_num: SeqNumberType,
+        skip_stale: bool,
         operation: F,
     ) -> OperationResult<bool>
     where
         F: FnOnce(&mut Segment) -> OperationResult<bool>,
     {
         // Global version to check if operation has already been applied, then skip without execution
-        if self.version.unwrap_or(0) > op_num {
+        if skip_stale && self.version.unwrap_or(0) > op_num {
             return Ok(false);
         }
 

--- a/lib/segment/src/segment/tests/test_vector_name_ops.rs
+++ b/lib/segment/src/segment/tests/test_vector_name_ops.rs
@@ -483,3 +483,66 @@ fn test_persistence_after_delete_with_data() {
         );
     }
 }
+
+/// Regression test for the WAL-replay version-skip bug.
+///
+/// `handle_segment_version` skips an operation when `segment.version > op_num`, treating it as
+/// already applied. That premise holds for point data but not for structural schema ops: a
+/// segment's version is the *maximum* op it ever applied, not proof it saw every earlier op. A
+/// segment created partway through a run (or loaded from a config that no longer lists the
+/// vector) can have a high version yet never have received an early `CreateVectorName`.
+///
+/// If the replayed create is version-skipped, the segment never gets the vector's storage, and a
+/// later replayed upsert naming it is declined with "Not existing vector name" -- silently losing
+/// its points on reload. The create must therefore run regardless of the segment version; its
+/// `*_impl` is idempotent, so doing so on a segment that already has the vector is a no-op.
+#[test]
+fn test_create_vector_name_applies_below_segment_version() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_appendable_segment_with_data(dir.path());
+    let hw = hw();
+
+    // Points were upserted at op 1..=NUM_POINTS, so the segment sits at that version.
+    let segment_version = segment.version();
+    assert_eq!(segment_version, NUM_POINTS as u64);
+
+    // Replay a `CreateVectorName` whose op_num predates the segment version -- exactly what
+    // happens when a historical schema op replays against a segment that has advanced past it.
+    // It must still create the storage, not be skipped as already-applied.
+    let stale_op_num = segment_version - 1;
+    let created = segment
+        .create_vector_name(stale_op_num, "v2", &dense_vector_name_config(DIM))
+        .unwrap();
+    assert!(
+        created,
+        "below-version CreateVectorName must be applied, not version-skipped",
+    );
+    assert!(
+        segment.segment_config.vector_data.contains_key("v2"),
+        "vector storage must exist after a below-version CreateVectorName",
+    );
+
+    // An upsert naming the new vector must now validate against the segment instead of being
+    // declined with "Not existing vector name".
+    let new_point = (NUM_POINTS as u64 + 1).into();
+    let mut vectors = NamedVectors::default();
+    vectors.insert(DEFAULT_VECTOR_NAME.to_owned(), vec![9.0f32; DIM].into());
+    vectors.insert("v2".to_owned(), vec![1.0f32; DIM].into());
+    segment
+        .upsert_point(NUM_POINTS as u64 + 1, new_point, vectors, &hw)
+        .expect("upsert naming the below-version vector must not be declined");
+
+    // The vector and its data survive a reload.
+    let segment_path = segment.data_path();
+    let segment_uuid = segment.uuid;
+    segment.flush(true).unwrap();
+    drop(segment);
+
+    let stopped = AtomicBool::new(false);
+    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped).unwrap();
+    assert!(loaded.segment_config.vector_data.contains_key("v2"));
+    assert!(
+        loaded.vector("v2", new_point, &hw).unwrap().is_some(),
+        "point must keep its below-version vector after reload",
+    );
+}


### PR DESCRIPTION
## Problem

A named vector that was created/deleted via `CreateVectorName` / `DeleteVectorName` can go missing — or take its points down with it — after a restart. Replayed upserts that reference the vector are declined with `Wrong input: Not existing vector name`, the operation is dropped, and the points it would have created never appear.

## Root cause

Schema ops route through the same version-skip as point ops, in `handle_segment_version`:

```rust
if segment.version > op_num { return Ok(false); } // "already applied → skip"
```

That premise — *`segment.version ≥ op_num` ⟹ this op is already reflected here* — holds for point data but **not** for structural schema ops.

`segment.version` is the **maximum** op_num a segment ever applied, **not** a guarantee that every earlier op reached it. Point ops are partitioned (each upsert goes to one segment), so per-segment max-version is a correct skip key. Schema ops are **broadcast to every segment** — including segments born *after* the schema op's (low) op_num, which never witnessed it.

### Worked example

```
op 190    CreateVectorName c        applied to segments alive at the time
op 5000   upserts using c
op 8246   DeleteVectorName c        c removed everywhere
op 12000  new appendable segment S born  → its config has no c; S.version jumps to 12000
...restart, replay WAL...
          CreateVectorName c @190   → on S: 12000 > 190 → SKIP → S still has no c slot
          upsert carrying c routed to S → validated against S → "Not existing vector name: c"
                                        → operation declined, points lost
```

S's version (12000) reported "you already handled op 190", but S did not exist at op 190 and was created from a config without `c`. A *max-of-applied* counter was used as a *applied-everything-below* guarantee, for an op that must reach segments younger than itself.

This was observed in collection model-testing: replayed `CreateVectorName` reported `applied to 0/N segments` on every reload after the first, followed by thousands of `Not existing vector name` declines and silently dropped points.

## Fix

Run `create_vector_name` / `delete_vector_name` on replay **unconditionally**, via a non-version-skipping variant `handle_segment_schema_op_and_failure` (same error/version-bump bookkeeping as `handle_segment_version_and_failure`, minus the stale-version early-return). Every segment then reconstructs the exact vector schema for each op in WAL order.

This is safe because the underlying `*_impl` are already idempotent:
- `create_vector_name_impl` no-ops if the vector already exists,
- `delete_vector_name_impl` no-ops if it is absent,

so applying a create/delete redundantly across segments does nothing.

## Why version-skip stays for point ops

Point operations are unaffected — they keep the version-skip, which is correct for partitioned, point-versioned data. Only the two structural schema ops opt out.

## Related

Complementary to #9317 (`start recreated named vector from a clean slate`): that PR ensures a *recreated* vector starts empty rather than reopening stale on-disk files; this PR ensures the create/delete are actually *applied* to every segment on replay. Both are needed for correct replay of schema ops.

## Status

Draft — opening for review of the approach. Regression test (a late-born segment that skips a replayed `CreateVectorName`) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)