### PR TITLE
Move trait `ConditionChecker` to `common`

### DIFF
--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -1,0 +1,26 @@
+use crate::types::PointOffsetType;
+
+/// A check that tests whether points satisfy a condition.
+pub trait ConditionChecker {
+    type Error;
+
+    fn check(&self, point_id: PointOffsetType) -> Result<bool, Self::Error>;
+
+    /// Same as [`Self::check`] but ignoring errors.
+    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
+        // This method is a workaround to keep the performance on-par.
+        // It's faster to do `.unwrap_or(false)` *inside* the trait method
+        // because the compiler can't inline `&dyn Trait` methods.
+        //
+        // TODO(uio): remove this method and handle errors properly.
+        self.check(point_id).unwrap_or(false)
+    }
+}
+
+impl<E, F: Fn(PointOffsetType) -> Result<bool, E>> ConditionChecker for F {
+    type Error = E;
+
+    fn check(&self, point_id: PointOffsetType) -> Result<bool, E> {
+        self(point_id)
+    }
+}

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bitpacking_ordered;
 pub mod bitvec;
 pub mod budget;
 pub mod bytes;
+pub mod condition_checker;
 pub mod counter;
 pub mod cow;
 pub mod cpu;

--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for ImmutableBoolIndex {
@@ -79,7 +79,7 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -19,7 +19,7 @@ use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::facets::{FacetHit, FacetValueRef};
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::FieldCondition;
 
@@ -140,7 +140,7 @@ impl PayloadFieldIndexRead for BoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for MutableBoolIndex {
@@ -77,7 +77,7 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -12,7 +12,7 @@ use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, PayloadKeyType};
 
@@ -89,7 +89,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -29,7 +29,7 @@ use crate::common::operation_error::OperationResult;
 use crate::common::utils::MultiValue;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -268,7 +268,7 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
     idx: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -14,7 +14,7 @@ use crate::index::field_index::geo_index::GeoIndexRead;
 use crate::index::field_index::null_index::NullIndexRead;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -101,7 +101,7 @@ impl PayloadFieldIndexRead for FieldIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         match self {
             FieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Read-only operations available on every payload field index.
@@ -56,7 +56,7 @@ pub trait PayloadFieldIndexRead {
         &'a self,
         _condition: &FieldCondition,
         _hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>>;
+    ) -> OperationResult<Option<DynConditionChecker<'a>>>;
 
     /// Index-aware check for conditions that need parameters held by
     /// the index (today: full-text tokenizers).

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -17,7 +17,7 @@ use crate::index::field_index::numeric_index::{
 use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -112,7 +112,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),

--- a/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`FullTextIndexRead`] method to the active
@@ -193,7 +193,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         read_ops::condition_checker(self, condition, hw_acc)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     FieldCondition, Match, MatchAny, MatchExcept, MatchPhrase, MatchText, MatchTextAny, MatchValue,
     PayloadKeyType,
@@ -180,7 +180,7 @@ impl PayloadFieldIndexRead for FullTextIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         condition_checker(self, condition, hw_acc)
     }
 
@@ -280,7 +280,7 @@ pub fn condition_checker<'a, T: FullTextIndexRead>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+) -> OperationResult<Option<DynConditionChecker<'a>>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -14,7 +14,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -144,7 +144,7 @@ impl PayloadFieldIndexRead for GeoIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
@@ -13,7 +13,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`GeoIndexRead`] method to the active
@@ -243,7 +243,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -31,7 +31,7 @@ use crate::index::field_index::geo_hash::{
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -328,7 +328,7 @@ pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
     geo: &'a G,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
@@ -77,7 +77,7 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -119,7 +119,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -244,7 +244,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<IntPayloadType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
@@ -78,7 +78,7 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -120,7 +120,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -247,7 +247,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<str> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -22,7 +22,7 @@ use crate::index::field_index::{
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
@@ -81,7 +81,7 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -123,7 +123,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(condition_checker_impl(self, condition, hw_acc))
     }
 }
