### PR TITLE
test: stabilize flaky cancellation timing tests

### DIFF
--- a/lib/collection/src/tests/hw_metrics.rs
+++ b/lib/collection/src/tests/hw_metrics.rs
@@ -108,9 +108,13 @@ async fn test_hw_metrics_cancellation() {
         );
     }
 
-    // Cancellation and draining hardware counters is asynchronous on CI runners.
-    // Poll with a bounded timeout to avoid timing-sensitive flakes.
-    let wait_timeout = Duration::from_secs(2);
+    // Cancellation and draining hardware counters is asynchronous: the
+    // counters are only drained once the timed-out search task reaches a
+    // cancellation checkpoint and is dropped, which on oversubscribed CI
+    // runners has been observed to take longer than 2s (see #9184). The loop
+    // exits as soon as the drain happens, so a generous ceiling adds no
+    // latency to healthy runs.
+    let wait_timeout = Duration::from_secs(60);
     let poll_interval = Duration::from_millis(10);
     let wait_started = std::time::Instant::now();
     while outer_hw.get_cpu() == 0 {

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -504,8 +504,11 @@ fn test_building_cancellation() {
     let (time_long, was_cancelled_later) = estimate_build_time(&segment_2, Some(late_stop_delay));
 
     // Timing on CI (especially Windows) can be noisy due to scheduler delays.
-    // Keep a fixed lower bound but scale tolerance for slower baseline runs.
-    let acceptable_stopping_delay = std::cmp::max(600, time_baseline / 8); // millis
+    // Reaction to the stop flag is bounded by the largest non-interruptible
+    // chunk of build work plus scheduler noise, neither of which shrinks with
+    // the baseline, so the fixed floor must dominate. Reactions of ~860ms were
+    // observed on windows-latest with a ~3.5s baseline (see #9183).
+    let acceptable_stopping_delay = std::cmp::max(1500, time_baseline / 4); // millis
 
     assert!(was_cancelled_early);
     assert!(
@@ -518,15 +521,13 @@ fn test_building_cancellation() {
         time_long < late_stop_delay + acceptable_stopping_delay,
         "time_later: {time_long}, late_stop_delay: {late_stop_delay}"
     );
-    assert!(
-        time_long < time_baseline,
-        "cancelled build should be faster than baseline: time_later={time_long}, baseline={time_baseline}",
-    );
 
-    assert!(
-        time_fast < time_long,
-        "time_early: {time_fast}, time_later: {time_long}, was_cancelled_later: {was_cancelled_later}",
-    );
+    // Comparative assertions between runs (early vs late vs baseline) are
+    // deliberately avoided: the reaction time to the stop flag can vary by
+    // more than the difference between the stop delays, which made such
+    // assertions flaky on CI. Ignored cancellation is already caught by the
+    // `was_cancelled_*` checks (the build would complete with `Ok`), and
+    // prompt reaction is covered by the per-run bounds above.
 }
 
 /// `SegmentBuilder::update` must reject schema mismatches in both directions


### PR DESCRIPTION
`test_building_cancellation` (#9183): reaction time to the stop flag is bounded by the largest non-interruptible chunk of build work plus scheduler noise — neither shrinks with the baseline, and ~860ms reactions were observed on windows-latest against the 600ms allowance. Raises the tolerance floor to 1500ms (scaling with baseline/4) and removes the cross-run comparative assertions, which fail whenever reaction variance exceeds the gap between stop delays. Ignored cancellation is still caught by the `was_cancelled` checks.

`test_hw_metrics_cancellation` (#9184): counters drain only when the timed-out search task reaches a cancellation checkpoint; on oversubscribed macOS runners this exceeded the 2s polling ceiling. Raises the ceiling to 60s — the loop exits as soon as the drain happens, so healthy runs are unaffected.

Fixes #9183
Fixes #9184

🤖 Generated with [Claude Code](https://claude.com/claude-code)