### PR TITLE
Explicit `Populate` in gridstore reader

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -176,6 +176,10 @@ impl UniversalRead for CachedSlice {
         Ok(self.populate()?)
     }
 
+    fn populate_auto() -> bool {
+        false
+    }
+
     fn clear_ram_cache(&self) -> Result<()> {
         // TODO: issue fadvise DONTNEED on the cache file's backing mmap region.
         Ok(())

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -204,6 +204,10 @@ impl UniversalRead for IoUringFile {
         Ok(())
     }
 
+    fn populate_auto() -> bool {
+        false
+    }
+
     fn clear_ram_cache(&self) -> Result<()> {
         crate::fs::clear_disk_cache(self.file.path())?;
         Ok(())

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -107,7 +107,8 @@ impl MmapFile {
         } = options;
 
         let populate = match populate {
-            Populate::Auto | Populate::No => false, // don't populate by default
+            Populate::Auto => Self::populate_auto(),
+            Populate::No => false,
             Populate::PreferBackground | // mmap does not yet implement background populate
             Populate::Blocking => true,
         };
@@ -277,6 +278,10 @@ impl UniversalRead for MmapFile {
     fn populate(&self) -> Result<()> {
         self.mmap.lock().populate();
         Ok(())
+    }
+
+    fn populate_auto() -> bool {
+        false
     }
 
     fn clear_ram_cache(&self) -> Result<()> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -319,6 +319,10 @@ where
         self.populate_from(0)
     }
 
+    fn populate_auto() -> bool {
+        false
+    }
+
     fn clear_ram_cache(&self) -> Result<()> {
         if let Some(state) = self.local.get() {
             state.mmap().clear_ram_cache()?;

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -152,6 +152,9 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// For example in MMAP-based files we do `madvise` with `MADV_POPULATE_READ`.
     fn populate(&self) -> Result<()>;
 
+    /// Whether the backend chooses to populate when using `Populate::Auto`
+    fn populate_auto() -> bool;
+
     /// Ask to evict related data from RAM cache, if applicable for this implementation.
     ///
     /// For example in MMAP-based files we do `madvise` with `MADV_PAGEOUT`.

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use super::UniversalIoError;
 use super::traits::UniversalReadFs;
 use crate::mmap::{Advice, AdviceSetting};
-use crate::universal_io::UserData;
+use crate::universal_io::{UniversalRead, UserData};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum UniversalKind {
@@ -55,6 +55,16 @@ impl From<bool> for Populate {
             Populate::Blocking
         } else {
             Populate::No
+        }
+    }
+}
+
+impl Populate {
+    pub fn to_bool<S: UniversalRead>(self) -> bool {
+        match self {
+            Populate::Auto => S::populate_auto(),
+            Populate::No => false,
+            Populate::Blocking | Populate::PreferBackground => true,
         }
     }
 }

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -210,6 +210,11 @@ where
     }
 
     #[inline]
+    fn populate_auto() -> bool {
+        S::populate_auto()
+    }
+
+    #[inline]
     fn clear_ram_cache(&self) -> Result<()> {
         self.0.clear_ram_cache()
     }

--- a/lib/common/io_bridge_object_store/src/file.rs
+++ b/lib/common/io_bridge_object_store/src/file.rs
@@ -101,6 +101,10 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Ok(())
     }
 
+    fn populate_auto() -> bool {
+        false
+    }
+
     fn clear_ram_cache(&self) -> Result<()> {
         Ok(())
     }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -14,7 +14,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::is_alive_lock::IsAliveLock;
-use common::universal_io::{MmapFile, UniversalReadFileOps, UniversalWrite};
+use common::universal_io::{MmapFile, Populate, UniversalReadFileOps, UniversalWrite};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use reader::CONFIG_FILENAME;
@@ -98,10 +98,11 @@ where
         fs: S::Fs,
         base_path: PathBuf,
         create_options: StorageOptions,
+        populate: Populate,
     ) -> Result<Self> {
         let config_path = base_path.join(CONFIG_FILENAME);
         if config_path.exists() {
-            Self::open(fs, base_path)
+            Self::open(fs, base_path, populate)
         } else {
             fs.create_dir(&base_path)?;
             Self::new(fs, base_path, create_options)
@@ -132,7 +133,10 @@ where
         let new_page_id = storage.next_page_id();
         let path = page_path(&storage.base_path, new_page_id);
         storage.create_page_file(&path)?;
-        storage.pages.write().attach_page(&storage.fs, &path)?;
+        storage
+            .pages
+            .write()
+            .attach_page(&storage.fs, &path, Populate::No)?;
 
         let config_bytes = serde_json::to_vec(&storage.config)?;
         storage.fs.atomic_save(&config_path, &config_bytes)?;
@@ -143,13 +147,13 @@ where
     /// Open an existing storage at the given path.
     ///
     /// Uses the bitmask to infer page count for consistency with the write path.
-    pub fn open(fs: S::Fs, base_path: PathBuf) -> Result<Self> {
+    pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
         let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
         let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
-        let pages = Pages::open(&fs, &base_path, true)?;
+        let pages = Pages::open(&fs, &base_path, true, populate)?;
         let loaded_pages = pages.num_pages();
 
         if loaded_pages != num_pages {
@@ -176,7 +180,9 @@ where
         let new_page_id = self.next_page_id();
         let path = page_path(&self.base_path, new_page_id);
         self.create_page_file(&path)?;
-        self.pages.write().attach_page(&self.fs, &path)?;
+        self.pages
+            .write()
+            .attach_page(&self.fs, &path, Populate::No)?;
 
         self.bitmask.write().cover_new_page()?;
 

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -5,7 +5,7 @@ use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
-use common::universal_io::{UniversalRead, UniversalReadFs, read_json_via};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs, read_json_via};
 
 use super::view::GridstoreView;
 use crate::Result;
@@ -28,6 +28,8 @@ pub struct GridstoreReader<V, S: UniversalRead> {
     pub(super) pages: Pages<S>,
     pub(super) base_path: PathBuf,
     pub(super) _value_type: std::marker::PhantomData<V>,
+    /// How to populate new attached pages
+    populate: Populate,
 }
 
 impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
@@ -59,19 +61,20 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// Open an existing read-only storage at the given path.
     ///
     /// Infers page count by scanning for page files on disk.
-    pub fn open(fs: &S::Fs, base_path: PathBuf) -> Result<Self> {
+    pub fn open(fs: &S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
         // A reader only reads, so open pages and tracker non-writable. This
         // lets the backend be write-enforced (e.g. `ReadOnly<MmapFile>`); the
         // writable `Gridstore` opens these same files writable instead.
         let (config, tracker) = read_config_and_tracker(fs, &base_path, false)?;
 
-        let pages = Pages::<S>::open(fs, &base_path, false)?;
+        let pages = Pages::<S>::open(fs, &base_path, false, populate)?;
 
         Ok(Self {
             tracker,
             config,
             pages,
             base_path,
+            populate,
             _value_type: std::marker::PhantomData,
         })
     }
@@ -168,18 +171,16 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
             return Ok(());
         }
 
-        self.pages.live_reload(fs)?;
+        self.pages.live_reload(fs, self.populate)?;
 
         Ok(())
     }
 }
 
 impl<V, S: UniversalRead> GridstoreReader<V, S> {
-    /// Populate all pages and the tracker in the mmap.
-    pub fn populate(&self) -> Result<()> {
-        self.pages.populate()?;
-        self.tracker.populate()?;
-        Ok(())
+    /// Returns `true` if GridstoreReader is on disk, i.e. not populated on start/reload
+    pub fn is_on_disk(&self) -> bool {
+        !self.populate.to_bool::<S>()
     }
 
     /// Drop disk cache for pages.
@@ -189,6 +190,7 @@ impl<V, S: UniversalRead> GridstoreReader<V, S> {
             tracker: _,
             pages,
             base_path: _,
+            populate: _,
             _value_type,
         } = self;
         pages.clear_cache()?;

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -543,7 +543,8 @@ fn test_behave_like_hashmap(
     drop(storage);
 
     // reopen storage
-    let storage = Gridstore::<Payload>::open(MmapFs, dir.path().to_path_buf()).unwrap();
+    let storage =
+        Gridstore::<Payload>::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
     // assert same size
     assert_eq!(storage.get_storage_size_bytes().unwrap(), before_size);
     // assert same length
@@ -658,7 +659,7 @@ fn test_storage_persistence_basic() {
     }
 
     // reopen storage
-    let storage = Gridstore::<Payload>::open(MmapFs, path).unwrap();
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let stored_payload = storage.get_value::<Random>(0, &hw_counter).unwrap();
@@ -751,7 +752,7 @@ fn test_with_real_hm_data() {
     storage.flusher()().unwrap();
     drop(storage);
 
-    let mut storage = Gridstore::open(MmapFs, dir.path().to_path_buf()).unwrap();
+    let mut storage = Gridstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
     assert_eq!(point_offset, EXPECTED_LEN as u32 * 2);
     assert_eq!(storage.pages.read().num_pages(), 4);
     assert_eq!(
@@ -908,7 +909,7 @@ fn test_deferred_flush() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, we expect to read the data at the time the flusher was created
@@ -990,7 +991,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let flusher = storage.flusher();
@@ -1009,7 +1010,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, delete was flushed this time, expect point to be missing
@@ -1034,7 +1035,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, value 4 was flushed, expect to read it
@@ -1060,28 +1061,28 @@ fn test_deferred_flush_with_delete() {
 
     // Not flushed, still expect to read value 4
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 4");
     }
 
     // First flusher flushed, expect to read value 5 if we load from disk
     flusher_1_value_5().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 5");
     }
 
     // Second flusher flushed, expect point to be missing if we load from disk
     flusher_2_delete().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
         assert!(get_payload(&tmp_storage).is_none());
     }
 
     // Third flusher flushed, expect to read value 6 if we load from disk
     flusher_3_value_6().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path).unwrap();
+        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 6");
     }
 
@@ -1130,7 +1131,8 @@ fn test_live_reload() {
     storage.flusher()().unwrap();
 
     // Step 2: Open a reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone()).unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(reader.max_point_offset(), 2);
 
     // Step 3: Verify reader sees initial data
@@ -1206,7 +1208,8 @@ fn test_live_reload_across_pages() {
     let initial_pages = storage.pages.read().num_pages();
 
     // Open reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone()).unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(reader.max_point_offset(), first_batch);
 
     // Verify reader can read all initial data
@@ -1310,7 +1313,7 @@ fn test_skip_deferred_flush_after_clear() {
 
     // If we reopen the storage it must still be empty
     drop(storage);
-    let storage = Gridstore::<Payload>::open(MmapFs, path.clone()).unwrap();
+    let storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
     assert!(storage.get_pointer(0).is_none(), "point must not exist");
     assert_eq!(storage.max_point_offset(), 0, "must have zero points");
@@ -1506,9 +1509,12 @@ fn read_only_reader_over_write_enforced_backend() {
     // Reopen read-only over the write-enforced backend.
     type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
     let fs = RoFs::from_context(Default::default()).unwrap();
-    let reader =
-        GridstoreReader::<Payload, ReadOnly<MmapFile>>::open(&fs, dir.path().to_path_buf())
-            .unwrap();
+    let reader = GridstoreReader::<Payload, ReadOnly<MmapFile>>::open(
+        &fs,
+        dir.path().to_path_buf(),
+        Populate::No,
+    )
+    .unwrap();
 
     let stored = reader.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(stored, Some(payload));

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -52,7 +52,7 @@ impl<S: UniversalRead> Pages<S> {
         }
     }
 
-    pub fn open(fs: &S::Fs, dir: &Path, writeable: bool) -> Result<Self> {
+    pub fn open(fs: &S::Fs, dir: &Path, writeable: bool, populate: Populate) -> Result<Self> {
         let mut pages = Self::new(dir.to_path_buf(), writeable);
 
         let page_files: HashSet<_> = fs.list_files(&dir.join("page_"))?.into_iter().collect();
@@ -62,17 +62,17 @@ impl<S: UniversalRead> Pages<S> {
             if !page_files.contains(&page_path) {
                 break;
             }
-            pages.attach_page(fs, &page_path)?;
+            pages.attach_page(fs, &page_path, populate)?;
         }
 
         Ok(pages)
     }
 
-    pub fn attach_page(&mut self, fs: &S::Fs, path: &Path) -> Result<()> {
+    pub fn attach_page(&mut self, fs: &S::Fs, path: &Path, populate: Populate) -> Result<()> {
         let options = OpenOptions {
             writeable: self.writeable,
             need_sequential: true,
-            populate: Populate::No,
+            populate,
             advice: AdviceSetting::Advice(Advice::Random),
         };
 
@@ -384,7 +384,7 @@ impl<S: UniversalRead> Pages<S> {
     /// - Should only be called on read-only instances of the Pages.
     /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
-    pub fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
+    pub fn live_reload(&mut self, fs: &S::Fs, populate: Populate) -> Result<()> {
         let num_pages = self.pages.len();
         let next_page_id = num_pages as PageId;
 
@@ -392,7 +392,7 @@ impl<S: UniversalRead> Pages<S> {
             // Re-attach the last page, which should have the latest data.
             self.pages.pop();
             let page_path = self.page_path((num_pages - 1) as PageId);
-            self.attach_page(fs, &page_path)?;
+            self.attach_page(fs, &page_path, populate)?;
         }
 
         for page_id in next_page_id.. {
@@ -400,7 +400,7 @@ impl<S: UniversalRead> Pages<S> {
             if !fs.exists(&page_path)? {
                 break;
             }
-            self.attach_page(fs, &page_path)?;
+            self.attach_page(fs, &page_path, populate)?;
         }
 
         Ok(())

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use std::iter;
 use std::sync::atomic::AtomicBool;
 
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -21,8 +21,9 @@ fn dynamic_mmap_flag_count(c: &mut Criterion) {
     let stopped = AtomicBool::new(false);
 
     // Build dynamic mmap flags with random deletions
+    let populate = Populate::No;
     let mut dynamic_flags =
-        DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir.path(), false).unwrap();
+        DynamicStoredFlags::<MmapFile>::open(&MmapFs, dir.path(), populate).unwrap();
     dynamic_flags.set_len(&MmapFs, FLAG_COUNT).unwrap();
     dynamic_flags
         .set_ascending_bits(

--- a/lib/segment/src/common/flags/bitvec_flags.rs
+++ b/lib/segment/src/common/flags/bitvec_flags.rs
@@ -132,6 +132,7 @@ where
 #[cfg(test)]
 mod tests_mod {
     use common::types::PointOffsetType;
+    use common::universal_io::Populate;
     #[cfg_predicate]
     use common::universal_io::{Fs, S};
 
@@ -148,7 +149,7 @@ mod tests_mod {
         // Create and update flags
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             let mut bitvec_flags = BitvecFlags::new(Fs::default(), mmap_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
@@ -178,7 +179,8 @@ mod tests_mod {
         // Verify bitmap consistency after reload
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let bitvec_flags = BitvecFlags::new(Fs::default(), mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/common/flags/buffered_dynamic_flags.rs
+++ b/lib/segment/src/common/flags/buffered_dynamic_flags.rs
@@ -147,6 +147,7 @@ fn reconcile_persisted_buffer(
 mod tests_mod {
 
     use common::types::PointOffsetType;
+    use common::universal_io::Populate;
     #[cfg_predicate]
     use common::universal_io::{Fs, S};
     use rand::rngs::StdRng;
@@ -165,7 +166,7 @@ mod tests_mod {
         // Start with smaller flags
         {
             let mut mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             mmap_flags.set_len(&Fs::default(), 3).unwrap();
             mmap_flags.set(0, true).unwrap();
             mmap_flags.set(2, true).unwrap();
@@ -175,7 +176,8 @@ mod tests_mod {
         // Grow and update with BufferedDynamicFlags
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -203,7 +205,8 @@ mod tests_mod {
         // Verify growth persisted
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             assert_eq!(mmap_flags.len(), 9);
 
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
@@ -233,7 +236,7 @@ mod tests_mod {
         // Create initial flags
         {
             let mut mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             mmap_flags.set_len(&Fs::default(), num_flags).unwrap();
 
             for (i, &value) in initial_flags.iter().enumerate() {
@@ -257,7 +260,8 @@ mod tests_mod {
         // Apply updates and flush
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             // Verify initial state loaded correctly
@@ -280,7 +284,8 @@ mod tests_mod {
         // Verify persistence
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             // Calculate expected final state
@@ -313,7 +318,7 @@ mod tests_mod {
         // Initial empty state
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             mmap_flags.flusher()().unwrap();
         }
 
@@ -329,7 +334,8 @@ mod tests_mod {
             // Apply updates and flush
             {
                 let mmap_flags =
-                    DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                    DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                        .unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
                 // The flusher will handle length expansion as needed
@@ -346,7 +352,8 @@ mod tests_mod {
             // Verify state after each cycle
             {
                 let mmap_flags =
-                    DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                    DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                        .unwrap();
                 let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
                 for (i, &expected) in expected_state.iter().enumerate() {
@@ -376,7 +383,7 @@ mod tests_mod {
         // Test with single true flag
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             buffered_flags.buffer_set(0, true);
@@ -388,7 +395,8 @@ mod tests_mod {
         // Verify single flag persisted
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -413,7 +421,7 @@ mod tests_mod {
         // Test with very sparse indices (large gaps)
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             // Set flags at sparse indices
@@ -429,7 +437,8 @@ mod tests_mod {
         // Verify sparse indices persisted correctly
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             let flags = buffered_flags.storage.lock();
@@ -463,7 +472,7 @@ mod tests_mod {
         // Create initial state
         {
             let mut mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             mmap_flags.set_len(&Fs::default(), 10).unwrap();
             for i in 0..10 {
                 mmap_flags.set(i, i % 2 == 0).unwrap(); // Even indices true
@@ -474,7 +483,8 @@ mod tests_mod {
         // Test overwriting existing flags multiple times
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             // Initial state: [true, false, true, false, true, false, true, false, true, false]
@@ -502,7 +512,8 @@ mod tests_mod {
         // Verify final state (all false) persisted
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let buffered_flags = BufferedDynamicFlags::new(Fs::default(), mmap_flags);
 
             let flags = buffered_flags.storage.lock();

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -107,7 +107,7 @@ where
         Ok(status_file)
     }
 
-    pub fn open(fs: &S::Fs, directory: &Path, populate: bool) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, directory: &Path, populate: Populate) -> OperationResult<Self> {
         fs::create_dir_all(directory)?;
         let status_path = Self::ensure_status_file(fs, directory)?;
 
@@ -146,7 +146,7 @@ where
         fs: &S::Fs,
         num_flags: usize,
         directory: &Path,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<StoredBitSlice<S>> {
         let capacity_bytes = file_size_for(num_flags);
         let path = directory.join(FLAGS_FILE);
@@ -163,7 +163,7 @@ where
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            populate: Populate::from(populate),
+            populate,
             advice: AdviceSetting::Global,
         };
         let flags = StoredBitSlice::open(fs, &path, options, Default::default())?;
@@ -197,8 +197,8 @@ where
             self.flags.flusher()()?;
 
             // Don't read the whole file on resize
-            let populate = false;
-            // TODO: consider using UniversalRead::reopen
+            let populate = Populate::No;
+            // TODO(uio): consider using UniversalRead::reopen
             let flags = Self::open_storage(fs, new_len, &self.directory, populate)?;
 
             // Swap operation. It is important this section is not interrupted by errors.
@@ -335,7 +335,7 @@ mod tests_mod {
 
         {
             let mut dynamic_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             dynamic_flags.set_len(&Fs::default(), num_flags).unwrap();
             random_flags
                 .iter()
@@ -357,7 +357,8 @@ mod tests_mod {
 
         {
             let dynamic_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             assert_eq!(dynamic_flags.status.len, num_flags * 2);
             for (i, flag) in random_flags.iter().enumerate() {
                 assert_eq!(dynamic_flags.get(i).unwrap(), *flag);
@@ -374,7 +375,7 @@ mod tests_mod {
 
         // Create randomized dynamic mmap flags to test counting
         let mut dynamic_flags =
-            DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+            DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking).unwrap();
         dynamic_flags.set_len(&Fs::default(), num_flags).unwrap();
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
         random_flags

--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -126,7 +126,7 @@ mod tests_mod {
 
     /// Persist `flags` via the writable storage so the read-only path can open it.
     fn persist(fs: &Fs, dir: &Path, flags: &[bool]) {
-        let mut dynamic_flags = DynamicStoredFlags::<S>::open(fs, dir, false).unwrap();
+        let mut dynamic_flags = DynamicStoredFlags::<S>::open(fs, dir, Populate::No).unwrap();
         dynamic_flags.set_len(fs, flags.len()).unwrap();
         flags
             .iter()

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -191,6 +191,7 @@ where
 #[cfg(test)]
 mod tests_mod {
     use common::types::PointOffsetType;
+    use common::universal_io::Populate;
     #[cfg_predicate]
     use common::universal_io::{Fs, S};
 
@@ -207,7 +208,7 @@ mod tests_mod {
         // Create and update flags
         {
             let dynamic_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), false).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
             let mut roaring_flags = RoaringFlags::new(Fs::default(), dynamic_flags).unwrap();
 
             // Set various flags - we'll set up to index 19 to have a length of 20
@@ -228,7 +229,8 @@ mod tests_mod {
         // Verify bitmap consistency after reload
         {
             let mmap_flags =
-                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), true).unwrap();
+                DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::Blocking)
+                    .unwrap();
             let roaring_flags = RoaringFlags::new(Fs::default(), mmap_flags).unwrap();
 
             // Verify iteration consistency after reload

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use fs_err as fs;
 
 use super::super::read_ops::BoolIndexRead;
@@ -48,12 +48,12 @@ impl MutableBoolIndex {
 
         // Trues bitslice
         let trues_path = path.join(TRUES_DIRNAME);
-        let trues_slice = DynamicStoredFlags::open(&MmapFs, &trues_path, false)?;
+        let trues_slice = DynamicStoredFlags::open(&MmapFs, &trues_path, Populate::No)?;
         let trues_flags = RoaringFlags::new(MmapFs, trues_slice)?;
 
         // Falses bitslice
         let falses_path = path.join(FALSES_DIRNAME);
-        let falses_slice = DynamicStoredFlags::open(&MmapFs, &falses_path, false)?;
+        let falses_slice = DynamicStoredFlags::open(&MmapFs, &falses_path, Populate::No)?;
         let falses_flags = RoaringFlags::new(MmapFs, falses_slice)?;
 
         let trues_count = trues_flags.count_trues();

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use gridstore::Gridstore;
 use itertools::Itertools;
 
@@ -30,13 +30,15 @@ impl MutableFullTextIndex {
         create_if_missing: bool,
     ) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
-            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS).map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to open mutable full text index on gridstore: {err}"
-                ))
-            })?
+            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS, Populate::Blocking).map_err(
+                |err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable full text index on gridstore: {err}"
+                    ))
+                },
+            )?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable full text index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{OkNotFound, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead};
 use gridstore::GridstoreReader;
 
 use super::super::inner::MutableFullTextIndexInner;
@@ -34,7 +34,9 @@ impl<S: UniversalRead> ReadOnlyAppendableFullTextIndex<S> {
         path: PathBuf,
         config: TextIndexParams,
     ) -> OperationResult<Option<Self>> {
-        let Some(storage) = GridstoreReader::<Vec<u8>, S>::open(fs, path).ok_not_found()? else {
+        let Some(storage) =
+            GridstoreReader::<Vec<u8>, S>::open(fs, path, Populate::Blocking).ok_not_found()?
+        else {
             // Files don't exist, cannot load
             return Ok(None);
         };

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use gridstore::Gridstore;
 use gridstore::config::StorageOptions;
 
@@ -31,13 +31,15 @@ impl MutableGeoIndex {
     /// loaded.
     pub fn open(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
-            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS).map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to open mutable geo index on gridstore: {err}"
-                ))
-            })?
+            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS, Populate::Blocking).map_err(
+                |err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable geo index on gridstore: {err}"
+                    ))
+                },
+            )?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable geo index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{OkNotFound, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead};
 use gridstore::GridstoreReader;
 
 use super::super::inner::InMemoryGeoIndex;
@@ -27,7 +27,8 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoIndex<S> {
     /// [1]: super::super::MutableGeoIndex::open_gridstore
     pub fn open(fs: &S::Fs, path: PathBuf) -> OperationResult<Option<Self>> {
         let Some(storage) =
-            GridstoreReader::<Vec<RawGeoPoint>, S>::open(fs, path).ok_not_found()?
+            GridstoreReader::<Vec<RawGeoPoint>, S>::open(fs, path, Populate::Blocking)
+                .ok_not_found()?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use gridstore::config::StorageOptions;
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, Gridstore};
@@ -36,13 +36,13 @@ where
     pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
             let options = default_gridstore_options(N::gridstore_block_size());
-            Gridstore::open_or_create(MmapFs, path, options).map_err(|err| {
+            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable map index on gridstore: {err}"
                 ))
             })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable map index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{OkNotFound, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead};
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, GridstoreReader};
 
@@ -30,8 +30,12 @@ where
     ///
     /// [1]: super::super::MutableMapIndex::open_gridstore
     pub fn open(fs: &S::Fs, path: PathBuf) -> OperationResult<Option<Self>> {
-        let Some(storage) =
-            GridstoreReader::<Vec<<N as MapIndexKey>::Owned>, S>::open(fs, path).ok_not_found()?
+        let Some(storage) = GridstoreReader::<Vec<<N as MapIndexKey>::Owned>, S>::open(
+            fs,
+            path,
+            Populate::Blocking,
+        )
+        .ok_not_found()?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use fs_err as fs;
 use serde_json::Value;
 
@@ -77,11 +77,11 @@ impl MutableNullIndex {
         })?;
 
         let has_values_path = path.join(HAS_VALUES_DIRNAME);
-        let has_values_mmap = DynamicStoredFlags::open(&MmapFs, &has_values_path, false)?;
+        let has_values_mmap = DynamicStoredFlags::open(&MmapFs, &has_values_path, Populate::No)?;
         let has_values_flags = RoaringFlags::new(MmapFs, has_values_mmap)?;
 
         let is_null_path = path.join(IS_NULL_DIRNAME);
-        let is_null_mmap = DynamicStoredFlags::open(&MmapFs, &is_null_path, false)?;
+        let is_null_mmap = DynamicStoredFlags::open(&MmapFs, &is_null_path, Populate::No)?;
         let is_null_flags = RoaringFlags::new(MmapFs, is_null_mmap)?;
 
         let storage = Storage {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFs, UniversalRead};
+use common::universal_io::{MmapFs, Populate, UniversalRead};
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, Gridstore};
 
@@ -157,13 +157,13 @@ where
     pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
             let options = default_gridstore_options::<T>();
-            Gridstore::open_or_create(MmapFs, path, options).map_err(|err| {
+            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable numeric index on gridstore: {err}"
                 ))
             })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable numeric index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{OkNotFound, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead};
 use gridstore::{Blob, GridstoreReader};
 
 use super::super::InMemoryNumericIndex;
@@ -31,7 +31,9 @@ where
     ///
     /// [1]: super::super::MutableNumericIndex::open_gridstore
     pub fn open(fs: &S::Fs, path: PathBuf) -> OperationResult<Option<Self>> {
-        let Some(storage) = GridstoreReader::<Vec<T>, S>::open(fs, path).ok_not_found()? else {
+        let Some(storage) =
+            GridstoreReader::<Vec<T>, S>::open(fs, path, Populate::Blocking).ok_not_found()?
+        else {
             // Files don't exist, cannot load
             return Ok(None);
         };

--- a/lib/segment/src/payload_storage/payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/payload_storage_impl.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, UniversalWrite};
+use common::universal_io::{MmapFile, Populate, UniversalWrite};
 use fs_err as fs;
 use gridstore::config::StorageOptions;
 use gridstore::{Blob, Gridstore};
@@ -52,13 +52,11 @@ where
     }
 
     fn open(path: PathBuf, populate: bool) -> OperationResult<Self> {
-        let storage = Gridstore::open(S::Fs::default(), path).map_err(|err| {
-            OperationError::service_error(format!("Failed to open mmap payload storage: {err}"))
-        })?;
-
-        if populate {
-            storage.populate()?;
-        }
+        // TODO(uio): use Populate as argument and propagate in callers
+        let storage =
+            Gridstore::open(S::Fs::default(), path, Populate::from(populate)).map_err(|err| {
+                OperationError::service_error(format!("Failed to open mmap payload storage: {err}"))
+            })?;
 
         Ok(Self { storage, populate })
     }

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlyPayloadStorage;
@@ -10,25 +10,13 @@ use crate::types::Payload;
 
 impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
     /// Open the payload storage read-only over the generic filesystem `fs` —
-    /// the read-only counterpart of [`MmapPayloadStorage::open_or_create`][1].
+    /// the read-only counterpart of [`PayloadStorageImpl::open_or_create`][1].
     ///
-    /// Resolves the `payload_storage` sub-directory (matching the writable
-    /// storage's on-disk layout) and opens a [`GridstoreReader`] over it.
-    /// `Payload` values are read straight from the reader, so unlike the
-    /// read-only field indexes there is no in-memory index to rebuild. When
-    /// `populate` is set the pages are loaded eagerly, exactly as the writable
-    /// storage does; the flag is retained to answer
-    /// [`is_on_disk`](super::super::PayloadStorageRead::is_on_disk).
-    ///
-    /// [1]: crate::payload_storage::mmap_payload_storage::MmapPayloadStorage::open_or_create
-    pub fn open(fs: &S::Fs, path: PathBuf, populate: bool) -> OperationResult<Self> {
+    /// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl::open_or_create
+    pub fn open(fs: &S::Fs, path: PathBuf, populate: Populate) -> OperationResult<Self> {
         let path = storage_dir(path);
-        let storage = GridstoreReader::<Payload, S>::open(fs, path)?;
+        let storage = GridstoreReader::<Payload, S>::open(fs, path, populate)?;
 
-        if populate {
-            storage.populate()?;
-        }
-
-        Ok(Self { storage, populate })
+        Ok(Self { storage })
     }
 }

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -17,13 +17,12 @@ use crate::types::Payload;
 /// mutation surface.
 pub struct ReadOnlyPayloadStorage<S: UniversalRead> {
     storage: GridstoreReader<Payload, S>,
-    populate: bool,
 }
 
 #[cfg(test)]
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
-    use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
+    use common::universal_io::{MmapFile, Populate, ReadOnly, UniversalRead, UniversalReadFileOps};
     use rstest::rstest;
     use tempfile::TempDir;
 
@@ -36,7 +35,9 @@ mod tests {
     /// files read-only through the write-enforced `ReadOnly<MmapFile>` backend
     /// and assert the reader returns what was written.
     #[rstest]
-    fn read_only_payload_storage_round_trip(#[values(false, true)] populate: bool) {
+    fn read_only_payload_storage_round_trip(
+        #[values(Populate::No, Populate::PreferBackground)] populate: Populate,
+    ) {
         let dir = TempDir::with_prefix("read_only_payload").unwrap();
         let hw_counter = HardwareCounterCell::new();
 
@@ -63,7 +64,7 @@ mod tests {
         let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> =
             ReadOnlyPayloadStorage::open(&fs, dir.path().to_path_buf(), populate).unwrap();
 
-        assert_eq!(storage.is_on_disk(), !populate);
+        assert_eq!(storage.is_on_disk(), !populate.to_bool::<MmapFile>());
         for i in 0..5 {
             assert_eq!(storage.get(i, &hw_counter).unwrap(), payload);
         }

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -78,6 +78,6 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     }
 
     fn is_on_disk(&self) -> bool {
-        !self.populate
+        self.storage.is_on_disk()
     }
 }

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFileOps, read_json_via};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFileOps, read_json_via};
 use uuid::Uuid;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
@@ -54,7 +54,12 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
         let deferred_internal_id = deferred_internal_id.filter(|_| is_appendable);
 
         // TODO(uio): use `Populate::PreferBackground` here and drill it into gridstore
-        let payload_populate = matches!(config.payload_storage_type, PayloadStorageType::InRamMmap);
+        let payload_populate =
+            if matches!(config.payload_storage_type, PayloadStorageType::InRamMmap) {
+                Populate::PreferBackground
+            } else {
+                Populate::No
+            };
         let payload_storage = Arc::new(AtomicRefCell::new(ReadOnlyPayloadStorage::open(
             fs,
             segment_path.to_path_buf(),

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use fs_err as fs;
 
 use crate::common::Flusher;
@@ -279,7 +279,7 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
 
     let deleted = BitvecFlags::new(
         MmapFs,
-        DynamicStoredFlags::open(&MmapFs, &deleted_path, populate)?,
+        DynamicStoredFlags::open(&MmapFs, &deleted_path, Populate::from(populate))?,
     )?;
     let deleted_count = deleted.count_trues();
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead};
 use fs_err as fs;
 
 use super::buffered_offsets::BufferedOffsets;
@@ -584,7 +584,7 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
 
     let deleted = BitvecFlags::new(
         MmapFs,
-        DynamicStoredFlags::open(&MmapFs, &deleted_path, populate)?,
+        DynamicStoredFlags::open(&MmapFs, &deleted_path, Populate::from(populate))?,
     )?;
     let deleted_count = deleted.count_trues();
 

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use fs_err as fs;
 use gridstore::Gridstore;
 use gridstore::config::{Compression, StorageOptions};
@@ -55,17 +55,17 @@ impl MmapSparseVectorStorage {
     }
 
     fn open(path: &Path) -> OperationResult<Self> {
+        // Sparse vector storage does not need to be populated
+        // as it is not required in the index search step
+        let populate = Populate::No;
+
         // Storage
         let storage_dir = path.join(STORAGE_DIRNAME);
-        let storage = Gridstore::open(MmapFs, storage_dir).map_err(|err| {
+        let storage = Gridstore::open(MmapFs, storage_dir, populate).map_err(|err| {
             OperationError::service_error(format!(
                 "Failed to open mmap sparse vector storage: {err}"
             ))
         })?;
-
-        // Payload storage does not need to be populated
-        // as it is not required in the index search step
-        let populate = false;
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
@@ -115,7 +115,7 @@ impl MmapSparseVectorStorage {
         let deleted_path = path.join(DELETED_DIRNAME);
         let deleted = BitvecFlags::new(
             MmapFs,
-            DynamicStoredFlags::open(&MmapFs, &deleted_path, populate)?,
+            DynamicStoredFlags::open(&MmapFs, &deleted_path, Populate::from(populate))?,
         )?;
 
         Ok(Self {

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlySparseVectorStorage;
@@ -16,13 +16,18 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
     /// writable storage on reopen: the highest deleted id or the Gridstore
     /// pointer count, whichever is larger.
     pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
-        let storage =
-            GridstoreReader::<StoredSparseVector, S>::open(fs, path.join(STORAGE_DIRNAME))
-                .map_err(|err| {
-                    OperationError::service_error(format!(
-                        "Failed to open read-only sparse vector storage: {err}"
-                    ))
-                })?;
+        // Sparse vector storage is not used during search
+        let populate = Populate::No;
+        let storage = GridstoreReader::<StoredSparseVector, S>::open(
+            fs,
+            path.join(STORAGE_DIRNAME),
+            populate,
+        )
+        .map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to open read-only sparse vector storage: {err}"
+            ))
+        })?;
 
         let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIRNAME))?;
 

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -22,7 +22,7 @@ use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use quantization::turboquant::quantization::TurboQuantizer;
 use quantization::turboquant::{EncodedQueryTQ, TQBits, TQMode, TQRotation};
 
@@ -243,6 +243,7 @@ fn open_turbo_vector_storage_impl(
 
     let storage = open_storage(&path.join(VECTORS_PATH), quantizer.quantized_size())?;
 
+    let populate = Populate::from(populate);
     let deleted = BitvecFlags::new(
         MmapFs,
         DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), populate)?,

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -17,7 +17,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::mmap::AdviceSetting;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use quantization::EncodedStorage;
 use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
@@ -93,6 +93,8 @@ pub fn open_appendable_turbo_multi_vector_storage(
 ) -> OperationResult<TurboMultiVectorStorage> {
     fs_err::create_dir_all(path)?;
 
+    let populate = Populate::from(in_ram);
+
     let quantizer = TurboQuantizer::new(
         dim,
         TQDT_BITS,
@@ -119,7 +121,7 @@ pub fn open_appendable_turbo_multi_vector_storage(
 
     let deleted = BitvecFlags::new(
         MmapFs,
-        DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), in_ram)?,
+        DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), populate)?,
     )?;
     let deleted_count = deleted.count_trues();
 


### PR DESCRIPTION
Makes the `open` function of gridstore reader choose the `Populate` variant explicitly.

In more detail, this PR:

- Makes the entrypoint of payload storage choose the `Populate` variant
- Mutable payload indexes now populate gridstore blockingly before using it to load
- Propagates `Populate` into `flags` module
- Adds `UniversalRead::populate_auto` to know whether a backend chooses to populate or not when `Populate::Auto`