@@ -303,7 +303,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<UuidIntType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for ImmutableNullIndex {
@@ -72,7 +72,7 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -17,7 +17,7 @@ use super::{PayloadFieldIndex, PayloadFieldIndexRead};
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::FieldCondition;
 
 pub enum NullIndex {
@@ -134,7 +134,7 @@ impl PayloadFieldIndexRead for NullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for MutableNullIndex {
@@ -68,7 +68,7 @@ impl PayloadFieldIndexRead for MutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
@@ -10,7 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
@@ -68,7 +68,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(read_ops::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_ops.rs
@@ -25,7 +25,7 @@ use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::FieldCondition;
 
@@ -225,7 +225,7 @@ pub(super) fn condition_checker<'a, N: NullIndexRead>(
     null_index: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>> {
+) -> Option<DynConditionChecker<'a>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -27,7 +27,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::utils::check_boundaries;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     FieldCondition, Match, MatchValue, PayloadKeyType, Range, RangeInterface, ValueVariants,
 };
@@ -304,7 +304,7 @@ pub(super) fn condition_checker<'a, T, I>(
     index: &'a I,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<Box<dyn ConditionChecker + 'a>>
+) -> Option<DynConditionChecker<'a>>
 where
     T: Encodable + Numericable + StoredValue + Send + Sync + Default,
     I: NumericIndexRead<T>,

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -20,7 +20,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, P, S: UniversalRead>
@@ -129,7 +129,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_ops.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, Range, RangeInterface};
 
 pub trait StreamRange<T> {
@@ -86,7 +86,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, S: UniversalRead>
@@ -60,7 +60,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(query::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
@@ -28,7 +28,7 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, RangeInterface};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> PayloadFieldIndex
@@ -95,7 +95,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<Box<dyn ConditionChecker + 'a>>> {
+    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
         Ok(query::condition_checker(self, condition, hw_acc))
     }
 }

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -1,7 +1,7 @@
+use common::condition_checker::ConditionChecker;
 use common::types::PointOffsetType;
 
-use crate::common::operation_error::OperationResult;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::visited_pool::VisitedListHandle;
 
 pub struct BuildConditionChecker<'a> {
@@ -10,6 +10,8 @@ pub struct BuildConditionChecker<'a> {
 }
 
 impl ConditionChecker for BuildConditionChecker<'_> {
+    type Error = OperationError;
+
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         if point_id == self.current_point {
             return Ok(false); // Do not match current point while inserting it (second time)

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -18,7 +18,7 @@ use crate::index::hnsw_index::gpu::gpu_insert_context::GpuInsertContext;
 use crate::index::hnsw_index::gpu::gpu_vector_storage::GpuVectorStorage;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::visited_pool::VisitedListHandle;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
@@ -89,11 +89,10 @@ pub(super) fn build_filtered_graph_on_gpu(
         1,
         |block_point_id| -> OperationResult<_> {
             let hardware_counter = HardwareCounterCell::disposable();
-            let block_condition_checker: Box<dyn ConditionChecker> =
-                Box::new(BuildConditionChecker {
-                    filter_list: block_filter_list,
-                    current_point: block_point_id,
-                });
+            let block_condition_checker: DynConditionChecker = Box::new(BuildConditionChecker {
+                filter_list: block_filter_list,
+                current_point: block_point_id,
+            });
             FilteredScorer::new_internal(
                 block_point_id,
                 vector_storage,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -12,7 +12,7 @@ use crate::index::PayloadIndexRead;
 use crate::index::hnsw_index::graph_layers::{GraphLayersWithVectors, SearchAlgorithm};
 use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
 use crate::index::query_estimator::adjust_to_available_vectors;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::vector_index_search_common::{
     get_oversampled_top, is_quantized_search, postprocess_search_result,
 };
@@ -361,7 +361,7 @@ fn construct_search_scorer<'a, V, Q>(
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
-    filter_context: Option<Box<dyn ConditionChecker + 'a>>,
+    filter_context: Option<DynConditionChecker<'a>>,
 ) -> OperationResult<FilteredScorer<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,
@@ -387,7 +387,7 @@ fn construct_batch_searcher<'a, V, Q>(
     deleted_points: &'a BitSlice,
     params: Option<&SearchParams>,
     hardware_counter: HardwareCounterCell,
-    filter_context: Option<Box<dyn ConditionChecker + 'a>>,
+    filter_context: Option<DynConditionChecker<'a>>,
 ) -> OperationResult<BatchFilteredSearcher<'a>>
 where
     V: VectorStorageRead + RawScorerBuilder,

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 
 use common::bitvec::BitSlice;
+use common::condition_checker::ConditionChecker;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::cow::BoxCow;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
@@ -8,9 +9,8 @@ use common::generic_consts::Random;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use smallvec::SmallVec;
 
-use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::vectors::QueryVector;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
@@ -70,7 +70,7 @@ pub struct ScorerFilters<'a> {
     vec_deleted: &'a BitSlice,
 }
 
-type DynConditionChecker<'a> = BoxCow<'a, dyn ConditionChecker + 'a>;
+type DynConditionChecker<'a> = BoxCow<'a, dyn ConditionChecker<Error = OperationError> + 'a>;
 
 impl<'a> ScorerFilters<'a> {
     /// Return true if vector satisfies current search context for given point:

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -60,7 +60,7 @@ pub struct FilteredScorer<'a> {
 }
 
 pub struct ScorerFilters<'a> {
-    filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
+    filter_context: Option<DynConditionChecker<'a>>,
     /// Point deleted flags should be explicitly present as `false`
     /// for each existing point in the segment.
     /// If there are no flags for some points, they are considered deleted.
@@ -69,6 +69,8 @@ pub struct ScorerFilters<'a> {
     /// [`BitSlice`] defining flags for deleted vectors in this segment.
     vec_deleted: &'a BitSlice,
 }
