### PR TITLE
perf(segment): software-prefetch vectors in dense batch scoring

### DIFF
--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -214,14 +214,22 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             let (vectors, _) = maybe_uninit_fill_from(
                 &mut vectors_buffer,
                 keys.iter().map(|&key| {
-                    self.get_many_impl(key.offset(), 1, force_sequential)
-                        .expect("vectors read")
+                    let vector = self
+                        .get_many_impl(key.offset(), 1, force_sequential)
+                        .expect("vectors read");
+                    // Start pulling the first lines into cache early; the rest
+                    // is prefetched one vector ahead in the scoring loop below.
+                    prefetch_first_line(vector.as_ref());
+                    vector
                 }),
             );
 
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
             for (vector_idx, vec) in vectors.iter().enumerate() {
+                if let Some(next) = vectors.get(vector_idx + 1) {
+                    prefetch_full(next.as_ref());
+                }
                 callback(batch_offset + vector_idx, vec.as_ref());
             }
         }
@@ -317,6 +325,34 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
 
         0
     }
+}
+
+#[inline(always)]
+fn prefetch_first_line<T>(slice: &[T]) {
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        _mm_prefetch(slice.as_ptr().cast::<i8>(), _MM_HINT_T0);
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    let _ = slice;
+}
+
+#[inline(always)]
+fn prefetch_full<T>(slice: &[T]) {
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        let bytes = std::mem::size_of_val(slice);
+        let ptr = slice.as_ptr().cast::<i8>();
+        let mut offset = 0;
+        while offset < bytes {
+            _mm_prefetch(ptr.add(offset), _MM_HINT_T0);
+            offset += 64;
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    let _ = slice;
 }
 
 pub(super) fn read_status_len<Fs: UniversalReadFs>(


### PR DESCRIPTION
## What

`ChunkedVectorsRead::for_each_in_batch` resolves all vector references for a batch first and only touches the data in the scoring callback, so each vector is a cold DRAM access serialized behind the previous distance computation. This PR:

- prefetches the first cache line of each vector while the batch is being resolved,
- prefetches the next vector in full while the current one is scored (hnswlib does the equivalent in its search loop).

x86_64 only (`_mm_prefetch`), no-op elsewhere. No behavior change.

## Why

Investigation into HNSW build being ~1.9× slower than vanilla hnswlib (1M × 512d cosine, 4 cores) showed ~73% of build time is memory-stall-dominated dot-product self time; hnswlib hides part of that latency with software prefetch and we don't.

## Measurements

HNSW build path harness (200k × 512d cosine, M=16, ef_construct=100, 4 pinned cores, in-RAM chunked mmap storage), AMD Zen 4/5:

| variant | throughput |
|---|---|
| baseline | 3173 pts/s |
| this PR | 3292 pts/s (+3.7%) |

Effect should be larger on CPUs with weaker hardware prefetchers / higher memory latency (the original benchmark box is EPYC Rome class). This path is also used by query-time dense scoring, so search benchmarks are worth a look — expected neutral-to-positive.

## Checklist

- [x] `cargo test -p segment` scoring paths unaffected (zero-copy reads unchanged, prefetch is side-effect-free)
- [ ] re-run 1M × 512d build benchmark on the original (EPYC Rome) setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)