### PR TITLE
feat: config reload for read-only segments

### DIFF
--- a/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::universal_io::UniversalRead;
+
+use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::IdTrackerRead;
+use crate::index::field_index::ReadOnlyFieldIndex;
+use crate::index::payload_config::PayloadConfig;
+use crate::types::{PayloadKeyType, VectorName, VectorNameBuf};
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+
+/// Difference between the in-memory payload field indexes and the on-disk
+/// payload config, with every new or changed field index already loaded.
+///
+/// Produced by [`ReadOnlyStructPayloadIndex::config_reload_diff`] (heavy load,
+/// shared `&self`) and consumed by [`ReadOnlyStructPayloadIndex::apply_config_reload`]
+/// (cheap swap, `&mut self`).
+pub struct PayloadIndexReloadDiff<S: UniversalRead> {
+    /// Full on-disk payload config to install on apply.
+    new_config: PayloadConfig,
+    /// Field indexes that are new, or whose config changed — loaded, ready to
+    /// install. Installing overwrites any existing entry for the same field; an
+    /// empty entry means the field is no longer indexed and is dropped instead.
+    added: ReadOnlyIndexesMap<S>,
+    /// Fields that disappeared from the config entirely — to drop.
+    removed: Vec<PayloadKeyType>,
+}
+
+impl<S: UniversalRead> PayloadIndexReloadDiff<S> {
+    /// Whether the on-disk config matches the loaded field indexes (nothing to apply).
+    pub fn is_empty(&self) -> bool {
+        let Self {
+            new_config: _,
+            added,
+            removed,
+        } = self;
+        added.is_empty() && removed.is_empty()
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
+    /// Compute the difference between the loaded field indexes and `new_config`,
+    /// eagerly loading every new or changed field index through `fs`.
+    ///
+    /// Uses shared `&self`, so the index keeps serving reads while the (heavy)
+    /// loading happens. A field present in both configs but with a different
+    /// schema/type set is reloaded — it lands in `added` and overwrites the old
+    /// entry on apply.
+    pub fn config_reload_diff(
+        &self,
+        fs: &S::Fs,
+        new_config: PayloadConfig,
+    ) -> OperationResult<PayloadIndexReloadDiff<S>> {
+        let mut added: ReadOnlyIndexesMap<S> = HashMap::new();
+        {
+            let id_tracker = self.id_tracker.borrow();
+            let total_point_count = id_tracker.total_point_count();
+            let deleted_points = id_tracker.deleted_point_bitslice();
+
+            for (field, indexed) in new_config.indices.iter() {
+                // Unchanged fields keep their already-loaded indexes untouched.
+                if self.config.indices.get(field) == Some(indexed) {
+                    continue;
+                }
+
+                let mut indexes = Vec::with_capacity(indexed.types.len());
+                for index_type in &indexed.types {
+                    if let Some(index) = ReadOnlyFieldIndex::open(
+                        fs,
+                        &self.path,
+                        field,
+                        &indexed.schema,
+                        index_type,
+                        total_point_count,
+                        deleted_points,
+                    )? {
+                        indexes.push(index);
+                    }
+                }
+                // Keep empty vectors: apply turns them into a removal so the map
+                // never holds an empty entry (mirrors `open`).
+                added.insert(field.clone(), indexes);
+            }
+        }
+
+        let removed = self
+            .config
+            .indices
+            .keys()
+            .filter(|field| !new_config.indices.contains_key(*field))
+            .cloned()
+            .collect();
+
+        Ok(PayloadIndexReloadDiff {
+            new_config,
+            added,
+            removed,
+        })
+    }
+
+    /// Install a [`PayloadIndexReloadDiff`] produced by [`config_reload_diff`].
+    ///
+    /// Cheap, `&mut self`: no I/O, just swapping the already-loaded field indexes
+    /// and the config into place.
+    ///
+    /// [`config_reload_diff`]: Self::config_reload_diff
+    pub fn apply_config_reload(&mut self, diff: PayloadIndexReloadDiff<S>) {
+        let PayloadIndexReloadDiff {
+            new_config,
+            added,
+            removed,
+        } = diff;
+
+        for field in &removed {
+            self.field_indexes.remove(field);
+        }
+        for (field, indexes) in added {
+            // An empty index set means the field dropped all its index types.
+            if indexes.is_empty() {
+                self.field_indexes.remove(&field);
+            } else {
+                self.field_indexes.insert(field, indexes);
+            }
+        }
+
+        self.config = new_config;
+    }
+
+    /// Register a vector storage in the `has_vector` lookup map.
+    ///
+    /// Must be called whenever a named vector is added to the segment, otherwise
+    /// `has_vector` queries cannot see the new storage.
+    pub fn register_vector_storage(
+        &mut self,
+        vector_name: VectorNameBuf,
+        vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+    ) {
+        self.vector_storages.insert(vector_name, vector_storage);
+    }
+
+    /// Drop a vector storage from the `has_vector` lookup map.
+    ///
+    /// Must be called whenever a named vector is removed from the segment,
+    /// otherwise `has_vector` queries keep matching against the deleted storage.
+    pub fn unregister_vector_storage(&mut self, vector_name: &VectorName) {
+        self.vector_storages.remove(vector_name);
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -19,11 +19,13 @@ use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::{PayloadKeyType, VectorNameBuf};
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
+mod config_reload;
 mod lifecycle;
+
+pub use config_reload::PayloadIndexReloadDiff;
 
 type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
-#[expect(dead_code)] // `path` is read once live-reload lands
 pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     /// Payload storage
     pub(super) payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,

--- a/lib/segment/src/segment/read_only/config_reload.rs
+++ b/lib/segment/src/segment/read_only/config_reload.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use common::storage_version::StorageVersion;
+use common::universal_io::{UniversalRead, read_json_via};
+
+use super::{ReadOnlySegment, ReadOnlyVectorData};
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::payload_config::PayloadConfig;
+use crate::index::struct_payload_index::read_only::PayloadIndexReloadDiff;
+use crate::segment::{SEGMENT_STATE_FILE, SegmentVersion};
+use crate::segment_constructor::{get_payload_index_path, get_vector_storage_path};
+use crate::types::{
+    SegmentConfig, SegmentState, SegmentType, VectorDataConfig, VectorName, VectorNameBuf,
+};
+use crate::vector_storage::read_only::VectorStorageReadEnum;
+use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
+
+/// Vectors loaded by the diff phase, keyed by name, ready to install.
+type AddedVectors<S> = HashMap<VectorNameBuf, ReadOnlyVectorData<S>>;
+
+/// Split two config maps into the names to (re)load and the names to drop.
+///
+/// A name is loaded when it is new or its config changed; it is removed when it
+/// vanished or its config changed. A changed name appears in *both* lists so the
+/// stale component is dropped and the freshly loaded one installed.
+fn diff_config_map<C: PartialEq>(
+    old: &HashMap<VectorNameBuf, C>,
+    new: &HashMap<VectorNameBuf, C>,
+) -> (Vec<VectorNameBuf>, Vec<VectorNameBuf>) {
+    let to_load = new
+        .iter()
+        .filter(|(name, config)| old.get(*name) != Some(config))
+        .map(|(name, _)| name.clone())
+        .collect();
+    let to_remove = old
+        .iter()
+        .filter(|(name, config)| new.get(*name) != Some(config))
+        .map(|(name, _)| name.clone())
+        .collect();
+    (to_load, to_remove)
+}
+
+/// Difference between a read-only segment's in-memory config and the current
+/// on-disk config, with every newly added (or reloaded) vector already loaded.
+///
+/// Produced by [`ReadOnlySegment::config_reload_diff`] and consumed by
+/// [`ReadOnlySegment::apply_config_reload`]. The split exists so the heavy
+/// loading runs under a shared `&self` borrow (the segment keeps serving reads),
+/// while the exclusive `&mut self` apply is a cheap swap.
+///
+/// A vector present in both configs but with a changed config is *reloaded*: its
+/// name appears in both `removed_vectors` and `added_vectors`, so apply drops the
+/// stale component and installs the freshly loaded one.
+pub struct SegmentConfigReloadDiff<S: UniversalRead + 'static> {
+    /// Full on-disk segment config to install on apply.
+    new_config: SegmentConfig,
+    /// Vectors that are new or changed — loaded, ready to install.
+    added_vectors: AddedVectors<S>,
+    /// Vectors that disappeared or changed — to drop before installing.
+    removed_vectors: Vec<VectorNameBuf>,
+    /// Payload field-index changes, with new indexes already loaded.
+    payload: PayloadIndexReloadDiff<S>,
+}
+
+impl<S: UniversalRead + 'static> SegmentConfigReloadDiff<S> {
+    /// Whether the on-disk config matches the in-memory state (nothing to apply).
+    pub fn is_empty(&self) -> bool {
+        let Self {
+            new_config: _,
+            added_vectors,
+            removed_vectors,
+            payload,
+        } = self;
+        added_vectors.is_empty() && removed_vectors.is_empty() && payload.is_empty()
+    }
+}
+
+impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+    /// Re-read the on-disk config and compute its difference against the
+    /// in-memory config, eagerly loading every new or changed component.
+    ///
+    /// Heavy I/O (opening vector storages, indexes, quantized vectors and payload
+    /// field indexes) happens here under a shared `&self` borrow, so the segment
+    /// keeps answering queries while loading. Apply the result with
+    /// [`apply_config_reload`](Self::apply_config_reload) under `&mut self`.
+    ///
+    /// Covers added/removed dense vectors, sparse vectors and payload field
+    /// indexes. Vectors whose config changed are reloaded (drop + load).
+    pub fn config_reload_diff(&self, fs: &S::Fs) -> OperationResult<SegmentConfigReloadDiff<S>> {
+        let new_config = self.read_new_config(fs)?;
+        let (added_vectors, removed_vectors) = self.diff_vectors(fs, &new_config)?;
+        let payload = self.diff_payload(fs)?;
+
+        Ok(SegmentConfigReloadDiff {
+            new_config,
+            added_vectors,
+            removed_vectors,
+            payload,
+        })
+    }
+
+    /// Re-read the on-disk segment config, verifying the version file is present.
+    fn read_new_config(&self, fs: &S::Fs) -> OperationResult<SegmentConfig> {
+        let segment_path = &self.segment_path;
+        if SegmentVersion::load_universal(fs, segment_path)?.is_none() {
+            return Err(OperationError::service_error(format!(
+                "Segment version file not found in segment: {}",
+                segment_path.display(),
+            )));
+        }
+
+        let SegmentState {
+            initial_version: _,
+            version: _,
+            config,
+        } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
+        Ok(config)
+    }
+
+    /// Compute the dense + sparse vector diff against `new_config`, eagerly
+    /// loading every new or changed vector. Returns `(added, removed)`.
+    fn diff_vectors(
+        &self,
+        fs: &S::Fs,
+        new_config: &SegmentConfig,
+    ) -> OperationResult<(AddedVectors<S>, Vec<VectorNameBuf>)> {
+        let mut added = HashMap::new();
+        let mut removed = Vec::new();
+
+        let (load, drop) =
+            diff_config_map(&self.segment_config.vector_data, &new_config.vector_data);
+        for name in load {
+            let config = &new_config.vector_data[&name];
+            let data = self.load_dense_vector(fs, &name, config, new_config)?;
+            added.insert(name, data);
+        }
+        removed.extend(drop);
+
+        let (load, drop) = diff_config_map(
+            &self.segment_config.sparse_vector_data,
+            &new_config.sparse_vector_data,
+        );
+        for name in load {
+            let data = self.load_sparse_vector(fs, &name)?;
+            added.insert(name, data);
+        }
+        removed.extend(drop);
+
+        Ok((added, removed))
+    }
+
+    /// Open one dense vector's storage, index and quantized vectors from disk.
+    fn load_dense_vector(
+        &self,
+        fs: &S::Fs,
+        name: &VectorName,
+        config: &VectorDataConfig,
+        new_config: &SegmentConfig,
+    ) -> OperationResult<ReadOnlyVectorData<S>> {
+        let path = get_vector_storage_path(&self.segment_path, name);
+        let storage = VectorStorageReadEnum::open(fs, config, &path)?.ok_or_else(|| {
+            OperationError::service_error(format!(
+                "Read-only dense vector storage '{name}' was not found, or is corrupted.",
+            ))
+        })?;
+        let storage = Arc::new(AtomicRefCell::new(storage));
+        ReadOnlyVectorData::open_dense(
+            fs,
+            &self.segment_path,
+            name,
+            config,
+            new_config,
+            self.id_tracker.clone(),
+            self.payload_index.clone(),
+            storage,
+        )
+    }
+
+    /// Open one sparse vector's storage and index from disk (never quantized).
+    fn load_sparse_vector(
+        &self,
+        fs: &S::Fs,
+        name: &VectorName,
+    ) -> OperationResult<ReadOnlyVectorData<S>> {
+        let path = get_vector_storage_path(&self.segment_path, name);
+        let storage =
+            VectorStorageReadEnum::Sparse(Box::new(ReadOnlySparseVectorStorage::open(fs, &path)?));
+        let storage = Arc::new(AtomicRefCell::new(storage));
+        ReadOnlyVectorData::open_sparse(
+            fs,
+            &self.segment_path,
+            name,
+            self.id_tracker.clone(),
+            self.payload_index.clone(),
+            storage,
+        )
+    }
+
+    /// Load the payload field-index diff (delegates to the payload index, which
+    /// loads its own new/changed field indexes under a shared borrow).
+    fn diff_payload(&self, fs: &S::Fs) -> OperationResult<PayloadIndexReloadDiff<S>> {
+        let payload_index_path = get_payload_index_path(&self.segment_path);
+        let payload_config_path = PayloadConfig::get_config_path(&payload_index_path);
+        let new_payload_config = PayloadConfig::load_universal(fs, &payload_config_path)?
+            .ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "Read-only payload index missing config at {}",
+                    payload_config_path.display(),
+                ))
+            })?;
+        self.payload_index
+            .borrow()
+            .config_reload_diff(fs, new_payload_config)
+    }
+
+    /// Install a [`SegmentConfigReloadDiff`] produced by
+    /// [`config_reload_diff`](Self::config_reload_diff).
+    ///
+    /// Cheap, `&mut self`: no loading happens here — components were loaded while
+    /// computing the diff. Removals run before insertions so a reloaded vector
+    /// (present in both lists) ends up with its fresh component.
+    pub fn apply_config_reload(&mut self, diff: SegmentConfigReloadDiff<S>) {
+        let Self {
+            uuid: _,
+            segment_path: _,
+            id_tracker: _,
+            vector_data,
+            payload_index,
+            payload_storage: _,
+            pending_reload: _,
+            segment_type,
+            segment_config,
+        } = self;
+
+        let SegmentConfigReloadDiff {
+            new_config,
+            added_vectors,
+            removed_vectors,
+            payload,
+        } = diff;
+
+        // Keep the payload index's `has_vector` map and field indexes in sync
+        // under a single exclusive borrow.
+        {
+            let mut payload_index = payload_index.borrow_mut();
+            for vector_name in &removed_vectors {
+                payload_index.unregister_vector_storage(vector_name);
+            }
+            for (vector_name, data) in &added_vectors {
+                payload_index
+                    .register_vector_storage(vector_name.clone(), data.vector_storage.clone());
+            }
+            payload_index.apply_config_reload(payload);
+        }
+
+        for vector_name in &removed_vectors {
+            vector_data.remove(vector_name);
+        }
+        for (vector_name, data) in added_vectors {
+            vector_data.insert(vector_name, data);
+        }
+
+        *segment_type = if new_config.is_any_vector_indexed() {
+            SegmentType::Indexed
+        } else {
+            SegmentType::Plain
+        };
+        *segment_config = new_config;
+    }
+}

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -159,7 +159,7 @@ impl<S: UniversalRead + 'static> ReadOnlyVectorData<S> {
     /// Open one dense vector's quantized vectors and index over `fs`, mirroring
     /// `open_dense_vector_data`. No `prefill`: read-only never writes.
     #[allow(clippy::too_many_arguments)]
