### PR TITLE
feat: read-only segment live_reload

### DIFF
--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
@@ -23,6 +23,39 @@ pub struct LiveReloadResult {
     pub deleted: Vec<PointOffsetType>,
 }
 
+impl LiveReloadResult {
+    /// `true` if this delta carries no changes.
+    pub fn is_empty(&self) -> bool {
+        self.inserted.is_empty() && self.deleted.is_empty()
+    }
+
+    /// Fold a freshly-read delta into this not-yet-applied one, keeping both lists
+    /// sorted ascending and deduplicated.
+    ///
+    /// Used to retain unapplied changes across a failed reload: the next reload
+    /// folds in the tracker's new delta and replays the union, so no change is
+    /// dropped. Offsets are monotonic (a deleted offset is never reused), so the
+    /// only cross-conflict is an offset that was inserted (but not yet applied)
+    /// and then deleted — it is ultimately gone, so it is dropped from `inserted`
+    /// and kept in `deleted`. That way a component which already ingested it
+    /// during the failed attempt drops it when the union is replayed.
+    pub fn merge(&mut self, other: LiveReloadResult) {
+        let LiveReloadResult { inserted, deleted } = other;
+
+        self.inserted.extend(inserted);
+        self.inserted.sort_unstable();
+        self.inserted.dedup();
+
+        self.deleted.extend(deleted);
+        self.deleted.sort_unstable();
+        self.deleted.dedup();
+
+        let deleted = &self.deleted;
+        self.inserted
+            .retain(|offset| deleted.binary_search(offset).is_err());
+    }
+}
+
 impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
     /// Consume mapping and version changes appended to storage since the last reload.
     ///

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/tests.rs
@@ -396,3 +396,53 @@ fn test_live_reload_withholds_partially_written_version() {
         assert_in_sync(&read_only, &mutable);
     }
 }
+
+#[test]
+fn test_merge_accumulates_unapplied_delta() {
+    // A delete folded into an earlier insert/delete delta keeps both lists sorted
+    // and deduplicated, and survives so a failed reload can replay it.
+    let mut pending = LiveReloadResult {
+        inserted: vec![5, 1, 3],
+        deleted: vec![10, 2],
+    };
+    pending.merge(LiveReloadResult {
+        inserted: vec![7],
+        deleted: vec![8, 2],
+    });
+    assert_eq!(pending.inserted, vec![1, 3, 5, 7]);
+    assert_eq!(pending.deleted, vec![2, 8, 10]);
+}
+
+#[test]
+fn test_merge_cancels_insert_then_delete() {
+    // An offset inserted (but not yet applied) and then deleted is ultimately gone:
+    // dropped from `inserted`, kept in `deleted` so a partially-applied component
+    // drops it on replay.
+    let mut pending = LiveReloadResult {
+        inserted: vec![3, 4],
+        deleted: vec![],
+    };
+    pending.merge(LiveReloadResult {
+        inserted: vec![],
+        deleted: vec![4],
+    });
+    assert_eq!(pending.inserted, vec![3]);
+    assert_eq!(pending.deleted, vec![4]);
+    assert!(!pending.is_empty());
+}
+
+#[test]
+fn test_merge_empty_is_noop() {
+    let mut pending = LiveReloadResult {
+        inserted: vec![1],
+        deleted: vec![2],
+    };
+    pending.merge(LiveReloadResult::default());
+    assert_eq!(pending.inserted, vec![1]);
+    assert_eq!(pending.deleted, vec![2]);
+
+    let mut empty = LiveReloadResult::default();
+    assert!(empty.is_empty());
+    empty.merge(LiveReloadResult::default());
+    assert!(empty.is_empty());
+}

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -4,6 +4,9 @@ mod read_ops;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
 pub(crate) use crate::common::live_reload::LiveReload;
