### PR TITLE
Sparse InvertedIndex: bring back generic methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7498,6 +7498,7 @@ dependencies = [
  "common",
  "criterion",
  "dataset",
+ "duplicate",
  "fs-err",
  "generic-tests",
  "gridstore",

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -15,7 +15,6 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
-use segment::fixtures::sparse_fixtures::{open_sparse_index, ram_from_ram, ram_open};
 use segment::index::VectorIndex;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
@@ -85,8 +84,9 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     // intent: measure in-memory build time from storage
     group.bench_function("build-ram-index", |b| {
         b.iter(|| {
-            let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = open_sparse_index(
-                SparseVectorIndexOpenArgs {
+            let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
+                SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+                    fs: &MmapFs,
                     config: index_config,
                     id_tracker: id_tracker.clone(),
                     vector_storage: vector_storage.clone(),
@@ -94,18 +94,16 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
                     path: index_dir.path(),
                     stopped: &stopped,
                     tick_progress: || (),
-                },
-                ram_open,
-                ram_from_ram,
-            )
-            .unwrap();
+                })
+                .unwrap();
             assert_eq!(sparse_vector_index.indexed_vector_count(), NUM_VECTORS);
         })
     });
 
     // build once to reuse in mmap conversion benchmark
-    let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> = open_sparse_index(
-        SparseVectorIndexOpenArgs {
+    let sparse_vector_index: SparseVectorIndex<InvertedIndexRam> =
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
             config: index_config,
             id_tracker,
             vector_storage,
@@ -113,11 +111,8 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
             path: index_dir.path(),
             stopped: &stopped,
             tick_progress: || (),
-        },
-        ram_open,
-        ram_from_ram,
-    )
-    .unwrap();
+        })
+        .unwrap();
 
     // intent: measure mmap conversion time
     group.bench_function("convert-mmap-index-f32", |b| {

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -2,17 +2,14 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFile;
+use common::universal_io::{MmapFile, MmapFs};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use dataset::Dataset;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use itertools::Itertools as _;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use segment::fixtures::sparse_fixtures::{
-    fixture_sparse_index_from_iter, mmap_from_ram, mmap_open, open_sparse_index, ram_from_ram,
-    ram_open,
-};
+use segment::fixtures::sparse_fixtures::fixture_sparse_index_from_iter;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
@@ -82,8 +79,6 @@ fn sparse_vector_index_search_benchmark_impl(
         progress("Indexing (1/2)", vectors_len).wrap_iter(vectors),
         FULL_SCAN_THRESHOLD,
         SparseIndexType::MutableRam,
-        ram_open,
-        ram_from_ram,
     )
     .unwrap();
 
@@ -111,19 +106,16 @@ fn sparse_vector_index_search_benchmark_impl(
         SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
     let pb = progress("Indexing (2/2)", vectors_len);
     let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexCompressedMmap<f32, MmapFile>> =
-        open_sparse_index(
-            SparseVectorIndexOpenArgs {
-                config: sparse_index_config,
-                id_tracker: sparse_vector_index.id_tracker().clone(),
-                vector_storage: sparse_vector_index.vector_storage().clone(),
-                payload_index: sparse_vector_index.payload_index().clone(),
-                path: mmap_index_dir.path(),
-                stopped: &stopped,
-                tick_progress: || pb.inc(1),
-            },
-            mmap_open::<f32>,
-            mmap_from_ram::<f32>,
-        )
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
+            config: sparse_index_config,
+            id_tracker: sparse_vector_index.id_tracker().clone(),
+            vector_storage: sparse_vector_index.vector_storage().clone(),
+            payload_index: sparse_vector_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+            tick_progress: || pb.inc(1),
+        })
         .unwrap();
     pb.finish_and_clear();
     assert_eq!(sparse_vector_index_mmap.indexed_vector_count(), vectors_len);

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::path::Path;
 use std::sync::Arc;
@@ -11,124 +10,26 @@ use common::universal_io::{MmapFile, MmapFs};
 use rand::Rng;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::random_sparse_vector;
-use sparse::common::types::Weight;
-use sparse::index::inverted_index::InvertedIndex;
-use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
-use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
-use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use sparse::index::inverted_index::InvertedIndexReadWrite;
 
 use crate::common::operation_error::OperationResult;
 use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use crate::index::VectorIndexRead;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::index::sparse_index::sparse_vector_index::{
-    SparseOpenPlan, SparseVectorIndex, SparseVectorIndexOpenArgs,
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum, VectorStorageRead};
 
-// Per-type constructors over the local mmap filesystem, passed to the fixtures
-// and `SparseVectorIndex::open` in place of trait-level construction.
-pub fn ram_open(path: &Path) -> common::universal_io::Result<InvertedIndexRam> {
-    InvertedIndexRam::open(&MmapFs, path)
-}
-pub fn ram_from_ram(
-    ram: Cow<InvertedIndexRam>,
-    path: &Path,
-) -> common::universal_io::Result<InvertedIndexRam> {
-    InvertedIndexRam::from_ram_index(&MmapFs, ram, path)
-}
-pub fn iram_open<W: Weight + 'static>(
-    path: &Path,
-) -> common::universal_io::Result<InvertedIndexCompressedImmutableRam<W>> {
-    InvertedIndexCompressedImmutableRam::open(&MmapFs, path)
-}
-pub fn iram_from_ram<W: Weight + 'static>(
-    ram: Cow<InvertedIndexRam>,
-    path: &Path,
-) -> common::universal_io::Result<InvertedIndexCompressedImmutableRam<W>> {
-    InvertedIndexCompressedImmutableRam::from_ram_index(&MmapFs, ram, path)
-}
-pub fn mmap_open<W: Weight + 'static>(
-    path: &Path,
-) -> common::universal_io::Result<InvertedIndexCompressedMmap<W, MmapFile>> {
-    InvertedIndexCompressedMmap::open(&MmapFs, path)
-}
-pub fn mmap_from_ram<W: Weight + 'static>(
-    ram: Cow<InvertedIndexRam>,
-    path: &Path,
-) -> common::universal_io::Result<InvertedIndexCompressedMmap<W, MmapFile>> {
-    InvertedIndexCompressedMmap::from_ram_index(&MmapFs, ram, path)
-}
-
-/// Test/bench convenience that runs the load-or-build orchestration and
-/// assembles a [`SparseVectorIndex`], given the concrete inverted-index
-/// constructors. Production code (`create_sparse_vector_index`) inlines the same
-/// `plan` → construct → `finish` steps per type without these callbacks.
-pub fn open_sparse_index<I: InvertedIndex>(
-    args: SparseVectorIndexOpenArgs<impl FnMut()>,
-    open_index: impl FnOnce(&Path) -> common::universal_io::Result<I>,
-    from_ram_index: impl FnOnce(Cow<InvertedIndexRam>, &Path) -> common::universal_io::Result<I>,
-) -> OperationResult<SparseVectorIndex<I>> {
-    let SparseVectorIndexOpenArgs {
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        stopped,
-        mut tick_progress,
-    } = args;
-    let plan = SparseVectorIndex::<I>::plan(
-        config,
-        &id_tracker,
-        &vector_storage,
-        path,
-        stopped,
-        &mut tick_progress,
-    )?;
-    let (inverted_index, config, indices_tracker, persist) = match plan {
-        SparseOpenPlan::Load {
-            config,
-            indices_tracker,
-        } => (open_index(path)?, config, indices_tracker, false),
-        SparseOpenPlan::Build {
-            config,
-            ram_index,
-            indices_tracker,
-            persist,
-        } => (
-            from_ram_index(Cow::Owned(ram_index), path)?,
-            config,
-            indices_tracker,
-            persist,
-        ),
-    };
-    SparseVectorIndex::finish(
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        inverted_index,
-        indices_tracker,
-        persist,
-    )
-}
-
-/// Prepares a sparse vector index with a given iterator of sparse vectors.
-///
-/// `open_index` / `from_ram_index` build the concrete inverted index (the caller
-/// knows the type and filesystem); see `SparseVectorIndex::open`.
-pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
+/// Prepares a sparse vector index with a given iterator of sparse vectors
+pub fn fixture_sparse_index_from_iter<I: InvertedIndexReadWrite<MmapFile>>(
     data_dir: &Path,
     vectors: impl ExactSizeIterator<Item = SparseVector>,
     full_scan_threshold: usize,
     index_type: SparseIndexType,
-    open_index: impl FnOnce(&Path) -> common::universal_io::Result<I>,
-    from_ram_index: impl FnOnce(Cow<InvertedIndexRam>, &Path) -> common::universal_io::Result<I>,
 ) -> OperationResult<SparseVectorIndex<I>> {
     let stopped = AtomicBool::new(false);
 
@@ -174,8 +75,9 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
     );
 
     let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type, None);
