### PR TITLE
feat: ReadOnlyStructPayloadIndex::open

### DIFF
--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -55,7 +55,6 @@ impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
     /// and null leaves ignore it (a single `open` serves both modes).
     ///
     /// [1]: crate::index::field_index::index_selector::IndexSelector::new_index_with_type
-    #[allow(dead_code)] // no caller in the lib yet
     pub fn open(
         fs: &S::Fs,
         dir: &Path,

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 
 use common::fs::{atomic_save_json, read_json};
+use common::universal_io::{OkNotFound, UniversalReadFs, read_json_via};
 use serde::{Deserialize, Serialize};
 
 use crate::common::operation_error::OperationResult;
@@ -25,6 +26,15 @@ impl PayloadConfig {
 
     pub fn load(path: &Path) -> OperationResult<Self> {
         Ok(read_json(path)?)
+    }
+
+    /// Read-only mirror of [`load`](Self::load) over the universal filesystem
+    /// `fs`. Returns `Ok(None)` when the config file is absent.
+    pub fn load_universal<Fs: UniversalReadFs>(
+        fs: &Fs,
+        path: &Path,
+    ) -> OperationResult<Option<Self>> {
+        Ok(read_json_via(fs, path).ok_not_found()?)
     }
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -6,12 +6,11 @@ use atomic_refcell::AtomicRefCell;
 use common::universal_io::UniversalRead;
 
 use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::IdTrackerRead;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
-use crate::index::struct_payload_index::StorageType;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::VectorNameBuf;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
@@ -26,8 +25,13 @@ impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
         vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<S>>>>,
         path: &Path,
     ) -> OperationResult<Self> {
-        let config = PayloadConfig::load_universal(fs, &PayloadConfig::get_config_path(path))?
-            .unwrap_or_default();
+        let config_path = PayloadConfig::get_config_path(path);
+        let config = PayloadConfig::load_universal(fs, &config_path)?.ok_or_else(|| {
+            OperationError::service_error(format!(
+                "Read-only payload index missing config at {}",
+                config_path.display()
+            ))
+        })?;
 
         let field_indexes = {
             let id_tracker = id_tracker.borrow();
@@ -50,7 +54,9 @@ impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
                         indexes.push(index);
                     }
                 }
-                field_indexes.insert(field.clone(), indexes);
+                if !indexes.is_empty() {
+                    field_indexes.insert(field.clone(), indexes);
+                }
             }
             field_indexes
         };
@@ -63,7 +69,6 @@ impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
             config,
             path: path.to_owned(),
             visited_pool: Default::default(),
-            storage_type: StorageType::NonAppendable,
         })
     }
 }

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+
+use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::IdTrackerRead;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::field_index::ReadOnlyFieldIndex;
+use crate::index::payload_config::PayloadConfig;
+use crate::index::struct_payload_index::StorageType;
+use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
+use crate::types::VectorNameBuf;
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
+    /// Read-only mirror of `StructPayloadIndex::open`: loads the payload config
+    /// and each persisted field index through `fs` (never builds/migrates/writes).
+    pub fn open(
+        fs: &S::Fs,
+        payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
+        id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+        vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<S>>>>,
+        path: &Path,
+    ) -> OperationResult<Self> {
+        let config = PayloadConfig::load_universal(fs, &PayloadConfig::get_config_path(path))?
+            .unwrap_or_default();
+
+        let field_indexes = {
+            let id_tracker = id_tracker.borrow();
+            let total_point_count = id_tracker.total_point_count();
+            let deleted_points = id_tracker.deleted_point_bitslice();
+
+            let mut field_indexes: ReadOnlyIndexesMap<S> = HashMap::new();
+            for (field, indexed) in config.indices.iter() {
+                let mut indexes = Vec::with_capacity(indexed.types.len());
+                for index_type in &indexed.types {
+                    if let Some(index) = ReadOnlyFieldIndex::open(
+                        fs,
+                        path,
+                        field,
+                        &indexed.schema,
+                        index_type,
+                        total_point_count,
+                        deleted_points,
+                    )? {
+                        indexes.push(index);
+                    }
+                }
+                field_indexes.insert(field.clone(), indexes);
+            }
+            field_indexes
+        };
+
+        Ok(Self {
+            payload,
+            id_tracker,
+            vector_storages,
+            field_indexes,
+            config,
+            path: path.to_owned(),
+            visited_pool: Default::default(),
+            storage_type: StorageType::NonAppendable,
+        })
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -8,7 +8,7 @@ use common::universal_io::UniversalRead;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
-use crate::index::struct_payload_index::{StorageType, StructPayloadIndexReadView};
+use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::{PayloadKeyType, VectorNameBuf};
@@ -18,7 +18,7 @@ mod lifecycle;
 
 type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
-#[expect(dead_code)] // `path`/`storage_type` are read once live-reload lands
+#[expect(dead_code)] // `path` is read once live-reload lands
 pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     /// Payload storage
     pub(super) payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
@@ -34,8 +34,6 @@ pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     path: PathBuf,
     /// Used to select unique point ids
     pub(super) visited_pool: VisitedPool,
-    /// Desired storage type for payload indices, used in builder to pick correct type
-    storage_type: StorageType,
 }
 
 impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -18,7 +18,7 @@ mod lifecycle;
 
 type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
-#[allow(dead_code)] // `path`/`storage_type` are read once live-reload lands
+#[expect(dead_code)] // `path`/`storage_type` are read once live-reload lands
 pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     /// Payload storage
     pub(super) payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -14,9 +14,11 @@ use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::{PayloadKeyType, VectorNameBuf};
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
+mod lifecycle;
+
 type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
-#[allow(dead_code)] // ToDo: remove when open and live-reload implemented
+#[allow(dead_code)] // `path`/`storage_type` are read once live-reload lands
 pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     /// Payload storage
     pub(super) payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,


### PR DESCRIPTION
Read-only mirror of `StructPayloadIndex::open` (+ `PayloadConfig::load_universal`): loads the payload config and each persisted field index through `fs`. Never builds, migrates or writes — a field whose index files are missing is simply skipped (a read-only segment can't rebuild it). `NonAppendable` storage type. Toward the read-only segment, #9241.