-    fn open_dense(
+    pub(super) fn open_dense(
         fs: &S::Fs,
         segment_path: &Path,
         vector_name: &VectorName,
@@ -211,7 +211,7 @@ impl<S: UniversalRead + 'static> ReadOnlyVectorData<S> {
 
     /// Open one sparse vector's index over `fs`, mirroring
     /// `open_sparse_vector_data`. Sparse vectors are never quantized.
-    fn open_sparse(
+    pub(super) fn open_sparse(
         fs: &S::Fs,
         segment_path: &Path,
         vector_name: &VectorName,

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -20,8 +20,11 @@ use crate::types::{SegmentConfig, SegmentType, VectorNameBuf};
 use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
+mod config_reload;
 mod lifecycle;
 mod live_reload;
+
+pub use config_reload::SegmentConfigReloadDiff;
 mod read_entry;
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -304,3 +304,77 @@ fn read_only_segment_over_s3() {
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
     assert_query_equivalence(&mutable, &read_only);
 }
+
+/// Drive `config_reload_diff` + `apply_config_reload`: toggle the on-disk
+/// payload config (the `num` field index) while its index files stay in place,
+/// and assert the read-only segment loads/drops the field index accordingly and
+/// keeps answering queries identically to the reference.
+#[test]
+fn read_only_segment_config_reload_payload_index() {
+    use crate::index::payload_config::PayloadConfig;
+    use crate::segment_constructor::get_payload_index_path;
+
+    let segments_dir = Builder::new().prefix("ro_cfg_segments").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("ro_cfg_builder").tempdir().unwrap();
+
+    let mutable = build_immutable_segment(segments_dir.path(), temp_dir.path());
+    let segment_path = mutable.data_path();
+    let segment_uuid = mutable.uuid;
+
+    let kw_field = JsonPath::new("kw");
+    let num_field = JsonPath::new("num");
+
+    // The built segment indexes both `kw` and `num`. Stash the full config, then
+    // write a reduced one that drops `num` (its index files are left untouched).
+    let payload_index_path = get_payload_index_path(&segment_path);
+    let config_path = PayloadConfig::get_config_path(&payload_index_path);
+    let full_config = PayloadConfig::load(&config_path).unwrap();
+    assert!(full_config.indices.contains_key(&num_field));
+    let mut reduced_config = full_config.clone();
+    reduced_config.indices.remove(&num_field);
+    reduced_config.save(&config_path).unwrap();
+
+    // Open read-only: only `kw` is indexed.
+    let mut read_only =
+        ReadOnlySegment::<MmapFile>::open(&MmapFs, &segment_path, segment_uuid, None)
+            .expect("read-only open");
+    {
+        let payload_index = read_only.payload_index.borrow();
+        assert!(payload_index.field_indexes.contains_key(&kw_field));
+        assert!(!payload_index.field_indexes.contains_key(&num_field));
+    }
+
+    // Restore the full config and reload: the `num` index is loaded and installed.
+    full_config.save(&config_path).unwrap();
+    let diff = read_only
+        .config_reload_diff(&MmapFs)
+        .expect("config reload diff");
+    assert!(!diff.is_empty());
+    read_only.apply_config_reload(diff);
+    {
+        let payload_index = read_only.payload_index.borrow();
+        assert!(payload_index.field_indexes.contains_key(&kw_field));
+        assert!(payload_index.field_indexes.contains_key(&num_field));
+    }
+    assert_query_equivalence(&mutable, &read_only);
+
+    // Reloading against the unchanged on-disk config is a no-op.
+    let diff = read_only
+        .config_reload_diff(&MmapFs)
+        .expect("config reload diff");
+    assert!(diff.is_empty());
+
+    // Drop `num` again on disk and reload: the index is removed.
+    reduced_config.save(&config_path).unwrap();
+    let diff = read_only
+        .config_reload_diff(&MmapFs)
+        .expect("config reload diff");
+    assert!(!diff.is_empty());
+    read_only.apply_config_reload(diff);
+    {
+        let payload_index = read_only.payload_index.borrow();
+        assert!(payload_index.field_indexes.contains_key(&kw_field));
+        assert!(!payload_index.field_indexes.contains_key(&num_field));
+    }
+    assert_query_equivalence(&mutable, &read_only);
+}


### PR DESCRIPTION
## What

Adds a two-phase **config reload** to `ReadOnlySegment`, alongside the existing live-reload. It picks up on-disk config changes (added/removed/changed dense vectors, sparse vectors, and payload field indexes) without rebuilding the segment.

The split into two functions exists so the segment is **not blocked while new components load**:

- **`config_reload_diff(&self, fs)`** — re-reads the on-disk config, diffs it against the in-memory config, and **eagerly loads** every new or changed component (vector storages, indexes, quantized vectors, payload field indexes). Runs under a shared `&self` borrow, so the segment keeps serving queries during the (heavy) load.
- **`apply_config_reload(&mut self, diff)`** — installs the pre-loaded components and drops removed ones. Cheap, no I/O, so the exclusive `&mut self` borrow is held only briefly.

A vector or field present in both configs but **changed** is reloaded (drop + load): its name lands in both the removed and added sets, so apply replaces the stale component.

## Structure

- `lib/segment/src/segment/read_only/config_reload.rs` — `SegmentConfigReloadDiff<S>` + the segment-level diff/apply (orchestrator + small helpers: `read_new_config`, `diff_vectors`, `load_dense_vector`, `load_sparse_vector`, `diff_payload`).
- `lib/segment/src/index/struct_payload_index/read_only/config_reload.rs` — `PayloadIndexReloadDiff<S>` + the payload-index diff/apply, plus `register_vector_storage`/`unregister_vector_storage` for the `has_vector` map.
- `open_dense`/`open_sparse` made `pub(super)` so the diff phase reuses them; dropped the now-fulfilled `#[expect(dead_code)]` on the payload index `path`.

## Notes

- No higher-level caller is wired up yet — these are standalone APIs ready to hook into whatever drives reloads, same status as `live_reload` today.
- `is_empty()` on both diff types lets callers skip a no-op apply.

## Test

`read_only_segment_config_reload_payload_index` toggles the on-disk payload config (load → add `num` index → no-op reload → drop `num`) while index files stay on disk, asserting field-index presence and query equivalence against the mutable reference at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)