### PR TITLE
feat: immutable field index live_reload

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
@@ -1,0 +1,26 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ImmutableFullTextIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ImmutableFullTextIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/mod.rs
@@ -4,6 +4,7 @@ use super::inverted_index::immutable_inverted_index::ImmutableInvertedIndex;
 use super::on_disk_text_index::OnDiskFullTextIndex;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableFullTextIndex<S: UniversalRead = MmapFile> {

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
@@ -1,0 +1,26 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ImmutableGeoIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ImmutableGeoIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/mod.rs
@@ -7,6 +7,7 @@ use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues
 use crate::types::GeoPoint;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub(super) const DELETED_SENTINEL: PointOffsetType = PointOffsetType::MAX;

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -141,14 +141,7 @@ where
         }
         false
     }
-}
 
-impl<N, S> ImmutableMapIndex<N, S>
-where
-    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
-    N: MapIndexKey + ?Sized,
-    S: UniversalWrite,
-{
     /// Removes `idx` from values-to-points-container.
     /// It is implemented by shrinking the range of values-to-points by one and moving the removed element
     /// out of the range.
@@ -208,6 +201,7 @@ where
         }
     }
 
+    /// Read-safe in-memory deletion; callable from the read-only live_reload path.
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
             let mut removed_values_count = 0;
@@ -233,7 +227,14 @@ where
         self.point_to_values.remove_point(idx);
         Ok(())
     }
+}
 
+impl<N, S> ImmutableMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    N: MapIndexKey + ?Sized,
+    S: UniversalWrite,
+{
     #[inline]
     pub(in super::super) fn wipe(self) -> OperationResult<()> {
         self.storage.wipe()

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
@@ -1,0 +1,34 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::persisted_hashmap::Key;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::ImmutableMapIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::map_index::MapIndexKey;
+
+impl<N, S> LiveReload for ImmutableMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    N: MapIndexKey + Key + ?Sized,
+    S: UniversalRead,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
@@ -11,6 +11,7 @@ use super::on_disk_map_index::OnDiskMapIndex;
 use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableMapIndex<N, S = MmapFile>

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
@@ -1,0 +1,34 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::ImmutableNumericIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::numeric_index::Encodable;
+use crate::index::field_index::numeric_point::Numericable;
+use crate::index::field_index::on_disk_point_to_values::StoredValue;
+
+impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, S: UniversalRead> LiveReload
+    for ImmutableNumericIndex<T, S>
+where
+    Vec<T>: Blob,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
@@ -11,6 +11,7 @@ use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableNumericIndex<


### PR DESCRIPTION
Adds `LiveReload` for the **immutable** read-only field-index variants (numeric / map / geo / full-text). The per-component live-reload PRs (#9296/#9297/#9298/#9313) covered the *appendable* + *on_disk* variants but left the *immutable* ones, which the immutable read-only segment actually uses. Immutable reload just applies `deleted_points` to the in-memory deletion structure (`fs`/`new_points` unused — nothing is appended after build).

⚠️ **One shared read/write change** (flagging per the shared-code review rule): `ImmutableMapIndex::remove_point` (+ its private helper) moved from the `UniversalWrite` impl block to the `UniversalRead` one. Read-safe in-memory deletion (no on-disk write); write callers unaffected since `UniversalWrite: UniversalRead`. The other three families already had `remove_point` in read blocks.

Prerequisite for the segment-level `live_reload` PR.
