### PR TITLE
[TQDT] Dense TQ inline scoring

### DIFF
--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -88,8 +88,6 @@ where
     TEncodedVectors: quantization::EncodedVectors,
     TQuery: Query<TEncodedVectors::EncodedQuery>,
 {
-    type TVector = [TElement];
-
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
@@ -115,10 +113,6 @@ where
             self.quantized_storage
                 .score_point(this, idx, &self.hardware_counter)
         })
-    }
-
-    fn score(&self, _v2: &[TElement]) -> ScoreType {
-        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -100,8 +100,6 @@ where
     OffsetStorage: MultivectorOffsetsStorage,
     TQuery: Query<Vec<QuantizedStorage::EncodedQuery>>,
 {
-    type TVector = ();
-
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
@@ -130,10 +128,6 @@ where
             self.quantized_multivector_storage
                 .score_point(this, idx, &self.hardware_counter)
         })
-    }
-
-    fn score(&self, _v2: &()) -> ScoreType {
-        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_query_scorer.rs
@@ -97,8 +97,6 @@ where
     QuantizedStorage: quantization::EncodedVectors,
     OffsetStorage: MultivectorOffsetsStorage,
 {
-    type TVector = ();
-
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
@@ -124,10 +122,6 @@ where
         // quantized multivector storage handles hardware counter to batch vector IO
         self.quantized_multivector_storage
             .score_point(&self.query, idx, &self.hardware_counter)
-    }
-
-    fn score(&self, _v2: &()) -> ScoreType {
-        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -4,7 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
 
 use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{DenseVector, VectorElementType};
+use crate::data_types::vectors::DenseVector;
 use crate::spaces::metric::Metric;
 use crate::types::QuantizationConfig;
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -78,8 +78,6 @@ impl<TEncodedVectors> QueryScorer for QuantizedQueryScorer<'_, TEncodedVectors>
 where
     TEncodedVectors: quantization::EncodedVectors,
 {
-    type TVector = [VectorElementType];
-
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
         debug_assert_eq!(ids.len(), scores.len());
 
@@ -100,10 +98,6 @@ where
             .incr_delta(self.quantized_data.quantized_vector_size());
         self.quantized_data
             .score_point(&self.query, idx, &self.hardware_counter)
-    }
-
-    fn score(&self, _v2: &[VectorElementType]) -> ScoreType {
-        unimplemented!("This method is not expected to be called for quantized scorer");
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -71,6 +71,19 @@ impl<
             hardware_counter,
         }
     }
+
+    /// Score the query against an explicit vector (not one stored in the
+    /// storage). Used internally by `score_stored`/`score_stored_batch`/
+    /// [`QueryScorer::score_bytes`].
+    #[inline]
+    fn score(&self, against: &[TElement]) -> ScoreType {
+        let cpu_counter = self.hardware_counter.cpu_counter();
+
+        self.query.score_by(|example| {
+            cpu_counter.incr();
+            TMetric::similarity(example, against)
+        })
+    }
 }
 
 impl<
@@ -80,8 +93,6 @@ impl<
     TStoredQuery: Query<TypedDenseVector<TElement>>,
 > QueryScorer for CustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TStoredQuery>
 {
-    type TVector = [TElement];
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self.vector_storage.get_dense::<Random>(idx);
@@ -98,16 +109,6 @@ impl<
 
         self.vector_storage
             .for_each_in_dense_batch(ids, |idx, vector| scores[idx] = self.score(vector));
-    }
-
-    #[inline]
-    fn score(&self, against: &[TElement]) -> ScoreType {
-        let cpu_counter = self.hardware_counter.cpu_counter();
-
-        self.query.score_by(|example| {
-            cpu_counter.incr();
-            TMetric::similarity(example, against)
-        })
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/metric_query_scorer.rs
@@ -56,6 +56,12 @@ impl<
             hardware_counter,
         }
     }
