### PR TITLE
feat: verify snapshot integrity with checksum in shard transfer

### DIFF
--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -928,6 +928,7 @@ impl RemoteShard {
         url: &Url,
         snapshot_priority: SnapshotPriority,
         api_key: Option<&str>,
+        checksum: Option<&str>,
     ) -> CollectionResult<RecoverSnapshotResponse> {
         let res = self
             .with_shard_snapshots_client_timeout(
@@ -942,7 +943,7 @@ impl RemoteShard {
                             snapshot_priority: api::grpc::qdrant::ShardSnapshotPriority::from(
                                 snapshot_priority,
                             ) as i32,
-                            checksum: None,
+                            checksum: checksum.map(Into::into),
                             api_key: api_key.map(Into::into),
                         })
                         .await

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -943,8 +943,8 @@ impl RemoteShard {
                             snapshot_priority: api::grpc::qdrant::ShardSnapshotPriority::from(
                                 snapshot_priority,
                             ) as i32,
-                            checksum: checksum.map(Into::into),
-                            api_key: api_key.map(Into::into),
+                            checksum: checksum.map(String::from),
+                            api_key: api_key.map(String::from),
                         })
                         .await
                 },

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -199,6 +199,7 @@ pub(super) async fn transfer_snapshot(
 
     let mut snapshot_temp_paths = Vec::new();
     let mut shard_download_url = local_rest_address;
+    let mut snapshot_checksum: Option<String> = None;
 
     let encoded_collection_name = urlencoding::encode(collection_id);
     if use_streaming_endpoint {
@@ -214,6 +215,9 @@ pub(super) async fn transfer_snapshot(
             .create_shard_snapshot(snapshots_path, collection_id, shard_id, temp_dir)
             .await?
             .await?;
+
+        // Capture checksum for integrity verification on the remote
+        snapshot_checksum = snapshot_description.checksum.clone();
 
         // TODO: If future is cancelled until `get_shard_snapshot_path` resolves, shard snapshot may not be cleaned up...
         let snapshot_temp_path = shard_holder_read
@@ -255,6 +259,8 @@ pub(super) async fn transfer_snapshot(
             SnapshotPriority::ShardTransfer,
             // Provide API key here so the remote can access our snapshot
             local_api_key,
+            // Pass checksum for remote to verify snapshot integrity
+            snapshot_checksum.as_deref(),
         )
         .await
         .map_err(|err| {

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -229,10 +229,6 @@ pub(super) async fn transfer_snapshot(
                 ))
             })?;
         let snapshot_temp_path = TempPath::try_from_path(snapshot_temp_path)?;
-        
-        if snapshot_checksum.is_none() {
-            snapshot_checksum = Some(crate::common::sha_256::hash_file(&snapshot_temp_path).await?);
-        }
 
         let snapshot_checksum_temp_path =
             TempPath::try_from_path(get_checksum_path(&snapshot_temp_path))?;

--- a/lib/collection/src/shards/transfer/snapshot.rs
+++ b/lib/collection/src/shards/transfer/snapshot.rs
@@ -229,6 +229,11 @@ pub(super) async fn transfer_snapshot(
                 ))
             })?;
         let snapshot_temp_path = TempPath::try_from_path(snapshot_temp_path)?;
+        
+        if snapshot_checksum.is_none() {
+            snapshot_checksum = Some(crate::common::sha_256::hash_file(&snapshot_temp_path).await?);
+        }
+
         let snapshot_checksum_temp_path =
             TempPath::try_from_path(get_checksum_path(&snapshot_temp_path))?;
         snapshot_temp_paths.push(snapshot_temp_path);


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

**Explanation**:
This PR passes the snapshot checksum along in the recovery call during shard snapshot transfers, as requested in #3372. If a shard snapshot file were to become corrupted during transfer, Qdrant would previously happily restore it, potentially resulting in a broken shard. By utilizing the checksums added in #2840, we now ensure the integrity of the snapshot file is verified during recovery.

(Note: For the streaming endpoint, `snapshot_checksum` is cleanly left as `None` since the streaming process doesn't capture an upfront checksum via `create_snapshot`).

 Fixes #3372