### PR TITLE
Reject invalid vector name formats during upsert

### DIFF
--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -1,10 +1,11 @@
 use std::cmp;
+use std::collections::BTreeMap;
 use std::sync::{Arc, LazyLock};
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use futures::{TryStreamExt as _, future};
-use segment::types::{Payload, QuantizationConfig, StrictModeConfig};
+use segment::types::{Payload, QuantizationConfig, StrictModeConfig, VectorNameBuf};
 use semver::Version;
 use shard::count::CountRequestInternal;
 use shard::operations::optimization::{OptimizationsRequestOptions, OptimizationsResponse};
@@ -371,6 +372,17 @@ impl Collection {
 
     pub async fn vectors_config(&self) -> VectorsConfig {
         self.collection_config.read().await.params.vectors.clone()
+    }
+
+    pub async fn sparse_vectors_config(
+        &self,
+    ) -> Option<BTreeMap<VectorNameBuf, SparseVectorParams>> {
+        self.collection_config
+            .read()
+            .await
+            .params
+            .sparse_vectors
+            .clone()
     }
 
     pub async fn info(

--- a/lib/collection/src/collection/collection_ops.rs
+++ b/lib/collection/src/collection/collection_ops.rs
@@ -370,19 +370,17 @@ impl Collection {
             .clone()
     }
 
-    pub async fn vectors_config(&self) -> VectorsConfig {
-        self.collection_config.read().await.params.vectors.clone()
-    }
-
-    pub async fn sparse_vectors_config(
+    pub async fn vector_configs(
         &self,
-    ) -> Option<BTreeMap<VectorNameBuf, SparseVectorParams>> {
-        self.collection_config
-            .read()
-            .await
-            .params
-            .sparse_vectors
-            .clone()
+    ) -> (
+        VectorsConfig,
+        Option<BTreeMap<VectorNameBuf, SparseVectorParams>>,
+    ) {
+        let config = self.collection_config.read().await;
+        (
+            config.params.vectors.clone(),
+            config.params.sparse_vectors.clone(),
+        )
     }
 
     pub async fn info(

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -376,7 +376,8 @@ pub async fn do_upsert_points(
             .check_collection_access(&collection_name, AccessRequirements::new())?;
         let collection = toc.get_collection(&collection_pass).await?;
         let vectors_config = collection.vectors_config().await;
-        validate_vector_dimensions(&operation, &vectors_config)?;
+        let sparse_vectors_config = collection.sparse_vectors_config().await;
+        validate_vector_dimensions(&operation, &vectors_config, sparse_vectors_config.as_ref())?;
     }
 
     // Decide which operation to use based on update_filter and update_mode

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -375,8 +375,7 @@ pub async fn do_upsert_points(
             .unlogged_access()
             .check_collection_access(&collection_name, AccessRequirements::new())?;
         let collection = toc.get_collection(&collection_pass).await?;
-        let vectors_config = collection.vectors_config().await;
-        let sparse_vectors_config = collection.sparse_vectors_config().await;
+        let (vectors_config, sparse_vectors_config) = collection.vector_configs().await;
         validate_vector_dimensions(&operation, &vectors_config, sparse_vectors_config.as_ref())?;
     }
 

--- a/src/common/validate_vectors.rs
+++ b/src/common/validate_vectors.rs
@@ -1,9 +1,12 @@
+use std::collections::BTreeMap;
+
 use collection::operations::point_ops::{
     BatchVectorStructPersisted, PointInsertOperationsInternal, VectorPersisted,
     VectorStructPersisted,
 };
-use collection::operations::types::VectorsConfig;
+use collection::operations::types::{SparseVectorParams, VectorsConfig};
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
+use segment::types::VectorNameBuf;
 use storage::content_manager::errors::StorageError;
 
 /// Validate vector dimensions in an upsert operation against the collection config.
@@ -13,14 +16,15 @@ use storage::content_manager::errors::StorageError;
 pub fn validate_vector_dimensions(
     operation: &PointInsertOperationsInternal,
     vectors_config: &VectorsConfig,
+    sparse_vectors_config: Option<&BTreeMap<VectorNameBuf, SparseVectorParams>>,
 ) -> Result<(), StorageError> {
     match operation {
         PointInsertOperationsInternal::PointsBatch(batch) => {
-            validate_batch_vectors(&batch.vectors, vectors_config)?;
+            validate_batch_vectors(&batch.vectors, vectors_config, sparse_vectors_config)?;
         }
         PointInsertOperationsInternal::PointsList(points) => {
             for point in points {
-                validate_point_vectors(&point.vector, vectors_config)?;
+                validate_point_vectors(&point.vector, vectors_config, sparse_vectors_config)?;
             }
         }
     }
@@ -30,11 +34,12 @@ pub fn validate_vector_dimensions(
 fn validate_batch_vectors(
     batch_vectors: &BatchVectorStructPersisted,
     vectors_config: &VectorsConfig,
+    sparse_vectors_config: Option<&BTreeMap<VectorNameBuf, SparseVectorParams>>,
 ) -> Result<(), StorageError> {
     match batch_vectors {
         BatchVectorStructPersisted::Single(vectors) => {
             let Some(params) = vectors_config.get_params(DEFAULT_VECTOR_NAME) else {
-                return Ok(());
+                return Err(unnamed_vector_error());
             };
             let expected_dim = params.size.get() as usize;
             for vector in vectors {
@@ -48,7 +53,7 @@ fn validate_batch_vectors(
         }
         BatchVectorStructPersisted::MultiDense(vectors) => {
             let Some(params) = vectors_config.get_params(DEFAULT_VECTOR_NAME) else {
-                return Ok(());
+                return Err(unnamed_vector_error());
             };
             let expected_dim = params.size.get() as usize;
             for multi_vec in vectors {
@@ -64,12 +69,8 @@ fn validate_batch_vectors(
         }
         BatchVectorStructPersisted::Named(named_vectors) => {
             for (name, vectors) in named_vectors {
-                let Some(params) = vectors_config.get_params(name) else {
-                    continue;
-                };
-                let expected_dim = params.size.get() as usize;
                 for vector in vectors {
-                    validate_single_vector_dim(vector, name, expected_dim)?;
+                    validate_named_vector(vector, name, vectors_config, sparse_vectors_config)?;
                 }
             }
         }
@@ -80,11 +81,12 @@ fn validate_batch_vectors(
 fn validate_point_vectors(
     vector: &VectorStructPersisted,
     vectors_config: &VectorsConfig,
+    sparse_vectors_config: Option<&BTreeMap<VectorNameBuf, SparseVectorParams>>,
 ) -> Result<(), StorageError> {
     match vector {
         VectorStructPersisted::Single(vec) => {
             let Some(params) = vectors_config.get_params(DEFAULT_VECTOR_NAME) else {
-                return Ok(());
+                return Err(unnamed_vector_error());
             };
             let expected_dim = params.size.get() as usize;
             if vec.len() != expected_dim {
@@ -96,7 +98,7 @@ fn validate_point_vectors(
         }
         VectorStructPersisted::MultiDense(multi_vec) => {
             let Some(params) = vectors_config.get_params(DEFAULT_VECTOR_NAME) else {
-                return Ok(());
+                return Err(unnamed_vector_error());
             };
             let expected_dim = params.size.get() as usize;
             for vec in multi_vec {
@@ -110,15 +112,47 @@ fn validate_point_vectors(
         }
         VectorStructPersisted::Named(named_vectors) => {
             for (name, vector) in named_vectors {
-                let Some(params) = vectors_config.get_params(name) else {
-                    continue;
-                };
-                let expected_dim = params.size.get() as usize;
-                validate_single_vector_dim(vector, name, expected_dim)?;
+                validate_named_vector(vector, name, vectors_config, sparse_vectors_config)?;
             }
         }
     }
     Ok(())
+}
+
+fn unknown_vector_name_error(name: &str) -> StorageError {
+    StorageError::bad_input(format!(
+        "Vector name error: vector '{name}' does not exist in collection"
+    ))
+}
+
+fn unnamed_vector_error() -> StorageError {
+    StorageError::bad_input("Vector name error: unnamed vector does not exist in collection")
+}
+
+fn validate_named_vector(
+    vector: &VectorPersisted,
+    name: &VectorNameBuf,
+    vectors_config: &VectorsConfig,
+    sparse_vectors_config: Option<&BTreeMap<VectorNameBuf, SparseVectorParams>>,
+) -> Result<(), StorageError> {
+    match vector {
+        VectorPersisted::Dense(_) | VectorPersisted::MultiDense(_) => {
+            let Some(params) = vectors_config.get_params(name) else {
+                return Err(unknown_vector_name_error(name));
+            };
+            validate_single_vector_dim(vector, name, params.size.get() as usize)
+        }
+        VectorPersisted::Sparse(_) => {
+            if sparse_vectors_config
+                .map(|sparse_vectors| sparse_vectors.contains_key(name))
+                .unwrap_or(false)
+            {
+                Ok(())
+            } else {
+                Err(unknown_vector_name_error(name))
+            }
+        }
+    }
 }
 
 fn validate_single_vector_dim(

--- a/tests/openapi/test_named_vector_crud.py
+++ b/tests/openapi/test_named_vector_crud.py
@@ -107,6 +107,36 @@ def test_delete_recreate_vector_scroll(collection_name):
         assert len(point['vector']['vec_b']) == VECTOR_SIZE2
 
 
+def test_unnamed_vector_in_named_vector_collection_rejected(collection_name):
+    """Unnamed vector input should not be accepted by named-vector collections."""
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1000,
+                    "vector": [0.1, 0.2, 0.3, 0.4],
+                }
+            ]
+        },
+    )
+    assert not response.ok
+    assert response.status_code == 400
+    assert "vector name" in response.json()["status"]["error"].lower()
+    assert "unnamed vector" in response.json()["status"]["error"].lower()
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 1000},
+    )
+    assert response.ok
+    assert response.json()["result"] is None
+
+
 # Input-validation tests below intentionally use plain `requests` because
 # `request_with_validation` would reject the body client-side (size violates
 # the spec's minimum/maximum), preventing the server-side rejection from

--- a/tests/openapi/test_named_vector_crud.py
+++ b/tests/openapi/test_named_vector_crud.py
@@ -133,8 +133,7 @@ def test_unnamed_vector_in_named_vector_collection_rejected(collection_name):
         method="GET",
         path_params={'collection_name': collection_name, 'id': 1000},
     )
-    assert response.ok
-    assert response.json()["result"] is None
+    assert response.status_code == 404
 
 
 # Input-validation tests below intentionally use plain `requests` because

--- a/tests/openapi/test_sparse_update.py
+++ b/tests/openapi/test_sparse_update.py
@@ -174,3 +174,75 @@ def test_unknown_sparse_vector_name_rejected(collection_name):
     assert response.status_code == 400
     assert "vector name" in response.json()["status"]["error"].lower()
     assert "missing" in response.json()["status"]["error"].lower()
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+    )
+    assert response.status_code == 404
+
+
+def test_batch_sparse_vector_names_are_validated(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "batch": {
+                "ids": [3],
+                "vectors": {
+                    "text": [
+                        {
+                            "indices": [10],
+                            "values": [0.9],
+                        }
+                    ]
+                },
+            }
+        },
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 3},
+    )
+    assert response.ok
+    assert response.json()["result"]["vector"]["text"] == {
+        "indices": [10],
+        "values": [0.9],
+    }
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "batch": {
+                "ids": [4],
+                "vectors": {
+                    "missing": [
+                        {
+                            "indices": [10],
+                            "values": [0.9],
+                        }
+                    ]
+                },
+            }
+        },
+    )
+    assert not response.ok
+    assert response.status_code == 400
+    assert "vector name" in response.json()["status"]["error"].lower()
+    assert "missing" in response.json()["status"]["error"].lower()
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 4},
+    )
+    assert response.status_code == 404

--- a/tests/openapi/test_sparse_update.py
+++ b/tests/openapi/test_sparse_update.py
@@ -144,8 +144,33 @@ def test_sparse_dense_updates(collection_name):
                     "values": [0.9]
                 }
             }
-        }
+        },
     )
     assert response.ok
     assert len(response.json()['result']) == 1
 