+
+    #[inline]
+    fn score(&self, v2: &[TElement]) -> ScoreType {
+        self.hardware_counter.cpu_counter().incr();
+        TMetric::similarity(&self.query, v2)
+    }
 }
 
 impl<
@@ -64,8 +70,6 @@ impl<
     TVectorStorage: DenseVectorStorageRead<TElement>,
 > QueryScorer for MetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
-    type TVector = [TElement];
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.hardware_counter.cpu_counter().incr();
@@ -84,12 +88,6 @@ impl<
             .for_each_in_dense_batch(ids, |idx, vector| {
                 scores[idx] = TMetric::similarity(&self.query, vector);
             });
-    }
-
-    #[inline]
-    fn score(&self, v2: &[TElement]) -> ScoreType {
-        self.hardware_counter.cpu_counter().incr();
-        TMetric::similarity(&self.query, v2)
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -18,8 +18,6 @@ pub mod turbo_custom_query_scorer;
 pub mod turbo_query_scorer;
 
 pub trait QueryScorer {
-    type TVector: ?Sized;
-
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType;
 
     /// Score a batch of points
@@ -32,8 +30,6 @@ pub trait QueryScorer {
             scores[idx] = self.score_stored(*id);
         }
     }
-
-    fn score(&self, v2: &Self::TVector) -> ScoreType;
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType;
 

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -112,8 +112,6 @@ impl<
     TQuery: Query<TypedMultiDenseVector<TElement>>,
 > QueryScorer for MultiCustomQueryScorer<'_, TElement, TMetric, TVectorStorage, TQuery>
 {
-    type TVector = TypedMultiDenseVector<TElement>;
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self.vector_storage.get_multi::<Random>(idx);
@@ -133,11 +131,6 @@ impl<
                 vectors_read.incr_delta(vector.vectors_count());
                 scores[idx] = self.score_ref(vector);
             });
-    }
-
-    #[inline]
-    fn score(&self, against: &TypedMultiDenseVector<TElement>) -> ScoreType {
-        self.score_ref(TypedMultiDenseVectorRef::from(against))
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_metric_query_scorer.rs
@@ -89,8 +89,6 @@ impl<
     TVectorStorage: MultiVectorStorageRead<TElement>,
 > QueryScorer for MultiMetricQueryScorer<'_, TElement, TMetric, TVectorStorage>
 {
-    type TVector = TypedMultiDenseVector<TElement>;
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self.vector_storage.get_multi::<Random>(idx);
@@ -99,14 +97,6 @@ impl<
             .incr_delta(stored.as_ref().vectors_count());
 
         self.score_multi(TypedMultiDenseVectorRef::from(&self.query), stored.as_ref())
-    }
-
-    #[inline]
-    fn score(&self, v2: &TypedMultiDenseVector<TElement>) -> ScoreType {
-        self.score_multi(
-            TypedMultiDenseVectorRef::from(&self.query),
-            TypedMultiDenseVectorRef::from(v2),
-        )
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -52,11 +52,21 @@ impl<
     }
 }
 
+impl<TVectorStorage: SparseVectorStorageRead, TQuery: Query<SparseVector>>
+    SparseCustomQueryScorer<'_, TVectorStorage, TQuery>
+{
+    fn score(&self, v: &SparseVector) -> ScoreType {
+        self.query.score_by(|example| {
+            let cpu_units = v.indices.len() + example.indices.len();
+            self.hardware_counter.cpu_counter().incr_delta(cpu_units);
+            example.score(v).unwrap_or(0.0)
+        })
+    }
+}
+
 impl<TVectorStorage: SparseVectorStorageRead, TQuery: Query<SparseVector>> QueryScorer
     for SparseCustomQueryScorer<'_, TVectorStorage, TQuery>
 {
-    type TVector = SparseVector;
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self
@@ -70,14 +80,6 @@ impl<TVectorStorage: SparseVectorStorageRead, TQuery: Query<SparseVector>> Query
             .incr_delta(stored.indices.len() + stored.values.len());
 
         self.score(&stored)
-    }
-
-    fn score(&self, v: &SparseVector) -> ScoreType {
-        self.query.score_by(|example| {
-            let cpu_units = v.indices.len() + example.indices.len();
-            self.hardware_counter.cpu_counter().incr_delta(cpu_units);
-            example.score(v).unwrap_or(0.0)
-        })
     }
 
     fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -49,8 +49,6 @@ impl<'a> SparseMetricQueryScorer<'a> {
 }
 
 impl QueryScorer for SparseMetricQueryScorer<'_> {
