### PR TITLE
[DiskCache] Proper background populate on `reopen`

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -89,9 +89,9 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        let length = self.file.len::<u8>() as u64;
-        self.schedule::<Sequential>(user_data, 0..length, 1)
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+        let eof = self.file.len::<u8>() as u64;
+        self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -91,6 +91,9 @@ where
 
     fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
         let eof = self.file.len::<u8>() as u64;
+        if from >= eof {
+            return Ok(());
+        }
         self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -103,4 +103,8 @@ where
         let bytes = self.file.get_range_bytes(start..end, align)?;
         Ok(Some((user_data, bytes)))
     }
+
+    fn into_inner(self) -> CachedSlice {
+        self.file
+    }
 }

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -110,10 +110,13 @@ where
         // Wrap in `ManuallyDrop` so our own `Drop` impl doesn't run; we take
         // both fields out by hand instead.
         let mut this = ManuallyDrop::new(self);
+
+        let Self { file, inner } = &mut *this;
+
         // SAFETY: `this` is `ManuallyDrop`, so its destructor never runs and
         // each field is taken exactly once.
-        let file = unsafe { ManuallyDrop::take(&mut this.file) };
-        let inner = unsafe { ManuallyDrop::take(&mut this.inner) };
+        let file = unsafe { ManuallyDrop::take(file) };
+        let inner = unsafe { ManuallyDrop::take(inner) };
         drop(inner);
         file
     }

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -105,6 +105,18 @@ where
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {
         self.inner.wait()
     }
+
+    fn into_inner(self) -> IoUringFile {
+        // Wrap in `ManuallyDrop` so our own `Drop` impl doesn't run; we take
+        // both fields out by hand instead.
+        let mut this = ManuallyDrop::new(self);
+        // SAFETY: `this` is `ManuallyDrop`, so its destructor never runs and
+        // each field is taken exactly once.
+        let file = unsafe { ManuallyDrop::take(&mut this.file) };
+        let inner = unsafe { ManuallyDrop::take(&mut this.inner) };
+        drop(inner);
+        file
+    }
 }
 
 impl<U> Drop for OwnedIoUringPipeline<U>

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -94,9 +94,12 @@ where
         }
     }
 
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        let length = self.file.len::<u8>()?;
-        self.schedule::<Sequential>(user_data, 0..length, 1)
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+        let eof = self.file.len::<u8>()?;
+        if from >= eof {
+            return Ok(());
+        }
+        self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -82,9 +82,12 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        let length = self.file.len::<u8>()?;
-        self.schedule::<Sequential>(user_data, 0..length, 1)
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+        let eof = self.file.len::<u8>()?;
+        if from >= eof {
+            return Ok(());
+        }
+        self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -102,4 +102,8 @@ where
         let slice = read_bytes(bytes, range)?;
         Ok(Some((user_data, ACow::Borrowed(slice))))
     }
+
+    fn into_inner(self) -> MmapFile {
+        self.file
+    }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -75,9 +75,9 @@ pub(super) enum InitSource<R: UniversalRead> {
     /// Build an empty local mmap and let reads fill blocks on demand.
     FromScratch,
     /// Wait for the prefill pipeline.
-    FromPrefiller(R::OwnedReadPipeline<()>),
+    Prefiller(R::OwnedReadPipeline<()>),
     /// Wait for the prefill pipeline, but from reopen
-    FromPartialPrefiller {
+    PartialPrefiller {
         prefiller: R::OwnedReadPipeline<u64>,
         local_state: LocalState,
     },
@@ -90,8 +90,8 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InitSource::FromScratch => write!(f, "FromScratch"),
-            InitSource::FromPrefiller(_) => write!(f, "FromPrefiller"),
-            InitSource::FromPartialPrefiller { .. } => write!(f, "FromPartialPrefiller"),
+            InitSource::Prefiller(_) => write!(f, "Prefiller"),
+            InitSource::PartialPrefiller { .. } => write!(f, "PartialPrefiller"),
         }
     }
 }
@@ -180,7 +180,7 @@ where
                 }
                 self.new_local_state_from_scratch(known_length)?
             }
