### PR TITLE
Replace DynConditionChecker with ConditionCheckerEnum

### DIFF
--- a/lib/edge/src/read_only/holder.rs
+++ b/lib/edge/src/read_only/holder.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use common::universal_io::UniversalRead;
 use parking_lot::RwLock;
+use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
 
@@ -11,12 +11,12 @@ use uuid::Uuid;
 ///
 /// The UUID is the stable cross-process identity of a segment directory; the [`Slot::id`] is a
 /// follower-local ordering counter only.
-pub(crate) struct ReadOnlySegmentHolder<S: UniversalRead + 'static> {
+pub(crate) struct ReadOnlySegmentHolder<S: UniversalReadExt + 'static> {
     by_uuid: HashMap<Uuid, Slot<S>>,
     id_source: usize,
 }
 
-struct Slot<S: UniversalRead + 'static> {
+struct Slot<S: UniversalReadExt + 'static> {
     /// Follower-local ordering id. Cross-segment retrieval dedup keys on point version, not on this
     /// id, so it need not match the leader's segment ids.
     id: usize,
@@ -24,7 +24,7 @@ struct Slot<S: UniversalRead + 'static> {
     segment: Arc<RwLock<ReadOnlySegment<S>>>,
 }
 
-impl<S: UniversalRead + 'static> Default for ReadOnlySegmentHolder<S> {
+impl<S: UniversalReadExt + 'static> Default for ReadOnlySegmentHolder<S> {
     fn default() -> Self {
         Self {
             by_uuid: HashMap::new(),
@@ -33,7 +33,7 @@ impl<S: UniversalRead + 'static> Default for ReadOnlySegmentHolder<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> ReadOnlySegmentHolder<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlySegmentHolder<S> {
     pub(crate) fn contains(&self, uuid: &Uuid) -> bool {
         self.by_uuid.contains_key(uuid)
     }

--- a/lib/edge/src/read_only/lifecycle.rs
+++ b/lib/edge/src/read_only/lifecycle.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use common::universal_io::{MmapFile, MmapFs, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs};
 use parking_lot::RwLock;
 use segment::common::operation_error::OperationResult;
+use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 
 use crate::EdgeConfig;
@@ -20,7 +21,7 @@ impl ReadOnlyEdgeShard<MmapFile> {
     }
 }
 
-impl<S: UniversalRead + 'static> ReadOnlyEdgeShard<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// Open a read-only follower over the edge-shard directory at `path` using read backend `fs`.
     ///
     /// Segments are discovered through the leader's segment manifest (read via `fs`) — a read-only

--- a/lib/edge/src/read_only/mod.rs
+++ b/lib/edge/src/read_only/mod.rs
@@ -22,8 +22,8 @@ mod tests;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::universal_io::UniversalRead;
 use parking_lot::RwLock;
+use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 
 use crate::EdgeConfig;
@@ -38,7 +38,7 @@ use crate::read_view::EdgeShardRead;
 /// Generic over the read backend `S` (e.g. `MmapFile` for local memory-mapped files; the same
 /// abstraction `ReadOnlySegment` uses, so blob/S3 backends are possible). Use
 /// [`open_mmap`](ReadOnlyEdgeShard::open_mmap) for the common local case.
-pub struct ReadOnlyEdgeShard<S: UniversalRead + 'static> {
+pub struct ReadOnlyEdgeShard<S: UniversalReadExt + 'static> {
     path: PathBuf,
     /// Read backend handle; passed to segment `open` and `live_reload`.
     fs: S::Fs,
@@ -52,7 +52,7 @@ pub struct ReadOnlyEdgeShard<S: UniversalRead + 'static> {
     enumerator: Box<dyn SegmentEnumerator>,
 }
 