-    type TVector = SparseVector;
-
     #[inline]
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let stored = self
@@ -59,11 +57,6 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
             .expect("Sparse vector not found");
 
         self.score_ref(&stored)
-    }
-
-    #[inline]
-    fn score(&self, v2: &SparseVector) -> ScoreType {
-        self.score_ref(v2)
     }
 
     #[inline]

--- a/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
@@ -3,7 +3,7 @@ use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
-use crate::data_types::vectors::{DenseVector, VectorElementType};
+use crate::data_types::vectors::DenseVector;
 use crate::vector_storage::DenseTQVectorStorage;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
@@ -62,8 +62,6 @@ impl<TQuery> QueryScorer for TurboCustomQueryScorer<'_, TQuery>
 where
     TQuery: Query<EncodedQueryTQ>,
 {
-    type TVector = [VectorElementType];
-
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         // Read the stored vector once (one vector of IO), then score every
         // sub-query against it — each sub-query is one vector of CPU work.
@@ -76,10 +74,6 @@ where
             cpu_counter.incr();
             self.storage.score_query_bytes(query, &bytes)
         })
-    }
-
-    fn score(&self, _v2: &[VectorElementType]) -> ScoreType {
-        unimplemented!("This method is not expected to be called for turbo scorer");
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
@@ -1,5 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::typelevel::False;
+use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
@@ -86,9 +86,14 @@ where
         unimplemented!("Custom scorer compares against multiple vectors, not just one");
     }
 
-    // TODO(TQDT): add inline scoring support
-    type SupportsBytes = False;
-    fn score_bytes(&self, enabled: Self::SupportsBytes, _bytes: &[u8]) -> ScoreType {
-        match enabled {}
+    type SupportsBytes = True;
+    fn score_bytes(&self, _: Self::SupportsBytes, bytes: &[u8]) -> ScoreType {
+        // `bytes` are an already-fetched TQ-encoded vector: no IO, and one
+        // vector of CPU work per sub-query (matching `score_stored`).
+        let cpu_counter = self.hardware_counter.cpu_counter();
+        self.query.score_by(|query| {
+            cpu_counter.incr();
+            self.storage.score_query_bytes(query, bytes)
+        })
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
@@ -1,5 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::typelevel::False;
+use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
@@ -64,9 +64,11 @@ impl QueryScorer for TurboQueryScorer<'_> {
         self.storage.score_internal_encoded(point_a, point_b)
     }
 
-    // TODO(TQDT): add inline scoring support
-    type SupportsBytes = False;
-    fn score_bytes(&self, enabled: Self::SupportsBytes, _bytes: &[u8]) -> ScoreType {
-        match enabled {}
+    type SupportsBytes = True;
+    fn score_bytes(&self, _: Self::SupportsBytes, bytes: &[u8]) -> ScoreType {
+        // `bytes` are an already-fetched TQ-encoded vector: one vector of CPU
+        // work, no IO (the caller owns the read).
+        self.hardware_counter.cpu_counter().incr();
+        self.storage.score_query_bytes(&self.query, bytes)
     }
 }

--- a/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
@@ -3,7 +3,7 @@ use common::typelevel::True;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
-use crate::data_types::vectors::{DenseVector, VectorElementType};
+use crate::data_types::vectors::DenseVector;
 use crate::vector_storage::DenseTQVectorStorage;
 use crate::vector_storage::query_scorer::QueryScorer;
 use crate::vector_storage::turbo::TurboVectorStorage;
@@ -46,17 +46,11 @@ impl<'a> TurboQueryScorer<'a> {
 }
 
 impl QueryScorer for TurboQueryScorer<'_> {
-    type TVector = [VectorElementType];
-
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let bytes = self.storage.get_quantized_vector(idx);
         self.hardware_counter.vector_io_read().incr();
         self.hardware_counter.cpu_counter().incr();
         self.storage.score_query_bytes(&self.query, &bytes)
-    }
-
-    fn score(&self, _v2: &[VectorElementType]) -> ScoreType {
-        unimplemented!("This method is not expected to be called for turbo scorer");
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -1088,6 +1088,75 @@ mod tests {
         }
     }
 
