### PR TITLE
Improve REST serde error diagnostics

### DIFF
--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -38,6 +38,50 @@ pub(crate) fn validate_non_empty_dense(vector: &[f32]) -> Result<(), ValidationE
     Ok(())
 }
 
+fn deserialize_limit<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_usize_field(deserializer, "limit", 1)
+}
+
+fn deserialize_optional_limit<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_usize_field(deserializer, "limit", 1)
+}
+
+fn deserialize_group_size<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_u32_field(deserializer, "group_size", 1)
+}
+
+fn deserialize_u32_limit<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_u32_field(deserializer, "limit", 1)
+}
+
+fn deserialize_optional_group_size<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_usize_field(deserializer, "group_size", 1)
+}
+
+fn deserialize_optional_score_threshold<'de, D>(
+    deserializer: D,
+) -> Result<Option<ScoreType>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_f32_field(deserializer, "score_threshold")
+}
+
 /// Vector Data
 /// Vectors can be described directly with values
 /// Or specified with source "objects" for inference
@@ -586,9 +630,11 @@ pub struct QueryRequestInternal {
     pub params: Option<SearchParams>,
 
     /// Return points with scores better than this threshold.
+    #[serde(default, deserialize_with = "deserialize_optional_score_threshold")]
     pub score_threshold: Option<ScoreType>,
 
     /// Max number of points to return. Default is 10.
+    #[serde(default, deserialize_with = "deserialize_optional_limit")]
     #[validate(range(min = 1))]
     pub limit: Option<usize>,
 
@@ -1137,10 +1183,12 @@ pub struct BaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group
+    #[serde(deserialize_with = "deserialize_group_size")]
     #[validate(range(min = 1))]
     pub group_size: u32,
 
     /// Maximum amount of groups to return
+    #[serde(deserialize_with = "deserialize_u32_limit")]
     #[validate(range(min = 1))]
     pub limit: u32,
 
@@ -1173,6 +1221,7 @@ pub struct SearchGroupsRequestInternal {
     /// If defined, less similar results will not be returned.
     /// Score of the returned result might be higher or smaller than the threshold depending on the
     /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    #[serde(default, deserialize_with = "deserialize_optional_score_threshold")]
     pub score_threshold: Option<ScoreType>,
 
     #[serde(flatten)]
@@ -1197,6 +1246,7 @@ pub struct SearchRequestInternal {
     pub params: Option<SearchParams>,
     /// Max number of result to return
     #[serde(alias = "top")]
+    #[serde(deserialize_with = "deserialize_limit")]
     #[validate(range(min = 1))]
     pub limit: usize,
     /// Offset of the first result to return.
@@ -1212,6 +1262,7 @@ pub struct SearchRequestInternal {
     /// If defined, less similar results will not be returned.
     /// Score of the returned result might be higher or smaller than the threshold depending on the
     /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    #[serde(default, deserialize_with = "deserialize_optional_score_threshold")]
     pub score_threshold: Option<ScoreType>,
 }
 
@@ -1224,10 +1275,12 @@ pub struct QueryBaseGroupRequest {
     pub group_by: JsonPath,
 
     /// Maximum amount of points to return per group. Default is 3.
+    #[serde(default, deserialize_with = "deserialize_optional_group_size")]
     #[validate(range(min = 1))]
     pub group_size: Option<usize>,
 
     /// Maximum amount of groups to return. Default is 10.
+    #[serde(default, deserialize_with = "deserialize_optional_limit")]
     #[validate(range(min = 1))]
     pub limit: Option<usize>,
 
@@ -1572,5 +1625,60 @@ impl From<MaxOptimizationThreads> for Option<usize> {
             MaxOptimizationThreads::Setting(MaxOptimizationThreadsSetting::Auto) => None,
             MaxOptimizationThreads::Threads(threads) => Some(threads),
         }
+    }
+}
+
+#[cfg(test)]
+mod serde_error_tests {
+    use super::*;
+
+    fn deserialize_error<T>(json: &str) -> String
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        match serde_json::from_str::<T>(json) {
+            Ok(_) => panic!("expected deserialization error"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn search_limit_deserialization_error_names_field() {
+        let err = deserialize_error::<SearchRequestInternal>(
+            r#"{"vector":[0.1,0.2,0.3,0.4],"limit":-1}"#,
+        );
+
+        assert!(err.contains("limit"), "{err}");
+        assert!(!err.contains("usize"), "{err}");
+    }
+
+    #[test]
+    fn search_score_threshold_deserialization_error_names_field() {
+        let err = deserialize_error::<SearchRequestInternal>(
+            r#"{"vector":[0.1,0.2,0.3,0.4],"limit":5,"score_threshold":"not_a_number"}"#,
+        );
+
+        assert!(err.contains("score_threshold"), "{err}");
+        assert!(!err.contains("f32"), "{err}");
+    }
+
+    #[test]
+    fn query_limit_deserialization_error_names_field() {
+        let err = deserialize_error::<QueryRequestInternal>(
+            r#"{"query":{"nearest":[0.1,0.2,0.3,0.4]},"limit":-1}"#,
+        );
+
+        assert!(err.contains("limit"), "{err}");
+        assert!(!err.contains("usize"), "{err}");
+    }
+
+    #[test]
+    fn group_size_deserialization_error_names_field() {
+        let err = deserialize_error::<BaseGroupRequest>(
+            r#"{"group_by":"group","group_size":-1,"limit":5}"#,
+        );
+
+        assert!(err.contains("group_size"), "{err}");
+        assert!(!err.contains("u32"), "{err}");
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -86,13 +86,8 @@ fn deserialize_optional_recommend_strategy<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<Value>::deserialize(deserializer)?;
-    value
-        .map(|value| {
-            serde_json::from_value(value)
-                .map_err(|err| serde::de::Error::custom(format!("strategy: {err}")))
-        })
-        .transpose()
+    Option::<api::rest::RecommendStrategy>::deserialize(deserializer)
+        .map_err(|err| serde::de::Error::custom(format!("strategy: {err}")))
 }
 
 /// Current state of the collection.

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -57,6 +57,44 @@ use crate::shards::resharding::ReshardingStage;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::transfer::ShardTransferMethod;
 
+fn deserialize_limit<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_usize_field(deserializer, "limit", 1)
+}
+
+fn deserialize_optional_offset<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_usize_field(deserializer, "offset", 0)
+}
+
+fn deserialize_optional_score_threshold<'de, D>(
+    deserializer: D,
+) -> Result<Option<ScoreType>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_f32_field(deserializer, "score_threshold")
+}
+
+fn deserialize_optional_recommend_strategy<'de, D>(
+    deserializer: D,
+) -> Result<Option<api::rest::RecommendStrategy>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    value
+        .map(|value| {
+            serde_json::from_value(value)
+                .map_err(|err| serde::de::Error::custom(format!("strategy: {err}")))
+        })
+        .transpose()
+}
+
 /// Current state of the collection.
 /// `Green` - all good. `Yellow` - optimization is running, 'Grey' - optimizations are possible but not triggered, `Red` - some operations failed and was not recovered
 #[derive(Debug, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
