### PR TITLE
perf(segment): runtime-dispatched AVX-512 dot product kernel

### DIFF
--- a/lib/segment/src/spaces/mod.rs
+++ b/lib/segment/src/spaces/mod.rs
@@ -8,6 +8,9 @@ pub mod simple_sse;
 #[cfg(target_arch = "x86_64")]
 pub mod simple_avx;
 
+#[cfg(target_arch = "x86_64")]
+pub mod simple_avx512;
+
 pub mod metric_f16;
 pub mod metric_uint;
 

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -3,6 +3,8 @@ use common::types::ScoreType;
 use super::metric::{Metric, MetricPostProcessing};
 #[cfg(target_arch = "x86_64")]
 use super::simple_avx::*;
+#[cfg(target_arch = "x86_64")]
+use super::simple_avx512::*;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -13,6 +15,9 @@ use crate::types::Distance;
 
 #[cfg(target_arch = "x86_64")]
 pub(crate) const MIN_DIM_SIZE_AVX: usize = 32;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) const MIN_DIM_SIZE_AVX512: usize = 64;
 
 #[cfg(any(
     target_arch = "x86",
@@ -129,6 +134,10 @@ impl Metric<VectorElementType> for DotProductMetric {
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
+            if is_x86_feature_detected!("avx512f") && v1.len() >= MIN_DIM_SIZE_AVX512 {
+                return unsafe { dot_similarity_avx512(v1, v2) };
+            }
+
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
                 && v1.len() >= MIN_DIM_SIZE_AVX

--- a/lib/segment/src/spaces/simple_avx512.rs
+++ b/lib/segment/src/spaces/simple_avx512.rs
@@ -1,0 +1,79 @@
+use std::arch::x86_64::*;
+
+use common::types::ScoreType;
+
+use crate::data_types::vectors::VectorElementType;
+
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn dot_similarity_avx512(
+    v1: &[VectorElementType],
+    v2: &[VectorElementType],
+) -> ScoreType {
+    unsafe {
+        let n = v1.len();
+        let m = n - (n % 64);
+        let mut ptr1: *const f32 = v1.as_ptr();
+        let mut ptr2: *const f32 = v2.as_ptr();
+        let mut sum512_1: __m512 = _mm512_setzero_ps();
+        let mut sum512_2: __m512 = _mm512_setzero_ps();
+        let mut sum512_3: __m512 = _mm512_setzero_ps();
+        let mut sum512_4: __m512 = _mm512_setzero_ps();
+        let mut i: usize = 0;
+        while i < m {
+            sum512_1 = _mm512_fmadd_ps(_mm512_loadu_ps(ptr1), _mm512_loadu_ps(ptr2), sum512_1);
+            sum512_2 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(16)),
+                _mm512_loadu_ps(ptr2.add(16)),
+                sum512_2,
+            );
+            sum512_3 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(32)),
+                _mm512_loadu_ps(ptr2.add(32)),
+                sum512_3,
+            );
+            sum512_4 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(48)),
+                _mm512_loadu_ps(ptr2.add(48)),
+                sum512_4,
+            );
+
+            ptr1 = ptr1.add(64);
+            ptr2 = ptr2.add(64);
+            i += 64;
+        }
+
+        let mut result = _mm512_reduce_add_ps(_mm512_add_ps(
+            _mm512_add_ps(sum512_1, sum512_2),
+            _mm512_add_ps(sum512_3, sum512_4),
+        ));
+
+        for j in 0..n - m {
+            result += (*ptr1.add(j)) * (*ptr2.add(j));
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_dot_avx512() {
+        use crate::spaces::simple::dot_similarity;
+
+        if !is_x86_feature_detected!("avx512f") {
+            println!("avx512 test skipped");
+            return;
+        }
+        // Sizes around the 64-element unroll boundary, including remainders.
+        for n in [64, 65, 127, 128, 512, 517] {
+            let v1: Vec<f32> = (0..n).map(|i| (i as f32).sin()).collect();
+            let v2: Vec<f32> = (0..n).map(|i| (i as f32 * 0.7).cos()).collect();
+            let simd = unsafe { super::dot_similarity_avx512(&v1, &v2) };
+            let scalar = dot_similarity(&v1, &v2);
+            assert!(
+                (simd - scalar).abs() <= scalar.abs().max(1.0) * 1e-5,
+                "n={n}: {simd} vs {scalar}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `dot_similarity_avx512` (4 × 512-bit FMA accumulators, 64 floats/iteration, remainder loop) in `spaces/simple_avx512.rs`, runtime-dispatched in `DotProductMetric::similarity` (and therefore `CosineMetric`) when `avx512f` is detected and `dim >= 64`. Existing AVX2/SSE/scalar paths unchanged and used as fallback. Unit test compares against the scalar kernel across unroll-boundary sizes.

## Context

Earlier AVX-512 experiments were inconclusive, so this is intentionally a **draft** with the measurement attached; it should only land if it proves out on relevant hardware.

From the HNSW-build-vs-hnswlib investigation (1M × 512d cosine benchmark): the original benchmark box (Hetzner cx43) turned out to be EPYC Rome **without** AVX-512, so this kernel is *not* the explanation for that gap, and on memory-bound workloads it contributes little:

| setup | result |
|---|---|
| HNSW build, 200k × 512d, 4 pinned cores, AMD Zen 4/5 (double-pumped AVX-512) | +1.8% over AVX2 kernel |

Where it could matter more: Intel server CPUs with two native 512-bit FMA ports (Ice Lake SP / Sapphire Rapids+) and cache-resident scoring (quantization rescoring, small datasets, full-scan), where the kernel is compute-bound rather than DRAM-bound.

## Before undrafting

- [ ] Benchmark on an Intel AVX-512 machine (build + search + full-scan)
- [ ] Decide whether Euclid/Manhattan/cosine-preprocess get the same treatment (this PR wires Dot only)
- [ ] Check no frequency-throttling regression on older Intel (Skylake-SP license-based downclocking) — possibly gate on family or keep dim threshold higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)