### PR TITLE
ci: fix GCS multipart upload (disable default AWS CLI checksums)

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -73,6 +73,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.GCS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.GCS_SECRET_ACCESS_KEY }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
+          # Recent AWS CLI adds default CRC32 integrity checksums that GCS's
+          # S3-compatible UploadPart rejects (SignatureDoesNotMatch). Opt out so
+          # multipart uploads of the larger binaries work.
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
         run: |
           branch="${BRANCH//\//-}" # replace all / with -
           sha="$(git rev-parse HEAD)" # actual commit built from the chosen branch


### PR DESCRIPTION
## Problem

The `Build debug tools` workflow failed uploading the larger binaries to GCS:

```
upload failed: ... An error occurred (SignatureDoesNotMatch) when calling the UploadPart operation: Invalid argument.
```

Small files uploaded fine; only the ~70 MiB binaries (`segment_inspector`, `model_testing`, ...) failed — i.e. the ones the AWS CLI sends via **multipart upload** (`UploadPart`).

## Cause

Since botocore ~2.23 (Jan 2025) the AWS CLI adds **default CRC32 integrity checksums** to uploads. GCS's S3-compatible XML API rejects those on `UploadPart`, surfacing as `SignatureDoesNotMatch`. This is a known incompatibility affecting GCS / MinIO / R2 and other S3-compatible stores.

## Fix

Opt out of the new default checksums for the upload step:

```yaml
AWS_REQUEST_CHECKSUM_CALCULATION: when_required
AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
```

This restores the pre-2.23 behavior so multipart uploads succeed against GCS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)