### PR TITLE
perf: use Entry API to avoid redundant map double-lookups

### DIFF
--- a/lib/collection/src/shards/resolve.rs
+++ b/lib/collection/src/shards/resolve.rs
@@ -89,10 +89,10 @@ impl Resolve for FacetResponse {
                     if let Some(counts) = map.get_mut(&hit.value) {
                         counts.push(CountResult { count: hit.count });
                     } else {
-                        map.entry(hit.value.clone())
-                            .or_insert(Vec::with_capacity(num_replicas))
-                            .push(CountResult { count: hit.count });
-                    };
+                        let mut counts = Vec::with_capacity(num_replicas);
+                        counts.push(CountResult { count: hit.count });
+                        map.insert(hit.value.clone(), counts);
+                    }
                     map
                 },
             )

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::path::PathBuf;
 
 use ahash::AHashSet;
@@ -96,19 +97,17 @@ impl InMemoryGeoIndex {
                 continue;
             }
 
-            let is_last = if let Some(hash_ids) = self.points_map.get_mut(&removed_geo_hash) {
+            if let Entry::Occupied(mut entry) = self.points_map.entry(removed_geo_hash) {
+                let hash_ids = entry.get_mut();
                 hash_ids.remove(&idx);
-                hash_ids.is_empty()
+                if hash_ids.is_empty() {
+                    entry.remove();
+                }
             } else {
                 debug_assert!(
                     false,
                     "Geo index error: no points for hash {removed_geo_hash} was found",
                 );
-                false
-            };
-
-            if is_last {
-                self.points_map.remove(&removed_geo_hash);
             }
         }
 
