### PR TITLE
fix(quantization): scale TQ dequantize by l2/cn to stop requantization drift

### DIFF
--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -299,15 +299,24 @@ impl TurboQuantizer {
         // bytes twice for every dequantize call.
         let unpacked: Vec<f64> = unpacked_iter.collect();
 
-        // Stored `scaling_factor` is `l2/cn_quant` for Dot/Cosine/L2 (`l2 ==
-        // 1.0` for Cosine). To recover the original l2 length we either
-        // multiply by `cn_quant` recomputed from the unpacked centroids
-        // (Dot/Cosine — `l2` isn't stored separately) or read the dedicated
-        // `l2_length` field (L2 stores it directly, no recompute needed).
-        // For TQ+, `cn_quant` is measured in the EC-reverted (rescaled) space,
-        // matching `compute_centroid_norm`'s convention.
-        let recovered_l2 = match self.distance {
-            DistanceType::Dot | DistanceType::Cosine => {
+        // Reconstruct as `c · l2/cn`, the same renorm convention the scorers
+        // use (`score_symmetric` / `score_precomputed` multiply the centroid
+        // dot by `scaling_factor = l2/cn`), NOT `c · l2/sqrt(d)`. Scaling by
+        // the measured centroid norm makes the read-back norm exactly `l2`,
+        // which makes quantize(dequantize(x)) a fixed point for padding-free
+        // dims: re-quantizing a read-back reproduces both the codes and the
+        // stored norm, so repeated requantization (e.g. the copy-on-write
+        // point move between segments) cannot drift the vector. With the old
+        // `sqrt(d)` denominator every extra round-trip rescaled the read-back
+        // by `cn/sqrt(d)`, degrading (or inflating) it geometrically.
+        let scale = match self.distance {
+            // `scaling_factor` is already `l2/cn` (`1/cn` for Cosine).
+            DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => scaling_factor,
+            // L1 stores the raw `l2` only; divide by the centroid norm
+            // recomputed from the unpacked codes. For TQ+, `cn_quant` is
+            // measured in the EC-reverted (rescaled) space, matching
+            // `compute_centroid_norm`'s convention.
+            DistanceType::L1 => {
                 let cn_quant = match &self.error_correction {
                     Some(ec) => unpacked
                         .iter()
@@ -320,13 +329,9 @@ impl TurboQuantizer {
                         .sqrt(),
                     None => unpacked.iter().map(|&x| x * x).sum::<f64>().sqrt(),
                 };
-                scaling_factor * cn_quant
+                scaling_factor / cn_quant
             }
-            DistanceType::L2 => f64::from(extras.l2_length()),
-            DistanceType::L1 => scaling_factor,
         };
-
-        let scale = recovered_l2 / (self.padded_dim as f64).sqrt();
         match &self.error_correction {
             // TQ+: stored centroids approximate `X+`; revert EC to recover the
             // rescaled coordinate before applying the length scale.

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -251,6 +251,24 @@ fn open_turbo_vector_storage_impl(
     })
 }
 
+/// Quantize then dequantize `vector` exactly as a [`TurboVectorStorage`] with this
+/// `distance` does across `insert_vector` + `get_vector`. Pure function of its inputs:
+/// the quantizer is fully determined by `(dim, distance)` (the rotation derives from
+/// fixed seeds), so the result is identical across storage instances, segment rebuilds,
+/// and reloads. Lets model-based tests predict the read-back value of a Turbo4-backed
+/// vector without opening a storage.
+pub fn turbo_storage_roundtrip(vector: &[f32], distance: Distance) -> Vec<f32> {
+    let dim = vector.len();
+    let quantizer = TurboQuantizer::new(dim, TQDT_BITS, TQDT_MODE, distance.into(), None);
+    let mut buf = vec![0.0; quantizer.get_padded_dim()];
+    let encoded = quantizer.quantize(vector, &mut buf);
+    // Mirror of `TurboVectorStorage::dequantize_vector`: dequantize, rotate back, drop
+    // the padding tail, cast to f32.
+    let mut dequantized = quantizer.dequantize::<f64>(&encoded);
+    quantizer.rotation.apply_inverse(&mut dequantized);
+    dequantized[..dim].iter().map(|&x| x as f32).collect()
+}
+
 impl VectorStorageRead for TurboVectorStorage {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.quantized_vector_size()
@@ -395,6 +413,35 @@ mod tests {
     use super::*;
     use crate::data_types::vectors::DenseVector;
     use crate::vector_storage::prefill_deleted::fill_turbo;
+
+    /// The quantize -> dequantize round-trip must be a fixed point for
+    /// padding-free dims: `dequantize` scales by the measured centroid norm
+    /// (`l2/cn`), so re-quantizing a read-back reproduces both the codes and
+    /// the stored norm. Without this, every value-based point relocation
+    /// (e.g. the copy-on-write move between segments) rescales the vector by
+    /// `cn/sqrt(d)`, drifting it geometrically. Padded dims (odd for Bits4)
+    /// are excluded: truncating the padding tail on read makes the round-trip
+    /// only approximately stable there.
+    #[test]
+    fn roundtrip_is_fixed_point_for_padding_free_dims() {
+        for dim in [8usize, 128, 1024] {
+            let mut rng = StdRng::seed_from_u64(42);
+            let original: Vec<f32> = (0..dim).map(|_| rng.random_range(0.0f32..1.0)).collect();
+            let once = turbo_storage_roundtrip(&original, Distance::Dot);
+
+            // Read-back norm equals the original norm exactly (up to f32).
+            let orig_norm: f32 = original.iter().map(|&x| x * x).sum::<f32>().sqrt();
+            let once_norm: f32 = once.iter().map(|&x| x * x).sum::<f32>().sqrt();
+            assert!(
+                (once_norm / orig_norm - 1.0).abs() < 1e-5,
+                "dim {dim}: read-back norm {once_norm} != original norm {orig_norm}",
+            );
+
+            // Further round-trips are bitwise identical.
+            let twice = turbo_storage_roundtrip(&once, Distance::Dot);
+            assert_eq!(twice, once, "dim {dim}: roundtrip is not a fixed point");
+        }
+    }
 
     /// Deterministic test vectors in `[-1, 1]`, seeded so that the storage and
     /// the independent oracle observe exactly the same inputs across runs.


### PR DESCRIPTION
## Problem

Turbo4 vectors degrade every time a point is relocated between segments by value. 

A Turbo4 storage keeps only the 4-bit codes; the original f32 vector is discarded at insert, so `get_vector` can only return an f32 *reconstruction* obtained by dequantizing the codes. 

The copy-on-write move (`apply_points_with_conditional_move` in `lib/shard/src/segment_holder/mod.rs`) reads a point's vectors through exactly that path and re-inserts the reconstruction into the destination segment as if it were a fresh user vector, quantizing it a second time. 

Each cycle uniformly rescales the vector by `cn/sqrt(d)`:

| dim | scale per round-trip | after 10 round-trips (insert + 9 moves) |
|---|---|---|
| 8 | x0.960 | 0.66 |
| 128 | x0.969 | 0.73 |
| 1024 | x0.992 | 0.92 |
| 7 (padded) | x1.068 | **1.93, grows** |

In practice: repeatedly setting payload on a point that lives in an optimized segment shrinks (or, for padded dims, inflates) its vector and its Dot scores without bound, silently corrupting ranking relative to untouched points.

The optimizer's segment rebuild is unaffected (it copies encoded bytes via `update_from`), but CoW moves, proxy flushes, and shard transfers all go through values.

## Root cause

`TurboQuantizer::quantize` stores `scaling_factor = l2/cn` (original norm over centroid norm), and both scorers already use that renorm convention: `score_symmetric` and `score_precomputed` multiply the centroid dot by `scaling_factor`. 

But `dequantize` reconstructed with `c * recovered_l2/sqrt(d)`, so the read-back norm was `l2 * cn/sqrt(d)`, not `l2`. 

Re-quantizing a read-back reproduces the same centroid codes (the rescale maps it back onto the grid), but measures and stores the shrunken norm, compounding per cycle.

## Fix

`dequantize` now scales by `l2/cn`, matching the scorers:

- **Dot/Cosine/L2**: `scale = scaling_factor` directly (it is already `l2/cn`). This also drops the centroid-norm recompute from these branches.
- **L1**: stores raw `l2` only, so it divides by a centroid norm recomputed from the codes (EC-reverted space for TQ+, matching `compute_centroid_norm`).

Consequences:
- Read-back norm now equals the stored `l2` to f32 precision.
- For padding-free dims, re-quantizing a read-back reproduces the codes, and the re-measured norm matches the stored one up to last-bit f32 rounding: repeated relocation can wobble the read-back by a few ulps, but the systematic geometric drift is gone. The new `roundtrip_is_fixed_point_for_padding_free_dims` test pins bitwise round-trip stability for seeded sample vectors at dims 8/128/1024.
- Padded dims (odd dims for Bits4): drift drops from ~6.8% growth per move to ~0.1% decay per move. Not fully eliminated, because the truncated padding tail re-enters quantization; a complete fix for padded dims would need a bytes-preserving point move.

Also adds `turbo_storage_roundtrip`, a pure helper mirroring `TurboVectorStorage` insert + read, used by the regression test (and by the collection model-testing harness in a follow-up).

## How it was found

The collection model-testing soak harness, running with the optimizer enabled, retrieved a vector that matched the model's prediction times exactly 0.9301 on every component, which is `cn/sqrt(d)` for that vector: the signature of one extra quantize/dequantize cycle through a CoW move.

## Validation

- All `quantization` crate tests pass (113 + 79).
- All `segment` turbo storage tests pass (16, including the new fixed-point test).
- 10k-op model-testing soaks with the optimizer enabled (seeds 1-3, including mid-run restart/WAL-replay verification) run clean with this fix paired with a few-ulp tolerance for Turbo4 vectors in the harness comparison (separate harness branch). Before the fix they failed on the first retrieve after a CoW move with percent-scale divergence; with it the residual mismatch is at most 1 ulp.

## Remaining known gaps (out of scope)

- Padded dims retain a small residual drift per value-based move (see above).
- Re-quantization re-measures `l2` through two f64 rotation round-trips and can land a few ulps off, so read-backs after a CoW move are ulp-stable, not bitwise-stable.
- Shard transfer still streams vectors as values and re-quantizes once on the target node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

