### PR TITLE
feat: read-only immutable id tracker open + enum open dispatcher

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::read_only::ReadOnlyAppendableIdTracker;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
@@ -10,6 +13,29 @@ use crate::types::{PointIdType, SeqNumberType};
 pub enum ReadOnlyIdTrackerEnum<S: UniversalRead> {
     Appendable(ReadOnlyAppendableIdTracker<S>),
     Immutable(ReadOnlyImmutableIdTracker<S>),
+}
+
+impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
+    /// Open the read-only ID tracker, mirroring the writable `create_segment_id_tracker` selection.
+    pub fn open(
+        fs: &S::Fs,
+        segment_path: &Path,
+        mutable_id_tracker: bool,
+        deferred_internal_id: Option<PointOffsetType>,
+    ) -> OperationResult<Self> {
+        if mutable_id_tracker {
+            Ok(Self::Appendable(ReadOnlyAppendableIdTracker::open(
+                fs,
+                segment_path,
+                deferred_internal_id,
+            )?))
+        } else {
+            Ok(Self::Immutable(ReadOnlyImmutableIdTracker::open(
+                fs,
+                segment_path,
+            )?))
+        }
+    }
 }
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -1,0 +1,64 @@
+use std::io::Cursor;
+use std::path::Path;
+
+use common::bitvec::BitVec;
+use common::generic_consts::Sequential;
+use common::mmap::AdviceSetting;
+use common::stored_bitslice::StoredBitSlice;
+use common::universal_io::{
+    OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalReadFs,
+};
+
+use super::ReadOnlyImmutableIdTracker;
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::compressed::versions_store::CompressedVersions;
+use crate::id_tracker::immutable_id_tracker::deleted_storage::deleted_path;
+use crate::id_tracker::immutable_id_tracker::mappings_storage::{load_mapping, mappings_path};
+use crate::id_tracker::immutable_id_tracker::versions_storage::version_mapping_path;
+use crate::types::SeqNumberType;
+
+impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
+    /// Open a read-only view over immutable ID tracker data at `segment_path`, threading every file
+    /// open through `fs`. Read-only mirror of [`ImmutableIdTracker::open`]; it never writes.
+    ///
+    /// The `deleted` bitslice handle is kept for [`live_reload`](Self::live_reload); versions and
+    /// mappings are immutable and read once into memory.
+    ///
+    /// [`ImmutableIdTracker::open`]: crate::id_tracker::immutable_id_tracker::ImmutableIdTracker::open
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        let options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::Blocking,
+            advice: AdviceSetting::Global,
+        };
+
+        let deleted =
+            StoredBitSlice::open(fs, deleted_path(segment_path), options, Default::default())?;
+        let mut deleted_bitvec = BitVec::new();
+        deleted_bitvec.extend_from_bitslice(deleted.read_all()?.as_ref());
+
+        let internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
+            fs,
+            version_mapping_path(segment_path),
+            options,
+            Default::default(),
+        )?;
+        let internal_to_version =
+            CompressedVersions::from_slice(&internal_to_version_file.read_whole()?);
+
+        let mappings_file = fs.open(mappings_path(segment_path), options, Default::default())?;
+        let mappings_bytes = mappings_file.read::<Sequential, u8>(ReadRange {
+            byte_offset: 0,
+            length: mappings_file.len::<u8>()?,
+        })?;
+        let mappings = load_mapping(Cursor::new(mappings_bytes.as_ref()), Some(deleted_bitvec))?;
+
+        Ok(Self {
+            path: segment_path.to_path_buf(),
+            deleted,
+            internal_to_version,
+            mappings,
+        })
+    }
+}

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/mod.rs
@@ -1,4 +1,5 @@
 pub mod id_tracker_read;
+mod lifecycle;
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
`ReadOnlyImmutableIdTracker::open` (mirror of `ImmutableIdTracker::open`, fs-threaded, never writes) + `ReadOnlyIdTrackerEnum::open` dispatcher (Appendable/Immutable, mirrors `create_segment_id_tracker`).

Construct read-only segment → ID Tracker.