@@ -664,6 +702,7 @@ pub struct RecommendRequestInternal {
     pub negative: Vec<RecommendExample>,
 
     /// How to use positive and negative examples to find the results
+    #[serde(default, deserialize_with = "deserialize_optional_recommend_strategy")]
     pub strategy: Option<api::rest::RecommendStrategy>,
 
     /// Look only for points which satisfies this conditions
@@ -676,12 +715,14 @@ pub struct RecommendRequestInternal {
 
     /// Max number of result to return
     #[serde(alias = "top")]
+    #[serde(deserialize_with = "deserialize_limit")]
     #[validate(range(min = 1))]
     pub limit: usize,
 
     /// Offset of the first result to return.
     /// May be used to paginate results.
     /// Note: large offset values may cause performance issues.
+    #[serde(default, deserialize_with = "deserialize_optional_offset")]
     pub offset: Option<usize>,
 
     /// Select which payload to return with the response. Default is false.
@@ -695,6 +736,7 @@ pub struct RecommendRequestInternal {
     /// If defined, less similar results will not be returned.
     /// Score of the returned result might be higher or smaller than the threshold depending on the
     /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    #[serde(default, deserialize_with = "deserialize_optional_score_threshold")]
     pub score_threshold: Option<ScoreType>,
 
     /// Define which vector to use for recommendation, if not specified - try to use default vector
@@ -736,7 +778,7 @@ pub struct RecommendGroupsRequestInternal {
     pub negative: Vec<RecommendExample>,
 
     /// How to use positive and negative examples to find the results
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_recommend_strategy")]
     pub strategy: Option<RecommendStrategy>,
 
     /// Look only for points which satisfies this conditions
@@ -758,6 +800,7 @@ pub struct RecommendGroupsRequestInternal {
     /// If defined, less similar results will not be returned.
     /// Score of the returned result might be higher or smaller than the threshold depending on the
     /// Distance function used. E.g. for cosine similarity only higher scores will be returned.
+    #[serde(default, deserialize_with = "deserialize_optional_score_threshold")]
     pub score_threshold: Option<ScoreType>,
 
     /// Define which vector to use for recommendation, if not specified - try to use default vector
@@ -834,12 +877,14 @@ pub struct DiscoverRequestInternal {
 
     /// Max number of result to return
     #[serde(alias = "top")]
+    #[serde(deserialize_with = "deserialize_limit")]
     #[validate(range(min = 1))]
     pub limit: usize,
 
     /// Offset of the first result to return.
     /// May be used to paginate results.
     /// Note: large offset values may cause performance issues.
+    #[serde(default, deserialize_with = "deserialize_optional_offset")]
     pub offset: Option<usize>,
 
     /// Select which payload to return with the response. Default is false.
@@ -1838,5 +1883,21 @@ impl PeerMetadata {
     /// Whether this metadata has a different version than our current Qdrant instance.
     pub fn is_different_version(&self) -> bool {
         self.version != *defaults::QDRANT_VERSION
+    }
+}
+
+#[cfg(test)]
+mod serde_error_tests {
+    use super::*;
+
+    #[test]
+    fn recommend_strategy_deserialization_error_names_field() {
+        let err = serde_json::from_str::<RecommendRequestInternal>(
+            r#"{"positive":[1],"limit":5,"strategy":123}"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("strategy"), "{err}");
     }
 }

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
-use serde::Serialize;
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
 
 // Multivector should be small enough to fit the chunk of vector storage
@@ -63,6 +65,125 @@ where
         err.add_param(Cow::from("max"), &max);
     }
     Err(err)
+}
+
+pub fn deserialize_usize_field<'de, D>(
+    deserializer: D,
+    field: &str,
+    min: usize,
+) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    value_to_usize(value, field, min)
+}
+
+pub fn deserialize_option_usize_field<'de, D>(
+    deserializer: D,
+    field: &str,
+    min: usize,
+) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    value
+        .map(|value| value_to_usize(value, field, min))
+        .transpose()
+}
+
+pub fn deserialize_u32_field<'de, D>(
+    deserializer: D,
+    field: &str,
+    min: u32,
+) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    let value = value_to_usize(value, field, min as usize)?;
+    u32::try_from(value).map_err(|_| {
+        D::Error::custom(format!(
+            "{field}: value {value} invalid, must fit into a 32-bit unsigned integer"
+        ))
+    })
+}
+
+pub fn deserialize_option_f32_field<'de, D>(
+    deserializer: D,
+    field: &str,
+) -> Result<Option<f32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    value.map(|value| value_to_f32(value, field)).transpose()
+}
+
+fn value_to_usize<E>(value: Value, field: &str, min: usize) -> Result<usize, E>
+where
+    E: Error,
+{
+    match value {
+        Value::Number(number) => {
+            if let Some(value) = number.as_u64() {
+                usize::try_from(value).map_err(|_| {
+                    E::custom(format!(
+                        "{field}: value {value} invalid, must fit into an unsigned integer"
+                    ))
+                })
+            } else if let Some(value) = number.as_i64() {
+                Err(E::custom(format!(
+                    "{field}: value {value} invalid, must be {min} or larger"
+                )))
+            } else {
+                Err(E::custom(format!(
+                    "{field}: invalid value {number}, expected an integer"
+                )))
+            }
+        }
+        other => Err(E::custom(format!(
+            "{field}: invalid type {}, expected an integer",
+            json_type_name(&other)
+        ))),
+    }
+}
+
+fn value_to_f32<E>(value: Value, field: &str) -> Result<f32, E>
+where
+    E: Error,
+{
+    match value {
+        Value::Number(number) => {
+            let Some(value) = number.as_f64() else {
+                return Err(E::custom(format!(
+                    "{field}: invalid value {number}, expected a finite number"
+                )));
+            };
+            if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
+                return Err(E::custom(format!(
+                    "{field}: value {value} invalid, expected a finite 32-bit float"
+                )));
+            }
+            Ok(value as f32)
+        }
+        other => Err(E::custom(format!(
+            "{field}: invalid type {}, expected a number",
+            json_type_name(&other)
+        ))),
+    }
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 /// Build the `ValidationError` for a sparse vector configured with the

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
+use std::fmt;
 
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
+use serde::de::{Error, MapAccess, SeqAccess, Visitor};
+use serde::{Deserializer, Serialize};
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
 
 // Multivector should be small enough to fit the chunk of vector storage
