### PR TITLE
feat: LiveReload dispatch for read-only vector index enum

### DIFF
--- a/lib/segment/src/index/read_only/live_reload.rs
+++ b/lib/segment/src/index/read_only/live_reload.rs
@@ -1,0 +1,27 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::VectorIndexReadEnum;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for VectorIndexReadEnum<S> {
+    type Fs = S::Fs;
+
+    /// No-op for every variant: read-only vector indexes are immutable — the HNSW
+    /// graph and the sparse inverted index are built once, and plain has no index
+    /// files at all. Deletions and newly appended points are served from the
+    /// shared id-tracker and vector storage, which reload separately, so the index
+    /// itself has no on-disk state to refresh.
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        _deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -1,3 +1,5 @@
+mod live_reload;
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;


### PR DESCRIPTION
`LiveReload` for `VectorIndexReadEnum` — no-op: read-only vector indexes are immutable (graph / inverted index built once; plain has no files). Deletions & new points are served from the shared id-tracker + vector storage, which reload separately.

Stacked on #9435.