### PR TITLE
feat: feature-flagged segment manifest for LocalShard

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12682,6 +12682,16 @@
             "description": "Use io_uring-based payload storage implementation.",
             "default": false,
             "type": "boolean"
+          },
+          "write_segment_manifest": {
+            "description": "Write a segment manifest (`segments/manifest.json`) listing the shard's segments and their state, so out-of-process readers can discover segments without scanning the filesystem.",
+            "default": false,
+            "type": "boolean"
+          },
+          "append_only_mutations": {
+            "description": "Build new segments in append-only mode: in-place point mutations become clone-and-tombstone appends instead. Intended for testing the append-only storage path.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -287,7 +287,7 @@ mod tests {
             payload_storage_type: Default::default(),
         };
 
-        let mut segment = build_segment(
+        let (mut segment, _) = build_segment(
             segments_dir.path(),
             &segment_config,
             deferred_internal_id,
@@ -1011,7 +1011,7 @@ mod tests {
         let segment_config = segment_optimizer_config.plain_segment_config();
 
         let hw_counter = HardwareCounterCell::new();
-        let mut segment = build_segment(
+        let (mut segment, _) = build_segment(
             segments_dir.path(),
             &segment_config,
             Some(deferred_internal_id),

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -51,11 +51,12 @@ use segment::types::{
     Filter, PayloadIndexInfo, PayloadKeyType, PointIdType, SegmentConfig, SegmentType,
     SeqNumberType, StrictModeConfig,
 };
-use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles};
+use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::optimization::{OptimizationSegmentInfo, PendingOptimization};
 use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_manifest::SegmentsManifest;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
@@ -240,6 +241,7 @@ impl LocalShard {
         collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         wal: SerdeWal<OperationWithClockTag>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizer_resource_budget: ResourceBudget,
@@ -275,6 +277,7 @@ impl LocalShard {
             collection_name.clone(),
             shared_storage_config.clone(),
             payload_index_schema.clone(),
+            segment_manifest,
             optimizers.clone(),
             optimizers_log.clone(),
             total_optimized_points.clone(),
@@ -342,6 +345,24 @@ impl LocalShard {
     #[cfg(any(test, feature = "testing"))]
     pub fn segments(&self) -> LockedSegmentHolder {
         self.segments.clone()
+    }
+
+    /// Initialize the segment manifest from the current segments, when the `write_segment_manifest`
+    /// feature flag is enabled. Returns `None` (and writes nothing) when disabled.
+    fn init_segment_manifest(
+        shard_path: &Path,
+        segment_holder: &SegmentHolder,
+    ) -> CollectionResult<Option<Arc<SaveOnDisk<SegmentsManifest>>>> {
+        if !common::flags::feature_flags().write_segment_manifest {
+            return Ok(None);
+        }
+
+        let manifest = SegmentsManifest::from_segment_holder(segment_holder);
+        let manifest =
+            SaveOnDisk::new(segment_manifest_path(shard_path), manifest).map_err(|err| {
+                CollectionError::service_error(format!("failed to write segment manifest: {err}"))
+            })?;
+        Ok(Some(Arc::new(manifest)))
     }
 
     /// Recovers shard from disk.
@@ -509,12 +530,15 @@ impl LocalShard {
             )?;
         }
 
+        let segment_manifest = Self::init_segment_manifest(shard_path, &segment_holder)?;
+
         let local_shard = LocalShard::new(
             collection_id.clone(),
             segment_holder,
             collection_config,
             shared_storage_config,
             payload_index_schema,
+            segment_manifest,
             wal,
             optimizers,
             optimizer_resource_budget,
@@ -672,12 +696,15 @@ impl LocalShard {
 
         drop(config); // release `shared_config` from borrow checker
 
+        let segment_manifest = Self::init_segment_manifest(shard_path, &segment_holder)?;
+
         let local_shard = LocalShard::new(
             collection_id,
             segment_holder,
             collection_config,
             shared_storage_config,
             payload_index_schema,
+            segment_manifest,
             wal,
             optimizers,
             optimizer_resource_budget,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -51,12 +51,11 @@ use segment::types::{
     Filter, PayloadIndexInfo, PayloadKeyType, PointIdType, SegmentConfig, SegmentType,
     SeqNumberType, StrictModeConfig,
 };
-use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles, segment_manifest_path};
+use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::optimization::{OptimizationSegmentInfo, PendingOptimization};
 use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
 use shard::segment_holder::locked::LockedSegmentHolder;
-use shard::segment_manifest::SegmentsManifest;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
@@ -241,7 +240,6 @@ impl LocalShard {
         collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         wal: SerdeWal<OperationWithClockTag>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizer_resource_budget: ResourceBudget,
@@ -277,7 +275,6 @@ impl LocalShard {
             collection_name.clone(),
             shared_storage_config.clone(),
             payload_index_schema.clone(),
-            segment_manifest,
             optimizers.clone(),
             optimizers_log.clone(),
             total_optimized_points.clone(),
@@ -345,24 +342,6 @@ impl LocalShard {
     #[cfg(any(test, feature = "testing"))]
     pub fn segments(&self) -> LockedSegmentHolder {
         self.segments.clone()
-    }
-
-    /// Initialize the segment manifest from the current segments, when the `write_segment_manifest`
-    /// feature flag is enabled. Returns `None` (and writes nothing) when disabled.
-    fn init_segment_manifest(
-        shard_path: &Path,
-        segment_holder: &SegmentHolder,
-    ) -> CollectionResult<Option<Arc<SaveOnDisk<SegmentsManifest>>>> {
-        if !common::flags::feature_flags().write_segment_manifest {
-            return Ok(None);
-        }
-
-        let manifest = SegmentsManifest::from_segment_holder(segment_holder);
-        let manifest =
-            SaveOnDisk::new(segment_manifest_path(shard_path), manifest).map_err(|err| {
-                CollectionError::service_error(format!("failed to write segment manifest: {err}"))
-            })?;
-        Ok(Some(Arc::new(manifest)))
     }
 
     /// Recovers shard from disk.
@@ -481,7 +460,7 @@ impl LocalShard {
                     .get(),
             );
 
-        let mut segment_holder = SegmentHolder::default();
+        let mut segment_holder = SegmentHolder::builder();
 
         while let Some(result) = segment_stream.next().await {
             let Some(segment) = result?? else {
@@ -530,7 +509,8 @@ impl LocalShard {
             )?;
         }
 
-        let segment_manifest = Self::init_segment_manifest(shard_path, &segment_holder)?;
+        // Finalize the holder, wiring up the segment manifest from the freshly populated set.
+        let segment_holder = segment_holder.build(shard_path)?;
 
         let local_shard = LocalShard::new(
             collection_id.clone(),
@@ -538,7 +518,6 @@ impl LocalShard {
             collection_config,
             shared_storage_config,
             payload_index_schema,
-            segment_manifest,
             wal,
             optimizers,
             optimizer_resource_budget,
@@ -635,7 +614,7 @@ impl LocalShard {
                 ))
             })?;
 
-        let mut segment_holder = SegmentHolder::default();
+        let mut segment_holder = SegmentHolder::builder();
         let mut build_handlers = vec![];
 
         let vector_params = config
@@ -670,7 +649,7 @@ impl LocalShard {
             .collect_vec();
 
         for join_result in join_results {
-            let segment = join_result.map_err(|err| {
+            let (segment, _token) = join_result.map_err(|err| {
                 let message = panic::downcast_str(&err).unwrap_or("");
                 let separator = if !message.is_empty() { "with:\n" } else { "" };
 
@@ -696,7 +675,8 @@ impl LocalShard {
 
         drop(config); // release `shared_config` from borrow checker
 
-        let segment_manifest = Self::init_segment_manifest(shard_path, &segment_holder)?;
+        // Finalize the holder, wiring up the segment manifest from the freshly populated set.
+        let segment_holder = segment_holder.build(shard_path)?;
 
         let local_shard = LocalShard::new(
             collection_id,
@@ -704,7 +684,6 @@ impl LocalShard {
             collection_config,
             shared_storage_config,
             payload_index_schema,
-            segment_manifest,
             wal,
             optimizers,
             optimizer_resource_budget,

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -158,6 +158,109 @@ async fn test_optimization_process() {
     assert_eq!(total_optimized_points.load(Ordering::Relaxed), 119);
 }
 
+/// Regression test for the manifest safety invariant: the on-disk segment manifest must never
+/// reference a segment that has been deleted from disk while its replacement is unregistered (that
+/// would lose data when loading a read replica from that moment).
+///
+/// During a merge optimization the input segments are deleted from disk and replaced by a new
+/// optimized segment. The holder drops the superseded segments from the manifest as part of the
+/// swap, and `finish_optimization` confirms the manifest is in sync *before* deleting them from
+/// disk, so afterwards the persisted manifest must list exactly the live segment set — never a
+/// merged-away segment. This test runs the optimization directly (no worker loop, so the lazy
+/// backstop never runs); the holder's in-place manifest maintenance is the only thing keeping it
+/// correct here.
+#[tokio::test]
+async fn optimization_keeps_manifest_consistent_with_live_segments() {
+    use shard::segment_manifest::SegmentsManifest;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let dim = 256;
+    let mut holder = SegmentHolder::default();
+
+    let segments_to_merge = [
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 3, dim)),
+    ];
+    let segment_to_index = holder.add_new(random_segment(dir.path(), 100, 110, dim));
+    let _other_segment_ids = [
+        holder.add_new(random_segment(dir.path(), 100, 20, dim)),
+        holder.add_new(random_segment(dir.path(), 100, 20, dim)),
+    ];
+
+    // UUIDs of the segments that will be optimized away and deleted from disk.
+    let optimized_away_uuids = segments_to_merge
+        .iter()
+        .chain(std::iter::once(&segment_to_index))
+        .map(|&sid| holder.get(sid).unwrap().get().read().segment_uuid())
+        .collect_vec();
+
+    // Initialize the manifest from the starting segment set and attach it to the holder, like a
+    // freshly built shard would. From here on the holder keeps it in sync automatically.
+    let manifest_path = dir.path().join("manifest.json");
+    let manifest = Arc::new(
+        SaveOnDisk::new(
+            manifest_path.clone(),
+            SegmentsManifest::from_segment_holder(&holder),
+        )
+        .unwrap(),
+    );
+    holder.set_segment_manifest(Some(manifest));
+
+    let merge_optimizer: Arc<Optimizer> =
+        Arc::new(get_merge_optimizer(dir.path(), temp_dir.path(), dim, None));
+    let indexing_optimizer: Arc<Optimizer> =
+        Arc::new(get_indexing_optimizer(dir.path(), temp_dir.path(), dim));
+    let optimizers = Arc::new(vec![merge_optimizer, indexing_optimizer]);
+
+    let optimizers_log = Arc::new(Mutex::new(Default::default()));
+    let total_optimized_points = Arc::new(AtomicUsize::new(0));
+    let segments = LockedSegmentHolder::new(holder);
+
+    // Drain all scheduled optimizations (may take several rounds under a tight CPU budget).
+    loop {
+        let handles = UpdateWorkers::launch_optimization(
+            optimizers.clone(),
+            optimizers_log.clone(),
+            total_optimized_points.clone(),
+            &ResourceBudget::default(),
+            segments.clone(),
+            || {},
+            None,
+        );
+        if handles.is_empty() {
+            break;
+        }
+        let join_res = join_all(handles.into_iter().map(|x| x.join_handle).collect_vec()).await;
+        for res in join_res {
+            assert!(res.is_ok());
+        }
+    }
+
+    // Sanity: an optimization actually happened, otherwise the test is vacuous.
+    assert!(total_optimized_points.load(Ordering::Relaxed) > 0);
+
+    // The persisted manifest must reflect exactly the live segment set: never missing a live
+    // segment, never referencing a deleted one.
+    let persisted: SegmentsManifest = common::fs::read_json(&manifest_path).unwrap();
+    let live = SegmentsManifest::from_segment_holder(&segments.read());
+    assert_eq!(
+        persisted, live,
+        "persisted manifest must match the live segment set after optimization",
+    );
+
+    // Explicitly assert the optimized-away segments (deleted from disk) are not referenced.
+    for uuid in &optimized_away_uuids {
+        assert!(
+            persisted.get(uuid).is_none(),
+            "manifest must not reference an optimized-away (deleted) segment {uuid}",
+        );
+    }
+    assert!(!persisted.is_empty());
+}
+
 #[tokio::test]
 async fn test_cancel_optimization() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
@@ -336,6 +439,90 @@ async fn test_new_segment_when_all_over_capacity() {
     )
     .unwrap();
     assert_eq!(segments.read().len(), 7);
+}
+
+/// Regression test: when a new appendable segment is created at runtime because all existing
+/// appendable segments are over capacity, it must be registered in the manifest *before* it
+/// becomes a live write target. The holder does this automatically when the segment is added; this
+/// test calls `ensure_appendable_segment_with_capacity` in isolation (no worker loop, so the lazy
+/// backstop never runs), so the holder's in-place registration is the only thing keeping it correct.
+#[tokio::test]
+async fn ensure_appendable_segment_registers_in_manifest() {
+    use std::collections::HashSet;
+
+    use shard::segment_manifest::SegmentsManifest;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dim = 256;
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(dim as u64, Distance::Dot).build()),
+        ..CollectionParams::empty()
+    };
+    // Tiny max segment size so all existing segments are considered over capacity.
+    let optimizer_thresholds = OptimizerThresholds {
+        max_segment_size_kb: 1,
+        memmap_threshold_kb: 1_000_000,
+        indexing_threshold_kb: 1_000_000,
+        deferred_internal_id: None,
+    };
+    let hnsw_config = Default::default();
+    let segment_config =
+        build_segment_optimizer_config(&collection_params, &hnsw_config, &Default::default());
+
+    let payload_schema_file = dir.path().join("payload.schema");
+    let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_schema_file).unwrap());
+
+    let mut holder = SegmentHolder::default();
+    for _ in 0..3 {
+        holder.add_new(random_segment(dir.path(), 100, 3, dim));
+    }
+
+    let initial_uuids: HashSet<_> = holder
+        .iter()
+        .map(|(_, seg)| seg.get().read().segment_uuid())
+        .collect();
+
+    // Initialize the manifest from the starting segment set and attach it to the holder, like a
+    // freshly built shard would.
+    let manifest_path = dir.path().join("manifest.json");
+    let manifest = Arc::new(
+        SaveOnDisk::new(
+            manifest_path.clone(),
+            SegmentsManifest::from_segment_holder(&holder),
+        )
+        .unwrap(),
+    );
+    holder.set_segment_manifest(Some(manifest));
+
+    let segments = LockedSegmentHolder::new(holder);
+
+    UpdateWorkers::ensure_appendable_segment_with_capacity(
+        &segments,
+        dir.path(),
+        &segment_config,
+        &optimizer_thresholds,
+        payload_index_schema,
+    )
+    .unwrap();
+
+    // A new appendable segment must have been created.
+    assert_eq!(segments.read().len(), initial_uuids.len() + 1);
+
+    // It must already be in the persisted manifest, which must match the live segment set exactly:
+    // never missing a live (writable) segment.
+    let persisted: SegmentsManifest = common::fs::read_json(&manifest_path).unwrap();
+    let live = SegmentsManifest::from_segment_holder(&segments.read());
+    assert_eq!(
+        persisted, live,
+        "manifest must include the newly created appendable segment",
+    );
+
+    // Sanity: the manifest grew by exactly the new segment and still lists the originals.
+    assert_eq!(persisted.len(), initial_uuids.len() + 1);
+    for uuid in &initial_uuids {
+        assert!(persisted.get(uuid).is_some());
+    }
 }
 
 #[test]

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod hw_metrics;
 mod payload;
 mod points_dedup;
 mod query_prefetch_offset_limit;
+mod segment_manifest;
 mod sha_256_test;
 mod shard_query;
 mod shard_telemetry;

--- a/lib/collection/src/tests/segment_manifest.rs
+++ b/lib/collection/src/tests/segment_manifest.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use common::budget::ResourceBudget;
+use common::flags::{FeatureFlags, init_feature_flags};
+use common::fs::read_json;
+use common::save_on_disk::SaveOnDisk;
+use shard::files::segment_manifest_path;
+use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
+use tempfile::Builder;
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::shards::local_shard::LocalShard;
+use crate::tests::fixtures::create_collection_config;
+
+/// With the `write_segment_manifest` flag enabled, building a shard writes `segments/manifest.json`
+/// listing the shard's segments as `active`.
+#[tokio::test]
+#[allow(clippy::field_reassign_with_default)]
+async fn writes_segment_manifest_when_flag_enabled() {
+    let mut flags = FeatureFlags::default();
+    flags.write_segment_manifest = true;
+    init_feature_flags(flags);
+
+    let collection_dir = Builder::new().prefix("segment-manifest").tempdir().unwrap();
+    let payload_schema_dir = Builder::new().prefix("payload-schema").tempdir().unwrap();
+    let config = create_collection_config();
+
+    let payload_index_schema = Arc::new(
+        SaveOnDisk::load_or_init_default(payload_schema_dir.path().join("payload-schema.json"))
+            .unwrap(),
+    );
+
+    let _shard = LocalShard::build(
+        0,
+        "segment_manifest_test".to_string(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        Handle::current(),
+        AdaptiveSearchHandle::current_for_tests(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Skip when the global flag wasn't actually applied (another test in this process initialized
+    // the feature flags first); the assertions below only hold with the flag enabled.
+    if !common::flags::feature_flags().write_segment_manifest {
+        return;
+    }
+
+    let manifest_path = segment_manifest_path(collection_dir.path());
+    assert!(
+        manifest_path.exists(),
+        "manifest.json should be written when the flag is enabled",
+    );
+
+    let manifest: SegmentsManifest = read_json(&manifest_path).unwrap();
+    assert!(
+        !manifest.is_empty(),
+        "manifest should list at least the appendable segment",
+    );
+    for (_uuid, state) in manifest.iter() {
+        assert_eq!(*state, SegmentManifestState::Active);
+    }
+}

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -10,6 +10,7 @@ use parking_lot::Mutex;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_manifest::SegmentsManifest;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::{Mutex as TokioMutex, oneshot, watch};
@@ -76,6 +77,7 @@ pub struct UpdateHandler {
     collection_name: CollectionId,
     shared_storage_config: Arc<SharedStorageConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+    segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
     /// List of used optimizers
     pub optimizers: Arc<Vec<Arc<Optimizer>>>,
     /// Log of optimizer statuses
@@ -142,6 +144,7 @@ impl UpdateHandler {
         collection_name: CollectionId,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizers_log: Arc<Mutex<TrackerLog>>,
         total_optimized_points: Arc<AtomicUsize>,
@@ -162,6 +165,7 @@ impl UpdateHandler {
             collection_name,
             shared_storage_config,
             payload_index_schema,
+            segment_manifest,
             optimizers,
             segments,
             update_worker: None,
@@ -208,6 +212,7 @@ impl UpdateHandler {
                 self.max_optimization_threads,
                 self.has_triggered_optimizers.clone(),
                 self.payload_index_schema.clone(),
+                self.segment_manifest.clone(),
                 self.scroll_read_lock.clone(),
                 self.update_tracker.clone(),
                 optimization_finished_sender,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -10,7 +10,6 @@ use parking_lot::Mutex;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
-use shard::segment_manifest::SegmentsManifest;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::{Mutex as TokioMutex, oneshot, watch};
@@ -77,7 +76,6 @@ pub struct UpdateHandler {
     collection_name: CollectionId,
     shared_storage_config: Arc<SharedStorageConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-    segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
     /// List of used optimizers
     pub optimizers: Arc<Vec<Arc<Optimizer>>>,
     /// Log of optimizer statuses
@@ -144,7 +142,6 @@ impl UpdateHandler {
         collection_name: CollectionId,
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
         optimizers_log: Arc<Mutex<TrackerLog>>,
         total_optimized_points: Arc<AtomicUsize>,
@@ -165,7 +162,6 @@ impl UpdateHandler {
             collection_name,
             shared_storage_config,
             payload_index_schema,
-            segment_manifest,
             optimizers,
             segments,
             update_worker: None,
@@ -212,7 +208,6 @@ impl UpdateHandler {
                 self.max_optimization_threads,
                 self.has_triggered_optimizers.clone(),
                 self.payload_index_schema.clone(),
-                self.segment_manifest.clone(),
                 self.scroll_read_lock.clone(),
                 self.update_tracker.clone(),
                 optimization_finished_sender,

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -15,6 +15,7 @@ use shard::operations::optimization::OptimizerThresholds;
 use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_manifest::SegmentsManifest;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{Mutex as TokioMutex, watch};
 use tokio::task;
@@ -55,6 +56,7 @@ impl UpdateWorkers {
         max_handles: Option<usize>,
         has_triggered_optimizers: Arc<AtomicBool>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         optimization_finished_sender: watch::Sender<()>,
@@ -121,6 +123,11 @@ impl UpdateWorkers {
                 log::error!("Failed to ensure there are appendable segments with capacity: {err}");
                 panic!("Failed to ensure there are appendable segments with capacity: {err}");
             }
+
+            // Keep the segment manifest in sync with the live segment set. This wake-up follows a
+            // completed optimization (reaped above by `cleanup_optimization_handles`) and/or a new
+            // appendable segment, both of which change the set; the helper no-ops if it didn't.
+            update_segment_manifest(&segment_manifest, &segments);
 
             // If not forcing, wait on next signal if we have too many handles
             if !ignore_max_handles && optimization_handles.lock().await.len() >= max_handles {
@@ -532,5 +539,28 @@ impl UpdateWorkers {
             }
         };
         Ok(0)
+    }
+}
+
+/// Rewrite the segment manifest (`segments/manifest.json`) to match the live segment set, if the
+/// `write_segment_manifest` feature flag is enabled (i.e. `segment_manifest` is `Some`).
+///
+/// Idempotent and cheap: it reads the current segment UUIDs and only writes when they differ from
+/// the persisted manifest, so it is safe to call on every optimizer wake-up.
+fn update_segment_manifest(
+    segment_manifest: &Option<Arc<SaveOnDisk<SegmentsManifest>>>,
+    segments: &LockedSegmentHolder,
+) {
+    let Some(segment_manifest) = segment_manifest else {
+        return;
+    };
+
+    let current = SegmentsManifest::from_segment_holder(&segments.read());
+    if *segment_manifest.read() == current {
+        return;
+    }
+
+    if let Err(err) = segment_manifest.write(|manifest| *manifest = current) {
+        log::error!("Failed to write segment manifest: {err}");
     }
 }

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -15,7 +15,6 @@ use shard::operations::optimization::OptimizerThresholds;
 use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
-use shard::segment_manifest::SegmentsManifest;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{Mutex as TokioMutex, watch};
 use tokio::task;
@@ -56,7 +55,6 @@ impl UpdateWorkers {
         max_handles: Option<usize>,
         has_triggered_optimizers: Arc<AtomicBool>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-        segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         optimization_finished_sender: watch::Sender<()>,
@@ -124,10 +122,13 @@ impl UpdateWorkers {
                 panic!("Failed to ensure there are appendable segments with capacity: {err}");
             }
 
-            // Keep the segment manifest in sync with the live segment set. This wake-up follows a
-            // completed optimization (reaped above by `cleanup_optimization_handles`) and/or a new
-            // appendable segment, both of which change the set; the helper no-ops if it didn't.
-            update_segment_manifest(&segment_manifest, &segments);
+            // Backstop: reconcile the segment manifest with the live segment set. Registration
+            // normally happens at each publication site via the `NewSegmentToken`; this wake-up is
+            // the recovery path that picks up any registration that was skipped (e.g. an ignored
+            // token). No-op if already in sync.
+            if let Err(err) = segments.read().sync_segment_manifest(None) {
+                log::error!("Failed to write segment manifest: {err}");
+            }
 
             // If not forcing, wait on next signal if we have too many handles
             if !ignore_max_handles && optimization_handles.lock().await.len() >= max_handles {
@@ -472,13 +473,15 @@ impl UpdateWorkers {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");
 
             let segments_guard = segments.upgradable_read();
-            let new_segment = segments_guard.build_tmp_segment(
+            // Building the segment yields a `NewSegmentToken` obliging us to register it.
+            let (new_segment, token) = segments_guard.build_tmp_segment(
                 segments_path,
                 Some(segment_config.plain_segment_config()),
                 payload_index_schema,
                 thresholds_config.deferred_internal_id,
                 true,
             )?;
+            segments_guard.sync_segment_manifest(Some(token))?;
             let mut write_guard = parking_lot::RwLockUpgradableReadGuard::upgrade(segments_guard);
             write_guard.add_new_locked(new_segment);
         }
@@ -539,28 +542,5 @@ impl UpdateWorkers {
             }
         };
         Ok(0)
-    }
-}
-
-/// Rewrite the segment manifest (`segments/manifest.json`) to match the live segment set, if the
-/// `write_segment_manifest` feature flag is enabled (i.e. `segment_manifest` is `Some`).
-///
-/// Idempotent and cheap: it reads the current segment UUIDs and only writes when they differ from
-/// the persisted manifest, so it is safe to call on every optimizer wake-up.
-fn update_segment_manifest(
-    segment_manifest: &Option<Arc<SaveOnDisk<SegmentsManifest>>>,
-    segments: &LockedSegmentHolder,
-) {
-    let Some(segment_manifest) = segment_manifest else {
-        return;
-    };
-
-    let current = SegmentsManifest::from_segment_holder(&segments.read());
-    if *segment_manifest.read() == current {
-        return;
-    }
-
-    if let Err(err) = segment_manifest.write(|manifest| *manifest = current) {
-        log::error!("Failed to write segment manifest: {err}");
     }
 }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -31,6 +31,10 @@ pub struct FeatureFlags {
 
     /// Use io_uring-based payload storage implementation.
     pub async_payload_storage: bool,
+
+    /// Write a segment manifest (`segments/manifest.json`) listing the shard's segments and their
+    /// state, so out-of-process readers can discover segments without scanning the filesystem.
+    pub write_segment_manifest: bool,
 }
 
 impl Default for FeatureFlags {
@@ -41,6 +45,7 @@ impl Default for FeatureFlags {
             appendable_quantization: true,
             single_file_mmap_vector_storage: true,
             async_payload_storage: false,
+            write_segment_manifest: false,
         }
     }
 }
@@ -58,6 +63,7 @@ impl FeatureFlags {
             appendable_quantization: true,
             single_file_mmap_vector_storage: true,
             async_payload_storage: true,
+            write_segment_manifest: true,
         }
     }
 }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -35,6 +35,10 @@ pub struct FeatureFlags {
     /// Write a segment manifest (`segments/manifest.json`) listing the shard's segments and their
     /// state, so out-of-process readers can discover segments without scanning the filesystem.
     pub write_segment_manifest: bool,
+
+    /// Build new segments in append-only mode: in-place point mutations become clone-and-tombstone
+    /// appends instead. Intended for testing the append-only storage path.
+    pub append_only_mutations: bool,
 }
 
 impl Default for FeatureFlags {
@@ -46,6 +50,7 @@ impl Default for FeatureFlags {
             single_file_mmap_vector_storage: true,
             async_payload_storage: false,
             write_segment_manifest: false,
+            append_only_mutations: false,
         }
     }
 }
@@ -64,6 +69,9 @@ impl FeatureFlags {
             single_file_mmap_vector_storage: true,
             async_payload_storage: true,
             write_segment_manifest: true,
+            // Deliberately not enabled by `all`: this is a test-only escape hatch that changes
+            // mutation semantics, and `all` is enabled in dev and e2e configs.
+            append_only_mutations: false,
         }
     }
 }

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -91,7 +91,7 @@ fn make_segment_index<R: Rng + ?Sized>(rng: &mut R, distance: Distance) -> HNSWI
 
     let hw_counter = HardwareCounterCell::new();
 
-    let mut segment = build_segment(segment_dir.path(), &segment_config, None, true).unwrap();
+    let (mut segment, _) = build_segment(segment_dir.path(), &segment_config, None, true).unwrap();
     for n in 0..NUM_POINTS {
         let idx = (n as u64).into();
         let multi_vec = random_multi_vector(rng, VECTOR_DIM, NUM_VECTORS_PER_POINT);

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -40,7 +40,7 @@ fn build_immutable_segment(segments_path: &Path, temp_path: &Path) -> Segment {
     let hw = HardwareCounterCell::new();
 
     let source_dir = Builder::new().prefix("ro_source").tempdir().unwrap();
-    let mut source = build_segment(
+    let (mut source, _) = build_segment(
         source_dir.path(),
         &SegmentConfig {
             vector_data: HashMap::from([(

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -776,7 +776,7 @@ fn create_deferred_segment(
     let deferred_internal_id = (n_deferred > 0).then_some(n_vectors as PointOffsetType);
 
     let total_vectors = n_vectors + n_deferred;
-    let mut segment = build_segment(
+    let (mut segment, _) = build_segment(
         dir.path(),
         &SegmentConfig {
             vector_data: HashMap::from([(
@@ -1215,7 +1215,7 @@ fn test_deferred_point_with_behavior_accessors() {
     let dim = 4;
 
     // Threshold so any new point lands beyond the cutoff (deferred).
-    let mut segment = build_segment(
+    let (mut segment, _) = build_segment(
         dir.path(),
         &SegmentConfig {
             vector_data: HashMap::from([(

--- a/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
+++ b/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
@@ -85,7 +85,7 @@ fn build_immutable_segment_with_indexed_payload(segments_path: &Path, temp_path:
 
     // Step 1: appendable source segment with payload + field indices.
     let source_dir = Builder::new().prefix("source_seg").tempdir().unwrap();
-    let mut source = build_segment(
+    let (mut source, _) = build_segment(
         source_dir.path(),
         &SegmentConfig {
             vector_data: HashMap::from([(

--- a/lib/segment/src/segment/tests/test_vector_name_ops.rs
+++ b/lib/segment/src/segment/tests/test_vector_name_ops.rs
@@ -68,7 +68,7 @@ fn hw() -> HardwareCounterCell {
 
 /// Build an appendable segment with NUM_POINTS points on the default vector.
 fn build_appendable_segment_with_data(path: &std::path::Path) -> Segment {
-    let mut segment = build_segment(
+    let (mut segment, _) = build_segment(
         path,
         &SegmentConfig {
             vector_data: HashMap::from([(

--- a/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
@@ -157,10 +157,7 @@ pub(super) fn create_segment(
         vector_data,
         segment_type,
         appendable_flag,
-        // Debug-only escape hatch — `QDRANT_APPEND_ONLY_MUTATIONS=1` flips
-        // newly built segments into append-only mode for test runs.
-        append_only_mutations: cfg!(debug_assertions)
-            && std::env::var("QDRANT_APPEND_ONLY_MUTATIONS").ok() == Some("1".to_string()),
+        append_only_mutations: common::flags::feature_flags().append_only_mutations,
         payload_index,
         payload_storage,
         segment_config: config.clone(),

--- a/lib/segment/src/segment_constructor/segment_constructor_base/mod.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/mod.rs
@@ -34,7 +34,7 @@ pub use paths::{
     get_vector_name_with_prefix, get_vector_storage_path,
 };
 pub(crate) use payload_storage::create_payload_storage;
-pub use segment::{build_segment, load_segment, normalize_segment_dir};
+pub use segment::{NewSegmentToken, build_segment, load_segment, normalize_segment_dir};
 #[cfg(feature = "testing")]
 pub use sparse_vector_index::create_sparse_vector_index_test;
 pub(crate) use sparse_vector_index::open_or_create_sparse_vector_index;

--- a/lib/segment/src/segment_constructor/segment_constructor_base/segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/segment.rs
@@ -17,6 +17,31 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::segment::{Segment, SegmentVersion};
 use crate::types::SegmentConfig;
 
+/// Proof that a segment was just built, obliging the builder to register it in the segment manifest.
+///
+/// Returned by [`build_segment`] (and the shard-level builders that wrap it). The `#[must_use]` lint
+/// turns "built a segment but forgot to register it" into a compiler warning: discharge it by
+/// registering the segment (its [`id`](Self::id) is the segment UUID), or drop it explicitly
+/// (`let _ = token`) for segments that will not join a manifest-tracked holder (loading, tests,
+/// transient segments).
+///
+/// Carries only the segment UUID; there is deliberately no `Drop` bomb — the lint is the enforcement.
+#[must_use = "a newly built segment must be registered in the segment manifest, or explicitly dropped"]
+pub struct NewSegmentToken(Uuid);
+
+impl NewSegmentToken {
+    /// Mint a token for a freshly built segment. Restricted to this crate so the obligation can
+    /// only originate from a real segment build ([`build_segment`]).
+    pub(crate) fn new(uuid: Uuid) -> Self {
+        NewSegmentToken(uuid)
+    }
+
+    /// UUID of the newly built segment, to register in the manifest.
+    pub fn id(&self) -> Uuid {
+        self.0
+    }
+}
+
 /// Normalize segment directory.
 ///
 /// Might delete or rename the directory.
@@ -161,8 +186,10 @@ pub fn build_segment(
     config: &SegmentConfig,
     deferred_internal_id: Option<PointOffsetType>,
     ready: bool,
-) -> OperationResult<Segment> {
+) -> OperationResult<(Segment, NewSegmentToken)> {
     let uuid = Uuid::new_v4();
+    let token = NewSegmentToken::new(uuid);
+
     let segment_path = segments_path.join(uuid.to_string());
     let stopped = AtomicBool::new(false);
 
@@ -185,5 +212,5 @@ pub fn build_segment(
         SegmentVersion::save(&segment_path)?;
     }
 
-    Ok(segment)
+    Ok((segment, token))
 }

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -45,6 +45,7 @@ pub fn build_simple_segment(
         None,
         true,
     )
+    .map(|(segment, _token)| segment)
 }
 
 pub fn build_simple_segment_with_payload_storage(
@@ -74,6 +75,7 @@ pub fn build_simple_segment_with_payload_storage(
         None,
         true,
     )
+    .map(|(segment, _token)| segment)
 }
 
 pub fn build_multivec_segment(
@@ -118,6 +120,7 @@ pub fn build_multivec_segment(
         None,
         true,
     )
+    .map(|(segment, _token)| segment)
 }
 
 #[cfg(test)]

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -100,7 +100,7 @@ fn test_byte_storage_hnsw(
     let int_key = "int";
 
     let mut segment_float = build_simple_segment(dir_float.path(), dim, distance).unwrap();
-    let mut segment_byte = build_segment(dir_byte.path(), &config_byte, None, true).unwrap();
+    let (mut segment_byte, _) = build_segment(dir_byte.path(), &config_byte, None, true).unwrap();
     // check that `segment_byte` uses byte or half storage
     {
         let borrowed_storage = segment_byte.vector_data[DEFAULT_VECTOR_NAME]

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -240,7 +240,7 @@ fn test_byte_storage_binary_quantization_hnsw(
 
     let int_key = "int";
 
-    let mut segment_byte = build_segment(dir_byte.path(), &config_byte, None, true).unwrap();
+    let (mut segment_byte, _) = build_segment(dir_byte.path(), &config_byte, None, true).unwrap();
     // check that `segment_byte` uses byte or half storage
     {
         let borrowed_storage = segment_byte.vector_data[DEFAULT_VECTOR_NAME]

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -128,7 +128,7 @@ pub fn build_segment_2(path: &Path) -> Segment {
 }
 
 pub fn build_segment_3(path: &Path) -> Segment {
-    let mut segment3 = build_segment(
+    let (mut segment3, _) = build_segment(
         path,
         &SegmentConfig {
             vector_data: HashMap::from([
@@ -255,7 +255,7 @@ pub fn build_segment_3(path: &Path) -> Segment {
 }
 
 pub fn build_segment_sparse_1(path: &Path) -> Segment {
-    let mut segment1 = build_segment(
+    let (mut segment1, _) = build_segment(
         path,
         &SegmentConfig {
             vector_data: Default::default(),
@@ -349,7 +349,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
 }
 
 pub fn build_segment_sparse_2(path: &Path) -> Segment {
-    let mut segment2 = build_segment(
+    let (mut segment2, _) = build_segment(
         path,
         &SegmentConfig {
             vector_data: Default::default(),

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -84,7 +84,7 @@ fn test_multi_filterable_hnsw(
 
     let hw_counter = HardwareCounterCell::new();
 
-    let mut segment = build_segment(dir.path(), &config, None, true).unwrap();
+    let (mut segment, _) = build_segment(dir.path(), &config, None, true).unwrap();
     for n in 0..num_points {
         let idx = n.into();
         // Random number of vectors per multivec point

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -224,7 +224,7 @@ fn test_multivector_quantization_hnsw(
 
     let int_key = "int";
 
-    let mut segment = build_segment(dir.path(), &config, None, true).unwrap();
+    let (mut segment, _) = build_segment(dir.path(), &config, None, true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -88,9 +88,9 @@ impl TestSegments {
 
         let config = Self::make_simple_config(true);
 
-        let mut plain_segment =
+        let (mut plain_segment, _) =
             build_segment(&base_dir.path().join("plain"), &config, None, true).unwrap();
-        let mut struct_segment =
+        let (mut struct_segment, _) =
             build_segment(&base_dir.path().join("struct"), &config, None, true).unwrap();
 
         let num_points = 3000;

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -615,7 +615,7 @@ fn test_segment_builder_rejects_source_with_extra_vector_name() {
     );
     drop(template);
     let source_dir2 = Builder::new().prefix("segment_source2").tempdir().unwrap();
-    let mut source = build_segment(source_dir2.path(), &source_config, None, true).unwrap();
+    let (mut source, _) = build_segment(source_dir2.path(), &source_config, None, true).unwrap();
     for i in 0..3u64 {
         let vectors = NamedVectors::from_pairs([
             (DEFAULT_VECTOR_NAME.to_owned(), vec![0.5, 0.5, 0.5, 0.5]),

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -153,8 +153,8 @@ fn sparse_index_discover_test() {
         sparse_vector_data: Default::default(),
     };
 
-    let mut sparse_segment = build_segment(dir.path(), &sparse_config, None, true).unwrap();
-    let mut dense_segment = build_segment(dir.path(), &dense_config, None, true).unwrap();
+    let (mut sparse_segment, _) = build_segment(dir.path(), &sparse_config, None, true).unwrap();
+    let (mut dense_segment, _) = build_segment(dir.path(), &dense_config, None, true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -276,7 +276,7 @@ fn sparse_index_hardware_measurement_test() {
         payload_storage_type: Default::default(),
     };
 
-    let mut sparse_segment = build_segment(dir.path(), &sparse_config, None, true).unwrap();
+    let (mut sparse_segment, _) = build_segment(dir.path(), &sparse_config, None, true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -609,7 +609,7 @@ fn sparse_vector_index_persistence_test() {
         )]),
         payload_storage_type: Default::default(),
     };
-    let mut segment = build_segment(dir.path(), &config, None, true).unwrap();
+    let (mut segment, _) = build_segment(dir.path(), &config, None, true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -785,7 +785,7 @@ fn sparse_vector_test_large_index() {
         )]),
         payload_storage_type: Default::default(),
     };
-    let mut segment = build_segment(dir.path(), &config, None, true).unwrap();
+    let (mut segment, _) = build_segment(dir.path(), &config, None, true).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/shard/src/files/mod.rs
+++ b/lib/shard/src/files/mod.rs
@@ -4,6 +4,8 @@ use fs_err as fs;
 
 pub const WAL_PATH: &str = "wal";
 pub const SEGMENTS_PATH: &str = "segments";
+/// Segment manifest, written inside the `segments/` directory.
+pub const SEGMENT_MANIFEST_FILE: &str = "manifest.json";
 pub const NEWEST_CLOCKS_PATH: &str = "newest_clocks.json";
 pub const OLDEST_CLOCKS_PATH: &str = "oldest_clocks.json";
 pub const APPLIED_SEQ_FILE: &str = "applied_seq.json";
@@ -22,6 +24,12 @@ pub struct ShardDataFiles {
 #[inline]
 pub fn segments_path(shard_path: &Path) -> PathBuf {
     shard_path.join(SEGMENTS_PATH)
+}
+
+/// Path to the segment manifest (`segments/manifest.json`) for a shard.
+#[inline]
+pub fn segment_manifest_path(shard_path: &Path) -> PathBuf {
+    segments_path(shard_path).join(SEGMENT_MANIFEST_FILE)
 }
 
 #[inline]

--- a/lib/shard/src/fixtures.rs
+++ b/lib/shard/src/fixtures.rs
@@ -192,6 +192,7 @@ pub fn empty_segment_with_deferred(path: &Path, deferred_internal_id: u32) -> Se
         true,
     )
     .unwrap()
+    .0
 }
 
 /// Builds a segment with a deferred threshold that causes points 4 and 5 to be deferred, while points 1, 2, and 3 are not deferred.
@@ -207,7 +208,7 @@ pub fn build_segment_with_deferred_1(path: &Path) -> Segment {
     let hw_counter = HardwareCounterCell::new();
 
     // Build segment with deferred threshold
-    let mut segment = build_segment(
+    let (mut segment, _) = build_segment(
         path,
         &segment::types::SegmentConfig {
             vector_data: HashMap::from([(

--- a/lib/shard/src/lib.rs
+++ b/lib/shard/src/lib.rs
@@ -15,6 +15,7 @@ pub mod scroll;
 pub mod search;
 pub mod search_result_aggregator;
 pub mod segment_holder;
+pub mod segment_manifest;
 pub mod snapshots;
 pub mod tracker;
 pub mod update;

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -41,6 +41,7 @@ use crate::proxy_segment::{
 };
 use crate::segment_holder::SegmentId;
 use crate::segment_holder::locked::LockedSegmentHolder;
+use crate::segment_manifest::NewSegmentToken;
 
 /// Result of optimization execution
 #[derive(Debug)]
@@ -69,7 +70,10 @@ pub trait OptimizationStrategy: Send {
     ) -> OperationResult<SegmentBuilder>;
 
     /// Create a temporary COW segment for writes during optimization.
-    fn create_temp_segment(&self) -> OperationResult<LockedSegment>;
+    ///
+    /// Returns the segment together with the [`NewSegmentToken`] obliging the caller to register it
+    /// in the manifest once it is published into the holder.
+    fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)>;
 }
 
 /// Restores original segments from proxies
@@ -583,6 +587,11 @@ fn finish_optimization(
             .try_for_each(|chunk| read_segment_holder.deduplicate_points(chunk, hw_counter))?;
     }
 
+    // It is important to update manifest before we drop proxy data,
+    // as we don't want to have a situation, where new segment is not yet registered, but
+    // old segment data is already dropped.
+    read_segment_holder.sync_segment_manifest(None)?;
+
     drop(read_segment_holder);
     // Allow updates again
     drop(update_guard);
@@ -746,9 +755,14 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
 
     let hw_counter = HardwareCounterCell::disposable();
 
-    let extra_cow_segment_opt = need_extra_cow_segment
-        .then(|| factory.create_temp_segment())
-        .transpose()?;
+    // Building the cow segment yields a `NewSegmentToken`; we register it below, once it is added to
+    // the holder, and before the slow build can route writes into it.
+    let (extra_cow_segment_opt, extra_cow_token_opt) = if need_extra_cow_segment {
+        let (segment, token) = factory.create_temp_segment()?;
+        (Some(segment), Some(token))
+    } else {
+        (None, None)
+    };
 
     let mut proxies = Vec::new();
     for sg in input_segments.iter() {
@@ -765,6 +779,9 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     // If this ends up not being saved due to a crash, the segment will not be used
     match &extra_cow_segment_opt {
         Some(LockedSegment::Original(segment)) => {
+            // Register the freshly added cow segment in the manifest before we save the version,
+            // it guarantees that no writes will happen into unregistered segment.
+            segment_holder_read.sync_segment_manifest(extra_cow_token_opt)?;
             let segment_path = &segment.read().segment_path;
             SegmentVersion::save(segment_path)?;
         }

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -25,6 +25,7 @@ use crate::operations::optimization::OptimizerThresholds;
 use crate::optimize::{OptimizationPaths, OptimizationStrategy, execute_optimization};
 use crate::segment_holder::locked::LockedSegmentHolder;
 use crate::segment_holder::{SegmentHolder, SegmentId};
+use crate::segment_manifest::NewSegmentToken;
 
 const BYTES_IN_KB: usize = 1024;
 
@@ -57,7 +58,7 @@ impl<O: SegmentOptimizer + ?Sized> OptimizationStrategy for ShardOptimizationStr
         self.optimizer.optimized_segment_builder(input_segments)
     }
 
-    fn create_temp_segment(&self) -> OperationResult<LockedSegment> {
+    fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)> {
         self.optimizer.temp_segment(false)
     }
 }
@@ -137,14 +138,19 @@ pub trait SegmentOptimizer: Sync {
     fn get_telemetry_counter(&self) -> &Mutex<OperationDurationsAggregator>;
 
     /// Build temp segment
-    fn temp_segment(&self, save_version: bool) -> OperationResult<LockedSegment> {
+    fn temp_segment(
+        &self,
+        save_version: bool,
+    ) -> OperationResult<(LockedSegment, NewSegmentToken)> {
         let config = self.segment_optimizer_config().plain_segment_config();
-        Ok(LockedSegment::new(build_segment(
+        let (segment, token) = build_segment(
             self.segments_path(),
             &config,
             self.threshold_config().deferred_internal_id,
             save_version,
-        )?))
+        )?;
+        let segment = LockedSegment::new(segment);
+        Ok((segment, token))
     }
 
     /// Build optimized segment

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -35,6 +35,7 @@ use smallvec::SmallVec;
 
 use crate::locked_segment::LockedSegment;
 use crate::payload_index_schema::PayloadIndexSchema;
+use crate::segment_manifest::{NewSegmentToken, SegmentsManifest};
 
 pub type SegmentId = usize;
 
@@ -74,6 +75,16 @@ pub struct SegmentHolder {
 
     /// The amount of currently running optimizations.
     pub running_optimizations: ProcessCounter,
+
+    /// On-disk manifest of this shard's segments, kept in sync with the live segment set so that
+    /// out-of-process readers can discover segments. `None` when the `write_segment_manifest`
+    /// feature flag is off (or before the holder has been wired up, e.g. during loading).
+    ///
+    /// The manifest is owned here, by the single source of truth for segment membership, precisely
+    /// so that no segment can be added or removed without the manifest following: every mutation
+    /// funnels through [`add_existing_locked`](Self::add_existing_locked) and
+    /// [`remove`](Self::remove), which reconcile it.
+    segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
 }
 
 impl Drop for SegmentHolder {
@@ -81,6 +92,45 @@ impl Drop for SegmentHolder {
         if let Err(flushing_err) = self.lock_flushing() {
             log::error!("Failed to flush segments holder during drop: {flushing_err}");
         }
+    }
+}
+
+/// Builder for a [`SegmentHolder`] that guarantees its segment manifest is wired up.
+///
+/// The only way to get a finished [`SegmentHolder`] out is [`build`](Self::build), which initializes
+/// the manifest from the populated segment set — so a shard's holder can never be constructed
+/// without it (no separate, easy-to-forget init step). Populate it through the deref to
+/// [`SegmentHolder`] (e.g. [`add_new`](SegmentHolder::add_new)), then call `build`.
+#[must_use = "the segment holder is only created by calling `.build(shard_path)`"]
+pub struct SegmentHolderBuilder {
+    holder: SegmentHolder,
+}
+
+impl SegmentHolderBuilder {
+    fn new() -> Self {
+        Self {
+            holder: SegmentHolder::default(),
+        }
+    }
+
+    /// Finalize: initialize the segment manifest from the current segment set and return the holder.
+    pub fn build(mut self, shard_path: &Path) -> OperationResult<SegmentHolder> {
+        self.holder.init_segment_manifest(shard_path)?;
+        Ok(self.holder)
+    }
+}
+
+impl Deref for SegmentHolderBuilder {
+    type Target = SegmentHolder;
+
+    fn deref(&self) -> &Self::Target {
+        &self.holder
+    }
+}
+
+impl DerefMut for SegmentHolderBuilder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.holder
     }
 }
 
@@ -101,6 +151,55 @@ impl SegmentHolder {
             LockedSegment::Original(original) => Some((id, original)),
             LockedSegment::Proxy(_) => None,
         })
+    }
+
+    /// Start building a holder. The only way to obtain a finished [`SegmentHolder`] from the builder
+    /// is [`SegmentHolderBuilder::build`], which wires up the segment manifest — so a shard's holder
+    /// can never be constructed without it.
+    pub fn builder() -> SegmentHolderBuilder {
+        SegmentHolderBuilder::new()
+    }
+
+    /// Attach a pre-built segment manifest to this holder. Test-only escape hatch; production code
+    /// goes through [`SegmentHolder::builder`] so the manifest is always initialized.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn set_segment_manifest(&mut self, manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>) {
+        self.segment_manifest = manifest;
+    }
+
+    /// Initialize the segment manifest from the current segments and attach it to this holder, when
+    /// the `write_segment_manifest` feature flag is enabled. No-op when disabled.
+    ///
+    /// Private: only [`SegmentHolderBuilder::build`] calls this, right after the holder has been
+    /// populated, so the manifest reflects the initial segment set. From then on the holder keeps it
+    /// in sync.
+    fn init_segment_manifest(&mut self, shard_path: &Path) -> OperationResult<()> {
+        if !common::flags::feature_flags().write_segment_manifest {
+            return Ok(());
+        }
+
+        let manifest = SegmentsManifest::from_segment_holder(self);
+        let manifest = SaveOnDisk::new(crate::files::segment_manifest_path(shard_path), manifest)
+            .map_err(|err| {
+            OperationError::service_error(format!("failed to write segment manifest: {err}"))
+        })?;
+        self.segment_manifest = Some(Arc::new(manifest));
+        Ok(())
+    }
+
+    /// Register a newly built segment in the on-disk manifest, consuming its [`NewSegmentToken`].
+    ///
+    /// The token is produced when a segment is built (e.g. [`build_tmp_segment`](Self::build_tmp_segment));
+    /// its `#[must_use]` marker turns "built a segment but forgot to register it" into a compiler
+    /// warning. Reconciles the manifest with the current live segment set.
+    ///
+    /// No-op when no manifest is attached (feature flag off / not yet wired). Errors propagate so
+    /// callers that gate destructive work (deleting superseded segments from disk) on a fresh
+    /// manifest can abort instead of risking a stale manifest. Idempotent: only writes on change.
+    pub fn sync_segment_manifest(&self, token: Option<NewSegmentToken>) -> OperationResult<()> {
+        // Register the newly built segment ASAP: it exists on disk, so it must be in the manifest,
+        // even if it has not been added to the holder yet (passed as `extra_segment`).
+        SegmentsManifest::sync(self.segment_manifest.as_ref(), self, token.map(|t| t.id()))
     }
 
     pub fn len(&self) -> usize {
@@ -778,13 +877,16 @@ impl SegmentHolder {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<LockedSegment> {
-        let segment = self.build_tmp_segment(
+        let (segment, token) = self.build_tmp_segment(
             segments_path,
             Some(segment_config),
             payload_index_schema,
             deferred_internal_id,
             true,
         )?;
+        // Register the new segment ASAP — it exists on disk, so it must be in the manifest. No-op
+        // when no manifest is attached yet (e.g. during shard load).
+        self.sync_segment_manifest(Some(token))?;
         self.add_new_locked(segment.clone());
         Ok(segment)
     }
@@ -813,7 +915,7 @@ impl SegmentHolder {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         deferred_internal_id: Option<PointOffsetType>,
         save_version: bool,
-    ) -> OperationResult<LockedSegment> {
+    ) -> OperationResult<(LockedSegment, NewSegmentToken)> {
         let config = match segment_config {
             // Base config on collection params
             Some(config) => config,
@@ -832,7 +934,7 @@ impl SegmentHolder {
                 .clone(),
         };
 
-        let mut segment =
+        let (mut segment, token) =
             build_segment(segments_path, &config, deferred_internal_id, save_version)?;
 
         // Internal operation.
@@ -843,7 +945,7 @@ impl SegmentHolder {
             segment.create_field_index(0, key, Some(schema), &hw_counter)?;
         }
 
-        Ok(LockedSegment::new(segment))
+        Ok((LockedSegment::new(segment), token))
     }
 
     /// Method tries to remove the segment with the given ID under the following conditions:

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -48,7 +48,7 @@ impl SegmentHolder {
         let hw_counter = HardwareCounterCell::disposable();
 
         // Create temporary appendable segment to direct all proxy writes into
-        let tmp_segment = segments_lock.build_tmp_segment(
+        let (tmp_segment, tmp_token) = segments_lock.build_tmp_segment(
             segments_path,
             segment_config,
             payload_index_schema,
@@ -75,6 +75,9 @@ impl SegmentHolder {
         // If this ends up not being saved due to a crash, the segment will not be used
         match &tmp_segment {
             LockedSegment::Original(segment) => {
+                // Register the temp segment before saving its version, so it exists in the manifest
+                // before it can receive proxied writes.
+                segments_lock.sync_segment_manifest(Some(tmp_token))?;
                 let segment_path = &segment.read().segment_path;
                 SegmentVersion::save(segment_path)?;
             }

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -1,0 +1,109 @@
+//! The segment manifest (`segments/manifest.json`): a small file listing the shard's segments and
+//! their state, so out-of-process readers (e.g. a read-only follower, possibly over object storage)
+//! can discover segments without scanning the filesystem.
+//!
+//! Defines the on-disk structure and a helper to build it from a [`SegmentHolder`]. The *logic* of
+//! when to write it lives in the owner of the segments (e.g. `LocalShard`).
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::segment_holder::SegmentHolder;
+
+/// State of a segment in the manifest.
+///
+/// Only [`Active`](SegmentManifestState::Active) is written today. The other variants are defined so
+/// the on-disk format can grow to describe in-progress segment transitions without breaking
+/// compatibility for readers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SegmentManifestState {
+    /// Live segment, part of the shard's data and safe to read.
+    Active,
+    /// Reserved for future use: a segment being built that is not yet ready to read.
+    UnderConstruction,
+    /// Reserved for future use: a superseded segment that is still readable but pending removal.
+    Retiring,
+}
+
+/// Contents of `segments/manifest.json`: a flat map of segment UUID to its state, e.g.
+/// `{ "1b4e28ba-...": "active", "6ba7b810-...": "active" }`.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SegmentsManifest {
+    segments: HashMap<Uuid, SegmentManifestState>,
+}
+
+impl SegmentsManifest {
+    /// Build a manifest from the current live segments in the holder, marking every segment
+    /// [`Active`](SegmentManifestState::Active).
+    ///
+    /// Includes segments temporarily wrapped as proxies during optimization — they are still live.
+    pub fn from_segment_holder(holder: &SegmentHolder) -> Self {
+        let segments = holder
+            .iter()
+            .map(|(_, locked_segment)| {
+                let uuid = locked_segment.get_read().read().segment_uuid();
+                (uuid, SegmentManifestState::Active)
+            })
+            .collect();
+        Self { segments }
+    }
+
+    pub fn get(&self, uuid: &Uuid) -> Option<SegmentManifestState> {
+        self.segments.get(uuid).copied()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Uuid, &SegmentManifestState)> {
+        self.segments.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_active_as_snake_case_uuid_map() {
+        let uuid = Uuid::parse_str("1b4e28ba-2fa1-11d2-883f-0016d3cca427").unwrap();
+        let manifest = SegmentsManifest {
+            segments: HashMap::from([(uuid, SegmentManifestState::Active)]),
+        };
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert_eq!(json, r#"{"1b4e28ba-2fa1-11d2-883f-0016d3cca427":"active"}"#);
+
+        let parsed: SegmentsManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, manifest);
+        assert_eq!(parsed.get(&uuid), Some(SegmentManifestState::Active));
+    }
+
+    #[test]
+    fn deserializes_future_states_for_forward_compat() {
+        let active = Uuid::parse_str("1b4e28ba-2fa1-11d2-883f-0016d3cca427").unwrap();
+        let building = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let retiring = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
+
+        let json = format!(
+            r#"{{"{active}":"active","{building}":"under_construction","{retiring}":"retiring"}}"#,
+        );
+        let parsed: SegmentsManifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.get(&active), Some(SegmentManifestState::Active));
+        assert_eq!(
+            parsed.get(&building),
+            Some(SegmentManifestState::UnderConstruction),
+        );
+        assert_eq!(parsed.get(&retiring), Some(SegmentManifestState::Retiring));
+    }
+}

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -6,7 +6,12 @@
 //! when to write it lives in the owner of the segments (e.g. `LocalShard`).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use common::save_on_disk::SaveOnDisk;
+use segment::common::operation_error::{OperationError, OperationResult};
+// Re-exported from `segment` (where `build_segment` mints it) since the manifest is what consumes it.
+pub use segment::segment_constructor::NewSegmentToken;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -30,6 +35,27 @@ pub enum SegmentManifestState {
 
 /// Contents of `segments/manifest.json`: a flat map of segment UUID to its state, e.g.
 /// `{ "1b4e28ba-...": "active", "6ba7b810-...": "active" }`.
+///
+/// # Consistency assumptions (important for readers)
+///
+/// The manifest is *not* an exact, instantaneous snapshot of the on-disk segment set. To guarantee
+/// that no data is ever lost across the non-atomic create/delete transitions, it deliberately errs
+/// on the side of listing more segments than strictly necessary:
+///
+/// - **May list a segment that is not yet fully created.** A new segment is registered here as soon
+///   as it exists on disk — potentially *before* its version file is written (i.e. before it is
+///   finalized). This guarantees a real, writable segment is never missing from the manifest. A
+///   reader must therefore tolerate a listed segment that is incomplete / not yet loadable and skip
+///   it (a segment without a saved version is not ready to read).
+/// - **May list a segment that has already been (or is about to be) deleted.** Removal from the
+///   manifest is intentionally not strict: a superseded segment may linger in the manifest after its
+///   data has been dropped, or be dropped from disk slightly after it leaves the manifest. A reader
+///   must tolerate a listed segment that no longer exists on disk and skip it.
+///
+/// In other words: the manifest is a *superset-biased* view. Over-listing (duplicate/extra segments)
+/// is always safe and is resolved by point versioning during reads; under-listing a live segment is
+/// the only thing that would lose data, and the writer ordering prevents it. Readers must handle
+/// both of the above cases gracefully rather than assuming every listed segment is present and ready.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SegmentsManifest {
@@ -50,6 +76,43 @@ impl SegmentsManifest {
             })
             .collect();
         Self { segments }
+    }
+
+    fn add_extra(&mut self, uuid: Uuid, state: SegmentManifestState) {
+        self.segments.insert(uuid, state);
+    }
+
+    /// Rebuild the manifest from `holder` and persist it if it changed.
+    ///
+    /// No-op when `manifest` is `None` (the `write_segment_manifest` flag is off). Errors
+    /// propagate so callers that gate destructive work (e.g. deleting superseded segments) on a
+    /// fresh manifest can abort instead of risking a stale manifest.
+    ///
+    /// Idempotent and cheap: it only writes when the live segment set differs from what is
+    /// persisted, so it is safe to call on every relevant segment-set transition. Usually invoked
+    /// via [`SegmentHolder::sync_segment_manifest`], which owns the manifest.
+    pub fn sync(
+        manifest: Option<&Arc<SaveOnDisk<SegmentsManifest>>>,
+        holder: &SegmentHolder,
+        extra_segment: Option<Uuid>,
+    ) -> OperationResult<()> {
+        let Some(manifest) = manifest else {
+            return Ok(());
+        };
+
+        let mut current = Self::from_segment_holder(holder);
+        if let Some(uuid) = extra_segment {
+            current.add_extra(uuid, SegmentManifestState::Active);
+        }
+
+        if *manifest.read() == current {
+            return Ok(());
+        }
+
+        manifest.write(|m| *m = current).map_err(|err| {
+            OperationError::service_error(format!("failed to persist segment manifest: {err}"))
+        })?;
+        Ok(())
     }
 
     pub fn get(&self, uuid: &Uuid) -> Option<SegmentManifestState> {


### PR DESCRIPTION
## What

Adds an on-disk **segment manifest** (`segments/manifest.json`) that lists a shard's segments and their state, so out-of-process readers (a read-only follower, possibly over object storage) can discover segments without scanning the filesystem.

Gated by a new `write_segment_manifest` feature flag — **off by default**.

## Format

A flat map of segment UUID → state:

```json
{
  "1b4e28ba-2fa1-11d2-883f-0016d3cca427": "active",
  "6ba7b810-9dad-11d1-80b4-00c04fd430c8": "active"
}
```

Only `active` is written today. `under_construction` and `retiring` are defined in the `SegmentManifestState` enum so the format is **forward-compatible** and can describe in-progress segment transitions later, without breaking readers.

### Consistency model (important for readers)

The manifest is a **superset-biased** view of the on-disk segment set — it deliberately errs toward listing *more* segments than strictly necessary so that no data is ever lost across the non-atomic create/delete transitions:

- It **may list a segment that is not yet fully created** (registered as soon as it exists on disk, possibly before its version file is written). This guarantees a live, writable segment is never missing.
- It **may list a segment that has already been / is about to be deleted** (removal is intentionally not strict).

Under-listing a live segment is the only thing that would lose data, and the writer ordering prevents it. Readers must tolerate listed segments that are incomplete or already gone, and skip them (over-listing is resolved by point versioning during reads).

## Structure (lib/shard)

- `shard::segment_manifest` holds the on-disk types: `SegmentsManifest`, `SegmentManifestState`, and `SegmentsManifest::from_segment_holder(&SegmentHolder)` (every live segment → `active`, proxies included).
- Adds the `SEGMENT_MANIFEST_FILE` constant + `segment_manifest_path()` helper in `shard::files`.
- The manifest is **owned by `SegmentHolder`** (`Option<Arc<SaveOnDisk<SegmentsManifest>>>`), the single source of truth for segment membership, so no segment can be added/removed without the manifest following. `None` when the flag is off or before the holder is wired up (e.g. during load).
- A new `SegmentHolderBuilder` (`SegmentHolder::builder()`) is the only way to construct a shard's holder: `build(shard_path)` initializes the manifest from the populated segment set, so the manifest can never be forgotten.

## The `NewSegmentToken` obligation

Instead of threading per-transition state by hand, a freshly built segment carries proof it must be registered:

- `build_segment` now returns `(Segment, NewSegmentToken)`. The token is `#[must_use]` and carries the segment UUID — "built a segment but forgot to register it" becomes a compiler warning. Discharge it by registering the segment, or drop it explicitly for transient/load/test segments.
- This propagates through all segment-construction sites: shard-level builders (`build_tmp_segment`, `temp_segment`, `create_temp_segment`), the simple-segment constructors, fixtures, benches, and tests (mostly mechanical `let (seg, _) = build_segment(...)` updates).
- `SegmentHolder::sync_segment_manifest(token)` consumes the token and reconciles the manifest with the live set. It's idempotent and **no-ops when the set is unchanged**, and **no-ops when no manifest is attached** (flag off / loading). Errors propagate so callers that gate destructive work on a fresh manifest can abort.

## Logic — registration at each publication site

Registration happens **in-place, before a new segment can take writes or before old data is dropped**, not lazily:

- **lib/shard/src/optimize.rs**: in `execute_optimization`, the temporary COW segment is registered before its version is saved (before writes can route into it); in `finish_optimization`, the manifest is synced **before** proxy data is dropped, so a new segment is never unregistered while the old segment's data is already gone.
- **Snapshotting** (`segment_holder/snapshot.rs`): the temp segment is registered before its version is saved.
- **New appendable segment at runtime** (`optimization_worker.rs` / `ensure_appendable_segment_with_capacity`): registered before it becomes a live write target.
- **Backstop**: on each optimization-worker wake-up, `sync_segment_manifest(None)` reconciles the manifest with the live set as a recovery path for any registration that was skipped (e.g. an ignored token). No-op when already in sync.

## Feature flag

`FeatureFlags::write_segment_manifest` (default `false`). Settable via config/env (`QDRANT__FEATURE_FLAGS__WRITE_SEGMENT_MANIFEST=true`) or `init_feature_flags` in tests. Included in `FeatureFlags::all()`.

## Tests

- `shard::segment_manifest`: serde round-trip to the exact `{ "<uuid>": "active" }` JSON, and a forward-compat test deserializing `under_construction`/`retiring`.
- `collection::tests::segment_manifest`: with the flag enabled, building a shard writes `manifest.json` listing its segments as `active`.
- `collection::tests` regression tests for the safety invariant (manifest must match the live segment set, driven directly without the worker loop so only the in-place maintenance is exercised):
  - `optimization_keeps_manifest_consistent_with_live_segments`: after a merge optimization, the persisted manifest never references an optimized-away (deleted) segment.
  - `ensure_appendable_segment_registers_in_manifest`: a runtime-created appendable segment is registered before it can take writes.

`cargo clippy -p common -p shard -p collection --tests` clean; `cargo build --workspace` and the collection lib test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Bonus: `append_only_mutations` feature flag

Second commit, unrelated to the manifest but bundled here since it edits the same `FeatureFlags` struct (avoids a merge conflict on adjacent fields). Replaces the debug-only `QDRANT_APPEND_ONLY_MUTATIONS=1` env-var hack in segment construction (`create_segment.rs`) with a proper `FeatureFlags::append_only_mutations` flag — now works in release and is config/env-driven like the others. Deliberately **excluded from `FeatureFlags::all()`** because it changes mutation semantics and `all: true` is set in dev (`config/development.yaml`) and the e2e cluster config.
