### PR TITLE
ci: cache debug-tools build even when job fails

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -63,6 +63,9 @@ jobs:
           key: ${{ env.TARGET }}
           # Only save the cache on dev; feature-branch caches would just get evicted under the 10 GB budget
           save-if: ${{ (inputs.branch || github.ref_name) == 'dev' }}
+          # The build succeeds but later steps (e.g. the GCS upload) can fail; still
+          # persist the compiled artifacts so the next run doesn't rebuild from scratch.
+          cache-on-failure: true
 
       - name: Build debug tools
         run: |


### PR DESCRIPTION
## Problem

The debug-tools build was recompiling the entire dependency tree on every run, despite `Swatinem/rust-cache` being configured.

## Cause

`Swatinem/rust-cache` defaults to **`cache-on-failure: false`** — it only writes the cache when the whole job succeeds. The recent runs all *fail at the upload step* (the `AccessDenied` object-overwrite issue). The compile itself succeeds, but because the job ends in failure, the cache is never saved → the next run starts cold.

(The one earlier successful run was the `gnu` build, before #9569 switched the cache key to `x86_64-unknown-linux-musl`, so that saved cache no longer matches either.)

## Fix

Set `cache-on-failure: true` so the compiled artifacts are persisted even when a later step (like the GCS upload) fails the job.

Once the upload role issue is also resolved, runs will save on success too — this just makes caching robust regardless of upload status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)