### PR TITLE
fix: read-only on-disk field index opens are non-writeable

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -218,7 +218,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             fs,
             &deleted_points_path,
             OpenOptions {
-                writeable: true,
+                writeable: false,
                 need_sequential: false,
                 populate,
                 advice: AdviceSetting::Global,

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -199,7 +199,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             fs,
             &deleted_path,
             OpenOptions {
-                writeable: true,
+                writeable: false,
                 need_sequential: false,
                 populate,
                 advice: AdviceSetting::Global,

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -64,7 +64,7 @@ where
             fs,
             &deleted_path,
             OpenOptions {
-                writeable: true,
+                writeable: false,
                 need_sequential: false,
                 populate,
                 advice: AdviceSetting::Global,

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -148,7 +148,7 @@ where
             fs,
             &deleted_path,
             OpenOptions {
-                writeable: true,
+                writeable: false,
                 need_sequential: false,
                 populate: Populate::Auto,
                 advice: AdviceSetting::Global,


### PR DESCRIPTION
The on-disk map/numeric/geo/full-text field-index `open()` opened the deleted-bits handle `writeable: true` but only `read_all()`s it (the binding isn't even `mut`) — leftover copy-paste from `build()`, where the write is real. Open it read-only.

Needed by the read-only disk cache (write-enforced) over S3/GCS, which rejects writeable opens. `open()` is shared with the mutable segment, where `false` is also correct (covered by `payload_index_files_are_immutable_after_build`). For #9241.