### PR TITLE
fix: enable disk cache over a network (S3) remote

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -20,12 +20,12 @@ pub struct DiskCacheConfig {
 
 impl DiskCacheConfig {
     pub fn new(remote_dir: PathBuf, local_dir: PathBuf) -> Result<Self> {
-        let remote_dir = fs::canonicalize(&remote_dir)
-            .map_err(|err| UniversalIoError::extract_not_found(err, &remote_dir))?;
+        // Require the local cache dir; the remote may be a network store, so
+        // resolve it best-effort.
         let local_dir = fs::canonicalize(&local_dir)
             .map_err(|err| UniversalIoError::extract_not_found(err, &local_dir))?;
         Ok(Self {
-            remote_dir,
+            remote_dir: canonicalize_or_keep(&remote_dir),
             local_dir,
         })
     }
@@ -34,13 +34,12 @@ impl DiskCacheConfig {
         &self.local_dir
     }
 
-    /// Canonicalises `remote_path` (does filesystem I/O); returns
-    /// [`UniversalIoError::NotFound`] if the result isn't under `remote_dir`.
+    /// Maps a remote path to its local mirror (`<local_dir>/<rel>` + `.partial`);
+    /// `NotFound` if `remote_path` isn't under `remote_dir`.
     pub fn local_path_for(&self, remote_path: &Path) -> Result<PathBuf> {
-        let canonical = fs::canonicalize(remote_path)
-            .map_err(|err| UniversalIoError::extract_not_found(err, remote_path))?;
+        let resolved = canonicalize_or_keep(remote_path);
         let rel =
-            canonical
+            resolved
                 .strip_prefix(&self.remote_dir)
                 .map_err(|_| UniversalIoError::NotFound {
                     path: remote_path.to_path_buf(),
@@ -50,6 +49,12 @@ impl DiskCacheConfig {
         local.as_mut_os_string().push(LOCAL_FILE_SUFFIX);
         Ok(local)
     }
+}
+
+/// Canonicalise `path` if it's a real local path; otherwise keep it verbatim
+/// (network/remote keys don't exist locally).
+fn canonicalize_or_keep(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -102,5 +107,23 @@ mod tests {
         let err = cfg.local_path_for(&outside).unwrap_err();
 
         assert_matches!(err, crate::universal_io::UniversalIoError::NotFound { .. });
+    }
+
+    #[test]
+    fn maps_logical_remote_key_without_local_canonicalize() {
+        let tmp = tempfile::Builder::new()
+            .prefix("simplediskcache-tests")
+            .tempdir()
+            .unwrap();
+        let local_dir = tmp.path().join("local");
+        fs::create_dir_all(&local_dir).unwrap();
+
+        let cfg =
+            DiskCacheConfig::new(std::path::PathBuf::from("bucket/segments"), local_dir).unwrap();
+        let local = cfg
+            .local_path_for(std::path::Path::new("bucket/segments/seg/abc/page_0.dat"))
+            .unwrap();
+
+        assert_eq!(local, cfg.local_dir().join("seg/abc/page_0.dat.partial"));
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -19,13 +19,14 @@ pub struct DiskCacheConfig {
 }
 
 impl DiskCacheConfig {
+    /// Initialize the config for [`DiskCacheConfig`]
+    ///
+    /// The `remote_dir` may be a network store, but `local_dir` must be a local path.
     pub fn new(remote_dir: PathBuf, local_dir: PathBuf) -> Result<Self> {
-        // Require the local cache dir; the remote may be a network store, so
-        // resolve it best-effort.
         let local_dir = fs::canonicalize(&local_dir)
             .map_err(|err| UniversalIoError::extract_not_found(err, &local_dir))?;
         Ok(Self {
-            remote_dir: canonicalize_or_keep(&remote_dir),
+            remote_dir: canonicalize_remote(&remote_dir),
             local_dir,
         })
     }
@@ -37,7 +38,7 @@ impl DiskCacheConfig {
     /// Maps a remote path to its local mirror (`<local_dir>/<rel>` + `.partial`);
     /// `NotFound` if `remote_path` isn't under `remote_dir`.
     pub fn local_path_for(&self, remote_path: &Path) -> Result<PathBuf> {
-        let resolved = canonicalize_or_keep(remote_path);
+        let resolved = canonicalize_remote(remote_path);
         let rel =
             resolved
                 .strip_prefix(&self.remote_dir)
@@ -53,7 +54,7 @@ impl DiskCacheConfig {
 
 /// Canonicalise `path` if it's a real local path; otherwise keep it verbatim
 /// (network/remote keys don't exist locally).
-fn canonicalize_or_keep(path: &Path) -> PathBuf {
+fn canonicalize_remote(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 

--- a/lib/common/io_bridge_object_store/src/file.rs
+++ b/lib/common/io_bridge_object_store/src/file.rs
@@ -16,6 +16,7 @@ use crate::runtime::BridgeRuntime;
 /// backend's async operations through a [`BridgeRuntime`]:
 ///   * single reads / metadata lookups via `block_on`,
 ///   * batched/pipelined reads via the runtime's worker thread (MPSC channel).
+#[derive(Clone)]
 pub struct BlobFile<A: AsyncRead> {
     pub(crate) inner: A,
     pub(crate) runtime: BridgeRuntime,


### PR DESCRIPTION
Two changes so `DiskCacheFs<BlobFile<S3>>` (local disk cache over S3) works:
1. `DiskCacheConfig` resolves the remote path best-effort instead of `canonicalize`-ing it on the local FS (S3 keys never exist locally).
2. derive `Clone` for `BlobFile` so it satisfies the `DiskCacheRemote` bound.

Local-remote tests unchanged; logical-key unit test added. For #9241.