### PR TITLE
Fix scalar quantized Dot query scaling

### DIFF
--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -46,6 +46,10 @@ pub trait EncodedVectors: Sized {
 
     fn encode_query(&self, query: &[f32]) -> Self::EncodedQuery;
 
+    fn encode_query_scaled(&self, query: &[f32]) -> Self::EncodedQuery {
+        self.encode_query(query)
+    }
+
     /// This function is expected to:
     /// - be implemented by non-multivector storages
     /// - be used by multivector storages

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -37,6 +37,7 @@ pub struct EncodedVectorsU8<TStorage: EncodedStorage> {
 pub struct EncodedQueryU8 {
     offset: f32,
     encoded_query: Vec<u8>,
+    score_multiplier: f32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -344,6 +345,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
 
                 self.metadata
                     .postprocess_score(score as f32, query.offset, vector_offset)
+                    * query.score_multiplier
             }
         }
     }
@@ -382,6 +384,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 };
                 self.metadata
                     .postprocess_score(score, query.offset, vector_offset)
+                    * query.score_multiplier
             }
         }
     }
@@ -424,6 +427,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 };
                 self.metadata
                     .postprocess_score(score, query.offset, vector_offset)
+                    * query.score_multiplier
             }
         }
     }
@@ -466,6 +470,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
                 };
                 self.metadata
                     .postprocess_score(score, query.offset, vector_offset)
+                    * query.score_multiplier
             }
         }
     }
@@ -547,9 +552,27 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         }
     }
 
-    fn encode_int8_query(metadata: &MetadataInt8, query: &[f32]) -> EncodedQueryU8 {
+    fn encode_int8_query(
+        metadata: &MetadataInt8,
+        query: &[f32],
+        scale_invariant: bool,
+    ) -> EncodedQueryU8 {
         let dim = query.len();
-        let mut query: Vec<_> = query.iter().map(|&v| metadata.encode_value(v)).collect();
+        let score_multiplier = match (scale_invariant, metadata.vector_parameters.distance_type) {
+            (true, DistanceType::Dot | DistanceType::Cosine) => {
+                let max_abs = query.iter().map(|v| v.abs()).fold(0.0, f32::max);
+                if max_abs > 0.0 {
+                    max_abs
+                } else {
+                    1.0
+                }
+            }
+            _ => 1.0,
+        };
+        let mut query: Vec<_> = query
+            .iter()
+            .map(|&v| metadata.encode_value(v / score_multiplier))
+            .collect();
         if !dim.is_multiple_of(ALIGNMENT) {
             for _ in 0..(ALIGNMENT - dim % ALIGNMENT) {
                 let placeholder = match metadata.vector_parameters.distance_type {
@@ -582,6 +605,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         EncodedQueryU8 {
             offset,
             encoded_query: query,
+            score_multiplier,
         }
     }
 }
@@ -608,7 +632,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
 
     fn encode_query(&self, query: &[f32]) -> EncodedQueryU8 {
         match &self.metadata {
-            Metadata::Int8(meta) => Self::encode_int8_query(meta, query),
+            Metadata::Int8(meta) => Self::encode_int8_query(meta, query, false),
+        }
+    }
+
+    fn encode_query_scaled(&self, query: &[f32]) -> EncodedQueryU8 {
+        match &self.metadata {
+            Metadata::Int8(meta) => Self::encode_int8_query(meta, query, true),
         }
     }
 
@@ -689,6 +719,7 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
                     encoded_query: unsafe {
                         std::slice::from_raw_parts(q_ptr, metadata.actual_dim).to_vec()
                     },
+                    score_multiplier: 1.0,
                 })
             }
         }

