### PR TITLE
ci: build debug tools as static musl binaries + per-target cache

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -4,6 +4,9 @@ name: Build debug tools
 # and uploads them to a GCS bucket via the S3-compatible XML API. These are debug-only
 # tools built between releases; they are intentionally NOT part of the release artifacts.
 #
+# Built for x86_64-unknown-linux-musl so the binaries are statically linked and run on
+# any Linux host (glibc or musl, any distro).
+#
 # Download (public):
 #   curl -LO https://storage.googleapis.com/<bucket>/debug-tools/dev/wal_inspector
 
@@ -24,6 +27,8 @@ env:
   CARGO_TERM_COLOR: always
   # Keep this list in sync with the `service_debug` [[bin]] targets in Cargo.toml
   DEBUG_BINS: wal_inspector wal_pop segment_inspector schema_generator model_testing
+  # Static target so the binaries run everywhere
+  TARGET: x86_64-unknown-linux-musl
   # ---- Adjust to your GCS bucket ----
   GCS_BUCKET: qdrant-debug
   GCS_ENDPOINT: https://storage.googleapis.com
@@ -34,37 +39,42 @@ jobs:
   build-debug-tools:
     runs-on: ubuntu-latest
     steps:
-      - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib clang cmake protobuf-compiler
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # `inputs.branch` on manual dispatch; the pushed branch otherwise
           ref: ${{ inputs.branch || github.ref_name }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          # Only save the cache on dev; feature-branch caches would just get evicted under the 10 GB budget
-          save-if: ${{ (inputs.branch || github.ref_name) == 'dev' }}
+          targets: x86_64-unknown-linux-musl
       - name: Install Protoc
         uses: ./.github/actions/setup-protoc
-      - name: Install mold
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - name: Enable mold
-        run: |
-          mkdir -p .cargo
-          echo "[target.x86_64-unknown-linux-gnu]" >> .cargo/config.toml
-          echo "linker = \"clang\"" >> .cargo/config.toml
-          echo "rustflags = [\"-C\", \"link-arg=-fuse-ld=/usr/local/bin/mold\"]" >> .cargo/config.toml
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@3d9770ce98eb7dbcf378563182a5e8031165f75b # v1.41.0
+        with:
+          target: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Namespace the cache per target so the musl build doesn't collide with gnu caches
+          key: ${{ env.TARGET }}
+          # Only save the cache on dev; feature-branch caches would just get evicted under the 10 GB budget
+          save-if: ${{ (inputs.branch || github.ref_name) == 'dev' }}
 
       - name: Build debug tools
         run: |
           cargo build --release --locked --features service_debug \
+            --target "$TARGET" \
             $(printf -- '--bin %s ' $DEBUG_BINS)
 
       - name: Collect binaries
         run: |
           mkdir -p debug-tools
           for bin in $DEBUG_BINS; do
-            cp "target/release/$bin" debug-tools/
+            cp "target/$TARGET/release/$bin" debug-tools/
           done
 
       - name: Upload to GCS


### PR DESCRIPTION
Updates the `Build debug tools` workflow per request:

## 1. Static musl binaries (run everywhere)

Builds the debug tools for `x86_64-unknown-linux-musl` so they're statically linked and run on any Linux host regardless of distro / libc — no more glibc-version coupling to `ubuntu-latest`.

Mirrors the musl setup already used in `release-artifacts.yml`:
- apt deps: `gcc-multilib clang cmake protobuf-compiler`
- `dtolnay/rust-toolchain` with `targets: x86_64-unknown-linux-musl`
- `taiki-e/setup-cross-toolchain-action` to wire up the musl linker/CC

The old gnu-specific mold linker hack (`.cargo/config.toml`) is removed — the cross toolchain handles linking for the musl target, and that hack only applied to `x86_64-unknown-linux-gnu` anyway.

Binaries are now collected from `target/$TARGET/release/`.

## 2. Caching

The workflow already used `Swatinem/rust-cache`; this keeps it and adds `key: x86_64-unknown-linux-musl` so the musl artifacts are cached per-target and don't collide with any gnu caches. Save is still restricted to `dev` (consistent with the other CIs / the 10 GB cache budget).

## Note

musl builds the full dependency tree from scratch on the first run, so expect that run to be slow; subsequent runs hit the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)