### PR TITLE
ci: also build debug tools on push to dev

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -8,6 +8,8 @@ name: Build debug tools
 #   curl -LO https://storage.googleapis.com/<bucket>/debug-tools/dev/wal_inspector
 
 on:
+  push:
+    branches: [ dev ]
   workflow_dispatch:
     inputs:
       branch:
@@ -36,11 +38,12 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.branch }}
+          # `inputs.branch` on manual dispatch; the pushed branch otherwise
+          ref: ${{ inputs.branch || github.ref_name }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Only save the cache on dev; feature-branch caches would just get evicted under the 10 GB budget
-          save-if: ${{ inputs.branch == 'dev' }}
+          save-if: ${{ (inputs.branch || github.ref_name) == 'dev' }}
       - name: Install Protoc
         uses: ./.github/actions/setup-protoc
       - name: Install mold
@@ -69,7 +72,7 @@ jobs:
           # GCS HMAC interoperability keys (AWS-style), stored as repo secrets.
           AWS_ACCESS_KEY_ID: ${{ secrets.GCS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.GCS_SECRET_ACCESS_KEY }}
-          BRANCH: ${{ inputs.branch }}
+          BRANCH: ${{ inputs.branch || github.ref_name }}
         run: |
           branch="${BRANCH//\//-}" # replace all / with -
           sha="$(git rev-parse HEAD)" # actual commit built from the chosen branch


### PR DESCRIPTION
Re-adds a `push` trigger on `dev` so the debug tools are rebuilt and uploaded automatically on every merge to `dev`, while keeping the manual `workflow_dispatch` (with the `branch` input) intact.

Because the workflow reads `inputs.branch` for the checkout ref and the object prefix — which is empty on a `push` event — those now fall back to `github.ref_name`:

- **push to dev** → builds `dev`, uploads under `debug-tools/dev/` (+ immutable `debug-tools/dev-<sha>/`)
- **manual dispatch** → builds the chosen `branch` input, prefixed accordingly

No master change required: `push` triggers fire on any branch that contains the workflow file, so merging this to `dev` is enough to activate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)