### PR TITLE
Enable multivector in Collection model test, fix multi-dense reload corruption

### DIFF
--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -58,8 +58,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
 ];
 
 /// Names present in the collection schema at fixture time.
-// "m" (multivector) is temporarily disabled while its reload divergence is unresolved.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s"];
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m"];
 
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -428,12 +428,9 @@ impl Op {
             22 => {
                 // CreateVectorName: pick a candidate currently absent from the active set.
                 // If all candidates are active, fall back to a regular upsert.
-                // Multivector (`MultiDense`) candidates are excluded while their reload
-                // divergence is unresolved — see the note on `INITIAL_ACTIVE`.
                 let inactive: Vec<&'static super::VectorCandidate> = ALL_CANDIDATES
                     .iter()
                     .filter(|c| !active.contains(c.name))
-                    .filter(|c| !matches!(c.kind, VectorKind::MultiDense(_)))
                     .collect();
                 if inactive.is_empty() {
                     return upsert_fallback(rng, active, id_pool);

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -230,6 +230,22 @@ where
         Ok(new_id)
     }
 
+    /// Widen the recorded length to at least `len` without writing any vector data.
+    ///
+    /// Reload-time repair hook: flushers snapshot `status.len` at creation time but msync
+    /// chunk data at execution time, so a crash can leave durable rows (and durable
+    /// references to them in a sibling store) beyond the recorded length. The data is
+    /// already on disk; only the length lagged. Clamped to the physically existing chunk
+    /// space so a corrupt caller-supplied value can't make reads address missing chunks.
+    pub fn ensure_len_at_least(&mut self, len: usize) {
+        let physical_capacity = self.inner.chunks.len() * self.inner.config.chunk_size_vectors;
+        let len = len.min(physical_capacity);
+        if len > self.status.len {
+            self.status.len = len;
+            self.inner.len = len;
+        }
+    }
+
     pub fn flusher(&self) -> Flusher {
         Box::new({
             let status_flusher = self.status.flusher();

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -573,8 +573,9 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     let offsets_path = path.join(OFFSETS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors = ChunkedVectors::open(MmapFs, &vectors_path, dim, madvise, Some(populate))?;
+    let mut vectors = ChunkedVectors::open(MmapFs, &vectors_path, dim, madvise, Some(populate))?;
     let offsets = ChunkedVectors::open(MmapFs, &offsets_path, 1, madvise, Some(populate))?;
+    repair_vectors_len(&mut vectors, &offsets);
 
     let deleted = BitvecFlags::new(
         MmapFs,
@@ -590,6 +591,52 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
         multi_vector_config,
         deleted_count,
     })
+}
+
+/// Reload-time repair for the two-store flush skew.
+///
+/// `vectors` and `offsets` are flushed independently, and each flusher snapshots its
+/// `status.len` at creation time while msyncing chunk data at execution time. A point
+/// re-upserted through the append path in that window rewrites its `offsets` entry in
+/// place to a freshly-appended row region; the entry can land durably while `vectors`'
+/// recorded length still predates the rows it references. The rows themselves are
+/// durable (the storage flusher msyncs `vectors` before `offsets`), so it suffices to
+/// widen the recorded length to cover the maximum referenced row-end. Without this,
+/// reads of such entries are rejected and, worse, a WAL-replayed append reuses those
+/// rows (`new_key = vectors.len()`) and overwrites another point's data.
+fn repair_vectors_len<T: PrimitiveVectorElement>(
+    vectors: &mut ChunkedVectors<T, MmapFile>,
+    offsets: &ChunkedVectors<MultivectorMmapOffset, MmapFile>,
+) {
+    let mut max_row_end = 0;
+    for key in 0..offsets.len() {
+        let Some(entry) = offsets.get::<Sequential>(key as VectorOffsetType) else {
+            continue;
+        };
+        let &[
+            MultivectorMmapOffset {
+                offset,
+                count: _,
+                // The reserved region is `offset..offset + capacity`; `count` only shrinks
+                // within it on in-place re-upserts, and the original append recorded
+                // `offset + capacity` as the length contribution.
+                capacity,
+            },
+        ] = entry.as_ref()
+        else {
+            unreachable!("multi-vector offsets are stored as vectors of length 1");
+        };
+        max_row_end = max_row_end.max(offset as usize + capacity as usize);
+    }
+    if max_row_end > vectors.len() {
+        log::warn!(
+            "Multi-vector offsets reference rows beyond the recorded vectors length \
+             ({} > {}); widening it (stale length snapshot from an interrupted flush)",
+            max_row_end,
+            vectors.len(),
+        );
+        vectors.ensure_len_at_least(max_row_end);
+    }
 }
 
 /// Find files related to this dense vector storage
@@ -674,5 +721,90 @@ mod tests {
             storage_files, found_files,
             "find_storage_files must find same files that storage reports",
         );
+    }
+
+    /// Reproduces the on-disk state left by an interrupted flush: rows and the offsets
+    /// entries referencing them are durable, but the vectors store's recorded length
+    /// (`status.dat`) is stale. Without `repair_vectors_len`, reopening makes those
+    /// points unreadable and lets appends overwrite their rows.
+    #[test]
+    fn repair_stale_vectors_len_on_reload() {
+        const POINT_COUNT: PointOffsetType = 100;
+        const DIM: usize = 4;
+
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(RAND_SEED);
+        let hw_counter = HardwareCounterCell::disposable();
+
+        let mut expected = Vec::new();
+        {
+            let mut storage =
+                open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                    dir.path(),
+                    DIM,
+                    Distance::Dot,
+                    MultiVectorConfig::default(),
+                    AdviceSetting::Global,
+                    false,
+                )
+                .unwrap();
+            for internal_id in 0..POINT_COUNT {
+                let size = rng.random_range(2..=4);
+                let vectors = std::iter::repeat_with(|| {
+                    std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                        .take(DIM)
+                        .collect()
+                })
+                .take(size)
+                .collect::<Vec<Vec<_>>>();
+                let multivec = MultiDenseVectorInternal::try_from(vectors).unwrap();
+                storage
+                    .insert_vector(internal_id, VectorRef::from(&multivec), &hw_counter)
+                    .unwrap();
+                expected.push(multivec);
+            }
+            storage.flusher()().unwrap();
+        }
+
+        // Rewind the recorded length to 1 row, leaving the row data and the offsets
+        // entries untouched: the exact skew an interrupted flush persists.
+        let status_file = ChunkedVectorsRead::<VectorElementType, MmapFile>::status_file(
+            &dir.path().join(VECTORS_DIR_PATH),
+        );
+        let mut status_bytes = fs::read(&status_file).unwrap();
+        let true_len = usize::from_ne_bytes(
+            status_bytes[..std::mem::size_of::<usize>()]
+                .try_into()
+                .unwrap(),
+        );
+        assert!(true_len > 1, "fixture must have appended multiple rows");
+        status_bytes[..std::mem::size_of::<usize>()].copy_from_slice(&1usize.to_ne_bytes());
+        fs::write(&status_file, &status_bytes).unwrap();
+
+        let storage = open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            MultiVectorConfig::default(),
+            AdviceSetting::Global,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            storage.vectors.len(),
+            true_len,
+            "repair must restore the full recorded length",
+        );
+        for (internal_id, multivec) in expected.iter().enumerate() {
+            let read = storage
+                .get_multi_opt::<Random>(internal_id as PointOffsetType)
+                .unwrap_or_else(|| panic!("point {internal_id} unreadable after reload"));
+            assert_eq!(
+                read.as_vec_ref().flattened_vectors,
+                multivec.flattened_vectors.as_slice(),
+                "point {internal_id} content diverged after reload",
+            );
+        }
     }
 }


