### PR TITLE
Add timeout to snapshot starting, use semaphore to enforce exclusivity

### DIFF
--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -23,6 +23,7 @@ fs-err = { workspace = true, features = ["debug"] }
 proptest = { workspace = true }
 rstest = { workspace = true }
 tar = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 approx = "0.5.1"
 collection = { path = ".", features = ["testing"] }
 common = { path = "../common/common", features = ["testing"] }

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -120,7 +120,16 @@ impl Collection {
 
             for future in futures {
                 future.await.map_err(|err| {
-                    CollectionError::service_error(format!("failed to create snapshot: {err}"))
+                    // Keep the transient timeout class (e.g. another snapshot of a shard is
+                    // still in flight), so the collection snapshot fails as retriable timeout
+                    // rather than internal error
+                    if let CollectionError::Timeout { description } = err {
+                        CollectionError::Timeout {
+                            description: format!("failed to create snapshot: {description}"),
+                        }
+                    } else {
+                        CollectionError::service_error(format!("failed to create snapshot: {err}"))
+                    }
                 })?;
             }
         }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -59,7 +59,7 @@ use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
-use tokio::sync::{Mutex, RwLock as TokioRwLock, mpsc, oneshot};
+use tokio::sync::{Mutex, RwLock as TokioRwLock, Semaphore, mpsc, oneshot};
 use tokio_util::task::AbortOnDropHandle;
 
 use self::clock_map::{ClockMap, RecoveryPoint};
@@ -142,6 +142,14 @@ pub struct LocalShard {
 
     /// Persist the applied op_num sequence number
     applied_seq_handler: Arc<AppliedSeqHandler>,
+
+    /// Limits the shard to a single in-flight snapshot at a time.
+    ///
+    /// Acquired in async context when creating a snapshot, before the snapshot task occupies a
+    /// blocking thread and takes the segment holder lock. Waiting for an in-flight snapshot must
+    /// happen on this semaphore, where it is cancellable and threadless, never on the segment
+    /// holder lock inside a blocking task. See [`LocalShard::get_snapshot_creator`].
+    snapshot_semaphore: Arc<Semaphore>,
 }
 
 /// Shard holds information about segments and WAL.
@@ -336,6 +344,7 @@ impl LocalShard {
             is_gracefully_stopped: false,
             update_operation_lock: scroll_read_lock,
             applied_seq_handler,
+            snapshot_semaphore: Arc::new(Semaphore::new(1)),
         }
     }
 

--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use common::save_on_disk::SaveOnDisk;
 use common::tar_ext;
@@ -28,13 +29,56 @@ use wal::{Wal, WalOptions};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::local_shard::{LocalShard, LocalShardClocks};
 