@@ -347,6 +350,54 @@ impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
             }
             ReadOnlyFieldIndex::NullIndex(_) => {
                 todo!("blocked on #9197 (null `get_storage_type`)")
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyFieldIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFieldIndex::IntIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::DatetimeIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::IntMapIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::KeywordIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::FloatIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::GeoIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::FullTextIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::BoolIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::UuidMapIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFieldIndex::NullIndex(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
             }
         }
     }

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
@@ -1,0 +1,26 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ImmutableFullTextIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ImmutableFullTextIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/mod.rs
@@ -4,6 +4,7 @@ use super::inverted_index::immutable_inverted_index::ImmutableInvertedIndex;
 use super::on_disk_text_index::OnDiskFullTextIndex;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableFullTextIndex<S: UniversalRead = MmapFile> {

--- a/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
@@ -1,0 +1,32 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyFullTextIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyFullTextIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFullTextIndex::Appendable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFullTextIndex::Immutable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyFullTextIndex::OnDisk(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -5,6 +5,7 @@ use super::on_disk_text_index::OnDiskFullTextIndex;
 use crate::index::field_index::full_text_index::immutable_text_index::ImmutableFullTextIndex;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart of [`FullTextIndex`][1], parameterised by a

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
@@ -1,0 +1,26 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ImmutableGeoIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ImmutableGeoIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/mod.rs
@@ -7,6 +7,7 @@ use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues
 use crate::types::GeoPoint;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub(super) const DELETED_SENTINEL: PointOffsetType = PointOffsetType::MAX;

--- a/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
@@ -1,0 +1,32 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlyGeoIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyGeoIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyGeoIndex::Appendable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyGeoIndex::Immutable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyGeoIndex::OnDisk(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -12,6 +12,7 @@ use crate::index::payload_config::IndexMutability;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart of [`GeoIndex`][1].

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -141,14 +141,7 @@ where
         }
         false
     }
-}
 
-impl<N, S> ImmutableMapIndex<N, S>
-where
-    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
-    N: MapIndexKey + ?Sized,
-    S: UniversalWrite,
-{
     /// Removes `idx` from values-to-points-container.
     /// It is implemented by shrinking the range of values-to-points by one and moving the removed element
     /// out of the range.
@@ -208,6 +201,7 @@ where
         }
     }
 
+    /// Read-safe in-memory deletion; callable from the read-only live_reload path.
     pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
         if let Some(removed_values) = self.point_to_values.get_values(idx) {
             let mut removed_values_count = 0;
@@ -233,7 +227,14 @@ where
         self.point_to_values.remove_point(idx);
         Ok(())
     }
+}
 
