### PR TITLE
chore: implement Anonymize for f32

### DIFF
--- a/lib/segment/src/common/anonymize.rs
+++ b/lib/segment/src/common/anonymize.rs
@@ -151,6 +151,12 @@ impl Anonymize for bool {
     }
 }
 
+impl Anonymize for f32 {
+    fn anonymize(&self) -> Self {
+        *self
+    }
+}
+
 impl Anonymize for DateTime<Utc> {
     fn anonymize(&self) -> Self {
         let coeff: f32 = rand::random();


### PR DESCRIPTION
Implements `Anonymize` for `f32` as an identity impl, consistent with the existing `bool` impl. `Option<f32>` is covered by the existing blanket `impl<T: Anonymize> Anonymize for Option<T>`.

Note on scope: the `#[anonymize(false)]` workarounds on `magnitude_bound` mentioned in #9207 live in #9202, which is not merged yet — so this PR provides just the impl that lets #9202 drop those annotations and TODOs.

Closes #9207 (note: #9205 appears to be a duplicate of #9207)

🤖 Generated with [Claude Code](https://claude.com/claude-code)