+/// Maximum time a new snapshot attempt waits for the previous snapshot of the same shard to
+/// finish.
+///
+/// Waiting happens in async context, before any blocking thread or lock is occupied, and is
+/// always safe to cancel. The timeout is longer than the streamed snapshot write idle timeout
+/// (`SNAPSHOT_STREAM_WRITE_IDLE_TIMEOUT`, 5 minutes), so that a snapshot queued behind a stalled
+/// streamed snapshot is still around to proceed once the stalled one times out and unwinds.
+const SHARD_SNAPSHOT_PERMIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Maximum time the snapshot task waits for the segment holder lock.
+///
+/// This wait happens on a blocking thread and cannot be cancelled, so it must be bounded — a
+/// wedged lock holder must never pin blocking threads indefinitely. Snapshots are serialized
+/// through the shard snapshot permit before reaching this lock, so contention here comes from
+/// optimizers, which hold this lock only for bounded local work (proxying and finalization),
+/// never across network-paced writes. The timeout is generous to never fail on legitimate
+/// contention.
+const SEGMENT_HOLDER_LOCK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
 impl LocalShard {
     pub async fn snapshot_manifest(&self) -> CollectionResult<SnapshotManifest> {
         let task = {
             let _runtime = self.search_runtime.tokio_handle().enter();
 
             let segments = self.segments.clone();
-            cancel::blocking::spawn_cancel_on_drop(move |_| segments.read().snapshot_manifest())
+            cancel::blocking::spawn_cancel_on_drop(move |cancel| {
+                // This runs on a blocking thread, where an unbounded lock wait would pin the
+                // thread for as long as the current lock holder is stuck (e.g. a snapshot paced
+                // by a stalled remote consumer). Wait in slices, so the thread is freed early
+                // when the request is dropped, and bounded in total.
+                const LOCK_WAIT_SLICE: Duration = Duration::from_secs(1);
+                let deadline = Instant::now() + SEGMENT_HOLDER_LOCK_TIMEOUT;
+                let segments = loop {
+                    if cancel.is_cancelled() {
+                        return Err(OperationError::cancelled(
+                            "snapshot manifest request was cancelled",
+                        ));
+                    }
+                    if let Some(guard) = segments.try_read_for(LOCK_WAIT_SLICE) {
+                        break guard;
+                    }
+                    if Instant::now() >= deadline {
+                        return Err(OperationError::timeout(
+                            SEGMENT_HOLDER_LOCK_TIMEOUT,
+                            "acquire segment holder lock for snapshot manifest",
+                        ));
+                    }
+                };
+                segments.snapshot_manifest()
+            })
         };
 
         Ok(task.await??)
@@ -46,7 +90,12 @@ impl LocalShard {
         Ok(())
     }
 
-    /// Create snapshot for local shard into `target_path`
+    /// Create snapshot for local shard
+    ///
+    /// At most one snapshot of a shard is created at a time: the returned future first waits
+    /// for any in-flight snapshot of this shard to finish — in async context, where the wait is
+    /// cancellable and threadless — and fails with a transient [`CollectionError::Timeout`]
+    /// after [`SHARD_SNAPSHOT_PERMIT_TIMEOUT`].
     pub async fn get_snapshot_creator(
         &self,
         temp_path: &Path,
@@ -79,6 +128,7 @@ impl LocalShard {
 
         let tar = tar.clone();
         let temp_path = temp_path.to_path_buf();
+        let snapshot_semaphore = Arc::clone(&self.snapshot_semaphore);
 
         let plunger_notify = if !save_wal {
             // If we are not saving WAL, we still need to make sure that all submitted by this point
@@ -90,11 +140,37 @@ impl LocalShard {
         };
 
         let future = async move {
+            // Take the shard snapshot permit: at most one snapshot per shard is created at a
+            // time. Waiting for an in-flight snapshot happens here, in async context, instead of
+            // on the segment holder lock inside the blocking task below. Snapshots can be paced
+            // by a slow remote consumer (streamed shard transfers), so waiting on that lock can
+            // pin a blocking thread for a long time — with retried transfers, one thread per
+            // attempt, eventually exhausting the blocking pool.
+            let snapshot_permit = tokio::time::timeout(
+                SHARD_SNAPSHOT_PERMIT_TIMEOUT,
+                snapshot_semaphore.acquire_owned(),
+            )
+            .await
+            .map_err(|_elapsed| {
+                CollectionError::timeout(
+                    SHARD_SNAPSHOT_PERMIT_TIMEOUT,
+                    "wait until the previous snapshot of this shard is finished",
+                )
+            })?
+            .map_err(|_closed| {
+                CollectionError::service_error("Shard snapshot semaphore is closed")
+            })?;
+
             if let Some(plunger_notify) = plunger_notify {
                 plunger_notify.await?;
             }
 
             let handle = tokio::task::spawn_blocking(move || {
+                // Hold the permit for all snapshot work: both the segment holder lock and the
+                // WAL lock below are held across writes into the (possibly network-paced) tar
+                // archive.
+                let _snapshot_permit = snapshot_permit;
+
                 // Do not change segments while snapshotting
                 snapshot_all_segments(
                     segments.clone(),
@@ -272,6 +348,7 @@ pub fn snapshot_all_segments(
         segment_config,
         payload_index_schema,
         deferred_internal_id,
+        SEGMENT_HOLDER_LOCK_TIMEOUT,
         |segment| {
             let read_segment = segment.read();
             let request_segment_manifest = if let Some(manifest) = manifest {
@@ -309,6 +386,11 @@ pub fn snapshot_all_segments(
 /// the segment holder while segments are in proxified state. That means no other actors can
 /// take a write lock while this operation is running.
 ///
+/// Acquiring the segment holder lock is bounded by `segments_lock_timeout`: this function runs
+/// on a blocking thread and the wait cannot be cancelled, so it must never wait indefinitely.
+/// On timeout a transient [`OperationError::Timeout`] error is returned and the operation can
+/// be retried.
+///
 /// As part of this process, a new segment is created. All proxies direct their writes to this
 /// segment. The segment is added to the collection if it has any operations, otherwise it is
 /// deleted when all segments are unproxied again.
@@ -323,12 +405,20 @@ pub fn proxy_all_segments_and_apply<F>(
     segment_config: Option<SegmentConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     deferred_internal_id: Option<PointOffsetType>,
+    segments_lock_timeout: Duration,
     mut operation: F,
 ) -> OperationResult<()>
 where
     F: FnMut(&RwLock<dyn StorageSegmentEntry>) -> OperationResult<()>,
 {
-    let segments_lock = segments.upgradable_read();
+    let segments_lock = segments
+        .try_upgradable_read_for(segments_lock_timeout)
+        .ok_or_else(|| {
+            OperationError::timeout(
+                segments_lock_timeout,
+                "acquire segment holder lock for snapshot",
+            )
+        })?;
 
     // Proxy all segments
     // Proxied segments are sorted by flush ordering

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -1,17 +1,25 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
+use common::budget::ResourceBudget;
 use common::save_on_disk::SaveOnDisk;
 use common::tar_ext;
 use fs_err::File;
+use segment::common::operation_error::OperationError;
 use segment::types::SnapshotFormat;
 use shard::fixtures::{build_segment_1, build_segment_2};
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::SegmentHolder;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tempfile::Builder;
+use tokio::runtime::Handle;
 
-use crate::shards::local_shard::snapshot::snapshot_all_segments;
+use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::operations::types::CollectionError;
+use crate::shards::local_shard::LocalShard;
+use crate::shards::local_shard::snapshot::{proxy_all_segments_and_apply, snapshot_all_segments};
+use crate::tests::fixtures::create_collection_config;
 
 #[test]
 fn test_snapshot_all() {
@@ -70,4 +78,171 @@ fn test_snapshot_all() {
     let archive_count = tar.entries_with_seek().unwrap().count();
     // one archive produced per concrete segment in the SegmentHolder
     assert_eq!(archive_count, 2);
+}
+
+/// Taking the segment holder lock for snapshotting must be bounded: this wait happens on a
+/// blocking thread, and an unbounded wait pins that thread for as long as the current lock
+/// holder is stuck (e.g. a snapshot paced by a stalled remote consumer).
+#[test]
+fn test_snapshot_segment_holder_lock_timeout() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_segment_1(dir.path());
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(segment);
+    let holder = LockedSegmentHolder::new(holder);
+
+    let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+
+    let payload_schema_file = dir.path().join("payload.schema");
+    let schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_schema_file).unwrap());
+
+    // Hold the single upgradable slot, like a wedged snapshot or a running optimizer would
+    let _guard = holder.upgradable_read();
+
+    let result = proxy_all_segments_and_apply(
+        holder.clone(),
+        segments_dir.path(),
+        None,
+        schema,
+        None,
+        Duration::from_millis(100),
+        |_segment| Ok(()),
+    );
+
+    assert!(
+        matches!(result, Err(OperationError::Timeout { .. })),
+        "expected timeout error, got {result:?}",
+    );
+}
+
+/// Only one snapshot of a shard may be in flight at a time. A second snapshot attempt must wait
+/// for the first one in async context (cancellable, threadless), not on the segment holder lock
+/// inside a blocking task.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shard_snapshot_single_flight() {
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let config = create_collection_config();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        "test".to_string(),
+        collection_dir.path(),
+        Arc::new(tokio::sync::RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        Handle::current(),
+        AdaptiveSearchHandle::current_for_tests(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Simulate an in-flight snapshot by taking the shard's snapshot permit
+    let permit = shard
+        .snapshot_semaphore
+        .clone()
+        .try_acquire_owned()
+        .unwrap();
+
+    let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
+    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+
+    let snapshot_creator = shard
+        .get_snapshot_creator(temp_dir.path(), &tar, SnapshotFormat::Regular, None, true)
+        .await
+        .unwrap();
+    let mut snapshot_creator = std::pin::pin!(snapshot_creator);
+
+    // While the permit is held, the snapshot must stay queued on the semaphore
+    let queued = tokio::time::timeout(Duration::from_millis(300), &mut snapshot_creator).await;
+    assert!(
+        queued.is_err(),
+        "second snapshot must wait for the in-flight one, got {queued:?}",
+    );
+
+    // Releasing the permit must let the queued snapshot proceed and succeed
+    drop(permit);
+    tokio::time::timeout(Duration::from_secs(30), snapshot_creator)
+        .await
+        .expect("queued snapshot did not proceed after the in-flight one finished")
+        .unwrap();
+}
+
+/// Waiting for an in-flight snapshot is bounded: a queued snapshot fails with a transient
+/// timeout error instead of waiting forever.
+///
+/// The shard is built on a regular runtime, but the snapshot creator future — pending only on
+/// the semaphore wait and its timeout — runs on a paused-time runtime, which auto-advances
+/// through the 10 minute wait instantly.
+#[test]
+fn test_shard_snapshot_permit_timeout() {
+    let build_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let config = create_collection_config();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = build_runtime
+        .block_on(LocalShard::build(
+            0,
+            "test".to_string(),
+            collection_dir.path(),
+            Arc::new(tokio::sync::RwLock::new(config.clone())),
+            Arc::new(Default::default()),
+            payload_index_schema,
+            build_runtime.handle().clone(),
+            AdaptiveSearchHandle::new_fixed(build_runtime.handle().clone()),
+            ResourceBudget::default(),
+            config.optimizer_config.clone(),
+        ))
+        .unwrap();
+
+    // Simulate an in-flight snapshot that never finishes
+    let _permit = shard
+        .snapshot_semaphore
+        .clone()
+        .try_acquire_owned()
+        .unwrap();
+
+    let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
+    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+
+    let snapshot_creator = build_runtime
+        .block_on(shard.get_snapshot_creator(
+            temp_dir.path(),
+            &tar,
+            SnapshotFormat::Regular,
+            None,
+            true,
+        ))
+        .unwrap();
+
+    let paused_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()
+        .unwrap();
+
+    let result = paused_runtime.block_on(snapshot_creator);
+    assert!(
+        matches!(result, Err(CollectionError::Timeout { .. })),
+        "queued snapshot must fail with a transient timeout, got {result:?}",
+    );
 }

--- a/lib/shard/src/segment_holder/locked.rs
+++ b/lib/shard/src/segment_holder/locked.rs
@@ -51,6 +51,13 @@ impl LockedSegmentHolder {
         self.holder.upgradable_read()
     }
 
+    pub fn try_upgradable_read_for(
+        &self,
+        timeout: Duration,
+    ) -> Option<RwLockUpgradableReadGuard<'_, SegmentHolder>> {
+        self.holder.try_upgradable_read_for(timeout)
+    }
+
     pub fn try_read_for(&self, timeout: Duration) -> Option<RwLockReadGuard<'_, SegmentHolder>> {
         self.holder.try_read_for(timeout)
     }


### PR DESCRIPTION
_WIP_

Enforce snapshots on a shard to be sequential rather than concurrent. Use a semaphore for this to allow waiting in async context, rather than waiting on a blocking lock further down.

Add a timeout to obtaining the semaphore permit and on taking segment locks to prevent these snapshot tasks from getting stuck forever.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [ ] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
