### PR TITLE
Buffer multi-dense offsets store to prevent reload corruption

### DIFF
--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -58,8 +58,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
 ];
 
 /// Names present in the collection schema at fixture time.
-// "m" (multivector) is temporarily disabled while its reload divergence is unresolved.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s"];
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m"];
 
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -476,12 +476,9 @@ impl Op {
             22 => {
                 // CreateVectorName: pick a candidate currently absent from the active set.
                 // If all candidates are active, fall back to a regular upsert.
-                // Multivector (`MultiDense`) candidates are excluded while their reload
-                // divergence is unresolved — see the note on `INITIAL_ACTIVE`.
                 let inactive: Vec<&'static super::VectorCandidate> = ALL_CANDIDATES
                     .iter()
                     .filter(|c| !active.contains(c.name))
-                    .filter(|c| !matches!(c.kind, VectorKind::MultiDense(_)))
                     .collect();
                 if inactive.is_empty() {
                     return upsert_fallback(rng, active, id_pool);

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -11,6 +11,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, MmapFs, UniversalRead};
 use fs_err as fs;
 
+use super::buffered_offsets::BufferedOffsets;
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
@@ -96,7 +97,7 @@ where
 #[derive(Debug)]
 pub struct AppendableMmapMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     vectors: ChunkedVectors<T, MmapFile>,
-    offsets: ChunkedVectors<MultivectorMmapOffset, MmapFile>,
+    offsets: BufferedOffsets,
     /// Flags marking deleted vectors
     ///
     /// Structure grows dynamically, but may be smaller than actual number of vectors. Must not
@@ -151,7 +152,6 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
         let mut offset = self
             .offsets
             .get::<Random>(key as VectorOffsetType)
-            .map(|x| x.first().copied().unwrap_or_default())
             .unwrap_or_default();
 
         if multi_vector.vectors_count() > offset.capacity as usize {
@@ -178,8 +178,7 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
             multi_vector.vectors_count(),
             hw_counter,
         )?;
-        self.offsets
-            .insert(key as VectorOffsetType, &[offset], hw_counter)?;
+        self.offsets.set(key as VectorOffsetType, offset);
         self.set_deleted(key, false);
 
         Ok(())
@@ -229,20 +228,28 @@ impl<T: PrimitiveVectorElement> MultiVectorStorageRead<T>
         &self,
         key: PointOffsetType,
     ) -> Option<CowMultiVector<'_, T>> {
-        read_multi_vector::<T, P, _>(&self.offsets, &self.vectors, key)
+        // Resolve the offset through the buffer (pending overlay then durable),
+        // then fetch the row slice from `vectors`.
+        let offset = self.offsets.get::<P>(key as VectorOffsetType)?;
+        let flattened = self
+            .vectors
+            .get_many::<P>(offset.offset as _, offset.count as _)?;
+        Some(flattened_to_multi_vector(flattened, self.vectors.dim()))
     }
 
     fn for_each_in_batch_multi<F>(&self, keys: &[PointOffsetType], mut callback: F)
     where
         F: FnMut(usize, TypedMultiDenseVectorRef<'_, T>),
     {
-        let point_offsets = keys.iter().copied().enumerate();
+        // Resolve offsets through the buffer first (so unflushed writes are seen),
+        // then reuse the row-side prefetch iterator over `vectors`.
+        let row_offsets = self
+            .offsets
+            .resolve_rows::<Sequential, _, _>(keys.iter().copied().enumerate());
 
-        let vectors = super::read_only::iter_vectors::<Sequential, _, _, _>(
-            &self.offsets,
-            &self.vectors,
-            point_offsets,
-        );
+        let vectors = self
+            .vectors
+            .iter_vectors::<Sequential, _>(row_offsets.into_iter());
 
         for (index, flattened) in vectors {
             let vector = TypedMultiDenseVectorRef::new(&flattened, self.vector_dim());
@@ -257,9 +264,6 @@ impl<T: PrimitiveVectorElement> MultiVectorStorageRead<T>
             let mmap_offset = self
                 .offsets
                 .get::<Sequential>(key as VectorOffsetType)
-                .unwrap()
-                .first()
-                .copied()
                 .unwrap();
             (0..mmap_offset.count).map(move |i| {
                 self.vectors
@@ -329,15 +333,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
     ) {
-        let point_offsets = keys
-            .into_iter()
-            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
-
-        let vectors = super::read_only::iter_vectors::<P, _, _, _>(
-            &self.offsets,
-            &self.vectors,
-            point_offsets,
+        // Resolve offsets through the buffer first (so unflushed writes are seen),
+        // then reuse the row-side prefetch iterator over `vectors`.
+        let row_offsets = self.offsets.resolve_rows::<P, _, _>(
+            keys.into_iter()
+                .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset)),
         );
+
+        let vectors = self.vectors.iter_vectors::<P, _>(row_offsets.into_iter());
 
         for ((user_data, point_offset), flattened) in vectors {
             let vector = CowVector::MultiDense(T::into_float_multivector(
@@ -575,6 +578,9 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
 
     let vectors = ChunkedVectors::open(MmapFs, &vectors_path, dim, madvise, Some(populate))?;
     let offsets = ChunkedVectors::open(MmapFs, &offsets_path, 1, madvise, Some(populate))?;
+    // The offsets store is buffered so its durable state can never race ahead of
+    // the durable `vectors` length, which would corrupt points on reload.
+    let offsets = BufferedOffsets::new(offsets);
 
     let deleted = BitvecFlags::new(
         MmapFs,
@@ -673,6 +679,86 @@ mod tests {
         assert_eq!(
             storage_files, found_files,
             "find_storage_files must find same files that storage reports",
+        );
+    }
+
+    fn multivec(rows: usize, fill: VectorElementType, dim: usize) -> MultiDenseVectorInternal {
+        MultiDenseVectorInternal::try_from(vec![vec![fill; dim]; rows]).unwrap()
+    }
+
+    /// A re-upsert that relocates a point's rows *after* a flush has already been
+    /// started must be deferred to the next flush, not become durable ahead of the
+    /// `vectors` length. Reopening then sees a consistent pre-relocation state —
+    /// never the head-clobbered corruption the unbuffered skew produced.
+    ///
+    /// This is the buffered-store alternative to the reload-time repair: the skew
+    /// is prevented rather than patched.
+    #[test]
+    fn relocation_after_flush_start_is_deferred_not_corrupt() {
+        const DIM: usize = 4;
+
+        let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::disposable();
+
+        let open = || {
+            open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                MultiVectorConfig::default(),
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap()
+        };
+
+        // Baseline: point 0 (2 rows) then point 1 (2 rows), durably flushed.
+        let p0_small = multivec(2, 1.0, DIM);
+        let p1 = multivec(2, 7.0, DIM);
+        {
+            let mut storage = open();
+            storage
+                .insert_vector(0, VectorRef::from(&p0_small), &hw_counter)
+                .unwrap();
+            storage
+                .insert_vector(1, VectorRef::from(&p1), &hw_counter)
+                .unwrap();
+            storage.flusher()().unwrap();
+
+            // Start a flush: it snapshots vectors.len and the (now empty) offsets
+            // pending set at this instant.
+            let flush = storage.flusher();
+
+            // Grow point 0 past its capacity -> append path relocates its rows to
+            // the end. This is the dangerous in-window write.
+            let p0_grown = multivec(4, 2.0, DIM);
+            storage
+                .insert_vector(0, VectorRef::from(&p0_grown), &hw_counter)
+                .unwrap();
+
+            // Execute the in-window flush. The relocation must NOT be persisted.
+            flush().unwrap();
+        }
+
+        // Reopen and verify a consistent, uncorrupted state.
+        let storage = open();
+
+        let read0 = storage
+            .get_multi_opt::<Random>(0)
+            .expect("point 0 readable after reload");
+        assert_eq!(
+            read0.as_vec_ref().flattened_vectors,
+            p0_small.flattened_vectors.as_slice(),
+            "point 0 must read its durable pre-relocation value, not a rejected/garbled one",
+        );
+
+        let read1 = storage
+            .get_multi_opt::<Random>(1)
+            .expect("point 1 readable after reload");
+        assert_eq!(
+            read1.as_vec_ref().flattened_vectors,
+            p1.flattened_vectors.as_slice(),
+            "point 1 must be intact — the unbuffered skew would clobber its head rows",
         );
     }
 }

--- a/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
+++ b/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
@@ -194,8 +194,6 @@ impl BufferedOffsets {
             // a failed offsets sync stranded while `vectors` recovered, reopening the
             // very skew this buffer closes.
             let store_flusher = {
-                let mut inner = inner.write();
-
                 // Apply in ascending key order so the backing store grows its
                 // chunks/length monotonically (appends sit at the current end).
                 // Dense key allocation (`new_id = len`) guarantees no gaps: any
@@ -204,6 +202,8 @@ impl BufferedOffsets {
                 let mut items: Vec<(VectorOffsetType, MultivectorMmapOffset)> =
                     snapshot.iter().map(|(key, entry)| (*key, *entry)).collect();
                 items.sort_unstable_by_key(|(key, _)| *key);
+
+                let mut inner = inner.write();
 
                 let hw_counter = HardwareCounterCell::disposable();
                 for (key, entry) in &items {
@@ -216,8 +216,8 @@ impl BufferedOffsets {
                     snapshot.get(key).is_none_or(|persisted| persisted != value)
                 });
 
-                // Built here so its `status.len` snapshot covers the entries just
-                // applied; executed below, outside the lock.
+                // Create the flusher here so its `status.len` snapshot covers the
+                // entries just applied; the inner guard drops before we sync below.
                 inner.store.flusher()
             };
 

--- a/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
+++ b/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
@@ -1,0 +1,320 @@
+//! Write-back buffer over the multi-vector `offsets` store.
+//!
+//! It prevents an inconsistent on-disk state from ever becoming durable, rather
+//! than patching it up after the fact on reload.
+//!
+//! The structure deliberately follows the Gridstore flusher convention
+//! (`lib/gridstore/src/gridstore/mod.rs` + `tracker/mod.rs`):
+//!
+//! - pending writes live *inside* the lock-guarded store (one `Arc<RwLock<_>>`),
+//!   so a read consults the pending overlay and the durable bytes under a single
+//!   lock, exactly like `Tracker::get`;
+//! - the flusher clones the pending set at creation time, then applies + reconciles
+//!   it under the write lock and builds the backing flusher there, but runs the
+//!   durable msync *after* releasing the lock — Gridstore's `flush_tracker` never
+//!   holds the store lock across the sync, and neither do we;
+//! - `is_alive` + `Weak` upgrades cancel the flush if the storage was dropped.
+//!
+//! ## The skew it closes
+//!
+//! Each `ChunkedVectors` flusher snapshots its `status.len` at *creation* time but
+//! msyncs chunk bytes at *execution* time. A re-upsert that grows a point past its
+//! reserved capacity rewrites its `offsets` entry in place to a freshly-appended
+//! row region. If that lands inside a flush's creation-to-execution window, the
+//! relocated entry becomes durable while the `vectors` store's recorded length
+//! still predates the rows it references: a durable forward reference into rows
+//! the length does not cover. On reload that point is unreadable, and a WAL append
+//! reuses the rows and overwrites another point.
+//!
+//! ## How buffering closes it
+//!
+//! Offset entries are staged in `pending` and only written into the durable store
+//! while a flush executes. The flusher snapshots the pending set at creation time,
+//! so any entry written after the flusher is created stays buffered for the *next*
+//! flush. Combined with the `vectors` store persisting its own (creation-time)
+//! length snapshot, the durable offsets can never reference rows beyond the durable
+//! `vectors` length:
+//!
+//! - In memory the two stores are always consistent: `insert_multi_native` writes
+//!   the rows (bumping `vectors.len`) before it sets the offset entry, so at every
+//!   instant `entry.offset + entry.capacity <= vectors.len`.
+//! - Both flushers snapshot at the same instant (the storage `flusher()` call), so
+//!   the durable offsets and the durable `vectors.len` are a consistent cut of that
+//!   instant. Rows written after the cut are durable-but-unreferenced garbage that
+//!   the next append harmlessly overwrites.
+//!
+//! As a bonus, the backing store is flushed synchronously at apply time, so the
+//! offsets store has no length smear of its own either — closing the residual
+//! `offsets`-length skew the repair approach left open.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
+use common::is_alive_lock::IsAliveLock;
+use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
+use parking_lot::RwLock;
+
+use super::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
+use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::ChunkedVectors;
+
+type OffsetsStore = ChunkedVectors<MultivectorMmapOffset, MmapFile>;
+
+/// Durable store plus the not-yet-flushed writes, guarded by a single lock so that
+/// reads see a consistent overlay (mirrors Gridstore's `Tracker`).
+#[derive(Debug)]
+struct Inner {
+    /// Durable backing store. Mutated only while a flush executes.
+    store: OffsetsStore,
+    /// Writes not yet flushed. Reads consult this before `store`.
+    pending: AHashMap<VectorOffsetType, MultivectorMmapOffset>,
+    /// Logical length, including not-yet-flushed appends (always `>= store.len()`).
+    len: usize,
+}
+
+impl Inner {
+    /// Read the offset entry for `key`: pending overlay first, then the durable store.
+    fn get<P: AccessPattern>(&self, key: VectorOffsetType) -> Option<MultivectorMmapOffset> {
+        if let Some(entry) = self.pending.get(&key) {
+            return Some(*entry);
+        }
+        let &[entry] = self.store.get::<P>(key)?.as_ref() else {
+            unreachable!("multi-vector offsets are stored as vectors of length 1");
+        };
+        Some(entry)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct BufferedOffsets {
+    inner: Arc<RwLock<Inner>>,
+    is_alive: IsAliveLock,
+}
+
+impl BufferedOffsets {
+    pub(super) fn new(store: OffsetsStore) -> Self {
+        let len = store.len();
+        Self {
+            inner: Arc::new(RwLock::new(Inner {
+                store,
+                pending: AHashMap::new(),
+                len,
+            })),
+            is_alive: IsAliveLock::new(),
+        }
+    }
+
+    /// Read the offset entry for `key` (pending overlay then durable store).
+    pub(super) fn get<P: AccessPattern>(
+        &self,
+        key: VectorOffsetType,
+    ) -> Option<MultivectorMmapOffset> {
+        self.inner.read().get::<P>(key)
+    }
+
+    /// Resolve a batch of keys to `(user_data, row_offset, count)` under a single
+    /// read lock, ready to hand to `ChunkedVectors::iter_vectors`. Holding the lock
+    /// once for the whole batch mirrors `Tracker::iter`.
+    pub(super) fn resolve_rows<P, U, I>(&self, keys: I) -> Vec<(U, PointOffsetType, u32)>
+    where
+        P: AccessPattern,
+        I: IntoIterator<Item = (U, PointOffsetType)>,
+    {
+        let inner = self.inner.read();
+        keys.into_iter()
+            .map(|(user_data, key)| {
+                let entry = inner
+                    .get::<P>(key as VectorOffsetType)
+                    .expect("offset entry exists");
+                (user_data, entry.offset, entry.count)
+            })
+            .collect()
+    }
+
+    /// Stage a write for `key`. It becomes durable on the first flush whose
+    /// flusher is created after this call returns.
+    pub(super) fn set(&self, key: VectorOffsetType, entry: MultivectorMmapOffset) {
+        let mut inner = self.inner.write();
+        inner.pending.insert(key, entry);
+        inner.len = inner.len.max(key + 1);
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.inner.read().len
+    }
+
+    pub(super) fn populate(&self) -> OperationResult<()> {
+        self.inner.read().store.populate()
+    }
+
+    pub(super) fn clear_cache(&self) -> OperationResult<()> {
+        self.inner.read().store.clear_cache()
+    }
+
+    pub(super) fn files(&self) -> Vec<PathBuf> {
+        self.inner.read().store.files()
+    }
+
+    pub(super) fn immutable_files(&self) -> Vec<PathBuf> {
+        self.inner.read().store.immutable_files()
+    }
+
+    pub(super) fn flusher(&self) -> Flusher {
+        // Snapshot the pending writes at *creation* time. Anything written after
+        // this clone stays buffered for the next flush — that is what keeps the
+        // durable offsets from racing ahead of the durable `vectors` length.
+        let snapshot: AHashMap<VectorOffsetType, MultivectorMmapOffset> =
+            self.inner.read().pending.clone();
+
+        let inner = Arc::downgrade(&self.inner);
+        let is_alive = self.is_alive.handle();
+
+        Box::new(move || {
+            let (Some(_guard), Some(inner)) = (is_alive.lock_if_alive(), inner.upgrade()) else {
+                // Storage was dropped before the flusher ran; nothing to persist.
+                return Ok(());
+            };
+
+            // Apply + reconcile + build the backing flusher under the write lock,
+            // then release the lock and run the durable sync — Gridstore's
+            // `flush_tracker` likewise never holds the store lock across the msync,
+            // so concurrent reads are not stalled by the sync.
+            //
+            // The backing flusher runs on every flush, even with an empty snapshot:
+            // the underlying mmap sync only writes still-dirty pages, so a sync that
+            // failed on an earlier flush is retried on the next one. This matches
+            // Gridstore (its tracker store is synced unconditionally) and the sibling
+            // `vectors` store; short-circuiting an empty snapshot would instead leave
+            // a failed offsets sync stranded while `vectors` recovered, reopening the
+            // very skew this buffer closes.
+            let store_flusher = {
+                let mut inner = inner.write();
+
+                // Apply in ascending key order so the backing store grows its
+                // chunks/length monotonically (appends sit at the current end).
+                // Dense key allocation (`new_id = len`) guarantees no gaps: any
+                // append key in the snapshot has every lower key already durable
+                // or applied in this same pass.
+                let mut items: Vec<(VectorOffsetType, MultivectorMmapOffset)> =
+                    snapshot.iter().map(|(key, entry)| (*key, *entry)).collect();
+                items.sort_unstable_by_key(|(key, _)| *key);
+
+                let hw_counter = HardwareCounterCell::disposable();
+                for (key, entry) in &items {
+                    inner.store.insert(*key, &[*entry], &hw_counter)?;
+                }
+
+                // Drop every key we just persisted from the live pending set, unless
+                // it was overwritten with a newer value after the snapshot was taken.
+                inner.pending.retain(|key, value| {
+                    snapshot.get(key).is_none_or(|persisted| persisted != value)
+                });
+
+                // Built here so its `status.len` snapshot covers the entries just
+                // applied; executed below, outside the lock.
+                inner.store.flusher()
+            };
+
+            store_flusher()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::generic_consts::Sequential;
+    use common::mmap::AdviceSetting;
+    use common::universal_io::MmapFs;
+    use tempfile::Builder;
+
+    use super::*;
+
+    fn offset(o: u32, c: u32) -> MultivectorMmapOffset {
+        MultivectorMmapOffset {
+            offset: o,
+            count: c,
+            capacity: c,
+        }
+    }
+
+    fn open_inner(dir: &std::path::Path) -> OffsetsStore {
+        ChunkedVectors::open(MmapFs, dir, 1, AdviceSetting::Global, Some(false)).unwrap()
+    }
+
+    /// The core property: a write that lands *after* a flusher is created must not
+    /// become durable through that flush. It stays buffered for the next one.
+    ///
+    /// This is exactly the creation-to-execution window that corrupts the storage
+    /// today; here it is a no-op on disk.
+    #[test]
+    fn post_snapshot_write_does_not_leak_into_durable_store() {
+        let dir = Builder::new().prefix("buffered_offsets").tempdir().unwrap();
+
+        let store = BufferedOffsets::new(open_inner(dir.path()));
+        // Two points appended and durable.
+        store.set(0, offset(0, 2));
+        store.set(1, offset(2, 3));
+
+        // A flush is started: its flusher snapshots {0, 1} now.
+        let flush = store.flusher();
+
+        // Point 1 then grows and relocates — the dangerous in-window write.
+        store.set(1, offset(5, 5));
+
+        // The flush executes. It must persist only the snapshot ({0,1-old}), not
+        // the post-snapshot relocation.
+        flush().unwrap();
+
+        // Reopen the durable store directly and inspect what actually landed.
+        drop(store);
+        let durable = open_inner(dir.path());
+        assert_eq!(durable.len(), 2, "both points are durable");
+        let &[e1] = durable.get::<Sequential>(1).unwrap().as_ref() else {
+            unreachable!()
+        };
+        assert_eq!(
+            e1,
+            offset(2, 3),
+            "durable entry for point 1 must be the pre-snapshot value, not the relocation",
+        );
+
+        // The in-memory view still reflects the latest write (read-through overlay),
+        // and the relocation persists on the *next* flush.
+        let store = BufferedOffsets::new(durable);
+        assert_eq!(store.get::<Sequential>(1), Some(offset(2, 3)));
+    }
+
+    /// A second flush commits what the first one deferred — no data is lost, the
+    /// commit point just moves forward consistently.
+    #[test]
+    fn deferred_write_commits_on_next_flush() {
+        let dir = Builder::new().prefix("buffered_offsets").tempdir().unwrap();
+
+        let store = BufferedOffsets::new(open_inner(dir.path()));
+        store.set(0, offset(0, 2));
+        let flush = store.flusher();
+        store.set(1, offset(2, 3)); // appended after the snapshot
+        flush().unwrap();
+
+        // Read-through sees it immediately even though it is not durable yet.
+        assert_eq!(store.get::<Sequential>(1), Some(offset(2, 3)));
+        assert_eq!(store.len(), 2);
+
+        // Next flush persists it.
+        store.flusher()().unwrap();
+        drop(store);
+
+        let durable = open_inner(dir.path());
+        assert_eq!(durable.len(), 2);
+        let &[e1] = durable.get::<Sequential>(1).unwrap().as_ref() else {
+            unreachable!()
+        };
+        assert_eq!(e1, offset(2, 3));
+    }
+}

--- a/lib/segment/src/vector_storage/multi_dense/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/mod.rs
@@ -1,3 +1,4 @@
 pub mod appendable_mmap_multi_dense_vector_storage;
+mod buffered_offsets;
 pub mod read_only;
 pub mod volatile_multi_dense_vector_storage;


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/9451#issuecomment-4719640375>

## Problem

The appendable multi-dense vector storage keeps two independently-flushed `ChunkedVectors` stores: `vectors` (flattened rows) and `offsets` (point key -> `{offset, count, capacity}`).

Each `ChunkedVectors` flusher snapshots its `status.len` at **creation** time but msyncs chunk bytes at **execution** time. When a re-upsert grows a point past its reserved capacity, the append path relocates the point's rows and rewrites its `offsets` entry in place to point at the freshly-appended region. If that rewrite lands inside a flush's creation-to-execution window, the relocated offset entry becomes durable while the `vectors` store's recorded length still predates the rows it references.

The result is a **durable forward reference**: on reload that point is unreadable, and a subsequent WAL append reuses the same row region, clobbering the head rows of another point. This surfaced as multi-dense reload divergence in the collection model test, which is why the `m` vector was disabled there.

## Fix

Wrap the offsets store in a write-back buffer (`BufferedOffsets`) so the durable offsets can never reference rows beyond the durable `vectors` length:

- Offset writes stage in a pending overlay (`set`) and only land in the durable store while a flush executes.
- The flusher snapshots the pending set at **creation** time, so any write after that stays buffered for the **next** flush.
- Both the `vectors` flusher and the offsets flusher snapshot at the same instant (the storage `flusher()` call), yielding a consistent durable cut. Rows written after the cut are unreferenced garbage the next append harmlessly overwrites.

This prevents the skew at the source rather than repairing an inconsistent state on reload, and as a side effect closes the residual offsets-length smear the storage had on its own.

## Convention

`BufferedOffsets` follows the Gridstore flusher convention (`lib/gridstore/src/gridstore/mod.rs`, `tracker/mod.rs`):

- Pending writes live **inside** the single lock-guarded store, so reads consult the overlay then the durable bytes under one lock (mirrors `Tracker::get`).
- The flusher applies + reconciles pending and builds the backing flusher under the write lock, then runs the durable msync **after** releasing the lock, so the sync never stalls concurrent reads (mirrors `flush_tracker`).
- Batch reads resolve all offsets under a single read lock (`resolve_rows`, mirroring `Tracker::iter`).

One deliberate divergence: on a cancelled flush (storage dropped) we return `Ok(())` rather than Gridstore's `Err(FlushCancelled)`, since `OperationError` has no cancellation variant and a dropped storage has nothing to persist.

## Testing

- New unit tests cover the corrupting in-window relocation at both the buffer level (`post_snapshot_write_does_not_leak_into_durable_store`, `deferred_write_commits_on_next_flush`) and the storage level (`relocation_after_flush_start_is_deferred_not_corrupt`).
- Re-enabled the `m` multivector in the collection model test (`INITIAL_ACTIVE` + the `CreateVectorName` op filter); model validation passed.

## Notes for reviewers

Reads now go through a `parking_lot::RwLock` overlay instead of straight mmap. The hot batch paths resolve under a single lock per batch, but this is still one lock acquisition that did not exist before. The previous shared `read_only::iter_vectors` offsets-side prefetch is dropped for the appendable variant (rows-side prefetch is retained). This is the cost tradeoff versus a reload-time repair; worth a benchmark if the read path is sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