@@ -75,8 +75,8 @@ pub fn deserialize_usize_field<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let value = Value::deserialize(deserializer)?;
-    value_to_usize(value, field, min)
+    let number = deserialize_number(deserializer, field)?;
+    number_to_usize(number, field, min)
 }
 
 pub fn deserialize_option_usize_field<'de, D>(
@@ -87,9 +87,9 @@ pub fn deserialize_option_usize_field<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let value = Option::<Value>::deserialize(deserializer)?;
-    value
-        .map(|value| value_to_usize(value, field, min))
+    let number = deserialize_optional_number(deserializer, field)?;
+    number
+        .map(|number| number_to_usize(number, field, min))
         .transpose()
 }
 
@@ -101,8 +101,8 @@ pub fn deserialize_u32_field<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let value = Value::deserialize(deserializer)?;
-    let value = value_to_usize(value, field, min as usize)?;
+    let number = deserialize_number(deserializer, field)?;
+    let value = number_to_usize(number, field, min as usize)?;
     u32::try_from(value).map_err(|_| {
         D::Error::custom(format!(
             "{field}: value {value} invalid, must fit into a 32-bit unsigned integer"
@@ -117,73 +117,161 @@ pub fn deserialize_option_f32_field<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let value = Option::<Value>::deserialize(deserializer)?;
-    value.map(|value| value_to_f32(value, field)).transpose()
+    let number = deserialize_optional_number(deserializer, field)?;
+    number
+        .map(|number| number_to_f32(number, field))
+        .transpose()
 }
 
-fn value_to_usize<E>(value: Value, field: &str, min: usize) -> Result<usize, E>
+/// Numeric token captured without materializing or echoing mismatched request data.
+#[derive(Clone, Copy)]
+enum Number {
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
+}
+
+struct NumberVisitor<'a> {
+    field: &'a str,
+}
+
+impl NumberVisitor<'_> {
+    fn invalid_type<E: Error>(&self, actual: &str) -> E {
+        E::custom(format!(
+            "{}: invalid type {actual}, expected a number",
+            self.field
+        ))
+    }
+}
+
+impl<'de> Visitor<'de> for NumberVisitor<'_> {
+    type Value = Number;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a number")
+    }
+
+    fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Number::Unsigned(value))
+    }
+
+    fn visit_i64<E: Error>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Number::Signed(value))
+    }
+
+    fn visit_f64<E: Error>(self, value: f64) -> Result<Self::Value, E> {
+        Ok(Number::Float(value))
+    }
+
+    fn visit_bool<E: Error>(self, _value: bool) -> Result<Self::Value, E> {
+        Err(self.invalid_type("boolean"))
+    }
+
+    fn visit_str<E: Error>(self, _value: &str) -> Result<Self::Value, E> {
+        Err(self.invalid_type("string"))
+    }
+
+    fn visit_bytes<E: Error>(self, _value: &[u8]) -> Result<Self::Value, E> {
+        Err(self.invalid_type("byte array"))
+    }
+
+    fn visit_unit<E: Error>(self) -> Result<Self::Value, E> {
+        Err(self.invalid_type("null"))
+    }
+
+    fn visit_none<E: Error>(self) -> Result<Self::Value, E> {
+        Err(self.invalid_type("null"))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, _sequence: A) -> Result<Self::Value, A::Error> {
+        Err(self.invalid_type("array"))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, _map: A) -> Result<Self::Value, A::Error> {
+        Err(self.invalid_type("object"))
+    }
+}
+
+struct OptionalNumberVisitor<'a> {
+    field: &'a str,
+}
+
+impl<'de> Visitor<'de> for OptionalNumberVisitor<'_> {
+    type Value = Option<Number>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a number or null")
+    }
+
+    fn visit_none<E: Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_unit<E: Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserialize_number(deserializer, self.field).map(Some)
+    }
+}
+
+fn deserialize_number<'de, D>(deserializer: D, field: &str) -> Result<Number, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(NumberVisitor { field })
+}
+
+fn deserialize_optional_number<'de, D>(
+    deserializer: D,
+    field: &str,
+) -> Result<Option<Number>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_option(OptionalNumberVisitor { field })
+}
+
+fn number_to_usize<E>(number: Number, field: &str, min: usize) -> Result<usize, E>
 where
     E: Error,
 {
-    match value {
-        Value::Number(number) => {
-            if let Some(value) = number.as_u64() {
-                usize::try_from(value).map_err(|_| {
-                    E::custom(format!(
-                        "{field}: value {value} invalid, must fit into an unsigned integer"
-                    ))
-                })
-            } else if let Some(value) = number.as_i64() {
-                Err(E::custom(format!(
-                    "{field}: value {value} invalid, must be {min} or larger"
-                )))
-            } else {
-                Err(E::custom(format!(
-                    "{field}: invalid value {number}, expected an integer"
-                )))
-            }
-        }
-        other => Err(E::custom(format!(
-            "{field}: invalid type {}, expected an integer",
-            json_type_name(&other)
+    match number {
+        Number::Unsigned(value) => usize::try_from(value).map_err(|_| {
+            E::custom(format!(
+                "{field}: value {value} invalid, must fit into an unsigned integer"
+            ))
+        }),
+        Number::Signed(value) if value >= 0 => usize::try_from(value).map_err(|_| {
+            E::custom(format!(
+                "{field}: value {value} invalid, must fit into an unsigned integer"
+            ))
+        }),
+        Number::Signed(value) => Err(E::custom(format!(
+            "{field}: value {value} invalid, must be {min} or larger"
+        ))),
+        Number::Float(value) => Err(E::custom(format!(
+            "{field}: invalid value {value}, expected an integer"
         ))),
     }
 }
 
-fn value_to_f32<E>(value: Value, field: &str) -> Result<f32, E>
+fn number_to_f32<E>(number: Number, field: &str) -> Result<f32, E>
 where
     E: Error,
 {
-    match value {
-        Value::Number(number) => {
-            let Some(value) = number.as_f64() else {
-                return Err(E::custom(format!(
-                    "{field}: invalid value {number}, expected a finite number"
-                )));
-            };
-            if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
-                return Err(E::custom(format!(
-                    "{field}: value {value} invalid, expected a finite 32-bit float"
-                )));
-            }
-            Ok(value as f32)
-        }
-        other => Err(E::custom(format!(
-            "{field}: invalid type {}, expected a number",
-            json_type_name(&other)
-        ))),
+    let value = match number {
+        Number::Unsigned(value) => value as f64,
+        Number::Signed(value) => value as f64,
+        Number::Float(value) => value,
+    };
+    if !value.is_finite() || value < f64::from(f32::MIN) || value > f64::from(f32::MAX) {
+        return Err(E::custom(format!(
+            "{field}: value {value} invalid, expected a finite 32-bit float"
+        )));
     }
-}
-
-fn json_type_name(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
+    Ok(value as f32)
 }
 
 /// Build the `ValidationError` for a sparse vector configured with the

--- a/lib/shard/src/scroll.rs
+++ b/lib/shard/src/scroll.rs
@@ -4,6 +4,13 @@ use segment::types::{Filter, PointIdType, WithPayloadInterface, WithVector};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+fn deserialize_optional_limit<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    common::validation::deserialize_option_usize_field(deserializer, "limit", 1)
+}
+
 /// Scroll request - paginate over all points which matches given condition
 #[derive(Clone, Debug, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
@@ -12,6 +19,7 @@ pub struct ScrollRequestInternal {
     pub offset: Option<PointIdType>,
 
     /// Page size. Default: 10
+    #[serde(default, deserialize_with = "deserialize_optional_limit")]
     #[validate(range(min = 1))]
     pub limit: Option<usize>,
 
@@ -54,5 +62,20 @@ impl ScrollRequestInternal {
 
     pub const fn default_with_vector() -> WithVector {
         WithVector::Bool(false)
+    }
+}
+
+#[cfg(test)]
+mod serde_error_tests {
+    use super::*;
+
+    #[test]
+    fn scroll_limit_deserialization_error_names_field() {
+        let err = serde_json::from_str::<ScrollRequestInternal>(r#"{"limit":-1}"#)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("limit"), "{err}");
+        assert!(!err.contains("usize"), "{err}");
     }
 }

--- a/tests/openapi/test_serde_error_messages.py
+++ b/tests/openapi/test_serde_error_messages.py
@@ -1,0 +1,170 @@
+import pytest
+import requests
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import qdrant_host_headers, request_with_validation
+from .helpers.settings import QDRANT_HOST
+
+BODY_SENTINEL = "do-not-echo-this-request-body"
+
+
+@pytest.fixture(autouse=True)
+def setup(collection_name):
+    drop_collection(collection_name=collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 4,
+                "distance": "Cosine",
+            },
+        },
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.1, 0.2, 0.3, 0.4],
+                    "payload": {"group": "A"},
+                }
+            ]
+        },
+    )
+    assert response.ok
+
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+# These requests intentionally bypass OpenAPI request validation so malformed field
+# values reach Qdrant's server-side serde diagnostics.
+@pytest.mark.parametrize(
+    ("path", "body", "field"),
+    [
+        (
+            "/points/search",
+            {"vector": [0.1, 0.2, 0.3, 0.4], "limit": -1},
+            "limit",
+        ),
+        (
+            "/points/search/groups",
+            {
+                "vector": [0.1, 0.2, 0.3, 0.4],
+                "group_by": "group",
+                "group_size": -1,
+                "limit": 5,
+            },
+            "group_size",
+        ),
+        (
+            "/points/query",
+            {"query": {"nearest": [0.1, 0.2, 0.3, 0.4]}, "limit": -1},
+            "limit",
+        ),
+        (
+            "/points/scroll",
+            {"limit": -1},
+            "limit",
+        ),
+        (
+            "/points/scroll",
+            {"limit": {"nested": BODY_SENTINEL}},
+            "limit",
+        ),
+        (
+            "/points/recommend",
+            {"positive": [1], "limit": 5, "strategy": 123},
+            "strategy",
+        ),
+        (
+            "/points/search",
+            {
+                "vector": [0.1, 0.2, 0.3, 0.4],
+                "limit": 5,
+                "score_threshold": BODY_SENTINEL,
+            },
+            "score_threshold",
+        ),
+    ],
+)
+def test_serde_errors_name_invalid_fields(collection_name, path, body, field):
+    body = {**body, "request_secret": BODY_SENTINEL}
+    response = requests.post(
+        f"{QDRANT_HOST}/collections/{collection_name}{path}",
+        json=body,
+        headers=qdrant_host_headers(),
+    )
+
+    assert response.status_code == 400
+    error = response.json()["status"]["error"]
+    assert f"{field}:" in error
+    assert "usize" not in error
+    assert "u32" not in error
+    assert "f32" not in error
+    assert BODY_SENTINEL not in error
+
+
+@pytest.mark.parametrize(
+    ("api", "body"),
+    [
+        (
+            '/collections/{collection_name}/points/search',
+            {
+                "vector": [0.1, 0.2, 0.3, 0.4],
+                "limit": 1,
+                "score_threshold": 0.0,
+            },
+        ),
+        (
+            '/collections/{collection_name}/points/search/groups',
+            {
+                "vector": [0.1, 0.2, 0.3, 0.4],
+                "group_by": "group",
+                "group_size": 1,
+                "limit": 1,
+                "score_threshold": 0.0,
+            },
+        ),
+        (
+            '/collections/{collection_name}/points/query',
+            {
+                "query": {"nearest": [0.1, 0.2, 0.3, 0.4]},
+                "limit": 1,
+                "score_threshold": 0.0,
+            },
+        ),
+        (
+            '/collections/{collection_name}/points/scroll',
+            {"limit": 1},
+        ),
+        (
+            '/collections/{collection_name}/points/recommend',
+            {
+                "positive": [1],
+                "strategy": "average_vector",
+                "limit": 1,
+                "offset": 0,
+                "score_threshold": 0.0,
+            },
+        ),
+    ],
+)
+def test_valid_serde_fields_still_work(collection_name, api, body):
+    response = request_with_validation(
+        api=api,
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body=body,
+    )
+
+    assert response.ok


