### PR TITLE
Add per-filter sparse IDF search option

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9961,6 +9961,17 @@
                 "nullable": true
               }
             ]
+          },
+          "idf": {
+            "description": "Scope for IDF statistics used by sparse vector queries with the IDF modifier.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IdfSearchScope"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -10005,6 +10016,25 @@
             "nullable": true
           }
         }
+      },
+      "IdfSearchScope": {
+        "description": "Scope for IDF statistics used by sparse vector queries.",
+        "oneOf": [
+          {
+            "description": "Use collection-wide IDF statistics.",
+            "type": "string",
+            "enum": [
+              "global"
+            ]
+          },
+          {
+            "description": "Use IDF statistics collected over the points matching the request filter.",
+            "type": "string",
+            "enum": [
+              "per_filter"
+            ]
+          }
+        ]
       },
       "ScoredPoint": {
         "description": "Search result",

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -949,7 +949,7 @@ impl From<SearchParams> for segment::types::SearchParams {
         Self {
             hnsw_ef: hnsw_ef.map(|x| x as usize),
             exact: exact.unwrap_or(false),
-            quantization: quantization.map(QuantizationSearchParams::into),
+            quantization: quantization.map(segment::types::QuantizationSearchParams::from),
             indexed_only: indexed_only.unwrap_or(false),
             acorn: acorn.map(segment::types::AcornSearchParams::from),
             idf: idf
@@ -972,7 +972,7 @@ impl From<segment::types::SearchParams> for SearchParams {
         Self {
             hnsw_ef: hnsw_ef.map(|x| x as u64),
             exact: Some(exact),
-            quantization: quantization.map(Into::into),
+            quantization: quantization.map(QuantizationSearchParams::from),
             indexed_only: Some(indexed_only),
             acorn: acorn.map(AcornSearchParams::from),
             idf: idf.map(|idf| i32::from(grpc::IdfSearchScope::from(idf))),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -918,6 +918,24 @@ impl From<segment::types::AcornSearchParams> for AcornSearchParams {
     }
 }
 
+impl From<grpc::IdfSearchScope> for segment::types::IdfSearchScope {
+    fn from(value: grpc::IdfSearchScope) -> Self {
+        match value {
+            grpc::IdfSearchScope::Global => Self::Global,
+            grpc::IdfSearchScope::PerFilter => Self::PerFilter,
+        }
+    }
+}
+
+impl From<segment::types::IdfSearchScope> for grpc::IdfSearchScope {
+    fn from(value: segment::types::IdfSearchScope) -> Self {
+        match value {
+            segment::types::IdfSearchScope::Global => Self::Global,
+            segment::types::IdfSearchScope::PerFilter => Self::PerFilter,
+        }
+    }
+}
+
 impl From<SearchParams> for segment::types::SearchParams {
     fn from(params: SearchParams) -> Self {
         let SearchParams {
@@ -926,6 +944,7 @@ impl From<SearchParams> for segment::types::SearchParams {
             quantization,
             indexed_only,
             acorn,
+            idf,
         } = params;
         Self {
             hnsw_ef: hnsw_ef.map(|x| x as usize),
@@ -933,6 +952,9 @@ impl From<SearchParams> for segment::types::SearchParams {
             quantization: quantization.map(QuantizationSearchParams::into),
             indexed_only: indexed_only.unwrap_or(false),
             acorn: acorn.map(segment::types::AcornSearchParams::from),
+            idf: idf
+                .and_then(|idf| grpc::IdfSearchScope::try_from(idf).ok())
+                .map(segment::types::IdfSearchScope::from),
         }
     }
 }
@@ -945,6 +967,7 @@ impl From<segment::types::SearchParams> for SearchParams {
             quantization,
             indexed_only,
             acorn,
+            idf,
         } = params;
         Self {
             hnsw_ef: hnsw_ef.map(|x| x as u64),
@@ -952,6 +975,7 @@ impl From<segment::types::SearchParams> for SearchParams {
             quantization: quantization.map(Into::into),
             indexed_only: Some(indexed_only),
             acorn: acorn.map(AcornSearchParams::from),
+            idf: idf.map(|idf| i32::from(grpc::IdfSearchScope::from(idf))),
         }
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -517,6 +517,14 @@ message SearchParams {
 
   // ACORN search params
   optional AcornSearchParams acorn = 5;
+
+  // Scope for IDF statistics used by sparse vector queries with the IDF modifier
+  optional IdfSearchScope idf = 6;
+}
+
+enum IdfSearchScope {
+  Global = 0;
+  PerFilter = 1;
 }
 
 message SearchPoints {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5681,6 +5681,9 @@ pub struct SearchParams {
     #[prost(message, optional, tag = "5")]
     #[validate(nested)]
     pub acorn: ::core::option::Option<AcornSearchParams>,
+    /// Scope for IDF statistics used by sparse vector queries with the IDF modifier
+    #[prost(enumeration = "IdfSearchScope", optional, tag = "6")]
+    pub idf: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -7667,6 +7670,33 @@ impl FieldType {
             "FieldTypeBool" => Some(Self::Bool),
             "FieldTypeDatetime" => Some(Self::Datetime),
             "FieldTypeUuid" => Some(Self::Uuid),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum IdfSearchScope {
+    Global = 0,
+    PerFilter = 1,
+}
+impl IdfSearchScope {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Global => "Global",
+            Self::PerFilter => "PerFilter",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Global" => Some(Self::Global),
+            "PerFilter" => Some(Self::PerFilter),
             _ => None,
         }
     }

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -65,7 +65,8 @@ mod qdrant_edge {
     use super::scroll::PyScrollRequest;
     #[pymodule_export]
     use super::search::{
-        PyAcornSearchParams, PyQuantizationSearchParams, PySearchParams, PySearchRequest,
+        PyAcornSearchParams, PyIdfSearchScope, PyQuantizationSearchParams, PySearchParams,
+        PySearchRequest,
     };
     #[pymodule_export]
     use super::types::filter::{

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -138,6 +138,7 @@ impl PySearchParams {
             quantization: quantization.map(QuantizationSearchParams::from),
             indexed_only,
             acorn: acorn.map(AcornSearchParams::from),
+            idf: None,
         })
     }
 
@@ -180,6 +181,7 @@ impl PySearchParams {
             quantization: _,
             indexed_only: _,
             acorn: _,
+            idf: _,
         } = self.0;
     }
 }

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bytemuck::TransparentWrapper;
 use derive_more::Into;
 use ordered_float::OrderedFloat;
@@ -124,6 +126,7 @@ impl PySearchParams {
         quantization = None,
         indexed_only = false,
         acorn = None,
+        idf = None,
     ))]
     pub fn new(
         hnsw_ef: Option<usize>,
@@ -131,6 +134,7 @@ impl PySearchParams {
         quantization: Option<PyQuantizationSearchParams>,
         indexed_only: bool,
         acorn: Option<PyAcornSearchParams>,
+        idf: Option<PyIdfSearchScope>,
     ) -> Self {
         Self(SearchParams {
             hnsw_ef,
@@ -138,7 +142,7 @@ impl PySearchParams {
             quantization: quantization.map(QuantizationSearchParams::from),
             indexed_only,
             acorn: acorn.map(AcornSearchParams::from),
-            idf: None,
+            idf: idf.map(IdfSearchScope::from),
         })
     }
 
@@ -167,6 +171,11 @@ impl PySearchParams {
         self.0.acorn.map(PyAcornSearchParams)
     }
 
+    #[getter]
+    pub fn idf(&self) -> Option<PyIdfSearchScope> {
+        self.0.idf.map(PyIdfSearchScope::from)
+    }
+
     pub fn __repr__(&self) -> String {
         self.repr()
     }
@@ -183,6 +192,49 @@ impl PySearchParams {
             acorn: _,
             idf: _,
         } = self.0;
+    }
+}
+
+#[pyclass(name = "IdfSearchScope", from_py_object)]
+#[derive(Copy, Clone, Debug)]
+pub enum PyIdfSearchScope {
+    Global,
+    PerFilter,
+}
+
+#[pymethods]
+impl PyIdfSearchScope {
+    pub fn __repr__(&self) -> String {
+        self.repr()
+    }
+}
+
+impl Repr for PyIdfSearchScope {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let repr = match self {
+            Self::Global => "Global",
+            Self::PerFilter => "PerFilter",
+        };
+
+        f.simple_enum::<Self>(repr)
+    }
+}
+
+impl From<IdfSearchScope> for PyIdfSearchScope {
+    fn from(scope: IdfSearchScope) -> Self {
+        match scope {
+            IdfSearchScope::Global => Self::Global,
+            IdfSearchScope::PerFilter => Self::PerFilter,
+        }
+    }
+}
+
+impl From<PyIdfSearchScope> for IdfSearchScope {
+    fn from(scope: PyIdfSearchScope) -> Self {
+        match scope {
+            PyIdfSearchScope::Global => Self::Global,
+            PyIdfSearchScope::PerFilter => Self::PerFilter,
+        }
     }
 }
 

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -9,19 +9,79 @@ use common::cow::SimpleCow;
 use common::types::ScoreType;
 use sparse::common::types::{DimId, DimWeight};
 
-use crate::data_types::tiny_map;
 use crate::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use crate::types::{ScoredPoint, VectorName, VectorNameBuf};
+use crate::types::{Filter, IdfSearchScope, ScoredPoint, SearchParams, VectorName, VectorNameBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum IdfStatsKey {
+    Global {
+        vector_name: VectorNameBuf,
+    },
+    PerFilter {
+        vector_name: VectorNameBuf,
+        filter: Filter,
+    },
+}
+
+impl IdfStatsKey {
+    pub fn global(vector_name: &VectorName) -> Self {
+        Self::Global {
+            vector_name: vector_name.to_owned(),
+        }
+    }
+
+    pub fn per_filter(vector_name: &VectorName, filter: Filter) -> Self {
+        Self::PerFilter {
+            vector_name: vector_name.to_owned(),
+            filter,
+        }
+    }
+
+    pub fn for_search(
+        vector_name: &VectorName,
+        filter: Option<&Filter>,
+        params: Option<&SearchParams>,
+    ) -> Self {
+        match params.and_then(|params| params.idf).unwrap_or_default() {
+            IdfSearchScope::Global => Self::global(vector_name),
+            IdfSearchScope::PerFilter => match filter {
+                Some(filter) => Self::per_filter(vector_name, filter.clone()),
+                None => Self::global(vector_name),
+            },
+        }
+    }
+
+    pub fn vector_name(&self) -> &VectorName {
+        match self {
+            Self::Global { vector_name } | Self::PerFilter { vector_name, .. } => vector_name,
+        }
+    }
+
+    pub fn filter(&self) -> Option<&Filter> {
+        match self {
+            Self::Global { .. } => None,
+            Self::PerFilter { filter, .. } => Some(filter),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct IdfStats {
+    /// Element frequency for sparse-vector query dimensions.
+    pub idf: HashMap<DimId, usize>,
+
+    /// Number of vectors in the IDF scope.
+    pub indexed_vectors: usize,
+}
 
 #[derive(Debug, Default)]
 pub struct QueryIdfStats {
-    /// Statistics of the element frequency,
-    /// collected over all segments.
+    /// Statistics of the element frequency, collected over all segments.
+    ///
     /// Required for processing sparse vector search with `idf-dot` similarity.
-    pub idf: tiny_map::TinyMap<VectorNameBuf, HashMap<DimId, usize>>,
-
-    /// Number of indexed vectors per vector name.
-    pub indexed_vectors: tiny_map::TinyMap<VectorNameBuf, usize>,
+    /// Global IDF scopes are keyed by vector name. Per-filter IDF scopes are
+    /// additionally keyed by the request filter.
+    pub stats: HashMap<IdfStatsKey, IdfStats>,
 }
 
 #[derive(Debug)]
@@ -85,28 +145,20 @@ impl QueryContext {
 
     /// Fill indices of sparse vectors, which are required for `idf-dot` similarity
     /// with zeros, so the statistics can be collected.
-    pub fn init_idf(&mut self, vector_name: &VectorName, indices: &[DimId]) {
-        self.idf_stats
-            .indexed_vectors
-            .insert(vector_name.to_owned(), 0);
-
-        // ToDo: Would be nice to have an implementation of `entry` for `TinyMap`.
-        let idf = if let Some(idf) = self.idf_stats.idf.get_mut(vector_name) {
-            idf
-        } else {
-            self.idf_stats
-                .idf
-                .insert(vector_name.to_owned(), HashMap::default());
-            self.idf_stats.idf.get_mut(vector_name).unwrap()
-        };
+    pub fn init_idf(&mut self, key: IdfStatsKey, indices: &[DimId]) {
+        let stats = self.idf_stats.stats.entry(key).or_default();
 
         for index in indices {
-            idf.insert(*index, 0);
+            stats.idf.insert(*index, 0);
         }
     }
 
     pub fn mut_idf_stats(&mut self) -> &mut QueryIdfStats {
         &mut self.idf_stats
+    }
+
+    pub fn is_stopped_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.is_stopped)
     }
 
     pub fn get_segment_query_context(&self) -> SegmentQueryContext<'_> {
@@ -143,16 +195,16 @@ impl<'a> SegmentQueryContext<'a> {
     }
 
     pub fn get_vector_context(&self, vector_name: &VectorName) -> VectorQueryContext<'_> {
+        self.get_vector_context_for_key(&IdfStatsKey::global(vector_name))
+    }
+
+    pub fn get_vector_context_for_key(&self, key: &IdfStatsKey) -> VectorQueryContext<'_> {
+        let stats = self.query_context.idf_stats.stats.get(key);
         VectorQueryContext {
             search_optimized_threshold_kb: self.query_context.search_optimized_threshold_kb,
             is_stopped: Some(&self.query_context.is_stopped),
-            idf: self.query_context.idf_stats.idf.get(vector_name),
-            indexed_vectors: self
-                .query_context
-                .idf_stats
-                .indexed_vectors
-                .get(vector_name)
-                .copied(),
+            idf: stats.map(|stats| &stats.idf),
+            indexed_vectors: stats.map(|stats| stats.indexed_vectors),
             deleted_points: self.deleted_points,
             hardware_counter: self.hardware_counter.fork(),
         }

--- a/lib/segment/src/data_types/query_context.rs
+++ b/lib/segment/src/data_types/query_context.rs
@@ -53,14 +53,21 @@ impl IdfStatsKey {
 
     pub fn vector_name(&self) -> &VectorName {
         match self {
-            Self::Global { vector_name } | Self::PerFilter { vector_name, .. } => vector_name,
+            Self::Global { vector_name } => vector_name,
+            Self::PerFilter {
+                vector_name,
+                filter: _,
+            } => vector_name,
         }
     }
 
     pub fn filter(&self) -> Option<&Filter> {
         match self {
-            Self::Global { .. } => None,
-            Self::PerFilter { filter, .. } => Some(filter),
+            Self::Global { vector_name: _ } => None,
+            Self::PerFilter {
+                vector_name: _,
+                filter,
+            } => Some(filter),
         }
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 
 use super::ReadOnlyHNSWIndex;
@@ -62,6 +63,17 @@ impl<S: UniversalReadExt> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     ) -> OperationResult<()> {
         // HNSW (dense) index doesn't track IDF.
         Ok(())
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _filtered_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+        _is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        // HNSW (dense) index doesn't track IDF.
+        Ok(0)
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
@@ -63,6 +64,17 @@ impl VectorIndexRead for HNSWIndex {
     ) -> OperationResult<()> {
         // HNSW (dense) index doesn't track IDF.
         Ok(())
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _filtered_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+        _is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        // HNSW (dense) index doesn't track IDF.
+        Ok(0)
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/plain_vector_index/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 
 use super::PlainVectorIndex;
@@ -81,6 +82,17 @@ impl VectorIndexRead for PlainVectorIndex {
     ) -> OperationResult<()> {
         // Plain (dense) index doesn't track IDF.
         Ok(())
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _filtered_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+        _is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        // Plain (dense) index doesn't track IDF.
+        Ok(0)
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/plain_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/read.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 
 use super::ReadOnlyPlainVectorIndex;
@@ -64,6 +65,17 @@ impl<S: UniversalReadExt> VectorIndexRead for ReadOnlyPlainVectorIndex<S> {
     ) -> OperationResult<()> {
         // Plain (dense) index doesn't track IDF.
         Ok(())
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _filtered_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+        _is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        // Plain (dense) index doesn't track IDF.
+        Ok(0)
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -3,11 +3,12 @@ mod live_reload;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::low_memory::low_memory_mode;
-use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use half::f16;
 use sparse::common::types::{DimId, QuantizedU8};
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
@@ -326,6 +327,41 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
             Self::SparseCompressedStoredF32(index) => index.fill_idf_statistics(idf, hw_counter),
             Self::SparseCompressedStoredF16(index) => index.fill_idf_statistics(idf, hw_counter),
             Self::SparseCompressedStoredU8(index) => index.fill_idf_statistics(idf, hw_counter),
+        }
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        match self {
+            Self::Plain(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::Hnsw(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedStoredF32(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedStoredF16(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedStoredU8(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
         }
     }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
-#[cfg(feature = "testing")]
+use common::bitvec::{BitVec, bitvec_set_deleted};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::storage_version::StorageVersion as _;
@@ -12,9 +12,11 @@ use common::universal_io::{MmapFile, MmapFs, UniversalReadFs};
 use fs_err as fs;
 use sparse::SearchScratchPool;
 use sparse::common::sparse_vector::SparseVector;
+use sparse::common::types::DimOffset;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::inverted_index_ram_builder::InvertedIndexBuilder;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadWrite};
+use sparse::index::posting_list_common::PostingListIter as _;
 
 use self::read_view::{SparseVectorIndexReadView, SparseVectorIndexReadViewEnum};
 use super::indices_tracker::IndicesTracker;
@@ -30,6 +32,24 @@ mod vector_index_impl;
 
 pub mod read_only;
 
+pub(super) fn collect_indexed_vector_ids<TInvertedIndex: InvertedIndex>(
+    inverted_index: &TInvertedIndex,
+) -> OperationResult<BitVec> {
+    let mut indexed_vector_ids = BitVec::new();
+    let arena = blink_alloc::Blink::new();
+    let hw_counter = HardwareCounterCell::disposable();
+    let iter = (0..inverted_index.len()).map(|dim_id| ((), dim_id as DimOffset));
+
+    inverted_index.get_batch(iter, &arena, &hw_counter, |(), posting_list_iter| {
+        for element in posting_list_iter.into_std_iter() {
+            bitvec_set_deleted(&mut indexed_vector_ids, element.record_id, true);
+        }
+        Ok(())
+    })?;
+
+    Ok(indexed_vector_ids)
+}
+
 #[derive(Debug)]
 pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     config: SparseIndexConfig,
@@ -38,6 +58,7 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     path: PathBuf,
     inverted_index: TInvertedIndex,
+    indexed_vector_ids: BitVec,
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,
     search_scratch_pool: SearchScratchPool,
@@ -155,6 +176,8 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             TInvertedIndex::Version::save(path)?;
         }
 
+        let indexed_vector_ids = collect_indexed_vector_ids(&inverted_index)?;
+
         Ok(Self {
             config,
             id_tracker,
@@ -162,6 +185,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             payload_index,
             path: path.to_path_buf(),
             inverted_index,
+            indexed_vector_ids,
             searches_telemetry: SparseSearchesTelemetry::new(),
             indices_tracker,
             search_scratch_pool: SearchScratchPool::new(),
@@ -300,6 +324,7 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
                 vector_storage: &*vector_storage,
                 payload_index: payload_index_view,
                 inverted_index: &self.inverted_index,
+                indexed_vector_ids: self.indexed_vector_ids.as_bitslice(),
                 searches_telemetry: &self.searches_telemetry,
                 indices_tracker: &self.indices_tracker,
                 search_scratch_pool: &self.search_scratch_pool,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -64,6 +64,9 @@ pub struct SparseVectorIndex<TInvertedIndex: InvertedIndex> {
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     path: PathBuf,
     inverted_index: TInvertedIndex,
+    /// Internal ids that have at least one sparse posting. This costs one bit
+    /// per sparse vector id and lets per-filter IDF compute the filtered
+    /// `indexed_vectors` denominator without reading sparse vector storage.
     indexed_vector_ids: BitVec,
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -20,7 +20,7 @@ use sparse::index::posting_list_common::PostingListIter as _;
 
 use self::read_view::{SparseVectorIndexReadView, SparseVectorIndexReadViewEnum};
 use super::indices_tracker::IndicesTracker;
-use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
@@ -38,7 +38,13 @@ pub(super) fn collect_indexed_vector_ids<TInvertedIndex: InvertedIndex>(
     let mut indexed_vector_ids = BitVec::new();
     let arena = blink_alloc::Blink::new();
     let hw_counter = HardwareCounterCell::disposable();
-    let iter = (0..inverted_index.len()).map(|dim_id| ((), dim_id as DimOffset));
+    let posting_count = DimOffset::try_from(inverted_index.len()).map_err(|_| {
+        OperationError::service_error(format!(
+            "Sparse inverted index contains too many posting lists: {}",
+            inverted_index.len(),
+        ))
+    })?;
+    let iter = (0..posting_count).map(|dim_id| ((), dim_id));
 
     inverted_index.get_batch(iter, &arena, &hw_counter, |(), posting_list_iter| {
         for element in posting_list_iter.into_std_iter() {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::bitvec::BitVec;
 use common::storage_version::StorageVersion as _;
 use sparse::SearchScratchPool;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
@@ -15,6 +16,7 @@ use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::sparse_index::indices_tracker::IndicesTracker;
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
+use crate::index::sparse_index::sparse_vector_index::collect_indexed_vector_ids;
 use crate::index::sparse_index::sparse_vector_index::read_view::SparseVectorIndexReadView;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
@@ -34,6 +36,7 @@ pub struct ReadOnlySparseVectorIndex<S: UniversalReadExt, TInvertedIndex: Invert
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
     inverted_index: TInvertedIndex,
+    indexed_vector_ids: BitVec,
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,
     search_scratch_pool: SearchScratchPool,
@@ -92,6 +95,7 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
         }
 
         let indices_tracker = IndicesTracker::open_universal(fs, path)?;
+        let indexed_vector_ids = collect_indexed_vector_ids(&inverted_index)?;
 
         Ok(Self {
             config,
@@ -99,6 +103,7 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
             vector_storage,
             payload_index,
             inverted_index,
+            indexed_vector_ids,
             searches_telemetry: SparseSearchesTelemetry::new(),
             indices_tracker,
             search_scratch_pool: SearchScratchPool::new(),
@@ -125,6 +130,7 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
                 vector_storage: &*vector_storage,
                 payload_index: payload_index_view,
                 inverted_index: &self.inverted_index,
+                indexed_vector_ids: self.indexed_vector_ids.as_bitslice(),
                 searches_telemetry: &self.searches_telemetry,
                 indices_tracker: &self.indices_tracker,
                 search_scratch_pool: &self.search_scratch_pool,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -36,6 +36,10 @@ pub struct ReadOnlySparseVectorIndex<S: UniversalReadExt, TInvertedIndex: Invert
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
     inverted_index: TInvertedIndex,
+    /// Internal ids that have at least one sparse posting. Read-only indexes
+    /// build this on open from postings; it costs one bit per sparse vector id
+    /// and lets per-filter IDF compute the filtered `indexed_vectors`
+    /// denominator without reading sparse vector storage.
     indexed_vector_ids: BitVec,
     searches_telemetry: SparseSearchesTelemetry,
     indices_tracker: IndicesTracker,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
 
@@ -45,6 +46,18 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex> VectorIndexRead
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        self.with_view(|view| {
+            view.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+        })
     }
 
     fn is_index(&self) -> bool {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
@@ -12,6 +12,7 @@ use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+use common::bitvec::BitSlice;
 
 /// Read-only view over a sparse vector index.
 ///
@@ -30,6 +31,7 @@ where
     pub(crate) vector_storage: &'a V,
     pub(crate) payload_index: P,
     pub(crate) inverted_index: &'a TInvertedIndex,
+    pub(crate) indexed_vector_ids: &'a BitSlice,
     pub(crate) searches_telemetry: &'a SparseSearchesTelemetry,
     pub(crate) indices_tracker: &'a IndicesTracker,
     pub(crate) search_scratch_pool: &'a SearchScratchPool,

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/mod.rs
@@ -1,5 +1,6 @@
 mod search;
 
+use common::bitvec::BitSlice;
 use sparse::SearchScratchPool;
 use sparse::index::inverted_index::InvertedIndex;
 
@@ -12,7 +13,6 @@ use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
-use common::bitvec::BitSlice;
 
 /// Read-only view over a sparse vector index.
 ///

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -136,26 +136,38 @@ where
         });
         let arena = blink_alloc::Blink::new();
 
-        self.inverted_index
-            .get_batch(iter, &arena, hw_counter, |count, posting_list_iter| {
-                let mut filtered_posting_len = 0;
+        let batch_result =
+            self.inverted_index
+                .get_batch(iter, &arena, hw_counter, |count, posting_list_iter| {
+                    let mut filtered_posting_len = 0;
 
-                for element in posting_list_iter.into_std_iter() {
-                    if is_stopped.load(Ordering::Relaxed) {
-                        break;
+                    for element in posting_list_iter.into_std_iter() {
+                        if is_stopped.load(Ordering::Relaxed) {
+                            return Err(common::universal_io::UniversalIoError::Io(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::Interrupted,
+                                    "operation stopped",
+                                ),
+                            ));
+                        }
+
+                        if filtered_indexed_vector_ids
+                            .get_bit(element.record_id as usize)
+                            .unwrap_or(false)
+                        {
+                            filtered_posting_len += 1;
+                        }
                     }
 
-                    if filtered_indexed_vector_ids
-                        .get_bit(element.record_id as usize)
-                        .unwrap_or(false)
-                    {
-                        filtered_posting_len += 1;
-                    }
-                }
+                    *count += filtered_posting_len;
+                    Ok(())
+                });
 
-                *count += filtered_posting_len;
-                Ok(())
-            })?;
+        if is_stopped.load(Ordering::Relaxed) {
+            check_process_stopped(is_stopped)?;
+        }
+
+        batch_result?;
 
         check_process_stopped(is_stopped)?;
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+use common::bitvec::{BitSliceExt as _, BitVec, bitvec_set_deleted};
 use common::condition_checker::ConditionChecker;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset, TelemetryDetail};
@@ -7,6 +9,7 @@ use itertools::Itertools;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
+use sparse::index::posting_list_common::PostingListIter as _;
 use sparse::index::search_context::SearchContext;
 
 use super::SparseVectorIndexReadView;
@@ -98,6 +101,65 @@ where
                 Ok(())
             })?;
         Ok(())
+    }
+
+    /// Update statistics for idf-dot similarity within a filtered point set.
+    pub fn fill_idf_statistics_filtered(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        let mut filtered_indexed_vector_ids = BitVec::new();
+        let mut indexed_vectors = 0;
+
+        for &point_id in filtered_points {
+            check_process_stopped(is_stopped)?;
+
+            if self
+                .indexed_vector_ids
+                .get_bit(point_id as usize)
+                .unwrap_or(false)
+            {
+                let was_present =
+                    bitvec_set_deleted(&mut filtered_indexed_vector_ids, point_id, true);
+                if !was_present {
+                    indexed_vectors += 1;
+                }
+            }
+        }
+
+        let iter = idf.iter_mut().filter_map(|(dim_id, count)| {
+            let offset = self.indices_tracker.remap_index(*dim_id)?;
+            Some((count, offset))
+        });
+        let arena = blink_alloc::Blink::new();
+
+        self.inverted_index
+            .get_batch(iter, &arena, hw_counter, |count, posting_list_iter| {
+                let mut filtered_posting_len = 0;
+
+                for element in posting_list_iter.into_std_iter() {
+                    if is_stopped.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    if filtered_indexed_vector_ids
+                        .get_bit(element.record_id as usize)
+                        .unwrap_or(false)
+                    {
+                        filtered_posting_len += 1;
+                    }
+                }
+
+                *count += filtered_posting_len;
+                Ok(())
+            })?;
+
+        check_process_stopped(is_stopped)?;
+
+        Ok(indexed_vectors)
     }
 
     fn get_query_cardinality(

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 
+use common::bitvec::bitvec_set_deleted;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::storage_version::VERSION_FILE;
@@ -79,6 +81,18 @@ impl<TInvertedIndex: InvertedIndex> VectorIndexRead for SparseVectorIndex<TInver
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.with_view(|view| view.fill_idf_statistics(idf, hw_counter))
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        self.with_view(|view| {
+            view.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+        })
     }
 
     fn is_index(&self) -> bool {
@@ -177,12 +191,16 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
             let vector = self.indices_tracker.remap_vector(vector);
             let old_vector = old_vector.map(|v| self.indices_tracker.remap_vector(v));
             self.inverted_index.upsert(id, vector, old_vector);
+            bitvec_set_deleted(&mut self.indexed_vector_ids, id, true);
         } else if let Some(old_vector) = old_vector {
             // Make sure empty vectors do not interfere with the index
             if !old_vector.is_empty() {
                 let old_vector = self.indices_tracker.remap_vector(old_vector);
                 self.inverted_index.remove(id, old_vector);
             }
+            bitvec_set_deleted(&mut self.indexed_vector_ids, id, false);
+        } else {
+            bitvec_set_deleted(&mut self.indexed_vector_ids, id, false);
         }
 
         Ok(())

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -61,13 +61,11 @@ pub trait VectorIndexRead {
     /// Returns the number of indexed vectors in the filtered point set.
     fn fill_idf_statistics_filtered(
         &self,
-        _idf: &mut HashMap<DimId, usize>,
-        _filtered_points: &[PointOffsetType],
-        _hw_counter: &HardwareCounterCell,
-        _is_stopped: &AtomicBool,
-    ) -> OperationResult<usize> {
-        Ok(0)
-    }
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize>;
 
     /// Whether this is a "real" index rather than a plain (full-scan) one.
     ///
@@ -316,7 +314,12 @@ impl VectorIndexRead for VectorIndexEnum {
         is_stopped: &AtomicBool,
     ) -> OperationResult<usize> {
         match self {
-            Self::Plain(_) | Self::Hnsw(_) => Ok(0),
+            Self::Plain(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::Hnsw(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
             Self::SparseRam(index) => {
                 index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
             }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
@@ -54,6 +55,19 @@ pub trait VectorIndexRead {
         idf: &mut HashMap<DimId, usize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
+
+    /// Augment IDF stats for the given dimensions within a filtered point set.
+    ///
+    /// Returns the number of indexed vectors in the filtered point set.
+    fn fill_idf_statistics_filtered(
+        &self,
+        _idf: &mut HashMap<DimId, usize>,
+        _filtered_points: &[PointOffsetType],
+        _hw_counter: &HardwareCounterCell,
+        _is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        Ok(0)
+    }
 
     /// Whether this is a "real" index rather than a plain (full-scan) one.
     ///
@@ -291,6 +305,39 @@ impl VectorIndexRead for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.fill_idf_statistics(idf, hw_counter),
             Self::SparseCompressedMmapF16(index) => index.fill_idf_statistics(idf, hw_counter),
             Self::SparseCompressedMmapU8(index) => index.fill_idf_statistics(idf, hw_counter),
+        }
+    }
+
+    fn fill_idf_statistics_filtered(
+        &self,
+        idf: &mut HashMap<DimId, usize>,
+        filtered_points: &[PointOffsetType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<usize> {
+        match self {
+            Self::Plain(_) | Self::Hnsw(_) => Ok(0),
+            Self::SparseRam(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedMmapF32(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedMmapF16(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
+            Self::SparseCompressedMmapU8(index) => {
+                index.fill_idf_statistics_filtered(idf, filtered_points, hw_counter, is_stopped)
+            }
         }
     }
 }

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -287,7 +287,10 @@ where
                                 .query_points(filter, &hw_counter, &is_stopped)?;
 
                         vector_storage.read_vectors::<Random, _>(
-                            filtered_points.into_iter().map(|idx| (idx, idx)),
+                            filtered_points
+                                .into_iter()
+                                .map(|idx| (idx, idx))
+                                .stop_if(is_stopped.as_ref()),
                             |_, _, vector| {
                                 let CowVector::Sparse(sparse) = vector else {
                                     return;
@@ -305,6 +308,7 @@ where
                                 }
                             },
                         );
+                        check_stopped(is_stopped.as_ref())?;
                     }
                 }
             }

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -8,7 +8,6 @@ use common::types::{DeferredBehavior, ScoredPointOffset};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::{check_query_vectors, check_stopped};
-use crate::data_types::named_vectors::CowVector;
 use crate::data_types::query_context::{IdfStatsKey, QueryContext, SegmentQueryContext};
 use crate::data_types::segment_record::{NamedVectorsOwned, SegmentRecord};
 use crate::data_types::vectors::{QueryVector, VectorStructInternal};
@@ -21,7 +20,6 @@ use crate::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SearchParams, VectorName, VectorNameBuf,
     WithPayload, WithVector,
 };
-use crate::vector_storage::VectorStorageRead;
 
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
 where
@@ -281,34 +279,17 @@ where
                         vector_index.fill_idf_statistics(&mut stats.idf, &hw_counter)?;
                     }
                     Some(filter) => {
-                        let vector_storage = vector_data.vector_storage();
+                        let vector_index = vector_data.vector_index();
                         let filtered_points =
                             self.payload_index
                                 .query_points(filter, &hw_counter, &is_stopped)?;
 
-                        vector_storage.read_vectors::<Random, _>(
-                            filtered_points
-                                .into_iter()
-                                .map(|idx| (idx, idx))
-                                .stop_if(is_stopped.as_ref()),
-                            |_, _, vector| {
-                                let CowVector::Sparse(sparse) = vector else {
-                                    return;
-                                };
-
-                                if sparse.indices.is_empty() {
-                                    return;
-                                }
-
-                                stats.indexed_vectors += 1;
-                                for dim_id in &sparse.indices {
-                                    if let Some(count) = stats.idf.get_mut(dim_id) {
-                                        *count += 1;
-                                    }
-                                }
-                            },
-                        );
-                        check_stopped(is_stopped.as_ref())?;
+                        stats.indexed_vectors += vector_index.fill_idf_statistics_filtered(
+                            &mut stats.idf,
+                            &filtered_points,
+                            &hw_counter,
+                            is_stopped.as_ref(),
+                        )?;
                     }
                 }
             }

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -8,7 +8,8 @@ use common::types::{DeferredBehavior, ScoredPointOffset};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::{check_query_vectors, check_stopped};
-use crate::data_types::query_context::{QueryContext, QueryIdfStats, SegmentQueryContext};
+use crate::data_types::named_vectors::CowVector;
+use crate::data_types::query_context::{IdfStatsKey, QueryContext, SegmentQueryContext};
 use crate::data_types::segment_record::{NamedVectorsOwned, SegmentRecord};
 use crate::data_types::vectors::{QueryVector, VectorStructInternal};
 use crate::id_tracker::IdTrackerRead;
@@ -20,6 +21,7 @@ use crate::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SearchParams, VectorName, VectorNameBuf,
     WithPayload, WithVector,
 };
+use crate::vector_storage::VectorStorageRead;
 
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
 where
@@ -235,7 +237,8 @@ where
             .vector_data
             .get(vector_name)
             .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
-        let vector_query_context = query_context.get_vector_context(vector_name);
+        let idf_stats_key = IdfStatsKey::for_search(vector_name, filter, params);
+        let vector_query_context = query_context.get_vector_context_for_key(&idf_stats_key);
         let internal_results = vector_data.vector_index().search(
             query_vectors,
             filter,
@@ -266,25 +269,44 @@ where
         query_context.add_available_point_count(self.available_point_count_without_deferred());
         let hw_acc = query_context.hardware_usage_accumulator();
         let hw_counter = hw_acc.get_counter_cell();
+        let is_stopped = query_context.is_stopped_flag();
 
-        let QueryIdfStats {
-            idf,
-            indexed_vectors,
-        } = query_context.mut_idf_stats();
+        for (idf_key, stats) in query_context.mut_idf_stats().stats.iter_mut() {
+            if let Some(vector_data) = self.vector_data.get(idf_key.vector_name()) {
+                match idf_key.filter() {
+                    None => {
+                        let vector_index = vector_data.vector_index();
 
-        for (vector_name, idf) in idf.iter_mut() {
-            if let Some(vector_data) = self.vector_data.get(vector_name) {
-                let vector_index = vector_data.vector_index();
+                        stats.indexed_vectors += vector_index.indexed_vector_count();
+                        vector_index.fill_idf_statistics(&mut stats.idf, &hw_counter)?;
+                    }
+                    Some(filter) => {
+                        let vector_storage = vector_data.vector_storage();
+                        let filtered_points =
+                            self.payload_index
+                                .query_points(filter, &hw_counter, &is_stopped)?;
 
-                let indexed_vector_count = vector_index.indexed_vector_count();
+                        vector_storage.read_vectors::<Random, _>(
+                            filtered_points.into_iter().map(|idx| (idx, idx)),
+                            |_, _, vector| {
+                                let CowVector::Sparse(sparse) = vector else {
+                                    return;
+                                };
 
-                if let Some(count) = indexed_vectors.get_mut(vector_name) {
-                    *count += indexed_vector_count;
-                } else {
-                    indexed_vectors.insert(vector_name.clone(), indexed_vector_count);
+                                if sparse.indices.is_empty() {
+                                    return;
+                                }
+
+                                stats.indexed_vectors += 1;
+                                for dim_id in &sparse.indices {
+                                    if let Some(count) = stats.idf.get_mut(dim_id) {
+                                        *count += 1;
+                                    }
+                                }
+                            },
+                        );
+                    }
                 }
-
-                vector_index.fill_idf_statistics(idf, &hw_counter)?;
             }
         }
         Ok(())

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -631,6 +631,22 @@ pub struct SearchParams {
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acorn: Option<AcornSearchParams>,
+
+    /// Scope for IDF statistics used by sparse vector queries with the IDF modifier.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idf: Option<IdfSearchScope>,
+}
+
+/// Scope for IDF statistics used by sparse vector queries.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Copy, Clone, PartialEq, Eq, Default, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum IdfSearchScope {
+    /// Use collection-wide IDF statistics.
+    #[default]
+    Global,
+    /// Use IDF statistics collected over the points matching the request filter.
+    PerFilter,
 }
 
 /// Configuration for vectors.

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -35,9 +35,10 @@ use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    Condition, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, FieldCondition, Filter, IdfSearchScope,
-    ScoredPoint, SearchParams, SegmentConfig, SeqNumberType, SparseVectorDataConfig,
-    SparseVectorStorageType, VectorName, VectorStorageDatatype, WithPayload, WithVector,
+    Condition, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, FieldCondition, Filter, IdfSearchScope, Match,
+    PayloadFieldSchema, PointIdType, ScoredPoint, SearchParams, SegmentConfig, SeqNumberType,
+    SparseVectorDataConfig, SparseVectorStorageType, VectorName, VectorStorageDatatype,
+    WithPayload, WithVector,
 };
 use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::{fixture_for_all_indices, payload_json};
@@ -468,7 +469,7 @@ fn sparse_vector_search_can_use_per_filter_idf() {
     let hw_counter = HardwareCounterCell::new();
     let field_name = "tenant";
 
-    let mut segment = build_segment(
+    let (mut segment, _) = build_segment(
         data_dir.path(),
         &SegmentConfig {
             vector_data: Default::default(),
@@ -487,7 +488,7 @@ fn sparse_vector_search_can_use_per_filter_idf() {
     )
     .unwrap();
 
-    let payload_schema = Keyword.into();
+    let payload_schema = PayloadFieldSchema::from(Keyword);
     segment
         .create_field_index(
             0,
@@ -518,7 +519,7 @@ fn sparse_vector_search_can_use_per_filter_idf() {
         segment
             .upsert_point(
                 point_id as SeqNumberType,
-                point_id.into(),
+                PointIdType::from(point_id),
                 NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&sparse_vector)),
                 &hw_counter,
             )
@@ -526,7 +527,7 @@ fn sparse_vector_search_can_use_per_filter_idf() {
         segment
             .set_full_payload(
                 point_id as SeqNumberType,
-                point_id.into(),
+                PointIdType::from(point_id),
                 &payload,
                 &hw_counter,
             )
@@ -535,10 +536,10 @@ fn sparse_vector_search_can_use_per_filter_idf() {
 
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
         JsonPath::new(field_name),
-        "a".to_owned().into(),
+        Match::from("a".to_owned()),
     )));
     let query = SparseVector::new(vec![0, 1], vec![1.0, 1.0]).unwrap();
-    let query_vector: QueryVector = query.clone().into();
+    let query_vector = QueryVector::from(query.clone());
 
     let search_with_params = |params: Option<&SearchParams>| -> Vec<ScoredPoint> {
         let mut query_context = QueryContext::default();
@@ -573,8 +574,8 @@ fn sparse_vector_search_can_use_per_filter_idf() {
     };
     let per_filter_results = search_with_params(Some(&per_filter_params));
 
-    assert_ne!(global_results[0].id, 2.into());
-    assert_eq!(per_filter_results[0].id, 2.into());
+    assert_ne!(global_results[0].id, PointIdType::from(2_u64));
+    assert_eq!(per_filter_results[0].id, PointIdType::from(2_u64));
 }
 
 #[test]

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -12,9 +12,12 @@ use itertools::Itertools;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use segment::common::operation_error::OperationResult;
+use segment::data_types::modifier::Modifier;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::vectors::{QueryVector, VectorInternal};
-use segment::entry::{SegmentEntry, StorageSegmentEntry as _};
+use segment::data_types::query_context::{IdfStatsKey, QueryContext};
+use segment::data_types::vectors::{QueryVector, VectorInternal, VectorRef};
+use segment::entry::entry_point::ReadSegmentEntry as _;
+use segment::entry::{NonAppendableSegmentEntry as _, SegmentEntry, StorageSegmentEntry as _};
 use segment::fixtures::payload_fixtures::STR_KEY;
 use segment::fixtures::sparse_fixtures::{fixture_sparse_index, fixture_sparse_index_from_iter};
 use segment::id_tracker::{IdTracker, IdTrackerRead};
@@ -32,9 +35,9 @@ use segment::segment_constructor::{build_segment, load_segment};
 use segment::types::PayloadFieldSchema::FieldType;
 use segment::types::PayloadSchemaType::Keyword;
 use segment::types::{
-    Condition, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, FieldCondition, Filter, ScoredPoint,
-    SegmentConfig, SeqNumberType, SparseVectorDataConfig, SparseVectorStorageType, VectorName,
-    VectorStorageDatatype,
+    Condition, DEFAULT_SPARSE_FULL_SCAN_THRESHOLD, FieldCondition, Filter, IdfSearchScope,
+    ScoredPoint, SearchParams, SegmentConfig, SeqNumberType, SparseVectorDataConfig,
+    SparseVectorStorageType, VectorName, VectorStorageDatatype, WithPayload, WithVector,
 };
 use segment::vector_storage::{VectorStorage, VectorStorageRead};
 use segment::{fixture_for_all_indices, payload_json};
@@ -457,6 +460,121 @@ fn sparse_vector_index_ram_filtered_search() {
         .unwrap();
     assert_eq!(after_result.len(), 1);
     assert_eq!(after_result[0].len(), half_indexed_count); // expect half of the points
+}
+
+#[test]
+fn sparse_vector_search_can_use_per_filter_idf() {
+    let data_dir = Builder::new().prefix("data_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let field_name = "tenant";
+
+    let mut segment = build_segment(
+        data_dir.path(),
+        &SegmentConfig {
+            vector_data: Default::default(),
+            sparse_vector_data: HashMap::from([(
+                SPARSE_VECTOR_NAME.to_owned(),
+                SparseVectorDataConfig {
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
+                    storage_type: SparseVectorStorageType::default(),
+                    modifier: Some(Modifier::Idf),
+                },
+            )]),
+            payload_storage_type: Default::default(),
+        },
+        None,
+        true,
+    )
+    .unwrap();
+
+    let payload_schema = Keyword.into();
+    segment
+        .create_field_index(
+            0,
+            &JsonPath::new(field_name),
+            Some(&payload_schema),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let vectors = [
+        (1_u64, vec![1], "a"),
+        (2_u64, vec![0], "a"),
+        (3_u64, vec![1], "a"),
+        (4_u64, vec![0], "b"),
+        (5_u64, vec![0], "b"),
+        (6_u64, vec![0], "b"),
+        (7_u64, vec![0], "b"),
+        (8_u64, vec![0], "b"),
+        (9_u64, vec![0], "b"),
+        (10_u64, vec![0], "b"),
+    ];
+
+    for (point_id, indices, tenant) in vectors {
+        let values = vec![1.0; indices.len()];
+        let sparse_vector = SparseVector::new(indices, values).unwrap();
+        let payload = payload_json! {field_name: tenant};
+
+        segment
+            .upsert_point(
+                point_id as SeqNumberType,
+                point_id.into(),
+                NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&sparse_vector)),
+                &hw_counter,
+            )
+            .unwrap();
+        segment
+            .set_full_payload(
+                point_id as SeqNumberType,
+                point_id.into(),
+                &payload,
+                &hw_counter,
+            )
+            .unwrap();
+    }
+
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        JsonPath::new(field_name),
+        "a".to_owned().into(),
+    )));
+    let query = SparseVector::new(vec![0, 1], vec![1.0, 1.0]).unwrap();
+    let query_vector: QueryVector = query.clone().into();
+
+    let search_with_params = |params: Option<&SearchParams>| -> Vec<ScoredPoint> {
+        let mut query_context = QueryContext::default();
+        query_context.init_idf(
+            IdfStatsKey::for_search(SPARSE_VECTOR_NAME, Some(&filter), params),
+            &query.indices,
+        );
+        segment.fill_query_context(&mut query_context).unwrap();
+
+        let segment_query_context = query_context.get_segment_query_context();
+        segment
+            .search_batch(
+                SPARSE_VECTOR_NAME,
+                &[&query_vector],
+                &WithPayload::default(),
+                &WithVector::default(),
+                Some(&filter),
+                3,
+                params,
+                &segment_query_context,
+            )
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+
+    let global_results = search_with_params(None);
+    let per_filter_params = SearchParams {
+        idf: Some(IdfSearchScope::PerFilter),
+        ..Default::default()
+    };
+    let per_filter_results = search_with_params(Some(&per_filter_params));
+
+    assert_ne!(global_results[0].id, 2.into());
+    assert_eq!(per_filter_results[0].id, 2.into());
 }
 
 #[test]

--- a/lib/shard/src/query/query_context.rs
+++ b/lib/shard/src/query/query_context.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::iterator_ext::IteratorExt;
 use segment::common::operation_error::{OperationError, OperationResult};
-use segment::data_types::query_context::QueryContext;
+use segment::data_types::query_context::{IdfStatsKey, QueryContext};
 use segment::types::VectorName;
 
 use crate::common::stopping_guard::StoppingGuard;
@@ -27,7 +27,12 @@ pub fn init_query_context(
             .query
             .iterate_sparse(|vector_name, sparse_vector| {
                 if check_idf_required(vector_name) {
-                    query_context.init_idf(vector_name, &sparse_vector.indices);
+                    let idf_stats_key = IdfStatsKey::for_search(
+                        vector_name,
+                        search_request.filter.as_ref(),
+                        search_request.params.as_ref(),
+                    );
+                    query_context.init_idf(idf_stats_key, &sparse_vector.indices);
                 }
             })
     }


### PR DESCRIPTION
Fixes #9445 

## Summary

- Adds a query-time `idf` search parameter for sparse vector queries.
- Keeps the default behavior as global IDF for compatibility.
- Adds `per_filter` as an opt-in scope that computes IDF statistics over the
  filtered subset.
- Adds a segment integration test showing that `per_filter` can change ranking
  when subset term frequencies differ from global term frequencies.

## Testing

- `cargo check -p segment`
- `$env:PROTOC='C:\Users\varun\Desktop\OpnSrcPrjcts\.tools\protoc-34.1\bin\protoc.exe'; cargo check -p api`
- `$env:PROTOC='C:\Users\varun\Desktop\OpnSrcPrjcts\.tools\protoc-34.1\bin\protoc.exe'; cargo check -p shard`
- `$env:PROTOC='C:\Users\varun\Desktop\OpnSrcPrjcts\.tools\protoc-34.1\bin\protoc.exe'; cargo check -p collection`
- `cargo fmt --all -- --check`
- `cargo test -p segment --test integration sparse_vector_search_can_use_per_filter_idf -- --nocapture`

## Notes

This PR intentionally keeps the first implementation narrow. It uses filtered
vector scanning for `per_filter` statistics so the API and correctness change
remain reviewable. Posting-list intersection and candidate bitmap reuse can be
follow-up optimizations.
