### PR TITLE
fix(optimizer): defer source segment data destruction until durable

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -568,6 +568,14 @@ mod tests {
             "Testing that only largest segment is not Mmap"
         );
 
+        // Optimizations retire their source segments rather than dropping them; the files are
+        // destroyed once a flush confirms the optimized data is durable (see
+        // `SegmentHolder::retire_segment`). Flush to mature the retirees before counting dirs.
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         let segment_dirs = fs::read_dir(segments_dir.path()).unwrap().collect_vec();
         assert_eq!(
             segment_dirs.len(),

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -195,6 +195,14 @@ mod tests {
             }
         }
 
+        // The optimization retires the merged source segments rather than dropping them; their
+        // files are destroyed once a flush confirms the merged data is durable (see
+        // `SegmentHolder::retire_segment`). Flush to mature the retirees before asserting.
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         // Check if optimized segments removed from disk
         old_path.into_iter().for_each(|x| assert!(!x.exists()));
     }

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -231,6 +231,16 @@ mod tests {
             }
         }
 
+        // The optimization retires the source segment rather than dropping it; its files are
+        // destroyed once a flush confirms the optimized data is durable (see
+        // `SegmentHolder::retire_segment`). Flush to mature the retiree before asserting.
+        drop(segment_guard);
+        drop(holder_guard);
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         // Check old segment data is removed from disk
         assert!(!original_segment_path.exists());
     }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -549,6 +549,7 @@ fn finish_optimization(
 
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
+    let optimized_segment_version = optimized_segment.version();
     let mut writable_segment_holder = RwLockUpgradableReadGuard::upgrade(upgradable_segment_holder);
 
     let (_, proxies) = writable_segment_holder.swap_new(optimized_segment, proxy_ids);
@@ -587,10 +588,27 @@ fn finish_optimization(
             .try_for_each(|chunk| read_segment_holder.deduplicate_points(chunk, hw_counter))?;
     }
 
-    // It is important to update manifest before we drop proxy data,
+    // It is important to update manifest before we retire proxy data,
     // as we don't want to have a situation, where new segment is not yet registered, but
     // old segment data is already dropped.
     read_segment_holder.sync_segment_manifest(None)?;
+
+    // Don't destroy the replaced segments' data yet. Points were copy-on-write moved out of
+    // them (and out of the optimized segment's in-memory state, which the next optimization
+    // bakes into its build output) while their new copies may still sit unflushed in appendable
+    // segments. WAL replay can only re-derive those moves from the on-disk pre-images, so the
+    // files must survive until the durable waterline covers this optimization; `flush_all`
+    // destroys them at that point. A restart in the meantime loads them next to their
+    // replacement and load-time deduplication resolves the overlap.
+    //
+    // While the files are on disk, the WAL acknowledge stays capped at the wrapped segment's
+    // persisted version (the same pin the proxy imposed while the optimization ran), so every
+    // operation the files contradict, deletions in particular, is replayed and re-applied on a
+    // restart.
+    for proxy in proxies {
+        let ack_cap = proxy.get().read().persistent_version();
+        read_segment_holder.retire_segment(optimized_segment_version, ack_cap, proxy);
+    }
 
     drop(read_segment_holder);
     // Allow updates again
@@ -598,12 +616,6 @@ fn finish_optimization(
 
     // Drop all pointers to proxies, so we can de-arc them
     drop(locked_proxies);
-
-    // Only remove data after we ensure the consistency of the collection.
-    // If remove fails - we will still have operational collection with reported error.
-    for proxy in proxies {
-        proxy.drop_data()?;
-    }
 
     Ok(point_count)
 }

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -64,8 +64,14 @@ impl SegmentHolder {
         let max_applied_version = segment_reads.iter().map(|s| s.version()).max().unwrap_or(0);
 
         if !sync && self.is_background_flushing() {
-            // There is already a background flush ongoing, return current max persisted version
-            return Ok(self.get_max_persisted_version(segment_reads, lock_order));
+            // There is already a background flush ongoing, return current max persisted version.
+            // Cap by pending retirees like the main path below, but leave their destruction to
+            // the next full pass.
+            let persisted_version = self.get_max_persisted_version(segment_reads, lock_order);
+            return Ok(match self.pending_retiree_ack_cap() {
+                Some(ack_cap) => min(persisted_version, ack_cap),
+                None => persisted_version,
+            });
         }
 
         // This lock also prevents multiple parallel sync flushes
@@ -107,7 +113,21 @@ impl SegmentHolder {
             );
         }
 
-        Ok(self.get_max_persisted_version(segment_reads, lock_order))
+        // Persisted versions at this point reflect completed flushes only (an ongoing
+        // background pass was joined by `lock_flushing` above; a freshly spawned one has not
+        // updated them yet), so the result is a durable waterline: every segment's state up to
+        // it is on disk. Retired segments scheduled at or below it can have their data
+        // destroyed, since all copies moved out of them are durable in their targets by now.
+        //
+        // Retirees that remain on disk cap the returned version (and with it the WAL
+        // acknowledge): their files contradict operations past their cap, so those operations
+        // must stay replayable until the files are gone. See `SegmentHolder::retire_segment`.
+        let persisted_version = self.get_max_persisted_version(segment_reads, lock_order);
+        let pending_ack_cap = self.drop_retired_segments(persisted_version)?;
+        Ok(match pending_ack_cap {
+            Some(ack_cap) => min(persisted_version, ack_cap),
+            None => persisted_version,
+        })
     }
 
     fn non_appendable_then_appendable_segments_ids(&self) -> impl Iterator<Item = SegmentId> {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -42,6 +42,17 @@ pub type SegmentId = usize;
 /// All occurrences of a point across segments: (segment_id, version, is_deferred).
 type PointOccurrences = SmallVec<[(SegmentId, SeqNumberType, bool); 2]>;
 
+/// A segment swapped out by an optimization, awaiting data destruction.
+/// See [`SegmentHolder::retire_segment`].
+#[derive(Debug)]
+struct RetiredSegment {
+    /// Destroy the data once the durable waterline reaches this version.
+    drop_after: SeqNumberType,
+    /// While the files are on disk, cap the WAL acknowledge at this version.
+    ack_cap: SeqNumberType,
+    segment: LockedSegment,
+}
+
 #[derive(Debug, Default)]
 pub struct SegmentHolder {
     /// Keep segments sorted by their ID for deterministic iteration order
@@ -68,6 +79,11 @@ pub struct SegmentHolder {
     /// Dependency graph also stores the maximum version of the operation, which created the dependency,
     /// so we can clear all dependencies after flushing up to certain operation.
     flush_dependency: Arc<Mutex<TopoSort<SegmentId, SeqNumberType>>>,
+
+    /// Segments swapped out by an optimization whose data destruction is deferred until the
+    /// durable waterline passes their recorded version.
+    /// See [`SegmentHolder::retire_segment`].
+    retired_segments: Mutex<Vec<RetiredSegment>>,
 
     /// Holder for a thread, which does flushing of all segments sequentially.
     /// This is used to avoid multiple concurrent flushes.
@@ -367,6 +383,101 @@ impl SegmentHolder {
     /// Return appendable segment IDs sorted by IDs
     pub fn appendable_segments_ids(&self) -> Vec<SegmentId> {
         self.appendable_segments.keys().copied().collect()
+    }
+
+    /// Schedule a segment that was swapped out of the holder for data destruction once the
+    /// durable waterline reaches `drop_after`.
+    ///
+    /// Points are copy-on-write moved between segments in memory; WAL replay can only re-derive
+    /// such a move if the source's pre-image copy of the point is still on disk. Destroying a
+    /// replaced segment's data right at the swap breaks that: the moved copies may exist only in
+    /// unflushed appendable segments, and a restart before they are persisted loses the points
+    /// (`flush_all` computes exactly when that can no longer happen, see `drop_retired_segments`).
+    ///
+    /// Until then the retired files stay on disk. A restart in the meantime loads them as
+    /// regular segments next to their replacement; the load-time deduplication resolves the
+    /// overlap, the same recovery state as a crash between swap and drop.
+    ///
+    /// `ack_cap` is the version up to which the retired files are truthful: the wrapped
+    /// segment's persisted version. Beyond it the files contradict newer state that lives in
+    /// other segments (most importantly deletions: the files keep a deleted point positively
+    /// alive, and an absence in the replacement segment cannot outvote it at load time). While
+    /// the files are on disk the WAL acknowledge is capped at `ack_cap`, so a restart replays
+    /// those operations and re-applies them; the same pin the proxy imposed while the
+    /// optimization ran, extended until the files are gone.
+    pub fn retire_segment(
+        &self,
+        drop_after: SeqNumberType,
+        ack_cap: SeqNumberType,
+        segment: LockedSegment,
+    ) {
+        self.retired_segments.lock().push(RetiredSegment {
+            drop_after,
+            ack_cap,
+            segment,
+        });
+    }
+
+    /// The WAL acknowledge cap imposed by pending retired segments, if any.
+    /// See [`SegmentHolder::retire_segment`].
+    pub(super) fn pending_retiree_ack_cap(&self) -> Option<SeqNumberType> {
+        self.retired_segments
+            .lock()
+            .iter()
+            .map(|retiree| retiree.ack_cap)
+            .min()
+    }
+
+    /// Destroy the data of retired segments whose `drop_after` version is covered by the
+    /// durable waterline `persisted_version` (every segment's state up to that version is on
+    /// disk, so all copies moved out of the retired segments are durable in their targets, and
+    /// replay of any still-unacknowledged operation on them is an idempotent no-op).
+    ///
+    /// Returns the WAL acknowledge cap of the retirees that remain: the minimum of their
+    /// `ack_cap` values (see [`SegmentHolder::retire_segment`]), or `None` when nothing is
+    /// pending.
+    ///
+    /// Like the WAL acknowledge, the maturity waterline is capped by the first failed
+    /// operation: its effects are not in the segments, and recovering it may need the retired
+    /// pre-images.
+    ///
+    /// Perf note: the waterline is the minimum persisted version across all segments, so a
+    /// freshly created appendable segment (which reports `persistent_version() == 0` until its
+    /// first flush) holds the waterline near zero and keeps retirees from maturing. Under heavy
+    /// optimizer churn this lets the retired-segment backlog and the capped WAL grow, slowing
+    /// startup replay. A fresh segment cannot hold any operation from before it existed, so it
+    /// could report its creation version as vacuously persisted (e.g. floor
+    /// `Segment::persistent_version()` on a stamped `initial_version`) and stop dragging the
+    /// waterline down. Left out here to keep this fix surgical: it changes the segment
+    /// durability contract for every caller and deserves its own change.
+    fn drop_retired_segments(
+        &self,
+        persisted_version: SeqNumberType,
+    ) -> OperationResult<Option<SeqNumberType>> {
+        let waterline = match self.failed_operation.iter().min() {
+            Some(failed) => persisted_version.min(*failed),
+            None => persisted_version,
+        };
+        let mut matured: Vec<_> = {
+            let mut retired = self.retired_segments.lock();
+            let (matured, keep): (Vec<_>, Vec<_>) = std::mem::take(&mut *retired)
+                .into_iter()
+                .partition(|retiree| retiree.drop_after <= waterline);
+            *retired = keep;
+            matured
+        };
+        // Destroy in retirement order (`drop_after` grows with each optimization; a re-queue
+        // below can leave the list unordered): a retiree can hold the last extra reference to a
+        // later retiree's segment (a proxy keeps its shared write segment alive), and
+        // `drop_data` needs sole ownership. On failure, re-queue the unprocessed remainder;
+        // abandoning a matured retiree would release its acknowledge cap while its files are
+        // still on disk.
+        matured.sort_by_key(|retiree| retiree.drop_after);
+        let mut matured = matured.into_iter();
+        let result = matured.try_for_each(|retiree| retiree.segment.drop_data());
+        self.retired_segments.lock().extend(matured);
+        result?;
+        Ok(self.pending_retiree_ack_cap())
     }
 
     /// Return non-appendable segment IDs sorted by IDs


### PR DESCRIPTION
## Problem

Optimizations copy-on-write move points out of their source segments **in memory**, and WAL replay can only re-derive those moves from the sources' on-disk pre-images.

Today `finish_optimization` calls `proxy.drop_data()` immediately after swapping in the optimized segment, destroying the source files right away.

That is unsafe: the moved copies may still sit **unflushed** in appendable segments (and chained optimizations bake deletions into their build outputs). A restart before those copies are persisted loses the points. Signature: old points missing after restart plus `No point with id` errors during WAL replay.

## Fix

Retire the replaced segments instead of dropping them:

- `SegmentHolder::retire_segment(drop_after, ack_cap, segment)` enqueues a swapped-out segment for deferred destruction.
- Its files survive until a flush proves the durable waterline (`drop_retired_segments`) covers the optimization; `flush_all` then destroys them.
- While the files are on disk, the WAL acknowledge is capped at the wrapped segment's persisted version (`ack_cap`), so every operation the files contradict (deletions in particular) stays replayable and is re-applied on restart. This is the same pin the proxy imposed while the optimization ran, extended until the files are gone.
- A crash in the meantime loads the retirees next to their replacement; load-time deduplication resolves the overlap.

Destruction happens in `drop_after` order so a proxy holding the last shared reference to a later retiree's segment is released first; on failure the unprocessed remainder is re-queued to preserve its ack cap.

## Cost / known follow-up

A freshly created appendable segment reports `persistent_version() == 0` until its first flush, holding the waterline near zero and slowing retiree maturation (larger retired-segment backlog and capped WAL, slower startup replay). The principled follow-up (floor `persistent_version` on a stamped `initial_version`) changes the segment durability contract for every caller and is intentionally left out to keep this fix surgical; it is documented inline in `drop_retired_segments`.

## Tests

Optimizer tests that assert source files are gone now `flush_all` first to mature the retirees before counting dirs / asserting (`indexing_optimizer`, `merge_optimizer`, `vacuum_optimizer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)