### PR TITLE
Add facet accuracy test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "pprof",
  "proptest",
  "rand 0.10.1",
+ "rand_distr",
  "ringbuffer",
  "rmp-serde",
  "rstest",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -21,6 +21,7 @@ staging = ["shard/staging"]
 criterion = { workspace = true }
 fs-err = { workspace = true, features = ["debug"] }
 proptest = { workspace = true }
+rand_distr = { workspace = true }
 rstest = { workspace = true }
 tar = { workspace = true }
 approx = "0.5.1"

--- a/lib/collection/src/tests/facet.rs
+++ b/lib/collection/src/tests/facet.rs
@@ -18,19 +18,22 @@
 //! and within each strategy the filter selectivity steers the terminal op
 //! (direct counts / filter-iter / facet-iter).
 //!
-//! Two invariants are asserted:
+//! Every case asserts one invariant: the top-[`LIMIT`] hits of approximate
+//! faceting equal those of exact faceting. The full strategy (low cardinality)
+//! enumerates exhaustively, so its entire result matches. The sampling strategy
+//! (high cardinality) may omit rare values, but the Zipf skew keeps the heaviest
+//! values — the only ones that can reach the top-[`LIMIT`] — over-represented
+//! enough to be sampled on every run, and each value it surfaces carries an
+//! exact count. Truncating both sides to their top hits therefore tolerates
+//! sampling's incompleteness while still catching any miscount.
 //!
-//! * **Full strategy (low cardinality)** — enumeration is exhaustive, so the
-//!   approximate result must equal the exact one *exactly* (same values, same
-//!   counts).
-//! * **Sampling strategy (high cardinality)** — sampling trades completeness for
-//!   speed: it may omit values, but every value it surfaces must carry the exact
-//!   count.
-//!
-//! The shard holds a single appendable segment with each point upserted once, so
-//! no point appears in multiple segments with different versions — the
-//! per-segment-sum `approx_facet` performs equals the cross-segment dedup
-//! `exact_facet` performs, and the two are expected to agree on counts.
+//! The shard holds a single appendable segment, and the fixture deletes and
+//! overwrites a slice of the points after the initial insert (see
+//! [`build_facet_fixture`]). Even so, no point ever lands in two segments with
+//! different versions: both mutations rewrite that one segment in place. The
+//! per-segment-sum `approx_facet` performs therefore still equals the
+//! cross-segment dedup `exact_facet` performs — now additionally proving both
+//! paths honour deletions and payload overwrites.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -59,7 +62,7 @@ use crate::operations::point_ops::{
 };
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
-use crate::tests::fixtures::{create_collection_config};
+use crate::tests::fixtures::create_collection_config;
 use crate::tests::payload::create_index;
 
 /// Total points in the fixture.
@@ -84,6 +87,15 @@ const TAG_KEY: &str = "tag";
 const SEQ_KEY: &str = "seq";
 
 const COLOURS: [&str; 4] = ["red", "blue", "green", "yellow"];
+
+/// New `colour` value introduced only by overwrites — never present at insert
+/// time, so the facet index must surface a value it did not originally index.
+const OVERWRITE_COLOUR: &str = "magenta";
+
+/// One point in every `MUTATION_STRIDE` is deleted and a different one is
+/// overwritten (disjoint residues). The stride is coprime with `COLOURS.len()`,
+/// so both mutation sets spread evenly across colours.
+const MUTATION_STRIDE: usize = 5;
 
 const LIMIT: usize = 10;
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -139,6 +151,23 @@ fn seq_below(n: usize) -> Filter {
     )))
 }
 
+/// Build one point. `id` and `seq` both derive from the index `i`; `colour` and
+/// `tag` populate the two facet fields.
+fn make_point(i: usize, colour: &str, tag: u64) -> PointStructPersisted {
+    PointStructPersisted {
+        id: (i as u64 + 1).into(),
+        vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+        payload: Some(
+            serde_json::from_value(serde_json::json!({
+                COLOUR_KEY: colour,
+                TAG_KEY: format!("tag_{tag}"),
+                SEQ_KEY: i as f64,
+            }))
+            .unwrap(),
+        ),
+    }
+}
+
 /// Build a single-shard fixture of `N_POINTS` points. Each point carries:
 /// * `colour` — keyword, `COLOURS.len()` uniques, low cardinality → full strategy.
 /// * `tag` — keyword, Zipf-distributed over a large vocabulary, high cardinality
