### PR TITLE
Simplify `IoUringRuntime` implementation

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -228,10 +228,10 @@ impl UniversalWrite for IoUringFile {
         &mut self,
         items: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        let mut rt = IoUringRuntime::new()?;
+        let mut rt = IoUringWriteRuntime::new()?;
         let mut items = items.into_iter().peekable();
 
-        while items.peek().is_some() || rt.in_progress > 0 {
+        while items.peek().is_some() || rt.in_progress() > 0 {
             rt.enqueue_while(|state| {
                 let Some((byte_offset, items)) = items.next() else {
                     return Ok(None);
@@ -244,8 +244,7 @@ impl UniversalWrite for IoUringFile {
             rt.submit_and_wait(1)?;
 
             for result in rt.completed() {
-                let (_, resp) = result?;
-                resp.expect_write();
+                result?;
             }
         }
 
@@ -256,10 +255,10 @@ impl UniversalWrite for IoUringFile {
         files: &mut [Self],
         writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
     ) -> Result<()> {
-        let mut rt = IoUringRuntime::new()?;
+        let mut rt = IoUringWriteRuntime::new()?;
         let mut writes = writes.into_iter().peekable();
 
-        while writes.peek().is_some() || rt.in_progress > 0 {
+        while writes.peek().is_some() || rt.in_progress() > 0 {
             rt.enqueue_while(|state| {
                 let Some((file_index, byte_offset, items)) = writes.next() else {
                     return Ok(None);
@@ -279,8 +278,7 @@ impl UniversalWrite for IoUringFile {
             rt.submit_and_wait(1)?;
 
             for result in rt.completed() {
-                let (_, resp) = result?;
-                resp.expect_write();
+                result?;
             }
         }
 

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -26,6 +26,9 @@ use super::*;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 
+/// Required alignment for `O_DIRECT` reads (both file offset and buffer).
+pub const KERNEL_PAGE_SIZE: usize = 4096; // 4 KB
+
 #[derive(Debug, Clone)]
 pub struct IoUringFile {
     file: Arc<fs::File>,

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
-use std::ops::Range;
+use std::ops::{DerefMut as _, Range};
 
 use ::io_uring::types::Fd;
 
@@ -15,19 +15,22 @@ pub struct BorrowedIoUringPipeline<'file, U>
 where
     U: UserData,
 {
-    inner: IoUringPipelineInner<'file, U>,
+    inner: IoUringPipelineInner<U>,
+    _phantom: PhantomData<&'file ()>,
 }
 
-impl<'file, U> BorrowedReadPipeline<'file, U> for BorrowedIoUringPipeline<'file, U>
-where
-    U: UserData,
-{
+impl<'file, U: UserData> BorrowedReadPipeline<'file, U> for BorrowedIoUringPipeline<'file, U> {
     type File = IoUringFile;
 
     fn new() -> Result<Self> {
-        Ok(Self {
-            inner: IoUringPipelineInner::new()?,
-        })
+        let inner = IoUringPipelineInner::new()?;
+
+        let pipeline = Self {
+            inner,
+            _phantom: PhantomData,
+        };
+
+        Ok(pipeline)
     }
 
     fn can_schedule(&mut self) -> bool {
@@ -41,8 +44,7 @@ where
         range: Range<u64>,
         align: usize,
     ) -> Result<()> {
-        // Safety: `file.fd()` doesn't outlive the inner pipeline because of
-        // `'file` lifetime.
+        // SAFETY: `fd` does not outlive inner pipeline because `Self` is bound to `'file` lifetime
         unsafe {
             self.inner
                 .schedule(user_data, file.fd(), file.direct_io, range, align)
@@ -54,26 +56,23 @@ where
     }
 }
 
-pub struct OwnedIoUringPipeline<U>
-where
-    U: UserData,
-{
+pub struct OwnedIoUringPipeline<U: UserData> {
+    inner: ManuallyDrop<IoUringPipelineInner<U>>,
     file: ManuallyDrop<IoUringFile>,
-    inner: ManuallyDrop<IoUringPipelineInner<'static, U>>,
 }
 
-impl<U> OwnedReadPipeline<U> for OwnedIoUringPipeline<U>
-where
-    U: UserData,
-{
+impl<U: UserData> OwnedReadPipeline<U> for OwnedIoUringPipeline<U> {
     type File = IoUringFile;
 
     fn new(file: IoUringFile) -> Result<Self> {
         let inner = IoUringPipelineInner::new()?;
-        Ok(Self {
-            file: ManuallyDrop::new(file),
+
+        let pipeline = Self {
             inner: ManuallyDrop::new(inner),
-        })
+            file: ManuallyDrop::new(file),
+        };
+
+        Ok(pipeline)
     }
 
     fn can_schedule(&mut self) -> bool {
@@ -86,8 +85,7 @@ where
         range: Range<u64>,
         align: usize,
     ) -> Result<()> {
-        // Safety: `self.file.fd()` doesn't outlive the inner pipeline because
-        // of explicit drop order in `impl Drop`.
+        // SAFETY: `fd` does not outlive inner pipeline because of explicit drop order in `Drop`
         unsafe {
             self.inner
                 .schedule(user_data, self.file.fd(), self.file.direct_io, range, align)
@@ -96,9 +94,11 @@ where
 
     fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
         let eof = self.file.len::<u8>()?;
+
         if from >= eof {
             return Ok(());
         }
+
         self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 
@@ -107,52 +107,39 @@ where
     }
 
     fn into_inner(self) -> IoUringFile {
-        // Wrap in `ManuallyDrop` so our own `Drop` impl doesn't run; we take
-        // both fields out by hand instead.
+        // Wrap `self` in `ManuallyDrop` so own `Drop` doesn't run at the end of `into_inner` scope
         let mut this = ManuallyDrop::new(self);
 
-        let Self { file, inner } = &mut *this;
+        // Drop `inner` before taking `file`
+        let Self { file, inner } = this.deref_mut();
 
-        // SAFETY: `this` is `ManuallyDrop`, so its destructor never runs and
-        // each field is taken exactly once.
-        let file = unsafe { ManuallyDrop::take(file) };
-        let inner = unsafe { ManuallyDrop::take(inner) };
-        drop(inner);
-        file
+        unsafe {
+            ManuallyDrop::drop(inner);
+            ManuallyDrop::take(file)
+        }
     }
 }
 
-impl<U> Drop for OwnedIoUringPipeline<U>
-where
-    U: UserData,
-{
+impl<U: UserData> Drop for OwnedIoUringPipeline<U> {
     fn drop(&mut self) {
-        // Drop `inner` before `file`.
+        // Drop `inner` before `file`
         let Self { file, inner } = self;
-        let file: IoUringFile = unsafe { ManuallyDrop::take(file) };
-        let inner: IoUringPipelineInner<_> = unsafe { ManuallyDrop::take(inner) };
-        drop(inner);
-        drop(file);
+
+        unsafe {
+            ManuallyDrop::drop(inner);
+            ManuallyDrop::drop(file);
+        }
     }
 }
 
-struct IoUringPipelineInner<'file, U>
-where
-    U: UserData,
-{
+struct IoUringPipelineInner<U: UserData> {
     runtime: IoUringReadRuntime<U>,
-    _phantom: PhantomData<&'file ()>,
 }
 
-impl<'file, U> IoUringPipelineInner<'file, U>
-where
-    U: UserData,
-{
+impl<U: UserData> IoUringPipelineInner<U> {
     fn new() -> Result<Self> {
-        Ok(Self {
-            runtime: IoUringReadRuntime::new()?,
-            _phantom: PhantomData,
-        })
+        let runtime = IoUringReadRuntime::new()?;
+        Ok(Self { runtime })
     }
 
     fn can_schedule(&mut self) -> bool {
@@ -161,7 +148,7 @@ where
 
     /// # Safety
     ///
-    /// The caller must ensure that the `fd` will not outlive the pipeline.
+    /// The caller must ensure that `fd` will not outlive the pipeline.
     unsafe fn schedule(
         &mut self,
         user_data: U,
@@ -184,7 +171,7 @@ where
         Ok(())
     }
 
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait<'a>(&mut self) -> Result<Option<(U, ACow<'a>)>> {
         let next = self.runtime.completed().next();
 
         let enqueued = self.runtime.enqueued();

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -4,7 +4,7 @@ use std::ops::{DerefMut as _, Range};
 
 use ::io_uring::types::Fd;
 
-use super::{IoUringFile, IoUringReadRuntime};
+use super::{IoUringFile, IoUringReadRuntime, KERNEL_PAGE_SIZE};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
 use crate::universal_io::{
@@ -99,7 +99,13 @@ impl<U: UserData> OwnedReadPipeline<U> for OwnedIoUringPipeline<U> {
             return Ok(());
         }
 
-        self.schedule::<Sequential>(user_data, from..eof, 1)
+        let align = if self.file.direct_io {
+            KERNEL_PAGE_SIZE
+        } else {
+            1
+        };
+
+        self.schedule::<Sequential>(user_data, from..eof, align)
     }
 
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,10 +1,10 @@
+use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::Range;
 
 use ::io_uring::types::Fd;
 
-use super::pool::IO_URING_QUEUE_LENGTH;
-use super::{IoUringFile, IoUringRuntime};
+use super::{IoUringFile, IoUringReadRuntime};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
 use crate::universal_io::{
@@ -140,7 +140,8 @@ struct IoUringPipelineInner<'file, U>
 where
     U: UserData,
 {
-    runtime: IoUringRuntime<'file, U>,
+    runtime: IoUringReadRuntime<U>,
+    _phantom: PhantomData<&'file ()>,
 }
 
 impl<'file, U> IoUringPipelineInner<'file, U>
@@ -149,13 +150,13 @@ where
 {
     fn new() -> Result<Self> {
         Ok(Self {
-            runtime: IoUringRuntime::new()?,
+            runtime: IoUringReadRuntime::new()?,
+            _phantom: PhantomData,
         })
     }
 
     fn can_schedule(&mut self) -> bool {
-        let squeue = self.runtime.io_uring.submission();
-        self.runtime.in_progress + squeue.len() < IO_URING_QUEUE_LENGTH as _
+        self.runtime.can_schedule()
     }
 
     /// # Safety
@@ -169,20 +170,16 @@ where
         range: Range<u64>,
         align: usize,
     ) -> Result<()> {
-        let mut squeue = self.runtime.io_uring.submission();
-
-        if self.runtime.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
+        if !self.can_schedule() {
             return Err(UniversalIoError::QueueIsFull);
         }
 
         let entry = self
             .runtime
-            .state
-            .read(user_data, fd, range, align, direct_io);
+            .state()
+            .read(user_data, fd, direct_io, range, align);
 
-        unsafe {
-            squeue.push(&entry).expect("submission queue is not full");
-        }
+        self.runtime.enqueue(entry)?;
 
         Ok(())
     }
@@ -194,7 +191,7 @@ where
 
         if next.is_some() && enqueued > 0 {
             self.runtime.submit_and_wait(0)?;
-        } else if next.is_none() && enqueued + self.runtime.in_progress > 0 {
+        } else if next.is_none() && enqueued + self.runtime.in_progress() > 0 {
             self.runtime.submit_and_wait(1)?;
         }
 
@@ -202,7 +199,7 @@ where
             return Ok(None);
         };
 
-        let (user_data, resp) = result?;
-        Ok(Some((user_data, ACow::Owned(resp.expect_read()))))
+        let (user_data, buffer) = result?;
+        Ok(Some((user_data, ACow::Owned(buffer))))
     }
 }

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
-use std::ops::{DerefMut as _, Range};
+use std::ops::Range;
 
 use ::io_uring::types::Fd;
 
@@ -44,7 +44,8 @@ impl<'file, U: UserData> BorrowedReadPipeline<'file, U> for BorrowedIoUringPipel
         range: Range<u64>,
         align: usize,
     ) -> Result<()> {
-        // SAFETY: `fd` does not outlive inner pipeline because `Self` is bound to `'file` lifetime
+        // SAFETY: `fd` does not outlive `inner` pipeline, because `Self` is bound by `'file` lifetime
+
         unsafe {
             self.inner
                 .schedule(user_data, file.fd(), file.direct_io, range, align)
@@ -85,7 +86,8 @@ impl<U: UserData> OwnedReadPipeline<U> for OwnedIoUringPipeline<U> {
         range: Range<u64>,
         align: usize,
     ) -> Result<()> {
-        // SAFETY: `fd` does not outlive inner pipeline because of explicit drop order in `Drop`
+        // SAFETY: `fd` does not outlive `inner` pipeline, because `inner` is always dropped before `file`
+
         unsafe {
             self.inner
                 .schedule(user_data, self.file.fd(), self.file.direct_io, range, align)
@@ -112,29 +114,50 @@ impl<U: UserData> OwnedReadPipeline<U> for OwnedIoUringPipeline<U> {
         self.inner.wait()
     }
 
+    #[expect(
+        clippy::let_and_return,
+        reason = "better readability around unsafe code"
+    )]
     fn into_inner(self) -> IoUringFile {
-        // Wrap `self` in `ManuallyDrop` so own `Drop` doesn't run at the end of `into_inner` scope
+        // Wrap `self` in `ManuallyDrop`, so `Drop` doesn't run at the end of `into_inner` scope
         let mut this = ManuallyDrop::new(self);
 
-        // Drop `inner` before taking `file`
-        let Self { file, inner } = this.deref_mut();
-
-        unsafe {
-            ManuallyDrop::drop(inner);
-            ManuallyDrop::take(file)
-        }
+        // Drop `inner` during `destructure`, then return `file`
+        let file = unsafe { this.destructure() };
+        file
     }
 }
 
-impl<U: UserData> Drop for OwnedIoUringPipeline<U> {
-    fn drop(&mut self) {
-        // Drop `inner` before `file`
-        let Self { file, inner } = self;
+impl<U> OwnedIoUringPipeline<U> {
+    /// Destructure the pipeline. Drop `inner` and return `file`.
+    ///
+    /// # Safety:
+    ///
+    /// Must only be called once. `self` is uninitilized after `destructure` call,
+    /// so caller must prevent `Drop` from running and ensure `self` is not accessed
+    /// after the call.
+    unsafe fn destructure(&mut self) -> IoUringFile {
+        // `inner` might borrow `file`, so we must drop it before returning `file`.
+        //
+        // Take `file` and `inner` out of `ManuallyDrop`, so that we can rely on drop
+        // at the end of scope or panic. Default drop order is *reverse* of declaration,
+        // so we must take `file` *before* `inner`.
 
-        unsafe {
-            ManuallyDrop::drop(inner);
-            ManuallyDrop::drop(file);
-        }
+        let Self { inner, file } = self;
+
+        let file = unsafe { ManuallyDrop::take(file) };
+        let inner = unsafe { ManuallyDrop::take(inner) };
+
+        drop(inner);
+        file
+    }
+}
+
+impl<U> Drop for OwnedIoUringPipeline<U> {
+    fn drop(&mut self) {
+        // Drop `inner` during `destructure`, then drop `file` explicitly
+        let file = unsafe { self.destructure() };
+        drop(file);
     }
 }
 
@@ -177,7 +200,7 @@ impl<U: UserData> IoUringPipelineInner<U> {
         Ok(())
     }
 
-    fn wait<'a>(&mut self) -> Result<Option<(U, ACow<'a>)>> {
+    fn wait(&mut self) -> Result<Option<(U, ACow<'static>)>> {
         let next = self.runtime.completed().next();
 
         let enqueued = self.runtime.enqueued();

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -3,28 +3,28 @@ use std::ops::Range;
 
 use ::io_uring::types::Fd;
 use ::io_uring::{opcode, squeue};
-use aligned_vec::{AVec, ConstAlign, RuntimeAlign};
+use aligned_vec::{AVec, RuntimeAlign};
 use slab::Slab;
 
 use super::*;
-use crate::universal_io::UserData;
 
 /// Required alignment for `O_DIRECT` reads (both file offset and buffer).
 const KERNEL_PAGE_SIZE: usize = 4096; // 4 kB
 
-pub struct IoUringRuntime<'data, U: UserData> {
-    pub io_uring: IoUringGuard,
-    pub state: IoUringState<'data, U>,
-    pub in_progress: usize,
+pub type IoUringReadRuntime<U> = IoUringRuntime<Read, U>;
+pub type IoUringWriteRuntime<'data, U> = IoUringRuntime<Write<'data>, U>;
+
+pub struct IoUringRuntime<Req, U> {
+    io_uring: IoUringGuard,
+    state: IoUringState<Req, U>,
+    in_progress: usize,
 }
 
-impl<'data, U> IoUringRuntime<'data, U>
-where
-    U: UserData,
-{
+impl<Req, U> IoUringRuntime<Req, U> {
     pub fn new() -> Result<Self> {
         let mut io_uring = pool::get_io_uring()?;
         let capacity = io_uring.submission().capacity();
+
         let rt = Self {
             io_uring,
             state: IoUringState::with_capacity(capacity),
@@ -34,22 +34,47 @@ where
         Ok(rt)
     }
 
+    pub fn can_schedule(&mut self) -> bool {
+        self.enqueued() + self.in_progress < IO_URING_QUEUE_LENGTH as _
+    }
+
+    pub fn enqueued(&mut self) -> usize {
+        self.io_uring.submission().len()
+    }
+
+    pub fn in_progress(&self) -> usize {
+        self.in_progress
+    }
+
+    pub fn state(&mut self) -> &mut IoUringState<Req, U> {
+        &mut self.state
+    }
+
+    pub fn enqueue(&mut self, entry: squeue::Entry) -> Result<()> {
+        unsafe {
+            self.io_uring
+                .submission()
+                .push(&entry)
+                .map_err(|_| UniversalIoError::QueueIsFull)
+        }
+    }
+
     /// Push entries into Submission Queue while `entries` returns `Ok(Something)`
     /// or the queue is full.
     pub fn enqueue_while<F>(&mut self, mut entries: F) -> Result<()>
     where
-        F: FnMut(&mut IoUringState<'data, U>) -> Result<Option<squeue::Entry>>,
+        F: FnMut(&mut IoUringState<Req, U>) -> Result<Option<squeue::Entry>>,
     {
         let mut squeue = self.io_uring.submission();
 
-        if self.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
+        if squeue.len() + self.in_progress >= IO_URING_QUEUE_LENGTH as _ {
             return Ok(());
         }
 
         while let Some(entry) = entries(&mut self.state)? {
             unsafe { squeue.push(&entry).expect("submission queue is not full") };
 
-            if self.in_progress + squeue.len() >= IO_URING_QUEUE_LENGTH as _ {
+            if squeue.len() + self.in_progress >= IO_URING_QUEUE_LENGTH as _ {
                 break;
             }
         }
@@ -57,12 +82,8 @@ where
         Ok(())
     }
 
-    pub fn enqueued(&mut self) -> usize {
-        self.io_uring.submission().len()
-    }
-
     pub fn submit_and_wait(&mut self, want: usize) -> io::Result<()> {
-        let enqueued = self.io_uring.submission().len();
+        let enqueued = self.enqueued();
 
         debug_assert!(
             want == 0 || enqueued + self.in_progress >= want,
@@ -73,7 +94,7 @@ where
 
         self.submit_and_wait_retry_early_wakeup(want)?;
 
-        let remaining = self.io_uring.submission().len();
+        let remaining = self.enqueued();
         debug_assert!(enqueued == 0 || enqueued > remaining);
         debug_assert_eq!(remaining, 0);
 
@@ -104,45 +125,49 @@ where
         Ok(())
     }
 
-    pub fn completed(&mut self) -> impl Iterator<Item = io::Result<(U, IoUringResponse)>> {
+    pub fn completed(&mut self) -> impl Iterator<Item = io::Result<(U, Req::Resp)>> + '_
+    where
+        Req: Finalize,
+    {
+        self.completions().map(|result| {
+            let (user_data, request, length) = result?;
+            let response = request.finalize(length);
+            Ok((user_data, response))
+        })
+    }
+
+    fn completions(&mut self) -> impl Iterator<Item = io::Result<(U, Req, u32)>> + '_ {
         self.io_uring.completion().map(|entry| {
             self.in_progress -= 1;
 
             let slot = entry.user_data() as usize;
             let result = entry.result();
 
-            if result < 0 {
-                self.state.abort(slot);
+            let (user_data, request) = self.state.complete(slot)?;
 
-                return Err(io_error_context(
+            if result >= 0 {
+                Ok((user_data, request, result as _))
+            } else {
+                Err(io_error_context(
                     io::Error::from_raw_os_error(-result),
                     format!("io_uring operation in slot {slot} failed"),
-                ));
+                ))
             }
-
-            let length = result as _;
-            let (user_data, resp) = self.state.finalize(slot, length)?;
-            Ok((user_data, resp))
         })
     }
 }
 
-impl<'data, U> Drop for IoUringRuntime<'data, U>
-where
-    U: UserData,
-{
+impl<Req, U> Drop for IoUringRuntime<Req, U> {
     fn drop(&mut self) {
-        while self.in_progress > 0 || !self.io_uring.submission().is_empty() {
-            // TODO: Cancel operations with `io_uring::Submitter::register_sync_cancel`?
+        // TODO: Cancel operations with `io_uring::Submitter::register_sync_cancel`?
 
-            // TODO: Implement `wait` (without submit) based on `io_uring::Submitter::enter`?
+        while self.enqueued() > 0 || self.in_progress > 0 {
             self.submit_and_wait(self.in_progress)
-                .expect("operations submitted");
+                .expect("pending operations submitted");
 
-            for result in self.completed() {
-                match result {
-                    Ok(_) => (),
-                    Err(err) => log::debug!("{err}"),
+            for result in self.completions() {
+                if let Err(err) = result {
+                    log::debug!("{err}");
                 }
             }
         }
@@ -150,242 +175,154 @@ where
 }
 
 #[derive(Debug)]
-pub struct IoUringState<'data, U> {
-    requests: Slab<PendingRequest<'data, U>>,
+pub struct IoUringState<Req, U> {
+    requests: Slab<Pending<Req, U>>,
 }
 
 #[derive(Debug)]
-struct PendingRequest<'data, U> {
+struct Pending<Req, U> {
+    request: Req,
     user_data: U,
-    request: IoUringRequest<'data>,
 }
 
-impl<'data, U> IoUringState<'data, U>
-where
-    U: UserData,
-{
+impl<Req, U> IoUringState<Req, U> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             requests: Slab::with_capacity(capacity),
         }
     }
+}
 
-    /// Prepare the buffer for storing the read with correct alignment, and returns the queue entry.
+impl<U> IoUringState<Read, U> {
     pub fn read(
         &mut self,
         user_data: U,
         fd: Fd,
+        direct_io: bool,
         range: Range<u64>,
         align: usize,
-        o_direct: bool,
     ) -> squeue::Entry {
-        if o_direct {
-            self.read_o_direct(user_data, fd, range, align)
+        let Range { start, end } = range;
+
+        let offset = start;
+        let length = u32::try_from(end - start).expect("read length fit within u32");
+
+        // Extend read range to next KERNEL_PAGE_SIZE boundary
+        let kernel_length = if direct_io {
+            assert!(
+                align.is_multiple_of(KERNEL_PAGE_SIZE),
+                "O_DIRECT read buffer must be aligned to {KERNEL_PAGE_SIZE} bytes (alignment: {align})",
+            );
+
+            assert!(
+                offset.is_multiple_of(KERNEL_PAGE_SIZE as _),
+                "O_DIRECT read offset must be aligned to {KERNEL_PAGE_SIZE} bytes (offset: {offset})",
+            );
+
+            // O_DIRECT read length must be aligned to KERNEL_PAGE_SIZE bytes
+            length
+                .checked_next_multiple_of(KERNEL_PAGE_SIZE as _)
+                .expect("read length fit within u32")
         } else {
-            self.read_exact(user_data, fd, range, align)
-        }
-    }
+            length
+        };
 
-    /// Allocates an `align`-aligned [`AlignedBuf`] sized exactly to the request,
-    /// so the kernel writes into a buffer that is already correctly aligned for
-    /// the caller's downstream cast.
-    fn read_exact(
-        &mut self,
-        user_data: U,
-        fd: Fd,
-        range: Range<u64>,
-        align: usize,
-    ) -> squeue::Entry {
-        let size =
-            u32::try_from(range.end - range.start).expect("read buffer length fit within u32");
-        let buffer = AVec::with_capacity(align, size as usize);
-        let (slot, req) = self.init(user_data, IoUringRequest::Read { buffer });
+        let read = Read {
+            buffer: AVec::with_capacity(align, kernel_length as _),
+            expected_length: length,
+        };
 
-        opcode::Read::new(fd, req.expect_read().as_mut_ptr(), size)
+        let (slot, read) = self.init(user_data, read);
+        opcode::Read::new(fd, read.buffer.as_mut_ptr(), kernel_length)
             .offset(range.start)
             .build()
             .user_data(slot as u64)
     }
+}
 
-    /// Allocates a page-aligned scratch byte buffer rounded up to whole pages.
-    fn read_o_direct(
-        &mut self,
-        user_data: U,
-        fd: Fd,
-        range: Range<u64>,
-        align: usize,
-    ) -> squeue::Entry {
-        // Make sure read buffer is kernel-page aligned
-        let pages_start = range.start & !(KERNEL_PAGE_SIZE as u64 - 1);
-        let pages_end = range.end.next_multiple_of(KERNEL_PAGE_SIZE as u64);
-
-        let buffer = AVec::with_capacity(KERNEL_PAGE_SIZE, (pages_end - pages_start) as usize);
-
-        // Range within the page-aligned buffer
-        let inner_range = (range.start - pages_start) as usize..(range.end - pages_start) as usize;
-
-        let (slot, req) = self.init(
-            user_data,
-            IoUringRequest::ODirectRead {
-                buffer,
-                inner_range,
-                align,
-            },
-        );
-        let buffer = req.expect_o_direct_read();
-
-        let pages_len_bytes =
-            u32::try_from(pages_end - pages_start).expect("read buffer length fit within u32");
-
-        opcode::Read::new(fd, buffer.as_mut_ptr(), pages_len_bytes)
-            .offset(pages_start)
-            .build()
-            .user_data(slot as u64)
-    }
-
+impl<'data, U> IoUringState<Write<'data>, U> {
     pub fn write(
         &mut self,
         user_data: U,
         fd: Fd,
-        byte_offset: u64,
+        offset: u64,
         bytes: &'data [u8],
     ) -> squeue::Entry {
-        let (slot, _) = self.init(user_data, IoUringRequest::Write(bytes));
-
-        let byte_length = u32::try_from(bytes.len()).expect("write buffer length fit within u32");
-        opcode::Write::new(fd, bytes.as_ptr(), byte_length)
-            .offset(byte_offset)
+        let length = u32::try_from(bytes.len()).expect("write length fit within u32");
+        let (slot, _) = self.init(user_data, Write { bytes });
+        opcode::Write::new(fd, bytes.as_ptr(), length)
+            .offset(offset)
             .build()
             .user_data(slot as u64)
     }
+}
 
-    fn init(
-        &mut self,
-        user_data: U,
-        request: IoUringRequest<'data>,
-    ) -> (usize, &mut IoUringRequest<'data>) {
+impl<Req, U> IoUringState<Req, U> {
+    fn init(&mut self, user_data: U, request: Req) -> (usize, &mut Req) {
         let entry = self.requests.vacant_entry();
         let slot = entry.key();
-        let pending = entry.insert(PendingRequest { user_data, request });
+        let pending = entry.insert(Pending { request, user_data });
         (slot, &mut pending.request)
     }
 
-    pub fn finalize(&mut self, slot: usize, byte_length: u32) -> io::Result<(U, IoUringResponse)> {
-        let PendingRequest { user_data, request } = self
-            .requests
-            .try_remove(slot)
-            .ok_or_else(|| io::Error::other(format!("request in slot {slot} does not exist")))?;
+    fn complete(&mut self, slot: usize) -> io::Result<(U, Req)> {
+        let pending = self.requests.try_remove(slot).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("request slot {slot} is empty"),
+            )
+        })?;
 
-        let byte_length = byte_length as usize;
-
-        let resp = match request {
-            IoUringRequest::Read { mut buffer } => {
-                assert!(buffer.capacity() >= byte_length);
-                // SAFETY: the kernel wrote `byte_length` into the buffer.
-                unsafe { buffer.set_len(byte_length) };
-                IoUringResponse::Read(buffer)
-            }
-            IoUringRequest::ODirectRead {
-                mut buffer,
-                inner_range,
-                align,
-            } => {
-                // SAFETY: the kernel wrote `byte_length` into the buffer.
-                unsafe { buffer.set_len(byte_length) };
-
-                // We need to return an `align`-aligned buffer
-
-                // TODO(perf): Currently, we are allocating 2 Vecs: a page-aligned vec, and then the `align`-aligned one.
-                //             In theory we can use `opcode::ReadFixed` to use preregistered buffers so that we only
-                //             allocate one extra buffer per read. Not done for now since it complicates implementation.
-
-                //
-                // buffer_bytes
-                // │     ┌────┬────items┬────┬────┐      byte_length    │
-                // ├─────┤ 1  │ 2  │ 3  │ 4  │ 5  ├───────────>|────────┤
-                // │     └────┴────┴────┴────┴────┘                     │
-                //       ^
-                //   inner_range.start
-
-                let result = AVec::from_slice(align, &buffer[inner_range]);
-                IoUringResponse::Read(result)
-            }
-
-            IoUringRequest::Write(bytes) => {
-                assert_eq!(bytes.len(), byte_length);
-                IoUringResponse::Write
-            }
-        };
-
-        Ok((user_data, resp))
-    }
-
-    pub fn abort(&mut self, slot: usize) {
-        self.requests.try_remove(slot);
+        let Pending { request, user_data } = pending;
+        Ok((user_data, request))
     }
 }
 
-impl<'data, U> Drop for IoUringState<'data, U> {
+impl<Req, U> Drop for IoUringState<Req, U> {
     fn drop(&mut self) {
         debug_assert!(self.requests.is_empty());
     }
 }
 
-#[derive(Debug)]
-pub enum IoUringRequest<'data> {
-    Read {
-        buffer: AVec<u8, RuntimeAlign>,
-    },
-
-    ODirectRead {
-        buffer: AVec<u8, ConstAlign<KERNEL_PAGE_SIZE>>,
-        inner_range: Range<usize>,
-        align: usize,
-    },
-
-    Write(&'data [u8]),
+/// Validate that io_uring request completed successfully and extract response to return
+pub trait Finalize {
+    type Resp;
+    fn finalize(self, result: u32) -> Self::Resp;
 }
 
-#[expect(
-    clippy::wildcard_enum_match_arm,
-    reason = "matchers for individual variants"
-)]
-impl<'data> IoUringRequest<'data> {
-    pub fn expect_read(&mut self) -> &mut AVec<u8, RuntimeAlign> {
-        match self {
-            IoUringRequest::Read { buffer } => buffer,
-            _ => panic!(),
-        }
-    }
+#[derive(Clone, Debug)]
+pub struct Read {
+    buffer: AVec<u8, RuntimeAlign>,
+    expected_length: u32,
+}
 
-    pub fn expect_o_direct_read(&mut self) -> &mut AVec<u8, ConstAlign<KERNEL_PAGE_SIZE>> {
-        match self {
-            IoUringRequest::ODirectRead { buffer, .. } => buffer,
-            _ => panic!(),
-        }
+impl Finalize for Read {
+    type Resp = AVec<u8, RuntimeAlign>;
+
+    fn finalize(self, bytes_read: u32) -> Self::Resp {
+        let Self {
+            mut buffer,
+            expected_length,
+        } = self;
+
+        assert_eq!(expected_length, bytes_read);
+
+        assert!(buffer.capacity() >= bytes_read as _);
+        unsafe { buffer.set_len(bytes_read as _) };
+        buffer
     }
 }
 
-#[derive(Debug)]
-pub enum IoUringResponse {
-    Read(AVec<u8, RuntimeAlign>),
-    Write,
+#[derive(Copy, Clone, Debug)]
+pub struct Write<'data> {
+    bytes: &'data [u8],
 }
 
-impl IoUringResponse {
-    pub fn expect_read(self) -> AVec<u8, RuntimeAlign> {
-        #[expect(clippy::match_wildcard_for_single_variants)]
-        match self {
-            Self::Read(buffer) => buffer,
-            _ => panic!(),
-        }
-    }
+impl<'data> Finalize for Write<'data> {
+    type Resp = ();
 
-    pub fn expect_write(self) {
-        #[expect(clippy::match_wildcard_for_single_variants)]
-        match self {
-            Self::Write => (),
-            _ => panic!(),
-        }
+    fn finalize(self, bytes_written: u32) {
+        let Self { bytes } = self;
+        assert_eq!(bytes.len(), bytes_written as usize);
     }
 }

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -8,9 +8,6 @@ use slab::Slab;
 
 use super::*;
 
-/// Required alignment for `O_DIRECT` reads (both file offset and buffer).
-const KERNEL_PAGE_SIZE: usize = 4096; // 4 kB
-
 pub type IoUringReadRuntime<U> = IoUringRuntime<Read, U>;
 pub type IoUringWriteRuntime<'data, U> = IoUringRuntime<Write<'data>, U>;
 

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
@@ -23,36 +24,34 @@ fn test_file<T: bytemuck::Pod>(path: &Path, data: &[T], direct_io: bool) -> Resu
     )
 }
 
+/// Build a [`ReadRange`] for type `T` spanning `length` elements starting at
+/// element `offset`. E.g. `read_range::<u64>(2, 10)` covers `[2_u64..12_u64]`
+/// from the start of the file.
+fn read_range<T>(offset: usize, length: usize) -> ReadRange {
+    ReadRange {
+        byte_offset: (offset * size_of::<T>()) as u64,
+        length: length as u64,
+    }
+}
+
 #[test]
-fn test_io_uring_file_for_u64() -> Result<()> {
-    // 1. Write some u64 binary data to a file using regular std::fs APIs
+fn test_io_uring_read() -> Result<()> {
+    // 1. Populate test file with u64 binary data
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("test_u64.bin");
 
     let data: Vec<u64> = (0..128).collect();
-    let bytes = bytemuck::cast_slice(&data);
-    fs_err::write(&path, bytes).unwrap();
+    let file = test_file(&dir.path().join("test_u64.bin"), &data, false)?;
+    let file = TypedStorage::<_, u64>::new(file);
 
-    let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra::default();
-    let fs = IoUringFs::from_context(Default::default())?;
-
-    // 2. Read data back using `IoUringFile` and verify it matches what was written
-    let file = TypedStorage::<IoUringFile, u64>::open(&fs, &path, opts, extra)?;
+    // 2. Read data back and verify it matches what was written
 
     // Read all elements
-    let read_back = file.read::<Sequential>(ReadRange {
-        byte_offset: 0,
-        length: data.len() as u64,
-    })?;
-    assert_eq!(read_back.as_ref(), &data);
+    let full = file.read::<Sequential>(read_range::<u64>(0, data.len()))?;
+    assert_eq!(full.as_ref(), &data);
 
-    // Read a sub-range (start at element 10, byte offset = 10 * size_of::<u64>())
-    let read_sub = file.read::<Sequential>(ReadRange {
-        byte_offset: 10 * size_of::<u64>() as u64,
-        length: 20,
-    })?;
-    assert_eq!(read_sub.as_ref(), &data[10..30]);
+    // Read a sub-range (elements 10..30)
+    let sub = file.read::<Sequential>(read_range::<u64>(10, 20))?;
+    assert_eq!(sub.as_ref(), &data[10..30]);
 
     // Verify len()
     let len = file.len()?;
@@ -62,30 +61,22 @@ fn test_io_uring_file_for_u64() -> Result<()> {
 }
 
 #[test]
-fn test_io_uring_read_batch() -> Result<()> {
+fn test_io_uring_read_batch_read_iter() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("test_batch.bin");
 
     let data: Vec<u64> = (0..256).collect();
-    fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
+    let file = test_file(&dir.path().join("test_batch.bin"), &data, false)?;
+    let file = TypedStorage::<_, u64>::new(file);
 
-    let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra::default();
-    let fs = IoUringFs::from_context(Default::default())?;
-
-    let file = TypedStorage::<IoUringFile, u64>::open(&fs, &path, opts, extra)?;
-    let elem = size_of::<u64>() as u64;
-
-    // Non-contiguous ranges across the file.
-    #[rustfmt::skip]
+    // Non-contiguous ranges across the file (element offset, elements count)
     let ranges = [
-        ReadRange { byte_offset: 0,          length: 10 }, // [0..10]
-        ReadRange { byte_offset: 50 * elem,  length: 20 }, // [50..70]
-        ReadRange { byte_offset: 100 * elem, length: 5  }, // [100..105]
-        ReadRange { byte_offset: 200 * elem, length: 56 }, // [200..256]
+        read_range::<u64>(0, 10),   // [0..10]
+        read_range::<u64>(50, 20),  // [50..70]
+        read_range::<u64>(100, 5),  // [100..105]
+        read_range::<u64>(200, 56), // [200..256]
     ];
 
-    let expected: Vec<&[u64]> = vec![
+    let expected = [
         &data[0..10],
         &data[50..70],
         &data[100..105],
@@ -93,62 +84,61 @@ fn test_io_uring_read_batch() -> Result<()> {
     ];
 
     // --- read_batch (callback API) ---
-    let mut batch_results: Vec<(usize, Vec<u64>)> = Vec::new();
-    file.read_batch::<Sequential, _>(ranges.iter().copied().enumerate(), |idx, slice| {
-        batch_results.push((idx, slice.to_vec()));
+    let mut batch_results = Vec::new();
+
+    file.read_batch::<Sequential, _>(ranges.into_iter().enumerate(), |idx, items| {
+        batch_results.push((idx, items.to_vec()));
         Ok(())
     })?;
 
-    batch_results.sort_by_key(|(idx, _)| *idx);
-    for (idx, items) in &batch_results {
+    batch_results.sort_by_key(|&(idx, _)| idx);
+
+    for (idx, items) in batch_results {
         assert_eq!(
             items.as_slice(),
-            expected[*idx],
+            expected[idx],
             "read_batch mismatch at index {idx}"
         );
     }
 
     // --- read_iter (iterator API) ---
-    let mut iter_results: Vec<(usize, Vec<u64>)> = Vec::new();
-    for record in file.read_iter::<Sequential, _>(ranges.iter().copied().enumerate())? {
-        let (idx, cow) = record?;
-        iter_results.push((idx, cow.into_owned()));
-    }
+    let read_iter = file.read_iter::<Sequential, _>(ranges.into_iter().enumerate())?;
 
-    iter_results.sort_by_key(|(idx, _)| *idx);
-    for (idx, items) in &iter_results {
+    let mut iter_results: Vec<_> = read_iter.collect::<Result<Vec<_>>>()?;
+    iter_results.sort_by_key(|&(idx, _)| idx);
+
+    for (idx, items) in iter_results {
         assert_eq!(
-            items.as_slice(),
-            expected[*idx],
+            items.as_ref(),
+            expected[idx],
             "read_iter mismatch at index {idx}"
         );
     }
 
     // --- read_iter with more ranges than the io_uring queue depth (64 > 16) ---
-    let many_ranges = (0..64).map(|i| ReadRange {
-        byte_offset: i as u64 * elem,
-        length: 1,
-    });
+    let many_ranges = (0..64).map(|i| read_range::<u64>(i, 1)).enumerate();
 
     let mut count = 0;
-    for record in file.read_iter::<Sequential, _>(many_ranges.enumerate())? {
-        let (idx, cow) = record?;
+    for record in file.read_iter::<Sequential, _>(many_ranges)? {
+        let (idx, items) = record?;
+
         assert_eq!(
-            cow.as_ref(),
+            items.as_ref(),
             &[data[idx]],
             "many-ranges mismatch at index {idx}"
         );
+
         count += 1;
     }
+
     assert_eq!(count, 64);
 
     Ok(())
 }
 
 #[test]
-fn test_io_uring_concurrent_read_iter() -> Result<()> {
+fn test_io_uring_read_iter_concurrent() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
-    let elem = size_of::<u64>() as u64;
 
     // Large enough to span many io_uring batches (64 ranges, queue depth 16).
     const NUM_ELEMENTS: u64 = 6400;
@@ -156,30 +146,18 @@ fn test_io_uring_concurrent_read_iter() -> Result<()> {
     const CHUNK: u64 = NUM_ELEMENTS / NUM_RANGES; // 100 elements per range
 
     // File A: 0..NUM_ELEMENTS
-    let path_a = dir.path().join("a.bin");
     let data_a: Vec<u64> = (0..NUM_ELEMENTS).collect();
-    fs_err::write(&path_a, bytemuck::cast_slice(&data_a)).unwrap();
+    let file_a = test_file(&dir.path().join("a.bin"), &data_a, false)?;
+    let file_a = TypedStorage::<_, u64>::new(file_a);
 
     // File B: offset so values never overlap with A.
-    let path_b = dir.path().join("b.bin");
     let data_b: Vec<u64> = (1_000_000..1_000_000 + NUM_ELEMENTS).collect();
-    fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
-
-    let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra::default();
-    let fs = IoUringFs::from_context(Default::default())?;
-    let file_a = TypedStorage::<IoUringFile, u64>::open(&fs, &path_a, opts, extra)?;
-    let file_b = TypedStorage::<IoUringFile, u64>::open(&fs, &path_b, opts, extra)?;
+    let file_b = test_file(&dir.path().join("b.bin"), &data_b, false)?;
+    let file_b = TypedStorage::<_, u64>::new(file_b);
 
     // NUM_RANGES ranges, each reading CHUNK elements — well over the queue depth.
-    let ranges_a = (0..NUM_RANGES).map(|i| ReadRange {
-        byte_offset: i * CHUNK * elem,
-        length: CHUNK,
-    });
-    let ranges_b = (0..NUM_RANGES).map(|i| ReadRange {
-        byte_offset: i * CHUNK * elem,
-        length: CHUNK,
-    });
+    let ranges_a = (0..NUM_RANGES).map(|i| read_range::<u64>((i * CHUNK) as usize, CHUNK as usize));
+    let ranges_b = (0..NUM_RANGES).map(|i| read_range::<u64>((i * CHUNK) as usize, CHUNK as usize));
 
     let iter_a = file_a.read_iter::<Sequential, _>(ranges_a.enumerate())?;
     let iter_b = file_b.read_iter::<Sequential, _>(ranges_b.enumerate())?;
@@ -188,25 +166,32 @@ fn test_io_uring_concurrent_read_iter() -> Result<()> {
     // thread-local io_uring ring. With in-flight operations left across
     // next() calls, one iterator can reap the other's CQEs.
     let mut count = 0u64;
+
     for (rec_a, rec_b) in iter_a.zip(iter_b) {
         let (idx_a, cow_a) = rec_a?;
         let (idx_b, cow_b) = rec_b?;
 
-        let start_a = idx_a as u64 * CHUNK;
+        let chunk_len = CHUNK as usize;
+
+        let offset_a = idx_a * chunk_len;
+        let data_a = &data_a[offset_a..offset_a + chunk_len];
         assert_eq!(
             cow_a.as_ref(),
-            &data_a[start_a as usize..(start_a + CHUNK) as usize],
+            data_a,
             "file A mismatch at range index {idx_a}"
         );
 
-        let start_b = idx_b as u64 * CHUNK;
+        let offset_b = idx_b * chunk_len;
+        let data_b = &data_b[offset_b..offset_b + chunk_len];
         assert_eq!(
             cow_b.as_ref(),
-            &data_b[start_b as usize..(start_b + CHUNK) as usize],
+            data_b,
             "file B mismatch at range index {idx_b}"
         );
+
         count += 1;
     }
+
     assert_eq!(count, NUM_RANGES);
 
     Ok(())
@@ -215,50 +200,44 @@ fn test_io_uring_concurrent_read_iter() -> Result<()> {
 #[test]
 fn test_io_uring_read_multi_iter_basic() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
-    let elem = size_of::<u64>() as u64;
 
-    // File 0: 0..128
-    let path_0 = dir.path().join("f0.bin");
-    let data_0: Vec<u64> = (0..128).collect();
-    fs_err::write(&path_0, bytemuck::cast_slice(&data_0)).unwrap();
+    // File A: 0..128
+    let data_a: Vec<u64> = (0..128).collect();
+    let file_a = test_file(&dir.path().join("f0.bin"), &data_a, false)?;
 
-    // File 1: 1000..1128
-    let path_1 = dir.path().join("f1.bin");
-    let data_1: Vec<u64> = (1000..1128).collect();
-    fs_err::write(&path_1, bytemuck::cast_slice(&data_1)).unwrap();
-
-    let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra::default();
-    let fs = IoUringFs::from_context(Default::default())?;
-    let file_0 = fs.open(&path_0, opts, extra)?;
-    let file_1 = fs.open(&path_1, opts, extra)?;
-    let files = [file_0, file_1];
+    // File B: 1000..1128
+    let data_b: Vec<u64> = (1000..1128).collect();
+    let file_b = test_file(&dir.path().join("f1.bin"), &data_b, false)?;
 
     // Interleaved reads across both files.
-    #[rustfmt::skip]
     let reads = [
-        ('a', &files[0], ReadRange { byte_offset: 0,         length: 10 }), // f0[0..10]
-        ('b', &files[1], ReadRange { byte_offset: 20 * elem,  length: 5 }),  // f1[20..25]
-        ('c', &files[0], ReadRange { byte_offset: 50 * elem, length: 20 }), // f0[50..70]
-        ('d', &files[1], ReadRange { byte_offset: 0,         length: 10 }), // f1[0..10]
+        ('a', &file_a, read_range::<u64>(0, 10)),  // f0[0..10]
+        ('b', &file_b, read_range::<u64>(20, 5)),  // f1[20..25]
+        ('c', &file_a, read_range::<u64>(50, 20)), // f0[50..70]
+        ('d', &file_b, read_range::<u64>(0, 10)),  // f1[0..10]
     ];
 
     let expected = [
-        ('a', data_0[0..10].to_vec()),
-        ('b', data_1[20..25].to_vec()),
-        ('c', data_0[50..70].to_vec()),
-        ('d', data_1[0..10].to_vec()),
+        ('a', &data_a[0..10]),
+        ('b', &data_b[20..25]),
+        ('c', &data_a[50..70]),
+        ('d', &data_b[0..10]),
     ];
 
-    let mut results: Vec<(char, Vec<u64>)> = Vec::new();
-    for record in IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)? {
-        let (idx, cow) = record?;
-        results.push((idx, cow.into_owned()));
-    }
+    let iter = IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)?;
 
-    results.sort_by_key(|(idx, _)| *idx);
-    for (result, expected) in std::iter::zip(&results, &expected) {
-        assert_eq!(result, expected, "mismatch for read index {}", result.0);
+    let mut results: Vec<_> = iter.collect::<Result<_>>()?;
+    results.sort_by_key(|&(idx, _)| idx);
+
+    for (result, expected) in results.into_iter().zip(expected) {
+        let (res_char, res_bytes) = result;
+        let (exp_char, exp_bytes) = expected;
+
+        assert_eq!(
+            (res_char, res_bytes.as_ref()),
+            (exp_char, exp_bytes),
+            "mismatch for read index {res_char}",
+        );
     }
 
     Ok(())
@@ -267,7 +246,6 @@ fn test_io_uring_read_multi_iter_basic() -> Result<()> {
 #[test]
 fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
-    let elem = size_of::<u64>() as u64;
 
     const NUM_FILES: usize = 4;
     const ELEMENTS_PER_FILE: u64 = 256;
@@ -276,53 +254,41 @@ fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
     let mut all_data: Vec<Vec<u64>> = Vec::new();
     let mut files: Vec<IoUringFile> = Vec::new();
 
-    let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra::default();
-    let fs = IoUringFs::from_context(Default::default())?;
-
     for i in 0..NUM_FILES {
         let base = (i as u64) * 10_000;
-        let data: Vec<u64> = (base..base + ELEMENTS_PER_FILE).collect();
-        let path = dir.path().join(format!("f{i}.bin"));
-        fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
-        let file = fs.open(&path, opts, extra)?;
-        files.push(file);
+        let data: Vec<u64> = (base..base + ELEMENTS_PER_FILE).collect();
+        let file = test_file(&dir.path().join(format!("f{i}.bin")), &data, false)?;
+
         all_data.push(data);
+        files.push(file);
     }
 
     // Generate reads: round-robin across files, each reading a small chunk.
-    let reads: Vec<((usize, usize), &IoUringFile, ReadRange)> = (0..NUM_FILES as u64
-        * RANGES_PER_FILE)
-        .map(|i| {
-            let file_idx = (i as usize) % NUM_FILES;
-            let range_idx = i / NUM_FILES as u64;
-            let offset = range_idx * 10; // non-overlapping chunks of 10
-            (
-                (file_idx, offset as usize),
-                &files[file_idx],
-                ReadRange {
-                    byte_offset: offset * elem,
-                    length: 10,
-                },
-            )
-        })
-        .collect();
+    let reads = (0..NUM_FILES as u64 * RANGES_PER_FILE).map(|i| {
+        let file_idx = (i as usize) % NUM_FILES;
+        let range_idx = i / NUM_FILES as u64;
+        let offset = (range_idx * 10) as usize; // non-overlapping chunks of 10
 
-    let mut results: Vec<((usize, usize), Vec<u64>)> = Vec::new();
-    for record in IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)? {
-        let (idx, cow) = record?;
-        results.push((idx, cow.into_owned()));
-    }
+        let meta = (file_idx, offset);
+        let file = &files[file_idx];
+        let range = read_range::<u64>(offset, 10);
+
+        (meta, file, range)
+    });
+
+    let iter = IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)?;
+
+    let mut results: Vec<_> = iter.collect::<Result<_>>()?;
+    results.sort_by_key(|&(idx, _)| idx);
 
     assert_eq!(results.len(), NUM_FILES * RANGES_PER_FILE as usize);
 
-    results.sort_by_key(|(idx, _)| *idx);
-    for ((file_idx, offset), result) in results {
+    for ((file_idx, offset), items) in results {
         assert_eq!(
-            result.as_slice(),
+            items.as_ref(),
             &all_data[file_idx][offset..offset + 10],
-            "data mismatch at offset {offset}, file {file_idx}"
+            "data mismatch at offset {offset}, file {file_idx}",
         );
     }
 
@@ -332,55 +298,49 @@ fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
 /// Verify that `read_multi` (callback API) and `read_multi_iter` produce identical
 /// results, confirming the callback version correctly delegates to the iterator.
 #[test]
-fn test_io_uring_read_multi_callback_matches_iter() -> Result<()> {
+fn test_io_uring_read_multi_read_multi_iter() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
-    let elem = size_of::<u64>() as u64;
 
-    let path_a = dir.path().join("a.bin");
     let data_a: Vec<u64> = (0..200).collect();
-    fs_err::write(&path_a, bytemuck::cast_slice(&data_a)).unwrap();
+    let file_a = test_file(&dir.path().join("a.bin"), &data_a, false)?;
 
-    let path_b = dir.path().join("b.bin");
     let data_b: Vec<u64> = (5000..5200).collect();
-    fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
+    let file_b = test_file(&dir.path().join("b.bin"), &data_b, false)?;
 
-    let opts = OpenOptions::new_for_test();
-    #[allow(clippy::default_constructed_unit_structs)]
-    let fs = IoUringFs::default();
-    let file_a = fs.open(&path_a, opts, IoUringOpenExtra::default())?;
-    let file_b = fs.open(&path_b, opts, IoUringOpenExtra::default())?;
-    let files = [file_a, file_b];
-
-    #[rustfmt::skip]
-    let reads: Vec<(usize, &IoUringFile, ReadRange)> = vec![
-        (0, &files[0], ReadRange { byte_offset: 0,           length: 50  }),
-        (1, &files[1], ReadRange { byte_offset: 10 * elem,   length: 30  }),
-        (2, &files[0], ReadRange { byte_offset: 100 * elem,  length: 50  }),
-        (3, &files[1], ReadRange { byte_offset: 0,           length: 100 }),
-        (4, &files[0], ReadRange { byte_offset: 150 * elem,  length: 50  }),
+    let reads = vec![
+        (0, &file_a, read_range::<u64>(0, 50)),
+        (1, &file_b, read_range::<u64>(10, 30)),
+        (2, &file_a, read_range::<u64>(100, 50)),
+        (3, &file_b, read_range::<u64>(0, 100)),
+        (4, &file_a, read_range::<u64>(150, 50)),
     ];
 
     // Collect via callback.
-    let mut callback_results: Vec<(usize, Vec<u64>)> = Vec::new();
-    IoUringFile::read_multi::<Sequential, u64, _>(reads.clone(), |idx, data| {
-        callback_results.push((idx, data.to_vec()));
+    let mut callback_results = Vec::new();
+
+    IoUringFile::read_multi::<Sequential, u64, _>(reads.clone(), |idx, items| {
+        callback_results.push((idx, items.to_vec()));
         Ok(())
     })?;
 
+    callback_results.sort_by_key(|&(idx, _)| idx);
+
     // Collect via iterator.
-    let mut iter_results: Vec<(usize, Vec<u64>)> = Vec::new();
-    for record in IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)? {
-        let (idx, cow) = record?;
-        iter_results.push((idx, cow.into_owned()));
-    }
+    let iter = IoUringFile::read_multi_iter::<Sequential, u64, _>(reads)?;
 
-    callback_results.sort_by_key(|(idx, _)| *idx);
-    iter_results.sort_by_key(|(idx, _)| *idx);
+    let mut iter_results: Vec<_> = iter.collect::<Result<_>>()?;
+    iter_results.sort_by_key(|&(idx, _)| idx);
 
+    // Compare results
     assert_eq!(callback_results.len(), iter_results.len());
-    for (cb, it) in callback_results.iter().zip(iter_results.iter()) {
-        assert_eq!(cb.0, it.0, "operation index mismatch");
-        assert_eq!(cb.1, it.1, "data mismatch at op {}", cb.0);
+    for ((cb_idx, cb_items), (it_idx, it_items)) in callback_results.into_iter().zip(iter_results) {
+        assert_eq!(cb_idx, it_idx, "operation index mismatch");
+
+        assert_eq!(
+            cb_items.as_slice(),
+            it_items.as_ref(),
+            "data mismatch at op {cb_idx}"
+        );
     }
 
     Ok(())
@@ -400,6 +360,7 @@ fn test_io_uring_eintr_handling() -> Result<()> {
         sa.sa_sigaction = noop_signal_handler as *const () as usize;
         sa.sa_flags = 0;
         libc::sigemptyset(&mut sa.sa_mask);
+
         let ret = libc::sigaction(libc::SIGUSR1, &sa, std::ptr::null_mut());
         assert_eq!(ret, 0, "failed to install SIGUSR1 handler");
     }
@@ -411,18 +372,10 @@ fn test_io_uring_eintr_handling() -> Result<()> {
     const TEST_DURATION_SECS: u64 = 10;
 
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("eintr_test.bin");
-    let data: Vec<u64> = (0..NUM_ELEMENTS).collect();
-    fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
-    #[allow(clippy::default_constructed_unit_structs)]
-    let fs = IoUringFs::default();
-    let file = TypedStorage::<IoUringFile, u64>::open(
-        &fs,
-        &path,
-        OpenOptions::new_for_test(),
-        IoUringOpenExtra::default(),
-    )?;
+    let data: Vec<u64> = (0..NUM_ELEMENTS).collect();
+    let file = test_file(&dir.path().join("eintr_test.bin"), &data, false)?;
+    let file = TypedStorage::<_, u64>::new(file);
 
     let stop = Arc::new(AtomicBool::new(false));
     let signals_sent = Arc::new(AtomicU64::new(0));
@@ -440,7 +393,6 @@ fn test_io_uring_eintr_handling() -> Result<()> {
         })
     };
 
-    let elem = size_of::<u64>() as u64;
     let chunk_size = NUM_ELEMENTS / RANGES_PER_ROUND;
     let mut eintr_errors = 0u64;
     let mut panics = 0u64;
@@ -453,31 +405,27 @@ fn test_io_uring_eintr_handling() -> Result<()> {
         // Evict pages so reads actually block in io_uring_enter.
         file.clear_ram_cache().ok();
 
-        let ranges: Vec<(u64, ReadRange)> = (0..RANGES_PER_ROUND)
-            .map(|i| {
-                (
-                    i,
-                    ReadRange {
-                        byte_offset: i * chunk_size * elem,
-                        length: chunk_size,
-                    },
-                )
-            })
-            .collect();
+        let ranges = (0..RANGES_PER_ROUND).map(|i| {
+            let range = read_range::<u64>((i * chunk_size) as usize, chunk_size as usize);
+            (i, range)
+        });
 
         // catch_unwind: the Drop path has debug_assert!(self.is_empty())
         // which panics when in-flight requests leak due to EINTR.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut errors = 0u64;
+
             let Ok(iter) = file.read_iter::<Sequential, _>(ranges) else {
                 return 1;
             };
+
             for record in iter {
                 if record.is_err() {
                     errors += 1;
                     break;
                 }
             }
+
             errors
         }));
 

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -2,16 +2,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use nix::libc;
-use rstest::rstest;
 
 use super::super::*;
 use super::*;
 use crate::generic_consts::Sequential;
 
-#[rstest]
-#[case(false)]
-#[case(true)]
-fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
+#[test]
+fn test_io_uring_file_for_u64() -> Result<()> {
     // 1. Write some u64 binary data to a file using regular std::fs APIs
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test_u64.bin");
@@ -21,9 +18,7 @@ fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytes).unwrap();
 
     let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra {
-        prevent_caching: o_direct,
-    };
+    let extra = IoUringOpenExtra::default();
     let fs = IoUringFs::from_context(Default::default())?;
 
     // 2. Read data back using `IoUringFile` and verify it matches what was written
@@ -50,10 +45,8 @@ fn test_io_uring_file_for_u64(#[case] o_direct: bool) -> Result<()> {
     Ok(())
 }
 
-#[rstest]
-#[case(false)]
-#[case(true)]
-fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
+#[test]
+fn test_io_uring_read_batch() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test_batch.bin");
 
@@ -61,9 +54,7 @@ fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path, bytemuck::cast_slice(&data)).unwrap();
 
     let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra {
-        prevent_caching: o_direct,
-    };
+    let extra = IoUringOpenExtra::default();
     let fs = IoUringFs::from_context(Default::default())?;
 
     let file = TypedStorage::<IoUringFile, u64>::open(&fs, &path, opts, extra)?;
@@ -138,10 +129,8 @@ fn test_io_uring_read_batch(#[case] o_direct: bool) -> Result<()> {
     Ok(())
 }
 
-#[rstest]
-#[case(true)]
-#[case(false)]
-fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
+#[test]
+fn test_io_uring_concurrent_read_iter() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -161,9 +150,7 @@ fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_b, bytemuck::cast_slice(&data_b)).unwrap();
 
     let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra {
-        prevent_caching: o_direct,
-    };
+    let extra = IoUringOpenExtra::default();
     let fs = IoUringFs::from_context(Default::default())?;
     let file_a = TypedStorage::<IoUringFile, u64>::open(&fs, &path_a, opts, extra)?;
     let file_b = TypedStorage::<IoUringFile, u64>::open(&fs, &path_b, opts, extra)?;
@@ -209,10 +196,8 @@ fn test_io_uring_concurrent_read_iter(#[case] o_direct: bool) -> Result<()> {
     Ok(())
 }
 
-#[rstest]
-#[case(false)]
-#[case(true)]
-fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
+#[test]
+fn test_io_uring_read_multi_iter_basic() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -227,9 +212,7 @@ fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
     fs_err::write(&path_1, bytemuck::cast_slice(&data_1)).unwrap();
 
     let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra {
-        prevent_caching: o_direct,
-    };
+    let extra = IoUringOpenExtra::default();
     let fs = IoUringFs::from_context(Default::default())?;
     let file_0 = fs.open(&path_0, opts, extra)?;
     let file_1 = fs.open(&path_1, opts, extra)?;
@@ -265,10 +248,8 @@ fn test_io_uring_read_multi_iter_basic(#[case] o_direct: bool) -> Result<()> {
     Ok(())
 }
 
-#[rstest]
-#[case(false)]
-#[case(true)]
-fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<()> {
+#[test]
+fn test_io_uring_read_multi_iter_many_ranges() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let elem = size_of::<u64>() as u64;
 
@@ -280,9 +261,7 @@ fn test_io_uring_read_multi_iter_many_ranges(#[case] o_direct: bool) -> Result<(
     let mut files: Vec<IoUringFile> = Vec::new();
 
     let opts = OpenOptions::new_for_test();
-    let extra = IoUringOpenExtra {
-        prevent_caching: o_direct,
-    };
+    let extra = IoUringOpenExtra::default();
     let fs = IoUringFs::from_context(Default::default())?;
 
     for i in 0..NUM_FILES {

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -7,6 +7,22 @@ use super::super::*;
 use super::*;
 use crate::generic_consts::Sequential;
 
+/// Create `path`, populate it with the binary representation of `data`,
+/// then open and return it.
+fn test_file<T: bytemuck::Pod>(path: &Path, data: &[T], direct_io: bool) -> Result<IoUringFile> {
+    fs_err::write(path, bytemuck::cast_slice(data))?;
+
+    let fs = IoUringFs::from_context(Default::default())?;
+
+    fs.open(
+        path,
+        OpenOptions::new_for_test(),
+        IoUringOpenExtra {
+            prevent_caching: direct_io,
+        },
+    )
+}
+
 #[test]
 fn test_io_uring_file_for_u64() -> Result<()> {
     // 1. Write some u64 binary data to a file using regular std::fs APIs
@@ -487,6 +503,65 @@ fn test_io_uring_eintr_handling() -> Result<()> {
          {eintr_errors} errors, {panics} panics in {rounds} rounds ({total_signals} signals). \
          Fix: retry submit_and_wait when it returns io::ErrorKind::Interrupted."
     );
+
+    Ok(())
+}
+
+/// Reads an `O_DIRECT` file via [`IoUringFile::read_bytes`] and [`BorrowedIoUringPipeline`].
+///
+/// Every read is `KERNEL_PAGE_SIZE` aligned on both ends, with `align` set to `KERNEL_PAGE_SIZE`.
+/// The last block extends past EOF, so its read returns a truncated tail of valid bytes.
+#[test]
+fn test_io_uring_direct_io() -> Result<()> {
+    use super::pipeline::BorrowedIoUringPipeline;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // 2 + some pages of data
+    let data: Vec<u8> = (0..KERNEL_PAGE_SIZE * 2 + 1337)
+        .map(|idx| (idx % 256) as u8)
+        .collect();
+
+    let file = test_file(&dir.path().join("o_direct.bin"), &data, true)?;
+
+    // Read each page-aligned block. Both ends of the range and `align` are `KERNEL_PAGE_SIZE`
+    // aligned, as `O_DIRECT` requires.
+
+    // --- via `read_bytes` ---
+    for (idx, expected) in data.chunks(KERNEL_PAGE_SIZE).enumerate() {
+        let start = idx * KERNEL_PAGE_SIZE;
+        let end = start + expected.len();
+
+        let range = start as u64..end as u64;
+        let bytes = file.read_bytes::<Sequential>(range, KERNEL_PAGE_SIZE)?;
+
+        assert_eq!(bytes.as_ref(), expected, "O_DIRECT block {idx} mismatch");
+    }
+
+    // --- via read pipeline ---
+    let mut pipeline = BorrowedIoUringPipeline::new()?;
+
+    for (idx, expected) in data.chunks(KERNEL_PAGE_SIZE).enumerate() {
+        let start = idx * KERNEL_PAGE_SIZE;
+        let end = start + expected.len();
+
+        let range = start as u64..end as u64;
+        pipeline.schedule::<Sequential>((idx, expected), &file, range, KERNEL_PAGE_SIZE)?;
+    }
+
+    let mut count = 0;
+    while let Some(((idx, expected), bytes)) = pipeline.wait()? {
+        assert_eq!(
+            bytes.as_ref(),
+            expected,
+            "O_DIRECT pipeline block {idx} mismatch",
+        );
+
+        count += 1;
+    }
+
+    let num_blocks = data.len().div_ceil(KERNEL_PAGE_SIZE);
+    assert_eq!(count, num_blocks);
 
     Ok(())
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -12,6 +12,14 @@ use crate::universal_io::{
     self, OwnedReadPipeline, Result, UniversalIoError, UniversalRead, UserData,
 };
 
+#[cfg(target_os = "linux")]
+/// Required alignment when using io_uring with `O_DIRECT` on Linux
+const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
+
+#[cfg(not(target_os = "linux"))]
+/// Default alignment on non-Linux platforms
+const REMOTE_READ_ALIGNMENT: usize = 1;
+
 struct RemoteMeta<File, U> {
     file: File,
     scheduled_read: ScheduledRead,
@@ -215,7 +223,7 @@ where
         user_data: U,
         file: &'file DiskCache<R>,
         range: Range<u64>,
-        align: usize,
+        _align: usize,
     ) -> universal_io::Result<()> {
         let state = file.state()?;
         match pick_source::<P>(&state.local, range.clone())? {
@@ -244,7 +252,7 @@ where
                     remote_meta,
                     &state.remote,
                     blocks_byte_range,
-                    align,
+                    REMOTE_READ_ALIGNMENT,
                 )?;
             }
         }
@@ -335,7 +343,7 @@ where
         &mut self,
         user_data: U,
         range: Range<u64>,
-        align: usize,
+        _align: usize,
     ) -> universal_io::Result<()> {
         match pick_source::<P>(&self.file.state()?.local, range.clone())? {
             Source::Local {
@@ -357,7 +365,11 @@ where
                     user_data,
                 };
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
-                remote_pipeline.schedule::<P>(remote_meta, blocks_byte_range, align)?;
+                remote_pipeline.schedule::<P>(
+                    remote_meta,
+                    blocks_byte_range,
+                    REMOTE_READ_ALIGNMENT,
+                )?;
             }
         }
         Ok(())

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -47,6 +47,13 @@ where
     S: UniversalRead,
     T: Item,
 {
+    pub fn new(inner: S) -> Self {
+        TypedStorage {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Open through the provided filesystem handle and wrap the result.
     #[inline]
     pub fn open(
@@ -55,10 +62,7 @@ where
         options: OpenOptions,
         extra: <S::Fs as UniversalReadFs>::OpenExtra,
     ) -> Result<Self> {
-        fs.open(path, options, extra).map(|inner| TypedStorage {
-            inner,
-            _phantom: PhantomData,
-        })
+        fs.open(path, options, extra).map(Self::new)
     }
 
     pub fn reopen(&mut self) -> Result<()> {


### PR DESCRIPTION
We never really read and write to io_uring at the same time, so this PR splits `enum IoUringRequest` into separate `Read` and `Write` types and shuffles generics, so that we have separate "read" and "write" runtimes, but everything works the same as before.

Since we switched universal I/O interface to bytes-with-explicit-alignment (instead of explicit type parameter `T`) in #9040, we can greatly simplify `O_DIRECT` handling and almost entirely unify it with "regular" I/O.

Now, `IoUringFile` has the same requirements for `O_DIRECT` as regular files in `O_DIRECT` mode: byte range should be `KERNEL_PAGE_SIZE` bytes aligned and `align` should be a multiple of `KERNEL_PAGE_SIZE`. When reading "tail" of the file, range should be exactly `offset..file.len()`. `SimpleDiskCache` is already reading in blocks anyway.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
