### PR TITLE
Fix data loss when a payload index drop races the background segment flush

### DIFF
--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -227,19 +227,32 @@ impl PayloadIndex for StructPayloadIndex {
     fn flusher(&self) -> Flusher {
         // Most field indices have either 2 or 3 indices (including null), we also have an extra
         // payload storage flusher. Overallocate to save potential reallocations.
-        let mut flushers = Vec::with_capacity(self.field_indexes.len() * 3 + 1);
+        let mut field_flushers = Vec::with_capacity(self.field_indexes.len() * 3);
 
         for field_indexes in self.field_indexes.values() {
             for index in field_indexes {
-                flushers.push(index.flusher());
+                field_flushers.push(index.flusher());
             }
         }
-        flushers.push(self.payload.borrow().flusher());
+        let payload_flusher = self.payload.borrow().flusher();
 
         Box::new(move || {
-            for flusher in flushers {
-                flusher()?;
+            for flusher in field_flushers {
+                match flusher() {
+                    Ok(()) => {}
+                    // Cancelled = the index storage was dropped after flusher capture (e.g. a
+                    // concurrent DropIndex). Skip it but keep flushing: aborting would leave the
+                    // already-flushed indexes durably ahead of payload storage and point
+                    // versions, and WAL replay would re-derive filter-based operations through
+                    // that too-new index, silently skipping points (data loss). The drop itself
+                    // is a versioned operation that replay re-applies.
+                    Err(OperationError::Cancelled { description }) => {
+                        log::debug!("Skipping flush of dropped field index storage: {description}");
+                    }
+                    Err(err) => return Err(err),
+                }
             }
+            payload_flusher()?;
             Ok(())
         })
     }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -477,12 +477,27 @@ impl StorageSegmentEntry for Segment {
                     _ => OperationError::service_error(format!("Failed to flush {what}: {err}")),
                 };
 
+                // Cancelled = the storage was dropped after flusher capture (e.g. a concurrent
+                // vector name deletion). Skip it but keep flushing: aborting mid-sequence would
+                // leave the already-flushed components durably ahead of the rest (notably the
+                // point versions), breaking the per-point consistency WAL replay relies on.
+                // The drop itself is a versioned operation that replay re-applies. Field
+                // indexes get the same treatment in `StructPayloadIndex::flusher`.
+                let skip_if_cancelled = |result: OperationResult<()>, what| match result {
+                    Ok(()) => Ok(()),
+                    Err(OperationError::Cancelled { description }) => {
+                        log::debug!("Skipping flush of dropped {what}: {description}");
+                        Ok(())
+                    }
+                    Err(err) => Err(wrap_err(err, what)),
+                };
+
                 id_tracker_mapping_flusher().map_err(|err| wrap_err(err, "id_tracker mapping"))?;
                 for vector_storage_flusher in vector_storage_flushers {
-                    vector_storage_flusher().map_err(|err| wrap_err(err, "vector_storage"))?;
+                    skip_if_cancelled(vector_storage_flusher(), "vector_storage")?;
                 }
                 for quantization_flusher in quantization_flushers {
-                    quantization_flusher().map_err(|err| wrap_err(err, "quantized vectors"))?;
+                    skip_if_cancelled(quantization_flusher(), "quantized vectors")?;
                 }
                 payload_index_flusher().map_err(|err| wrap_err(err, "payload_index"))?;
                 // Id Tracker contains versions of points. We need to flush it after vector_storage and payload_index flush.

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1658,3 +1658,56 @@ fn test_deleted_deferred_point_count() {
         assert_eq!(segment.available_point_count_without_deferred(), N_POINTS);
     }
 }
+
+/// A field index dropped between flusher capture and execution (a `DropIndex`
+/// racing the background flush) must not abort the rest of the flush sequence.
+///
+/// Aborting used to leave the field indexes flushed before the cancellation
+/// point durably ahead of payload storage and point versions; WAL replay then
+/// re-derived filter-based operations through that too-new index and silently
+/// skipped points whose payload still needed the operation re-applied.
+#[test]
+fn test_flush_survives_concurrent_field_index_drop() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    segment
+        .upsert_point(
+            1,
+            1.into(),
+            only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    let payload: Payload = serde_json::from_str(r#"{"num": 20}"#).unwrap();
+    segment
+        .set_full_payload(2, 1.into(), &payload, &hw_counter)
+        .unwrap();
+    segment
+        .create_field_index(
+            3,
+            &JsonPath::new("num"),
+            Some(&PayloadFieldSchema::FieldType(PayloadSchemaType::Integer)),
+            &hw_counter,
+        )
+        .unwrap();
+
+    // Capture the flushers (as the background flush thread does), then drop the
+    // index before executing them.
+    let flusher = segment
+        .flusher(true)
+        .expect("segment has unflushed changes");
+    segment
+        .delete_field_index(4, &JsonPath::new("num"))
+        .unwrap();
+
+    flusher().expect("flush must not fail");
+
+    // The flush must skip the dropped index storage and still complete the
+    // sequence: payload storage, point versions, and the segment state captured
+    // at version 3. A cancelled (aborted) flush would have left the persisted
+    // version at 0.
+    assert_eq!(segment.persistent_version(), 3);
+}


### PR DESCRIPTION
## Problem

Filter-based updates (`DeletePayloadByFilter`, `SetPayloadByFilter`, ...) can be silently lost for some points across a restart. The trigger is a `DropIndex` racing the background segment flush.

A segment flush executes its captured component flushers in order: id-tracker mappings, vector storages, quantization, field indexes, payload storage, id-tracker versions. Versions go last on purpose. If a flush stops partway, the durable versions are stale, and WAL replay re-applies whatever the data stores are missing.

That recovery argument has a gap. If a field index is dropped between flusher capture and execution, its captured flusher returns `Cancelled`. The flush then aborted the whole remaining sequence. Field indexes flushed before the cancellation point end up durably *ahead* of payload storage and point versions.

This breaks replay. Filter-based operations are not replayed against recorded point ids. They are re-derived via `points_by_filter`, which reads the field index. An index from the future already contains the replayed operation's own effect. The operation finds no candidates and is skipped. The per-point version gate is never consulted.

## Example

Point 3 has an integer-indexed field `num`. The WAL contains:

1. op 9271: upsert point 3 with `{num: 20, f: 0.75, g: {...}, ...}`
2. op 9699: `DeletePayloadByFilter(num=20, keys=[num, f, g])`, applied live
3. The background flush captures a snapshot that includes op 9699, and starts executing
4. A concurrent `DropIndex(tag)` drops the tag index storage
5. The flush lands vectors and the `f`, `g`, `t`, `d`, `num` indexes on disk. Then `tag` returns `Cancelled` and the flush aborts. Payload storage and versions are never written
6. Restart. The durable `num` index already knows op 9699 deleted `num` from point 3. Payload storage and versions are one cycle older
7. Replay reaches op 9699 and asks the `num` index "who has num=20?". Point 3 is not listed, so the op is skipped for it
8. Point 3 keeps `f` and `g` forever

Note that the dropped index (`tag`) and the damaged data (via `num`) are unrelated. Any index that flushed before the cancellation point can carry the inconsistency.

## Fix

Treat `Cancelled` from a component flusher as "this storage was structurally dropped after capture". Skip that flusher and keep flushing. Payload storage and versions then land in the same snapshot as the field indexes that did flush.

- `StructPayloadIndex::flusher`: skip cancelled field index flushers, still flush payload storage
- `Segment::flusher`: same for vector storage and quantization flushers (the analogous race is a concurrent vector name deletion)
- id-tracker mapping and versions flushers keep failing hard. The id tracker cannot be structurally dropped while the segment is alive (`is_alive_flush_lock` blocks segment teardown for the duration of the flush op)

Skipping is safe. The structural drop is itself a versioned WAL operation that replay re-applies. Re-dropping an absent index is a no-op. A replayed index creation rebuilds from payload storage.

An alternative was rejected: serializing structural drops with flush execution. `flush_all` takes segment read locks before the flush-thread mutex. A dropper would need them in the opposite order, an ABBA deadlock.

## Testing

New unit test `test_flush_survives_concurrent_field_index_drop` reproduces the race deterministically. It captures the flusher, drops the index, executes, and asserts the persisted version advanced. It fails on `dev` and passes with the fix.

Model-testing soak (1 shard, optimizer disabled, restart probability 0.001, 100k ops per run, harness on the `collection-model-testing` branch): seed 42 and seeds 1/2/3 with `--on-disk` all pass. That covers 417 restart/replay verification round-trips and ~1500 occurrences of the race fired and survived. Before the fix, seed 42 failed its first restart verification inside the DropIndex window, and seed 1 had four recorded failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