@@ -178,18 +207,7 @@ async fn build_facet_fixture() -> ShardFixture {
     let points: Vec<PointStructPersisted> = (0..N_POINTS)
         .map(|i| {
             let tag = zipf.sample(&mut rng) as u64;
-            PointStructPersisted {
-                id: (i as u64 + 1).into(),
-                vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
-                payload: Some(
-                    serde_json::from_value(serde_json::json!({
-                        COLOUR_KEY: COLOURS[i % COLOURS.len()],
-                        TAG_KEY: format!("tag_{tag}"),
-                        SEQ_KEY: i as f64,
-                    }))
-                    .unwrap(),
-                ),
-            }
+            make_point(i, COLOURS[i % COLOURS.len()], tag)
         })
         .collect();
 
@@ -215,6 +233,52 @@ async fn build_facet_fixture() -> ShardFixture {
     ] {
         create_index(&shard, &payload_index_schema, name, field_type).await;
     }
+
+    // Mutate the fresh insert so both facet paths must reconcile removals and
+    // payload rewrites, not just a pristine load. The two mutation sets are
+    // disjoint residues mod `MUTATION_STRIDE`.
+
+    // Delete one point in every `MUTATION_STRIDE`. Deleted points must vanish
+    // from both counts (this exercises `DeferredBehavior::VisibleOnly`).
+    let delete = CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+        ids: (0..N_POINTS)
+            .filter(|i| i % MUTATION_STRIDE == 0)
+            .map(|i| (i as u64 + 1).into())
+            .collect(),
+    });
+    shard
+        .update(
+            delete.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    // Overwrite a different point in every `MUTATION_STRIDE` with a fresh
+    // payload: the brand-new `OVERWRITE_COLOUR` and a freshly Zipf-sampled `tag`,
+    // keeping `seq` so the range filters keep their selectivity. The facet index
+    // must drop the stale values and adopt the new ones.
+    let overwrites: Vec<PointStructPersisted> = (0..N_POINTS)
+        .filter(|i| i % MUTATION_STRIDE == 1)
+        .map(|i| {
+            let tag = zipf.sample(&mut rng) as u64;
+            make_point(i, OVERWRITE_COLOUR, tag)
+        })
+        .collect();
+    let overwrite = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(overwrites),
+    ));
+    shard
+        .update(
+            overwrite.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
 
     ShardFixture {
         _collection_dir: collection_dir,

--- a/lib/collection/src/tests/facet.rs
+++ b/lib/collection/src/tests/facet.rs
@@ -67,7 +67,7 @@ const BROAD: usize = N_POINTS * 9 / 10;
 /// values, so the field engages the sampling strategy.
 const ZIPF_CARDINALITY: usize = 2_000;
 /// Zipf exponent — a realistic, moderately skewed facet distribution.
-const ZIPF_SKEW: f64 = 0.7;
+const ZIPF_SKEW: f64 = 0.6;
 /// Fixed seed: the fixture must be deterministic.
 const ZIPF_SEED: u64 = 0xFACE_F00D;
 

--- a/lib/collection/src/tests/facet.rs
+++ b/lib/collection/src/tests/facet.rs
@@ -1,0 +1,279 @@
+//! Accuracy coverage for approximate faceting, comparing it against exact
+//! faceting on a real [`LocalShard`].
+//!
+//! The approximate facet implementation lives in
+//! `segment/src/segment/read_view/facet.rs`, but the *exact* counterpart is only
+//! reachable one level up, at the shard: [`LocalShard::exact_facet`] enumerates
+//! every value and counts each with a filtered read, deduplicating points across
+//! segments. The shard is therefore the lowest level where both paths can be run
+//! against the same data and compared.
+//!
+//! The test sweeps a 2×3 matrix to exercise every approximate plan:
+//!
+//! | field                         | no filter | selective filter | broad filter |
+//! |-------------------------------|-----------|------------------|--------------|
+//! | low cardinality (`colour`)    | full      | full             | full         |
+//! | high cardinality (`tag`, Zipf)| sampling  | sampling         | sampling     |
+//!
+//! and within each strategy the filter selectivity steers the terminal op
+//! (direct counts / filter-iter / facet-iter).
+//!
+//! Two invariants are asserted:
+//!
+//! * **Full strategy (low cardinality)** — enumeration is exhaustive, so the
+//!   approximate result must equal the exact one *exactly* (same values, same
+//!   counts).
+//! * **Sampling strategy (high cardinality)** — sampling trades completeness for
+//!   speed: it may omit values, but every value it surfaces must carry the exact
+//!   count.
+//!
+//! The shard holds a single appendable segment with each point upserted once, so
+//! no point appears in multiple segments with different versions — the
+//! per-segment-sum `approx_facet` performs equals the cross-segment dedup
+//! `exact_facet` performs, and the two are expected to agree on counts.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::save_on_disk::SaveOnDisk;
+use ordered_float::OrderedFloat;
+use rand::SeedableRng;
+use rand::distr::Distribution;
+use rand::rngs::StdRng;
+use rand_distr::Zipf;
+use rstest::rstest;
+use segment::data_types::facets::{FacetParams, FacetValue};
+use segment::data_types::vectors::VectorStructInternal;
+use segment::json_path::JsonPath;
+use segment::types::{Condition, FieldCondition, Filter, PayloadSchemaType, Range};
+use tempfile::{Builder, TempDir};
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+};
+use crate::shards::local_shard::LocalShard;
+use crate::shards::shard_trait::{ShardOperation, WaitUntil};
+use crate::tests::fixtures::{create_collection_config};
+use crate::tests::payload::create_index;
+
+/// Total points in the fixture.
+const N_POINTS: usize = 300_000;
+/// `seq <` this matches 5% of points — selective enough for the full strategy to
+/// iterate the filter, and to drive the sampling strategy's selective branch.
+const SELECTIVE: usize = N_POINTS / 20;
+/// `seq <` this matches 90% of points — broad enough to walk the facet index.
+const BROAD: usize = N_POINTS * 9 / 10;
+
+/// `tag` vocabulary size. Zipf samples land in `1..=ZIPF_CARDINALITY`; combined
+/// with the skew below this realises well over [`MIN_SAMPLE_TARGET`] unique
+/// values, so the field engages the sampling strategy.
+const ZIPF_CARDINALITY: usize = 2_000;
+/// Zipf exponent — a realistic, moderately skewed facet distribution.
+const ZIPF_SKEW: f64 = 0.7;
+/// Fixed seed: the fixture must be deterministic.
+const ZIPF_SEED: u64 = 0xFACE_F00D;
+
+const COLOUR_KEY: &str = "colour";
+const TAG_KEY: &str = "tag";
+const SEQ_KEY: &str = "seq";
+
+const COLOURS: [&str; 4] = ["red", "blue", "green", "yellow"];
+
+const LIMIT: usize = 10;
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+type Counts = HashMap<FacetValue, usize>;
+
+/// A built shard plus the temp dirs and runtime it borrows. The temp dirs are
+/// kept alive for the shard's lifetime.
+struct ShardFixture {
+    _collection_dir: TempDir,
+    _schema_dir: TempDir,
+    shard: LocalShard,
+    search_runtime: AdaptiveSearchHandle,
+}
+
+impl ShardFixture {
+    /// Run the approximate facet path (the code under test).
+    async fn approx(&self, key: &str, filter: Option<Filter>) -> Counts {
+        self.facet(key, filter, false).await
+    }
+
+    /// Run the exact facet path (the reference).
+    async fn exact(&self, key: &str, filter: Option<Filter>) -> Counts {
+        self.facet(key, filter, true).await
+    }
+
+    async fn facet(&self, key: &str, filter: Option<Filter>, exact: bool) -> Counts {
+        let request = Arc::new(FacetParams {
+            key: JsonPath::new(key),
+            limit: LIMIT,
+            filter,
+            exact,
+        });
+        let runtime = &self.search_runtime;
+        let hw = HwMeasurementAcc::new();
+        let hits = if exact {
+            self.shard.exact_facet(request, runtime, TIMEOUT, hw).await
+        } else {
+            self.shard.approx_facet(request, runtime, TIMEOUT, hw).await
+        }
+        .unwrap();
+        hits.into_iter().map(|hit| (hit.value, hit.count)).collect()
+    }
+}
+
+/// `seq < n`: matches exactly the first `n` points (`seq` equals the point index).
+fn seq_below(n: usize) -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_range(
+        JsonPath::new(SEQ_KEY),
+        Range {
+            lt: Some(OrderedFloat(n as f64)),
+            ..Default::default()
+        },
+    )))
+}
+
+/// Every value the approximate facet reported must carry the exact count. The
+/// approximate set may be a subset of the exact one (sampling can omit values),
+/// but it must never be wrong about a count.
+fn assert_subset_counts_exact(approx: &Counts, exact: &Counts) {
+    for (value, &count) in approx {
+        assert_eq!(
+            exact.get(value).copied(),
+            Some(count),
+            "Approximate facet reported {value:?} = {count}, exact = {:?}",
+            exact.get(value),
+        );
+    }
+}
+
+/// Build a single-shard fixture of `N_POINTS` points. Each point carries:
+/// * `colour` — keyword, `COLOURS.len()` uniques, low cardinality → full strategy.
+/// * `tag` — keyword, Zipf-distributed over a large vocabulary, high cardinality
+///   → sampling strategy.
+/// * `seq` — float equal to the point index, for filters of exact selectivity.
+async fn build_facet_fixture() -> ShardFixture {
+    let collection_dir = Builder::new().prefix("facet_collection").tempdir().unwrap();
+    let schema_dir = Builder::new().prefix("facet_schema").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let update_runtime = Handle::current();
+    let search_runtime = AdaptiveSearchHandle::current_for_tests();
+
+    let schema_file = schema_dir.path().join("payload-schema.json");
+    let payload_index_schema = Arc::new(SaveOnDisk::load_or_init_default(schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        "test".to_string(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema.clone(),
+        update_runtime,
+        search_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Upsert all points in a single operation, drawing `tag` from a deterministic
+    // Zipf distribution so the high-cardinality field has a realistic skew.
+    let mut rng = StdRng::seed_from_u64(ZIPF_SEED);
+    let zipf = Zipf::new(ZIPF_CARDINALITY as f64, ZIPF_SKEW).unwrap();
+    let points: Vec<PointStructPersisted> = (0..N_POINTS)
+        .map(|i| {
+            let tag = zipf.sample(&mut rng) as u64;
+            PointStructPersisted {
+                id: (i as u64 + 1).into(),
+                vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+                payload: Some(
+                    serde_json::from_value(serde_json::json!({
+                        COLOUR_KEY: COLOURS[i % COLOURS.len()],
+                        TAG_KEY: format!("tag_{tag}"),
+                        SEQ_KEY: i as f64,
+                    }))
+                    .unwrap(),
+                ),
+            }
+        })
+        .collect();
+
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(points),
+    ));
+    shard
+        .update(
+            upsert.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    // Faceting requires a map index (keyword); `seq` is indexed too so range
+    // filters resolve against an index.
+    for (name, field_type) in [
+        (COLOUR_KEY, PayloadSchemaType::Keyword),
+        (TAG_KEY, PayloadSchemaType::Keyword),
+        (SEQ_KEY, PayloadSchemaType::Float),
+    ] {
+        create_index(&shard, &payload_index_schema, name, field_type).await;
+    }
+
+    ShardFixture {
+        _collection_dir: collection_dir,
+        _schema_dir: schema_dir,
+        shard,
+        search_runtime,
+    }
+}
+
+/// Sweep no-filter / selective / broad filtering for both a low- and a
+/// high-cardinality field, comparing approximate faceting against exact.
+#[tokio::test(flavor = "multi_thread")]
+#[rstest]
+#[case::no_filter(None)]
+#[case::selective_filter(Some(seq_below(SELECTIVE)))]
+#[case::broad_filter(Some(seq_below(BROAD)))]
+async fn approx_facet_matches_exact_across_strategies(#[case] filter: Option<Filter>) {
+    let fixture = build_facet_fixture().await;
+    let approx = fixture.approx(COLOUR_KEY, filter.clone()).await;
+    let exact = fixture.exact(COLOUR_KEY, filter.clone()).await;
+    assert_eq!(
+        approx, exact,
+        "approximate faceting must reproduce exact counts",
+    );
+
+    // High-cardinality Zipf keyword field → "sampling" strategy. It may omit
+    // values, but every value it surfaces must carry the exact count.
+    let approx = fixture.approx(TAG_KEY, filter.clone()).await;
+    let exact = fixture.exact(TAG_KEY, filter.clone()).await;
+
+    if filter.is_none() {
+        // Without a filter, exact enumerates the whole vocabulary; assert the
+        // field is high-cardinality enough to actually engage sampling.
+        assert!(
+            !approx.is_empty(),
+            "expected some hits",
+        );
+        assert!(
+            approx.len() <= LIMIT,
+            "result must be bounded by the limit",
+        );
+        assert_subset_counts_exact(&approx, &exact);
+    }
+
+    fixture.shard.stop_gracefully().await;
+}

--- a/lib/collection/src/tests/facet.rs
+++ b/lib/collection/src/tests/facet.rs
@@ -1,39 +1,27 @@
-//! Accuracy coverage for approximate faceting, comparing it against exact
-//! faceting on a real [`LocalShard`].
+//! Accuracy coverage for approximate faceting, checked against exact faceting on
+//! a real [`LocalShard`] — the lowest level where both run on the same data
+//! ([`LocalShard::exact_facet`] dedups points across segments; the approximate
+//! path lives in `segment/src/segment/read_view/facet.rs`).
 //!
-//! The approximate facet implementation lives in
-//! `segment/src/segment/read_view/facet.rs`, but the *exact* counterpart is only
-//! reachable one level up, at the shard: [`LocalShard::exact_facet`] enumerates
-//! every value and counts each with a filtered read, deduplicating points across
-//! segments. The shard is therefore the lowest level where both paths can be run
-//! against the same data and compared.
-//!
-//! The test sweeps a 2×3 matrix to exercise every approximate plan:
+//! The test sweeps a 2×3 matrix to hit every approximate plan, with filter
+//! selectivity steering the terminal op (direct counts / filter-iter / facet-iter):
 //!
 //! | field                         | no filter | selective filter | broad filter |
 //! |-------------------------------|-----------|------------------|--------------|
 //! | low cardinality (`colour`)    | full      | full             | full         |
 //! | high cardinality (`tag`, Zipf)| sampling  | sampling         | sampling     |
 //!
-//! and within each strategy the filter selectivity steers the terminal op
-//! (direct counts / filter-iter / facet-iter).
+//! Each case asserts the same invariant: the top-[`LIMIT`] hits of approximate
+//! faceting equal those of exact faceting. The full strategy enumerates
+//! exhaustively; the sampling strategy may drop rare values, but the Zipf skew
+//! keeps the top-[`LIMIT`] values frequent enough to always be sampled (with
+//! exact counts), so truncating to the top hits hides the incompleteness.
 //!
-//! Every case asserts one invariant: the top-[`LIMIT`] hits of approximate
-//! faceting equal those of exact faceting. The full strategy (low cardinality)
-//! enumerates exhaustively, so its entire result matches. The sampling strategy
-//! (high cardinality) may omit rare values, but the Zipf skew keeps the heaviest
-//! values — the only ones that can reach the top-[`LIMIT`] — over-represented
-//! enough to be sampled on every run, and each value it surfaces carries an
-//! exact count. Truncating both sides to their top hits therefore tolerates
-//! sampling's incompleteness while still catching any miscount.
-//!
-//! The shard holds a single appendable segment, and the fixture deletes and
-//! overwrites a slice of the points after the initial insert (see
-//! [`build_facet_fixture`]). Even so, no point ever lands in two segments with
-//! different versions: both mutations rewrite that one segment in place. The
-//! per-segment-sum `approx_facet` performs therefore still equals the
-//! cross-segment dedup `exact_facet` performs — now additionally proving both
-//! paths honour deletions and payload overwrites.
+//! The fixture also optimizes the insert into an immutable, indexed segment, then
+//! deletes and overwrites a slice of points (see [`build_facet_fixture`]), so the
+//! read paths must handle soft-deletes in immutable postings and points living in
+//! two segments at different versions — the cross-segment case `exact_facet`
+//! dedups and `approx_facet` sums visibly.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,6 +48,7 @@ use crate::operations::CollectionUpdateOperations;
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
+use crate::operations::types::ShardStatus;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::create_collection_config;
@@ -96,6 +85,15 @@ const OVERWRITE_COLOUR: &str = "magenta";
 /// overwritten (disjoint residues). The stride is coprime with `COLOURS.len()`,
 /// so both mutation sets spread evenly across colours.
 const MUTATION_STRIDE: usize = 5;
+
+/// Indexing threshold (KB of vector data) used to force optimization, derived to
+/// sit midway between the full insert and the smaller overwrite batch: the
+/// initial `N_POINTS` exceed it so they get indexed into an immutable segment,
+/// while the later `N_POINTS / MUTATION_STRIDE` overwrites stay below it and
+/// remain appendable — so no second optimization pass disturbs the cross-segment
+/// state at query time. Tracks the fixture sizes instead of hard-coding a value
+/// coupled to them. (Vectors are 4-dim `f32` = 16 bytes.)
+const INDEXING_THRESHOLD_KB: usize = (N_POINTS + N_POINTS / MUTATION_STRIDE) * 16 / 2 / 1024;
 
 const LIMIT: usize = 10;
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -168,6 +166,50 @@ fn make_point(i: usize, colour: &str, tag: u64) -> PointStructPersisted {
     }
 }
 
+/// Issue `op` against the shard and wait for it to become visible.
+async fn apply(shard: &LocalShard, op: CollectionUpdateOperations) {
+    shard
+        .update(op.into(), WaitUntil::Visible, None, HwMeasurementAcc::new())
+        .await
+        .unwrap();
+}
+
+/// Poll until the shard reaches a stable optimized state — `Green` with no proxy
+/// segment in flight — so the segment layout is deterministic before querying.
+async fn wait_for_optimization(shard: &LocalShard) {
+    let start = std::time::Instant::now();
+    loop {
+        let (status, _) = shard.local_shard_status().await;
+        let has_proxy = shard
+            .segments()
+            .read()
+            .iter()
+            .any(|(_, segment)| !segment.is_original());
+        if status == ShardStatus::Green && !has_proxy {
+            return;
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "timed out waiting for optimization (status: {status:?}, has_proxy: {has_proxy})",
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Assert the shard holds at least one immutable (non-appendable) segment, i.e.
+/// optimization actually produced the indexed segment the test means to cover.
+fn assert_has_immutable_segment(shard: &LocalShard) {
+    let segments = shard.segments();
+    let has_immutable = segments
+        .read()
+        .iter()
+        .any(|(_, segment)| !segment.get().read().is_appendable());
+    assert!(
+        has_immutable,
+        "expected an immutable segment after optimization",
+    );
+}
+
 /// Build a single-shard fixture of `N_POINTS` points. Each point carries:
 /// * `colour` — keyword, `COLOURS.len()` uniques, low cardinality → full strategy.
 /// * `tag` — keyword, Zipf-distributed over a large vocabulary, high cardinality
@@ -177,7 +219,10 @@ async fn build_facet_fixture() -> ShardFixture {
     let collection_dir = Builder::new().prefix("facet_collection").tempdir().unwrap();
     let schema_dir = Builder::new().prefix("facet_schema").tempdir().unwrap();
 
-    let config = create_collection_config();
+    let mut config = create_collection_config();
+    // Force the initial insert to be optimized into an immutable, indexed segment
+    // so the facet paths run against immutable storage, not only appendable.
+    config.optimizer_config.indexing_threshold = Some(INDEXING_THRESHOLD_KB);
 
     let update_runtime = Handle::current();
     let search_runtime = AdaptiveSearchHandle::current_for_tests();
@@ -200,6 +245,17 @@ async fn build_facet_fixture() -> ShardFixture {
     .await
     .unwrap();
 
+    // Faceting requires a map index (keyword); `seq` is indexed too so range
+    // filters resolve against an index. Create the indexes up front, before any
+    // data, so the optimizer carries them into the immutable segment it builds.
+    for (name, field_type) in [
+        (COLOUR_KEY, PayloadSchemaType::Keyword),
+        (TAG_KEY, PayloadSchemaType::Keyword),
+        (SEQ_KEY, PayloadSchemaType::Float),
+    ] {
+        create_index(&shard, &payload_index_schema, name, field_type).await;
+    }
+
     // Upsert all points in a single operation, drawing `tag` from a deterministic
     // Zipf distribution so the high-cardinality field has a realistic skew.
     let mut rng = StdRng::seed_from_u64(ZIPF_SEED);
@@ -210,51 +266,41 @@ async fn build_facet_fixture() -> ShardFixture {
             make_point(i, COLOURS[i % COLOURS.len()], tag)
         })
         .collect();
+    apply(
+        &shard,
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::from(points),
+        )),
+    )
+    .await;
 
-    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperationsInternal::from(points),
-    ));
-    shard
-        .update(
-            upsert.into(),
-            WaitUntil::Visible,
-            None,
-            HwMeasurementAcc::new(),
-        )
-        .await
-        .unwrap();
+    // Optimize the insert into an immutable, indexed segment and confirm it
+    // actually materialized before mutating.
+    wait_for_optimization(&shard).await;
+    assert_has_immutable_segment(&shard);
 
-    // Faceting requires a map index (keyword); `seq` is indexed too so range
-    // filters resolve against an index.
-    for (name, field_type) in [
-        (COLOUR_KEY, PayloadSchemaType::Keyword),
-        (TAG_KEY, PayloadSchemaType::Keyword),
-        (SEQ_KEY, PayloadSchemaType::Float),
-    ] {
-        create_index(&shard, &payload_index_schema, name, field_type).await;
-    }
-
-    // Mutate the fresh insert so both facet paths must reconcile removals and
-    // payload rewrites, not just a pristine load. The two mutation sets are
-    // disjoint residues mod `MUTATION_STRIDE`.
+    // Mutate the optimized fixture so both facet paths must reconcile removals
+    // and payload rewrites against immutable storage, not just a pristine load.
+    // The two mutation sets are disjoint residues mod `MUTATION_STRIDE`.
+    //
+    // Since the points now live in an immutable segment, a delete becomes a
+    // soft-delete recorded against it, and an overwrite soft-deletes the old copy
+    // there while writing the new one to the appendable segment — so the same
+    // point exists in two segments with different versions, the cross-segment
+    // case `exact_facet` must dedup and `approx_facet` must sum visibly.
 
     // Delete one point in every `MUTATION_STRIDE`. Deleted points must vanish
     // from both counts (this exercises `DeferredBehavior::VisibleOnly`).
-    let delete = CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
-        ids: (0..N_POINTS)
-            .filter(|i| i % MUTATION_STRIDE == 0)
-            .map(|i| (i as u64 + 1).into())
-            .collect(),
-    });
-    shard
-        .update(
-            delete.into(),
-            WaitUntil::Visible,
-            None,
-            HwMeasurementAcc::new(),
-        )
-        .await
-        .unwrap();
+    apply(
+        &shard,
+        CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+            ids: (0..N_POINTS)
+                .filter(|i| i % MUTATION_STRIDE == 0)
+                .map(|i| (i as u64 + 1).into())
+                .collect(),
+        }),
+    )
+    .await;
 
     // Overwrite a different point in every `MUTATION_STRIDE` with a fresh
     // payload: the brand-new `OVERWRITE_COLOUR` and a freshly Zipf-sampled `tag`,
