### PR TITLE
refactor: explicit index-type arms for Turbo4 in read-only open

### DIFF
--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -205,7 +205,10 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
                     InvertedIndexCompressedMmap::load_universal(fs, path)?,
                 )?))
             }
-            (_, VectorStorageDatatype::Turbo4) => {
+            (
+                SparseIndexType::ImmutableRam | SparseIndexType::Mmap,
+                VectorStorageDatatype::Turbo4,
+            ) => {
                 return Err(OperationError::service_error(
                     "Turbo4 datatype storage is not yet supported",
                 ));


### PR DESCRIPTION
Follow-up to #9435: replace the catch-all `(_, Turbo4)` arm in `open_sparse` with explicit `ImmutableRam | Mmap`, so a new `SparseIndexType` variant fails to compile here instead of being silently swallowed. Addresses https://github.com/qdrant/qdrant/pull/9435#discussion_r3416077075