### PR TITLE
fix: don't optimize empty min_should with min_count > 0 into match-all

### DIFF
--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -76,7 +76,10 @@ where
                 conditions,
                 min_count,
             }) = filter.min_should.as_ref()
-                && !conditions.is_empty()
+                // An empty condition list is only a no-op for `min_count == 0`.
+                // With `min_count > 0` no point can satisfy the clause, so it
+                // must be kept to evaluate to false instead of match-all.
+                && !(conditions.is_empty() && *min_count == 0)
             {
                 let (optimized_conditions, estimation) = self.optimize_min_should(
                     conditions,

--- a/lib/segment/src/index/struct_payload_index/read_view/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/tests.rs
@@ -13,13 +13,14 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 
 use crate::common::utils::IndexesMap;
+use crate::id_tracker::IdTracker;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use crate::index::PayloadIndexRead;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
-use crate::types::{Filter, VectorNameBuf};
+use crate::types::{Filter, MinShould, PointIdType, VectorNameBuf};
 use crate::vector_storage::VectorStorageEnum;
 
 /// Build a view directly over in-memory backends and exercise the
@@ -61,4 +62,65 @@ fn smoke_view_over_in_memory_backends() {
 
     // `available_point_count` (inherent helper) reflects the empty tracker.
     assert_eq!(view.available_point_count(), 0);
+}
+
+/// An empty `min_should.conditions` with `min_count > 0` can never be
+/// satisfied, so it must match no points instead of being optimized away
+/// into match-all. With `min_count == 0` it is a no-op and matches all.
+///
+/// Regression test for <https://github.com/qdrant/qdrant/issues/9369>.
+#[test]
+fn empty_min_should_with_min_count_matches_nothing() {
+    let payload: Arc<AtomicRefCell<InMemoryPayloadStorage>> =
+        Arc::new(AtomicRefCell::new(InMemoryPayloadStorage::default()));
+    let mut id_tracker = InMemoryIdTracker::new();
+    for internal_id in 0..2 {
+        id_tracker
+            .set_link(PointIdType::NumId(u64::from(internal_id) + 1), internal_id)
+            .unwrap();
+        id_tracker.set_internal_version(internal_id, 1).unwrap();
+    }
+    let vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>> =
+        HashMap::new();
+    let field_indexes = IndexesMap::new();
+    let config = PayloadConfig::default();
+    let visited_pool = VisitedPool::new();
+
+    let view: StructPayloadIndexReadView<'_, _, _, VectorStorageEnum, _> =
+        StructPayloadIndexReadView {
+            payload: &payload,
+            id_tracker: &id_tracker,
+            vector_storages: &vector_storages,
+            field_indexes: &field_indexes,
+            config: &config,
+            visited_pool: &visited_pool,
+        };
+
+    let hw_counter = HardwareCounterCell::new();
+    let is_stopped = AtomicBool::new(false);
+
+    let unsatisfiable = Filter::new_min_should(MinShould {
+        conditions: vec![],
+        min_count: 1,
+    });
+    let result = view
+        .query_points(&unsatisfiable, &hw_counter, &is_stopped)
+        .expect("query_points");
+    assert!(
+        result.is_empty(),
+        "empty min_should with min_count=1 must match no points, got {result:?}"
+    );
+
+    let noop = Filter::new_min_should(MinShould {
+        conditions: vec![],
+        min_count: 0,
+    });
+    let result = view
+        .query_points(&noop, &hw_counter, &is_stopped)
+        .expect("query_points");
+    assert_eq!(
+        result.len(),
+        2,
+        "empty min_should with min_count=0 is a no-op and must match all points"
+    );
 }


### PR DESCRIPTION
`optimize_filter` dropped the `min_should` clause whenever its condition list was empty, turning an unsatisfiable filter (`conditions: [], min_count: 1`) into no filter at all — count/scroll/search returned every point. The optimized-filter checker and the cardinality estimator both already handle the empty list correctly (always-false / `exact(0)`), so the clause is now only dropped when `min_count == 0`, where "at least 0 conditions match" is genuinely a no-op.

Includes a regression test exercising `query_points` through the read view; verified it fails on the unfixed optimizer.

Fixes #9369

🤖 Generated with [Claude Code](https://claude.com/claude-code)