@@ -267,18 +313,18 @@ async fn build_facet_fixture() -> ShardFixture {
             make_point(i, OVERWRITE_COLOUR, tag)
         })
         .collect();
-    let overwrite = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        PointInsertOperationsInternal::from(overwrites),
-    ));
-    shard
-        .update(
-            overwrite.into(),
-            WaitUntil::Visible,
-            None,
-            HwMeasurementAcc::new(),
-        )
-        .await
-        .unwrap();
+    apply(
+        &shard,
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::from(overwrites),
+        )),
+    )
+    .await;
+
+    // The overwrite batch stays below `INDEXING_THRESHOLD_KB` and the soft-deletes
+    // stay below the vacuum threshold, so nothing else should optimize; wait
+    // anyway to pin down a deterministic segment layout before querying.
+    wait_for_optimization(&shard).await;
 
     ShardFixture {
         _collection_dir: collection_dir,

--- a/lib/collection/src/tests/facet.rs
+++ b/lib/collection/src/tests/facet.rs
@@ -32,7 +32,6 @@
 //! per-segment-sum `approx_facet` performs equals the cross-segment dedup
 //! `exact_facet` performs, and the two are expected to agree on counts.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,7 +44,7 @@ use rand::distr::Distribution;
 use rand::rngs::StdRng;
 use rand_distr::Zipf;
 use rstest::rstest;
-use segment::data_types::facets::{FacetParams, FacetValue};
+use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::vectors::VectorStructInternal;
 use segment::json_path::JsonPath;
 use segment::types::{Condition, FieldCondition, Filter, PayloadSchemaType, Range};
@@ -64,7 +63,7 @@ use crate::tests::fixtures::{create_collection_config};
 use crate::tests::payload::create_index;
 
 /// Total points in the fixture.
-const N_POINTS: usize = 300_000;
+const N_POINTS: usize = 5_000;
 /// `seq <` this matches 5% of points — selective enough for the full strategy to
 /// iterate the filter, and to drive the sampling strategy's selective branch.
 const SELECTIVE: usize = N_POINTS / 20;
@@ -89,8 +88,6 @@ const COLOURS: [&str; 4] = ["red", "blue", "green", "yellow"];
 const LIMIT: usize = 10;
 const TIMEOUT: Duration = Duration::from_secs(60);
 
-type Counts = HashMap<FacetValue, usize>;
-
 /// A built shard plus the temp dirs and runtime it borrows. The temp dirs are
 /// kept alive for the shard's lifetime.
 struct ShardFixture {
@@ -102,16 +99,16 @@ struct ShardFixture {
 
 impl ShardFixture {
     /// Run the approximate facet path (the code under test).
-    async fn approx(&self, key: &str, filter: Option<Filter>) -> Counts {
+    async fn approx(&self, key: &str, filter: Option<Filter>) -> FacetResponse {
         self.facet(key, filter, false).await
     }
 
     /// Run the exact facet path (the reference).
-    async fn exact(&self, key: &str, filter: Option<Filter>) -> Counts {
+    async fn exact(&self, key: &str, filter: Option<Filter>) -> FacetResponse {
         self.facet(key, filter, true).await
     }
 
-    async fn facet(&self, key: &str, filter: Option<Filter>, exact: bool) -> Counts {
+    async fn facet(&self, key: &str, filter: Option<Filter>, exact: bool) -> FacetResponse {
         let request = Arc::new(FacetParams {
             key: JsonPath::new(key),
             limit: LIMIT,
@@ -126,7 +123,8 @@ impl ShardFixture {
             self.shard.approx_facet(request, runtime, TIMEOUT, hw).await
         }
         .unwrap();
-        hits.into_iter().map(|hit| (hit.value, hit.count)).collect()
+        let counts = hits.into_iter().map(|hit| (hit.value, hit.count)).collect();
+        FacetResponse::top_hits(counts, LIMIT)
     }
 }
 
@@ -139,20 +137,6 @@ fn seq_below(n: usize) -> Filter {
             ..Default::default()
         },
     )))
-}
-
-/// Every value the approximate facet reported must carry the exact count. The
-/// approximate set may be a subset of the exact one (sampling can omit values),
-/// but it must never be wrong about a count.
-fn assert_subset_counts_exact(approx: &Counts, exact: &Counts) {
-    for (value, &count) in approx {
-        assert_eq!(
-            exact.get(value).copied(),
-            Some(count),
-            "Approximate facet reported {value:?} = {count}, exact = {:?}",
-            exact.get(value),
-        );
-    }
 }
 
 /// Build a single-shard fixture of `N_POINTS` points. Each point carries:
@@ -244,36 +228,23 @@ async fn build_facet_fixture() -> ShardFixture {
 /// high-cardinality field, comparing approximate faceting against exact.
 #[tokio::test(flavor = "multi_thread")]
 #[rstest]
-#[case::no_filter(None)]
-#[case::selective_filter(Some(seq_below(SELECTIVE)))]
-#[case::broad_filter(Some(seq_below(BROAD)))]
-async fn approx_facet_matches_exact_across_strategies(#[case] filter: Option<Filter>) {
+#[case::low_card_no_filter(COLOUR_KEY, None)]
+#[case::low_card_selective_filter(COLOUR_KEY, Some(seq_below(SELECTIVE)))]
+#[case::low_card_broad_filter(COLOUR_KEY, Some(seq_below(BROAD)))]
+#[case::high_card_no_filter(TAG_KEY, None)]
+#[case::high_card_selective_filter(TAG_KEY, Some(seq_below(SELECTIVE)))]
+#[case::high_card_broad_filter(TAG_KEY, Some(seq_below(BROAD)))]
+async fn approx_facet_matches_exact_across_strategies(
+    #[case] key: &str,
+    #[case] filter: Option<Filter>,
+) {
     let fixture = build_facet_fixture().await;
-    let approx = fixture.approx(COLOUR_KEY, filter.clone()).await;
-    let exact = fixture.exact(COLOUR_KEY, filter.clone()).await;
+    let approx = fixture.approx(key, filter.clone()).await;
+    let exact = fixture.exact(key, filter.clone()).await;
     assert_eq!(
         approx, exact,
         "approximate faceting must reproduce exact counts",
     );
-
-    // High-cardinality Zipf keyword field → "sampling" strategy. It may omit
-    // values, but every value it surfaces must carry the exact count.
-    let approx = fixture.approx(TAG_KEY, filter.clone()).await;
-    let exact = fixture.exact(TAG_KEY, filter.clone()).await;
-
-    if filter.is_none() {
-        // Without a filter, exact enumerates the whole vocabulary; assert the
-        // field is high-cardinality enough to actually engage sampling.
-        assert!(
-            !approx.is_empty(),
-            "expected some hits",
-        );
-        assert!(
-            approx.len() <= LIMIT,
-            "result must be bounded by the limit",
-        );
-        assert_subset_counts_exact(&approx, &exact);
-    }
 
     fixture.shard.stop_gracefully().await;
 }

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod deferred_points_dedup;
 mod deferred_points_tests;
 mod delete_vector_name_replay;
+mod facet;
 mod fix_payload_indices;
 pub mod fixtures;
 mod hw_metrics;

--- a/lib/collection/src/tests/payload.rs
+++ b/lib/collection/src/tests/payload.rs
@@ -153,7 +153,7 @@ async fn test_payload_missing_index_check() {
     );
 }
 
-async fn create_index(
+pub async fn create_index(
     shard: &LocalShard,
     payload_index_schema: &Arc<SaveOnDisk<PayloadIndexSchema>>,
     name: &str,

--- a/lib/segment/src/data_types/facets.rs
+++ b/lib/segment/src/data_types/facets.rs
@@ -106,7 +106,7 @@ pub struct FacetHit<T: FacetValueTrait> {
     pub count: usize,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(PartialEq, Clone, Debug, Default)]
 pub struct FacetResponse {
     pub hits: Vec<FacetValueHit>,
 }


### PR DESCRIPTION
Adds an integration test, at shard level, of `facet` queries. 

Since we have a total of 6 different codepaths that handle approximate facets, this test exercises all of them by comparing it to `exact=true` output. 

The new tests didn't find any bugs, which is good, so let's keep this in CI.

It covers:
- deleted points
- no filter
- selective filter
- broad filter
- zipf-distributed key (many unique values)
- few unique values
- immutable & mutable segments