+
+def test_unknown_sparse_vector_name_rejected(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 2,
+                    "vector": {
+                        "missing": {
+                            "indices": [10],
+                            "values": [0.9],
+                        }
+                    },
+                }
+            ]
+        },
+    )
+    assert not response.ok
+    assert response.status_code == 400
+    assert "vector name" in response.json()["status"]["error"].lower()
+    assert "missing" in response.json()["status"]["error"].lower()

--- a/tests/openapi/test_vector_dimension_validation.py
+++ b/tests/openapi/test_vector_dimension_validation.py
@@ -103,3 +103,34 @@ def test_async_batch_upsert_wrong_dimension_rejected(collection_name):
     assert not response.ok
     assert response.status_code == 400
     assert "dimension" in response.json()["status"]["error"].lower()
+
+
+def test_named_vector_in_single_vector_collection_rejected(collection_name):
+    """Named vector input should not be silently accepted by single-vector collections."""
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 102,
+                    "vector": {"name": [0.1, 0.2, 0.3, 0.4]},
+                }
+            ]
+        }
+    )
+    assert not response.ok
+    assert response.status_code == 400
+    assert "vector name" in response.json()["status"]["error"].lower()
+    assert "name" in response.json()["status"]["error"].lower()
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/count',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={"exact": True},
+    )
+    assert response.ok
+    assert response.json()["result"]["count"] == 0


### PR DESCRIPTION
Fixes #9521.

## What
- Reject named-vector upserts when the supplied vector name is not present in the collection config.
- Reject unnamed vector upserts when the collection has only named vectors and no default vector.
- Add OpenAPI regressions for both format mismatches so invalid input fails before WAL instead of being accepted and later dropped/ignored.

## Why
Previously `validate_vectors` skipped unknown named vectors. A request like `{"vector": {"name": [...]}}` against a single-vector collection could pass validation even though `name` is not a configured vector, leading to a successful response with no stored point. The reverse unnamed-vector shape had the same early-validation gap for named-vector collections.

## Validation
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/qdrant-pycache /usr/bin/python3 -m py_compile tests/openapi/test_vector_dimension_validation.py tests/openapi/test_named_vector_crud.py`
- `RUSTUP_HOME=/private/tmp/qdrant-rustup CARGO_HOME=/private/tmp/qdrant-cargo rustfmt +stable --check src/common/validate_vectors.rs`
- `RUSTUP_HOME=/private/tmp/qdrant-rustup CARGO_HOME=/private/tmp/qdrant-cargo cargo +stable check -p qdrant`