@@ -195,18 +194,16 @@ impl InMemoryGeoIndex {
     fn decrement_hash_value_counts(&mut self, geo_hash: GeoHash) {
         for i in 0..=geo_hash.len() {
             let sub_geo_hash = geo_hash.truncate(i);
-            match self.values_per_hash.get_mut(&sub_geo_hash) {
-                None => {
+            match self.values_per_hash.entry(sub_geo_hash) {
+                Entry::Occupied(mut entry) => *entry.get_mut() -= 1,
+                Entry::Vacant(entry) => {
                     debug_assert!(
                         false,
                         "Hash value count is not found for hash: {sub_geo_hash}",
                     );
-                    self.values_per_hash.insert(sub_geo_hash, 0);
+                    entry.insert(0);
                 }
-                Some(count) => {
-                    *count -= 1;
-                }
-            };
+            }
         }
     }
 
@@ -215,22 +212,18 @@ impl InMemoryGeoIndex {
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
                 let sub_geo_hash = geo_hash.truncate(i);
-                if seen_hashes.contains(&sub_geo_hash) {
-                    continue;
+                if seen_hashes.insert(sub_geo_hash) {
+                    match self.points_per_hash.entry(sub_geo_hash) {
+                        Entry::Occupied(mut entry) => *entry.get_mut() -= 1,
+                        Entry::Vacant(entry) => {
+                            debug_assert!(
+                                false,
+                                "Hash point count is not found for hash: {sub_geo_hash}",
+                            );
+                            entry.insert(0);
+                        }
+                    }
                 }
-                seen_hashes.insert(sub_geo_hash);
-                match self.points_per_hash.get_mut(&sub_geo_hash) {
-                    None => {
-                        debug_assert!(
-                            false,
-                            "Hash point count is not found for hash: {sub_geo_hash}",
-                        );
-                        self.points_per_hash.insert(sub_geo_hash, 0);
-                    }
-                    Some(count) => {
-                        *count -= 1;
-                    }
-                };
             }
         }
     }

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/inner.rs
@@ -175,14 +175,7 @@ impl InMemoryGeoIndex {
     pub(super) fn increment_hash_value_counts(&mut self, geo_hash: GeoHash) {
         for i in 0..=geo_hash.len() {
             let sub_geo_hash = geo_hash.truncate(i);
-            match self.values_per_hash.get_mut(&sub_geo_hash) {
-                None => {
-                    self.values_per_hash.insert(sub_geo_hash, 1);
-                }
-                Some(count) => {
-                    *count += 1;
-                }
-            };
+            *self.values_per_hash.entry(sub_geo_hash).or_insert(0) += 1;
         }
     }
 
@@ -192,18 +185,9 @@ impl InMemoryGeoIndex {
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
                 let sub_geo_hash = geo_hash.truncate(i);
-                if seen_hashes.contains(&sub_geo_hash) {
-                    continue;
+                if seen_hashes.insert(sub_geo_hash) {
+                    *self.points_per_hash.entry(sub_geo_hash).or_insert(0) += 1;
                 }
-                seen_hashes.insert(sub_geo_hash);
-                match self.points_per_hash.get_mut(&sub_geo_hash) {
-                    None => {
-                        self.points_per_hash.insert(sub_geo_hash, 1);
-                    }
-                    Some(count) => {
-                        *count += 1;
-                    }
-                };
             }
         }
     }

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -38,9 +38,8 @@ impl IndicesTracker {
 
     pub fn register_indices(&mut self, vector: &SparseVector) {
         for index in &vector.indices {
-            if !self.map.contains_key(index) {
-                self.map.insert(*index, self.map.len() as DimId);
-            }
+            let next = self.map.len() as DimId;
+            self.map.entry(*index).or_insert(next);
         }
     }
 

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -106,10 +107,10 @@ impl PayloadStorage for InMemoryPayloadStorage {
         payload: &Payload,
         _hw_counter: &HardwareCounterCell, // No measurement needed for in memory payload
     ) -> OperationResult<()> {
-        match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge(payload),
-            None => {
-                self.payload.insert(point_id, payload.to_owned());
+        match self.payload.entry(point_id) {
+            Entry::Occupied(mut e) => e.get_mut().merge(payload),
+            Entry::Vacant(e) => {
+                e.insert(payload.to_owned());
             }
         }
         Ok(())
@@ -122,12 +123,12 @@ impl PayloadStorage for InMemoryPayloadStorage {
         key: &JsonPath,
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<()> {
-        match self.payload.get_mut(&point_id) {
-            Some(point_payload) => point_payload.merge_by_key(payload, key),
-            None => {
+        match self.payload.entry(point_id) {
+            Entry::Occupied(mut e) => e.get_mut().merge_by_key(payload, key),
+            Entry::Vacant(e) => {
                 let mut dest_payload = Payload::default();
                 dest_payload.merge_by_key(payload, key);
-                self.payload.insert(point_id, dest_payload);
+                e.insert(dest_payload);
             }
         }
         Ok(())

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Display;
@@ -733,14 +734,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             let (sender, mut receiver) = broadcast::channel(1);
             let mut on_apply_lock = self.on_consensus_op_apply.lock();
             // check that the exact same operation is not already in-flight
-            match on_apply_lock.get(&operation) {
-                Some(existing_sender) => {
+            match on_apply_lock.entry(operation) {
+                Entry::Occupied(e) => {
                     // subscribe to existing sender for faster feedback
-                    receiver = existing_sender.subscribe()
+                    receiver = e.get().subscribe()
                 }
-                None => {
+                Entry::Vacant(e) => {
                     // insert new sender
-                    on_apply_lock.insert(operation, sender);
+                    e.insert(sender);
                 }
             };
             receivers.push(receiver);


### PR DESCRIPTION
## What

Replace `get_mut` / `contains_key` followed by `insert` with the `entry` API across several maps, collapsing two hash lookups into one.

Sites changed:
- `geo_index/inner.rs`: `increment_hash_value_counts` and `increment_hash_point_counts` (also folds a redundant `contains`+`insert` into a single `seen_hashes.insert`)
- `indices_tracker.rs`: `register_indices`
- `in_memory_payload_storage_impl.rs`: `set` and `set_by_key`
- `consensus_manager.rs`: `await_for_multiple_operations`
- `resolve.rs`: the known-absent `else` branch now inserts directly instead of re-looking-up via `entry().or_insert()`

## Notes

Limited to sites where the key is `Copy` or already owned and moved, so no extra key clone is added to any hot path. Cases where `entry` would force eager key allocation or value construction on the common path (for example the full-text vocab and JSON path merge) were deliberately left as-is.

All changes are behavior preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)