+
+type DynConditionChecker<'a> = BoxCow<'a, dyn ConditionChecker + 'a>;
 
 impl<'a> ScorerFilters<'a> {
     /// Return true if vector satisfies current search context for given point:
@@ -121,7 +123,7 @@ impl<'a> FilteredScorer<'a> {
         query: QueryVector,
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
+        filter_context: Option<DynConditionChecker<'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Self>
@@ -148,7 +150,7 @@ impl<'a> FilteredScorer<'a> {
         point_id: PointOffsetType,
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
+        filter_context: Option<DynConditionChecker<'a>>,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,
     ) -> OperationResult<Self>
@@ -289,7 +291,7 @@ impl<'a> BatchFilteredSearcher<'a> {
         queries: &[&QueryVector],
         vectors: &'a V,
         quantized_vectors: Option<&'a Q>,
-        filter_context: Option<BoxCow<'a, dyn ConditionChecker + 'a>>,
+        filter_context: Option<DynConditionChecker<'a>>,
         top: usize,
         point_deleted: &'a BitSlice,
         hardware_counter: HardwareCounterCell,

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -15,7 +15,7 @@ use super::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::json_path::JsonPath;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
@@ -75,7 +75,7 @@ pub trait PayloadIndexRead {
         &'a self,
         filter: &'a Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn ConditionChecker + 'a>>;
+    ) -> OperationResult<DynConditionChecker<'a>>;
 
     /// Look up a numeric index for the given payload key, if one exists.
     ///

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -21,7 +21,7 @@ use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, FacetIndex, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::{ConditionChecker, DynConditionChecker};
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
@@ -132,7 +132,7 @@ impl PayloadIndexRead for PlainPayloadIndex {
         &'a self,
         filter: &'a Filter,
         _: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn ConditionChecker + 'a>> {
+    ) -> OperationResult<DynConditionChecker<'a>> {
         Ok(Box::new(PlainFilterContext {
             filter,
             condition_checker: self.condition_checker.clone(),

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
+use common::condition_checker::ConditionChecker;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
@@ -21,7 +22,7 @@ use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, FacetIndex, PayloadBlockCondition};
 use crate::index::payload_config::PayloadConfig;
-use crate::index::query_optimization::optimized_filter::{ConditionChecker, DynConditionChecker};
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
@@ -336,6 +337,8 @@ pub struct PlainFilterContext<'a> {
 }
 
 impl ConditionChecker for PlainFilterContext<'_> {
+    type Error = OperationError;
+
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         Ok(self.condition_checker.check(point_id, self.filter))
     }

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -1,30 +1,10 @@
+use common::condition_checker::ConditionChecker;
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 
-pub type DynConditionChecker<'a> = Box<dyn ConditionChecker + 'a>;
-
-/// A check that tests whether points satisfy a condition.
-pub trait ConditionChecker {
-    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool>;
-
-    /// Same as [`Self::check`] but without [`OperationResult`].
-    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
-        // This method is a workaround to keep the performance on-par.
-        // It's faster to do `.unwrap_or(false)` *inside* the trait method
-        // because the compiler can't inline `&dyn Trait` methods.
-        //
-        // TODO(uio): remove this method and handle errors properly.
-        self.check(point_id).unwrap_or(false)
-    }
-}
-
-impl<F: Fn(PointOffsetType) -> OperationResult<bool>> ConditionChecker for F {
-    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
-        self(point_id)
-    }
-}
+pub type DynConditionChecker<'a> = Box<dyn ConditionChecker<Error = OperationError> + 'a>;
 
 pub enum OptimizedCondition<'a> {
     Checker(DynConditionChecker<'a>),
@@ -49,6 +29,8 @@ pub struct OptimizedFilter<'a> {
 }
 
 impl ConditionChecker for OptimizedFilter<'_> {
+    type Error = OperationError;
+
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         let OptimizedFilter {
             should,
@@ -110,6 +92,8 @@ impl ConditionChecker for OptimizedFilter<'_> {
 }
 
 impl ConditionChecker for OptimizedCondition<'_> {
+    type Error = OperationError;
+
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         match self {
             OptimizedCondition::Filter(filter) => filter.check(point_id),

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -3,6 +3,8 @@ use common::types::PointOffsetType;
 
 use crate::common::operation_error::OperationResult;
 
+pub type DynConditionChecker<'a> = Box<dyn ConditionChecker + 'a>;
+
 /// A check that tests whether points satisfy a condition.
 pub trait ConditionChecker {
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool>;
@@ -25,7 +27,7 @@ impl<F: Fn(PointOffsetType) -> OperationResult<bool>> ConditionChecker for F {
 }
 
 pub enum OptimizedCondition<'a> {
-    Checker(Box<dyn ConditionChecker + 'a>),
+    Checker(DynConditionChecker<'a>),
     /// Nested filter
     Filter(OptimizedFilter<'a>),
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::ops::Neg;
 
 use ahash::AHashMap;
+use common::condition_checker::ConditionChecker;
 use common::types::{PointOffsetType, ScoreType};
 use geo::{Distance, Haversine};
 use serde_json::Value;
@@ -11,7 +12,7 @@ use super::parsed_formula::{
 };
 use super::value_retriever::VariableRetrieverFn;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::query_optimization::optimized_filter::{ConditionChecker, OptimizedCondition};
+use crate::index::query_optimization::optimized_filter::OptimizedCondition;
 use crate::json_path::JsonPath;
 use crate::types::{DateTimePayloadType, GeoPoint};
 

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -9,7 +9,7 @@ use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndexRead;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
@@ -33,7 +33,7 @@ where
         payload_provider: PayloadProvider<S>,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn ConditionChecker + 'b>> {
+    ) -> OperationResult<DynConditionChecker<'b>> {
         let id_tracker = self.id_tracker;
         let field_indexes = self.field_indexes;
         Ok(match condition {
@@ -178,7 +178,7 @@ fn field_condition_checker<'a>(
     field_condition: &FieldCondition,
     payload_provider: PayloadProvider<impl PayloadStorageRead + 'a>,
     check: impl Fn(OwnedPayloadRef, &HardwareCounterCell) -> OperationResult<bool> + 'a,
-) -> OperationResult<Box<dyn ConditionChecker + 'a>> {
+) -> OperationResult<DynConditionChecker<'a>> {
     // 1. Find first index that can check condition.
     if let Some(indexes) = field_indexes.get(key) {
         for index in indexes {

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -18,7 +18,7 @@ use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition,
 };
 use crate::index::query_estimator::estimate_filter;
-use crate::index::query_optimization::optimized_filter::ConditionChecker;
+use crate::index::query_optimization::optimized_filter::{ConditionChecker, DynConditionChecker};
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
@@ -256,7 +256,7 @@ where
         &'b self,
         filter: &'b Filter,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Box<dyn ConditionChecker + 'b>> {
+    ) -> OperationResult<DynConditionChecker<'b>> {
         Ok(Box::new(self.optimized_filter(
             filter,
             DeferredBehavior::VisibleOnly,

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
+use common::condition_checker::ConditionChecker;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::either_variant::EitherVariant;
@@ -18,7 +19,7 @@ use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition,
 };
 use crate::index::query_estimator::estimate_filter;
-use crate::index::query_optimization::optimized_filter::{ConditionChecker, DynConditionChecker};
+use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::index::query_optimization::rescore_formula::FormulaScorer;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;


### PR DESCRIPTION
# Why

I want to replace [this generic](https://github.com/qdrant/qdrant/blob/a8d70398521bc9801b7725eba33b0b4226b417b4/lib/sparse/src/index/search_context.rs#L146) in the `sparse` package with something like this:
```diff
-    fn advance_batch<F: Fn(PointOffsetType) -> bool>( 
+    fn advance_batch<F: ConditionChecker>(
```

(later this trait will become batched)

But the problem is that `ConditionChecker` is defined in the `segment`, thus not available in the `sparse`.

# What

This PR moves `trait ConditionChecker` from `segment` to the `common` package, so it's available both in `segment` and `sparse`.

Also, it addressed https://github.com/qdrant/qdrant/pull/9405#discussion_r3390106073.