-    let sparse_vector_index: SparseVectorIndex<I> = open_sparse_index(
-        SparseVectorIndexOpenArgs {
+    let sparse_vector_index: SparseVectorIndex<I> =
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
             config: sparse_index_config,
             id_tracker,
             vector_storage: vector_storage.clone(),
@@ -183,10 +85,7 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
             path: index_dir,
             stopped: &stopped,
             tick_progress: || (),
-        },
-        open_index,
-        from_ram_index,
-    )?;
+        })?;
 
     assert_eq!(
         sparse_vector_index.indexed_vector_count(),
@@ -197,22 +96,33 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndex>(
 }
 
 /// Prepares a sparse vector index with random sparse vectors
-pub fn fixture_sparse_index<I: InvertedIndex + Debug, R: Rng + ?Sized>(
+pub fn fixture_sparse_index<I: InvertedIndexReadWrite<MmapFile> + Debug, R: Rng + ?Sized>(
     rnd: &mut R,
     num_vectors: usize,
     max_dim: usize,
     full_scan_threshold: usize,
     data_dir: &Path,
-    open_index: impl FnOnce(&Path) -> common::universal_io::Result<I>,
-    from_ram_index: impl FnOnce(Cow<InvertedIndexRam>, &Path) -> common::universal_io::Result<I>,
 ) -> SparseVectorIndex<I> {
     fixture_sparse_index_from_iter(
         data_dir,
         (0..num_vectors).map(|_| random_sparse_vector(rnd, max_dim)),
         full_scan_threshold,
         SparseIndexType::ImmutableRam,
-        open_index,
-        from_ram_index,
     )
     .unwrap()
+}
+
+#[macro_export]
+macro_rules! fixture_for_all_indices {
+    ($test:ident::<_>($($args:tt)*)) => {
+        eprintln!("InvertedIndexCompressedImmutableRam<f32>");
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam<f32>
+        >($($args)*);
+
+        eprintln!("InvertedIndexCompressedMmap<f32, MmapFile>");
+        $test::<
+            ::sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap<f32, MmapFile>
+        >($($args)*);
+    };
 }

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -111,7 +111,6 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
     /// Open the read-only sparse vector index from its persisted [`SparseIndexConfig`],
     /// mirroring `create_sparse_vector_index`'s `(index_type, datatype)` selection.
     /// `MutableRam` has no read-only representation.
-    #[allow(dead_code)] // pending: read-only segment constructor
     pub fn open_sparse(args: ReadOnlyVectorIndexOpenArgs<'_, S>) -> OperationResult<Self> {
         let ReadOnlyVectorIndexOpenArgs {
             fs,

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -11,9 +11,9 @@ use common::types::{ScoredPointOffset, TelemetryDetail};
 use common::universal_io::UniversalRead;
 use half::f16;
 use sparse::common::types::{DimId, QuantizedU8};
-use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
+use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::query_context::VectorQueryContext;
@@ -22,7 +22,9 @@ use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::hnsw_index::hnsw::read_only::ReadOnlyHNSWIndex;
 use crate::index::plain_vector_index::read_only::ReadOnlyPlainVectorIndex;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
-use crate::index::sparse_index::sparse_vector_index::read_only::ReadOnlySparseVectorIndex;
+use crate::index::sparse_index::sparse_vector_index::read_only::{
+    ReadOnlySparseVectorIndex, ReadOnlySparseVectorIndexOpenArgs,
+};
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
 use crate::index::vector_index_base::VectorIndexRead;
 use crate::telemetry::VectorIndexSearchesTelemetry;
@@ -133,6 +135,21 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
             SparseIndexType::Mmap => SparseIndexType::Mmap,
         };
 
+        let args = ReadOnlySparseVectorIndexOpenArgs {
+            fs,
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path,
+        };
+
+        fn open<S: UniversalRead + 'static, TInvertedIndex: InvertedIndexReadOnly<S>>(
+            args: ReadOnlySparseVectorIndexOpenArgs<'_, S>,
+        ) -> OperationResult<Box<ReadOnlySparseVectorIndex<S, TInvertedIndex>>> {
+            Ok(Box::new(ReadOnlySparseVectorIndex::open(args)?))
+        }
+
         let index = match (effective_index_type, config.datatype.unwrap_or_default()) {
             (SparseIndexType::MutableRam, _) => {
                 return Err(OperationError::service_error(
@@ -140,70 +157,22 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
                 ));
             }
             (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float32) => {
-                Self::SparseCompressedImmutableRamF32(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedImmutableRam::load_universal::<S>(fs, path)?,
-                )?))
+                Self::SparseCompressedImmutableRamF32(open(args)?)
             }
             (SparseIndexType::Mmap, VectorStorageDatatype::Float32) => {
-                Self::SparseCompressedStoredF32(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedMmap::load_universal(fs, path)?,
-                )?))
+                Self::SparseCompressedStoredF32(open(args)?)
             }
             (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float16) => {
-                Self::SparseCompressedImmutableRamF16(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedImmutableRam::load_universal::<S>(fs, path)?,
-                )?))
+                Self::SparseCompressedImmutableRamF16(open(args)?)
             }
             (SparseIndexType::Mmap, VectorStorageDatatype::Float16) => {
-                Self::SparseCompressedStoredF16(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedMmap::load_universal(fs, path)?,
-                )?))
+                Self::SparseCompressedStoredF16(open(args)?)
             }
             (SparseIndexType::ImmutableRam, VectorStorageDatatype::Uint8) => {
-                Self::SparseCompressedImmutableRamU8(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedImmutableRam::load_universal::<S>(fs, path)?,
-                )?))
+                Self::SparseCompressedImmutableRamU8(open(args)?)
             }
             (SparseIndexType::Mmap, VectorStorageDatatype::Uint8) => {
-                Self::SparseCompressedStoredU8(Box::new(ReadOnlySparseVectorIndex::open(
-                    fs,
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    InvertedIndexCompressedMmap::load_universal(fs, path)?,
-                )?))
+                Self::SparseCompressedStoredU8(open(args)?)
             }
             (
                 SparseIndexType::ImmutableRam | SparseIndexType::Mmap,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -7,13 +8,13 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::storage_version::StorageVersion as _;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFile, MmapFs, UniversalReadFs};
 use fs_err as fs;
 use sparse::SearchScratchPool;
 use sparse::common::sparse_vector::SparseVector;
-use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
+use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadWrite};
 
 use self::read_view::{SparseVectorIndexReadView, SparseVectorIndexReadViewEnum};
 use super::indices_tracker::IndicesTracker;
@@ -66,7 +67,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     }
 }
 
-pub struct SparseVectorIndexOpenArgs<'a, F: FnMut()> {
+pub struct SparseVectorIndexOpenArgs<'a, Fs: UniversalReadFs, F: FnMut()> {
+    pub fs: &'a Fs,
     pub config: SparseIndexConfig,
     pub id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
@@ -98,6 +100,74 @@ pub enum SparseOpenPlan {
 }
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
+    /// Open a sparse vector index at a given path
+    pub fn open<F: FnMut()>(args: SparseVectorIndexOpenArgs<'_, MmapFs, F>) -> OperationResult<Self>
+    where
+        TInvertedIndex: InvertedIndexReadWrite<MmapFile>,
+    {
+        let SparseVectorIndexOpenArgs {
+            fs,
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path,
+            stopped,
+            tick_progress,
+        } = args;
+
+        let plan = Self::plan(
+            config,
+            &id_tracker,
+            &vector_storage,
+            path,
+            stopped,
+            tick_progress,
+        )?;
+        let (inverted_index, config, indices_tracker, persist) = match plan {
+            SparseOpenPlan::Load {
+                config,
+                indices_tracker,
+            } => (
+                TInvertedIndex::open_rw(fs, path)?,
+                config,
+                indices_tracker,
+                false,
+            ),
+            SparseOpenPlan::Build {
+                config,
+                ram_index,
+                indices_tracker,
+                persist,
+            } => (
+                TInvertedIndex::from_ram_index(fs, Cow::Owned(ram_index), path)?,
+                config,
+                indices_tracker,
+                persist,
+            ),
+        };
+
+        if persist {
+            config.save(&SparseIndexConfig::get_config_path(path))?;
+            inverted_index.save(path)?;
+            indices_tracker.save(path)?;
+            // Save the version last to mark a successful (re)build.
+            TInvertedIndex::Version::save(path)?;
+        }
+
+        Ok(Self {
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path: path.to_path_buf(),
+            inverted_index,
+            searches_telemetry: SparseSearchesTelemetry::new(),
+            indices_tracker,
+            search_scratch_pool: SearchScratchPool::new(),
+        })
+    }
+
     /// Decide whether the on-disk index can be loaded or must be (re)built.
     ///
     /// A rebuild assembles the RAM index here (it is type-agnostic); the caller
@@ -155,41 +225,6 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             ram_index,
             indices_tracker,
             persist: true,
-        })
-    }
-
-    /// Assemble the index from the caller-constructed inverted index and the
-    /// finalization fields resolved from a [`SparseOpenPlan`]. Freshly (re)built
-    /// indexes are persisted (`persist`); loaded ones are not.
-    #[allow(clippy::too_many_arguments)]
-    pub fn finish(
-        config: SparseIndexConfig,
-        id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-        payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-        path: &Path,
-        inverted_index: TInvertedIndex,
-        indices_tracker: IndicesTracker,
-        persist: bool,
-    ) -> OperationResult<Self> {
-        if persist {
-            config.save(&SparseIndexConfig::get_config_path(path))?;
-            inverted_index.save(path)?;
-            indices_tracker.save(path)?;
-            // Save the version last to mark a successful (re)build.
-            TInvertedIndex::Version::save(path)?;
-        }
-
-        Ok(Self {
-            config,
-            id_tracker,
-            vector_storage,
-            payload_index,
-            path: path.to_path_buf(),
-            inverted_index,
-            searches_telemetry: SparseSearchesTelemetry::new(),
-            indices_tracker,
-            search_scratch_pool: SearchScratchPool::new(),
         })
     }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -7,7 +7,7 @@ use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion as _;
 use common::universal_io::UniversalRead;
 use sparse::SearchScratchPool;
-use sparse::index::inverted_index::InvertedIndex;
+use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
@@ -54,26 +54,32 @@ type ReadView<'a, S, TInvertedIndex> = SparseVectorIndexReadView<
     TInvertedIndex,
 >;
 
+pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalRead> {
+    pub fs: &'a S::Fs,
+    pub config: SparseIndexConfig,
+    pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+    pub vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    pub payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
+    pub path: &'a Path,
+}
+
 impl<S: UniversalRead, TInvertedIndex: InvertedIndex> ReadOnlySparseVectorIndex<S, TInvertedIndex> {
-    /// Universal-IO mirror of `SparseVectorIndex::finish`: version gate and
-    /// indices tracker load via `fs`, then assemble from the caller-loaded
-    /// `config` and already-constructed `inverted_index`.
-    ///
-    /// The caller (the [`VectorIndexReadEnum`] dispatcher) loads `config` to pick
-    /// the concrete inverted-index type, constructs it, and hands both here — so
-    /// this stays free of inverted-index construction callbacks, just as
-    /// `SparseVectorIndex` does.
-    ///
-    /// [`VectorIndexReadEnum`]: crate::index::read_only::VectorIndexReadEnum
-    pub fn open(
-        fs: &S::Fs,
-        config: SparseIndexConfig,
-        id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
-        vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
-        payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
-        path: &Path,
-        inverted_index: TInvertedIndex,
-    ) -> OperationResult<Self> {
+    /// Similar to [`super::SparseVectorIndex::open`].
+    pub fn open(args: ReadOnlySparseVectorIndexOpenArgs<S>) -> OperationResult<Self>
+    where
+        TInvertedIndex: InvertedIndexReadOnly<S>,
+    {
+        let ReadOnlySparseVectorIndexOpenArgs {
+            fs,
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            path,
+        } = args;
+
+        let inverted_index = TInvertedIndex::open_ro(fs, path)?;
+
         let stored_version = TInvertedIndex::Version::load_universal(fs, path)?;
         if stored_version != Some(TInvertedIndex::Version::current()) {
             return Err(OperationError::service_error_light(format!(

--- a/lib/segment/src/segment/vector_name_ops.rs
+++ b/lib/segment/src/segment/vector_name_ops.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
+use common::universal_io::MmapFs;
 
 use super::Segment;
 use crate::common::operation_error::OperationResult;
@@ -178,6 +179,7 @@ impl Segment {
         let vector_index_path = get_vector_index_path(&self.segment_path, vector_name);
         let stopped = AtomicBool::new(false);
         let vector_index = open_or_create_sparse_vector_index(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
             config: effective_config.index,
             id_tracker: self.id_tracker.clone(),
             vector_storage: vector_storage.clone(),

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -699,6 +699,7 @@ impl SegmentBuilder {
                 let vector_storage_arc = vector_storages_arc.remove(vector_name).unwrap();
 
                 let index = open_or_create_sparse_vector_index(SparseVectorIndexOpenArgs {
+                    fs: &MmapFs,
                     config: sparse_vector_config.index,
                     id_tracker: id_tracker_arc.clone(),
                     vector_storage: vector_storage_arc.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
@@ -8,6 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use common::defaults::log_load_timing;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
+use common::universal_io::MmapFs;
 use parking_lot::Mutex;
 use uuid::Uuid;
 
@@ -248,6 +249,7 @@ fn open_sparse_vector_data(
     let started = Instant::now();
     let vector_index = sp(open_or_create_sparse_vector_index(
         SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
             config: sparse_vector_config.index,
             id_tracker: id_tracker.clone(),
             vector_storage: vector_storage.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base/sparse_vector_index.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/sparse_vector_index.rs
@@ -1,36 +1,22 @@
-use std::borrow::Cow;
-use std::path::Path;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-
-use atomic_refcell::AtomicRefCell;
-use common::universal_io::{MmapFile, MmapFs};
-use half::f16;
-use sparse::common::types::{QuantizedU8, Weight};
-use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
-use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
-use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use common::universal_io::MmapFs;
 
 use crate::common::operation_error::OperationResult;
-use crate::id_tracker::IdTrackerEnum;
 use crate::index::VectorIndexEnum;
-use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use crate::index::sparse_index::sparse_index_config::SparseIndexType;
 use crate::index::sparse_index::sparse_vector_index::{
-    SparseOpenPlan, SparseVectorIndex, SparseVectorIndexOpenArgs,
+    SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
-use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::types::VectorStorageDatatype;
-use crate::vector_storage::VectorStorageEnum;
 
 #[cfg(feature = "testing")]
 pub fn create_sparse_vector_index_test(
-    args: SparseVectorIndexOpenArgs<impl FnMut()>,
+    args: SparseVectorIndexOpenArgs<MmapFs, impl FnMut()>,
 ) -> OperationResult<VectorIndexEnum> {
     open_or_create_sparse_vector_index(args)
 }
 
 pub(crate) fn open_or_create_sparse_vector_index(
-    args: SparseVectorIndexOpenArgs<impl FnMut()>,
+    args: SparseVectorIndexOpenArgs<MmapFs, impl FnMut()>,
 ) -> OperationResult<VectorIndexEnum> {
     let effective_index_type = match args.config.index_type {
         SparseIndexType::ImmutableRam => {
@@ -49,96 +35,34 @@ pub(crate) fn open_or_create_sparse_vector_index(
         SparseIndexType::MutableRam => SparseIndexType::MutableRam,
         SparseIndexType::Mmap => SparseIndexType::Mmap,
     };
-    let SparseVectorIndexOpenArgs {
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        stopped,
-        tick_progress,
-    } = args;
 
     // Each family helper runs the load-vs-build orchestration for its concrete
     // inverted-index type; here we only pick the helper and wrap its result in the
     // matching `VectorIndexEnum` variant.
-    let vector_index = match (effective_index_type, config.datatype.unwrap_or_default()) {
-        (SparseIndexType::MutableRam, _) => VectorIndexEnum::SparseRam(open_sparse_mutable_ram(
-            config,
-            id_tracker,
-            vector_storage,
-            payload_index,
-            path,
-            stopped,
-            tick_progress,
-        )?),
+    let vector_index = match (
+        effective_index_type,
+        args.config.datatype.unwrap_or_default(),
+    ) {
+        (SparseIndexType::MutableRam, _) => {
+            VectorIndexEnum::SparseRam(SparseVectorIndex::open(args)?)
+        }
         (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float32) => {
-            VectorIndexEnum::SparseCompressedImmutableRamF32(open_sparse_immutable_ram::<f32>(
-                config,
-                id_tracker,
-                vector_storage,
-                payload_index,
-                path,
-                stopped,
-                tick_progress,
-            )?)
+            VectorIndexEnum::SparseCompressedImmutableRamF32(SparseVectorIndex::open(args)?)
         }
         (SparseIndexType::Mmap, VectorStorageDatatype::Float32) => {
-            VectorIndexEnum::SparseCompressedMmapF32(open_sparse_mmap::<f32>(
-                config,
-                id_tracker,
-                vector_storage,
-                payload_index,
-                path,
-                stopped,
-                tick_progress,
-            )?)
+            VectorIndexEnum::SparseCompressedMmapF32(SparseVectorIndex::open(args)?)
         }
         (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float16) => {
-            VectorIndexEnum::SparseCompressedImmutableRamF16(open_sparse_immutable_ram::<f16>(
-                config,
-                id_tracker,
-                vector_storage,
-                payload_index,
-                path,
-                stopped,
-                tick_progress,
-            )?)
+            VectorIndexEnum::SparseCompressedImmutableRamF16(SparseVectorIndex::open(args)?)
         }
         (SparseIndexType::Mmap, VectorStorageDatatype::Float16) => {
-            VectorIndexEnum::SparseCompressedMmapF16(open_sparse_mmap::<f16>(
-                config,
-                id_tracker,
-                vector_storage,
-                payload_index,
-                path,
-                stopped,
-                tick_progress,
-            )?)
+            VectorIndexEnum::SparseCompressedMmapF16(SparseVectorIndex::open(args)?)
         }
         (SparseIndexType::ImmutableRam, VectorStorageDatatype::Uint8) => {
-            VectorIndexEnum::SparseCompressedImmutableRamU8(
-                open_sparse_immutable_ram::<QuantizedU8>(
-                    config,
-                    id_tracker,
-                    vector_storage,
-                    payload_index,
-                    path,
-                    stopped,
-                    tick_progress,
-                )?,
-            )
+            VectorIndexEnum::SparseCompressedImmutableRamU8(SparseVectorIndex::open(args)?)
         }
         (SparseIndexType::Mmap, VectorStorageDatatype::Uint8) => {
-            VectorIndexEnum::SparseCompressedMmapU8(open_sparse_mmap::<QuantizedU8>(
-                config,
-                id_tracker,
-                vector_storage,
-                payload_index,
-                path,
-                stopped,
-                tick_progress,
-            )?)
+            VectorIndexEnum::SparseCompressedMmapU8(SparseVectorIndex::open(args)?)
         }
         (_, VectorStorageDatatype::Turbo4) => {
             unreachable!("Sparse index incompatible with turbo. Validated at API level.")
@@ -146,174 +70,4 @@ pub(crate) fn open_or_create_sparse_vector_index(
     };
 
     Ok(vector_index)
-}
-
-/// Load-or-build a mutable RAM sparse index ([`InvertedIndexRam`]).
-///
-/// `plan` decides load-vs-build generically; this runs the one type-specific
-/// construction step and assembles via `finish`. Mutable RAM indexes are never
-/// persisted, so the build path always reports `persist = false`.
-fn open_sparse_mutable_ram(
-    config: SparseIndexConfig,
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    path: &Path,
-    stopped: &AtomicBool,
-    tick_progress: impl FnMut(),
-) -> OperationResult<SparseVectorIndex<InvertedIndexRam>> {
-    let plan = SparseVectorIndex::<InvertedIndexRam>::plan(
-        config,
-        &id_tracker,
-        &vector_storage,
-        path,
-        stopped,
-        tick_progress,
-    )?;
-    let (inverted_index, config, indices_tracker, persist) = match plan {
-        SparseOpenPlan::Load {
-            config,
-            indices_tracker,
-        } => (
-            InvertedIndexRam::open(&MmapFs, path)?,
-            config,
-            indices_tracker,
-            false,
-        ),
-        SparseOpenPlan::Build {
-            config,
-            ram_index,
-            indices_tracker,
-            persist,
-        } => (
-            InvertedIndexRam::from_ram_index(&MmapFs, Cow::Owned(ram_index), path)?,
-            config,
-            indices_tracker,
-            persist,
-        ),
-    };
-    SparseVectorIndex::finish(
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        inverted_index,
-        indices_tracker,
-        persist,
-    )
-}
-
-/// Load-or-build an immutable RAM compressed sparse index
-/// ([`InvertedIndexCompressedImmutableRam<W>`]), generic over the weight type.
-fn open_sparse_immutable_ram<W: Weight + 'static>(
-    config: SparseIndexConfig,
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    path: &Path,
-    stopped: &AtomicBool,
-    tick_progress: impl FnMut(),
-) -> OperationResult<SparseVectorIndex<InvertedIndexCompressedImmutableRam<W>>> {
-    let plan = SparseVectorIndex::<InvertedIndexCompressedImmutableRam<W>>::plan(
-        config,
-        &id_tracker,
-        &vector_storage,
-        path,
-        stopped,
-        tick_progress,
-    )?;
-    let (inverted_index, config, indices_tracker, persist) = match plan {
-        SparseOpenPlan::Load {
-            config,
-            indices_tracker,
-        } => (
-            InvertedIndexCompressedImmutableRam::<W>::open(&MmapFs, path)?,
-            config,
-            indices_tracker,
-            false,
-        ),
-        SparseOpenPlan::Build {
-            config,
-            ram_index,
-            indices_tracker,
-            persist,
-        } => (
-            InvertedIndexCompressedImmutableRam::<W>::from_ram_index(
-                &MmapFs,
-                Cow::Owned(ram_index),
-                path,
-            )?,
-            config,
-            indices_tracker,
-            persist,
-        ),
-    };
-    SparseVectorIndex::finish(
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        inverted_index,
-        indices_tracker,
-        persist,
-    )
-}
-
-/// Load-or-build an mmap compressed sparse index
-/// ([`InvertedIndexCompressedMmap<W, MmapFile>`]), generic over the weight type.
-fn open_sparse_mmap<W: Weight + 'static>(
-    config: SparseIndexConfig,
-    id_tracker: Arc<AtomicRefCell<IdTrackerEnum>>,
-    vector_storage: Arc<AtomicRefCell<VectorStorageEnum>>,
-    payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
-    path: &Path,
-    stopped: &AtomicBool,
-    tick_progress: impl FnMut(),
-) -> OperationResult<SparseVectorIndex<InvertedIndexCompressedMmap<W, MmapFile>>> {
-    let plan = SparseVectorIndex::<InvertedIndexCompressedMmap<W, MmapFile>>::plan(
-        config,
-        &id_tracker,
-        &vector_storage,
-        path,
-        stopped,
-        tick_progress,
-    )?;
-    let (inverted_index, config, indices_tracker, persist) = match plan {
-        SparseOpenPlan::Load {
-            config,
-            indices_tracker,
-        } => (
-            InvertedIndexCompressedMmap::<W, MmapFile>::open(&MmapFs, path)?,
-            config,
-            indices_tracker,
-            false,
-        ),
-        SparseOpenPlan::Build {
-            config,
-            ram_index,
-            indices_tracker,
-            persist,
-        } => (
-            InvertedIndexCompressedMmap::<W, MmapFile>::from_ram_index(
-                &MmapFs,
-                Cow::Owned(ram_index),
-                path,
-            )?,
-            config,
-            indices_tracker,
-            persist,
-        ),
-    };
-    SparseVectorIndex::finish(
-        config,
-        id_tracker,
-        vector_storage,
-        payload_index,
-        path,
-        inverted_index,
-        indices_tracker,
-        persist,
-    )
 }

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::TelemetryDetail;
+use common::universal_io::MmapFs;
 use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
@@ -173,6 +174,7 @@ fn sparse_index_discover_test() {
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
     let sparse_index = create_sparse_vector_index_test(SparseVectorIndexOpenArgs {
+        fs: &MmapFs,
         config: SparseIndexConfig {
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,
@@ -290,6 +292,7 @@ fn sparse_index_hardware_measurement_test() {
 
     let vector_storage = &sparse_segment.vector_data[SPARSE_VECTOR_NAME].vector_storage;
     let sparse_index = create_sparse_vector_index_test(SparseVectorIndexOpenArgs {
+        fs: &MmapFs,
         config: SparseIndexConfig {
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -1,13 +1,12 @@
 use std::cmp::max;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::storage_version::VERSION_FILE;
 use common::types::{PointOffsetType, TelemetryDetail};
-use common::universal_io::MmapFile;
+use common::universal_io::{MmapFile, MmapFs};
 use fs_err as fs;
 use itertools::Itertools;
 use rand::SeedableRng;
@@ -17,10 +16,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::{SegmentEntry, StorageSegmentEntry as _};
 use segment::fixtures::payload_fixtures::STR_KEY;
-use segment::fixtures::sparse_fixtures::{
-    fixture_sparse_index, fixture_sparse_index_from_iter, iram_from_ram, iram_open, mmap_from_ram,
-    mmap_open, open_sparse_index, ram_from_ram, ram_open,
-};
+use segment::fixtures::sparse_fixtures::{fixture_sparse_index, fixture_sparse_index_from_iter};
 use segment::id_tracker::{IdTracker, IdTrackerRead};
 use segment::index::field_index::PayloadFieldIndexRead;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -31,7 +27,6 @@ use segment::index::{
     PayloadIndex, PayloadIndexRead, VectorIndex, VectorIndexEnum, VectorIndexRead,
 };
 use segment::json_path::JsonPath;
-use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::PayloadFieldSchema::FieldType;
@@ -42,13 +37,14 @@ use segment::types::{
     VectorStorageDatatype,
 };
 use segment::vector_storage::{VectorStorage, VectorStorageRead};
+use segment::{fixture_for_all_indices, payload_json};
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::sparse_vector_fixture::{random_full_sparse_vector, random_sparse_vector};
 use sparse::common::types::DimId;
-use sparse::index::inverted_index::InvertedIndex;
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
 use sparse::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadWrite};
 use sparse::index::posting_list_common::PostingListIter as _;
 use tempfile::Builder;
 use uuid::Uuid;
@@ -80,8 +76,6 @@ fn compare_sparse_vectors_search_with_without_filter(full_scan_threshold: usize)
         MAX_SPARSE_DIM,
         full_scan_threshold,
         data_dir.path(),
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
     );
 
     // random query vectors
@@ -220,8 +214,6 @@ fn sparse_vector_index_consistent_with_storage() {
         MAX_SPARSE_DIM,
         LOW_FULL_SCAN_THRESHOLD,
         data_dir.path(),
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
     );
 
     // check consistency with underlying RAM inverted index
@@ -233,19 +225,16 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32, MmapFile>> =
-        open_sparse_index(
-            SparseVectorIndexOpenArgs {
-                config: sparse_index_config,
-                id_tracker: sparse_vector_ram_index.id_tracker().clone(),
-                vector_storage: sparse_vector_ram_index.vector_storage().clone(),
-                payload_index: sparse_vector_ram_index.payload_index().clone(),
-                path: mmap_index_dir.path(),
-                stopped: &stopped,
-                tick_progress: || (),
-            },
-            mmap_open::<f32>,
-            mmap_from_ram::<f32>,
-        )
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
+            config: sparse_index_config,
+            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+            payload_index: sparse_vector_ram_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+            tick_progress: || (),
+        })
         .unwrap();
 
     assert_eq!(
@@ -263,19 +252,16 @@ fn sparse_vector_index_consistent_with_storage() {
     let mut sparse_index_config = sparse_vector_ram_index.config();
     sparse_index_config.index_type = SparseIndexType::Mmap;
     let sparse_vector_mmap_index: SparseVectorIndex<InvertedIndexCompressedMmap<f32, MmapFile>> =
-        open_sparse_index(
-            SparseVectorIndexOpenArgs {
-                config: sparse_index_config,
-                id_tracker: sparse_vector_ram_index.id_tracker().clone(),
-                vector_storage: sparse_vector_ram_index.vector_storage().clone(),
-                payload_index: sparse_vector_ram_index.payload_index().clone(),
-                path: mmap_index_dir.path(),
-                stopped: &stopped,
-                tick_progress: || (),
-            },
-            mmap_open::<f32>,
-            mmap_from_ram::<f32>,
-        )
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
+            config: sparse_index_config,
+            id_tracker: sparse_vector_ram_index.id_tracker().clone(),
+            vector_storage: sparse_vector_ram_index.vector_storage().clone(),
+            payload_index: sparse_vector_ram_index.payload_index().clone(),
+            path: mmap_index_dir.path(),
+            stopped: &stopped,
+            tick_progress: || (),
+        })
         .unwrap();
 
     assert_eq!(
@@ -297,8 +283,6 @@ fn sparse_vector_index_load_missing_mmap() {
         [].iter().cloned(),
         10_000,
         SparseIndexType::Mmap,
-        mmap_open::<f32>,
-        mmap_from_ram::<f32>,
     );
     // absent configuration file for mmap are ignored
     // a new index is created
@@ -317,8 +301,6 @@ fn sparse_vector_index_ram_deleted_points_search() {
         (0..NUM_VECTORS).map(|_| random_sparse_vector(&mut rnd, MAX_SPARSE_DIM)),
         LOW_FULL_SCAN_THRESHOLD,
         SparseIndexType::MutableRam,
-        ram_open,
-        ram_from_ram,
     )
     .unwrap();
 
@@ -398,8 +380,6 @@ fn sparse_vector_index_ram_filtered_search() {
         MAX_SPARSE_DIM,
         LOW_FULL_SCAN_THRESHOLD,
         data_dir.path(),
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
     );
 
     // query index by payload
@@ -491,8 +471,6 @@ fn sparse_vector_index_plain_search() {
         MAX_SPARSE_DIM,
         LARGE_FULL_SCAN_THRESHOLD,
         data_dir.path(),
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
     );
 
     // query index by payload
@@ -568,8 +546,6 @@ fn handling_empty_sparse_vectors() {
             (0..NUM_VECTORS).map(|_| SparseVector::default()),
             DEFAULT_SPARSE_FULL_SCAN_THRESHOLD,
             SparseIndexType::ImmutableRam,
-            iram_open::<f32>,
-            iram_from_ram::<f32>,
         )
         .unwrap();
     let mut borrowed_storage = sparse_vector_index.vector_storage().borrow_mut();
@@ -686,35 +662,19 @@ fn sparse_vector_index_persistence_test() {
     assert_eq!(search_after_reload_result.len(), top);
     assert_eq!(search_result, search_after_reload_result);
 
-    check_persistence::<InvertedIndexCompressedImmutableRam<f32>>(
+    fixture_for_all_indices!(check_persistence::<_>(
         &segment,
         &search_result,
         &query_vector,
-        top,
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
-    );
-    check_persistence::<InvertedIndexCompressedMmap<f32, MmapFile>>(
-        &segment,
-        &search_result,
-        &query_vector,
-        top,
-        mmap_open::<f32>,
-        mmap_from_ram::<f32>,
-    );
+        top
+    ));
 }
 
-fn check_persistence<TInvertedIndex: InvertedIndex>(
+fn check_persistence<TInvertedIndex: InvertedIndexReadWrite<MmapFile>>(
     segment: &Segment,
     search_result: &[ScoredPoint],
     query_vector: &QueryVector,
     top: usize,
-    open_inverted_index: impl Fn(&Path) -> common::universal_io::Result<TInvertedIndex> + Copy,
-    from_ram_inverted_index: impl Fn(
-        std::borrow::Cow<sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam>,
-        &Path,
-    ) -> common::universal_io::Result<TInvertedIndex>
-    + Copy,
 ) {
     let stopped = AtomicBool::new(false);
 
@@ -724,25 +684,22 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
         .unwrap();
 
     let open_index = || -> SparseVectorIndex<TInvertedIndex> {
-        open_sparse_index(
-            SparseVectorIndexOpenArgs {
-                config: SparseIndexConfig {
-                    full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
-                    index_type: SparseIndexType::Mmap,
-                    datatype: Some(VectorStorageDatatype::Float32),
-                },
-                id_tracker: segment.id_tracker.clone(),
-                vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
-                    .vector_storage
-                    .clone(),
-                payload_index: segment.payload_index.clone(),
-                path: inverted_index_dir.path(),
-                stopped: &stopped,
-                tick_progress: || (),
+        SparseVectorIndex::open(SparseVectorIndexOpenArgs {
+            fs: &MmapFs,
+            config: SparseIndexConfig {
+                full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
+                index_type: SparseIndexType::Mmap,
+                datatype: Some(VectorStorageDatatype::Float32),
             },
-            open_inverted_index,
-            from_ram_inverted_index,
-        )
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[SPARSE_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            payload_index: segment.payload_index.clone(),
+            path: inverted_index_dir.path(),
+            stopped: &stopped,
+            tick_progress: || (),
+        })
         .unwrap()
     };
 
@@ -788,23 +745,10 @@ fn check_persistence<TInvertedIndex: InvertedIndex>(
 
 #[test]
 fn sparse_vector_index_files() {
-    check_sparse_vector_index_files::<InvertedIndexCompressedImmutableRam<f32>>(
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
-    );
-    check_sparse_vector_index_files::<InvertedIndexCompressedMmap<f32, MmapFile>>(
-        mmap_open::<f32>,
-        mmap_from_ram::<f32>,
-    );
+    fixture_for_all_indices!(check_sparse_vector_index_files::<_>());
 }
 
-fn check_sparse_vector_index_files<I: InvertedIndex>(
-    open_index: impl FnOnce(&Path) -> common::universal_io::Result<I>,
-    from_ram_index: impl FnOnce(
-        std::borrow::Cow<sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam>,
-        &Path,
-    ) -> common::universal_io::Result<I>,
-) {
+fn check_sparse_vector_index_files<I: InvertedIndexReadWrite<MmapFile>>() {
     let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
     let index = fixture_sparse_index::<I, _>(
         &mut StdRng::seed_from_u64(42),
@@ -812,8 +756,6 @@ fn check_sparse_vector_index_files<I: InvertedIndex>(
         MAX_SPARSE_DIM,
         LOW_FULL_SCAN_THRESHOLD,
         data_dir.path(),
-        open_index,
-        from_ram_index,
     );
 
     let files = index.files();
@@ -887,8 +829,6 @@ fn test_sparse_search_top_zero() {
         MAX_SPARSE_DIM,
         LOW_FULL_SCAN_THRESHOLD,
         data_dir.path(),
-        iram_open::<f32>,
-        iram_from_ram::<f32>,
     );
 
     let query_vector = random_sparse_vector(&mut rnd, MAX_SPARSE_DIM).into();

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -38,6 +38,7 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 dataset = { path = "../common/dataset" }
+duplicate = "2.0.1"
 fs-err = { workspace = true, features = ["debug"] }
 generic-tests = { workspace = true }
 indicatif = { workspace = true }

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -156,14 +156,15 @@ pub fn run_bench(
 
             run_bench2(
                 c.benchmark_group(format!("search/ram_{}/{name}", $name)),
-                &InvertedIndexCompressedImmutableRam::<$type>::open(&MmapFs, &index_path).unwrap(),
+                &InvertedIndexCompressedImmutableRam::<$type>::open_ro(&MmapFs, &index_path)
+                    .unwrap(),
                 query_vectors,
                 &hottest_query_vectors,
             );
 
             run_bench2(
                 c.benchmark_group(format!("search/mmap_{}/{name}", $name)),
-                &InvertedIndexCompressedMmap::<$type, MmapFile>::open(&MmapFs, &index_path)
+                &InvertedIndexCompressedMmap::<$type, MmapFile>::open_ro(&MmapFs, &index_path)
                     .unwrap(),
                 query_vectors,
                 &hottest_query_vectors,

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -5,7 +5,7 @@ use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::ext::VecExt;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFs, Result, UniversalRead, UserData};
+use common::universal_io::{MmapFs, Result, UniversalRead, UniversalWrite, UserData};
 
 use super::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use super::inverted_index_ram::InvertedIndexRam;
@@ -16,6 +16,8 @@ use crate::index::compressed_posting_list::{
     CompressedPostingBuilder, CompressedPostingList, CompressedPostingListIterator,
     CompressedPostingListView,
 };
+use crate::index::inverted_index::inverted_index_compressed_mmap::Version;
+use crate::index::inverted_index::{InvertedIndexReadOnly, InvertedIndexReadWrite};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InvertedIndexCompressedImmutableRam<W: Weight> {
@@ -26,10 +28,56 @@ pub struct InvertedIndexCompressedImmutableRam<W: Weight> {
 
 type Storage = common::universal_io::MmapFile;
 
+impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
+    for InvertedIndexCompressedImmutableRam<W>
+{
+    fn open_ro_impl(fs: &S::Fs, path: &Path) -> Result<Self> {
+        let mmap_inverted_index = InvertedIndexCompressedMmap::<W, S>::open_ro(fs, path)?;
+        Self::from_mmap_index(mmap_inverted_index)
+    }
+}
+
+impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
+    for InvertedIndexCompressedImmutableRam<W>
+{
+    fn open_rw_impl(fs: &<S as UniversalRead>::Fs, path: &Path) -> Result<Self> {
+        let mmap_inverted_index = InvertedIndexCompressedMmap::<W, S>::open_rw(fs, path)?;
+        Self::from_mmap_index(mmap_inverted_index)
+    }
+
+    fn from_ram_index_impl<P: AsRef<Path>>(
+        _fs: &S::Fs,
+        ram_index: Cow<InvertedIndexRam>,
+        _path: P,
+    ) -> Result<Self> {
+        let mut postings = Vec::with_capacity(ram_index.postings.len());
+        for old_posting_list in &ram_index.postings {
+            let mut new_posting_list = CompressedPostingBuilder::new();
+            for elem in &old_posting_list.elements {
+                new_posting_list.add(elem.record_id, elem.weight);
+            }
+            postings.push(new_posting_list.build());
+        }
+
+        let hw_counter = HardwareCounterCell::disposable();
+
+        let total_sparse_size = postings
+            .iter()
+            .map(|p| p.view(&hw_counter).store_size().total)
+            .sum();
+
+        Ok(InvertedIndexCompressedImmutableRam {
+            postings,
+            vector_count: ram_index.vector_count,
+            total_sparse_size,
+        })
+    }
+}
+
 impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
     type Iter<'a> = CompressedPostingListIterator<'a, W>;
 
-    type Version = <InvertedIndexCompressedMmap<W, Storage> as InvertedIndex>::Version;
+    type Version = Version;
 
     fn is_on_disk(&self) -> bool {
         false
@@ -108,52 +156,6 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
 }
 
 impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
-    /// Open an existing on-disk index through `fs`, copying it into RAM.
-    pub fn open(fs: &MmapFs, path: &Path) -> Result<Self> {
-        let mmap_inverted_index = InvertedIndexCompressedMmap::<W, Storage>::load(fs, path)?;
-        Self::from_mmap_index(mmap_inverted_index)
-    }
-
-    /// Build a RAM index from another RAM index (re-encoding the postings).
-    pub fn from_ram_index<P: AsRef<Path>>(
-        _fs: &MmapFs,
-        ram_index: Cow<InvertedIndexRam>,
-        _path: P,
-    ) -> Result<Self> {
-        let mut postings = Vec::with_capacity(ram_index.postings.len());
-        for old_posting_list in &ram_index.postings {
-            let mut new_posting_list = CompressedPostingBuilder::new();
-            for elem in &old_posting_list.elements {
-                new_posting_list.add(elem.record_id, elem.weight);
-            }
-            postings.push(new_posting_list.build());
-        }
-
-        let hw_counter = HardwareCounterCell::disposable();
-
-        let total_sparse_size = postings
-            .iter()
-            .map(|p| p.view(&hw_counter).store_size().total)
-            .sum();
-
-        Ok(InvertedIndexCompressedImmutableRam {
-            postings,
-            vector_count: ram_index.vector_count,
-            total_sparse_size,
-        })
-    }
-
-    /// Load purely through universal IO, streaming the postings through `fs`
-    /// instead of a local mmap. Used by the read-only index.
-    pub fn load_universal<S>(fs: &S::Fs, path: &Path) -> Result<Self>
-    where
-        S: UniversalRead + 'static,
-    {
-        Self::from_mmap_index(InvertedIndexCompressedMmap::<W, S>::load_universal(
-            fs, path,
-        )?)
-    }
-
     /// Materialize an mmap-layout index into owned in-RAM postings.
     fn from_mmap_index<S>(mmap_inverted_index: InvertedIndexCompressedMmap<W, S>) -> Result<Self>
     where
@@ -245,7 +247,8 @@ mod tests {
             .unwrap();
 
         let loaded_inverted_index =
-            InvertedIndexCompressedImmutableRam::<W>::open(&MmapFs, tmp_dir_path.path()).unwrap();
+            InvertedIndexCompressedImmutableRam::<W>::open_ro(&MmapFs, tmp_dir_path.path())
+                .unwrap();
         assert_eq!(inverted_index_immutable_ram, loaded_inverted_index);
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -16,8 +16,8 @@ use common::mmap::{transmute_to_u8, transmute_to_u8_slice};
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFs, OpenOptions, Populate, ReadBytesItem, Result, UniversalRead, UniversalReadFs, UserData,
-    read_json_via,
+    MmapFs, OpenOptions, Populate, ReadBytesItem, Result, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData, read_json_via,
 };
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
@@ -29,8 +29,8 @@ use crate::common::types::{DimId, DimOffset, Weight};
 use crate::index::compressed_posting_list::{
     CHUNK_SIZE, CompressedPostingChunk, CompressedPostingListIterator, CompressedPostingListView,
 };
-use crate::index::inverted_index::InvertedIndex;
 use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use crate::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly, InvertedIndexReadWrite};
 use crate::index::posting_list_common::GenericPostingElement;
 
 const INDEX_CONFIG_FILE_NAME: &str = "inverted_index_config.json";
@@ -40,6 +40,94 @@ pub struct Version;
 impl StorageVersion for Version {
     fn current_raw() -> &'static str {
         "0.2.0"
+    }
+}
+
+impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
+    for InvertedIndexCompressedMmap<W, S>
+{
+    fn open_ro_impl(fs: &S::Fs, path: &Path) -> Result<Self> {
+        let file_header: InvertedIndexFileHeader =
+            read_json_via(fs, Self::index_config_file_path(path))?;
+
+        let storage = fs.open(
+            Self::index_file_path(path),
+            OpenOptions {
+                writeable: false,
+                need_sequential: false,
+                populate: Populate::No,
+                advice: AdviceSetting::Advice(Advice::Normal),
+            },
+            Default::default(),
+        )?;
+
+        let mut index = Self {
+            path: path.to_owned(),
+            storage,
+            file_header,
+            _phantom: PhantomData,
+        };
+
+        if index.file_header.total_sparse_size.is_none() {
+            // legacy header: compute in memory, never write back
+            let hw_counter = HardwareCounterCell::disposable();
+            index.file_header.total_sparse_size =
+                Some(index.calculate_total_sparse_size(&hw_counter)?);
+        }
+
+        Ok(index)
+    }
+}
+
+impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
+    for InvertedIndexCompressedMmap<W, S>
+{
+    fn open_rw_impl(fs: &S::Fs, path: &Path) -> Result<Self> {
+        // read index config file
+        let config_file_path = Self::index_config_file_path(path);
+        // if the file header does not exist, the index is malformed
+        let file_header: InvertedIndexFileHeader = read_json_via(fs, &config_file_path)?;
+        // open index data via universal IO
+        let file_path = Self::index_file_path(path);
+        let storage = fs.open(
+            &file_path,
+            OpenOptions {
+                writeable: false,
+                need_sequential: false,
+                populate: Populate::No,
+                advice: AdviceSetting::Advice(Advice::Normal),
+            },
+            Default::default(),
+        )?;
+
+        let mut index = Self {
+            path: path.to_owned(),
+            storage,
+            file_header,
+            _phantom: PhantomData,
+        };
+
+        let hw_counter = HardwareCounterCell::disposable();
+
+        if index.file_header.total_sparse_size.is_none() {
+            index.file_header.total_sparse_size =
+                Some(index.calculate_total_sparse_size(&hw_counter)?);
+            atomic_save_json(&config_file_path, &index.file_header)?;
+        }
+
+        Ok(index)
+    }
+
+    fn from_ram_index_impl<P: AsRef<Path>>(
+        fs: &<S as UniversalRead>::Fs,
+        ram_index: Cow<InvertedIndexRam>,
+        path: P,
+    ) -> Result<Self> {
+        // The intermediate RAM index is built in memory; its no-op `MmapFs` is
+        // irrelevant. The conversion writes through the real `fs`.
+        let index =
+            InvertedIndexCompressedImmutableRam::<W>::from_ram_index(&MmapFs, ram_index, &path)?;
+        Self::convert_and_save(fs, &index, path)
     }
 }
 
@@ -193,23 +281,6 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndex for InvertedIndexCompr
 
 impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<W, S> {
     const HEADER_SIZE: usize = size_of::<PostingListFileHeader<W>>();
-
-    /// Open an existing on-disk index through `fs`. Equivalent to [`Self::load`].
-    pub fn open(fs: &S::Fs, path: &Path) -> Result<Self> {
-        Self::load(fs, path)
-    }
-
-    /// Build an on-disk index from a RAM index, writing it through `fs`.
-    pub fn from_ram_index<P: AsRef<Path>>(
-        fs: &S::Fs,
-        ram_index: Cow<InvertedIndexRam>,
-        path: P,
-    ) -> Result<Self> {
-        // The intermediate RAM index is built in memory; its no-op `MmapFs` is
-        // irrelevant. The conversion writes through the real `fs`.
-        let index = InvertedIndexCompressedImmutableRam::from_ram_index(&MmapFs, ram_index, &path)?;
-        Self::convert_and_save(fs, &index, path)
-    }
 
     pub fn index_file_path(path: &Path) -> PathBuf {
         path.join(INDEX_FILE_NAME)
@@ -446,76 +517,6 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         })
     }
 
-    pub fn load<P: AsRef<Path>>(fs: &S::Fs, path: P) -> Result<Self> {
-        // read index config file
-        let config_file_path = Self::index_config_file_path(path.as_ref());
-        // if the file header does not exist, the index is malformed
-        let file_header: InvertedIndexFileHeader = read_json_via(fs, &config_file_path)?;
-        // open index data via universal IO
-        let file_path = Self::index_file_path(path.as_ref());
-        let storage = fs.open(
-            &file_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate: Populate::No,
-                advice: AdviceSetting::Advice(Advice::Normal),
-            },
-            Default::default(),
-        )?;
-
-        let mut index = Self {
-            path: path.as_ref().to_owned(),
-            storage,
-            file_header,
-            _phantom: PhantomData,
-        };
-
-        let hw_counter = HardwareCounterCell::disposable();
-
-        if index.file_header.total_sparse_size.is_none() {
-            index.file_header.total_sparse_size =
-                Some(index.calculate_total_sparse_size(&hw_counter)?);
-            atomic_save_json(&config_file_path, &index.file_header)?;
-        }
-
-        Ok(index)
-    }
-
-    /// Load purely through universal IO, without the legacy-header upgrade
-    /// write path of [`Self::load`]. Used by the read-only index.
-    pub fn load_universal(fs: &S::Fs, path: &Path) -> Result<Self> {
-        let file_header: InvertedIndexFileHeader =
-            read_json_via(fs, Self::index_config_file_path(path))?;
-
-        let storage = fs.open(
-            Self::index_file_path(path),
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate: Populate::No,
-                advice: AdviceSetting::Advice(Advice::Normal),
-            },
-            Default::default(),
-        )?;
-
-        let mut index = Self {
-            path: path.to_owned(),
-            storage,
-            file_header,
-            _phantom: PhantomData,
-        };
-
-        if index.file_header.total_sparse_size.is_none() {
-            // legacy header: compute in memory, never write back
-            let hw_counter = HardwareCounterCell::disposable();
-            index.file_header.total_sparse_size =
-                Some(index.calculate_total_sparse_size(&hw_counter)?);
-        }
-
-        Ok(index)
-    }
-
     fn calculate_total_sparse_size(&self, hw_counter: &HardwareCounterCell) -> Result<usize> {
         let mut total = 0;
         self.for_each_view(hw_counter, |_id, view| {
@@ -622,8 +623,7 @@ mod tests {
             compare_indexes(&inverted_index_ram, &inverted_index_mmap);
         }
         let index =
-            InvertedIndexCompressedMmap::<W, MmapFile>::load(&Default::default(), &tmp_dir_path)
-                .unwrap();
+            InvertedIndexCompressedMmap::<W, _>::open_ro(&MmapFs, tmp_dir_path.path()).unwrap();
         // posting_count: 0th entry is always empty + 1st + 2nd + 3rd + 4th empty + 5th
         assert_eq!(index.file_header.posting_count, 6);
         assert_eq!(index.file_header.vector_count, 9);

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -42,7 +42,7 @@ pub struct InvertedIndexRam {
 
 impl<S: UniversalWrite> InvertedIndexReadWrite<S> for InvertedIndexRam {
     fn open_rw_impl(_fs: &<S as UniversalRead>::Fs, _path: &Path) -> Result<Self> {
-        panic!("InvertedIndexRam is not supposed to be loaded");
+        panic!("InvertedIndexRam is never persisted, so can't to be loaded");
     }
 
     fn from_ram_index_impl<P: AsRef<Path>>(

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -7,7 +7,7 @@ use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFs, Result, UserData};
+use common::universal_io::{Result, UniversalRead, UniversalWrite, UserData};
 #[cfg(feature = "testing")]
 use fs_err as fs;
 #[cfg(feature = "testing")]
@@ -15,7 +15,7 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::{DimId, DimOffset};
-use crate::index::inverted_index::{InvertedIndex, out_of_bounds};
+use crate::index::inverted_index::{InvertedIndex, InvertedIndexReadWrite, out_of_bounds};
 use crate::index::posting_list::{PostingList, PostingListIterator};
 use crate::index::posting_list_common::PostingElementEx;
 
@@ -38,6 +38,20 @@ pub struct InvertedIndexRam {
     pub vector_count: usize,
     /// Total size of all searchable sparse vectors in bytes
     pub total_sparse_size: usize,
+}
+
+impl<S: UniversalWrite> InvertedIndexReadWrite<S> for InvertedIndexRam {
+    fn open_rw_impl(_fs: &<S as UniversalRead>::Fs, _path: &Path) -> Result<Self> {
+        panic!("InvertedIndexRam is not supposed to be loaded");
+    }
+
+    fn from_ram_index_impl<P: AsRef<Path>>(
+        _fs: &<S as UniversalRead>::Fs,
+        ram_index: Cow<InvertedIndexRam>,
+        _path: P,
+    ) -> Result<Self> {
+        Ok(ram_index.into_owned())
+    }
 }
 
 impl InvertedIndex for InvertedIndexRam {
@@ -131,20 +145,6 @@ impl InvertedIndex for InvertedIndexRam {
 }
 
 impl InvertedIndexRam {
-    /// A RAM index is never persisted, so it cannot be opened from a path.
-    pub fn open(_fs: &MmapFs, _path: &Path) -> Result<Self> {
-        panic!("InvertedIndexRam is not supposed to be loaded");
-    }
-
-    /// Build a RAM index from a RAM index (takes ownership of the source).
-    pub fn from_ram_index<P: AsRef<Path>>(
-        _fs: &MmapFs,
-        ram_index: Cow<InvertedIndexRam>,
-        _path: P,
-    ) -> Result<Self> {
-        Ok(ram_index.into_owned())
-    }
-
     /// New empty inverted index
     pub fn empty() -> InvertedIndexRam {
         InvertedIndexRam {

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
@@ -5,11 +6,14 @@ use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{Result, UniversalIoError, UserData};
+use common::universal_io::{
+    Result, UniversalIoError, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+};
 
 use super::posting_list_common::PostingListIter;
 use crate::common::sparse_vector::RemappedSparseVector;
 use crate::common::types::DimOffset;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 
 pub mod inverted_index_compressed_immutable_ram;
 pub mod inverted_index_compressed_mmap;
@@ -22,6 +26,23 @@ pub mod inverted_index_ram_builder;
 // `inverted_index.data` to `inverted_index.dat`.
 pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
 
+pub trait InvertedIndexReadOnly<S: UniversalRead>: InvertedIndex {
+    /// See [`InvertedIndex::open_ro`].
+    fn open_ro_impl(fs: &S::Fs, path: &Path) -> Result<Self>;
+}
+
+pub trait InvertedIndexReadWrite<S: UniversalWrite>: InvertedIndex {
+    /// See [`InvertedIndex::open_rw`].
+    fn open_rw_impl(fs: &S::Fs, path: &Path) -> Result<Self>;
+
+    /// See [`InvertedIndex::from_ram_index`].
+    fn from_ram_index_impl<P: AsRef<Path>>(
+        fs: &S::Fs,
+        ram_index: Cow<InvertedIndexRam>,
+        path: P,
+    ) -> Result<Self>;
+}
+
 pub trait InvertedIndex: Sized + Debug + 'static {
     type Iter<'a>: PostingListIter + Clone
     where
@@ -30,6 +51,29 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     type Version: StorageVersion;
 
     fn is_on_disk(&self) -> bool;
+
+    /// Open existing index based on path.
+    fn open_ro<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> Result<Self>
+    where
+        Self: InvertedIndexReadOnly<Fs::File>,
+    {
+        Self::open_ro_impl(fs, path)
+    }
+
+    /// Open existing index based on path.
+    ///
+    /// Unlike [`Self::open_ro`], it might perform migration-related writes.
+    ///
+    /// TODO(uio): probably, this can be refactored into a single `open` with
+    /// boolean parameter, if we add something like
+    /// `UniversalReadFs::try_write(&self) -> Option<&impl UniversalWriteFs>`.
+    fn open_rw<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> Result<Self>
+    where
+        Self: InvertedIndexReadWrite<Fs::File>,
+        Fs::File: UniversalWrite<Fs = Fs>,
+    {
+        Self::open_rw_impl(fs, path)
+    }
 
     /// Save index
     fn save(&self, path: &Path) -> Result<()>;
@@ -73,6 +117,19 @@ pub trait InvertedIndex: Sized + Debug + 'static {
         vector: RemappedSparseVector,
         old_vector: Option<RemappedSparseVector>,
     );
+
+    /// Create inverted index from ram index
+    fn from_ram_index<P: AsRef<Path>, Fs: UniversalReadFs>(
+        fs: &Fs,
+        ram_index: Cow<InvertedIndexRam>,
+        path: P,
+    ) -> Result<Self>
+    where
+        Self: InvertedIndexReadWrite<Fs::File>,
+        Fs::File: UniversalWrite<Fs = Fs>,
+    {
+        Self::from_ram_index_impl(fs, ram_index, path)
+    }
 
     /// Number of indexed vectors
     fn vector_count(&self) -> usize;

--- a/lib/sparse/src/index/tests/common.rs
+++ b/lib/sparse/src/index/tests/common.rs
@@ -17,20 +17,18 @@ pub struct TestIndex<I: InvertedIndex> {
     _temp_dir: TempDir,
 }
 
-// These helpers are only ever instantiated with the on-disk mmap index.
 impl<W: Weight> TestIndex<InvertedIndexCompressedMmap<W, MmapFile>> {
     fn from_ram(ram_index: InvertedIndexRam) -> Self {
         let temp_dir = tempfile::Builder::new()
             .prefix("test_index_dir")
             .tempdir()
             .unwrap();
+
+        let index =
+            InvertedIndexCompressedMmap::from_ram_index(&MmapFs, Cow::Owned(ram_index), &temp_dir)
+                .unwrap();
         TestIndex {
-            index: InvertedIndexCompressedMmap::from_ram_index(
-                &MmapFs,
-                Cow::Owned(ram_index),
-                &temp_dir,
-            )
-            .unwrap(),
+            index,
             _temp_dir: temp_dir,
         }
     }

--- a/lib/sparse/src/index/tests/mod.rs
+++ b/lib/sparse/src/index/tests/mod.rs
@@ -1,4 +1,5 @@
 mod common;
 mod hw_counter_test;
 mod indexed_vs_plain_test;
+#[cfg(test)]
 mod search_context_tests;

--- a/lib/sparse/src/index/tests/search_context_tests.rs
+++ b/lib/sparse/src/index/tests/search_context_tests.rs
@@ -1,138 +1,82 @@
-#[cfg(test)]
-#[generic_tests::define]
-mod tests {
-    use std::any::TypeId;
-    use std::borrow::Cow;
-    use std::path::Path;
-    use std::sync::atomic::AtomicBool;
+use std::any::TypeId;
+use std::borrow::Cow;
+use std::sync::atomic::AtomicBool;
 
-    use common::counter::hardware_accumulator::HwMeasurementAcc;
-    use common::counter::hardware_counter::HardwareCounterCell;
-    use common::types::{PointOffsetType, ScoredPointOffset};
-    #[cfg(target_os = "linux")]
-    use common::universal_io::IoUringFile;
-    use common::universal_io::{MmapFile, MmapFs, UniversalRead};
-    use tempfile::TempDir;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::{PointOffsetType, ScoredPointOffset};
+#[cfg(target_os = "linux")]
+use common::universal_io::{IoUringFile, IoUringFs};
+use common::universal_io::{MmapFile, MmapFs};
+use tempfile::TempDir;
 
-    use crate::SearchScratch;
-    use crate::common::sparse_vector::RemappedSparseVector;
-    use crate::common::types::{QuantizedU8, Weight};
-    use crate::index::inverted_index::InvertedIndex;
-    use crate::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
-    use crate::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
-    use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
-    use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
-    use crate::index::posting_list_common::PostingListIter;
-    use crate::index::search_context::SearchContext;
-    // ---- Test instantiations ----
+use crate::SearchScratch;
+use crate::common::sparse_vector::RemappedSparseVector;
+use crate::common::types::QuantizedU8;
+use crate::index::inverted_index::InvertedIndex;
+use crate::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
+use crate::index::inverted_index::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
+use crate::index::inverted_index::inverted_index_ram::InvertedIndexRam;
+use crate::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
+use crate::index::posting_list_common::PostingListIter;
+use crate::index::search_context::SearchContext;
 
-    #[instantiate_tests(<InvertedIndexRam>)]
-    mod ram {}
+/// Match all filter condition for testing
+fn match_all(_p: PointOffsetType) -> bool {
+    true
+}
 
-    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<f32>>)]
-    mod iram_f32 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<half::f16>>)]
-    mod iram_f16 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<u8>>)]
-    mod iram_u8 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedImmutableRam<QuantizedU8>>)]
-    mod iram_q8 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedMmap<f32, MmapFile>>)]
-    mod mmap_f32 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedMmap<half::f16, MmapFile>>)]
-    mod mmap_f16 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedMmap<u8, MmapFile>>)]
-    mod mmap_u8 {}
-
-    #[instantiate_tests(<InvertedIndexCompressedMmap<QuantizedU8, MmapFile>>)]
-    mod mmap_q8 {}
-
-    #[cfg(target_os = "linux")]
-    #[instantiate_tests(<InvertedIndexCompressedMmap<f32, IoUringFile>>)]
-    mod uring_f32 {}
-
-    #[cfg(target_os = "linux")]
-    #[instantiate_tests(<InvertedIndexCompressedMmap<half::f16, IoUringFile>>)]
-    mod uring_f16 {}
-
-    #[cfg(target_os = "linux")]
-    #[instantiate_tests(<InvertedIndexCompressedMmap<u8, IoUringFile>>)]
-    mod uring_u8 {}
-
-    #[cfg(target_os = "linux")]
-    #[instantiate_tests(<InvertedIndexCompressedMmap<QuantizedU8, IoUringFile>>)]
-    mod uring_q8 {}
-
-    // --- End of test instantiations ---
-
-    /// Match all filter condition for testing
-    fn match_all(_p: PointOffsetType) -> bool {
-        true
-    }
-
-    /// Test-only bridge to the per-type inherent constructors. Production builds
-    /// inverted indexes through the segment dispatcher (`create_sparse_vector_index`),
-    /// but the generic `#[instantiate_tests]` harness needs to construct each `I`
-    /// uniformly from a RAM index.
-    trait BuildFromRam: InvertedIndex {
-        fn build_from_ram(ram_index: InvertedIndexRam, path: &Path) -> Self;
-    }
-
-    impl<W: Weight, S: UniversalRead + 'static> BuildFromRam for InvertedIndexCompressedMmap<W, S>
-    where
-        S::Fs: Default,
-    {
-        fn build_from_ram(ram_index: InvertedIndexRam, path: &Path) -> Self {
-            Self::from_ram_index(&S::Fs::default(), Cow::Owned(ram_index), path).unwrap()
-        }
-    }
-
-    impl<W: Weight> BuildFromRam for InvertedIndexCompressedImmutableRam<W> {
-        fn build_from_ram(ram_index: InvertedIndexRam, path: &Path) -> Self {
-            Self::from_ram_index(&MmapFs, Cow::Owned(ram_index), path).unwrap()
-        }
-    }
-
-    impl BuildFromRam for InvertedIndexRam {
-        fn build_from_ram(ram_index: InvertedIndexRam, _path: &Path) -> Self {
-            ram_index
-        }
-    }
+#[duplicate::duplicate_item(
+     test_mod   Idx                                                      Fs         cfg_pred;
+    [ram      ][InvertedIndexRam                                       ][MmapFs   ][cfg(true)];
+    [iram_f32 ][InvertedIndexCompressedImmutableRam::<f32>             ][MmapFs   ][cfg(true)];
+    [iram_f16 ][InvertedIndexCompressedImmutableRam::<half::f16>       ][MmapFs   ][cfg(true)];
+    [iram_u8  ][InvertedIndexCompressedImmutableRam::<u8>              ][MmapFs   ][cfg(true)];
+    [iram_q8  ][InvertedIndexCompressedImmutableRam::<QuantizedU8>     ][MmapFs   ][cfg(true)];
+    [mmap_f32 ][InvertedIndexCompressedMmap::<f32, MmapFile>           ][MmapFs   ][cfg(true)];
+    [mmap_f16 ][InvertedIndexCompressedMmap::<half::f16, MmapFile>     ][MmapFs   ][cfg(true)];
+    [mmap_u8  ][InvertedIndexCompressedMmap::<u8, MmapFile>            ][MmapFs   ][cfg(true)];
+    [mmap_q8  ][InvertedIndexCompressedMmap::<QuantizedU8, MmapFile>   ][MmapFs   ][cfg(true)];
+    [uring_f32][InvertedIndexCompressedMmap::<f32, IoUringFile>        ][IoUringFs][cfg(target_os = "linux")];
+    [uring_f16][InvertedIndexCompressedMmap::<half::f16, IoUringFile>  ][IoUringFs][cfg(target_os = "linux")];
+    [uring_u8 ][InvertedIndexCompressedMmap::<u8, IoUringFile>         ][IoUringFs][cfg(target_os = "linux")];
+    [uring_q8 ][InvertedIndexCompressedMmap::<QuantizedU8, IoUringFile>][IoUringFs][cfg(target_os = "linux")];
+)]
+#[cfg_pred]
+mod test_mod {
+    use super::*;
 
     /// Helper struct to store both an index and a temporary directory
-    struct TestIndex<I: InvertedIndex> {
-        index: I,
+    struct TestIndex {
+        index: Idx,
         _temp_dir: TempDir,
     }
 
-    impl<I: BuildFromRam> TestIndex<I> {
+    impl TestIndex {
         fn from_ram(ram_index: InvertedIndexRam) -> Self {
             let temp_dir = tempfile::Builder::new()
                 .prefix("test_index_dir")
                 .tempdir()
                 .unwrap();
+
+            #[expect(clippy::default_constructed_unit_structs, reason = "macroexpanded")]
+            let fs = Fs::default();
             TestIndex {
-                index: I::build_from_ram(ram_index, temp_dir.path()),
+                index: Idx::from_ram_index(&fs, Cow::Owned(ram_index), temp_dir.path()).unwrap(),
                 _temp_dir: temp_dir,
             }
         }
     }
 
     /// Round scores to allow some quantization errors
-    fn round_scores<I: 'static>(mut scores: Vec<ScoredPointOffset>) -> Vec<ScoredPointOffset> {
+    fn round_scores(mut scores: Vec<ScoredPointOffset>) -> Vec<ScoredPointOffset> {
         let errors_allowed_for = [
             TypeId::of::<InvertedIndexCompressedImmutableRam<QuantizedU8>>(),
             TypeId::of::<InvertedIndexCompressedMmap<QuantizedU8, MmapFile>>(),
             #[cfg(target_os = "linux")]
             TypeId::of::<InvertedIndexCompressedMmap<QuantizedU8, IoUringFile>>(),
         ];
-        if errors_allowed_for.contains(&TypeId::of::<I>()) {
+        if errors_allowed_for.contains(&TypeId::of::<Idx>()) {
             let precision = 0.25;
             scores.iter_mut().for_each(|score| {
                 score.score = (score.score / precision).round() * precision;
@@ -142,10 +86,9 @@ mod tests {
             scores
         }
     }
-
     #[test]
-    fn test_empty_query<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram(InvertedIndexRam::empty());
+    fn test_empty_query() {
+        let index = TestIndex::from_ram(InvertedIndexRam::empty());
 
         let hw_counter = HardwareCounterCell::disposable();
 
@@ -164,8 +107,8 @@ mod tests {
     }
 
     #[test]
-    fn search_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn search_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
@@ -191,7 +134,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            round_scores::<I>(search_context.search(&match_all)),
+            round_scores(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -219,13 +162,13 @@ mod tests {
     }
 
     #[test]
-    fn search_with_update_test<I: BuildFromRam + 'static>() {
-        if TypeId::of::<I>() != TypeId::of::<InvertedIndexRam>() {
+    fn search_with_update_test() {
+        if TypeId::of::<Idx>() != TypeId::of::<InvertedIndexRam>() {
             // Only InvertedIndexRam supports upserts
             return;
         }
 
-        let mut index = TestIndex::<I>::from_ram({
+        let mut index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
@@ -251,7 +194,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            round_scores::<I>(search_context.search(&match_all)),
+            round_scores(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -318,8 +261,8 @@ mod tests {
     }
 
     #[test]
-    fn search_with_hot_key_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn search_with_hot_key_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (2, 20.0), (3, 20.0)].into());
@@ -351,7 +294,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            round_scores::<I>(search_context.search(&match_all)),
+            round_scores(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -394,7 +337,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            round_scores::<I>(search_context.search(&match_all)),
+            round_scores(search_context.search(&match_all)),
             vec![
                 ScoredPointOffset {
                     score: 90.0,
@@ -421,8 +364,8 @@ mod tests {
     }
 
     #[test]
-    fn pruning_single_to_end_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn pruning_single_to_end_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0)].into());
             builder.add(2, [(1, 20.0)].into());
@@ -454,8 +397,8 @@ mod tests {
     }
 
     #[test]
-    fn pruning_multi_to_end_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn pruning_multi_to_end_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0)].into());
             builder.add(2, [(1, 20.0)].into());
@@ -490,12 +433,12 @@ mod tests {
     }
 
     #[test]
-    fn pruning_multi_under_prune_test<I: BuildFromRam>() {
-        if !I::Iter::reliable_max_next_weight() {
+    fn pruning_multi_under_prune_test() {
+        if !<Idx as InvertedIndex>::Iter::reliable_max_next_weight() {
             return;
         }
 
-        let index = TestIndex::<I>::from_ram({
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0)].into());
             builder.add(2, [(1, 20.0)].into());
@@ -537,8 +480,8 @@ mod tests {
     }
 
     #[test]
-    fn promote_longest_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn promote_longest_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (3, 20.0)].into());
@@ -571,8 +514,8 @@ mod tests {
     }
 
     #[test]
-    fn plain_search_all_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn plain_search_all_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (3, 20.0)].into());
@@ -599,7 +542,7 @@ mod tests {
 
         let scores = search_context.plain_search(&[1, 3, 2]);
         assert_eq!(
-            round_scores::<I>(scores),
+            round_scores(scores),
             vec![
                 ScoredPointOffset {
                     idx: 3,
@@ -626,8 +569,8 @@ mod tests {
     }
 
     #[test]
-    fn plain_search_gap_test<I: BuildFromRam>() {
-        let index = TestIndex::<I>::from_ram({
+    fn plain_search_gap_test() {
+        let index = TestIndex::from_ram({
             let mut builder = InvertedIndexBuilder::new();
             builder.add(1, [(1, 10.0), (2, 10.0), (3, 10.0)].into());
             builder.add(2, [(1, 20.0), (3, 20.0)].into());
@@ -655,7 +598,7 @@ mod tests {
 
         let scores = search_context.plain_search(&[1, 2, 3]);
         assert_eq!(
-            round_scores::<I>(scores),
+            round_scores(scores),
             vec![
                 ScoredPointOffset {
                     idx: 2,


### PR DESCRIPTION
The PR #9435 removed `open`/`from_ram_index` from the `InvertedIndex` trait and converted them to non-trait methods. This caused a lot of repetitive code. (manually expanded generics?)

A lot of it can be rolled back if we restore these methods. But this time:
- Make these methods generic over `UniversalReadFs` (via helper traits).
  - `InvertedIndexCompressedImmutableRam<W>` can open any `UniversalRead` impl.
  - `InvertedIndexCompressedMmap<W, S: UniversalRead>` is bounded to a particular `S: UniversalRead`, so it can open only it's own `UniversalRead` impl.
- Split `open()` into `open_ro()` and `open_rw()` (via separate helper traits).
  - `ReadOnlySparseVectorIndex` only uses the former.
  - The later wouldn't be available, e.g., on `S3File`.

Correct me if I miss something, but I think the proposed change still covers the read-only segment use-case.