### PR TITLE
Remove unecessary bm25 dep on Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5805,7 +5805,6 @@ name = "qdrant-edge-py"
 version = "0.7.2"
 dependencies = [
  "ahash",
- "bm25",
  "bytemuck",
  "derive_more 2.1.1",
  "edge",

--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -19,7 +19,6 @@ abi3 = ["pyo3/abi3-py310"]
 
 
 [dependencies]
-bm25 = { path = "../../bm25" }
 edge = { path = ".." }
 edge-py-codegen = { path = "./codegen" }
 segment = { path = "../../segment", default-features = false }


### PR DESCRIPTION
The `bm25` is a dependency on the `edge` crate itself, the `edge/python` does not need it.