### PR TITLE
Set GitHub workflow permissions explicitly

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight UTC
 
+permissions:
+  contents: read
+
 env:
   UV_VERSION: 0.9.17
 

--- a/.github/workflows/dev-docker-image-build-gpu.yml
+++ b/.github/workflows/dev-docker-image-build-gpu.yml
@@ -3,6 +3,10 @@ name: Build and push a branch gpu image to ghcr
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   branch-gpu-build-and-push:
     runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/dev-docker-image-build-gpu.yml
+++ b/.github/workflows/dev-docker-image-build-gpu.yml
@@ -5,11 +5,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   branch-gpu-build-and-push:
     runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: read
+      packages: write
     steps:
         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
           with:

--- a/.github/workflows/dev-docker-image-build.yml
+++ b/.github/workflows/dev-docker-image-build.yml
@@ -9,10 +9,16 @@ on:
   repository_dispatch:
     types: [benchmark-trigger-image-build]
 
+permissions:
+  contents: read
+
 jobs:
   branch-build-and-push:
     if: ${{ !github.event.client_payload.triggered }}
     runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: read
+      packages: write
     steps:
         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
           with:
@@ -30,6 +36,9 @@ jobs:
   triggered-branch-build-and-push:
     if: ${{ github.event.client_payload.triggered }}
     runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: read
+      packages: write
     steps:
         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
           with:

--- a/.github/workflows/dev-docker-image-prune.yml
+++ b/.github/workflows/dev-docker-image-prune.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *"  # every day at midnight
 
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   dev-clean-ghcr:

--- a/.github/workflows/dev-docker-image-prune.yml
+++ b/.github/workflows/dev-docker-image-prune.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 0 * * *"  # every day at midnight
 
 permissions:
-  contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -9,6 +9,8 @@ on:
         default: false
         required: true
 
+permissions:
+  contents: read
 
 jobs:
   edge-py-linux:

--- a/.github/workflows/edge-rust-release.yml
+++ b/.github/workflows/edge-rust-release.yml
@@ -9,6 +9,8 @@ on:
         default: false
         required: true
 
+permissions:
+  contents: read
 
 jobs:
   edge-rust-check:

--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   edge-test:
     name: Test Qdrant Edge

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   UV_VERSION: 0.9.17

--- a/.github/workflows/io-bridge-object-store-tests.yml
+++ b/.github/workflows/io-bridge-object-store-tests.yml
@@ -13,6 +13,9 @@ on:
       - "lib/common/common/src/universal_io/**"
       - ".github/workflows/io-bridge-object-store-tests.yml"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/long-e2e-tests.yml
+++ b/.github/workflows/long-e2e-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 6 * * *'  # At 06:30
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   UV_VERSION: 0.9.17

--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Explicitly sets permissions for all GitHub workflow jobs.

This is done to resolve a large number of CodeQL security alerts, including:
- https://github.com/qdrant/qdrant/security/code-scanning/7
- https://github.com/qdrant/qdrant/security/code-scanning/8
- https://github.com/qdrant/qdrant/security/code-scanning/9
- https://github.com/qdrant/qdrant/security/code-scanning/10
- ...

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
