### PR TITLE
Fix shard transfer snapshot cleanup cancellation window

### DIFF
--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1466,6 +1466,14 @@ impl ShardHolder {
         snapshot_file_name: impl AsRef<Path>,
     ) -> CollectionResult<PathBuf> {
         self.assert_shard_is_local_or_queue_proxy(shard_id).await?;
+        Self::shard_snapshot_path(snapshots_path, shard_id, snapshot_file_name)
+    }
+
+    pub(super) fn shard_snapshot_path(
+        snapshots_path: &Path,
+        shard_id: ShardId,
+        snapshot_file_name: impl AsRef<Path>,
+    ) -> CollectionResult<PathBuf> {
         Self::shard_snapshot_path_unchecked(snapshots_path, shard_id, snapshot_file_name)
     }
 

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -15,7 +15,7 @@ use crate::shards::channel_service::ChannelService;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::ShardId;
-use crate::shards::shard_holder::SharedShardHolder;
+use crate::shards::shard_holder::{ShardHolder, SharedShardHolder};
 
 /// Orchestrate shard snapshot transfer
 ///
@@ -215,15 +215,13 @@ pub(super) async fn transfer_snapshot(
             .await?
             .await?;
 
-        // TODO: If future is cancelled until `get_shard_snapshot_path` resolves, shard snapshot may not be cleaned up...
-        let snapshot_temp_path = shard_holder_read
-            .get_shard_snapshot_path(snapshots_path, shard_id, &snapshot_description.name)
-            .await
-            .map_err(|err| {
-                CollectionError::service_error(format!(
-                    "Failed to determine snapshot path, cannot continue with shard snapshot recovery: {err}",
-                ))
-            })?;
+        let snapshot_temp_path =
+            ShardHolder::shard_snapshot_path(snapshots_path, shard_id, &snapshot_description.name)
+                .map_err(|err| {
+                    CollectionError::service_error(format!(
+                        "Failed to determine snapshot path, cannot continue with shard snapshot recovery: {err}",
+                    ))
+                })?;
         let snapshot_temp_path = TempPath::try_from_path(snapshot_temp_path)?;
         let snapshot_checksum_temp_path =
             TempPath::try_from_path(get_checksum_path(&snapshot_temp_path))?;


### PR DESCRIPTION
### Summary

Related to #9532.

This fixes a cancellation window in legacy/non-streaming shard snapshot transfer.

After `create_shard_snapshot(...).await?.await?` succeeds, the transfer-created source snapshot is already stored. The previous code then awaited `get_shard_snapshot_path(...)` before registering the `TempPath` cleanup guards. If the transfer future was cancelled in that window, the stored source snapshot could be left in the shard snapshot namespace.

This PR resolves the path synchronously before registering the cleanup guards, avoiding a post-persistence await in that handoff.

### Changes

- Added an internal synchronous shard snapshot path helper that reuses the existing path validation.
- Kept the existing async `get_shard_snapshot_path(...)` API for existing callers.
- Updated legacy/non-streaming snapshot transfer to use synchronous path resolution after source snapshot creation.
- Removed the obsolete TODO about cancellation before `get_shard_snapshot_path` resolves.

### All Submissions:

> **WARNING: PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Testing

- [x] `git diff --check`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo +stable test --workspace --all-features`
  - Failed in `common::stoppable_task::tests::test_task_stop_many`.
  - The test failed twice in full workspace runs with counts `41` and `40`, while the assertion expected less than `30`.
  - The failing test is outside the files changed by this PR.
- [x] `cargo +stable test -p collection --lib common::stoppable_task::tests::test_task_stop_many`
No new regression test was added for this change. The fix removes the post-persistence async await between source snapshot storage and cleanup guard registration. A deterministic regression test for that timing window would require additional test instrumentation around shard transfer snapshot persistence and cleanup guard registration.

### AI assistance disclosure

AI assistance was used during local preparation to review the issue, check the minimal fix, and draft wording for this PR.

Initial intent: remove the cancellation cleanup window in legacy shard snapshot transfer while keeping the code change minimal.

I reviewed the final diff and take responsibility for the change.