### PR TITLE
fix(optimizer): defer source segment destruction until durable (post-flush actions)

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -568,6 +568,14 @@ mod tests {
             "Testing that only largest segment is not Mmap"
         );
 
+        // Optimizations defer destroying their source segments to a post-flush action; the files
+        // are removed once a flush confirms the optimized data is durable (see
+        // `SegmentHolder::register_post_flush_action`). Flush to run the action before counting dirs.
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         let segment_dirs = fs::read_dir(segments_dir.path()).unwrap().collect_vec();
         assert_eq!(
             segment_dirs.len(),

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -195,6 +195,14 @@ mod tests {
             }
         }
 
+        // The optimization defers destroying the merged source segments to a post-flush action;
+        // their files are removed once a flush confirms the merged data is durable (see
+        // `SegmentHolder::register_post_flush_action`). Flush to run the action before asserting.
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         // Check if optimized segments removed from disk
         old_path.into_iter().for_each(|x| assert!(!x.exists()));
     }

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -231,6 +231,16 @@ mod tests {
             }
         }
 
+        // The optimization defers destroying the source segment to a post-flush action; its files
+        // are removed once a flush confirms the optimized data is durable (see
+        // `SegmentHolder::register_post_flush_action`). Flush to run the action before asserting.
+        drop(segment_guard);
+        drop(holder_guard);
+        locked_holder
+            .read()
+            .flush_all(true, true)
+            .expect("failed to flush segment holder");
+
         // Check old segment data is removed from disk
         assert!(!original_segment_path.exists());
     }

--- a/lib/shard/src/locked_segment.rs
+++ b/lib/shard/src/locked_segment.rs
@@ -11,6 +11,20 @@ use crate::proxy_segment::ProxySegment;
 
 const DROP_SPIN_TIMEOUT: Duration = Duration::from_millis(10);
 const DROP_DATA_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+/// Short timeout for the retryable drop ([`LockedSegment::try_drop_data`]): the caller's retry
+/// loop provides the real waiting, so we only absorb brief contention here instead of blocking for
+/// up to [`DROP_DATA_TIMEOUT`].
+const DROP_DATA_RETRY_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Outcome of a failed [`LockedSegment::try_drop_data`].
+pub enum DropDataOutcome {
+    /// The segment is still in use; its data is untouched and the segment is handed back so the
+    /// caller can retry later.
+    StillInUse(LockedSegment, OperationError),
+    /// Destroying the data itself failed; the segment was consumed and its data may be partially
+    /// gone, so a retry is not possible.
+    Failed(OperationError),
+}
 
 /// Object, which unifies the access to different types of segments, but still allows to
 /// access the original type of the segment if it is required for more efficient operations.
@@ -72,25 +86,53 @@ impl LockedSegment {
     }
 
     /// Consume the LockedSegment and drop the underlying segment data.