### PR DESCRIPTION
Partially addresses #9525.

This adds field-aware REST deserialization helpers for common API parameters that previously fell through to raw serde errors. The affected request fields now return errors that name the API field and avoid exposing Rust internal type names such as `usize`, `u32`, and `f32`:

- `limit` on search/query/recommend/discover/scroll-style requests
- `group_size` and group `limit`
- `score_threshold`
- recommend `strategy` type mismatches preserve the enum deserializer while prefixing the field name

The existing validator path is preserved for values that deserialize successfully, so cases such as `limit = 0` still go through the current range validation.

## Scope

This covers the six standard-JSON diagnostic categories from #9525. It intentionally does not claim the `vector=[Infinity, ...]` case: bare `Infinity` is not valid JSON, and `serde_json` rejects it during token parsing before a vector field deserializer runs. Adding vector-aware context for that syntax error requires raw-body/path-aware handling at the Actix JSON extractor boundary and should be handled separately.

## Safety

Numeric fields use a type-only serde visitor. Invalid arrays and objects are rejected without materializing their contents, and nonnumeric request values are not echoed in error responses. Recommend strategy values deserialize directly into the enum without a `serde_json::Value` round trip.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +stable test -p api -p shard -p collection serde_error_tests --lib --locked` (6 passed)
- `cargo +stable check -p common -p api -p collection -p shard --locked`
- `cargo +stable build --bin qdrant --locked`
- Real Qdrant REST server: `pytest -q tests/openapi/test_serde_error_messages.py` (12 passed: 7 error cases and 5 valid-input regressions)
- Targeted stable clippy for `common`, `api`, `collection`, and `shard` passed with `-D warnings` after allowing two pre-existing Rust 1.97 lints in untouched shard files

Full-workspace stable 1.97 clippy is currently blocked by three pre-existing `useless_borrows_in_formatting` findings in `lib/wal`; this PR does not mix in unrelated WAL cleanup.
