### PR TITLE
refactor: move version() from ReadSegmentEntry to StorageSegmentEntry

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -33,9 +33,6 @@ use crate::types::{
 /// Assume all operations are idempotent - which means that no matter how many times an operation
 /// is executed - the storage state will be the same.
 pub trait ReadSegmentEntry {
-    /// Get current update version of the segment
-    fn version(&self) -> SeqNumberType;
-
     fn is_proxy(&self) -> bool;
 
     /// Get version of specified point
@@ -298,6 +295,9 @@ pub trait ReadSegmentEntry {
 
 /// Segment with storage.
 pub trait StorageSegmentEntry: ReadSegmentEntry + SnapshotEntry {
+    /// Get current update version of the segment
+    fn version(&self) -> SeqNumberType;
+
     /// Checks if segment errored during last operations
     fn check_error(&self) -> Option<SegmentFailedState>;
 

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -38,10 +38,6 @@ use crate::vector_storage::{VectorStorage, VectorStorageRead};
 /// This is a basic implementation of the trait, meaning that it implements the _actual_ operations with data and not
 /// any kind of proxy or wrapping.
 impl ReadSegmentEntry for Segment {
-    fn version(&self) -> SeqNumberType {
-        self.version.unwrap_or(0)
-    }
-
     fn is_proxy(&self) -> bool {
         false
     }
@@ -368,6 +364,10 @@ impl Segment {
 }
 
 impl StorageSegmentEntry for Segment {
+    fn version(&self) -> SeqNumberType {
+        self.version.unwrap_or(0)
+    }
+
     fn check_error(&self) -> Option<SegmentFailedState> {
         self.error_status.clone()
     }

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -45,8 +45,8 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
         }
 
         let SegmentState {
-            initial_version,
-            version,
+            initial_version: _,
+            version: _,
             config,
         } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
 
@@ -143,8 +143,6 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
 
         Ok(Self {
             uuid,
-            initial_version,
-            version,
             segment_path: segment_path.to_path_buf(),
             id_tracker,
             vector_data,

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -23,8 +23,6 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     ) -> OperationResult<()> {
         let Self {
             uuid: _,
-            initial_version: _,
-            version: _,
             segment_path: _,
             id_tracker,
             vector_data,

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -16,7 +16,7 @@ use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::segment::read_view::SegmentReadView;
 use crate::segment::vector_data_read::VectorDataRead;
-use crate::types::{SegmentConfig, SegmentType, SeqNumberType, VectorNameBuf};
+use crate::types::{SegmentConfig, SegmentType, VectorNameBuf};
 use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
@@ -28,11 +28,6 @@ mod tests;
 
 pub struct ReadOnlySegment<S: UniversalRead + 'static> {
     pub uuid: Uuid,
-    /// Initial version this segment was created at
-    pub initial_version: Option<SeqNumberType>,
-    /// Latest update operation number, applied to this segment
-    /// If None, there were no updates and segment is empty
-    pub version: Option<SeqNumberType>,
     /// Path to the segment directory
     pub segment_path: PathBuf,
 

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -35,10 +35,6 @@ use crate::types::{
 /// accordingly. All other operations delegate to the shared `SegmentReadView`,
 /// exactly like the mutable `Segment`.
 impl<S: UniversalRead + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
-    fn version(&self) -> SeqNumberType {
-        self.version.unwrap_or(0)
-    }
-
     fn is_proxy(&self) -> bool {
         false
     }

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::manifest::{FileVersion, SegmentManifest};
 use crate::entry::ReadSegmentEntry as _;
+use crate::entry::entry_point::StorageSegmentEntry as _;
 use crate::entry::snapshot_entry::SnapshotEntry;
 use crate::id_tracker::IdTracker;
 use crate::index::{PayloadIndex, VectorIndex};

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -31,7 +31,7 @@ use super::{
 };
 use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
-use crate::entry::ReadSegmentEntry;
+use crate::entry::entry_point::StorageSegmentEntry as _;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
     use crate::common::operation_error::OperationError;
     use crate::data_types::vectors::only_default_vector;
-    use crate::entry::entry_point::{ReadSegmentEntry as _, SegmentEntry as _};
+    use crate::entry::entry_point::{SegmentEntry as _, StorageSegmentEntry as _};
     use crate::payload_json;
 
     #[test]

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -20,7 +20,9 @@ use segment::data_types::index::{
     KeywordIndexType, TextIndexParams, TextIndexType,
 };
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
-use segment::entry::entry_point::{NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry};
+use segment::entry::entry_point::{
+    NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry, StorageSegmentEntry,
+};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::fixtures::payload_fixtures::{
     FLICKING_KEY, FLT_KEY, GEO_KEY, INT_KEY, INT_KEY_2, INT_KEY_3, LAT_RANGE, LON_RANGE, STR_KEY,

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -29,10 +29,6 @@ use super::{ProxyDeletedPoint, ProxyIndexChange, ProxySegment};
 use crate::locked_segment::LockedSegment;
 
 impl ReadSegmentEntry for ProxySegment {
-    fn version(&self) -> SeqNumberType {
-        cmp::max(self.wrapped_segment.get().read().version(), self.version)
-    }
-
     fn is_proxy(&self) -> bool {
         true
     }
@@ -761,6 +757,10 @@ impl ReadSegmentEntry for ProxySegment {
 }
 
 impl StorageSegmentEntry for ProxySegment {
+    fn version(&self) -> SeqNumberType {
+        cmp::max(self.wrapped_segment.get().read().version(), self.version)
+    }
+
     fn check_error(&self) -> Option<SegmentFailedState> {
         self.wrapped_segment.get().read().check_error()
     }

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -7,7 +7,7 @@ use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use segment::common::operation_error::OperationResult;
-use segment::entry::ReadSegmentEntry as _;
+use segment::entry::StorageSegmentEntry as _;
 use segment::segment::SegmentVersion;
 use segment::types::SegmentConfig;
 


### PR DESCRIPTION
## What

`ReadSegmentEntry::version()` returns the segment's *update* version — a property that only matters on the mutable/storage path. A trace of every `.version()` call site shows none reach it through the read-only base trait:

- **`StorageSegmentEntry`** (`dyn`): `segment_holder/flush.rs`, `proxy_segment/mod.rs`
- **`SegmentEntry`** (`dyn`): `update.rs`
- **concrete** `Segment` / `ProxySegment`: builder, optimizer, snapshot, etc.

The bare-`ReadSegmentEntry` consumers (`read_points`, `config_mismatch_optimizer`, segment-holder helpers) never call it.

## Changes

- Move `fn version()` declaration from `ReadSegmentEntry` → `StorageSegmentEntry` (the lowest trait it's actually used through).
- Relocate the `Segment` and `ProxySegment` impls into their `StorageSegmentEntry` blocks.
- `ReadOnlySegment` drops the `version()` method and the write-only `version` / `initial_version` fields — both were dead state (`live_reload` never refreshed `version`, neither field was ever read), so a read-only segment no longer exposes a meaningless/stale version.
- Import fixups where concrete `.version()` calls now need `StorageSegmentEntry` in scope (segment + shard + two test files).

Net: `ReadSegmentEntry` becomes a clean read-only surface; `point_version()` stays (reads use it).

## Forward note

If `ReadOnlySegment` is later promoted to a flushable `StorageSegmentEntry`, `version()` returns — and `live_reload` will need to refresh it.

## Test

`cargo build --workspace --tests` clean; `cargo clippy -p segment -p shard` clean; read-only + id-tracker suites green (55 passed, S3 ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)