-            InitSource::FromPrefiller(mut prefiller) => {
+            InitSource::Prefiller(mut prefiller) => {
                 let local = match prefiller.wait()? {
                     Some((_, bytes)) => {
                         let local = LocalState::new(
@@ -211,7 +211,7 @@ where
 
                 local
             }
-            InitSource::FromPartialPrefiller {
+            InitSource::PartialPrefiller {
                 mut prefiller,
                 mut local_state,
             } => {
@@ -355,7 +355,7 @@ where
                     InitSource::FromScratch,
                     "by this point, InitSource must be FromScratch"
                 );
-                *init_guard = InitSource::FromPartialPrefiller {
+                *init_guard = InitSource::PartialPrefiller {
                     prefiller: remote_pipeline,
                     local_state: local,
                 };

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -231,10 +231,9 @@ where
     }
 
     fn new_state_from_scratch(&self, remote: R, known_length: Option<u64>) -> Result<State<R>> {
-        let len = if let Some(len) = known_length {
-            len
-        } else {
-            remote.len::<u8>()?
+        let len = match known_length {
+            Some(len) => len,
+            None => remote.len::<u8>()?,
         };
         let local = LocalState::new(&self.local_path, len, self.open_options)?;
         Ok(State { remote, local })
@@ -286,17 +285,18 @@ where
         let mut init_guard = self.init_lock.lock();
         self.init_state(&mut init_guard, false, None)?;
 
-        let Some(State {
-            mut remote,
-            mut local,
-        }) = self.state.take()
-        else {
+        let Some(state) = self.state.take() else {
             // If `self.state` didn't initialize after `init_state`, we are not populating
             // and we haven't made any reads.
             //
             // The first read will take care of initializing to the remote length.
             return Ok(());
         };
+
+        let State {
+            mut remote,
+            mut local,
+        } = state;
 
         // Reopen remote so it reflects current length
         remote.reopen()?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 
 use super::BLOCK_SIZE;
 use super::fs::DiskCacheFs;
@@ -51,7 +51,7 @@ where
     /// Lazily-initialized local mirror.
     pub(super) local: OnceLock<LocalState>,
     /// Guards initialization of `local` and carries the source of init.
-    init_lock: Arc<Mutex<InitSource<R>>>,
+    pub(super) init_lock: Arc<Mutex<InitSource<R>>>,
 }
 
 impl<R> Debug for DiskCache<R>
@@ -141,7 +141,12 @@ where
             return Ok(state);
         }
 
-        self.init_local_state(true, None)?;
+        let mut init_guard = self.init_lock.lock();
+
+        // Try again now that we have the lock, in case another thread initialized it first.
+        if self.local.get().is_none() {
+            self.init_local_state(&mut init_guard, true, None)?;
+        }
 
         Ok(self.local.get().expect("just initialized"))
     }
@@ -152,16 +157,13 @@ where
     /// This is helpful for [`Self::reopen`] scenario where we can avoid work if no reads have taken place.
     pub(super) fn init_local_state(
         &self,
+        init_guard: &mut MutexGuard<'_, InitSource<R>>,
         allow_from_scratch: bool,
         known_length: Option<u64>,
     ) -> Result<()> {
         // Only the first thread is able to initialize.
-        let mut guard = self.init_lock.lock();
-        if self.local.get().is_some() {
-            return Ok(());
-        }
 
-        let local = match std::mem::replace(&mut *guard, InitSource::FromScratch) {
+        let local = match std::mem::replace(&mut **init_guard, InitSource::FromScratch) {
             InitSource::FromScratch => {
                 if !allow_from_scratch {
                     return Ok(());
@@ -255,7 +257,8 @@ where
 
     fn reopen(&mut self) -> Result<()> {
         // Wait for InitSource::Prefill, if set.
-        self.init_local_state(false, None)?;
+        let mut init_guard = self.init_lock.lock();
+        self.init_local_state(&mut init_guard, false, None)?;
 
         if self.local.get().is_none() {
             return Ok(());

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use parking_lot::{Mutex, MutexGuard};
+use parking_lot::Mutex;
 
 use super::BLOCK_SIZE;
 use super::fs::DiskCacheFs;
@@ -40,19 +40,21 @@ where
     remote_extra: <R::Fs as UniversalReadFs>::OpenExtra,
     /// Path to the remote file. Used to lazily open `remote`.
     remote_path: PathBuf,
-    /// Lazily-opened remote handle. Only initialized when needed (cache miss
-    /// or `len()` before local is set).
-    ///
-    // We could switch to LazyLock, but there is no fallible initialization
-    remote: OnceLock<R>,
     /// Open options for when the local mmap is initialized.
     pub(super) open_options: OpenOptions,
     /// Path to the local mmap file.
     pub(super) local_path: PathBuf,
-    /// Lazily-initialized local mirror.
-    pub(super) local: OnceLock<LocalState>,
+    /// Lazily-initialized mirror.
+    // We could switch to LazyLock, but there is no fallible initialization
+    pub(super) state: OnceLock<State<R>>,
     /// Guards initialization of `local` and carries the source of init.
     pub(super) init_lock: Arc<Mutex<InitSource<R>>>,
+}
+
+#[derive(Debug)]
+pub(super) struct State<R> {
+    pub remote: R,
+    pub local: LocalState,
 }
 
 impl<R> Debug for DiskCache<R>
@@ -61,11 +63,11 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DiskCache")
+            .field("remote_fs", &self.remote_fs)
             .field("remote_path", &self.remote_path)
-            .field("remote", &self.remote)
             .field("open_options", &self.open_options)
             .field("local_path", &self.local_path)
-            .field("local", &self.local)
+            .field("state", &self.state)
             .finish_non_exhaustive()
     }
 }
@@ -112,30 +114,14 @@ where
             remote_fs,
             remote_extra,
             remote_path: remote_path.as_ref().to_owned(),
-            remote: OnceLock::new(),
             open_options: options,
             local_path,
-            local: OnceLock::new(),
+            state: OnceLock::new(),
             init_lock: Arc::new(Mutex::new(init_source)),
         }
     }
 
-    /// Lazily open the remote handle. The remote is only needed for cache
-    /// misses and for `len()` before the local mmap exists.
-    pub(super) fn remote(&self) -> Result<&R> {
-        if let Some(r) = self.remote.get() {
-            return Ok(r);
-        }
-
-        let remote = self.open_remote()?;
-        // If another thread set this concurrently, let our R be dropped.
-        //
-        // OnceLock::get_or_try_init would be better but it is not available on stable
-        let _ = self.remote.set(remote);
-        Ok(self.remote.get().expect("just set or already set"))
-    }
-
-    fn open_remote(&self) -> Result<R> {
+    pub(super) fn open_remote(&self) -> Result<R> {
         let remote_options = OpenOptions {
             writeable: false,
             populate: Populate::No,
@@ -147,41 +133,41 @@ where
             .open(&self.remote_path, remote_options, self.remote_extra.clone())
     }
 
-    /// Return the cached [`LocalState`], initializing it on first call.
-    pub(super) fn local_state(&self) -> Result<&LocalState> {
-        if let Some(state) = self.local.get() {
+    /// Return the cached [`State`], initializing it on first call.
+    pub(super) fn state(&self) -> Result<&State<R>> {
+        if let Some(state) = self.state.get() {
             return Ok(state);
         }
 
         let mut init_guard = self.init_lock.lock();
 
         // Try again now that we have the lock, in case another thread initialized it first.
-        if self.local.get().is_none() {
-            self.init_local_state(&mut init_guard, true, None)?;
+        if self.state.get().is_none() {
+            self.init_state(&mut init_guard, true, None)?;
         }
 
-        Ok(self.local.get().expect("just initialized"))
+        Ok(self.state.get().expect("just initialized"))
     }
 
     /// Initialize the local state depending on `InitSource`
     ///
     /// If `allow_from_scratch` is false, this method will avoid initializing if `InitSource::FromScratch` is set.
     /// This is helpful for [`Self::reopen`] scenario where we can avoid work if no reads have taken place.
-    pub(super) fn init_local_state(
+    pub(super) fn init_state(
         &self,
-        init_guard: &mut MutexGuard<'_, InitSource<R>>,
+        init_guard: &mut InitSource<R>,
         allow_from_scratch: bool,
         known_length: Option<u64>,
     ) -> Result<()> {
-        let local = match std::mem::replace(&mut **init_guard, InitSource::FromScratch) {
+        let state = match std::mem::replace(init_guard, InitSource::FromScratch) {
             InitSource::FromScratch => {
                 if !allow_from_scratch {
                     return Ok(());
                 }
-                self.new_local_state_from_scratch(known_length)?
+                self.new_state_from_scratch(self.open_remote()?, known_length)?
             }
             InitSource::Prefiller(mut prefiller) => {
-                let local = match prefiller.wait()? {
+                match prefiller.wait()? {
                     Some((_, bytes)) => {
                         let local = LocalState::new(
                             &self.local_path,
@@ -191,7 +177,10 @@ where
                         )?;
                         let blocks_range = to_block_range(0..bytes.len() as u64);
                         unsafe { local.write_mmap_bytes(&bytes, blocks_range) };
-                        local
+                        State {
+                            local,
+                            remote: prefiller.into_inner(),
+                        }
                     }
                     None => {
                         debug_assert!(
@@ -202,14 +191,9 @@ where
                             return Ok(());
                         }
                         // init from scratch
-                        self.new_local_state_from_scratch(known_length)?
+                        self.new_state_from_scratch(prefiller.into_inner(), known_length)?
                     }
-                };
-
-                let remote = prefiller.into_inner();
-                let _ = self.remote.set(remote);
-
-                local
+                }
             }
             InitSource::PartialPrefiller {
                 mut prefiller,
@@ -231,25 +215,29 @@ where
                 };
 
                 let remote = prefiller.into_inner();
-                let _ = self.remote.set(remote);
 
-                local_state
+                State {
+                    remote,
+                    local: local_state,
+                }
             }
         };
 
-        self.local
-            .set(local)
+        self.state
+            .set(state)
             .expect("OnceLock::set must succeed while holding init_lock");
 
         Ok(())
     }
 
-    fn new_local_state_from_scratch(&self, known_length: Option<u64>) -> Result<LocalState> {
-        let len = match known_length {
-            Some(len) => len,
-            None => self.remote()?.len::<u8>()?,
+    fn new_state_from_scratch(&self, remote: R, known_length: Option<u64>) -> Result<State<R>> {
+        let len = if let Some(len) = known_length {
+            len
+        } else {
+            remote.len::<u8>()?
         };
-        LocalState::new(&self.local_path, len, self.open_options)
+        let local = LocalState::new(&self.local_path, len, self.open_options)?;
+        Ok(State { remote, local })
     }
 
     /// Make sure every byte in the range `byte_start..remote_len` is present on the local file
@@ -258,7 +246,7 @@ where
             return Ok(());
         }
 
-        let remote_len = self.remote()?.len::<u8>()?;
+        let remote_len = self.state()?.remote.len::<u8>()?;
         if remote_len == 0 {
             return Ok(());
         }
@@ -296,25 +284,22 @@ where
     fn reopen(&mut self) -> Result<()> {
         // Wait for InitSource::Prefill, if set.
         let mut init_guard = self.init_lock.lock();
-        self.init_local_state(&mut init_guard, false, None)?;
+        self.init_state(&mut init_guard, false, None)?;
 
-        let Self { remote, local, .. } = self;
-
-        let Some(mut local) = local.take() else {
-            // If init_local_state didn't initialize after `init_local_state`, we are not populating
+        let Some(State {
+            mut remote,
+            mut local,
+        }) = self.state.take()
+        else {
+            // If `self.state` didn't initialize after `init_state`, we are not populating
             // and we haven't made any reads.
             //
             // The first read will take care of initializing to the remote length.
             return Ok(());
         };
 
-        let remote = if let Some(mut remote) = remote.take() {
-            // Reopen the remote so `len()` reflects the current file size
-            remote.reopen()?;
-            remote
-        } else {
-            self.open_remote()?
-        };
+        // Reopen remote so it reflects current length
+        remote.reopen()?;
 
         let local_len = local.mmap().len::<u8>()?;
 
@@ -335,10 +320,9 @@ where
                 local.resize(&self.local_path, remote_len)?;
 
                 // return the updated local state and remote
-                self.local.set(local).expect("we just take()'d them");
-                self.remote
-                    .set(remote)
-                    .expect("we just take()'d them (or we didn't have it)");
+                self.state
+                    .set(State { remote, local })
+                    .expect("we just take()'d it");
             }
             Populate::Blocking | Populate::PreferBackground => {
                 // Re-fetch from the start of the (possibly partial) tail block so
@@ -362,7 +346,7 @@ where
 
                 // For blocking, resolve the prefill now instead of on first read.
                 if matches!(self.open_options.populate, Populate::Blocking) {
-                    self.init_local_state(&mut init_guard, false, None)?;
+                    self.init_state(&mut init_guard, false, None)?;
                 }
             }
         }
@@ -378,13 +362,7 @@ where
     }
 
     fn len<T>(&self) -> Result<u64> {
-        let len = if let Some(local) = self.local.get() {
-            local.mmap().len::<T>()?
-        } else {
-            self.remote()?.len::<T>()?
-        };
-
-        Ok(len)
+        self.state()?.local.mmap().len::<T>()
     }
 
     fn populate(&self) -> Result<()> {
@@ -396,8 +374,8 @@ where
     }
 
     fn clear_ram_cache(&self) -> Result<()> {
-        if let Some(state) = self.local.get() {
-            state.mmap().clear_ram_cache()?;
+        if let Some(state) = self.state.get() {
+            state.local.mmap().clear_ram_cache()?;
         }
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::fmt::Debug;
 use std::io::{self, ErrorKind};
 use std::ops::Range;
@@ -75,6 +76,24 @@ pub(super) enum InitSource<R: UniversalRead> {
     FromScratch,
     /// Wait for the prefill pipeline.
     FromPrefiller(R::OwnedReadPipeline<()>),
+    /// Wait for the prefill pipeline, but from reopen
+    FromPartialPrefiller {
+        prefiller: R::OwnedReadPipeline<u64>,
+        local_state: LocalState,
+    },
+}
+
+impl<R> Debug for InitSource<R>
+where
+    R: UniversalRead,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitSource::FromScratch => write!(f, "FromScratch"),
+            InitSource::FromPrefiller(_) => write!(f, "FromPrefiller"),
+            InitSource::FromPartialPrefiller { .. } => write!(f, "FromPartialPrefiller"),
+        }
+    }
 }
 
 impl<R> DiskCache<R>
@@ -108,6 +127,15 @@ where
             return Ok(r);
         }
 
+        let remote = self.open_remote()?;
+        // If another thread set this concurrently, let our R be dropped.
+        //
+        // OnceLock::get_or_try_init would be better but it is not available on stable
+        let _ = self.remote.set(remote);
+        Ok(self.remote.get().expect("just set or already set"))
+    }
+
+    fn open_remote(&self) -> Result<R> {
         let remote_options = OpenOptions {
             writeable: false,
             populate: Populate::No,
@@ -115,24 +143,8 @@ where
             advice: AdviceSetting::Global,
         };
 
-        let opened =
-            self.remote_fs
-                .open(&self.remote_path, remote_options, self.remote_extra.clone())?;
-        // If another thread set this concurrently, let our R be dropped.
-        //
-        // OnceLock::get_or_try_init would be better but it is not available on stable
-        let _ = self.remote.set(opened);
-        Ok(self.remote.get().expect("just set or already set"))
-    }
-
-    /// Drop the cached remote handle, releasing any mapping it holds on the
-    /// remote file. The next access re-opens it lazily via [`Self::remote`].
-    ///
-    /// Test-only: required so tests can shrink the remote on Windows, where a
-    /// file with an active memory mapping cannot be resized.
-    #[cfg(test)]
-    pub(super) fn release_remote(&mut self) {
-        self.remote = OnceLock::new();
+        self.remote_fs
+            .open(&self.remote_path, remote_options, self.remote_extra.clone())
     }
 
     /// Return the cached [`LocalState`], initializing it on first call.
@@ -161,8 +173,6 @@ where
         allow_from_scratch: bool,
         known_length: Option<u64>,
     ) -> Result<()> {
-        // Only the first thread is able to initialize.
-
         let local = match std::mem::replace(&mut **init_guard, InitSource::FromScratch) {
             InitSource::FromScratch => {
                 if !allow_from_scratch {
@@ -170,13 +180,12 @@ where
                 }
                 self.new_local_state_from_scratch(known_length)?
             }
-            InitSource::FromPrefiller(mut pipe) => {
-                match pipe.wait()? {
+            InitSource::FromPrefiller(mut prefiller) => {
+                let local = match prefiller.wait()? {
                     Some((_, bytes)) => {
                         let local = LocalState::new(
                             &self.local_path,
-                            // TODO: if we want partial prefill, we should still create local state with
-                            // entire length of remote file, not the partial data.
+                            // bytes length is the length of the remote file
                             bytes.len() as u64,
                             self.open_options,
                         )?;
@@ -195,7 +204,36 @@ where
                         // init from scratch
                         self.new_local_state_from_scratch(known_length)?
                     }
-                }
+                };
+
+                let remote = prefiller.into_inner();
+                let _ = self.remote.set(remote);
+
+                local
+            }
+            InitSource::FromPartialPrefiller {
+                mut prefiller,
+                mut local_state,
+            } => {
+                match prefiller.wait()? {
+                    Some((start, bytes)) => {
+                        let end = start + bytes.len() as u64;
+
+                        local_state.resize(&self.local_path, end)?;
+
+                        let blocks_range = to_block_range(start..end);
+                        unsafe { local_state.write_mmap_bytes(&bytes, blocks_range) }
+                    }
+                    None => {
+                        // The remote file didn't grow
+                        // TODO: double check that the remote didn't shrink?
+                    }
+                };
+
+                let remote = prefiller.into_inner();
+                let _ = self.remote.set(remote);
+
+                local_state
             }
         };
 
@@ -260,41 +298,72 @@ where
         let mut init_guard = self.init_lock.lock();
         self.init_local_state(&mut init_guard, false, None)?;
 
-        if self.local.get().is_none() {
+        let Self { remote, local, .. } = self;
+
+        let Some(mut local) = local.take() else {
+            // If init_local_state didn't initialize after `init_local_state`, we are not populating
+            // and we haven't made any reads.
+            //
+            // The first read will take care of initializing to the remote length.
             return Ok(());
-        }
+        };
 
-        // Reopen the remote so `len()` reflects the current file size
-        if let Some(remote) = self.remote.get_mut() {
+        let remote = if let Some(mut remote) = remote.take() {
+            // Reopen the remote so `len()` reflects the current file size
             remote.reopen()?;
-        }
-        let remote_len = self.remote()?.len::<u8>()?;
-
-        let local = self
-            .local
-            .get_mut()
-            .expect("We just ruled out `is_none` above, and we are holding &mut self");
+            remote
+        } else {
+            self.open_remote()?
+        };
 
         let local_len = local.mmap().len::<u8>()?;
-        if local_len > remote_len {
-            return Err(UniversalIoError::Io(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                format!(
-                    "Reopen encountered a smaller file than expected; old_len: {local_len}, new_len: {remote_len}"
-                ),
-            )));
-        }
-        if local_len == remote_len {
-            return Ok(());
-        }
-
-        local.resize(self.local_path.clone(), remote_len)?;
 
         match self.open_options.populate {
-            Populate::Auto | Populate::No => {}
-            Populate::Blocking => self.populate_from(local_len)?,
-            Populate::PreferBackground => {
-                // TODO: prefill old_len..new_len on background
+            Populate::Auto | Populate::No => {
+                let remote_len = remote.len::<u8>()?;
+
+                // The remote is assumed to be append-only; a smaller file is unexpected.
+                if local_len > remote_len {
+                    return Err(UniversalIoError::Io(io::Error::new(
+                        ErrorKind::UnexpectedEof,
+                        format!(
+                            "Reopen encountered a smaller file than expected; old_len: {local_len}, new_len: {remote_len}"
+                        ),
+                    )));
+                }
+                // Make the new length visible; new blocks will be filled lazily on read.
+                local.resize(&self.local_path, remote_len)?;
+
+                // return the updated local state and remote
+                self.local.set(local).expect("we just take()'d them");
+                self.remote
+                    .set(remote)
+                    .expect("we just take()'d them (or we didn't have it)");
+            }
+            Populate::Blocking | Populate::PreferBackground => {
+                // Re-fetch from the start of the (possibly partial) tail block so
+                // we still make an page-aligned read.
+                let from = local_len.saturating_sub(local_len % BLOCK_SIZE as u64);
+
+                let mut remote_pipeline = R::OwnedReadPipeline::new(remote)?;
+
+                // FIXME: check can_schedule in a loop?
+                remote_pipeline.schedule_whole(from, from)?;
+
+                assert_matches!(
+                    *init_guard,
+                    InitSource::FromScratch,
+                    "by this point, InitSource must be FromScratch"
+                );
+                *init_guard = InitSource::FromPartialPrefiller {
+                    prefiller: remote_pipeline,
+                    local_state: local,
+                };
+
+                // For blocking, resolve the prefill now instead of on first read.
+                if matches!(self.open_options.populate, Populate::Blocking) {
+                    self.init_local_state(&mut init_guard, false, None)?;
+                }
             }
         }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -155,7 +155,7 @@ where
                 // FIXME: check `can_schedule` in a loop first
                 pipeline.schedule_whole((), 0)?;
 
-                InitSource::FromPrefiller(pipeline)
+                InitSource::Prefiller(pipeline)
             }
         };
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -170,7 +170,7 @@ where
 
         if matches!(populate, Populate::Blocking) {
             // Force the prefill to resolve before returning.
-            cache.local_state()?;
+            cache.state()?;
         }
 
         Ok(cache)

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -153,7 +153,7 @@ where
                 let mut pipeline = R::OwnedReadPipeline::new(remote)?;
 
                 // FIXME: check `can_schedule` in a loop first
-                pipeline.schedule_whole(())?;
+                pipeline.schedule_whole((), 0)?;
 
                 InitSource::FromPrefiller(pipeline)
             }

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -20,6 +20,7 @@ pub trait DiskCacheRemote:
     UniversalRead<
         Fs: Clone + Send + Sync + UniversalReadFs<OpenExtra: Clone + Send + Sync>,
         OwnedReadPipeline<()>: Send,
+        OwnedReadPipeline<u64>: Send,
     > + Clone
 {
 }
@@ -30,6 +31,7 @@ where
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
     R::OwnedReadPipeline<()>: Send,
+    R::OwnedReadPipeline<u64>: Send,
 {
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -403,4 +403,8 @@ where
             unsafe { commit_and_read::<R>(&self.file, &bytes, scheduled_read)? };
         Ok(Some((user_data, ACow::Borrowed(items))))
     }
+
+    fn into_inner(self) -> DiskCache<R> {
+        self.file
+    }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -141,7 +141,10 @@ where
     let local = if let Some(state) = file.local.get() {
         state
     } else {
-        file.init_local_state(true, known_len)?;
+        let mut init_guard = file.init_lock.lock();
+        if file.local.get().is_none() {
+            file.init_local_state(&mut init_guard, true, known_len)?;
+        }
         file.local.get().expect("just initialized")
     };
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -23,7 +23,9 @@ enum ScheduledRead {
         blocks_range: Range<u32>,
         read_range: Range<u64>,
     },
-    Whole,
+    Whole {
+        from: u64,
+    },
 }
 
 /// Outcome of [`plan_schedule`]: either the requested range is already available
@@ -124,17 +126,19 @@ where
     R: DiskCacheRemote,
 {
     let mut known_len = None;
-    let (blocks_range, read_range) = match scheduled_read {
+    let (blocks_range, byte_range) = match scheduled_read {
         ScheduledRead::Range {
             blocks_range,
             read_range,
         } => (blocks_range, read_range),
-        ScheduledRead::Whole => {
+        ScheduledRead::Whole { from } => {
             // derive whole ranges from the actual bytes returned.
             let byte_len = bytes.len() as u64;
-            known_len = Some(byte_len);
-            let blocks_range = to_block_range(0..byte_len);
-            (blocks_range, 0..byte_len)
+            let eof = from + byte_len;
+            let byte_range = from..eof;
+            known_len = Some(eof);
+            let blocks_range = to_block_range(byte_range.clone());
+            (blocks_range, byte_range)
         }
     };
 
@@ -150,7 +154,7 @@ where
 
     unsafe {
         local.write_mmap_bytes(bytes, blocks_range);
-        local.read_mmap_bytes::<Random>(read_range)
+        local.read_mmap_bytes::<Random>(byte_range)
     }
 }
 
@@ -354,21 +358,24 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
         // If local has already been initialized, use the mmap length
         if let Some(local) = self.file.local.get() {
-            let length = local.mmap().len::<u8>()?;
-            return self.schedule::<Sequential>(user_data, 0..length, 1);
+            let eof = local.mmap().len::<u8>()?;
+            if from >= eof {
+                return Ok(());
+            }
+            return self.schedule::<Sequential>(user_data, from..eof, 1);
         }
 
         // Use schedule_whole on the remote pipeline directly
         let remote_meta = RemoteMeta {
             file: (),
-            scheduled_read: ScheduledRead::Whole,
+            scheduled_read: ScheduledRead::Whole { from },
             user_data,
         };
         let remote_pipeline = self.get_or_init_remote_pipeline()?;
-        remote_pipeline.schedule_whole(remote_meta)
+        remote_pipeline.schedule_whole(remote_meta, from)
     }
 
     fn wait(&mut self) -> universal_io::Result<Option<(U, ACow<'_>)>> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -105,7 +105,7 @@ where
     if range.is_empty() {
         return Ok(&[]);
     }
-    let local = file.local_state()?;
+    let local = &file.state()?.local;
     if is_sequential {
         unsafe { local.read_mmap_bytes::<Sequential>(range) }
     } else {
@@ -142,19 +142,19 @@ where
         }
     };
 
-    let local = if let Some(state) = file.local.get() {
+    let state = if let Some(state) = file.state.get() {
         state
     } else {
         let mut init_guard = file.init_lock.lock();
-        if file.local.get().is_none() {
-            file.init_local_state(&mut init_guard, true, known_len)?;
+        if file.state.get().is_none() {
+            file.init_state(&mut init_guard, true, known_len)?;
         }
-        file.local.get().expect("just initialized")
+        file.state.get().expect("just initialized")
     };
 
     unsafe {
-        local.write_mmap_bytes(bytes, blocks_range);
-        local.read_mmap_bytes::<Random>(byte_range)
+        state.local.write_mmap_bytes(bytes, blocks_range);
+        state.local.read_mmap_bytes::<Random>(byte_range)
     }
 }
 
@@ -217,7 +217,8 @@ where
         range: Range<u64>,
         align: usize,
     ) -> universal_io::Result<()> {
-        match pick_source::<P>(file.local_state()?, range.clone())? {
+        let state = file.state()?;
+        match pick_source::<P>(&state.local, range.clone())? {
             Source::Local {
                 range,
                 is_sequential,
@@ -241,7 +242,7 @@ where
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
                 remote_pipeline.schedule::<P>(
                     remote_meta,
-                    file.remote()?,
+                    &state.remote,
                     blocks_byte_range,
                     align,
                 )?;
@@ -282,7 +283,7 @@ where
     /// The file being cached.
     file: DiskCache<R>,
     /// Pipeline for queuing remote reads.
-    remote_pipeline: OnceCell<R::OwnedReadPipeline<RemoteMeta<(), U>>>,
+    remote_pipeline: Option<R::OwnedReadPipeline<RemoteMeta<(), U>>>,
     /// A result ready to be read, contains (user_data, byte_range).
     ready: Option<(U, Range<u64>, bool)>,
 }
@@ -295,12 +296,16 @@ where
     fn get_or_init_remote_pipeline(
         &mut self,
     ) -> universal_io::Result<&mut R::OwnedReadPipeline<RemoteMeta<(), U>>> {
-        if self.remote_pipeline.get().is_none() {
-            let remote = R::OwnedReadPipeline::new(self.file.remote()?.clone())?;
-            // We just observed the cell as empty and hold `&mut self`, so set cannot fail.
-            let _ = self.remote_pipeline.set(remote);
+        if self.remote_pipeline.is_none() {
+            let remote = if let Some(state) = self.file.state.get() {
+                state.remote.clone()
+            } else {
+                self.file.open_remote()?
+            };
+            let pipeline = R::OwnedReadPipeline::new(remote)?;
+            self.remote_pipeline = Some(pipeline);
         }
-        Ok(self.remote_pipeline.get_mut().expect("just initialized"))
+        Ok(self.remote_pipeline.as_mut().expect("just initialized"))
     }
 }
 
@@ -313,7 +318,7 @@ where
     fn new(file: Self::File) -> universal_io::Result<Self> {
         Ok(Self {
             file,
-            remote_pipeline: OnceCell::new(),
+            remote_pipeline: None,
             ready: None,
         })
     }
@@ -322,8 +327,8 @@ where
         self.ready.is_none()
             && self
                 .remote_pipeline
-                .get_mut()
-                .is_none_or(|remote| remote.can_schedule())
+                .as_mut()
+                .is_none_or(|pipeline| pipeline.can_schedule())
     }
 
     fn schedule<P: AccessPattern>(
@@ -332,7 +337,7 @@ where
         range: Range<u64>,
         align: usize,
     ) -> universal_io::Result<()> {
-        match pick_source::<P>(self.file.local_state()?, range.clone())? {
+        match pick_source::<P>(&self.file.state()?.local, range.clone())? {
             Source::Local {
                 range,
                 is_sequential,
@@ -360,8 +365,8 @@ where
 
     fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
         // If local has already been initialized, use the mmap length
-        if let Some(local) = self.file.local.get() {
-            let eof = local.mmap().len::<u8>()?;
+        if let Some(state) = &self.file.state.get() {
+            let eof = state.local.mmap().len::<u8>()?;
             if from >= eof {
                 return Ok(());
             }
@@ -385,7 +390,7 @@ where
             return Ok(Some((user_data, ACow::Borrowed(bytes))));
         }
 
-        let Some(remote_pipeline) = self.remote_pipeline.get_mut() else {
+        let Some(remote_pipeline) = self.remote_pipeline.as_mut() else {
             return Ok(None);
         };
         let Some((remote_meta, bytes)) = remote_pipeline.wait()? else {

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -244,7 +244,7 @@ mod tests_mod {
 
         // In both Populate::No and Populate::PreferBackground, we still
         // have local marked as uninitialized at this point
-        assert!(cache.local.get().is_none());
+        assert!(cache.state.get().is_none());
     }
 
     /// Reopen on an unchanged remote must not resize, repopulate, or mutate
@@ -262,7 +262,11 @@ mod tests_mod {
             .unwrap();
 
         let (len_before, populated_before, fetched_before) = {
-            let local = cache.local.get().expect("local initialized after read");
+            let local = &cache
+                .state
+                .get()
+                .expect("local initialized after read")
+                .local;
             (
                 local.mmap().len::<u8>().unwrap(),
                 local.fully_populated.load(Ordering::Acquire),
@@ -275,10 +279,14 @@ mod tests_mod {
         let local = if PREFILL {
             // in case of Populate::PreferBackground, we need to await for
             // completion to get the local_state back.
-            cache.local_state().unwrap()
+            &cache.state().unwrap().local
         } else {
             // in case of Populate::No, local_state should still be there
-            cache.local.get().expect("local must still be initialized")
+            &cache
+                .state
+                .get()
+                .expect("local must still be initialized")
+                .local
         };
 
         assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -96,16 +96,6 @@ impl Scenario {
         self.data = new_data.clone();
         new_data
     }
-
-    /// Shrink the remote file in-place to `new_len` bytes.
-    fn truncate_remote(&mut self, new_len: usize) {
-        let file = fs::OpenOptions::new()
-            .write(true)
-            .open(&self.remote_path)
-            .unwrap();
-        file.set_len(new_len as u64).unwrap();
-        self.data.truncate(new_len);
-    }
 }
 
 #[duplicate::duplicate_item(
@@ -117,7 +107,6 @@ impl Scenario {
 #[cfg_predicate]
 #[cfg(test)]
 mod tests_mod {
-    use std::io::ErrorKind;
     use std::sync::atomic::Ordering;
 
     use super::*;
@@ -246,14 +235,16 @@ mod tests_mod {
 
         cache.reopen().unwrap();
 
-        // unless it was scheduled for prefill
+        // it it was scheduled for prefill, it materializes the local file
         if PREFILL {
             assert!(expected_local.exists());
-            assert!(cache.local.get().is_some());
         } else {
             assert!(!expected_local.exists());
-            assert!(cache.local.get().is_none());
         }
+
+        // In both Populate::No and Populate::PreferBackground, we still
+        // have local marked as uninitialized at this point
+        assert!(cache.local.get().is_none());
     }
 
     /// Reopen on an unchanged remote must not resize, repopulate, or mutate
@@ -281,40 +272,21 @@ mod tests_mod {
 
         cache.reopen().unwrap();
 
-        let local = cache.local.get().expect("local must still be initialized");
+        let local = if PREFILL {
+            // in case of Populate::PreferBackground, we need to await for
+            // completion to get the local_state back.
+            cache.local_state().unwrap()
+        } else {
+            // in case of Populate::No, local_state should still be there
+            cache.local.get().expect("local must still be initialized")
+        };
+
         assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);
         assert_eq!(
             local.fully_populated.load(Ordering::Acquire),
             populated_before,
         );
         assert_eq!(local.fetched.lock().clone(), fetched_before);
-    }
-
-    /// Reopening over a shrunk remote must fail with `UnexpectedEof`.
-    #[test]
-    fn reopen_with_smaller_remote_fails() {
-        let mut scn = Scenario::new(BLOCK_SIZE * 4);
-        let mut cache = scn.open::<R>(PREFILL);
-
-        let _ = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 1,
-            })
-            .unwrap();
-
-        // The read above may have mapped the remote. Windows cannot shrink a
-        // file with an active mapping, so drop the cache's remote handle before
-        // shrinking the remote on disk. `reopen` re-opens it lazily afterward.
-        cache.release_remote();
-        scn.truncate_remote(BLOCK_SIZE * 2);
-
-        let err = cache.reopen().unwrap_err();
-        assert_matches!(
-            &err,
-            crate::universal_io::UniversalIoError::Io(io_err)
-                if io_err.kind() == ErrorKind::UnexpectedEof,
-        );
     }
 
     /// Reads into the new section must fail before reopen (local mirror is at

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -84,7 +84,7 @@ where
 
     /// Like `Self::schedule`, but doesn't need to know file length upfront.
     /// Reads the entire file, byte-aligned (align = 1).
-    fn schedule_whole(&mut self, user_data: U) -> Result<()>;
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()>;
 
     /// See [`BorrowedReadPipeline::wait()`].
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>>;

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -89,6 +89,13 @@ where
     /// See [`BorrowedReadPipeline::wait()`].
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>>;
 
+    /// Consume the pipeline and return the underlying file, so it can be reused
+    /// without re-opening it.
+    ///
+    /// Any reads that were scheduled but not yet drained via [`Self::wait`] are
+    /// discarded.
+    fn into_inner(self) -> Self::File;
+
     #[inline]
     fn wait_bytemuck<T: Item>(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
         let Some((user_data, bytes)) = self.wait()? else {

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -103,4 +103,9 @@ where
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {
         self.inner.wait()
     }
+
+    #[inline]
+    fn into_inner(self) -> File {
+        File::wrap(self.inner.into_inner())
+    }
 }

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -95,8 +95,8 @@ where
     }
 
     #[inline]
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        self.inner.schedule_whole(user_data)
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+        self.inner.schedule_whole(user_data, from)
     }
 
     #[inline]

--- a/lib/common/io_bridge_object_store/src/pipeline/owned.rs
+++ b/lib/common/io_bridge_object_store/src/pipeline/owned.rs
@@ -61,4 +61,8 @@ where
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {
         Ok(self.inner.wait()?.map(|(u, v)| (u, ACow::Owned(v))))
     }
+
+    fn into_inner(self) -> BlobFile<A> {
+        self.file
+    }
 }

--- a/lib/common/io_bridge_object_store/src/pipeline/owned.rs
+++ b/lib/common/io_bridge_object_store/src/pipeline/owned.rs
@@ -49,9 +49,13 @@ where
         self.inner.schedule(&self.file.runtime, user_data, future)
     }
 
-    fn schedule_whole(&mut self, user_data: U) -> Result<()> {
-        let length = self.file.len::<u8>()?;
-        self.schedule::<Sequential>(user_data, 0..length, 1)
+    fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+        // TODO(uio): implement schedule_whole in `AsyncRead`
+        let eof = self.file.len::<u8>()?;
+        if from >= eof {
+            return Ok(());
+        }
+        self.schedule::<Sequential>(user_data, from..eof, 1)
     }
 
     fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {


### PR DESCRIPTION
## Why
`DiskCache` was missing the implementation of background populate when `reopen`ing.

## What
This PR refactors the entire process to be able to populate without an extra `len()` call.
To achieve this, we add 2 new methods to uio interface.

- Changes the signature of `OwnedReadPipeline::schedule_whole` to include a `from: u64` argument, so that we can schedule a `from..` range, not just `0..`.
- Adds `OwnedReadPipeline::into_inner` function to return the ownership of the wrapped file, so that we can reuse the already opened remote.
- `DiskCache::reopen` & friends we refactor so that:
  - we hold `init_lock` for the entire process
  - we "de-initialize" the local state `OnceLock` during the reopening, so that we can leave it uninitialized if it uses `Populate::PreferBackground`
  - adds a new `InitSource::PartialPrefill` variant to represent waiting for the new `reopen` data.
- Not strictly necessary, but now `remote` and `local_state` are initialized/de-initialized together, which should simplify reasoning.