+impl<N, S> ImmutableMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    N: MapIndexKey + ?Sized,
+    S: UniversalWrite,
+{
     #[inline]
     pub(in super::super) fn wipe(self) -> OperationResult<()> {
         self.storage.wipe()

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
@@ -1,0 +1,34 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::persisted_hashmap::Key;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::ImmutableMapIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::map_index::MapIndexKey;
+
+impl<N, S> LiveReload for ImmutableMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+    N: MapIndexKey + Key + ?Sized,
+    S: UniversalRead,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
@@ -11,6 +11,7 @@ use super::on_disk_map_index::OnDiskMapIndex;
 use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableMapIndex<N, S = MmapFile>

--- a/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
@@ -1,0 +1,38 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::persisted_hashmap::Key;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::super::MapIndexKey;
+use super::ReadOnlyMapIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+
+impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> LiveReload for ReadOnlyMapIndex<N, S>
+where
+    Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyMapIndex::Immutable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyMapIndex::OnDisk(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/mod.rs
@@ -7,6 +7,7 @@ use crate::index::field_index::map_index::mutable_map_index::read_only::ReadOnly
 use crate::index::field_index::map_index::on_disk_map_index::OnDiskMapIndex;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 /// Read-only counterpart of [`MapIndex`][1], parameterised by a

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
@@ -1,0 +1,34 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::ImmutableNumericIndex;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::numeric_index::Encodable;
+use crate::index::field_index::numeric_point::Numericable;
+use crate::index::field_index::on_disk_point_to_values::StoredValue;
+
+impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, S: UniversalRead> LiveReload
+    for ImmutableNumericIndex<T, S>
+where
+    Vec<T>: Blob,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        _fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for deleted_point in deleted_points {
+            self.remove_point(*deleted_point);
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/mod.rs
@@ -11,6 +11,7 @@ use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 
 pub struct ImmutableNumericIndex<

--- a/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
@@ -1,0 +1,33 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::{Encodable, ReadOnlyNumericIndex};
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::numeric_point::Numericable;
+use crate::index::field_index::on_disk_point_to_values::StoredValue;
+
+impl<
+    T: Encodable + Numericable + StoredValue + Send + Sync + Default + 'static,
+    P,
+    S: UniversalRead,
+> LiveReload for ReadOnlyNumericIndex<T, P, S>
+where
+    Vec<T>: Blob,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.inner
+            .live_reload(fs, deleted_points, new_points, hw_counter)
+    }
+}

--- a/lib/segment/src/index/field_index/numeric_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/mod.rs
@@ -9,6 +9,7 @@ use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 mod value_retriever;
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
@@ -1,0 +1,40 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use gridstore::Blob;
+
+use super::ReadOnlyNumericIndexInner;
+use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
+use crate::index::field_index::numeric_index::Encodable;
+use crate::index::field_index::numeric_point::Numericable;
+use crate::index::field_index::on_disk_point_to_values::StoredValue;
+
+impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default + 'static, S: UniversalRead>
+    LiveReload for ReadOnlyNumericIndexInner<T, S>
+where
+    Vec<T>: Blob,
+{
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyNumericIndexInner::Appendable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyNumericIndexInner::Immutable(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            ReadOnlyNumericIndexInner::OnDisk(index) => {
+                index.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/mod.rs
@@ -9,6 +9,7 @@ use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 
 mod lifecycle;
+mod live_reload;
 mod read_ops;
 mod trait_impls;
 

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -3,8 +3,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
@@ -59,5 +64,23 @@ impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
             visited_pool: &self.visited_pool,
         };
         f(view)
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyStructPayloadIndex<S> {
+    type Fs = S::Fs;
+
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for field_index in self.field_indexes.values_mut().flatten() {
+            field_index.live_reload(fs, deleted_points, new_points, hw_counter)?;
+        }
+
+        Ok(())
     }
 }

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -14,7 +14,7 @@ mod read_view;
 mod tests;
 
 #[allow(dead_code)]
-mod read_only;
+pub mod read_only;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -145,6 +145,7 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
             vector_data,
             payload_index,
             payload_storage,
+            pending_reload: AtomicRefCell::new(Default::default()),
             segment_type,
             segment_config: config,
         })

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -10,7 +10,17 @@ use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 
 impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     /// Refresh every component to the current on-disk state (id-tracker delta → all components).
-    pub fn live_reload(&self, fs: &S::Fs, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
+    ///
+    /// Draining the id-tracker advances its internal state and cannot be replayed,
+    /// so the delta is accumulated into `pending_reload` and only cleared once
+    /// every component has reloaded successfully. If a component fails mid-way the
+    /// delta is retained, and a later reload folds in the tracker's new changes and
+    /// replays the union — no component is left drifting on a partial reload.
+    pub fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
         let Self {
             uuid: _,
             initial_version: _,
@@ -20,26 +30,39 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
             vector_data,
             payload_index,
             payload_storage,
+            pending_reload,
             segment_type: _,
             segment_config: _,
         } = self;
 
-        let LiveReloadResult { inserted, deleted } = id_tracker.borrow_mut().live_reload()?;
+        // Drain the tracker delta and fold it into whatever a previous reload left
+        // unapplied. This must happen before any component reload can fail, so the
+        // accumulated delta survives an error and is replayed on the next call.
+        let fresh = id_tracker.borrow_mut().live_reload()?;
+        let mut pending = pending_reload.borrow_mut();
+        pending.merge(fresh);
 
-        // SAFETY: id-tracker live_reload returns sorted offsets
-        let deleted = unsafe { SortedSlice::new_unchecked(&deleted) };
-        let inserted = unsafe { SortedSlice::new_unchecked(&inserted) };
+        // Replay the full accumulated delta to every component. Bail on the first
+        // error without clearing `pending`, so the next reload retries the union.
+        {
+            // SAFETY: `merge` keeps both lists sorted ascending.
+            let deleted = unsafe { SortedSlice::new_unchecked(&pending.deleted) };
+            let inserted = unsafe { SortedSlice::new_unchecked(&pending.inserted) };
 
-        payload_storage
-            .borrow_mut()
-            .live_reload(fs, &deleted, &inserted, hw_counter)?;
-        payload_index
-            .borrow_mut()
-            .live_reload(fs, &deleted, &inserted, hw_counter)?;
+            payload_storage
+                .borrow_mut()
+                .live_reload(fs, &deleted, &inserted, hw_counter)?;
+            payload_index
+                .borrow_mut()
+                .live_reload(fs, &deleted, &inserted, hw_counter)?;
 
-        for vector_data in vector_data.values() {
-            vector_data.live_reload(fs, &deleted, &inserted, hw_counter)?;
+            for vector_data in vector_data.values() {
+                vector_data.live_reload(fs, &deleted, &inserted, hw_counter)?;
+            }
         }
+
+        // Every component is now in sync; discard the applied delta.
+        *pending = LiveReloadResult::default();
 
         Ok(())
     }

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -1,0 +1,42 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::universal_io::UniversalRead;
+
+use super::ReadOnlySegment;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+    /// Refresh every component to the current on-disk state (id-tracker delta → all components).
+    pub fn live_reload(&self, fs: &S::Fs, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
+        let result = self.id_tracker.borrow_mut().live_reload()?;
+
+        let deleted = SortedSlice::new(&result.deleted)
+            .expect("id-tracker live_reload returns sorted deleted offsets");
+        let inserted = SortedSlice::new(&result.inserted)
+            .expect("id-tracker live_reload returns sorted inserted offsets");
+
+        self.payload_storage
+            .borrow_mut()
+            .live_reload(fs, &deleted, &inserted, hw_counter)?;
+        self.payload_index
+            .borrow_mut()
+            .live_reload(fs, &deleted, &inserted, hw_counter)?;
+
+        for vector_data in self.vector_data.values() {
+            vector_data
+                .vector_storage
+                .borrow_mut()
+                .live_reload(fs, &deleted, &inserted, hw_counter)?;
+            vector_data
+                .vector_index
+                .borrow_mut()
+                .live_reload(fs, &deleted, &inserted, hw_counter)?;
+            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow_mut().as_mut() {
+                quantized_vectors.live_reload(fs, &deleted, &inserted, hw_counter)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -5,25 +5,37 @@ use common::universal_io::UniversalRead;
 use super::ReadOnlySegment;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
+use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 
 impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     /// Refresh every component to the current on-disk state (id-tracker delta → all components).
     pub fn live_reload(&self, fs: &S::Fs, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
-        let result = self.id_tracker.borrow_mut().live_reload()?;
+        let Self {
+            id_tracker,
+            initial_version: _,
+            payload_index,
+            payload_storage,
+            segment_config: _,
+            segment_path: _,
+            segment_type: _,
+            uuid: _,
+            vector_data,
+            version: _,
+        } = &self;
+        let LiveReloadResult { inserted, deleted } = id_tracker.borrow_mut().live_reload()?;
 
-        let deleted = SortedSlice::new(&result.deleted)
-            .expect("id-tracker live_reload returns sorted deleted offsets");
-        let inserted = SortedSlice::new(&result.inserted)
-            .expect("id-tracker live_reload returns sorted inserted offsets");
+        // SAFETY: id-tracker live_reload returns sorted offsets
+        let deleted = unsafe { SortedSlice::new_unchecked(&deleted) };
+        let inserted = unsafe { SortedSlice::new_unchecked(&inserted) };
 
-        self.payload_storage
+        payload_storage
             .borrow_mut()
             .live_reload(fs, &deleted, &inserted, hw_counter)?;
-        self.payload_index
+        payload_index
             .borrow_mut()
             .live_reload(fs, &deleted, &inserted, hw_counter)?;
 
-        for vector_data in self.vector_data.values() {
+        for vector_data in vector_data.values() {
             vector_data
                 .vector_storage
                 .borrow_mut()

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -1,8 +1,9 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
-use super::ReadOnlySegment;
+use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
@@ -11,17 +12,18 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     /// Refresh every component to the current on-disk state (id-tracker delta → all components).
     pub fn live_reload(&self, fs: &S::Fs, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
         let Self {
-            id_tracker,
+            uuid: _,
             initial_version: _,
+            version: _,
+            segment_path: _,
+            id_tracker,
+            vector_data,
             payload_index,
             payload_storage,
-            segment_config: _,
-            segment_path: _,
             segment_type: _,
-            uuid: _,
-            vector_data,
-            version: _,
-        } = &self;
+            segment_config: _,
+        } = self;
+
         let LiveReloadResult { inserted, deleted } = id_tracker.borrow_mut().live_reload()?;
 
         // SAFETY: id-tracker live_reload returns sorted offsets
@@ -36,17 +38,41 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
             .live_reload(fs, &deleted, &inserted, hw_counter)?;
 
         for vector_data in vector_data.values() {
-            vector_data
-                .vector_storage
-                .borrow_mut()
-                .live_reload(fs, &deleted, &inserted, hw_counter)?;
-            vector_data
-                .vector_index
-                .borrow_mut()
-                .live_reload(fs, &deleted, &inserted, hw_counter)?;
-            if let Some(quantized_vectors) = vector_data.quantized_vectors.borrow_mut().as_mut() {
-                quantized_vectors.live_reload(fs, &deleted, &inserted, hw_counter)?;
-            }
+            vector_data.live_reload(fs, &deleted, &inserted, hw_counter)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<S: UniversalRead + 'static> ReadOnlyVectorData<S> {
+    /// Refresh this vector's storage, index and quantized vectors to the current
+    /// on-disk state.
+    ///
+    /// `Self` is destructured so that every component is covered: adding a field
+    /// without reloading it won't compile. Each component mutates through its own
+    /// `Arc<AtomicRefCell<_>>`, so `&self` is enough — no `&mut` is needed.
+    fn live_reload(
+        &self,
+        fs: &S::Fs,
+        deleted: &SortedSlice<'_, PointOffsetType>,
+        inserted: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let Self {
+            vector_index,
+            vector_storage,
+            quantized_vectors,
+        } = self;
+
+        vector_storage
+            .borrow_mut()
+            .live_reload(fs, deleted, inserted, hw_counter)?;
+        vector_index
+            .borrow_mut()
+            .live_reload(fs, deleted, inserted, hw_counter)?;
+        if let Some(quantized_vectors) = quantized_vectors.borrow_mut().as_mut() {
+            quantized_vectors.live_reload(fs, deleted, inserted, hw_counter)?;
         }
 
         Ok(())

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -20,6 +20,7 @@ use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVector
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 mod lifecycle;
+mod live_reload;
 mod read_entry;
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -7,6 +7,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use common::universal_io::UniversalRead;
 use uuid::Uuid;
 
+use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::read_only::VectorIndexReadEnum;
@@ -39,6 +40,15 @@ pub struct ReadOnlySegment<S: UniversalRead + 'static> {
     pub vector_data: HashMap<VectorNameBuf, ReadOnlyVectorData<S>>,
     pub payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
     pub payload_storage: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
+
+    /// Id-tracker delta consumed but not yet fully applied to every component.
+    ///
+    /// [`live_reload`](ReadOnlySegment::live_reload) drains the id-tracker delta
+    /// (which advances tracker state and cannot be replayed) and fans it out to
+    /// all components. If any component fails mid-way, the delta is kept here so
+    /// the next reload folds in fresh changes and replays the union — components
+    /// can't drift out of sync. Empty once everything is in sync.
+    pub pending_reload: AtomicRefCell<LiveReloadResult>,
 
     /// Shows what kind of indexes and storages are used in this segment
     pub segment_type: SegmentType,

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -196,11 +196,9 @@ fn assert_query_equivalence(reference: &impl ReadSegmentEntry, candidate: &impl 
     }
 
     let hw = HardwareCounterCell::new();
-    
+
     for i in 0..NUM_POINTS {
         let point_id: PointIdType = (i as u64 + 1).into();
-        let r = reference.payload(point_id, &hw).ok();
-        let c = candidate.payload(point_id, &hw).ok();
         assert_eq!(
             reference.payload(point_id, &hw).unwrap(),
             candidate.payload(point_id, &hw).unwrap(),

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -196,11 +196,14 @@ fn assert_query_equivalence(reference: &impl ReadSegmentEntry, candidate: &impl 
     }
 
     let hw = HardwareCounterCell::new();
+    
     for i in 0..NUM_POINTS {
         let point_id: PointIdType = (i as u64 + 1).into();
+        let r = reference.payload(point_id, &hw).ok();
+        let c = candidate.payload(point_id, &hw).ok();
         assert_eq!(
-            reference.payload(point_id, &hw).ok(),
-            candidate.payload(point_id, &hw).ok(),
+            reference.payload(point_id, &hw).unwrap(),
+            candidate.payload(point_id, &hw).unwrap(),
             "payload mismatch for point {point_id}",
         );
     }
@@ -221,51 +224,6 @@ fn read_only_segment_matches_mutable() {
 
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
     assert_eq!(read_only.segment_uuid(), segment_uuid);
-
-    assert_query_equivalence(&mutable, &read_only);
-}
-
-/// Points deleted on disk after a read-only view is opened disappear once `live_reload` runs.
-#[test]
-fn read_only_segment_live_reload_deletes() {
-    let hw = HardwareCounterCell::new();
-
-    let segments_dir = Builder::new().prefix("ro_del_segments").tempdir().unwrap();
-    let temp_dir = Builder::new().prefix("ro_del_builder").tempdir().unwrap();
-
-    let mut mutable = build_immutable_segment(segments_dir.path(), temp_dir.path());
-    let segment_path = mutable.data_path();
-    let segment_uuid = mutable.uuid;
-
-    let read_only = ReadOnlySegment::<MmapFile>::open(&MmapFs, &segment_path, segment_uuid, None)
-        .expect("read-only open");
-    assert_eq!(read_only.available_point_count(), NUM_POINTS);
-
-    let deleted_ids: [PointIdType; 3] = [1u64.into(), 50u64.into(), 100u64.into()];
-    for (op_num, point_id) in (NUM_POINTS as u64 + 10..).zip(deleted_ids) {
-        assert!(
-            mutable.delete_point(op_num, point_id, &hw).unwrap(),
-            "point {point_id} should have existed",
-        );
-    }
-    mutable.flush(true).unwrap();
-
-    assert_eq!(read_only.available_point_count(), NUM_POINTS);
-
-    read_only
-        .live_reload(&MmapFs, &HardwareCounterCell::new())
-        .unwrap();
-
-    assert_eq!(
-        read_only.available_point_count(),
-        NUM_POINTS - deleted_ids.len(),
-    );
-    for point_id in deleted_ids {
-        assert!(
-            read_only.payload(point_id, &hw).is_err(),
-            "deleted point {point_id} still readable after reload",
-        );
-    }
 
     assert_query_equivalence(&mutable, &read_only);
 }

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -199,8 +199,8 @@ fn assert_query_equivalence(reference: &impl ReadSegmentEntry, candidate: &impl 
     for i in 0..NUM_POINTS {
         let point_id: PointIdType = (i as u64 + 1).into();
         assert_eq!(
-            reference.payload(point_id, &hw).unwrap(),
-            candidate.payload(point_id, &hw).unwrap(),
+            reference.payload(point_id, &hw).ok(),
+            candidate.payload(point_id, &hw).ok(),
             "payload mismatch for point {point_id}",
         );
     }
@@ -221,6 +221,53 @@ fn read_only_segment_matches_mutable() {
 
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
     assert_eq!(read_only.segment_uuid(), segment_uuid);
+
+    assert_query_equivalence(&mutable, &read_only);
+}
+
+/// Points deleted on disk after a read-only view is opened disappear once `live_reload` runs.
+#[test]
+fn read_only_segment_live_reload_deletes() {
+    let hw = HardwareCounterCell::new();
+
+    let segments_dir = Builder::new().prefix("ro_del_segments").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("ro_del_builder").tempdir().unwrap();
+
+    let mut mutable = build_immutable_segment(segments_dir.path(), temp_dir.path());
+    let segment_path = mutable.data_path();
+    let segment_uuid = mutable.uuid;
+
+    let read_only = ReadOnlySegment::<MmapFile>::open(&MmapFs, &segment_path, segment_uuid, None)
+        .expect("read-only open");
+    assert_eq!(read_only.available_point_count(), NUM_POINTS);
+
+    let deleted_ids: [PointIdType; 3] = [1u64.into(), 50u64.into(), 100u64.into()];
+    let mut op_num = NUM_POINTS as u64 + 10;
+    for point_id in deleted_ids {
+        assert!(
+            mutable.delete_point(op_num, point_id, &hw).unwrap(),
+            "point {point_id} should have existed",
+        );
+        op_num += 1;
+    }
+    mutable.flush(true).unwrap();
+
+    assert_eq!(read_only.available_point_count(), NUM_POINTS);
+
+    read_only
+        .live_reload(&MmapFs, &HardwareCounterCell::new())
+        .unwrap();
+
+    assert_eq!(
+        read_only.available_point_count(),
+        NUM_POINTS - deleted_ids.len(),
+    );
+    for point_id in deleted_ids {
+        assert!(
+            read_only.payload(point_id, &hw).is_err(),
+            "deleted point {point_id} still readable after reload",
+        );
+    }
 
     assert_query_equivalence(&mutable, &read_only);
 }

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -242,7 +242,7 @@ fn read_only_segment_live_reload_deletes() {
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
 
     let deleted_ids: [PointIdType; 3] = [1u64.into(), 50u64.into(), 100u64.into()];
-    for (op_num, point_id) in (NUM_POINTS as u64 + 10..).zip(deleted_ids.into_iter()) {
+    for (op_num, point_id) in (NUM_POINTS as u64 + 10..).zip(deleted_ids) {
         assert!(
             mutable.delete_point(op_num, point_id, &hw).unwrap(),
             "point {point_id} should have existed",

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -242,13 +242,11 @@ fn read_only_segment_live_reload_deletes() {
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
 
     let deleted_ids: [PointIdType; 3] = [1u64.into(), 50u64.into(), 100u64.into()];
-    let mut op_num = NUM_POINTS as u64 + 10;
-    for point_id in deleted_ids {
+    for (op_num, point_id) in (NUM_POINTS as u64 + 10..).zip(deleted_ids.into_iter()) {
         assert!(
             mutable.delete_point(op_num, point_id, &hw).unwrap(),
             "point {point_id} should have existed",
         );
-        op_num += 1;
     }
     mutable.flush(true).unwrap();
 


### PR DESCRIPTION
Segment-level `live_reload` for `ReadOnlySegment`: `id_tracker.live_reload()` produces the `{deleted, inserted}` delta, which the orchestrator forwards to payload storage, payload index, and per named vector the vector storage / index (no-op for immutable) / quantized vectors.

Completes the field-index `LiveReload` dispatch chain on top of #9502: per-family dispatchers (numeric inner enum + wrapper, map, geo, full-text), the `ReadOnlyFieldIndex` enum dispatcher, and `ReadOnlyStructPayloadIndex`.

Stacked on #9502. Test `read_only_segment_live_reload_deletes`: build immutable segment → open read-only → delete points + flush → `live_reload` → queries reflect the deletions (parity with the mutable reference). All 17 live_reload tests green.
