### PR TITLE
[TQDT] for gpu indexing

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -12,10 +12,10 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::index::hnsw_index::gpu::GPU_TIMEOUT;
 use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilderParameters;
-use crate::vector_storage::MultiVectorStorage;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
     MultivectorOffsetsStorage, QuantizedMultivectorStorage,
 };
+use crate::vector_storage::{MultiVectorStorage, VectorStorageRead};
 
 // Multivector shader binding is after vectot data and quantization data bindings.
 const START_MULTIVECTORS_BINDING: usize = STORAGES_COUNT + MAX_QUANTIZATION_BINDINGS;
@@ -95,6 +95,31 @@ impl GpuMultivectors {
                         .vectors_count()
                 })
                 // Map count of vectors to start and count of vectors in multivector.
+                .scan(0, |acc, count| {
+                    let start = *acc;
+                    *acc += count;
+                    Some(GpuMultivectorOffset {
+                        start: start as u32,
+                        count: count as u32,
+                    })
+                }),
+        )
+    }
+
+    /// Construct multivectors data from a TurboQuant multivector storage.
+    ///
+    /// Unlike [`Self::new_multidense`], `TurboMultiVectorStorage` does not
+    /// implement [`MultiVectorStorage`], so the per-point inner counts are read
+    /// directly via `point_inner_vectors_count` and turned into start/count
+    /// offsets here.
+    pub fn new_turbo_multi(
+        device: Arc<gpu::Device>,
+        vector_storage: &crate::vector_storage::turbo::multi::TurboMultiVectorStorage,
+    ) -> OperationResult<GpuMultivectors> {
+        Self::new_impl(
+            device,
+            (0..vector_storage.total_vector_count())
+                .map(|id| vector_storage.point_inner_vectors_count(id as PointOffsetType))
                 .scan(0, |acc, count| {
                     let start = *acc;
                     *acc += count;

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -15,6 +15,7 @@ use crate::index::hnsw_index::gpu::shader_builder::ShaderBuilderParameters;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
     MultivectorOffsetsStorage, QuantizedMultivectorStorage,
 };
+use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
 use crate::vector_storage::{MultiVectorStorage, VectorStorageRead};
 
 // Multivector shader binding is after vectot data and quantization data bindings.
@@ -114,7 +115,7 @@ impl GpuMultivectors {
     /// offsets here.
     pub fn new_turbo_multi(
         device: Arc<gpu::Device>,
-        vector_storage: &crate::vector_storage::turbo::multi::TurboMultiVectorStorage,
+        vector_storage: &TurboMultiVectorStorage,
     ) -> OperationResult<GpuMultivectors> {
         Self::new_impl(
             device,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/gpu_multivectors.rs
@@ -87,23 +87,16 @@ impl GpuMultivectors {
     ) -> OperationResult<GpuMultivectors> {
         Self::new_impl(
             device,
-            (0..vector_storage.total_vector_count())
-                // map ID to count of vectors in multivector
-                .map(|id| {
-                    vector_storage
-                        .get_multi::<Random>(id as PointOffsetType)
-                        .as_ref()
-                        .vectors_count()
-                })
-                // Map count of vectors to start and count of vectors in multivector.
-                .scan(0, |acc, count| {
-                    let start = *acc;
-                    *acc += count;
-                    Some(GpuMultivectorOffset {
-                        start: start as u32,
-                        count: count as u32,
-                    })
-                }),
+            Self::counts_to_offsets(
+                (0..vector_storage.total_vector_count())
+                    // map ID to count of vectors in multivector
+                    .map(|id| {
+                        vector_storage
+                            .get_multi::<Random>(id as PointOffsetType)
+                            .as_ref()
+                            .vectors_count()
+                    }),
+            ),
         )
     }
 
@@ -119,17 +112,26 @@ impl GpuMultivectors {
     ) -> OperationResult<GpuMultivectors> {
         Self::new_impl(
             device,
-            (0..vector_storage.total_vector_count())
-                .map(|id| vector_storage.point_inner_vectors_count(id as PointOffsetType))
-                .scan(0, |acc, count| {
-                    let start = *acc;
-                    *acc += count;
-                    Some(GpuMultivectorOffset {
-                        start: start as u32,
-                        count: count as u32,
-                    })
-                }),
+            Self::counts_to_offsets(
+                (0..vector_storage.total_vector_count())
+                    .map(|id| vector_storage.point_inner_vectors_count(id as PointOffsetType)),
+            ),
         )
+    }
+
+    /// Map per-point inner vector counts to start/count offsets into the
+    /// flattened dense vectors buffer.
+    fn counts_to_offsets(
+        counts: impl Iterator<Item = usize> + Clone,
+    ) -> impl Iterator<Item = GpuMultivectorOffset> + Clone {
+        counts.scan(0, |acc, count| {
+            let start = *acc;
+            *acc += count;
+            Some(GpuMultivectorOffset {
+                start: start as u32,
+                count: count as u32,
+            })
+        })
     }
 
     /// Adds multivector data to the descriptor set builder.

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -599,6 +599,13 @@ impl GpuVectorStorage {
         // not rotation-invariant, so it must be rotated back.
         let keep_rotated = distance != Distance::Manhattan;
 
+        // Known inefficiency: `new_typed` re-iterates the vectors iterator once
+        // per GPU buffer (`STORAGES_COUNT` passes), and `skip`/`step_by` still
+        // evaluate the `map` closure for the skipped elements — so every vector
+        // is dequantized `STORAGES_COUNT` times instead of once. Accepted as a
+        // one-time index-build cost, dominated by the GPU graph build itself; a
+        // single-pass round-robin upload in `new_typed` would remove it if
+        // profiling ever shows it matters. Same applies to `new_multi_tq`.
         if device.has_half_precision() {
             Self::new_typed::<VectorElementTypeHalf>(
                 device,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -493,10 +493,10 @@ impl GpuVectorStorage {
             // back to float (or half-float, when the device supports it) and
             // upload it as a regular dense storage.
             VectorStorageEnum::DenseTurbo(vector_storage) => {
-                Self::new_dense_tq(device, vector_storage, force_half_precision, stopped)
+                Self::new_dense_tq(device, vector_storage, stopped)
             }
             VectorStorageEnum::MultiDenseTurbo(vector_storage) => {
-                Self::new_multi_tq(device, vector_storage, force_half_precision, stopped)
+                Self::new_multi_tq(device, vector_storage, stopped)
             }
             VectorStorageEnum::EmptyDense(_) | VectorStorageEnum::EmptySparse(_) => {
                 Err(OperationError::service_error(
@@ -584,7 +584,6 @@ impl GpuVectorStorage {
     fn new_dense_tq(
         device: Arc<gpu::Device>,
         vector_storage: &TurboVectorStorage,
-        force_half_precision: bool,
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         let count = vector_storage.total_vector_count();
@@ -598,7 +597,7 @@ impl GpuVectorStorage {
         // not rotation-invariant, so it must be rotated back.
         let keep_rotated = distance != Distance::Manhattan;
 
-        if force_half_precision && device.has_half_precision() {
+        if device.has_half_precision() {
             Self::new_typed::<VectorElementTypeHalf>(
                 device,
                 distance,
@@ -641,7 +640,6 @@ impl GpuVectorStorage {
     fn new_multi_tq(
         device: Arc<gpu::Device>,
         vector_storage: &TurboMultiVectorStorage,
-        force_half_precision: bool,
         stopped: &AtomicBool,
     ) -> OperationResult<Self> {
         let point_count = vector_storage.total_vector_count();
@@ -657,7 +655,7 @@ impl GpuVectorStorage {
         // inverse rotation; only Manhattan (L1) must be rotated back.
         let keep_rotated = distance != Distance::Manhattan;
 
-        if force_half_precision && device.has_half_precision() {
+        if device.has_half_precision() {
             Self::new_typed::<VectorElementTypeHalf>(
                 device,
                 distance,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -591,6 +591,13 @@ impl GpuVectorStorage {
         let distance = vector_storage.distance();
         let dim = vector_storage.vector_dim();
 
+        // The TurboQuant rotation is orthogonal, so it preserves Dot/Cosine/L2
+        // pairwise distances — the only distances the GPU graph builder computes.
+        // Keeping the vectors rotated therefore yields an equivalent graph while
+        // skipping the per-vector inverse rotation on the CPU. Manhattan (L1) is
+        // not rotation-invariant, so it must be rotated back.
+        let keep_rotated = distance != Distance::Manhattan;
+
         if force_half_precision && device.has_half_precision() {
             Self::new_typed::<VectorElementTypeHalf>(
                 device,
@@ -600,7 +607,8 @@ impl GpuVectorStorage {
                 dim,
                 (0..count).map(|id| {
                     VectorElementTypeHalf::slice_from_float_cow(Cow::Owned(
-                        vector_storage.get_dense_for_requantization(id as PointOffsetType, false),
+                        vector_storage
+                            .get_dense_for_requantization(id as PointOffsetType, keep_rotated),
                     ))
                 }),
                 None,
@@ -616,7 +624,8 @@ impl GpuVectorStorage {
                 dim,
                 (0..count).map(|id| {
                     Cow::Owned(
-                        vector_storage.get_dense_for_requantization(id as PointOffsetType, false),
+                        vector_storage
+                            .get_dense_for_requantization(id as PointOffsetType, keep_rotated),
                     )
                 }),
                 None,
@@ -643,6 +652,11 @@ impl GpuVectorStorage {
             .sum();
         let multivectors = GpuMultivectors::new_turbo_multi(device.clone(), vector_storage)?;
 
+        // See [`Self::new_dense_tq`]: the rotation is orthogonal, so keeping the
+        // inner vectors rotated preserves Dot/Cosine/L2 and skips the CPU-side
+        // inverse rotation; only Manhattan (L1) must be rotated back.
+        let keep_rotated = distance != Distance::Manhattan;
+
         if force_half_precision && device.has_half_precision() {
             Self::new_typed::<VectorElementTypeHalf>(
                 device,
@@ -652,7 +666,7 @@ impl GpuVectorStorage {
                 dim,
                 (0..point_count).flat_map(|id| {
                     vector_storage
-                        .get_inner_dense_for_requantization(id as PointOffsetType, false)
+                        .get_inner_dense_for_requantization(id as PointOffsetType, keep_rotated)
                         .into_iter()
                         .map(|inner| VectorElementTypeHalf::slice_from_float_cow(Cow::Owned(inner)))
                 }),
@@ -669,7 +683,7 @@ impl GpuVectorStorage {
                 dim,
                 (0..point_count).flat_map(|id| {
                     vector_storage
-                        .get_inner_dense_for_requantization(id as PointOffsetType, false)
+                        .get_inner_dense_for_requantization(id as PointOffsetType, keep_rotated)
                         .into_iter()
                         .map(Cow::Owned)
                 }),

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -26,8 +26,11 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectorStorage, QuantizedVectors,
 };
+use crate::vector_storage::turbo::TurboVectorStorage;
+use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
 use crate::vector_storage::{
-    DenseVectorStorage, MultiVectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseTQVectorStorage, DenseVectorStorage, MultiTQVectorStorage, MultiVectorStorage,
+    VectorStorageEnum, VectorStorageRead,
 };
 
 pub const ELEMENTS_PER_SUBGROUP: usize = 4;
@@ -97,7 +100,10 @@ impl ShaderBuilderParameters for GpuVectorStorage {
                 defines.insert("VECTOR_STORAGE_ELEMENT_UINT8".to_owned(), None);
             }
             VectorStorageDatatype::Turbo4 => {
-                unimplemented!("turbo4 datatype storage not yet wired up")
+                // Unreachable: TurboQuant storages are dequantized to `f32`/`f16`
+                // in `new_dense_tq`/`new_multi_tq`, so `element_type` is never
+                // `Turbo4`. The GPU has no native TQ element layout.
+                unreachable!("TurboQuant is dequantized to float before GPU upload")
             }
         }
 
@@ -483,11 +489,14 @@ impl GpuVectorStorage {
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(vector_storage) => {
                 Self::new_multi_f16(device, vector_storage.as_ref(), stopped)
             }
-            // TODO(TQDT): GPU f16 fallback
-            VectorStorageEnum::DenseTurbo(_) | VectorStorageEnum::MultiDenseTurbo(_) => {
-                Err(OperationError::from(gpu::GpuError::NotSupported(
-                    "Turbo4 vectors are not supported on GPU".to_string(),
-                )))
+            // TurboQuant has no native GPU element type: dequantize each vector
+            // back to float (or half-float, when the device supports it) and
+            // upload it as a regular dense storage.
+            VectorStorageEnum::DenseTurbo(vector_storage) => {
+                Self::new_dense_tq(device, vector_storage, force_half_precision, stopped)
+            }
+            VectorStorageEnum::MultiDenseTurbo(vector_storage) => {
+                Self::new_multi_tq(device, vector_storage, force_half_precision, stopped)
             }
             VectorStorageEnum::EmptyDense(_) | VectorStorageEnum::EmptySparse(_) => {
                 Err(OperationError::service_error(
@@ -567,6 +576,108 @@ impl GpuVectorStorage {
             None,
             stopped,
         )
+    }
+
+    /// Build a GPU storage from a TurboQuant dense storage by dequantizing each
+    /// encoded vector back to float. Uses half precision when forced and the
+    /// device supports it, full `f32` otherwise.
+    fn new_dense_tq(
+        device: Arc<gpu::Device>,
+        vector_storage: &TurboVectorStorage,
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        let count = vector_storage.total_vector_count();
+        let distance = vector_storage.distance();
+        let dim = vector_storage.vector_dim();
+
+        if force_half_precision && device.has_half_precision() {
+            Self::new_typed::<VectorElementTypeHalf>(
+                device,
+                distance,
+                count,
+                count,
+                dim,
+                (0..count).map(|id| {
+                    VectorElementTypeHalf::slice_from_float_cow(Cow::Owned(
+                        vector_storage.get_dense_for_requantization(id as PointOffsetType, false),
+                    ))
+                }),
+                None,
+                None,
+                stopped,
+            )
+        } else {
+            Self::new_typed::<VectorElementType>(
+                device,
+                distance,
+                count,
+                count,
+                dim,
+                (0..count).map(|id| {
+                    Cow::Owned(
+                        vector_storage.get_dense_for_requantization(id as PointOffsetType, false),
+                    )
+                }),
+                None,
+                None,
+                stopped,
+            )
+        }
+    }
+
+    /// Build a GPU storage from a TurboQuant multivector storage by dequantizing
+    /// every inner vector back to float. Mirrors [`Self::new_dense_tq`] for the
+    /// multivector case and uploads the multivector offsets alongside.
+    fn new_multi_tq(
+        device: Arc<gpu::Device>,
+        vector_storage: &TurboMultiVectorStorage,
+        force_half_precision: bool,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Self> {
+        let point_count = vector_storage.total_vector_count();
+        let distance = vector_storage.distance();
+        let dim = vector_storage.vector_dim();
+        let dense_count: usize = (0..point_count)
+            .map(|id| vector_storage.point_inner_vectors_count(id as PointOffsetType))
+            .sum();
+        let multivectors = GpuMultivectors::new_turbo_multi(device.clone(), vector_storage)?;
+
+        if force_half_precision && device.has_half_precision() {
+            Self::new_typed::<VectorElementTypeHalf>(
+                device,
+                distance,
+                dense_count,
+                point_count,
+                dim,
+                (0..point_count).flat_map(|id| {
+                    vector_storage
+                        .get_inner_dense_for_requantization(id as PointOffsetType, false)
+                        .into_iter()
+                        .map(|inner| VectorElementTypeHalf::slice_from_float_cow(Cow::Owned(inner)))
+                }),
+                None,
+                Some(multivectors),
+                stopped,
+            )
+        } else {
+            Self::new_typed::<VectorElementType>(
+                device,
+                distance,
+                dense_count,
+                point_count,
+                dim,
+                (0..point_count).flat_map(|id| {
+                    vector_storage
+                        .get_inner_dense_for_requantization(id as PointOffsetType, false)
+                        .into_iter()
+                        .map(Cow::Owned)
+                }),
+                None,
+                Some(multivectors),
+                stopped,
+            )
+        }
     }
 
     fn new_multi_f32<TVectorStorage: MultiVectorStorage<VectorElementType>>(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -579,8 +579,10 @@ impl GpuVectorStorage {
     }
 
     /// Build a GPU storage from a TurboQuant dense storage by dequantizing each
-    /// encoded vector back to float. Uses half precision when forced and the
-    /// device supports it, full `f32` otherwise.
+    /// encoded vector back to float. Always uses half precision when the device
+    /// supports it, regardless of `force_half_precision`: the 4-bit TQ
+    /// quantization error dwarfs f16 rounding, so `f32` would only waste GPU
+    /// memory and bandwidth. Falls back to `f32` on devices without f16.
     fn new_dense_tq(
         device: Arc<gpu::Device>,
         vector_storage: &TurboVectorStorage,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -655,12 +655,15 @@ fn test_gpu_vector_storage_turbo_dense(
     let turbo_storage = VectorStorageEnum::DenseTurbo(Box::new(turbo));
 
     let instance = gpu::GPU_TEST_INSTANCE.clone();
+    // `skip_half_precision = true`: the TQ path always picks f16 when the
+    // device supports it, so disable f16 to keep both storages on `f32` — the
+    // only difference under test is the dequantize-and-upload path, not f16
+    // rounding. The f16 datatype selection itself is covered by
+    // `test_gpu_vector_storage_tq_falls_back_to_half_precision`.
     let device =
-        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, false)
+        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, true)
             .unwrap();
 
-    // `force_half_precision = false` keeps both storages on `f32` so the only
-    // difference under test is the dequantize-and-upload path, not f16 rounding.
     let gpu_turbo = GpuVectorStorage::new(
         device.clone(),
         &turbo_storage,
@@ -745,8 +748,10 @@ fn test_gpu_vector_storage_turbo_multi(
     let turbo_storage = VectorStorageEnum::MultiDenseTurbo(Box::new(turbo));
 
     let instance = gpu::GPU_TEST_INSTANCE.clone();
+    // `skip_half_precision = true` — see the dense test: keep both storages on
+    // `f32` so the scores compare exactly, without f16 rounding.
     let device =
-        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, false)
+        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, true)
             .unwrap();
 
     let gpu_turbo = GpuVectorStorage::new(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -634,7 +634,12 @@ fn test_gpu_vector_storage_turbo_dense(
             .unwrap();
     }
 
-    // Reference plain-`f32` storage with the dequantized vectors the GPU uploads.
+    // Reference plain-`f32` storage holding the vectors in *original* (rotated-back)
+    // space. The production path keeps them rotated for the rotation-invariant
+    // metrics (everything but Manhattan), but the source's Unpadded rotation is
+    // orthogonal and leaves the padding at zero — so the truncated read-back is
+    // lossless and pairwise Dot/Cosine/L2 scores are identical. Comparing against
+    // original space here is what actually verifies that invariance.
     let mut reference = new_volatile_dense_vector_storage(dim, distance);
     for i in 0..num_vectors {
         let dequantized = turbo.get_dense_for_requantization(i as PointOffsetType, false);
@@ -720,7 +725,9 @@ fn test_gpu_vector_storage_turbo_multi(
             .unwrap();
     }
 
-    // Reference multivector storage with the dequantized inner vectors.
+    // Reference multivector storage with the inner vectors in original space (see
+    // the dense test): the Unpadded rotation is lossless on truncation, so keeping
+    // the production vectors rotated yields identical Dot/Cosine/L2 scores.
     let mut reference = new_volatile_multi_dense_vector_storage(dim, distance, multi_config);
     for i in 0..num_points {
         let inner = turbo.get_inner_dense_for_requantization(i as PointOffsetType, false);

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -24,6 +24,8 @@ use crate::vector_storage::multi_dense::volatile_multi_dense_vector_storage::{
     new_volatile_multi_dense_vector_storage_half,
 };
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsStorageType;
+use crate::vector_storage::turbo::multi::open_appendable_turbo_multi_vector_storage;
+use crate::vector_storage::turbo::open_appendable_turbo_vector_storage;
 use crate::vector_storage::{DEFAULT_STOPPED, RawScorer, VectorStorage, new_raw_scorer_for_test};
 
 #[derive(Debug, Clone, Copy)]
@@ -597,6 +599,174 @@ fn test_gpu_vector_storage_tq_falls_back_to_half_precision(
     );
 }
 
+/// A primary `VectorStorageEnum::DenseTurbo` storage built on GPU dequantizes
+/// each encoded vector back to float and uploads it as a regular dense storage.
+/// This pins that path by comparing GPU scores of the TurboQuant storage against
+/// GPU scores of a plain `f32` storage holding the *same* dequantized vectors —
+/// the two must be numerically identical.
+#[rstest]
+#[case::cosine(Distance::Cosine, 273, 1037)]
+#[case::dot(Distance::Dot, 256, 512)]
+#[case::euclid(Distance::Euclid, 273, 1037)]
+#[case::manhattan(Distance::Manhattan, 17, 1037)]
+fn test_gpu_vector_storage_turbo_dense(
+    #[case] distance: Distance,
+    #[case] dim: usize,
+    #[case] num_vectors: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let dir = tempfile::Builder::new().prefix("tq_dir").tempdir().unwrap();
+    let mut turbo = open_appendable_turbo_vector_storage(dir.path(), dim, distance, true).unwrap();
+
+    let mut rnd = StdRng::seed_from_u64(42);
+    for i in 0..num_vectors {
+        let vec = distance.preprocess_vector::<VectorElementType>(random_vector(&mut rnd, dim));
+        turbo
+            .insert_vector(
+                i as PointOffsetType,
+                VectorRef::from(&vec),
+                &HardwareCounterCell::new(),
+            )
+            .unwrap();
+    }
+
+    // Reference plain-`f32` storage with the dequantized vectors the GPU uploads.
+    let mut reference = new_volatile_dense_vector_storage(dim, distance);
+    for i in 0..num_vectors {
+        let dequantized = turbo.get_dense_for_requantization(i as PointOffsetType, false);
+        reference
+            .insert_vector(
+                i as PointOffsetType,
+                VectorRef::from(&dequantized),
+                &HardwareCounterCell::new(),
+            )
+            .unwrap();
+    }
+
+    let turbo_storage = VectorStorageEnum::DenseTurbo(Box::new(turbo));
+
+    let instance = gpu::GPU_TEST_INSTANCE.clone();
+    let device =
+        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, false)
+            .unwrap();
+
+    // `force_half_precision = false` keeps both storages on `f32` so the only
+    // difference under test is the dequantize-and-upload path, not f16 rounding.
+    let gpu_turbo = GpuVectorStorage::new(
+        device.clone(),
+        &turbo_storage,
+        None,
+        false,
+        &DEFAULT_STOPPED,
+    )
+    .unwrap();
+    let gpu_reference =
+        GpuVectorStorage::new(device.clone(), &reference, None, false, &DEFAULT_STOPPED).unwrap();
+
+    assert_eq!(gpu_turbo.element_type, VectorStorageDatatype::Float32);
+    assert_eq!(gpu_turbo.num_vectors(), num_vectors);
+
+    let turbo_scores = run_gpu_scoring(device.clone(), &gpu_turbo, num_vectors);
+    let reference_scores = run_gpu_scoring(device.clone(), &gpu_reference, num_vectors);
+
+    for (turbo_score, reference_score) in turbo_scores.iter().zip(reference_scores.iter()) {
+        assert!(
+            (turbo_score - reference_score).abs() < 1e-4,
+            "turbo GPU score {turbo_score} != reference GPU score {reference_score}",
+        );
+    }
+}
+
+/// Multivector counterpart of [`test_gpu_vector_storage_turbo_dense`].
+#[rstest]
+#[case::cosine(Distance::Cosine, 67, 1037)]
+#[case::dot(Distance::Dot, 67, 512)]
+fn test_gpu_vector_storage_turbo_multi(
+    #[case] distance: Distance,
+    #[case] dim: usize,
+    #[case] num_points: usize,
+) {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    let multi_config = Default::default();
+    let dir = tempfile::Builder::new().prefix("tq_dir").tempdir().unwrap();
+    let mut turbo =
+        open_appendable_turbo_multi_vector_storage(dir.path(), dim, distance, multi_config, true)
+            .unwrap();
+
+    let mut rnd = StdRng::seed_from_u64(42);
+    for i in 0..num_points {
+        let inner_count = 1 + rnd.random::<u8>() % 3;
+        let mut flattened = vec![];
+        for _ in 0..inner_count {
+            flattened.extend(
+                distance.preprocess_vector::<VectorElementType>(random_vector(&mut rnd, dim)),
+            );
+        }
+        let multivector = MultiDenseVectorInternal::new(flattened, dim);
+        turbo
+            .insert_vector(
+                i as PointOffsetType,
+                VectorRef::from(&multivector),
+                &HardwareCounterCell::new(),
+            )
+            .unwrap();
+    }
+
+    // Reference multivector storage with the dequantized inner vectors.
+    let mut reference = new_volatile_multi_dense_vector_storage(dim, distance, multi_config);
+    for i in 0..num_points {
+        let inner = turbo.get_inner_dense_for_requantization(i as PointOffsetType, false);
+        let flattened: Vec<VectorElementType> = inner.into_iter().flatten().collect();
+        let multivector = MultiDenseVectorInternal::new(flattened, dim);
+        reference
+            .insert_vector(
+                i as PointOffsetType,
+                VectorRef::from(&multivector),
+                &HardwareCounterCell::new(),
+            )
+            .unwrap();
+    }
+
+    let turbo_storage = VectorStorageEnum::MultiDenseTurbo(Box::new(turbo));
+
+    let instance = gpu::GPU_TEST_INSTANCE.clone();
+    let device =
+        gpu::Device::new_with_params(instance.clone(), &instance.physical_devices()[0], 0, false)
+            .unwrap();
+
+    let gpu_turbo = GpuVectorStorage::new(
+        device.clone(),
+        &turbo_storage,
+        None,
+        false,
+        &DEFAULT_STOPPED,
+    )
+    .unwrap();
+    let gpu_reference =
+        GpuVectorStorage::new(device.clone(), &reference, None, false, &DEFAULT_STOPPED).unwrap();
+
+    assert_eq!(gpu_turbo.element_type, VectorStorageDatatype::Float32);
+    assert_eq!(gpu_turbo.num_vectors(), num_points);
+
+    let turbo_scores = run_gpu_scoring(device.clone(), &gpu_turbo, num_points);
+    let reference_scores = run_gpu_scoring(device.clone(), &gpu_reference, num_points);
+
+    for (turbo_score, reference_score) in turbo_scores.iter().zip(reference_scores.iter()) {
+        assert!(
+            (turbo_score - reference_score).abs() < 1e-4,
+            "turbo GPU score {turbo_score} != reference GPU score {reference_score}",
+        );
+    }
+}
+
 fn get_precision(storage_type: TestStorageType, dim: usize, distance: Distance) -> f32 {
     let distance_persision = match distance {
         Distance::Cosine => 0.01,
@@ -844,6 +1014,35 @@ fn test_gpu_vector_storage_impl(
         }
     );
 
+    let gpu_scores = run_gpu_scoring(device.clone(), &gpu_vector_storage, num_vectors);
+
+    let query = QueryVector::Nearest(storage.get_vector::<Random>(test_point_id).to_owned());
+
+    let hardware_counter = HardwareCounterCell::new();
+    let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {
+        quantized_vectors
+            .raw_scorer(query, hardware_counter)
+            .unwrap()
+    } else {
+        new_raw_scorer_for_test(query, &storage).unwrap()
+    };
+
+    for (point_id, gpu_score) in gpu_scores.iter().enumerate() {
+        let score = scorer.score_internal(
+            test_point_id as PointOffsetType,
+            point_id as PointOffsetType,
+        );
+        assert!((score - gpu_score).abs() < precision);
+    }
+}
+
+/// Dispatch the `test_vector_storage.comp` shader, scoring every vector against
+/// target `0`, and download the resulting per-vector scores.
+fn run_gpu_scoring(
+    device: Arc<gpu::Device>,
+    gpu_vector_storage: &GpuVectorStorage,
+    num_vectors: usize,
+) -> Vec<f32> {
     let scores_buffer = gpu::Buffer::new(
         device.clone(),
         "Scores buffer",
@@ -864,7 +1063,7 @@ fn test_gpu_vector_storage_impl(
 
     let shader = ShaderBuilder::new(device.clone())
         .with_shader_code(include_str!("../shaders/tests/test_vector_storage.comp"))
-        .with_parameters(&gpu_vector_storage)
+        .with_parameters(gpu_vector_storage)
         .build("tests/test_vector_storage.comp")
         .unwrap();
 
@@ -908,24 +1107,5 @@ fn test_gpu_vector_storage_impl(
     context.run().unwrap();
     context.wait_finish(GPU_TIMEOUT).unwrap();
 
-    let gpu_scores = staging_buffer.download_vec(0, num_vectors).unwrap();
-
-    let query = QueryVector::Nearest(storage.get_vector::<Random>(test_point_id).to_owned());
-
-    let hardware_counter = HardwareCounterCell::new();
-    let scorer: Box<dyn RawScorer> = if let Some(quantized_vectors) = quantized_vectors.as_ref() {
-        quantized_vectors
-            .raw_scorer(query, hardware_counter)
-            .unwrap()
-    } else {
-        new_raw_scorer_for_test(query, &storage).unwrap()
-    };
-
-    for (point_id, gpu_score) in gpu_scores.iter().enumerate() {
-        let score = scorer.score_internal(
-            test_point_id as PointOffsetType,
-            point_id as PointOffsetType,
-        );
-        assert!((score - gpu_score).abs() < precision);
-    }
+    staging_buffer.download_vec(0, num_vectors).unwrap()
 }

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -174,14 +174,20 @@ impl TurboVectorStorage {
         keep_rotated: bool,
     ) -> DenseVector {
         let quantized = self.storage.get_quantized_vector(key);
-        let mut dequantized = self.quantizer.dequantize::<f64>(&quantized);
-        if !keep_rotated {
+        if keep_rotated {
+            // No inverse rotation — dequantize straight into `f32`, skipping
+            // the intermediate `Vec<f64>` (rotation needs an `f64` buffer).
+            let mut dequantized = self.quantizer.dequantize::<VectorElementType>(&quantized);
+            dequantized.truncate(self.dim);
+            dequantized
+        } else {
+            let mut dequantized = self.quantizer.dequantize::<f64>(&quantized);
             self.quantizer.apply_inverse_rotation(&mut dequantized);
+            dequantized[..self.dim]
+                .iter()
+                .map(|&x| x as VectorElementType)
+                .collect()
         }
-        dequantized[..self.dim]
-            .iter()
-            .map(|&x| x as VectorElementType)
-            .collect()
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -197,14 +197,21 @@ impl TurboMultiVectorStorage {
         (offset.offset..offset.offset + offset.count)
             .map(|inner_id| {
                 let encoded = self.storage.get_vector_data(inner_id);
-                let mut dequantized = self.quantizer.dequantize::<f64>(&encoded);
-                if !keep_rotated {
+                if keep_rotated {
+                    // No inverse rotation — dequantize straight into `f32`,
+                    // skipping the intermediate `Vec<f64>` (rotation needs an
+                    // `f64` buffer).
+                    let mut dequantized = self.quantizer.dequantize::<VectorElementType>(&encoded);
+                    dequantized.truncate(self.dim);
+                    dequantized
+                } else {
+                    let mut dequantized = self.quantizer.dequantize::<f64>(&encoded);
                     self.quantizer.apply_inverse_rotation(&mut dequantized);
+                    dequantized[..self.dim]
+                        .iter()
+                        .map(|&x| x as VectorElementType)
+                        .collect()
                 }
-                dequantized[..self.dim]
-                    .iter()
-                    .map(|&x| x as VectorElementType)
-                    .collect()
             })
             .collect()
     }


### PR DESCRIPTION
This PR adds support of GPU indexing for TQ-as-a-datatype.

No GPU-related stuff. This PR converts TQ into half-floats to process on GPU.

GPU tests: https://github.com/qdrant/qdrant/actions/runs/28578293575