-impl<S: UniversalRead + 'static> ReadOnlyEdgeShard<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -65,7 +65,7 @@ impl<S: UniversalRead + 'static> ReadOnlyEdgeShard<S> {
 
 /// The follower's segments are homogeneous, so its handle is the concrete
 /// `Arc<RwLock<ReadOnlySegment<S>>>` — the read path is fully monomorphized, no dynamic dispatch.
-impl<S: UniversalRead + 'static> EdgeShardRead for ReadOnlyEdgeShard<S> {
+impl<S: UniversalReadExt + 'static> EdgeShardRead for ReadOnlyEdgeShard<S> {
     type Handle = Arc<RwLock<ReadOnlySegment<S>>>;
 
     fn read_segments(&self) -> Vec<Arc<RwLock<ReadOnlySegment<S>>>> {

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::UniversalRead;
 use parking_lot::RwLock;
 use segment::common::operation_error::OperationResult;
+use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
 
 use crate::EdgeConfig;
 use crate::read_only::ReadOnlyEdgeShard;
 
-impl<S: UniversalRead + 'static> ReadOnlyEdgeShard<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// Refresh the follower to the leader's current on-disk state.
     ///
     /// Caller-driven (never self-triggered), mirroring `ReadOnlySegment::live_reload`: the host

--- a/lib/edge/src/read_view.rs
+++ b/lib/edge/src/read_view.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::ScoreType;
-use common::universal_io::UniversalRead;
 use parking_lot::{RwLock, RwLockReadGuard};
 use segment::common::operation_error::OperationResult;
 use segment::data_types::facets::FacetResponse;
 use segment::entry::ReadSegmentEntry;
+use segment::index::UniversalReadExt;
 use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
 use segment::segment::read_only::ReadOnlySegment;
 use segment::types::{ExtendedPointId, PointIdType, ScoredPoint, WithPayloadInterface, WithVector};
@@ -43,7 +43,7 @@ pub trait ReadSegmentHandle {
     fn segment_arc(&self) -> Arc<RwLock<Self::Segment>>;
 }
 
-impl<S: UniversalRead + 'static> ReadSegmentHandle for Arc<RwLock<ReadOnlySegment<S>>> {
+impl<S: UniversalReadExt + 'static> ReadSegmentHandle for Arc<RwLock<ReadOnlySegment<S>>> {
     type Segment = ReadOnlySegment<S>;
 
     fn read_segment(&self) -> RwLockReadGuard<'_, ReadOnlySegment<S>> {

--- a/lib/segment/src/index/condition_checker.rs
+++ b/lib/segment/src/index/condition_checker.rs
@@ -1,0 +1,246 @@
+use common::condition_checker::{ConditionChecker, ConstantConditionChecker};
+use common::types::PointOffsetType;
+#[cfg(target_os = "linux")]
+use common::universal_io::IoUringFile;
+use common::universal_io::MmapFile;
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::bool_index::{
+    BoolConditionChecker, ImmutableBoolIndex, MutableBoolIndex, ReadOnlyBoolIndex,
+};
+use crate::index::field_index::full_text_index::{
+    FullTextConditionChecker, FullTextIndex, ReadOnlyFullTextIndex,
+};
+use crate::index::field_index::geo_index::{GeoConditionChecker, GeoIndex, ReadOnlyGeoIndex};
+use crate::index::field_index::map_index::read_only::ReadOnlyMapIndex;
+use crate::index::field_index::map_index::{MapConditionChecker, MapIndex};
+use crate::index::field_index::null_index::{
+    ImmutableNullIndex, MutableNullIndex, NullConditionChecker, ReadOnlyNullIndex,
+};
+use crate::index::field_index::numeric_index::{
+    NumericIndexInner, RangeConditionChecker, ReadOnlyNumericIndexInner,
+};
+use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
+#[cfg(feature = "testing")]
+use crate::index::plain_payload_index::PlainFilterContext;
+use crate::index::query_optimization::optimized_filter::OptimizedFilter;
+use crate::index::struct_payload_index::IdsConditionChecker;
+use crate::types::{
+    FloatPayloadType, GeoBoundingBox, GeoRadius, IntPayloadType, PolygonWrapper, UuidIntType,
+};
+
+type BoolCC<'a, Idx> = BoolConditionChecker<'a, Idx>;
+type NullCC<'a, Idx> = NullConditionChecker<'a, Idx>;
+type GeoCC<'a, R, C> = GeoConditionChecker<'a, R, C>;
+type RangeRwCC<'a, T> = RangeConditionChecker<'a, NumericIndexInner<T>, T>;
+type RangeRoCC<'a, S, T> = RangeConditionChecker<'a, ReadOnlyNumericIndexInner<T, S>, T>;
+type FullTextCC<'a, Idx> = FullTextConditionChecker<'a, Idx>;
+type MapWrCC<'a, T> = MapConditionChecker<'a, T, MapIndex<T>>;
+type MapRoCC<'a, S, T> = MapConditionChecker<'a, T, ReadOnlyMapIndex<T, S>>;
+
+/// All [`ConditionChecker`] implementations used in this [crate].
+pub enum ConditionCheckerEnum<'a> {
+    Build(BuildConditionChecker<'a>),
+    Constant(ConstantConditionChecker<OperationError>),
+    Dyn(Box<dyn ConditionChecker<Error = OperationError> + 'a>),
+    Filter(OptimizedFilter<'a>),
+    Ids(IdsConditionChecker),
+    #[cfg(feature = "testing")]
+    Plain(PlainFilterContext<'a>),
+
+    // bool index
+    BoolImmutable(BoolCC<'a, ImmutableBoolIndex>),
+    BoolMutable(BoolCC<'a, MutableBoolIndex>),
+    #[cfg(target_os = "linux")]
+    BoolRoIoUring(BoolCC<'a, ReadOnlyBoolIndex<IoUringFile>>),
+    BoolRoMmap(BoolCC<'a, ReadOnlyBoolIndex<MmapFile>>),
+
+    // null index
+    NullImmutable(NullCC<'a, ImmutableNullIndex>),
+    NullMutable(NullCC<'a, MutableNullIndex>),
+    #[cfg(target_os = "linux")]
+    NullRoIoUring(NullCC<'a, ReadOnlyNullIndex<IoUringFile>>),
+    NullRoMmap(NullCC<'a, ReadOnlyNullIndex<MmapFile>>),
+
+    // geo index
+    GeoRadiusWritable(GeoCC<'a, GeoIndex, GeoRadius>),
+    GeoBoundingBoxWritable(GeoCC<'a, GeoIndex, GeoBoundingBox>),
+    GeoPolygonWritable(GeoCC<'a, GeoIndex, PolygonWrapper>),
+
+    #[cfg(target_os = "linux")]
+    GeoRadiusRoIoUring(GeoCC<'a, ReadOnlyGeoIndex<IoUringFile>, GeoRadius>),
+    #[cfg(target_os = "linux")]
+    GeoBoundingBoxRoIoUring(GeoCC<'a, ReadOnlyGeoIndex<IoUringFile>, GeoBoundingBox>),
+    #[cfg(target_os = "linux")]
+    GeoPolygonRoIoUring(GeoCC<'a, ReadOnlyGeoIndex<IoUringFile>, PolygonWrapper>),
+
+    GeoRadiusRoMmap(GeoCC<'a, ReadOnlyGeoIndex<MmapFile>, GeoRadius>),
+    GeoBoundingBoxRoMmap(GeoCC<'a, ReadOnlyGeoIndex<MmapFile>, GeoBoundingBox>),
+    GeoPolygonRoMmap(GeoCC<'a, ReadOnlyGeoIndex<MmapFile>, PolygonWrapper>),
+
+    // numeric index
+    NumericFloatWritable(RangeRwCC<'a, FloatPayloadType>),
+    NumericIntWritable(RangeRwCC<'a, IntPayloadType>),
+    NumericUuidWritable(RangeRwCC<'a, UuidIntType>),
+
+    #[cfg(target_os = "linux")]
+    NumericFloatRoIoUring(RangeRoCC<'a, IoUringFile, FloatPayloadType>),
+    #[cfg(target_os = "linux")]
+    NumericIntRoIoUring(RangeRoCC<'a, IoUringFile, IntPayloadType>),
+    #[cfg(target_os = "linux")]
+    NumericUuidRoIoUring(RangeRoCC<'a, IoUringFile, UuidIntType>),
+
+    NumericFloatRoMmap(RangeRoCC<'a, MmapFile, FloatPayloadType>),
+    NumericIntRoMmap(RangeRoCC<'a, MmapFile, IntPayloadType>),
+    NumericUuidRoMmap(RangeRoCC<'a, MmapFile, UuidIntType>),
+
+    // full-text index
+    FullTextWritable(FullTextCC<'a, FullTextIndex>),
+    #[cfg(target_os = "linux")]
+    FullTextRoIoUring(FullTextCC<'a, ReadOnlyFullTextIndex<IoUringFile>>),
+    FullTextRoMmap(FullTextCC<'a, ReadOnlyFullTextIndex<MmapFile>>),
+
+    // map index
+    MapIntWritable(MapWrCC<'a, IntPayloadType>),
+    MapStrWritable(MapWrCC<'a, str>),
+    MapUuidWritable(MapWrCC<'a, UuidIntType>),
+
+    #[cfg(target_os = "linux")]
+    MapIntRoIoUring(MapRoCC<'a, IoUringFile, IntPayloadType>),
+    #[cfg(target_os = "linux")]
+    MapStrRoIoUring(MapRoCC<'a, IoUringFile, str>),
+    #[cfg(target_os = "linux")]
+    MapUuidRoIoUring(MapRoCC<'a, IoUringFile, UuidIntType>),
+
+    MapIntRoMmap(MapRoCC<'a, MmapFile, IntPayloadType>),
+    MapStrRoMmap(MapRoCC<'a, MmapFile, str>),
+    MapUuidRoMmap(MapRoCC<'a, MmapFile, UuidIntType>),
+}
+
+impl ConditionChecker for ConditionCheckerEnum<'_> {
+    type Error = OperationError;
+
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        match self {
+            Self::Build(c) => c.check(point_id),
+            Self::Constant(c) => c.check(point_id),
+            Self::Dyn(c) => c.check(point_id),
+            Self::Filter(c) => c.check(point_id),
+            Self::Ids(c) => c.check(point_id),
+            #[cfg(feature = "testing")]
+            Self::Plain(c) => c.check(point_id),
+            Self::BoolImmutable(c) => c.check(point_id),
+            Self::BoolMutable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::BoolRoIoUring(c) => c.check(point_id),
+            Self::BoolRoMmap(c) => c.check(point_id),
+            Self::NullImmutable(c) => c.check(point_id),
+            Self::NullMutable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NullRoIoUring(c) => c.check(point_id),
+            Self::NullRoMmap(c) => c.check(point_id),
+            Self::GeoRadiusWritable(c) => c.check(point_id),
+            Self::GeoBoundingBoxWritable(c) => c.check(point_id),
+            Self::GeoPolygonWritable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoRadiusRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoBoundingBoxRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoPolygonRoIoUring(c) => c.check(point_id),
+            Self::GeoRadiusRoMmap(c) => c.check(point_id),
+            Self::GeoBoundingBoxRoMmap(c) => c.check(point_id),
+            Self::GeoPolygonRoMmap(c) => c.check(point_id),
+            Self::NumericFloatWritable(c) => c.check(point_id),
+            Self::NumericIntWritable(c) => c.check(point_id),
+            Self::NumericUuidWritable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericFloatRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericIntRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericUuidRoIoUring(c) => c.check(point_id),
+            Self::NumericFloatRoMmap(c) => c.check(point_id),
+            Self::NumericIntRoMmap(c) => c.check(point_id),
+            Self::NumericUuidRoMmap(c) => c.check(point_id),
+            Self::FullTextWritable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::FullTextRoIoUring(c) => c.check(point_id),
+            Self::FullTextRoMmap(c) => c.check(point_id),
+            Self::MapIntWritable(c) => c.check(point_id),
+            Self::MapStrWritable(c) => c.check(point_id),
+            Self::MapUuidWritable(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapIntRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapStrRoIoUring(c) => c.check(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapUuidRoIoUring(c) => c.check(point_id),
+            Self::MapIntRoMmap(c) => c.check(point_id),
+            Self::MapStrRoMmap(c) => c.check(point_id),
+            Self::MapUuidRoMmap(c) => c.check(point_id),
+        }
+    }
+
+    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
+        match self {
+            Self::Build(c) => c.check_infallible(point_id),
+            Self::Constant(c) => c.check_infallible(point_id),
+            Self::Dyn(c) => c.check_infallible(point_id),
+            Self::Filter(c) => c.check_infallible(point_id),
+            Self::Ids(c) => c.check_infallible(point_id),
+            #[cfg(feature = "testing")]
+            Self::Plain(c) => c.check_infallible(point_id),
+            Self::BoolImmutable(c) => c.check_infallible(point_id),
+            Self::BoolMutable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::BoolRoIoUring(c) => c.check_infallible(point_id),
+            Self::BoolRoMmap(c) => c.check_infallible(point_id),
+            Self::NullImmutable(c) => c.check_infallible(point_id),
+            Self::NullMutable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NullRoIoUring(c) => c.check_infallible(point_id),
+            Self::NullRoMmap(c) => c.check_infallible(point_id),
+            Self::GeoRadiusWritable(c) => c.check_infallible(point_id),
+            Self::GeoBoundingBoxWritable(c) => c.check_infallible(point_id),
+            Self::GeoPolygonWritable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoRadiusRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoBoundingBoxRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::GeoPolygonRoIoUring(c) => c.check_infallible(point_id),
+            Self::GeoRadiusRoMmap(c) => c.check_infallible(point_id),
+            Self::GeoBoundingBoxRoMmap(c) => c.check_infallible(point_id),
+            Self::GeoPolygonRoMmap(c) => c.check_infallible(point_id),
+            Self::NumericFloatWritable(c) => c.check_infallible(point_id),
+            Self::NumericIntWritable(c) => c.check_infallible(point_id),
+            Self::NumericUuidWritable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericFloatRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericIntRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::NumericUuidRoIoUring(c) => c.check_infallible(point_id),
+            Self::NumericFloatRoMmap(c) => c.check_infallible(point_id),
+            Self::NumericIntRoMmap(c) => c.check_infallible(point_id),
+            Self::NumericUuidRoMmap(c) => c.check_infallible(point_id),
+            Self::FullTextWritable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::FullTextRoIoUring(c) => c.check_infallible(point_id),
+            Self::FullTextRoMmap(c) => c.check_infallible(point_id),
+            Self::MapIntWritable(c) => c.check_infallible(point_id),
+            Self::MapStrWritable(c) => c.check_infallible(point_id),
+            Self::MapUuidWritable(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapIntRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapStrRoIoUring(c) => c.check_infallible(point_id),
+            #[cfg(target_os = "linux")]
+            Self::MapUuidRoIoUring(c) => c.check_infallible(point_id),
+            Self::MapIntRoMmap(c) => c.check_infallible(point_id),
+            Self::MapStrRoMmap(c) => c.check_infallible(point_id),
+            Self::MapUuidRoMmap(c) => c.check_infallible(point_id),
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
@@ -7,10 +7,10 @@ use super::super::read_ops::{self, BoolIndexRead};
 use super::ImmutableBoolIndex;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for ImmutableBoolIndex {
@@ -79,7 +79,8 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::BoolImmutable))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -10,7 +10,7 @@ use common::universal_io::MmapFile;
 pub use immutable_bool_index::ImmutableBoolIndex;
 pub use mutable_bool_index::MutableBoolIndex;
 pub use read_only_bool_index::ReadOnlyBoolIndex;
-pub use read_ops::BoolIndexRead;
+pub use read_ops::{BoolConditionChecker, BoolIndexRead};
 use serde_json::Value as JsonValue;
 
 use super::facet_index::FacetIndex;
@@ -18,8 +18,8 @@ use super::{PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer};
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::facets::{FacetHit, FacetValue, FacetValueRef};
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::FieldCondition;
 
@@ -140,8 +140,11 @@ impl PayloadFieldIndexRead for BoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        match self {
+            BoolIndex::Mutable(index) => index.condition_checker(condition, hw_acc),
+            BoolIndex::Immutable(index) => index.condition_checker(condition, hw_acc),
+        }
     }
 }
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
@@ -7,10 +7,10 @@ use super::super::read_ops::{self, BoolIndexRead};
 use super::MutableBoolIndex;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl BoolIndexRead for MutableBoolIndex {
@@ -77,7 +77,8 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::BoolMutable))
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -1,14 +1,13 @@
 use std::path::Path;
 
-use common::universal_io::UniversalRead;
-
 use super::super::mutable_bool_index::{FALSES_DIRNAME, TRUES_DIRNAME};
 use super::{ReadOnlyBoolIndex, ReadOnlyStorage};
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::UniversalReadExt;
 
-impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// Open a read-only bool index at `path`, threading every file open through
     /// the filesystem handle `fs`.
     ///

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -1,14 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 use super::ReadOnlyBoolIndex;
 use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::LiveReload;
 
-impl<S: UniversalRead> LiveReload for ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> LiveReload for ReadOnlyBoolIndex<S> {
     type Fs = S::Fs;
 
     fn live_reload(

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use common::universal_io::UniversalRead;
-
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
+use crate::index::UniversalReadExt;
 use crate::index::payload_config::IndexMutability;
 
 mod lifecycle;
@@ -26,7 +25,7 @@ mod read_ops;
 /// [3]: common::universal_io::UniversalRead
 /// [4]: super::read_ops::BoolIndexRead
 /// [5]: crate::index::field_index::LiveReload
-pub struct ReadOnlyBoolIndex<S: UniversalRead> {
+pub struct ReadOnlyBoolIndex<S: UniversalReadExt> {
     pub(super) _base_dir: PathBuf,
     pub(super) storage: ReadOnlyStorage<S>,
     pub(super) indexed_count: usize,
@@ -34,14 +33,14 @@ pub struct ReadOnlyBoolIndex<S: UniversalRead> {
     pub(super) falses_count: usize,
 }
 
-pub(super) struct ReadOnlyStorage<S: UniversalRead> {
+pub(super) struct ReadOnlyStorage<S: UniversalReadExt> {
     /// Points which have at least one `true` value
     pub(super) trues_flags: ReadOnlyRoaringFlags<S>,
     /// Points which have at least one `false` value
     pub(super) falses_flags: ReadOnlyRoaringFlags<S>,
 }
 
-impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// Reports the on-disk format's mutability, mirroring
     /// [`BoolIndex::get_mutability_type`][1].
     ///

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -1,22 +1,22 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 use super::super::read_ops::{self, BoolIndexRead};
 use super::ReadOnlyBoolIndex;
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValue, FacetValueRef};
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, PayloadKeyType};
 
-impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// Produce a closure that maps a point id to its indexed bool
     /// values as JSON `Value`s. Used by `ReadOnlyFieldIndex::value_retriever`.
     pub fn value_retriever<'a>(
@@ -27,7 +27,7 @@ impl<S: UniversalRead> ReadOnlyBoolIndex<S> {
     }
 }
 
-impl<S: UniversalRead> BoolIndexRead for ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> BoolIndexRead for ReadOnlyBoolIndex<S> {
     type Flags = ReadOnlyRoaringFlags<S>;
 
     fn trues_flags(&self) -> &Self::Flags {
@@ -55,7 +55,7 @@ impl<S: UniversalRead> BoolIndexRead for ReadOnlyBoolIndex<S> {
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_count()
     }
@@ -89,15 +89,16 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc)
+            .map(|x| UniversalReadExt::condition_checker_bool(x)))
     }
 }
 
 /// Faceting over the read-only bool index mirrors the `FacetIndex` impl for
 /// `BoolIndex`: every method delegates to a [`BoolIndexRead`] default, so the
 /// body is identical — only the `Self` type differs.
-impl<S: UniversalRead> FacetIndex for ReadOnlyBoolIndex<S> {
+impl<S: UniversalReadExt> FacetIndex for ReadOnlyBoolIndex<S> {
     fn unique_values_count(&self) -> usize {
         // Upper bound; see `BoolIndex::unique_values_count` for rationale.
         2

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -30,7 +30,6 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::MultiValue;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
@@ -294,7 +293,7 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
     idx: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
+) -> Option<BoolConditionChecker<'a, N>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -313,10 +312,10 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
     match cond_match {
         Match::Value(MatchValue {
             value: ValueVariants::Bool(is_true),
-        }) => Some(Box::new(BoolConditionChecker {
+        }) => Some(BoolConditionChecker {
             idx,
             is_true: *is_true,
-        })),
+        }),
         Match::Value(MatchValue {
             value: ValueVariants::String(_) | ValueVariants::Integer(_),
         })
@@ -332,7 +331,7 @@ pub(super) fn condition_checker<'a, N: BoolIndexRead>(
     }
 }
 
-struct BoolConditionChecker<'a, N> {
+pub struct BoolConditionChecker<'a, N> {
     idx: &'a N,
     is_true: bool,
 }

--- a/lib/segment/src/index/field_index/facet_index.rs
+++ b/lib/segment/src/index/field_index/facet_index.rs
@@ -1,6 +1,6 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, UniversalRead};
+use common::universal_io::MmapFile;
 use itertools::Itertools;
 
 use super::bool_index::{BoolIndex, ReadOnlyBoolIndex};
@@ -8,6 +8,7 @@ use super::map_index::MapIndex;
 use super::map_index::read_only::ReadOnlyMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::facets::{FacetHit, FacetValue, FacetValueRef};
+use crate::index::UniversalReadExt;
 use crate::types::{IntPayloadType, UuidIntType};
 
 pub trait FacetIndex {
@@ -109,13 +110,13 @@ pub trait FacetIndex {
 
 /// Borrowed view over any concrete index that can produce facet counts.
 ///
-/// The `S: UniversalRead` parameter is consumed by the map-based `*ReadOnly`
+/// The `S: UniversalReadExt` parameter is consumed by the map-based `*ReadOnly`
 /// variants (`ReadOnlyMapIndex<N, S>`) and threaded as a phantom by
 /// `ReadOnlyBoolIndex<S>` (so it can re-read its flags through `S::Fs` on
 /// live-reload); the in-memory variants (`Keyword`, `Int`, `Uuid`, `Bool`)
 /// ignore it. The default `S = MmapFile` keeps the common construction path
 /// (`FieldIndex::as_facet_index`) free of turbofish.
-pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
+pub enum FacetIndexEnum<'a, S: UniversalReadExt = MmapFile> {
     Keyword(&'a MapIndex<str>),
     Int(&'a MapIndex<IntPayloadType>),
     Uuid(&'a MapIndex<UuidIntType>),
@@ -133,7 +134,7 @@ pub enum FacetIndexEnum<'a, S: UniversalRead = MmapFile> {
     BoolReadOnly(&'a ReadOnlyBoolIndex<S>),
 }
 
-impl<'a, S: UniversalRead> FacetIndex for FacetIndexEnum<'a, S> {
+impl<'a, S: UniversalReadExt> FacetIndex for FacetIndexEnum<'a, S> {
     fn unique_values_count(&self) -> usize {
         match self {
             FacetIndexEnum::Keyword(index) => FacetIndex::unique_values_count(*index),

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -7,6 +7,7 @@ use super::field_index::FieldIndex;
 use super::field_index_read::FieldIndexRead;
 use super::payload_field_index::PayloadFieldIndexRead;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::bool_index::BoolIndexRead;
 use crate::index::field_index::facet_index::{FacetIndex, FacetIndexEnum};
 use crate::index::field_index::full_text_index::full_text_index_read::FullTextIndexRead;
@@ -14,7 +15,6 @@ use crate::index::field_index::geo_index::GeoIndexRead;
 use crate::index::field_index::null_index::NullIndexRead;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
@@ -101,7 +101,7 @@ impl PayloadFieldIndexRead for FieldIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
         match self {
             FieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             FieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Read-only operations available on every payload field index.
@@ -56,7 +56,7 @@ pub trait PayloadFieldIndexRead {
         &'a self,
         _condition: &FieldCondition,
         _hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>>;
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>>;
 
     /// Index-aware check for conditions that need parameters held by
     /// the index (today: full-text tokenizers).

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
 use common::bitvec::BitSlice;
-use common::universal_io::UniversalRead;
 
 use super::ReadOnlyFieldIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::index::TextIndexParams;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::bool_index::ReadOnlyBoolIndex;
 use crate::index::field_index::full_text_index::read_only::ReadOnlyFullTextIndex;
 use crate::index::field_index::geo_index::ReadOnlyGeoIndex;
@@ -24,7 +24,7 @@ use crate::types::{
 /// Which read-only open path a leaf index should take, derived from the stored
 /// [`StorageType`]. Phrased as a mutability distinction (matching the
 /// `open_appendable` / `open_immutable` leaf methods) rather than a concrete
-/// backend: the read-only stack is generic over [`UniversalRead`], so the
+/// backend: the read-only stack is generic over [`UniversalRead`](common::universal_io::UniversalRead), so the
 /// on-disk-vs-in-memory choice is just the `is_on_disk` flag on the immutable
 /// variant, picked from the index type rather than passed in by the caller.
 #[derive(Clone, Copy)]
@@ -36,7 +36,7 @@ enum ReadMode {
     Immutable { is_on_disk: bool },
 }
 
-impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
     /// Read-only mirror of [`IndexSelector::new_index_with_type`][1]: dispatches
     /// on [`FullPayloadIndexType::index_type`] and forwards to each per-index
     /// parent's open, wrapping the leaf in the matching variant.
@@ -44,7 +44,7 @@ impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
     /// The open path (appendable vs immutable) is picked from the stored
     /// [`FullPayloadIndexType::storage_type`]; `is_on_disk` rides on the
     /// immutable mode. Generic over `S`: every per-index open threads the
-    /// [`UniversalRead`] handle `fs` (the map, numeric, geo and full-text leaves
+    /// [`UniversalRead`](common::universal_io::UniversalRead) handle `fs` (the map, numeric, geo and full-text leaves
     /// are all fs-generic), so the dispatcher needn't fix a concrete backend.
     ///
     /// `payload_schema` is consulted only by the full-text arm (it carries the

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 pub(crate) use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::bool_index::ReadOnlyBoolIndex;
 use crate::index::field_index::full_text_index::read_only::ReadOnlyFullTextIndex;
 use crate::index::field_index::geo_index::ReadOnlyGeoIndex;
@@ -28,7 +28,7 @@ use crate::types::{
 // have no in-lib caller yet, so the variants would trip `dead_code`. Allow at
 // the enum level until a read-only segment wires the opens in.
 #[allow(dead_code, clippy::enum_variant_names)]
-pub enum ReadOnlyFieldIndex<S: UniversalRead> {
+pub enum ReadOnlyFieldIndex<S: UniversalReadExt> {
     IntIndex(ReadOnlyNumericIndex<IntPayloadType, IntPayloadType, S>),
     DatetimeIndex(ReadOnlyNumericIndex<IntPayloadType, DateTimePayloadType, S>),
     IntMapIndex(ReadOnlyMapIndex<IntPayloadType, S>),
@@ -47,7 +47,7 @@ pub enum ReadOnlyFieldIndex<S: UniversalRead> {
 /// writable side, where the underlying typed index is also not formatted).
 ///
 /// [1]: crate::index::field_index::FieldIndex
-impl<S: UniversalRead> Debug for ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> Debug for ReadOnlyFieldIndex<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ReadOnlyFieldIndex::IntIndex(_) => write!(f, "IntIndex"),
@@ -98,7 +98,7 @@ impl<S: UniversalRead> Debug for ReadOnlyFieldIndex<S> {
 ///
 /// [1]: crate::index::field_index::FieldIndex
 #[allow(dead_code)] // skeleton: no caller in the lib yet; surface is here for follow-ups
-impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
     pub fn files(&self) -> Vec<PathBuf> {
         match self {
             ReadOnlyFieldIndex::IntMapIndex(_)
@@ -355,7 +355,7 @@ impl<S: UniversalRead> ReadOnlyFieldIndex<S> {
     }
 }
 
-impl<S: UniversalRead> LiveReload for ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> LiveReload for ReadOnlyFieldIndex<S> {
     type Fs = S::Fs;
 
     fn live_reload(

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -1,10 +1,11 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 use serde_json::Value;
 
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::bool_index::BoolIndexRead;
 use crate::index::field_index::field_index_base::read_only::ReadOnlyFieldIndex;
 use crate::index::field_index::full_text_index::full_text_index_read::FullTextIndexRead;
@@ -17,12 +18,11 @@ use crate::index::field_index::numeric_index::{
 use crate::index::field_index::{
     CardinalityEstimation, FacetIndex, FieldIndexRead, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
     fn count_indexed_points(&self) -> usize {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.count_indexed_points(),
@@ -112,7 +112,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.condition_checker(condition, hw_acc),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => idx.condition_checker(condition, hw_acc),
@@ -172,7 +172,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
     }
 }
 
-impl<S: UniversalRead> FieldIndexRead for ReadOnlyFieldIndex<S> {
+impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.get_telemetry_data(),

--- a/lib/segment/src/index/field_index/full_text_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mod.rs
@@ -18,6 +18,9 @@ mod read_ops;
 pub mod stop_words;
 pub mod tokenizers;
 
+pub use read_only::ReadOnlyFullTextIndex;
+pub use read_ops::FullTextConditionChecker;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
@@ -9,11 +9,12 @@ use super::super::read_ops;
 use super::super::tokenizers::Tokenizer;
 use super::ReadOnlyFullTextIndex;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`FullTextIndexRead`] method to the active
@@ -159,7 +160,7 @@ impl<S: UniversalRead> FullTextIndexRead for ReadOnlyFullTextIndex<S> {
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
     fn count_indexed_points(&self) -> usize {
         FullTextIndexRead::points_count(self)
     }
@@ -193,8 +194,8 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        read_ops::condition_checker(self, condition, hw_acc)
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        read_ops::condition_checker(self, condition, hw_acc, S::condition_checker_full_text)
     }
 
     fn special_check_condition(

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -10,11 +10,11 @@ use super::full_text_index_read::{FullTextIndexRead, PayloadMatchQueryType};
 use super::inverted_index::{ParsedQuery, TokenId};
 use super::tokenizers::Tokenizer;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     FieldCondition, Match, MatchAny, MatchExcept, MatchPhrase, MatchText, MatchTextAny, MatchValue,
     PayloadKeyType,
@@ -181,8 +181,13 @@ impl PayloadFieldIndexRead for FullTextIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        condition_checker(self, condition, hw_acc)
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        condition_checker(
+            self,
+            condition,
+            hw_acc,
+            ConditionCheckerEnum::FullTextWritable,
+        )
     }
 
     fn special_check_condition(
@@ -281,7 +286,8 @@ pub fn condition_checker<'a, T: FullTextIndexRead>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> OperationResult<Option<DynConditionChecker<'a>>> {
+    to_enum: impl FnOnce(FullTextConditionChecker<'a, T>) -> ConditionCheckerEnum<'a>,
+) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -320,16 +326,18 @@ pub fn condition_checker<'a, T: FullTextIndexRead>(
     }?;
 
     let Some(parsed_query) = query_opt else {
-        return Ok(Some(Box::new(ConstantConditionChecker::MATCH_NONE)));
+        return Ok(Some(ConditionCheckerEnum::Constant(
+            ConstantConditionChecker::MATCH_NONE,
+        )));
     };
 
-    Ok(Some(Box::new(FullTextConditionChecker {
+    Ok(Some(to_enum(FullTextConditionChecker {
         index,
         parsed_query,
     })))
 }
 
-struct FullTextConditionChecker<'a, T> {
+pub struct FullTextConditionChecker<'a, T> {
     index: &'a T,
     parsed_query: ParsedQuery,
 }

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -21,7 +21,7 @@ use self::immutable_geo_index::ImmutableGeoIndex;
 use self::mutable_geo_index::MutableGeoIndex;
 use self::on_disk_geo_index::OnDiskGeoIndex;
 pub use self::read_only::ReadOnlyGeoIndex;
-pub use self::read_ops::GeoIndexRead;
+pub use self::read_ops::{GeoConditionChecker, GeoIndexRead};
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::geo_hash::GeoHash;
 use crate::index::payload_config::{IndexMutability, StorageType};

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -6,15 +6,15 @@ use common::types::PointOffsetType;
 use serde_json::Value;
 
 use super::GeoIndex;
-use super::read_ops::{self, GeoIndexRead};
+use super::read_ops::{self, GeoConditionChecker, GeoIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::utils::MultiValue;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -144,7 +144,31 @@ impl PayloadFieldIndexRead for GeoIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        let FieldCondition {
+            key: _,
+            r#match: _,
+            range: _,
+            geo_radius,
+            geo_bounding_box,
+            geo_polygon,
+            values_count: _,
+            is_empty: _,
+            is_null: _,
+        } = condition;
+        let hw_counter = hw_acc.get_counter_cell();
+        if let Some(filter) = *geo_radius {
+            let checker = GeoConditionChecker::new(self, hw_counter, filter);
+            return Ok(Some(ConditionCheckerEnum::GeoRadiusWritable(checker)));
+        }
+        if let Some(filter) = *geo_bounding_box {
+            let checker = GeoConditionChecker::new(self, hw_counter, filter);
+            return Ok(Some(ConditionCheckerEnum::GeoBoundingBoxWritable(checker)));
+        }
+        if let Some(polygon) = geo_polygon.as_ref() {
+            let checker = GeoConditionChecker::new(self, hw_counter, polygon.convert());
+            return Ok(Some(ConditionCheckerEnum::GeoPolygonWritable(checker)));
+        }
+        Ok(None)
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
@@ -5,15 +5,16 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
-use super::super::read_ops::{self, GeoIndexRead};
+use super::super::read_ops::{self, GeoConditionChecker, GeoIndexRead};
 use super::ReadOnlyGeoIndex;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::geo_hash::GeoHash;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, GeoPoint, PayloadKeyType};
 
 /// Dispatcher impl: forwards every [`GeoIndexRead`] method to the active
@@ -209,7 +210,7 @@ impl<S: UniversalRead> GeoIndexRead for ReadOnlyGeoIndex<S> {
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
     fn count_indexed_points(&self) -> usize {
         GeoIndexRead::points_count(self)
     }
@@ -243,7 +244,31 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        let FieldCondition {
+            key: _,
+            r#match: _,
+            range: _,
+            geo_radius,
+            geo_bounding_box,
+            geo_polygon,
+            values_count: _,
+            is_empty: _,
+            is_null: _,
+        } = condition;
+        let hw_counter = hw_acc.get_counter_cell();
+        if let Some(filter) = *geo_radius {
+            let checker = GeoConditionChecker::new(self, hw_counter, filter);
+            return Ok(Some(S::condition_checker_geo_radius(checker)));
+        }
+        if let Some(filter) = *geo_bounding_box {
+            let checker = GeoConditionChecker::new(self, hw_counter, filter);
+            return Ok(Some(S::condition_checker_geo_bounding_box(checker)));
+        }
+        if let Some(polygon) = geo_polygon.as_ref() {
+            let checker = GeoConditionChecker::new(self, hw_counter, polygon.convert());
+            return Ok(Some(S::condition_checker_geo_polygon(checker)));
+        }
+        Ok(None)
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -19,7 +19,6 @@ use std::cmp::{max, min};
 use std::path::PathBuf;
 
 use common::condition_checker::ConditionChecker;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
@@ -32,7 +31,6 @@ use crate::index::field_index::geo_hash::{
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{CheckGeoPoint, FieldCondition, GeoPoint, PayloadKeyType};
 
@@ -325,55 +323,20 @@ pub(super) fn for_each_payload_block<G: GeoIndexRead + ?Sized>(
         })
 }
 
-pub(super) fn condition_checker<'a, G: GeoIndexRead + ?Sized>(
-    geo: &'a G,
-    condition: &FieldCondition,
-    hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
-    // Destructure explicitly (no `..`) so a new field added to
-    // `FieldCondition` forces this method to be revisited.
-    let FieldCondition {
-        key: _,
-        r#match: _,
-        range: _,
-        geo_radius,
-        geo_bounding_box,
-        geo_polygon,
-        values_count: _,
-        is_empty: _,
-        is_null: _,
-    } = condition;
-
-    let hw_counter = hw_acc.get_counter_cell();
-
-    if let Some(geo_radius) = *geo_radius {
-        return Some(make_checker(geo, hw_counter, geo_radius));
-    }
-    if let Some(geo_bounding_box) = *geo_bounding_box {
-        return Some(make_checker(geo, hw_counter, geo_bounding_box));
-    }
-    if let Some(geo_polygon) = geo_polygon.as_ref() {
-        return Some(make_checker(geo, hw_counter, geo_polygon.convert()));
-    }
-    None
-}
-
-struct GeoConditionChecker<'a, G: ?Sized, F> {
+pub struct GeoConditionChecker<'a, G: ?Sized, F> {
     geo: &'a G,
     hw_counter: HardwareCounterCell,
     filter: F,
 }
 
-fn make_checker<'a>(
-    geo: &'a (impl GeoIndexRead + ?Sized),
-    hw_counter: HardwareCounterCell,
-    filter: impl CheckGeoPoint + 'a,
-) -> DynConditionChecker<'a> {
-    Box::new(GeoConditionChecker {
-        geo,
-        hw_counter,
-        filter,
-    })
+impl<'a, G: ?Sized, F> GeoConditionChecker<'a, G, F> {
+    pub(super) fn new(geo: &'a G, hw_counter: HardwareCounterCell, filter: F) -> Self {
+        Self {
+            geo,
+            hw_counter,
+            filter,
+        }
+    }
 }
 
 impl<G, P> ConditionChecker for GeoConditionChecker<'_, G, P>

--- a/lib/segment/src/index/field_index/map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/mod.rs
@@ -6,6 +6,7 @@ use self::immutable_map_index::ImmutableMapIndex;
 pub use self::key::MapIndexKey;
 use self::mutable_map_index::MutableMapIndex;
 use self::on_disk_map_index::OnDiskMapIndex;
+pub use self::read_ops::MapConditionChecker;
 
 mod builders;
 mod facet_index_impl;

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
@@ -3,21 +3,21 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::MapIndex;
 use super::super::key::MapIndexKey;
 use super::super::read_only::ReadOnlyMapIndex;
-use super::super::read_ops::MapIndexRead;
+use super::super::read_ops::{MapConditionChecker, MapIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     AnyVariants, FieldCondition, IntPayloadType, Match, MatchAny, MatchExcept, MatchValue,
     PayloadKeyType, ValueVariants,
@@ -75,12 +75,13 @@ impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::MapIntWritable))
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<IntPayloadType, S>
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<IntPayloadType, S>
 where
     Vec<<IntPayloadType as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -117,8 +118,8 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc).map(S::condition_checker_map_int))
     }
 }
 
@@ -239,7 +240,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<'a, IntPayloadType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
+) -> Option<MapConditionChecker<'a, IntPayloadType, T>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -4,22 +4,22 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::MapIndex;
 use super::super::key::MapIndexKey;
 use super::super::read_only::ReadOnlyMapIndex;
-use super::super::read_ops::MapIndexRead;
+use super::super::read_ops::{MapConditionChecker, MapIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::map_index::IdIter;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
     ValueVariants,
@@ -77,12 +77,13 @@ impl PayloadFieldIndexRead for MapIndex<str> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::MapStrWritable))
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<str, S>
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<str, S>
 where
     Vec<<str as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -119,8 +120,8 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc).map(S::condition_checker_map_str))
     }
 }
 
@@ -243,7 +244,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<'a, str> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
+) -> Option<MapConditionChecker<'a, str, T>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 use gridstore::Blob;
 use indexmap::IndexSet;
 use uuid::Uuid;
@@ -13,15 +12,16 @@ use uuid::Uuid;
 use super::super::MapIndex;
 use super::super::key::MapIndexKey;
 use super::super::read_only::ReadOnlyMapIndex;
-use super::super::read_ops::MapIndexRead;
+use super::super::read_ops::{MapConditionChecker, MapIndexRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
 use crate::index::query_estimator::combine_should_estimations;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
     UuidIntType, ValueVariants,
@@ -79,12 +79,13 @@ impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::MapUuidWritable))
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyMapIndex<UuidIntType, S>
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<UuidIntType, S>
 where
     Vec<<UuidIntType as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
@@ -121,8 +122,8 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(condition_checker_impl(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(condition_checker_impl(self, condition, hw_acc).map(S::condition_checker_map_uuid))
     }
 }
 
@@ -296,7 +297,7 @@ fn condition_checker_impl<'a, T: MapIndexRead<'a, UuidIntType> + 'a>(
     index: &'a T,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
+) -> Option<MapConditionChecker<'a, UuidIntType, T>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -15,7 +15,6 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::CardinalityEstimation;
 use crate::index::field_index::stat_tools::number_of_selected_points;
 use crate::index::payload_config::{IndexMutability, StorageType};
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::telemetry::PayloadIndexTelemetry;
 
@@ -233,12 +232,12 @@ pub trait MapIndexRead<'a, N: MapIndexKey + ?Sized + 'a>: Sized {
         &'a self,
         hw_counter: HardwareCounterCell,
         value: impl Borrow<N>,
-    ) -> DynConditionChecker<'a> {
-        Box::new(MapConditionChecker {
+    ) -> MapConditionChecker<'a, N, Self> {
+        MapConditionChecker {
             index: self,
             hw_counter,
             predicate: MapPredicate::Value(<N as MapIndexKey>::to_owned(value.borrow())),
-        })
+        }
     }
 
     /// Condition checker for
@@ -249,7 +248,7 @@ pub trait MapIndexRead<'a, N: MapIndexKey + ?Sized + 'a>: Sized {
         hw_counter: HardwareCounterCell,
         list: IndexSet<K, A>,
         negate: bool,
-    ) -> DynConditionChecker<'a>
+    ) -> MapConditionChecker<'a, N, Self>
     where
         A: BuildHasher,
         K: Borrow<N> + Hash + Eq,
@@ -259,7 +258,7 @@ pub trait MapIndexRead<'a, N: MapIndexKey + ?Sized + 'a>: Sized {
             .iter()
             .map(|key| <N as MapIndexKey>::to_owned(key.borrow()))
             .collect();
-        Box::new(MapConditionChecker {
+        MapConditionChecker {
             index: self,
             hw_counter,
             predicate: if scan {
@@ -267,7 +266,7 @@ pub trait MapIndexRead<'a, N: MapIndexKey + ?Sized + 'a>: Sized {
             } else {
                 MapPredicate::AnyProbe { list, negate }
             },
-        })
+        }
     }
 }
 
@@ -513,7 +512,7 @@ where
     }
 }
 
-struct MapConditionChecker<'a, N: MapIndexKey + ?Sized, T> {
+pub struct MapConditionChecker<'a, N: MapIndexKey + ?Sized, T> {
     index: &'a T,
     hw_counter: HardwareCounterCell,
     predicate: MapPredicate<N>,

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
@@ -7,10 +7,10 @@ use super::super::read_ops::{self, NullIndexRead};
 use super::ImmutableNullIndex;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for ImmutableNullIndex {
@@ -72,7 +72,8 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::NullImmutable))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -10,14 +10,14 @@ use common::universal_io::MmapFile;
 pub use immutable_null_index::ImmutableNullIndex;
 pub use mutable_null_index::MutableNullIndex;
 pub use read_only_null_index::ReadOnlyNullIndex;
-pub use read_ops::NullIndexRead;
+pub use read_ops::{NullConditionChecker, NullIndexRead};
 use serde_json::Value;
 
 use super::{PayloadFieldIndex, PayloadFieldIndexRead};
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::payload_config::IndexMutability;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::FieldCondition;
 
 pub enum NullIndex {
@@ -134,8 +134,11 @@ impl PayloadFieldIndexRead for NullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        match self {
+            NullIndex::Mutable(idx) => idx.condition_checker(condition, hw_acc),
+            NullIndex::Immutable(idx) => idx.condition_checker(condition, hw_acc),
+        }
     }
 }
 

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
@@ -7,10 +7,10 @@ use super::super::read_ops::{self, NullIndexRead};
 use super::MutableNullIndex;
 use crate::common::flags::roaring_flags::RoaringFlags;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl NullIndexRead for MutableNullIndex {
@@ -68,7 +68,8 @@ impl PayloadFieldIndexRead for MutableNullIndex {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc)
+            .map(ConditionCheckerEnum::NullMutable))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
@@ -7,10 +7,11 @@ use super::super::read_ops::{self, NullIndexRead};
 use super::ReadOnlyNullIndex;
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
@@ -33,7 +34,7 @@ impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
     }
 }
 
-impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
+impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
     fn count_indexed_points(&self) -> usize {
         self.indexed_points_count()
     }
@@ -68,7 +69,7 @@ impl<S: UniversalRead> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(read_ops::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(read_ops::condition_checker(self, condition, hw_acc).map(S::condition_checker_null))
     }
 }

--- a/lib/segment/src/index/field_index/null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_ops.rs
@@ -26,7 +26,6 @@ use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::{CardinalityEstimation, PrimaryCondition};
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::FieldCondition;
 
@@ -226,7 +225,7 @@ pub(super) fn condition_checker<'a, N: NullIndexRead>(
     null_index: &'a N,
     condition: &FieldCondition,
     _hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>> {
+) -> Option<NullConditionChecker<'a, N>> {
     // Destructure explicitly (no `..`) so a new field added to
     // `FieldCondition` forces this method to be revisited.
     let FieldCondition {
@@ -242,23 +241,23 @@ pub(super) fn condition_checker<'a, N: NullIndexRead>(
     } = condition;
 
     if let Some(is_empty) = *is_empty {
-        return Some(Box::new(NullConditionChecker {
+        return Some(NullConditionChecker {
             null_index,
             kind: CheckKind::IsEmpty,
             expected: is_empty,
-        }));
+        });
     }
     if let Some(is_null) = *is_null {
-        return Some(Box::new(NullConditionChecker {
+        return Some(NullConditionChecker {
             null_index,
             kind: CheckKind::IsNull,
             expected: is_null,
-        }));
+        });
     }
     None
 }
 
-struct NullConditionChecker<'a, N> {
+pub struct NullConditionChecker<'a, N> {
     null_index: &'a N,
     kind: CheckKind,
     expected: bool,

--- a/lib/segment/src/index/field_index/numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mod.rs
@@ -21,7 +21,7 @@ pub use numeric_field_index::{
     NumericFieldIndex, NumericFieldIndexRead, NumericFieldIndexView, ReadOnlyNumericFieldIndex,
 };
 pub use numeric_index_read::NumericIndexRead;
-pub use query::NumericIndexValue;
+pub use query::{NumericIndexValue, RangeConditionChecker};
 pub use read_only::{NumericValueToJson, ReadOnlyNumericIndex};
 pub use read_ops::StreamRange;
 pub use storage::NumericIndexInner;

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -21,15 +21,16 @@ use itertools::Either;
 use ordered_float::OrderedFloat;
 use uuid::Uuid;
 
-use super::Encodable;
 use super::numeric_index_read::NumericIndexRead;
+use super::{Encodable, NumericIndexInner, ReadOnlyNumericIndexInner};
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::stat_tools::estimate_multi_value_selection_cardinality;
 use crate::index::field_index::utils::check_boundaries;
 use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition, PrimaryCondition};
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{
     FieldCondition, FloatPayloadType, IntPayloadType, Match, MatchValue, PayloadKeyType, Range,
     RangeInterface, UuidIntType, ValueVariants,
@@ -307,7 +308,7 @@ pub(super) fn condition_checker<'a, T, I>(
     index: &'a I,
     condition: &FieldCondition,
     hw_acc: HwMeasurementAcc,
-) -> Option<DynConditionChecker<'a>>
+) -> Option<RangeConditionChecker<'a, I, T>>
 where
     T: Encodable + Numericable + StoredValue + Send + Sync + Default,
     I: NumericIndexRead<T>,
@@ -340,14 +341,14 @@ where
         }
     };
 
-    Some(Box::new(RangeConditionChecker {
+    Some(RangeConditionChecker {
         index,
         typed_range,
         hw_counter: hw_acc.get_counter_cell(),
-    }))
+    })
 }
 
-struct RangeConditionChecker<'a, I, T> {
+pub struct RangeConditionChecker<'a, I, T> {
     index: &'a I,
     typed_range: Range<T>,
     hw_counter: HardwareCounterCell,
@@ -373,13 +374,56 @@ pub trait NumericIndexValue: Encodable + Numericable + StoredValue + Send + Sync
 where
     Vec<Self>: Blob,
 {
+    fn condition_checker_writable<'a>(
+        checker: RangeConditionChecker<'a, NumericIndexInner<Self>, Self>,
+    ) -> ConditionCheckerEnum<'a>;
+
+    fn condition_checker_read_only<'a, S: UniversalReadExt>(
+        checker: RangeConditionChecker<'a, ReadOnlyNumericIndexInner<Self, S>, Self>,
+    ) -> ConditionCheckerEnum<'a>;
 }
 
-impl NumericIndexValue for IntPayloadType {}
+impl NumericIndexValue for IntPayloadType {
+    fn condition_checker_writable<'a>(
+        checker: RangeConditionChecker<'a, NumericIndexInner<Self>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        ConditionCheckerEnum::NumericIntWritable(checker)
+    }
 
-impl NumericIndexValue for FloatPayloadType {}
+    fn condition_checker_read_only<'a, S: UniversalReadExt>(
+        checker: RangeConditionChecker<'a, ReadOnlyNumericIndexInner<Self, S>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        S::condition_checker_numeric_int(checker)
+    }
+}
 
-impl NumericIndexValue for UuidIntType {}
+impl NumericIndexValue for FloatPayloadType {
+    fn condition_checker_writable<'a>(
+        checker: RangeConditionChecker<'a, NumericIndexInner<Self>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        ConditionCheckerEnum::NumericFloatWritable(checker)
+    }
+
+    fn condition_checker_read_only<'a, S: UniversalReadExt>(
+        checker: RangeConditionChecker<'a, ReadOnlyNumericIndexInner<Self, S>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        S::condition_checker_numeric_float(checker)
+    }
+}
+
+impl NumericIndexValue for UuidIntType {
+    fn condition_checker_writable<'a>(
+        checker: RangeConditionChecker<'a, NumericIndexInner<Self>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        ConditionCheckerEnum::NumericUuidWritable(checker)
+    }
+
+    fn condition_checker_read_only<'a, S: UniversalReadExt>(
+        checker: RangeConditionChecker<'a, ReadOnlyNumericIndexInner<Self, S>, Self>,
+    ) -> ConditionCheckerEnum<'a> {
+        S::condition_checker_numeric_uuid(checker)
+    }
+}
 
 /// Stream `(value, point)` pairs of the given range in ascending order.
 ///

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -13,6 +13,8 @@ use super::super::numeric_index_read::NumericIndexRead;
 use super::super::{Encodable, NumericIndexValue};
 use super::ReadOnlyNumericIndex;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
@@ -20,7 +22,6 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
 use crate::index::payload_config::StorageType;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, P, S: UniversalRead>
@@ -91,7 +92,7 @@ where
     }
 }
 
-impl<T: NumericIndexValue, P, S: UniversalRead> PayloadFieldIndexRead
+impl<T: NumericIndexValue, P, S: UniversalReadExt> PayloadFieldIndexRead
     for ReadOnlyNumericIndex<T, P, S>
 where
     Vec<T>: Blob,
@@ -129,7 +130,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_ops.rs
@@ -13,11 +13,11 @@ use serde_json::Value;
 
 use super::{Encodable, NumericIndex, NumericIndexValue};
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, Range, RangeInterface};
 
 pub trait StreamRange<T> {
@@ -84,7 +84,7 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
         self.inner.condition_checker(condition, hw_acc)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
@@ -7,20 +7,20 @@
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 use gridstore::Blob;
 
 use super::super::super::numeric_index_read::NumericIndexRead;
 use super::super::super::{NumericIndexValue, query};
 use super::ReadOnlyNumericIndexInner;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType};
 
-impl<T: NumericIndexValue, S: UniversalRead> PayloadFieldIndexRead
+impl<T: NumericIndexValue, S: UniversalReadExt> PayloadFieldIndexRead
     for ReadOnlyNumericIndexInner<T, S>
 where
     Vec<T>: Blob,
@@ -58,7 +58,8 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(query::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(query::condition_checker(self, condition, hw_acc)
+            .map(T::condition_checker_read_only::<S>))
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
@@ -23,12 +23,12 @@ use super::super::{Encodable, NumericIndexValue, StreamRange, query};
 use super::NumericIndexInner;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
 };
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::types::{FieldCondition, PayloadKeyType, RangeInterface};
 
 impl<T: NumericIndexValue> PayloadFieldIndex for NumericIndexInner<T>
@@ -93,8 +93,8 @@ where
         &'a self,
         condition: &FieldCondition,
         hw_acc: HwMeasurementAcc,
-    ) -> OperationResult<Option<DynConditionChecker<'a>>> {
-        Ok(query::condition_checker(self, condition, hw_acc))
+    ) -> OperationResult<Option<ConditionCheckerEnum<'a>>> {
+        Ok(query::condition_checker(self, condition, hw_acc).map(T::condition_checker_writable))
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -25,6 +25,7 @@ use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::PayloadIndexRead;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::PayloadBlockCondition;
 use crate::index::hnsw_index::HnswM;
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
@@ -673,7 +674,7 @@ fn build_filtered_graph(
         let internal_hardware_counter = HardwareCounterCell::disposable();
 
         let block_condition_checker =
-            OptimizedFilter::from_checker(Box::new(BuildConditionChecker {
+            OptimizedFilter::from_checker(ConditionCheckerEnum::Build(BuildConditionChecker {
                 filter_list: block_filter_list,
                 current_point: block_point_id,
             }));

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -8,6 +8,7 @@ use common::types::PointOffsetType;
 use super::SINGLE_THREADED_HNSW_BUILD_THRESHOLD;
 use crate::common::operation_error::{OperationResult, check_process_stopped};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::gpu::get_gpu_groups_count;
 use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
@@ -90,7 +91,7 @@ pub(super) fn build_filtered_graph_on_gpu(
         |block_point_id| -> OperationResult<_> {
             let hardware_counter = HardwareCounterCell::disposable();
             let block_condition_checker =
-                OptimizedFilter::from_checker(Box::new(BuildConditionChecker {
+                OptimizedFilter::from_checker(ConditionCheckerEnum::Build(BuildConditionChecker {
                     filter_list: block_filter_list,
                     current_point: block_point_id,
                 }));

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -4,13 +4,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::{Populate, UniversalRead};
+use common::universal_io::Populate;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
 use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -25,12 +26,12 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// Read-only, generic-over-storage counterpart of [`HNSWIndex`].
 ///
 /// The graph itself stays a plain [`GraphLayers`] (it materializes into RAM on
-/// load via [`GraphLayers::load_universal`] over a [`UniversalRead`] filesystem),
+/// load via [`GraphLayers::load_universal`] over a [`UniversalRead`](common::universal_io::UniversalRead) filesystem),
 /// so only the id tracker, vector storage and quantized vectors are
 /// parameterized by the backing storage `S`.
 ///
 /// [`HNSWIndex`]: super::super::HNSWIndex
-pub struct ReadOnlyHNSWIndex<S: UniversalRead> {
+pub struct ReadOnlyHNSWIndex<S: UniversalReadExt> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
@@ -61,7 +62,7 @@ type ReadView<'a, S> = HNSWIndexReadView<
     >,
 >;
 
-impl<S: UniversalRead> ReadOnlyHNSWIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
     /// Read-only mirror of `HNSWIndex::open`: loads the graph through `fs`.
     pub fn open(
         fs: &S::Fs,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/read.rs
@@ -2,19 +2,18 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 
 use super::ReadOnlyHNSWIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
-use crate::index::VectorIndexRead;
+use crate::index::{UniversalReadExt, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 use crate::vector_storage::VectorStorageRead;
 
-impl<S: UniversalRead> VectorIndexRead for ReadOnlyHNSWIndex<S> {
+impl<S: UniversalReadExt> VectorIndexRead for ReadOnlyHNSWIndex<S> {
     fn search(
         &self,
         vectors: &[&QueryVector],

--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -1,3 +1,4 @@
+mod condition_checker;
 pub mod field_index;
 pub mod hnsw_index;
 mod key_encoding;
@@ -18,6 +19,7 @@ pub mod vector_index_base;
 mod vector_index_search_common;
 mod visited_pool;
 
+pub use condition_checker::ConditionCheckerEnum;
 pub use payload_index_base::*;
 pub use universal_io::UniversalReadExt;
 pub use vector_index_base::*;

--- a/lib/segment/src/index/mod.rs
+++ b/lib/segment/src/index/mod.rs
@@ -13,9 +13,11 @@ pub mod read_only;
 mod sample_estimation;
 pub mod sparse_index;
 pub mod struct_payload_index;
+mod universal_io;
 pub mod vector_index_base;
 mod vector_index_search_common;
 mod visited_pool;
 
 pub use payload_index_base::*;
+pub use universal_io::UniversalReadExt;
 pub use vector_index_base::*;

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -18,6 +18,7 @@ use super::payload_config::PayloadFieldSchemaWithIndexType;
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::facet_index::FacetIndexEnum;
 use crate::index::field_index::numeric_index::{NumericFieldIndex, NumericFieldIndexRead};
 use crate::index::field_index::{CardinalityEstimation, FacetIndex, PayloadBlockCondition};
@@ -134,7 +135,7 @@ impl PayloadIndexRead for PlainPayloadIndex {
         filter: &'a Filter,
         _: &HardwareCounterCell,
     ) -> OperationResult<OptimizedFilter<'a>> {
-        Ok(OptimizedFilter::from_checker(Box::new(
+        Ok(OptimizedFilter::from_checker(ConditionCheckerEnum::Plain(
             PlainFilterContext {
                 filter,
                 condition_checker: self.condition_checker.clone(),

--- a/lib/segment/src/index/plain_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/mod.rs
@@ -3,12 +3,12 @@ mod read;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::UniversalRead;
 use parking_lot::Mutex;
 
 use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::OperationDurationsAggregator;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::plain_vector_index::read_view::PlainVectorIndexReadView;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
@@ -17,7 +17,7 @@ use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
-pub struct ReadOnlyPlainVectorIndex<S: UniversalRead> {
+pub struct ReadOnlyPlainVectorIndex<S: UniversalReadExt> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
@@ -45,7 +45,7 @@ type ReadView<'a, S> = PlainVectorIndexReadView<
     >,
 >;
 
-impl<S: UniversalRead> ReadOnlyPlainVectorIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyPlainVectorIndex<S> {
     /// Read-only mirror of `PlainVectorIndex::new`: wires the shared backends.
     pub fn open(
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,

--- a/lib/segment/src/index/plain_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/plain_vector_index/read_only/read.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 
 use super::ReadOnlyPlainVectorIndex;
@@ -10,12 +9,12 @@ use crate::common::operation_error::OperationResult;
 use crate::common::operation_time_statistics::OperationDurationStatistics;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
-use crate::index::VectorIndexRead;
+use crate::index::{UniversalReadExt, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 use crate::vector_storage::VectorStorageRead;
 
-impl<S: UniversalRead> VectorIndexRead for ReadOnlyPlainVectorIndex<S> {
+impl<S: UniversalReadExt> VectorIndexRead for ReadOnlyPlainVectorIndex<S> {
     fn search(
         &self,
         query_vectors: &[&QueryVector],

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -3,35 +3,28 @@ use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::{OperationError, OperationResult};
-
-pub type DynConditionChecker<'a> = Box<dyn ConditionChecker<Error = OperationError> + 'a>;
-
-pub enum OptimizedCondition<'a> {
-    Checker(DynConditionChecker<'a>),
-    /// Nested filter
-    Filter(OptimizedFilter<'a>),
-}
+use crate::index::condition_checker::ConditionCheckerEnum;
 
 pub struct OptimizedFilter<'a> {
     /// At least one of those conditions should match, if not empty.
-    pub should: Vec<OptimizedCondition<'a>>,
+    pub should: Vec<ConditionCheckerEnum<'a>>,
     /// At least minimum amount of given conditions should match
-    pub min_should: Vec<OptimizedCondition<'a>>,
+    pub min_should: Vec<ConditionCheckerEnum<'a>>,
     pub min_should_count: usize,
     /// All conditions must match
-    pub must: Vec<OptimizedCondition<'a>>,
+    pub must: Vec<ConditionCheckerEnum<'a>>,
     /// All conditions must NOT match
-    pub must_not: Vec<OptimizedCondition<'a>>,
+    pub must_not: Vec<ConditionCheckerEnum<'a>>,
 }
 
 impl<'a> OptimizedFilter<'a> {
     /// A filter that matches a point iff the single given checker matches it.
-    pub fn from_checker(checker: DynConditionChecker<'a>) -> Self {
+    pub fn from_checker(checker: ConditionCheckerEnum<'a>) -> Self {
         OptimizedFilter {
             should: Vec::new(),
             min_should: Vec::new(),
             min_should_count: 0,
-            must: vec![OptimizedCondition::Checker(checker)],
+            must: vec![checker],
             must_not: Vec::new(),
         }
     }
@@ -86,23 +79,5 @@ impl ConditionChecker for OptimizedFilter<'_> {
         }
 
         Ok(true)
-    }
-}
-
-impl ConditionChecker for OptimizedCondition<'_> {
-    type Error = OperationError;
-
-    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
-        match self {
-            OptimizedCondition::Filter(filter) => filter.check(point_id),
-            OptimizedCondition::Checker(checker) => checker.check(point_id),
-        }
-    }
-
-    fn check_infallible(&self, point_id: PointOffsetType) -> bool {
-        match self {
-            OptimizedCondition::Filter(filter) => filter.check_infallible(point_id),
-            OptimizedCondition::Checker(checker) => checker.check_infallible(point_id),
-        }
     }
 }

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -12,7 +12,7 @@ use super::parsed_formula::{
 };
 use super::value_retriever::VariableRetrieverFn;
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::query_optimization::optimized_filter::OptimizedCondition;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::json_path::JsonPath;
 use crate::types::{DateTimePayloadType, GeoPoint};
 
@@ -28,7 +28,7 @@ pub struct FormulaScorer<'a> {
     /// Payload key -> retriever function
     payload_retrievers: HashMap<JsonPath, VariableRetrieverFn<'a>>,
     /// Condition id -> checker function
-    condition_checkers: Vec<OptimizedCondition<'a>>,
+    condition_checkers: Vec<ConditionCheckerEnum<'a>>,
     /// Default values for all variables
     defaults: HashMap<VariableId, Value>,
 }
@@ -60,7 +60,7 @@ impl<'a> FormulaScorer<'a> {
         formula: ParsedExpression,
         prefetches_scores: &'a [AHashMap<PointOffsetType, ScoreType>],
         payload_retrievers: HashMap<JsonPath, VariableRetrieverFn<'a>>,
-        condition_checkers: Vec<OptimizedCondition<'a>>,
+        condition_checkers: Vec<ConditionCheckerEnum<'a>>,
         defaults: HashMap<VariableId, Value>,
     ) -> Self {
         FormulaScorer {
@@ -401,8 +401,8 @@ mod tests {
             );
 
             let condition_checkers = vec![
-                OptimizedCondition::Checker(Box::new(ConstantConditionChecker::MATCH_ALL)),
-                OptimizedCondition::Checker(Box::new(ConstantConditionChecker::MATCH_NONE)),
+                ConditionCheckerEnum::Constant(ConstantConditionChecker::MATCH_ALL),
+                ConditionCheckerEnum::Constant(ConstantConditionChecker::MATCH_NONE),
             ];
 
             FormulaScorer {

--- a/lib/segment/src/index/read_only/live_reload.rs
+++ b/lib/segment/src/index/read_only/live_reload.rs
@@ -1,13 +1,13 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 use super::VectorIndexReadEnum;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
+use crate::index::UniversalReadExt;
 
-impl<S: UniversalRead> LiveReload for VectorIndexReadEnum<S> {
+impl<S: UniversalReadExt> LiveReload for VectorIndexReadEnum<S> {
     type Fs = S::Fs;
 
     /// No-op for every variant: read-only vector indexes are immutable — the HNSW

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -8,7 +8,6 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::low_memory::low_memory_mode;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::UniversalRead;
 use half::f16;
 use sparse::common::types::{DimId, QuantizedU8};
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
@@ -19,6 +18,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::hnsw_index::hnsw::read_only::ReadOnlyHNSWIndex;
 use crate::index::plain_vector_index::read_only::ReadOnlyPlainVectorIndex;
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
@@ -37,7 +37,7 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// Wraps each read-capable index type with its read-only newtype. The mutable
 /// RAM sparse index is intentionally absent because it has no persisted
 /// read-only representation.
-pub enum VectorIndexReadEnum<S: UniversalRead + 'static> {
+pub enum VectorIndexReadEnum<S: UniversalReadExt + 'static> {
     Plain(Box<ReadOnlyPlainVectorIndex<S>>),
     Hnsw(Box<ReadOnlyHNSWIndex<S>>),
     SparseCompressedImmutableRamF32(
@@ -61,7 +61,7 @@ pub enum VectorIndexReadEnum<S: UniversalRead + 'static> {
 }
 
 /// Shared read-only backends plus the `fs`/`path` an index opens its files from.
-pub struct ReadOnlyVectorIndexOpenArgs<'a, S: UniversalRead + 'static> {
+pub struct ReadOnlyVectorIndexOpenArgs<'a, S: UniversalReadExt + 'static> {
     pub fs: &'a S::Fs,
     pub path: &'a Path,
     pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
@@ -70,7 +70,7 @@ pub struct ReadOnlyVectorIndexOpenArgs<'a, S: UniversalRead + 'static> {
     pub quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
 }
 
-impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
+impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
     /// Open the read-only dense vector index from its config (sparse: follow-up).
     pub fn open(
         vector_config: &VectorDataConfig,
@@ -143,7 +143,7 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
             path,
         };
 
-        fn open<S: UniversalRead + 'static, TInvertedIndex: InvertedIndexReadOnly<S>>(
+        fn open<S: UniversalReadExt + 'static, TInvertedIndex: InvertedIndexReadOnly<S>>(
             args: ReadOnlySparseVectorIndexOpenArgs<'_, S>,
         ) -> OperationResult<Box<ReadOnlySparseVectorIndex<S, TInvertedIndex>>> {
             Ok(Box::new(ReadOnlySparseVectorIndex::open(args)?))
@@ -228,7 +228,7 @@ impl<S: UniversalRead + 'static> VectorIndexReadEnum<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
+impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
     fn search(
         &self,
         vectors: &[&QueryVector],

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion as _;
-use common::universal_io::UniversalRead;
 use sparse::SearchScratchPool;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::sparse_index::indices_tracker::IndicesTracker;
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
@@ -28,7 +28,7 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// was loaded — an immutable-ram or an `S`-backed mmap variant.
 ///
 /// [`SparseVectorIndex`]: super::SparseVectorIndex
-pub struct ReadOnlySparseVectorIndex<S: UniversalRead, TInvertedIndex: InvertedIndex> {
+pub struct ReadOnlySparseVectorIndex<S: UniversalReadExt, TInvertedIndex: InvertedIndex> {
     config: SparseIndexConfig,
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
@@ -54,7 +54,7 @@ type ReadView<'a, S, TInvertedIndex> = SparseVectorIndexReadView<
     TInvertedIndex,
 >;
 
-pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalRead> {
+pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalReadExt> {
     pub fs: &'a S::Fs,
     pub config: SparseIndexConfig,
     pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
@@ -63,7 +63,9 @@ pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalRead> {
     pub path: &'a Path,
 }
 
-impl<S: UniversalRead, TInvertedIndex: InvertedIndex> ReadOnlySparseVectorIndex<S, TInvertedIndex> {
+impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
+    ReadOnlySparseVectorIndex<S, TInvertedIndex>
+{
     /// Similar to [`super::SparseVectorIndex::open`].
     pub fn open(args: ReadOnlySparseVectorIndexOpenArgs<S>) -> OperationResult<Self>
     where

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/read.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::UniversalRead;
 use sparse::common::types::DimId;
 use sparse::index::inverted_index::InvertedIndex;
 
@@ -10,11 +9,11 @@ use super::ReadOnlySparseVectorIndex;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::query_context::VectorQueryContext;
 use crate::data_types::vectors::QueryVector;
-use crate::index::VectorIndexRead;
+use crate::index::{UniversalReadExt, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
 
-impl<S: UniversalRead, TInvertedIndex: InvertedIndex> VectorIndexRead
+impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex> VectorIndexRead
     for ReadOnlySparseVectorIndex<S, TInvertedIndex>
 {
     fn search(

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -2,7 +2,7 @@ mod build;
 mod payload_index;
 mod read_view;
 
-pub use read_view::StructPayloadIndexReadView;
+pub use read_view::{IdsConditionChecker, StructPayloadIndexReadView};
 
 pub mod read_only;
 #[cfg(test)]

--- a/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::UniversalRead;
 
 use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
 use crate::types::{PayloadKeyType, VectorName, VectorNameBuf};
@@ -18,7 +18,7 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// Produced by [`ReadOnlyStructPayloadIndex::config_reload_diff`] (heavy load,
 /// shared `&self`) and consumed by [`ReadOnlyStructPayloadIndex::apply_config_reload`]
 /// (cheap swap, `&mut self`).
-pub struct PayloadIndexReloadDiff<S: UniversalRead> {
+pub struct PayloadIndexReloadDiff<S: UniversalReadExt> {
     /// Full on-disk payload config to install on apply.
     new_config: PayloadConfig,
     /// Field indexes that are new, or whose config changed — loaded, ready to
@@ -29,7 +29,7 @@ pub struct PayloadIndexReloadDiff<S: UniversalRead> {
     removed: Vec<PayloadKeyType>,
 }
 
-impl<S: UniversalRead> PayloadIndexReloadDiff<S> {
+impl<S: UniversalReadExt> PayloadIndexReloadDiff<S> {
     /// Whether the on-disk config matches the loaded field indexes (nothing to apply).
     pub fn is_empty(&self) -> bool {
         let Self {
@@ -41,7 +41,7 @@ impl<S: UniversalRead> PayloadIndexReloadDiff<S> {
     }
 }
 
-impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
     /// Compute the difference between the loaded field indexes and `new_config`,
     /// eagerly loading every new or changed field index through `fs`.
     ///

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -3,19 +3,19 @@ use std::path::Path;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::UniversalRead;
 
 use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::IdTrackerRead;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::VectorNameBuf;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
-impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
     /// Read-only mirror of `StructPayloadIndex::open`: loads the payload config
     /// and each persisted field index through `fs` (never builds/migrates/writes).
     pub fn open(

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -6,11 +6,11 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
@@ -26,7 +26,7 @@ pub use config_reload::PayloadIndexReloadDiff;
 
 type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
-pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
+pub struct ReadOnlyStructPayloadIndex<S: UniversalReadExt> {
     /// Payload storage
     pub(super) payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
     /// Used for `has_id` condition and estimating cardinality
@@ -43,7 +43,7 @@ pub struct ReadOnlyStructPayloadIndex<S: UniversalRead> {
     pub(super) visited_pool: VisitedPool,
 }
 
-impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
+impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
     pub fn with_view<R>(
         &self,
         f: impl FnOnce(
@@ -69,7 +69,7 @@ impl<S: UniversalRead> ReadOnlyStructPayloadIndex<S> {
     }
 }
 
-impl<S: UniversalRead> LiveReload for ReadOnlyStructPayloadIndex<S> {
+impl<S: UniversalReadExt> LiveReload for ReadOnlyStructPayloadIndex<S> {
     type Fs = S::Fs;
 
     fn live_reload(

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 use super::StructPayloadIndexReadView;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::IdTrackerRead;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::FieldIndexRead;
-use crate::index::query_optimization::optimized_filter::DynConditionChecker;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
@@ -36,7 +36,7 @@ where
         payload_provider: PayloadProvider<S>,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<DynConditionChecker<'b>> {
+    ) -> OperationResult<ConditionCheckerEnum<'b>> {
         let id_tracker = self.id_tracker;
         let field_indexes = self.field_indexes;
         Ok(match condition {
@@ -88,15 +88,15 @@ where
                         id_tracker.internal_id_with_behavior(*external_id, deferred_behavior)
                     })
                     .collect();
-                Box::new(IdsConditionChecker(segment_ids))
+                ConditionCheckerEnum::Ids(IdsConditionChecker(segment_ids))
             }
             Condition::HasVector(has_vector) => {
                 if let Some(vector_storage) =
                     self.vector_storages.get(&has_vector.has_vector).cloned()
                 {
-                    Box::new(HasVectorConditionChecker(vector_storage))
+                    ConditionCheckerEnum::Dyn(Box::new(HasVectorConditionChecker(vector_storage)))
                 } else {
-                    Box::new(ConstantConditionChecker::MATCH_NONE)
+                    ConditionCheckerEnum::Constant(ConstantConditionChecker::MATCH_NONE)
                 }
             }
             Condition::Nested(nested) => {
@@ -122,7 +122,7 @@ where
 
                 let nested_indexes = select_nested_indexes(&nested_path, field_indexes);
 
-                Box::new(PayloadConditionChecker {
+                ConditionCheckerEnum::Dyn(Box::new(PayloadConditionChecker {
                     payload_provider,
                     hw_counter: hw_counter.fork(),
                     check: move |payload, point_id, hw| {
@@ -150,7 +150,7 @@ where
                         }
                         Ok(false)
                     },
-                })
+                }))
             }
             Condition::CustomIdChecker(cond) => {
                 let segment_ids: AHashSet<_> = id_tracker
@@ -162,7 +162,7 @@ where
                     })
                     .collect();
 
-                Box::new(IdsConditionChecker(segment_ids))
+                ConditionCheckerEnum::Ids(IdsConditionChecker(segment_ids))
             }
             Condition::Filter(_) => unreachable!(),
         })
@@ -177,7 +177,7 @@ fn field_condition_checker<'a>(
     field_condition: &FieldCondition,
     payload_provider: PayloadProvider<impl PayloadStorageRead + 'a>,
     check: impl Fn(OwnedPayloadRef, &HardwareCounterCell) -> OperationResult<bool> + 'a,
-) -> OperationResult<DynConditionChecker<'a>> {
+) -> OperationResult<ConditionCheckerEnum<'a>> {
     // 1. Find first index that can check condition.
     if let Some(indexes) = field_indexes.get(key) {
         for index in indexes {
@@ -189,11 +189,13 @@ fn field_condition_checker<'a>(
     }
 
     // 2. None found => fallback to payload check.
-    Ok(Box::new(PayloadConditionChecker {
-        payload_provider,
-        hw_counter: hw_counter.fork(),
-        check: move |payload, _, hw| check(payload, hw),
-    }))
+    Ok(ConditionCheckerEnum::Dyn(Box::new(
+        PayloadConditionChecker {
+            payload_provider,
+            hw_counter: hw_counter.fork(),
+            check: move |payload, _, hw| check(payload, hw),
+        },
+    )))
 }
 
 /// For [`field_condition_checker`] and [`Condition::Nested`].
@@ -224,7 +226,7 @@ where
 }
 
 /// For [`Condition::HasId`] and [`Condition::CustomIdChecker`].
-struct IdsConditionChecker(AHashSet<PointOffsetType>);
+pub struct IdsConditionChecker(AHashSet<PointOffsetType>);
 
 impl ConditionChecker for IdsConditionChecker {
     type Error = OperationError;

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -1,4 +1,5 @@
 mod condition_converter;
+pub use condition_converter::IdsConditionChecker;
 mod filtering;
 mod optimizer;
 mod payload_index_read;

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -7,12 +7,13 @@ use itertools::Itertools;
 use super::StructPayloadIndexReadView;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
+use crate::index::condition_checker::ConditionCheckerEnum;
 use crate::index::field_index::{CardinalityEstimation, FieldIndexRead};
 use crate::index::query_estimator::{
     combine_min_should_estimations, combine_must_estimations, combine_should_estimations,
     invert_estimation,
 };
-use crate::index::query_optimization::optimized_filter::{OptimizedCondition, OptimizedFilter};
+use crate::index::query_optimization::optimized_filter::OptimizedFilter;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Condition, Filter, MinShould};
@@ -125,7 +126,7 @@ where
         total: usize,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Vec<(OptimizedCondition<'b>, CardinalityEstimation)>> {
+    ) -> OperationResult<Vec<(ConditionCheckerEnum<'b>, CardinalityEstimation)>> {
         conditions
             .iter()
             .map(|condition| match condition {
@@ -137,7 +138,7 @@ where
                         deferred_behavior,
                         hw_counter,
                     )?;
-                    Ok((OptimizedCondition::Filter(optimized_filter), estimation))
+                    Ok((ConditionCheckerEnum::Filter(optimized_filter), estimation))
                 }
                 Condition::Field(_)
                 | Condition::IsEmpty(_)
@@ -154,7 +155,7 @@ where
                         deferred_behavior,
                         hw_counter,
                     )?;
-                    Ok((OptimizedCondition::Checker(condition_checker), estimation))
+                    Ok((condition_checker, estimation))
                 }
             })
             .collect()
@@ -167,7 +168,7 @@ where
         total: usize,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<ConditionCheckerEnum<'b>>, CardinalityEstimation)> {
         if conditions.is_empty() {
             // Empty `should` => match every point.
             return Ok((Vec::new(), CardinalityEstimation::exact(total)));
@@ -195,7 +196,7 @@ where
         total: usize,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<ConditionCheckerEnum<'b>>, CardinalityEstimation)> {
         let mut converted = self.convert_conditions(
             conditions,
             payload_provider,
@@ -225,7 +226,7 @@ where
         total: usize,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<ConditionCheckerEnum<'b>>, CardinalityEstimation)> {
         let mut converted = self.convert_conditions(
             conditions,
             payload_provider,
@@ -247,7 +248,7 @@ where
         total: usize,
         deferred_behavior: DeferredBehavior,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<(Vec<OptimizedCondition<'b>>, CardinalityEstimation)> {
+    ) -> OperationResult<(Vec<ConditionCheckerEnum<'b>>, CardinalityEstimation)> {
         let mut converted = self.convert_conditions(
             conditions,
             payload_provider,

--- a/lib/segment/src/index/universal_io.rs
+++ b/lib/segment/src/index/universal_io.rs
@@ -1,0 +1,10 @@
+use common::universal_io::UniversalRead;
+
+/// Extensions over [`UniversalRead`].
+///
+/// Sometimes generic-over-[`UniversalRead`] code must branch on the concrete
+/// UIO type. This trait is a place for such branching. Any implementations of
+/// [`UniversalRead`] used in this [crate] should implement this.
+pub trait UniversalReadExt: UniversalRead {}
+
+impl<T: UniversalRead> UniversalReadExt for T {}

--- a/lib/segment/src/index/universal_io.rs
+++ b/lib/segment/src/index/universal_io.rs
@@ -1,10 +1,133 @@
-use common::universal_io::UniversalRead;
+#[cfg(target_os = "linux")]
+use common::universal_io::IoUringFile;
+#[cfg(test)]
+use common::universal_io::ReadOnly;
+use common::universal_io::{DiskCache, DiskCacheRemote, MmapFile, UniversalRead};
+
+use crate::index::condition_checker::ConditionCheckerEnum;
+use crate::index::field_index::bool_index::{BoolConditionChecker, ReadOnlyBoolIndex};
+use crate::index::field_index::full_text_index::{FullTextConditionChecker, ReadOnlyFullTextIndex};
+use crate::index::field_index::geo_index::{GeoConditionChecker, ReadOnlyGeoIndex};
+use crate::index::field_index::map_index::MapConditionChecker;
+use crate::index::field_index::map_index::read_only::ReadOnlyMapIndex;
+use crate::index::field_index::null_index::{NullConditionChecker, ReadOnlyNullIndex};
+use crate::index::field_index::numeric_index::{RangeConditionChecker, ReadOnlyNumericIndexInner};
+use crate::types::{
+    FloatPayloadType, GeoBoundingBox, GeoRadius, IntPayloadType, PolygonWrapper, UuidIntType,
+};
+
+type BoolCC<'a, S> = BoolConditionChecker<'a, ReadOnlyBoolIndex<S>>;
+type EnumCC<'a> = ConditionCheckerEnum<'a>;
+type FullTextCC<'a, S> = FullTextConditionChecker<'a, ReadOnlyFullTextIndex<S>>;
+type GeoCC<'a, S, C> = GeoConditionChecker<'a, ReadOnlyGeoIndex<S>, C>;
+type MapCC<'a, S, T> = MapConditionChecker<'a, T, ReadOnlyMapIndex<T, S>>;
+type NullCC<'a, S> = NullConditionChecker<'a, ReadOnlyNullIndex<S>>;
+type RangeCC<'a, S, T> = RangeConditionChecker<'a, ReadOnlyNumericIndexInner<T, S>, T>;
 
 /// Extensions over [`UniversalRead`].
 ///
 /// Sometimes generic-over-[`UniversalRead`] code must branch on the concrete
 /// UIO type. This trait is a place for such branching. Any implementations of
 /// [`UniversalRead`] used in this [crate] should implement this.
-pub trait UniversalReadExt: UniversalRead {}
+#[rustfmt::skip]
+pub trait UniversalReadExt: UniversalRead {
+    // Methods to convert generic `BlahBlahConditionChecker<S>` -> non-generic enum.
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a>;
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a>;
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a>;
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a>;
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a>;
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a>;
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a>;
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a>;
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a>;
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a>;
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a>;
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a>;
 
-impl<T: UniversalRead> UniversalReadExt for T {}
+    // Not limited to the condition-checker-related methods, might be extended in the future.
+}
+
+#[rustfmt::skip]
+impl UniversalReadExt for MmapFile {
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::BoolRoMmap          (i) }
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a> { EnumCC::FullTextRoMmap      (i) }
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a> { EnumCC::GeoBoundingBoxRoMmap(i) }
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a> { EnumCC::GeoPolygonRoMmap    (i) }
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a> { EnumCC::GeoRadiusRoMmap     (i) }
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a> { EnumCC::MapIntRoMmap        (i) }
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a> { EnumCC::MapStrRoMmap        (i) }
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a> { EnumCC::MapUuidRoMmap       (i) }
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::NullRoMmap          (i) }
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a> { EnumCC::NumericFloatRoMmap  (i) }
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a> { EnumCC::NumericIntRoMmap    (i) }
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::NumericUuidRoMmap   (i) }
+}
+
+#[cfg(target_os = "linux")]
+#[rustfmt::skip]
+impl UniversalReadExt for IoUringFile {
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::BoolRoIoUring          (i) }
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a> { EnumCC::FullTextRoIoUring      (i) }
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a> { EnumCC::GeoBoundingBoxRoIoUring(i) }
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a> { EnumCC::GeoPolygonRoIoUring    (i) }
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a> { EnumCC::GeoRadiusRoIoUring     (i) }
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a> { EnumCC::MapIntRoIoUring        (i) }
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a> { EnumCC::MapStrRoIoUring        (i) }
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a> { EnumCC::MapUuidRoIoUring       (i) }
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::NullRoIoUring          (i) }
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a> { EnumCC::NumericFloatRoIoUring  (i) }
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a> { EnumCC::NumericIntRoIoUring    (i) }
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::NumericUuidRoIoUring   (i) }
+}
+
+// TODO: add enum variants for these
+#[rustfmt::skip]
+impl<R: DiskCacheRemote> UniversalReadExt for DiskCache<R> {
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+impl UniversalReadExt for ReadOnly<MmapFile> {
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+impl<A: io_bridge_object_store::AsyncRead + Clone> UniversalReadExt for io_bridge_object_store::BlobFile<A> {
+    fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_full_text       <'a>(i: FullTextCC<'a, Self>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_bounding_box<'a>(i: GeoCC<'a, Self, GeoBoundingBox>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_polygon     <'a>(i: GeoCC<'a, Self, PolygonWrapper>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_geo_radius      <'a>(i: GeoCC<'a, Self, GeoRadius>)          -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_int         <'a>(i: MapCC<'a, Self, IntPayloadType>)     -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_str         <'a>(i: MapCC<'a, Self, str>)                -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_map_uuid        <'a>(i: MapCC<'a, Self, UuidIntType>)        -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_null            <'a>(i: NullCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_float   <'a>(i: RangeCC<'a, Self, FloatPayloadType>) -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_int     <'a>(i: RangeCC<'a, Self, IntPayloadType>)   -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+    fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
+}

--- a/lib/segment/src/segment/read_only/config_reload.rs
+++ b/lib/segment/src/segment/read_only/config_reload.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion;
-use common::universal_io::{UniversalRead, read_json_via};
+use common::universal_io::read_json_via;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::UniversalReadExt;
 use crate::index::payload_config::PayloadConfig;
 use crate::index::struct_payload_index::read_only::PayloadIndexReloadDiff;
 use crate::segment::{SEGMENT_STATE_FILE, SegmentVersion};
@@ -53,7 +54,7 @@ fn diff_config_map<C: PartialEq>(
 /// A vector present in both configs but with a changed config is *reloaded*: its
 /// name appears in both `removed_vectors` and `added_vectors`, so apply drops the
 /// stale component and installs the freshly loaded one.
-pub struct SegmentConfigReloadDiff<S: UniversalRead + 'static> {
+pub struct SegmentConfigReloadDiff<S: UniversalReadExt + 'static> {
     /// Full on-disk segment config to install on apply.
     new_config: SegmentConfig,
     /// Vectors that are new or changed — loaded, ready to install.
@@ -64,7 +65,7 @@ pub struct SegmentConfigReloadDiff<S: UniversalRead + 'static> {
     payload: PayloadIndexReloadDiff<S>,
 }
 
-impl<S: UniversalRead + 'static> SegmentConfigReloadDiff<S> {
+impl<S: UniversalReadExt + 'static> SegmentConfigReloadDiff<S> {
     /// Whether the on-disk config matches the in-memory state (nothing to apply).
     pub fn is_empty(&self) -> bool {
         let Self {
@@ -77,7 +78,7 @@ impl<S: UniversalRead + 'static> SegmentConfigReloadDiff<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Re-read the on-disk config and compute its difference against the
     /// in-memory config, eagerly loading every new or changed component.
     ///

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{Populate, UniversalRead, UniversalReadFileOps, read_json_via};
+use common::universal_io::{Populate, UniversalReadFileOps, read_json_via};
 use uuid::Uuid;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::immutable_id_tracker;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::read_only::{ReadOnlyVectorIndexOpenArgs, VectorIndexReadEnum};
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
@@ -28,7 +29,7 @@ use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVector
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
 
-impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Read-only mirror of `load_segment`: assembles every read-only component
     /// from `fs` (id tracker, payload storage+index, per-vector storage/index). No writes.
     pub fn open(
@@ -155,7 +156,7 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> ReadOnlyVectorData<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
     /// Open one dense vector's quantized vectors and index over `fs`, mirroring
     /// `open_dense_vector_data`. No `prefill`: read-only never writes.
     #[allow(clippy::too_many_arguments)]

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -1,14 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
+use crate::index::UniversalReadExt;
 
-impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Refresh every component to the current on-disk state (id-tracker delta → all components).
     ///
     /// Draining the id-tracker advances its internal state and cannot be replayed,
@@ -66,7 +66,7 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> ReadOnlyVectorData<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
     /// Refresh this vector's storage, index and quantized vectors to the current
     /// on-disk state.
     ///

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell};
-use common::universal_io::UniversalRead;
 use uuid::Uuid;
 
 use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::read_only::VectorIndexReadEnum;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
@@ -29,7 +29,7 @@ mod read_entry;
 #[cfg(test)]
 mod tests;
 
-pub struct ReadOnlySegment<S: UniversalRead + 'static> {
+pub struct ReadOnlySegment<S: UniversalReadExt + 'static> {
     pub uuid: Uuid,
     /// Path to the segment directory
     pub segment_path: PathBuf,
@@ -53,13 +53,13 @@ pub struct ReadOnlySegment<S: UniversalRead + 'static> {
     pub segment_config: SegmentConfig,
 }
 
-pub struct ReadOnlyVectorData<S: UniversalRead + 'static> {
+pub struct ReadOnlyVectorData<S: UniversalReadExt + 'static> {
     pub vector_index: Arc<AtomicRefCell<VectorIndexReadEnum<S>>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
     pub quantized_vectors: Arc<AtomicRefCell<Option<ReadOnlyQuantizedVectors<S>>>>,
 }
 
-impl<S: UniversalRead + 'static> VectorDataRead for ReadOnlyVectorData<S> {
+impl<S: UniversalReadExt + 'static> VectorDataRead for ReadOnlyVectorData<S> {
     type IndexRef<'a>
         = AtomicRef<'a, VectorIndexReadEnum<S>>
     where
@@ -94,7 +94,7 @@ pub type ReadOnlySegmentReadViewFor<'s, S> = SegmentReadView<
     ReadOnlyVectorData<S>,
 >;
 
-impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
+impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     pub fn with_view<T>(&self, f: impl FnOnce(ReadOnlySegmentReadViewFor<'_, S>) -> T) -> T {
         let id_tracker = self.id_tracker.borrow();
         let payload_index = self.payload_index.borrow();

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::AtomicBool;
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{DeferredBehavior, TelemetryDetail};
-use common::universal_io::UniversalRead;
 use uuid::Uuid;
 
 use super::ReadOnlySegment;
@@ -18,8 +17,8 @@ use crate::data_types::segment_record::SegmentRecord;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::ReadSegmentEntry;
 use crate::id_tracker::IdTrackerRead;
-use crate::index::PayloadIndexRead;
 use crate::index::field_index::CardinalityEstimation;
+use crate::index::{PayloadIndexRead, UniversalReadExt};
 use crate::json_path::JsonPath;
 use crate::telemetry::SegmentTelemetry;
 use crate::types::{
@@ -34,7 +33,7 @@ use crate::types::{
 /// `false` and the `appendable_flag` passed into the view builders is hard-coded
 /// accordingly. All other operations delegate to the shared `SegmentReadView`,
 /// exactly like the mutable `Segment`.
-impl<S: UniversalRead + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
+impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
     fn is_proxy(&self) -> bool {
         false
     }


### PR DESCRIPTION
PR dependency stack: #9555 -> #9559 -> this PR.

This PR replaces `Box<dyn ConditionChecker…>` with a huge `enum`.

```rust
// Before this PR
pub type DynConditionChecker<'a> = Box<dyn ConditionChecker<Error = OperationError> + 'a>;

// In this this PR
pub enum ConditionCheckerEnum<'a> {
    Build(BuildConditionChecker<'a>),
    Constant(ConstantConditionChecker<OperationError>),
    Dyn(Box<dyn ConditionChecker<Error = OperationError> + 'a>),
    Filter(OptimizedFilter<'a>),
    // < 40 more variants >
}
```

Rationale:
1. Non-dyn enum would allow us to use generic methods. Something like this:
   ```rust
   // (not in this PR)
   pub trait ConditionChecker {
       fn check_batched(
           &self,
           ids: impl Iterator<Item = PointOffsetType>,
           //   ^^^^^^^^^^^^^
           callback: impl FnMut(PointOffsetType, bool),
           //        ^^^^^^^^^^
           // This method can't be used via Box<dyn ConditionChecker>
           // because of these `impl` arguments.
       );
   }
   ```
   Would it be useful for the batched condition checker? Maybe, need more experimenting.
   But for sure, my attempts with dyn-friendly designs are too slow.
 
2. Significant speedup on some searches (short vectors + multiple payload filters).
   Perhaps, this PR is not the only cause; other PRs in the stack also contribute into it.
   (exact benchmarks tbd)

---

There are still a few remaining usages of `ConditionCheckerEnum::Dyn`. Not trivial to fix them right now.