### PR DESCRIPTION
### What

Two changes that belong together:

1. **Fix** a multi-dense storage corruption that occurs on reload after an interrupted flush.
2. **Enable** the `"m"` multivector in the model-testing soak. This is what surfaces the bug, and it gates against regressions.

### TL;DR for reviewers

The bug only manifests on a crash or restart during a narrow flush window.

The data on disk is never lost. Only a recorded length lags behind it.

The fix is a reload-time repair that widens that length to match the durable data.

It is a no-op on healthy storage, guarded by `max_row_end > vectors.len()`.

It cannot widen past physically existing chunks, clamped to allocated capacity.

The worst it can do on genuinely corrupt input is nothing.

There is no behavior change for any storage other than appendable multi-dense. `ensure_len_at_least` is added to `ChunkedVectors` but called from exactly one place.

### The bug

`AppendableMmapMultiDenseVectorStorage` splits each point across two independently-flushed stores:

```
offsets store:  key -> { offset, count, capacity }   (where the rows live)
vectors store:  [ row, row, row, ... ]  + recorded length
```

A flusher snapshots `status.len` at creation time, but msyncs chunk data at execution time.

When a **re-upsert grows a point past its reserved `capacity`,** its rows are appended to `vectors`. Its `offsets` entry is rewritten in place to point at them.

