### PR TITLE
ci: add debug-tools workflow to master so it is dispatchable

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -1,0 +1,92 @@
+name: Build debug tools
+
+# Builds the `service_debug` helper binaries (wal_inspector, segment_inspector, ...)
+# and uploads them to a GCS bucket via the S3-compatible XML API. These are debug-only
+# tools built between releases; they are intentionally NOT part of the release artifacts.
+#
+# Download (public):
+#   curl -LO https://storage.googleapis.com/<bucket>/debug-tools/dev/wal_inspector
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build the debug tools from'
+        required: true
+        default: dev
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # Keep this list in sync with the `service_debug` [[bin]] targets in Cargo.toml
+  DEBUG_BINS: wal_inspector wal_pop segment_inspector schema_generator model_testing
+  # ---- Adjust to your GCS bucket ----
+  GCS_BUCKET: qdrant-debug
+  GCS_ENDPOINT: https://storage.googleapis.com
+  # GCS interop ignores the region, but the AWS CLI requires one to be set.
+  AWS_REGION: auto
+
+jobs:
+  build-debug-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Only save the cache on dev; feature-branch caches would just get evicted under the 10 GB budget
+          save-if: ${{ inputs.branch == 'dev' }}
+      - name: Install Protoc
+        uses: ./.github/actions/setup-protoc
+      - name: Install mold
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - name: Enable mold
+        run: |
+          mkdir -p .cargo
+          echo "[target.x86_64-unknown-linux-gnu]" >> .cargo/config.toml
+          echo "linker = \"clang\"" >> .cargo/config.toml
+          echo "rustflags = [\"-C\", \"link-arg=-fuse-ld=/usr/local/bin/mold\"]" >> .cargo/config.toml
+
+      - name: Build debug tools
+        run: |
+          cargo build --release --locked --features service_debug \
+            $(printf -- '--bin %s ' $DEBUG_BINS)
+
+      - name: Collect binaries
+        run: |
+          mkdir -p debug-tools
+          for bin in $DEBUG_BINS; do
+            cp "target/release/$bin" debug-tools/
+          done
+
+      - name: Upload to GCS
+        env:
+          # GCS HMAC interoperability keys (AWS-style), stored as repo secrets.
+          AWS_ACCESS_KEY_ID: ${{ secrets.GCS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.GCS_SECRET_ACCESS_KEY }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          branch="${BRANCH//\//-}" # replace all / with -
+          sha="$(git rev-parse HEAD)" # actual commit built from the chosen branch
+          base="${GCS_ENDPOINT}/${GCS_BUCKET}/debug-tools"
+
+          # Upload under a moving branch prefix (always latest) and an immutable
+          # per-commit prefix (history). Public read is granted at the bucket/IAM
+          # level (allUsers -> Storage Object Viewer), so no per-object ACL here.
+          for prefix in "$branch" "$branch-${sha}"; do
+            aws s3 cp debug-tools/ "s3://${GCS_BUCKET}/debug-tools/${prefix}/" \
+              --recursive --endpoint-url "$GCS_ENDPOINT" --region "$AWS_REGION"
+          done
+
+          # Surface direct links in the job summary
+          echo "## Debug tools uploaded" >> "$GITHUB_STEP_SUMMARY"
+          echo "Latest (\`$branch\`):" >> "$GITHUB_STEP_SUMMARY"
+          for bin in $DEBUG_BINS; do
+            echo "- [\`$bin\`]($base/$branch/$bin)" >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "Immutable: \`$base/$branch-${sha}/<bin>\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the `Build debug tools` workflow to `master`.

The workflow was merged into `dev` (#9565), but `workflow_dispatch` workflows are only runnable once they exist on the repository's **default branch** (`master`). Without this, the Actions UI shows no "Run workflow" button and the API returns 404 on dispatch.

This is the same file already on `dev` — no behavior change, just makes it dispatchable. It still only runs on manual dispatch and takes a `branch` input selecting what to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)