+    /// `score_bytes` must agree with `score_stored` on a stored vector's own
+    /// encoded bytes, for both the nearest and the multi-vector (reco) scorers —
+    /// the inline-rescoring path scores the exact same TQ bytes the storage
+    /// holds, so the two must produce identical scores.
+    #[test]
+    fn score_bytes_matches_score_stored() {
+        use common::typelevel::True;
+
+        use crate::vector_storage::query::{RecoBestScoreQuery, RecoQuery};
+        use crate::vector_storage::query_scorer::QueryScorer;
+        use crate::vector_storage::query_scorer::turbo_custom_query_scorer::TurboCustomQueryScorer;
+        use crate::vector_storage::query_scorer::turbo_query_scorer::TurboQueryScorer;
+
+        const COUNT: usize = 8;
+
+        for distance in [
+            Distance::Dot,
+            Distance::Cosine,
+            Distance::Euclid,
+            Distance::Manhattan,
+        ] {
+            for dim in [4, 128] {
+                for seed in SEEDS {
+                    let dir = Builder::new()
+                        .prefix("turbo_score_bytes")
+                        .tempdir()
+                        .unwrap();
+                    let hw_counter = HardwareCounterCell::new();
+                    let mut storage =
+                        open_appendable_turbo_vector_storage(dir.path(), dim, distance, true)
+                            .unwrap();
+                    let inputs = make_vectors(dim, COUNT, seed);
+                    insert_all(&mut storage, &inputs, &hw_counter);
+
+                    let nearest = TurboQueryScorer::new(
+                        inputs[0].clone(),
+                        &storage,
+                        HardwareCounterCell::new(),
+                    );
+                    let reco = TurboCustomQueryScorer::new(
+                        RecoBestScoreQuery::from(RecoQuery::new(
+                            vec![inputs[1].clone()],
+                            vec![inputs[2].clone()],
+                        )),
+                        &storage,
+                        HardwareCounterCell::new(),
+                    );
+
+                    for key in 0..COUNT as PointOffsetType {
+                        let bytes = storage.get_quantized_vector(key);
+
+                        assert_eq!(
+                            nearest.score_bytes(True, &bytes),
+                            nearest.score_stored(key),
+                            "nearest score_bytes != score_stored at {key} \
+                             (dim {dim}, {distance:?}, seed {seed:#x})",
+                        );
+                        assert_eq!(
+                            reco.score_bytes(True, &bytes),
+                            reco.score_stored(key),
+                            "reco score_bytes != score_stored at {key} \
+                             (dim {dim}, {distance:?}, seed {seed:#x})",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     /// End-to-end check of [`TurboCustomQueryScorer`] for the multi-vector
     /// (reco) path: with a single positive equal to a stored vector, the
     /// best-score and sum-score combinators must both rank that vector first,


### PR DESCRIPTION
This PR adds inline storage scoring for TQ datatype and removes `QueryScorer::score` which is obsolete