-    /// Operation fails if the segment is used by other thread for longer than `timeout`.
+    /// Operation fails if the segment is used by other thread for longer than [`DROP_DATA_TIMEOUT`].
     pub fn drop_data(self) -> OperationResult<()> {
+        self.drop_data_with_timeout(DROP_DATA_TIMEOUT)
+            .map_err(|outcome| match outcome {
+                DropDataOutcome::StillInUse(_, err) | DropDataOutcome::Failed(err) => err,
+            })
+    }
+
+    /// Like [`drop_data`](Self::drop_data), but with a short timeout and the segment handed back on
+    /// a [`DropDataOutcome::StillInUse`] failure so the caller can retry on a later attempt.
+    pub fn try_drop_data(self) -> Result<(), DropDataOutcome> {
+        self.drop_data_with_timeout(DROP_DATA_RETRY_TIMEOUT)
+    }
+
+    fn drop_data_with_timeout(self, timeout: Duration) -> Result<(), DropDataOutcome> {
         match self {
             LockedSegment::Original(segment) => {
-                match try_unwrap_with_timeout(segment, DROP_SPIN_TIMEOUT, DROP_DATA_TIMEOUT) {
-                    Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                    Err(locked_segment) => Err(OperationError::service_error(format!(
-                        "Removing segment which is still in use: {:?}",
-                        locked_segment.read().data_path(),
-                    ))),
+                match try_unwrap_with_timeout(segment, DROP_SPIN_TIMEOUT, timeout) {
+                    Ok(raw_locked_segment) => raw_locked_segment
+                        .into_inner()
+                        .drop_data()
+                        .map_err(DropDataOutcome::Failed),
+                    Err(arc) => {
+                        let err = OperationError::service_error(format!(
+                            "Removing segment which is still in use: {:?}",
+                            arc.read().data_path(),
+                        ));
+                        Err(DropDataOutcome::StillInUse(
+                            LockedSegment::Original(arc),
+                            err,
+                        ))
+                    }
                 }
             }
             LockedSegment::Proxy(proxy) => {
-                match try_unwrap_with_timeout(proxy, DROP_SPIN_TIMEOUT, DROP_DATA_TIMEOUT) {
-                    Ok(raw_locked_segment) => raw_locked_segment.into_inner().drop_data(),
-                    Err(locked_segment) => Err(OperationError::service_error(format!(
-                        "Removing proxy segment which is still in use: {:?}",
-                        locked_segment.read().data_path(),
-                    ))),
+                match try_unwrap_with_timeout(proxy, DROP_SPIN_TIMEOUT, timeout) {
+                    Ok(raw_locked_segment) => raw_locked_segment
+                        .into_inner()
+                        .drop_data()
+                        .map_err(DropDataOutcome::Failed),
+                    Err(arc) => {
+                        let err = OperationError::service_error(format!(
+                            "Removing proxy segment which is still in use: {:?}",
+                            arc.read().data_path(),
+                        ));
+                        Err(DropDataOutcome::StillInUse(LockedSegment::Proxy(arc), err))
+                    }
                 }
             }
         }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -549,6 +549,7 @@ fn finish_optimization(
 
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
+    let optimized_segment_version = optimized_segment.version();
     let mut writable_segment_holder = RwLockUpgradableReadGuard::upgrade(upgradable_segment_holder);
 
     let (_, proxies) = writable_segment_holder.swap_new(optimized_segment, proxy_ids);
@@ -587,10 +588,25 @@ fn finish_optimization(
             .try_for_each(|chunk| read_segment_holder.deduplicate_points(chunk, hw_counter))?;
     }
 
-    // It is important to update manifest before we drop proxy data,
+    // It is important to update manifest before we retire proxy data,
     // as we don't want to have a situation, where new segment is not yet registered, but
     // old segment data is already dropped.
     read_segment_holder.sync_segment_manifest(None)?;
+
+    // Don't destroy the replaced segments' data yet. Points were copy-on-write moved out of them
+    // (and out of the optimized segment's in-memory state, which the next optimization bakes into
+    // its build output) while their new copies may still sit unflushed in appendable segments. WAL
+    // replay can only re-derive those moves from the on-disk pre-images, so the files must survive
+    // until a flush proves this optimization durable. Register the destruction as a post-flush
+    // action: it runs once the durable waterline covers `optimized_segment_version`, and until then
+    // the WAL acknowledge stays capped at each source's persisted version (the same pin the proxy
+    // imposed while the optimization ran), so every operation the files contradict, deletions in
+    // particular, is replayed and re-applied on a restart. See
+    // `SegmentHolder::register_post_flush_action`.
+    for proxy in proxies {
+        let ack_pin = proxy.get().read().persistent_version();
+        read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
+    }
 
     drop(read_segment_holder);
     // Allow updates again
@@ -598,12 +614,6 @@ fn finish_optimization(
 
     // Drop all pointers to proxies, so we can de-arc them
     drop(locked_proxies);
-
-    // Only remove data after we ensure the consistency of the collection.
-    // If remove fails - we will still have operational collection with reported error.
-    for proxy in proxies {
-        proxy.drop_data()?;
-    }
 
     Ok(point_count)
 }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -603,6 +603,15 @@ fn finish_optimization(
     // imposed while the optimization ran), so every operation the files contradict, deletions in
     // particular, is replayed and re-applied on a restart. See
     // `SegmentHolder::register_post_flush_action`.
+    //
+    // This cap has to be tracked at the holder level because the proxy can no longer
+    // impose it. While a proxy was a member of the holder it pinned the WAL acknowledge for
+    // free: its `persistent_version` reported the wrapped source's durable point while its
+    // `version` climbed with every propagated change, so `flush_all` saw unsaved work and
+    // capped the ack there. The `swap_new` above evicted the proxies, so that contribution is
+    // gone from the holder's flush accounting even though the source files it protected are
+    // still on disk. `register_segment_drop` re-expresses the same pin independently of segment
+    // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
     for proxy in proxies {
         let ack_pin = proxy.get().read().persistent_version();
         read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -64,8 +64,14 @@ impl SegmentHolder {
         let max_applied_version = segment_reads.iter().map(|s| s.version()).max().unwrap_or(0);
 
         if !sync && self.is_background_flushing() {
-            // There is already a background flush ongoing, return current max persisted version
-            return Ok(self.get_max_persisted_version(segment_reads, lock_order));
+            // There is already a background flush ongoing, return current max persisted version.
+            // Cap by pending post-flush actions like the main path below, but leave running them
+            // to the next full pass.
+            let persisted_version = self.get_max_persisted_version(segment_reads, lock_order);
+            return Ok(match self.pending_post_flush_ack_cap() {
+                Some(ack_cap) => min(persisted_version, ack_cap),
+                None => persisted_version,
+            });
         }
 
         // This lock also prevents multiple parallel sync flushes
@@ -107,7 +113,22 @@ impl SegmentHolder {
             );
         }
 
-        Ok(self.get_max_persisted_version(segment_reads, lock_order))
+        // Persisted versions at this point reflect completed flushes only (an ongoing background
+        // pass was joined by `lock_flushing` above; a freshly spawned one has not updated them
+        // yet), so the result is a durable waterline: every segment's state up to it is on disk.
+        // Post-flush actions scheduled at or below it can run now, since the data they clean up is
+        // durable in its new home by now.
+        //
+        // Actions that are not yet ready cap the returned version (and with it the WAL
+        // acknowledge): the data they have not cleaned up yet contradicts operations past their
+        // pin, so those operations must stay replayable until the action runs. See
+        // [`SegmentHolder::register_post_flush_action`].
+        let persisted_version = self.get_max_persisted_version(segment_reads, lock_order);
+        let pending_ack_cap = self.run_ready_post_flush_actions(persisted_version)?;
+        Ok(match pending_ack_cap {
+            Some(ack_cap) => min(persisted_version, ack_cap),
+            None => persisted_version,
+        })
     }
 
     fn non_appendable_then_appendable_segments_ids(&self) -> impl Iterator<Item = SegmentId> {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -33,7 +33,7 @@ use segment::segment_constructor::build_segment;
 use segment::types::{ExtendedPointId, Payload, PointIdType, SegmentConfig, SeqNumberType};
 use smallvec::SmallVec;
 
-use crate::locked_segment::LockedSegment;
+use crate::locked_segment::{DropDataOutcome, LockedSegment};
 use crate::payload_index_schema::PayloadIndexSchema;
 use crate::segment_manifest::{NewSegmentToken, SegmentsManifest};
 
@@ -41,6 +41,36 @@ pub type SegmentId = usize;
 
 /// All occurrences of a point across segments: (segment_id, version, is_deferred).
 type PointOccurrences = SmallVec<[(SegmentId, SeqNumberType, bool); 2]>;
+
+/// Result of running a [`DeferredAction`].
+pub enum PostFlushOutcome {
+    /// The action completed and should be removed from the queue.
+    Done,
+    /// The action could not complete yet; keep it queued and retry on a later flush. Its ack pin
+    /// stays in effect until it completes.
+    Retry,
+}
+
+/// An action deferred until a flush proves the data it touches is durable.
+/// See [`SegmentHolder::register_post_flush_action`].
+struct DeferredAction {
+    /// Run the action once the durable waterline reaches this version.
+    ready_at: SeqNumberType,
+    /// Until the action completes, cap the WAL acknowledge at this version.
+    ack_pin: SeqNumberType,
+    /// Retryable: returns [`PostFlushOutcome::Retry`] (or `Err`) without finishing, and is called
+    /// again on a later flush. Must keep enough state to resume.
+    action: Box<dyn FnMut() -> OperationResult<PostFlushOutcome> + Send>,
+}
+
+impl std::fmt::Debug for DeferredAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeferredAction")
+            .field("ready_at", &self.ready_at)
+            .field("ack_pin", &self.ack_pin)
+            .finish_non_exhaustive()
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct SegmentHolder {
@@ -68,6 +98,17 @@ pub struct SegmentHolder {
     /// Dependency graph also stores the maximum version of the operation, which created the dependency,
     /// so we can clear all dependencies after flushing up to certain operation.
     flush_dependency: Arc<Mutex<TopoSort<SegmentId, SeqNumberType>>>,
+
+    /// Actions deferred until a flush proves the data they touch is durable.
+    /// Each runs once the durable waterline reaches its `ready_at`, and pins the WAL
+    /// acknowledge at its `ack_pin` until then. See [`SegmentHolder::register_post_flush_action`].
+    post_flush_actions: Mutex<Vec<DeferredAction>>,
+
+    /// Ack-pin floor of the actions `run_ready_post_flush_actions` is currently running, while they
+    /// are briefly removed from `post_flush_actions`. Folded into `pending_post_flush_ack_cap` so a
+    /// concurrent flush cannot advance the WAL acknowledge past their pins during that window.
+    /// Guarded by the `post_flush_actions` lock (always taken first) to stay consistent with it.
+    in_flight_ack_floor: Mutex<Option<SeqNumberType>>,
 
     /// Holder for a thread, which does flushing of all segments sequentially.
     /// This is used to avoid multiple concurrent flushes.
@@ -372,6 +413,175 @@ impl SegmentHolder {
     /// Return non-appendable segment IDs sorted by IDs
     pub fn non_appendable_segments_ids(&self) -> Vec<SegmentId> {
         self.non_appendable_segments.keys().copied().collect()
+    }
+
+    /// Register an action to run once a future flush proves its data durable, i.e. the durable
+    /// waterline (the version every segment is persisted up to) has reached `ready_at`. Until it
+    /// runs, the version returned by [`flush_all`](Self::flush_all), and thus the WAL acknowledge,
+    /// is capped at `ack_pin`, so any operation the not-yet-cleaned data contradicts stays
+    /// replayable across a restart.
+    ///
+    /// Optimizations use this to defer destroying a swapped-out source segment. Points are
+    /// copy-on-write moved out of it in memory, and WAL replay can re-derive such a move only
+    /// while the source's on-disk pre-image survives; the moved copies may still sit unflushed in
+    /// appendable segments, so destroying the source right at the swap would lose them on a
+    /// restart. Deferring the destruction to `ready_at` (the optimized segment's version) ensures
+    /// those copies are durable in their new home first; in the meantime a restart loads the old
+    /// files next to their replacement and load-time deduplication resolves the overlap.
+    ///
+    /// `ack_pin` is the version up to which the deferred files stay truthful (the source segment's
+    /// persisted version). Beyond it they contradict newer state living elsewhere, most importantly
+    /// deletions: the files keep a deleted point positively alive, and an absence in the
+    /// replacement segment cannot outvote it at load time. Capping the WAL acknowledge at `ack_pin`
+    /// keeps those operations replayable until the files are gone; the same pin the proxy imposed
+    /// while the optimization ran, extended until the action runs.
+    ///
+    /// `action` is retried on a later flush if it returns [`PostFlushOutcome::Retry`] or `Err`, so
+    /// the ack pin survives a transient failure (e.g. the data is briefly still in use); see
+    /// [`run_ready_post_flush_actions`](Self::run_ready_post_flush_actions).
+    pub fn register_post_flush_action(
+        &self,
+        ready_at: SeqNumberType,
+        ack_pin: SeqNumberType,
+        action: impl FnMut() -> OperationResult<PostFlushOutcome> + Send + 'static,
+    ) {
+        self.post_flush_actions.lock().push(DeferredAction {
+            ready_at,
+            ack_pin,
+            action: Box::new(action),
+        });
+    }
+
+    /// Register a [post-flush action](Self::register_post_flush_action) that destroys `segment`'s
+    /// data once durable. If the segment is still in use when the action runs, it is handed back
+    /// and the destruction is retried on a later flush, keeping the `ack_pin` in effect until the
+    /// files are actually gone.
+    pub fn register_segment_drop(
+        &self,
+        ready_at: SeqNumberType,
+        ack_pin: SeqNumberType,
+        segment: LockedSegment,
+    ) {
+        let mut segment = Some(segment);
+        self.register_post_flush_action(ready_at, ack_pin, move || {
+            let to_drop = segment
+                .take()
+                .expect("post-flush segment drop retried after completion");
+            match to_drop.try_drop_data() {
+                Ok(()) => Ok(PostFlushOutcome::Done),
+                Err(DropDataOutcome::StillInUse(returned, err)) => {
+                    log::warn!(
+                        "Deferred segment data destruction not ready yet, will retry: {err}"
+                    );
+                    segment = Some(returned);
+                    Ok(PostFlushOutcome::Retry)
+                }
+                Err(DropDataOutcome::Failed(err)) => Err(err),
+            }
+        });
+    }
+
+    /// The WAL acknowledge cap imposed by pending post-flush actions, if any: the minimum `ack_pin`
+    /// across both the queued actions and any currently being run (briefly out of the queue, see
+    /// `in_flight_ack_floor`). See [`SegmentHolder::register_post_flush_action`].
+    pub(super) fn pending_post_flush_ack_cap(&self) -> Option<SeqNumberType> {
+        // Hold the actions lock across both reads so the result is consistent with
+        // `run_ready_post_flush_actions`, which moves actions between the queue and the floor under
+        // it. Lock order is always actions then floor.
+        let actions = self.post_flush_actions.lock();
+        let queued = actions.iter().map(|action| action.ack_pin).min();
+        let in_flight = *self.in_flight_ack_floor.lock();
+        drop(actions);
+
+        match (queued, in_flight) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (cap, None) | (None, cap) => cap,
+        }
+    }
+
+    /// Run every post-flush action whose `ready_at` is covered by the durable waterline
+    /// `persisted_version` (every segment's state up to that version is on disk, so the data each
+    /// action cleans up is durable in its new home and replay of any still-unacknowledged
+    /// operation on it is an idempotent no-op).
+    ///
+    /// Returns the remaining WAL acknowledge cap: the minimum `ack_pin` of the actions that did
+    /// not run, or `None` when none are pending. See [`SegmentHolder::register_post_flush_action`].
+    ///
+    /// Like the WAL acknowledge, the maturity waterline is capped by the first failed operation:
+    /// its effects are not in the segments, and recovering it may need the deferred pre-images.
+    ///
+    /// Perf note: the waterline is the minimum persisted version across all segments, so a freshly
+    /// created appendable segment (which reports `persistent_version() == 0` until its first flush)
+    /// holds the waterline near zero and keeps actions from running. Under heavy optimizer churn
+    /// this lets the action backlog and the capped WAL grow, slowing startup replay. A fresh
+    /// segment cannot hold any operation from before it existed, so it could report its creation
+    /// version as vacuously persisted (e.g. floor `Segment::persistent_version()` on a stamped
+    /// `initial_version`) and stop dragging the waterline down. Left out here to keep this change
+    /// surgical: it changes the segment durability contract for every caller and deserves its own
+    /// change.
+    fn run_ready_post_flush_actions(
+        &self,
+        persisted_version: SeqNumberType,
+    ) -> OperationResult<Option<SeqNumberType>> {
+        let waterline = match self.failed_operation.first() {
+            Some(failed) => persisted_version.min(*failed),
+            None => persisted_version,
+        };
+        let mut ready: Vec<_> = {
+            let mut actions = self.post_flush_actions.lock();
+            let (ready, keep): (Vec<_>, Vec<_>) = std::mem::take(&mut *actions)
+                .into_iter()
+                .partition(|action| action.ready_at <= waterline);
+            *actions = keep;
+            // Record the pins of the actions we are about to run while they are out of the queue, so
+            // a concurrent flush still accounts for them and cannot advance the WAL acknowledge past
+            // data their files still contradict. Set under the actions lock (see
+            // `pending_post_flush_ack_cap`).
+            *self.in_flight_ack_floor.lock() = ready.iter().map(|action| action.ack_pin).min();
+            ready
+        };
+        // Run in `ready_at` order: an action can release a resource a later action needs to take
+        // sole ownership of (a proxy keeps its shared write segment alive, and `drop_data` needs
+        // sole ownership; `ready_at` grows with each optimization). Once an action does not
+        // complete (`Retry` or `Err`), stop and re-queue the rest: a later action likely depends on
+        // the resource the blocked one still holds. Re-queued actions keep their ack pin in effect
+        // until they complete on a later flush, so a transient failure never advances the WAL
+        // acknowledge past data that is still on disk.
+        ready.sort_by_key(|action| action.ready_at);
+        let mut first_error = None;
+        let mut blocked = false;
+        let mut keep = Vec::new();
+        for mut action in ready {
+            if blocked {
+                keep.push(action);
+                continue;
+            }
+            match (action.action)() {
+                Ok(PostFlushOutcome::Done) => {}
+                Ok(PostFlushOutcome::Retry) => {
+                    keep.push(action);
+                    blocked = true;
+                }
+                // Hard failure: the action is dropped (its data is being destroyed and cannot be
+                // retried), the error is surfaced, and the rest is deferred to the next flush.
+                Err(err) => {
+                    first_error = Some(err);
+                    blocked = true;
+                }
+            }
+        }
+        {
+            // Re-queue survivors and clear the in-flight floor together under the actions lock:
+            // survivors are back in the queue before the floor stops covering them, so the cap never
+            // dips. Lock order is always actions then floor.
+            let mut actions = self.post_flush_actions.lock();
+            actions.extend(keep);
+            *self.in_flight_ack_floor.lock() = None;
+        }
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        Ok(self.pending_post_flush_ack_cap())
     }
 
     /// Suggests a new maximum persisted segment version when calling `flush_all`. This can be used to make WAL acknowledge no-op operations,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -550,32 +550,33 @@ impl SegmentHolder {
         ready.sort_by_key(|action| action.ready_at);
         let mut first_error = None;
         let mut blocked = false;
-        let mut keep = Vec::new();
-        for mut action in ready {
+        ready.retain_mut(|action| {
             if blocked {
-                keep.push(action);
-                continue;
+                return true;
             }
+
             match (action.action)() {
-                Ok(PostFlushOutcome::Done) => {}
+                Ok(PostFlushOutcome::Done) => false,
                 Ok(PostFlushOutcome::Retry) => {
-                    keep.push(action);
                     blocked = true;
+                    true
                 }
                 // Hard failure: the action is dropped (its data is being destroyed and cannot be
                 // retried), the error is surfaced, and the rest is deferred to the next flush.
                 Err(err) => {
                     first_error = Some(err);
                     blocked = true;
+                    false
                 }
             }
-        }
+        });
+
         {
             // Re-queue survivors and clear the in-flight floor together under the actions lock:
             // survivors are back in the queue before the floor stops covering them, so the cap never
             // dips. Lock order is always actions then floor.
             let mut actions = self.post_flush_actions.lock();
-            actions.extend(keep);
+            actions.extend(ready);
             *self.in_flight_ack_floor.lock() = None;
         }
         if let Some(err) = first_error {

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -1525,6 +1525,117 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
     );
 }
 
+/// A post-flush action that does not complete keeps its ack pin in effect across flushes,
+/// capping the returned WAL acknowledge until it finally completes.
+#[test]
+fn test_post_flush_action_retry_keeps_ack_pin() {
+    use std::sync::atomic::AtomicUsize;
+
+    const ACK_PIN: SeqNumberType = 5;
+    const WATERLINE: SeqNumberType = 100;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(empty_segment(dir.path()));
+    // Make the durable waterline observably higher than the ack pin so the cap is visible.
+    holder.bump_max_segment_version_overwrite(WATERLINE);
+
+    // An action that must run three times: Retry, Retry, then Done.
+    let runs = Arc::new(AtomicUsize::new(0));
+    let runs_in_action = Arc::clone(&runs);
+    holder.register_post_flush_action(0, ACK_PIN, move || {
+        let previous = runs_in_action.fetch_add(1, Ordering::SeqCst);
+        if previous < 2 {
+            Ok(PostFlushOutcome::Retry)
+        } else {
+            Ok(PostFlushOutcome::Done)
+        }
+    });
+
+    // While the action is pending, the ack pin caps the returned version.
+    let version = holder.flush_all(true, true).unwrap();
+    assert_eq!(version, ACK_PIN, "ack pin must cap the WAL acknowledge");
+    assert_eq!(runs.load(Ordering::SeqCst), 1);
+
+    // Still pending after the second retry: the pin remains in effect.
+    let version = holder.flush_all(true, true).unwrap();
+    assert_eq!(version, ACK_PIN);
+    assert_eq!(runs.load(Ordering::SeqCst), 2);
+
+    // The third flush completes the action, lifting the cap.
+    let version = holder.flush_all(true, true).unwrap();
+    assert_eq!(
+        version, WATERLINE,
+        "cap is lifted once the action completes"
+    );
+    assert_eq!(runs.load(Ordering::SeqCst), 3);
+
+    // The completed action is gone and is not run again.
+    let version = holder.flush_all(true, true).unwrap();
+    assert_eq!(version, WATERLINE);
+    assert_eq!(runs.load(Ordering::SeqCst), 3);
+}
+
+/// While an action is being run it is briefly removed from the queue, but its ack pin must stay
+/// visible to `pending_post_flush_ack_cap` so a concurrent flush cannot over-acknowledge the WAL.
+#[test]
+fn test_post_flush_action_in_flight_pin_stays_visible() {
+    const ACK_PIN: SeqNumberType = 5;
+    const WATERLINE: SeqNumberType = 100;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(empty_segment(dir.path()));
+    holder.bump_max_segment_version_overwrite(WATERLINE);
+    let holder = Arc::new(holder);
+
+    // From inside the action (when it is out of the queue) observe the cap a concurrent flush
+    // would see.
+    let observed = Arc::new(Mutex::new(None));
+    let observed_in_action = Arc::clone(&observed);
+    let holder_in_action = Arc::clone(&holder);
+    holder.register_post_flush_action(0, ACK_PIN, move || {
+        *observed_in_action.lock() = Some(holder_in_action.pending_post_flush_ack_cap());
+        Ok(PostFlushOutcome::Done)
+    });
+
+    let version = holder.flush_all(true, true).unwrap();
+
+    assert_eq!(
+        *observed.lock(),
+        Some(Some(ACK_PIN)),
+        "in-flight action's ack pin must remain visible while it runs",
+    );
+    // Once it completed, the cap is lifted.
+    assert_eq!(version, WATERLINE);
+    assert_eq!(holder.pending_post_flush_ack_cap(), None);
+}
+
+/// A post-flush action that fails hard (not retryable) is dropped and surfaces its error; a
+/// later flush is then unaffected.
+#[test]
+fn test_post_flush_action_hard_failure_is_dropped() {
+    const WATERLINE: SeqNumberType = 100;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(empty_segment(dir.path()));
+    holder.bump_max_segment_version_overwrite(WATERLINE);
+
+    holder.register_post_flush_action(0, 5, move || Err(OperationError::service_error("boom")));
+
+    // The flush surfaces the action's error.
+    let err = holder.flush_all(true, true).unwrap_err();
+    assert!(format!("{err}").contains("boom"));
+
+    // The failed action is gone, so the next flush is clean and uncapped.
+    let version = holder.flush_all(true, true).unwrap();
+    assert_eq!(version, WATERLINE);
+}
+
 /// Test that CoW deletes the source point when the destination copy is NOT deferred.
 ///
 /// This is the standard CoW behavior: after successfully moving a point to the appendable


### PR DESCRIPTION
Alternative implementation of #9463. 

Same fix, different mechanism: a generic post-flush action queue instead of the bespoke `retire_segment` machinery.

## Problem

Optimizations copy-on-write move points out of their source segments **in memory**. 

WAL replay can only re-derive those moves from the sources' on-disk pre-images, but `finish_optimization` destroys the sources immediately. 

If the moved copies are still unflushed when a restart happens, the points are lost (`No point with id` during replay).

## Approach

Defer the destruction instead of dropping it at the swap. `SegmentHolder` gains a small generic facility:

```rust
// Run `action` once a flush proves its data durable (waterline >= ready_at).
// Until then, cap the WAL acknowledge at `ack_pin`.
holder.register_post_flush_action(ready_at, ack_pin, action);
```

`finish_optimization` uses it to drop each source once durable:

```rust
for proxy in proxies {
    let ack_pin = proxy.get().read().persistent_version();
    holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
}
```

`flush_all` runs every ready action and caps its returned version at the minimum `ack_pin` of those still pending:

```rust
let persisted = self.get_max_persisted_version(...);
let pending = self.run_ready_post_flush_actions(persisted)?;
Ok(pending.map_or(persisted, |cap| min(persisted, cap)))
```

The cap keeps every operation the not-yet-dropped files contradict (deletions in particular) replayable until the files are gone. A crash in the meantime loads the old files next to their replacement; load-time deduplication resolves the overlap.

## Why an alternative

The post-flush action is reusable for any "clean up once durable" need, and the retry/ack-pin logic lives in one place rather than spread across segment-specific methods.

- A failed drop (segment briefly still in use) is **retried** on a later flush via `try_drop_data`, keeping its pin instead of leaking it, and uses a short timeout so it never blocks a flush for up to an hour.
- In-flight actions stay visible to `pending_post_flush_ack_cap`, so a concurrent flush cannot over-acknowledge the WAL while a drop is running.

## Tests

- Optimizer tests that assert source files are gone now `flush_all` first to run the deferred drop.
- New `SegmentHolder` unit tests cover the retry, hard-failure, and in-flight-pin-visibility paths.
- Validated with the model-based soak test (restart-heavy run): green.

## Known follow-ups

- A fresh appendable segment reports `persistent_version() == 0` until its first flush, dragging the waterline down and slowing maturation. Flooring it on a stamped `initial_version` is left out to keep this surgical (it changes the durability contract for every caller); documented inline.
- If the actual file deletion fails mid-way (a real fs error, not the common "still in use" case), the segment is already consumed so the action is dropped and its pin released. Narrow and pre-existing in behavior, but the pin release there is technically unsound.