--- a/lib/quantization/tests/integration/test_simple.rs
+++ b/lib/quantization/tests/integration/test_simple.rs
@@ -58,6 +58,89 @@ mod tests {
 
     #[rstest]
     #[case(ScalarQuantizationMethod::Int8)]
+    fn test_dot_query_positive_scaling_keeps_quantized_order(
+        #[case] method: ScalarQuantizationMethod,
+    ) {
+        let vectors_count = 3000;
+        let vector_dim = 16;
+        let scale = 2.0;
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(9000 + vector_dim as u64);
+        let vector_data: Vec<Vec<f32>> = (0..vectors_count)
+            .map(|_| {
+                (0..vector_dim)
+                    .map(|i| {
+                        if i % 17 == 0 {
+                            rng.random_range(-20.0..20.0)
+                        } else {
+                            rng.random_range(-1.0..1.0)
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        let query: Vec<f32> = (0..vector_dim)
+            .map(|_| rng.random_range(-1.0..1.0))
+            .collect();
+        let scaled_query: Vec<f32> = query.iter().map(|v| v * scale).collect();
+
+        let vector_parameters = VectorParameters {
+            dim: vector_dim,
+            deprecated_count: None,
+            distance_type: DistanceType::Dot,
+            invert: false,
+        };
+        let quantized_vector_size =
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
+        let encoded = EncodedVectorsU8::encode(
+            vector_data.iter(),
+            TestEncodedStorageBuilder::new(None, quantized_vector_size),
+            &vector_parameters,
+            vectors_count,
+            None,
+            method,
+            None,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+
+        let query_u8 = encoded.encode_query_scaled(&query);
+        let scaled_query_u8 = encoded.encode_query_scaled(&scaled_query);
+
+        let score_all = |encoded_query| {
+            let mut scores: Vec<_> = (0..vectors_count)
+                .map(|idx| {
+                    let quantized_vector = encoded.get_quantized_vector(idx as u32);
+                    (
+                        idx,
+                        encoded.score_point_simple(encoded_query, &quantized_vector),
+                    )
+                })
+                .collect();
+            scores.sort_by(|(_, left), (_, right)| right.total_cmp(left));
+            scores
+        };
+
+        let scores = score_all(&query_u8);
+        let scaled_scores = score_all(&scaled_query_u8);
+
+        let ids: Vec<_> = scores.iter().take(10).map(|(idx, _)| *idx).collect();
+        let scaled_ids: Vec<_> = scaled_scores
+            .iter()
+            .take(10)
+            .map(|(idx, _)| *idx)
+            .collect();
+
+        assert_eq!(ids, scaled_ids);
+        for ((idx, score), (scaled_idx, scaled_score)) in scores.iter().zip(&scaled_scores) {
+            assert_eq!(idx, scaled_idx);
+            let tolerance = (*score).abs() * 1e-5 + 1e-4;
+            assert!((*scaled_score - *score * scale).abs() <= tolerance);
+        }
+    }
+
+    #[rstest]
+    #[case(ScalarQuantizationMethod::Int8)]
     fn test_l2_simple(#[case] method: ScalarQuantizationMethod) {
         let vectors_count = 129;
         let vector_dim = 65;

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -43,7 +43,7 @@ where
             TMetric::distance(),
             original_query,
         );
-        let query = quantized_data.encode_query(&original_query_prequantized);
+        let query = quantized_data.encode_query_scaled(&original_query_prequantized);
 
         hardware_counter.set_vector_io_read_multiplier(usize::from(quantized_data.is_on_disk()));
 


### PR DESCRIPTION
## Summary
- add a scale-invariant encoded-query path for scalar U8 Dot/Cosine search queries
- use it for nearest quantized query scorers so positive query scaling keeps candidate ordering stable
- keep the existing encode_query behavior for internal vector scoring and non-search callers
- add a regression test covering Dot scalar quantized ordering under q vs 2*q

Fixes #9352.

## Root cause
Scalar int8 query encoding used the collection vector quantization range directly. For Dot/IP, scaling a query by a positive constant should only scale scores, but quantizing the scaled query changed rounded/clamped int8 bins before HNSW candidate selection. With rescore=true, exact rescoring only reorders candidates and cannot recover candidates missed in the quantized phase.

## Validation
- git diff --check
- Not run: cargo fmt/test because cargo is not installed in this environment.