### PR TITLE
ci: build edge-s3-scroll among the debug tools

### DIFF
--- a/.github/workflows/debug-tools.yml
+++ b/.github/workflows/debug-tools.yml
@@ -25,8 +25,12 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Tools in the main `qdrant` crate, gated behind its `service_debug` feature.
   # Keep this list in sync with the `service_debug` [[bin]] targets in Cargo.toml
   DEBUG_BINS: wal_inspector wal_pop segment_inspector schema_generator model_testing
+  # Standalone tool crates (own workspace member, no `service_debug` feature),
+  # built with `-p`. Bin name must match the crate name.
+  EDGE_BINS: edge-s3-scroll
   # Static target so the binaries run everywhere
   TARGET: x86_64-unknown-linux-musl
   # ---- Adjust to your GCS bucket ----
@@ -66,14 +70,19 @@ jobs:
 
       - name: Build debug tools
         run: |
+          # Tools in the qdrant crate (need the service_debug feature)
           cargo build --release --locked --features service_debug \
             --target "$TARGET" \
             $(printf -- '--bin %s ' $DEBUG_BINS)
+          # Standalone tool crates (no service_debug feature)
+          cargo build --release --locked \
+            --target "$TARGET" \
+            $(printf -- '-p %s ' $EDGE_BINS)
 
       - name: Collect binaries
         run: |
           mkdir -p debug-tools
-          for bin in $DEBUG_BINS; do
+          for bin in $DEBUG_BINS $EDGE_BINS; do
             cp "target/$TARGET/release/$bin" debug-tools/
           done
 
@@ -104,7 +113,7 @@ jobs:
           # Surface direct links in the job summary
           echo "## Debug tools uploaded" >> "$GITHUB_STEP_SUMMARY"
           echo "Latest (\`$branch\`):" >> "$GITHUB_STEP_SUMMARY"
-          for bin in $DEBUG_BINS; do
+          for bin in $DEBUG_BINS $EDGE_BINS; do
             echo "- [\`$bin\`]($base/$branch/$bin)" >> "$GITHUB_STEP_SUMMARY"
           done
           echo "Immutable: \`$base/$branch-${sha}/<bin>\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds `edge-s3-scroll` (`lib/edge/tools/s3_scroll`) to the debug-tools build & upload.

Unlike the existing tools, it lives in its **own workspace crate** and has **no `service_debug` feature**, so it can't go on the shared `--features service_debug` build line. It's built in a separate invocation:

```bash
cargo build --release --locked --target "$TARGET" -p edge-s3-scroll
```

and then collected/uploaded alongside the rest. New env var `EDGE_BINS` lists standalone tool crates so the collect step and job-summary links pick it up too.

Resulting upload, e.g.:
```
https://storage.googleapis.com/qdrant-debug/debug-tools/dev/edge-s3-scroll
```

Note: this is the first non-qdrant-crate tool built for musl; if `object_store`/TLS deps don't build statically against musl the CI will surface it, but the project already builds the S3 stack for musl in releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)