### PR TITLE
fix: validate lookup_from collection for query and recommend APIs

### DIFF
--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -219,7 +219,7 @@ pub fn measure_component(
 
     for entry in files {
         let ComponentFileEntry { path, intent } = &entry;
-        if let Ok(meta) = std::fs::metadata(path) {
+        if let Ok(meta) = fs_err::metadata(path) {
             disk_bytes += meta.len();
             if *intent == FileStorageIntent::Cached {
                 expected_cache_bytes += meta.len();

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -32,60 +32,6 @@ use crate::content_manager::errors::{StorageError, StorageResult};
 use crate::rbac::Auth;
 
 impl TableOfContent {
-    async fn validate_lookup_from_collection_exists(
-        &self,
-        collection_name: &str,
-    ) -> StorageResult<()> {
-        self.get_collection_unchecked(collection_name).await?;
-        Ok(())
-    }
-
-    async fn validate_recommend_lookup_from(
-        &self,
-        request: &RecommendRequestInternal,
-    ) -> StorageResult<()> {
-        if let Some(lookup_from) = &request.lookup_from {
-            self.validate_lookup_from_collection_exists(&lookup_from.collection)
-                .await?;
-        }
-        Ok(())
-    }
-
-    async fn validate_query_lookup_from(
-        &self,
-        request: &CollectionQueryRequest,
-    ) -> StorageResult<()> {
-        if let Some(lookup_from) = &request.lookup_from {
-            self.validate_lookup_from_collection_exists(&lookup_from.collection)
-                .await?;
-        }
-
-        let mut prefetches: Vec<&CollectionPrefetch> = request.prefetch.iter().collect();
-        while let Some(prefetch) = prefetches.pop() {
-            if let Some(lookup_from) = &prefetch.lookup_from {
-                self.validate_lookup_from_collection_exists(&lookup_from.collection)
-                    .await?;
-            }
-            prefetches.extend(prefetch.prefetch.iter());
-        }
-
-        Ok(())
-    }
-
-    async fn validate_group_lookup_from(&self, request: &GroupRequest) -> StorageResult<()> {
-        match &request.source {
-            SourceRequest::Search(_) => {}
-            SourceRequest::Recommend(request) => {
-                self.validate_recommend_lookup_from(request).await?;
-            }
-            SourceRequest::Query(request) => {
-                self.validate_query_lookup_from(request).await?;
-            }
-        }
-
-        Ok(())
-    }
-
     /// Recommend points using positive and negative example from the request
     ///
     /// # Arguments
@@ -758,5 +704,59 @@ impl TableOfContent {
         };
 
         Ok(res)
+    }
+
+    async fn validate_lookup_from_collection_exists(
+        &self,
+        collection_name: &str,
+    ) -> StorageResult<()> {
+        self.get_collection_unchecked(collection_name).await?;
+        Ok(())
+    }
+
+    async fn validate_recommend_lookup_from(
+        &self,
+        request: &RecommendRequestInternal,
+    ) -> StorageResult<()> {
+        if let Some(lookup_from) = &request.lookup_from {
+            self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_query_lookup_from(
+        &self,
+        request: &CollectionQueryRequest,
+    ) -> StorageResult<()> {
+        if let Some(lookup_from) = &request.lookup_from {
+            self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                .await?;
+        }
+
+        let mut prefetches: Vec<&CollectionPrefetch> = request.prefetch.iter().collect();
+        while let Some(prefetch) = prefetches.pop() {
+            if let Some(lookup_from) = &prefetch.lookup_from {
+                self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                    .await?;
+            }
+            prefetches.extend(prefetch.prefetch.iter());
+        }
+
+        Ok(())
+    }
+
+    async fn validate_group_lookup_from(&self, request: &GroupRequest) -> StorageResult<()> {
+        match &request.source {
+            SourceRequest::Search(_) => {}
+            SourceRequest::Recommend(request) => {
+                self.validate_recommend_lookup_from(request).await?;
+            }
+            SourceRequest::Query(request) => {
+                self.validate_query_lookup_from(request).await?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -710,8 +710,13 @@ impl TableOfContent {
         &self,
         collection_name: &str,
     ) -> StorageResult<()> {
-        self.get_collection_unchecked(collection_name).await?;
-        Ok(())
+        match self.get_collection_unchecked(collection_name).await {
+            Ok(_) => Ok(()),
+            Err(StorageError::NotFound { .. }) => Err(StorageError::not_found(format!(
+                "Collection {collection_name} not found"
+            ))),
+            Err(err) => Err(err),
+        }
     }
 
     async fn validate_recommend_lookup_from(

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -6,13 +6,15 @@ use collection::collection::distance_matrix::{
 };
 use collection::config::ShardingMethod;
 use collection::grouping::GroupBy;
-use collection::grouping::group_by::GroupRequest;
+use collection::grouping::group_by::{GroupRequest, SourceRequest};
 use collection::operations::consistency_params::ReadConsistency;
 use collection::operations::point_ops::WriteOrdering;
 use collection::operations::routing::RoutingToken;
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::*;
-use collection::operations::universal_query::collection_query::CollectionQueryRequest;
+use collection::operations::universal_query::collection_query::{
+    CollectionPrefetch, CollectionQueryRequest,
+};
 use collection::operations::{CollectionUpdateOperations, OperationWithClockTag};
 use collection::shards::shard_trait::WaitUntil;
 use collection::{discovery, recommendations};
@@ -30,6 +32,60 @@ use crate::content_manager::errors::{StorageError, StorageResult};
 use crate::rbac::Auth;
 
 impl TableOfContent {
+    async fn validate_lookup_from_collection_exists(
+        &self,
+        collection_name: &str,
+    ) -> StorageResult<()> {
+        self.get_collection_unchecked(collection_name).await?;
+        Ok(())
+    }
+
+    async fn validate_recommend_lookup_from(
+        &self,
+        request: &RecommendRequestInternal,
+    ) -> StorageResult<()> {
+        if let Some(lookup_from) = &request.lookup_from {
+            self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_query_lookup_from(
+        &self,
+        request: &CollectionQueryRequest,
+    ) -> StorageResult<()> {
+        if let Some(lookup_from) = &request.lookup_from {
+            self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                .await?;
+        }
+
+        let mut prefetches: Vec<&CollectionPrefetch> = request.prefetch.iter().collect();
+        while let Some(prefetch) = prefetches.pop() {
+            if let Some(lookup_from) = &prefetch.lookup_from {
+                self.validate_lookup_from_collection_exists(&lookup_from.collection)
+                    .await?;
+            }
+            prefetches.extend(prefetch.prefetch.iter());
+        }
+
+        Ok(())
+    }
+
+    async fn validate_group_lookup_from(&self, request: &GroupRequest) -> StorageResult<()> {
+        match &request.source {
+            SourceRequest::Search(_) => {}
+            SourceRequest::Recommend(request) => {
+                self.validate_recommend_lookup_from(request).await?;
+            }
+            SourceRequest::Query(request) => {
+                self.validate_query_lookup_from(request).await?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Recommend points using positive and negative example from the request
     ///
     /// # Arguments
@@ -55,6 +111,7 @@ impl TableOfContent {
         let collection_pass = auth.check_point_op(collection_name, &request, "recommend")?;
 
         let collection = self.get_collection(&collection_pass).await?;
+        self.validate_recommend_lookup_from(&request).await?;
         recommendations::recommend_by(
             request,
             &collection,
@@ -100,6 +157,9 @@ impl TableOfContent {
         };
 
         let collection = self.get_collection(&collection_pass).await?;
+        for (request, _shard_selector) in &requests {
+            self.validate_recommend_lookup_from(request).await?;
+        }
         recommendations::recommend_batch_by(
             requests,
             &collection,
@@ -256,6 +316,7 @@ impl TableOfContent {
         let collection_pass = auth.check_point_op(collection_name, &request, "group")?;
 
         let collection = self.get_collection(&collection_pass).await?;
+        self.validate_group_lookup_from(&request).await?;
 
         let collection_by_name = |name| self.get_collection_opt(name);
 
@@ -396,6 +457,9 @@ impl TableOfContent {
         };
 
         let collection = self.get_collection(&collection_pass).await?;
+        for (request, _shard_selector) in &requests {
+            self.validate_query_lookup_from(request).await?;
+        }
 
         collection
             .query_batch(

--- a/tests/openapi/test_group.py
+++ b/tests/openapi/test_group.py
@@ -509,3 +509,37 @@ def test_search_groups_with_full_lookup(collection_name, lookup_collection_name)
         lookup = group["lookup"]
         assert lookup["payload"]
         assert lookup["vector"]
+
+def test_query_and_recommend_groups_missing_lookup_from_collection(collection_name):
+    missing_collection = "missing_lookup_from_collection"
+    lookup_from = {"collection": missing_collection, "vector": "default"}
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": [1.0, 0.0, 0.0, 0.0],
+            "limit": 10,
+            "group_by": "docId",
+            "group_size": 3,
+            "lookup_from": lookup_from,
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend/groups",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [[1.0, 0.0, 0.0, 0.0]],
+            "limit": 10,
+            "group_by": "docId",
+            "group_size": 3,
+            "lookup_from": lookup_from,
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]

--- a/tests/openapi/test_query.py
+++ b/tests/openapi/test_query.py
@@ -664,3 +664,56 @@ def test_score_threshold(body, collection_name):
     assert len(points) < 8
     for point in points:
         assert point["score"] >= score_threshold
+
+def test_query_missing_lookup_from_collection(collection_name):
+    missing_collection = "missing_lookup_from_collection"
+    lookup_from = {"collection": missing_collection, "vector": "default"}
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": [0.1, 0.2, 0.3, 0.4],
+            "limit": 3,
+            "lookup_from": lookup_from,
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query/batch",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "searches": [
+                {
+                    "query": [0.1, 0.2, 0.3, 0.4],
+                    "limit": 3,
+                    "lookup_from": lookup_from,
+                }
+            ]
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": [
+                {
+                    "query": [0.1, 0.2, 0.3, 0.4],
+                    "limit": 3,
+                    "lookup_from": lookup_from,
+                }
+            ],
+            "query": {"fusion": "rrf"},
+            "limit": 3,
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]

--- a/tests/openapi/test_recommend.py
+++ b/tests/openapi/test_recommend.py
@@ -261,3 +261,37 @@ def test_raw_vectors(collection_name):
     assert len(response_raw.json()["result"]) == 4
 
     assert response_ids.json()["result"] == response_raw.json()["result"]
+
+def test_recommend_missing_lookup_from_collection_with_raw_vector(collection_name):
+    missing_collection = "missing_lookup_from_collection"
+    lookup_from = {"collection": missing_collection, "vector": "default"}
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "positive": [[0.1, 0.2, 0.3, 0.4]],
+            "limit": 3,
+            "lookup_from": lookup_from,
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/recommend/batch",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "searches": [
+                {
+                    "positive": [[0.1, 0.2, 0.3, 0.4]],
+                    "limit": 3,
+                    "lookup_from": lookup_from,
+                }
+            ]
+        },
+    )
+    assert response.status_code == 404, response.text
+    assert missing_collection in response.json()["status"]["error"]


### PR DESCRIPTION
Fixes #9522 

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## What changed

This PR validates `lookup_from.collection` before executing query and recommend requests.

Previously, requests with a raw vector query and a missing `lookup_from.collection` could return `200 OK`, because `lookup_from` was only used when resolving point IDs into vectors. If no ID resolution was needed, the missing lookup collection could be ignored.

The validation is added in the shared `TableOfContent` layer so it applies to both REST and gRPC paths for:

- query
- query batch
- query groups
- recommend
- recommend batch
- recommend groups

Nested query prefetches are also validated.

This PR also includes a small clippy cleanup in `memory_reporter.rs`, replacing `std::fs::metadata` with `fs_err::metadata`.

Used AI assistance. Everything was  reviewed and verified.