If that lands inside a flush's creation-to-execution window:

```
DURABLE on disk:        offsets[k] = { offset: 80, capacity: 8 }   <- references rows 80..88
                        vectors rows 0..88 all written
STALE recorded length:  vectors.len = 80                           <- snapshot predates the grow
```

On reload, the entry references rows past the recorded length. Two things follow.

Reads of that point are rejected, because the length check fails.

Worse, a WAL-replayed append picks `new_key = vectors.len()`, the stale 80. It overwrites rows that another durable entry already owns. Head rows are clobbered, tail intact. This is the observed signature.

### Fix: reload-time repair

Rows are always durable before the entries that reference them. The storage flusher msyncs `vectors` before `offsets`.

So only the recorded length can lie. The data never can.

We therefore trust the entries and rebuild the length.

`repair_vectors_len` is called when opening the storage. It scans live offset entries, computes the max referenced row-end (`offset + capacity`), and widens the recorded `vectors` length to cover it. It logs a warning when it fires.

`ChunkedVectors::ensure_len_at_least` widens the recorded length without writing data, clamped to physically allocated chunk space.

**Why this is safe to approve:**

It fires only when `max_row_end > vectors.len()`. That is exactly the corruption signature, never a healthy reload.

It is clamped to allocated chunks. A bad value cannot make reads address missing memory.

It uses `capacity`, the reserved region the original append sized the store for, not `count`. A later in-place shrink cannot under-repair.

**Why repair instead of a consistent flush snapshot:**

The alternative needs execution-time lengths threaded through core `ChunkedVectors` and `StoredStruct`, shared by every storage. That is a far larger and riskier change.

### Does this fully close the bug?

This PR makes the situation strictly better, and never worse.

There is one remaining skew it does not cover. The same mechanism can also lag the `offsets` store's own recorded length, hiding entries from the repair scan.

That case is rare. It needs even tighter flush timing. It is not reachable more often because of this change.

The proper fix requires persisting execution-consistent lengths, tracked separately. This is called out for honesty, not as a known regression.

### Scope

Storage fix: `chunked_vectors/write.rs`, `appendable_mmap_multi_dense_vector_storage.rs`.

Model test: `"m"` added to `INITIAL_ACTIVE`. The `CreateVectorName` generator no longer filters out `MultiDense`.

### Testing

New regression test `repair_stale_vectors_len_on_reload`. It reproduces the on-disk skew by rewinding `vectors/status.dat`, then verifies all points read back correctly after reopen. It fails without the repair.

Deterministic repro, fails without the fix:

```
model_testing --seed 1 --shard-count 1 --disable-optimizer \
  --restart-probability 0.002 --swarm-interval 2500
```

It panics at the op-1089 restart on point 4's `m` vector.

Soak seeds 1 through 7 (10k ops, 1 shard, optimizer off) all green.

Both `model_testing` harness smoke tests pass with multivector enabled.

Existing `multi_dense` and `chunked_vectors` suites pass. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
