### PR TITLE
feat: live_reload for read-only immutable id tracker + enum dispatch

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -6,7 +6,9 @@ use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
-use crate::id_tracker::mutable_id_tracker::read_only::ReadOnlyAppendableIdTracker;
+use crate::id_tracker::mutable_id_tracker::read_only::{
+    LiveReloadResult, ReadOnlyAppendableIdTracker,
+};
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::types::{PointIdType, SeqNumberType};
 
@@ -34,6 +36,14 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
                 fs,
                 segment_path,
             )?))
+        }
+    }
+
+    /// Reload externally-applied changes, dispatching to the active variant.
+    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
+        match self {
+            Self::Appendable(id_tracker) => id_tracker.live_reload(),
+            Self::Immutable(id_tracker) => id_tracker.live_reload(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
@@ -1,0 +1,39 @@
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyImmutableIdTracker;
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
+
+impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
+    /// Re-read the on-disk `deleted` bitslice and apply points deleted since the last reload.
+    ///
+    /// An immutable tracker only ever loses points (no inserts), so `inserted` is always empty.
+    /// Result offsets are sorted ascending.
+    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
+        self.deleted.reopen()?;
+
+        let newly_deleted: Vec<PointOffsetType> = {
+            let deleted = self.deleted.read_all()?;
+            deleted
+                .iter_ones()
+                .map(|internal_id| internal_id as PointOffsetType)
+                .filter(|&internal_id| !self.mappings.is_deleted_point(internal_id))
+                .collect()
+        };
+
+        let mut deleted = Vec::with_capacity(newly_deleted.len());
+        for internal_id in newly_deleted {
+            if let Some(external_id) = self.mappings.external_id(internal_id) {
+                self.mappings.drop(external_id);
+                deleted.push(internal_id);
+            }
+        }
+        deleted.sort_unstable();
+
+        Ok(LiveReloadResult {
+            inserted: Vec::new(),
+            deleted,
+        })
+    }
+}

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
@@ -29,7 +29,8 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
                 deleted.push(internal_id);
             }
         }
-        deleted.sort_unstable();
+
+        debug_assert!(deleted.is_sorted());
 
         Ok(LiveReloadResult {
             inserted: Vec::new(),

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/mod.rs
@@ -1,5 +1,6 @@
 pub mod id_tracker_read;
 mod lifecycle;
+mod live_reload;
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
`ReadOnlyImmutableIdTracker::live_reload` (re-reads the on-disk `deleted` bitslice; immutable ⇒ deletions only, no inserts) + `ReadOnlyIdTrackerEnum::live_reload` dispatch.

Stacked on #9433.