### PR TITLE
Respond HTTP 405 on cluster endpoints when in standalone mode

### DIFF
--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -30,6 +30,7 @@ impl From<StorageError> for Status {
             StorageError::NotFound { .. } => tonic::Code::NotFound,
             StorageError::ServiceError { .. } => tonic::Code::Internal,
             StorageError::BadRequest { .. } => tonic::Code::InvalidArgument,
+            StorageError::StandaloneMode { .. } => tonic::Code::Unimplemented,
             StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
             StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
             StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -25,6 +25,9 @@ pub enum StorageError {
     },
     #[error("Bad request: {description}")]
     BadRequest { description: String },
+    // operation requires distributed mode, but node runs standalone
+    #[error("{description}")]
+    StandaloneMode { description: String },
     #[error("Storage locked: {description}")]
     Locked { description: String },
     #[error("Timeout: {description}")]
@@ -65,6 +68,12 @@ impl StorageError {
     pub fn bad_request(description: impl Into<String>) -> Self {
         Self::BadRequest {
             description: description.into(),
+        }
+    }
+
+    pub fn standalone_mode() -> Self {
+        Self::StandaloneMode {
+            description: "Qdrant is running in standalone mode".into(),
         }
     }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -558,9 +558,11 @@ impl TableOfContent {
         let operation = ConsensusOperations::UpdateClusterMetadata { key, value };
 
         if wait {
-            let dispatcher = self.toc_dispatcher.lock().clone().ok_or_else(|| {
-                StorageError::service_error("Qdrant is running in standalone mode")
-            })?;
+            let dispatcher = self
+                .toc_dispatcher
+                .lock()
+                .clone()
+                .ok_or_else(StorageError::standalone_mode)?;
             dispatcher
                 .consensus_state()
                 .propose_consensus_op_with_await(operation, None)
@@ -774,7 +776,7 @@ impl TableOfContent {
     fn get_consensus_proposal_sender(&self) -> Result<&OperationSender, StorageError> {
         self.consensus_proposal_sender
             .as_ref()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))
+            .ok_or_else(StorageError::standalone_mode)
     }
 
     /// Insert dispatcher for access to table of contents and consensus.

--- a/src/actix/api/cluster_api.rs
+++ b/src/actix/api/cluster_api.rs
@@ -105,9 +105,7 @@ fn remove_peer(
                     )
                     .await
             }
-            None => Err(StorageError::bad_request(
-                "Distributed mode disabled.".to_string(),
-            )),
+            None => Err(StorageError::standalone_mode()),
         }
     })
 }
@@ -122,7 +120,7 @@ async fn get_cluster_metadata_keys(
 
         let keys = dispatcher
             .consensus_state()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))?
+            .ok_or_else(StorageError::standalone_mode)?
             .persistent
             .read()
             .get_cluster_metadata_keys();
@@ -143,7 +141,7 @@ async fn get_cluster_metadata_key(
 
         let value = dispatcher
             .consensus_state()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))?
+            .ok_or_else(StorageError::standalone_mode)?
             .persistent
             .read()
             .get_cluster_metadata_key(key.as_ref());

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -226,6 +226,7 @@ impl HttpError {
             StorageError::NotFound { .. } => {}
             StorageError::ServiceError { .. } => {}
             StorageError::BadRequest { .. } => {}
+            StorageError::StandaloneMode { .. } => {}
             StorageError::Locked { .. } => {}
             StorageError::Timeout { .. } => {}
             StorageError::ChecksumMismatch { .. } => {}
@@ -246,6 +247,7 @@ impl ResponseError for HttpError {
             StorageError::NotFound { .. } => http::StatusCode::NOT_FOUND,
             StorageError::ServiceError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
             StorageError::BadRequest { .. } => http::StatusCode::BAD_REQUEST,
+            StorageError::StandaloneMode { .. } => http::StatusCode::METHOD_NOT_ALLOWED,
             StorageError::Locked { .. } => http::StatusCode::FORBIDDEN,
             StorageError::Timeout { .. } => http::StatusCode::REQUEST_TIMEOUT,
             StorageError::AlreadyExists { .. } => http::StatusCode::CONFLICT,

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -259,9 +259,7 @@ pub async fn do_update_collection_cluster(
     )?;
 
     if dispatcher.consensus_state().is_none() {
-        return Err(StorageError::bad_request(
-            "Distributed mode disabled".to_string(),
-        ));
+        return Err(StorageError::standalone_mode());
     }
     let consensus_state = dispatcher.consensus_state().unwrap();
 

--- a/tests/openapi/helpers/helpers.py
+++ b/tests/openapi/helpers/helpers.py
@@ -206,3 +206,18 @@ def skip_if_no_feature(feature):
     feature_is_enabled = check_feature_enabled(feature)
     if not feature_is_enabled:
         pytest.skip(f"Skipping because the feature {feature} is disabled at runtime.")
+
+
+def is_distributed_mode() -> bool:
+    response = request_with_validation(
+        api='/cluster',
+        method="GET",
+    )
+    assert response.ok
+    # Standalone nodes report `disabled`; any other status means consensus is enabled.
+    return response.json()['result']['status'] != 'disabled'
+
+
+def skip_if_distributed_mode():
+    if is_distributed_mode():
+        pytest.skip("Skipping because Qdrant is running in distributed mode.")

--- a/tests/openapi/test_cluster.py
+++ b/tests/openapi/test_cluster.py
@@ -1,0 +1,30 @@
+from .helpers.helpers import request_with_validation
+
+
+def test_cluster_recover_standalone_returns_405():
+    """
+    POST /cluster/recover on a standalone (non-distributed) node must return
+    405 Method Not Allowed, not 500 Internal Server Error.
+
+    See https://github.com/qdrant/qdrant/issues/9421
+    """
+    response = request_with_validation(
+        api="/cluster/recover",
+        method="POST",
+    )
+    assert response.status_code == 405
+    assert "standalone mode" in response.json()["status"]["error"]
+
+
+def test_remove_peer_standalone_returns_405():
+    """
+    DELETE /cluster/peer/{peer_id} on a standalone node must return
+    405 Method Not Allowed, consistent with the other cluster endpoints.
+    """
+    response = request_with_validation(
+        api="/cluster/peer/{peer_id}",
+        method="DELETE",
+        path_params={"peer_id": 1},
+    )
+    assert response.status_code == 405
+    assert "standalone mode" in response.json()["status"]["error"]

--- a/tests/openapi/test_cluster.py
+++ b/tests/openapi/test_cluster.py
@@ -1,4 +1,4 @@
-from .helpers.helpers import request_with_validation
+from .helpers.helpers import request_with_validation, skip_if_distributed_mode
 
 
 def test_cluster_recover_standalone_returns_405():
@@ -8,6 +8,8 @@ def test_cluster_recover_standalone_returns_405():
 
     See https://github.com/qdrant/qdrant/issues/9421
     """
+    skip_if_distributed_mode()
+
     response = request_with_validation(
         api="/cluster/recover",
         method="POST",
@@ -21,6 +23,8 @@ def test_remove_peer_standalone_returns_405():
     DELETE /cluster/peer/{peer_id} on a standalone node must return
     405 Method Not Allowed, consistent with the other cluster endpoints.
     """
+    skip_if_distributed_mode()
+
     response = request_with_validation(
         api="/cluster/peer/{peer_id}",
         method="DELETE",


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/issues/9421>

Cluster specific endpoints are disabled in standalone mode. This adjusts the HTTP response from HTTP 500 to HTTP 405, which is more fitting.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
