### PR TITLE
fix: return 400 instead of 500 when cluster ops run in standalone mode

### DIFF
--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -559,7 +559,7 @@ impl TableOfContent {
 
         if wait {
             let dispatcher = self.toc_dispatcher.lock().clone().ok_or_else(|| {
-                StorageError::service_error("Qdrant is running in standalone mode")
+                StorageError::bad_request("Qdrant is running in standalone mode")
             })?;
             dispatcher
                 .consensus_state()
@@ -774,7 +774,7 @@ impl TableOfContent {
     fn get_consensus_proposal_sender(&self) -> Result<&OperationSender, StorageError> {
         self.consensus_proposal_sender
             .as_ref()
-            .ok_or_else(|| StorageError::service_error("Qdrant is running in standalone mode"))
+            .ok_or_else(|| StorageError::bad_request("Qdrant is running in standalone mode"))
     }
 
     /// Insert dispatcher for access to table of contents and consensus.


### PR DESCRIPTION
`POST /cluster/recover` (and the cluster metadata update path) constructed `StorageError::ServiceError` when no consensus is configured, mapping to HTTP 500 / gRPC `Internal`. Standalone mode is an expected configuration, not a server fault, so this changes both sites to `BadRequest` → HTTP 400 / gRPC `InvalidArgument`, matching the existing behavior of `DELETE /cluster/peer/{id}` ("Distributed mode disabled.").

Only two call sites use `get_consensus_proposal_sender()`, both user-facing; the internal raft snapshot path in `consensus.rs` is unrelated.

Fixes #9421

🤖 Generated with [Claude Code](https://claude.com/claude-code)