### PR TITLE
[UIO] Explicit Populate in R/O vector storages

### DIFF
--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -53,13 +53,10 @@ impl<S: UniversalRead + 'static> ReadOnlySegment<S> {
         let is_appendable = config.is_appendable();
         let deferred_internal_id = deferred_internal_id.filter(|_| is_appendable);
 
-        // TODO(uio): use `Populate::PreferBackground` here and drill it into gridstore
-        let payload_populate =
-            if matches!(config.payload_storage_type, PayloadStorageType::InRamMmap) {
-                Populate::PreferBackground
-            } else {
-                Populate::No
-            };
+        let payload_populate = match config.payload_storage_type {
+            PayloadStorageType::InRamMmap => Populate::PreferBackground,
+            PayloadStorageType::Mmap => Populate::No,
+        };
         let payload_storage = Arc::new(AtomicRefCell::new(ReadOnlyPayloadStorage::open(
             fs,
             segment_path.to_path_buf(),

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -22,7 +22,7 @@ pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
     fs: &S::Fs,
     directory: &Path,
     advice: AdviceSetting,
-    populate: bool,
+    populate: Populate,
     writeable: bool,
 ) -> Result<Vec<TypedStorage<S, T>>, UniversalIoError> {
     read_chunks_from(fs, directory, 0, advice, populate, writeable)
@@ -34,7 +34,7 @@ pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
     directory: &Path,
     start_chunk_id: usize,
     advice: AdviceSetting,
-    populate: bool,
+    populate: Populate,
     writeable: bool,
 ) -> Result<Vec<TypedStorage<S, T>>, UniversalIoError> {
     // List only the chunk files via the prefix, so unrelated files in the
@@ -68,7 +68,7 @@ pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
             OpenOptions {
                 writeable,
                 need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-                populate: Populate::from(populate),
+                populate,
                 advice,
             },
             Default::default(),

--- a/lib/segment/src/vector_storage/chunked_vectors/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/mod.rs
@@ -13,7 +13,7 @@ mod tests {
 
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::mmap::AdviceSetting;
-    use common::universal_io::{MmapFile, MmapFs};
+    use common::universal_io::{MmapFile, MmapFs, Populate};
     use rand::SeedableRng;
     use rand::prelude::StdRng;
     use tempfile::Builder;
@@ -37,8 +37,14 @@ mod tests {
 
         {
             let mut chunked_mmap: ChunkedVectors<VectorElementType, MmapFile> =
-                ChunkedVectors::open(MmapFs, dir.path(), dim, AdviceSetting::Global, Some(true))
-                    .unwrap();
+                ChunkedVectors::open(
+                    MmapFs,
+                    dir.path(),
+                    dim,
+                    AdviceSetting::Global,
+                    Populate::Blocking,
+                )
+                .unwrap();
 
             for vec in &vectors {
                 chunked_mmap.push(vec, &hw_counter).unwrap();

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -7,7 +7,7 @@ use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    ReadRange, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs, UserData,
+    Populate, ReadRange, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs, UserData,
     read_json_via, read_whole_via,
 };
 use num_traits::AsPrimitive;
@@ -36,7 +36,7 @@ pub struct ChunkedVectorsRead<T: bytemuck::Pod + Send, S: UniversalRead> {
     pub(super) directory: PathBuf,
     /// Open-time chunk settings, reused by live-reload to open new chunks.
     pub(super) advice: AdviceSetting,
-    pub(super) populate: bool,
+    pub(super) populate: Populate,
 }
 
 impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
@@ -63,13 +63,12 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
     ///
     /// Both `config.json` and `status.dat` must already exist; this function
     /// will not create them.
-    #[allow(dead_code)] // pending: read-only vector storage enum will use this
     pub fn open(
         fs: &S::Fs,
         directory: &Path,
         dim: usize,
         advice: AdviceSetting,
-        populate: Option<bool>,
+        populate: Populate,
     ) -> OperationResult<Self> {
         let config_file = Self::config_file(directory);
         let config = Self::load_config(fs, &config_file)?.ok_or_else(|| {
@@ -87,7 +86,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         }
 
         let len = read_status_len(fs, &Self::status_file(directory))?;
-        let chunks = read_chunks(fs, directory, advice, populate.unwrap_or_default(), false)?;
+        let chunks = read_chunks(fs, directory, advice, populate, false)?;
 
         Ok(Self {
             config,
@@ -95,7 +94,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             chunks,
             directory: directory.to_owned(),
             advice,
-            populate: populate.unwrap_or_default(),
+            populate,
         })
     }
 
@@ -371,7 +370,7 @@ mod tests {
             dir.path(),
             DIM,
             AdviceSetting::Global,
-            Some(false),
+            Populate::No,
         )
         .unwrap();
         for vector in &first {
@@ -384,7 +383,7 @@ mod tests {
             dir.path(),
             DIM,
             AdviceSetting::Global,
-            Some(false),
+            Populate::No,
         )
         .unwrap();
         assert_eq!(reader.len(), first.len());
@@ -421,7 +420,7 @@ mod tests {
             dir.path(),
             DIM,
             AdviceSetting::Global,
-            Some(false),
+            Populate::No,
         )
         .unwrap();
         for s in 0..4000 {
@@ -434,7 +433,7 @@ mod tests {
             dir.path(),
             DIM,
             AdviceSetting::Global,
-            Some(false),
+            Populate::No,
         )
         .unwrap();
         assert_eq!(reader.len(), 4000);

--- a/lib/segment/src/vector_storage/chunked_vectors/write.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/write.rs
@@ -66,7 +66,7 @@ where
         fs: &S::Fs,
         directory: &Path,
         dim: usize,
-        populate: Option<bool>,
+        populate: bool,
     ) -> OperationResult<ChunkedVectorsConfig> {
         let config_file = ChunkedVectorsRead::<T, S>::config_file(directory);
         match ChunkedVectorsRead::<T, S>::load_config(fs, &config_file) {
@@ -92,7 +92,7 @@ where
     fn create_config(
         config_file: &Path,
         dim: usize,
-        populate: Option<bool>,
+        populate: bool,
     ) -> OperationResult<ChunkedVectorsConfig> {
         if dim == 0 {
             return Err(OperationError::service_error(
@@ -109,7 +109,7 @@ where
             chunk_size_bytes: corrected_chunk_size_bytes,
             chunk_size_vectors,
             dim,
-            populate,
+            populate: Some(populate),
         };
         atomic_save_json(config_file, &config)?;
         Ok(config)
@@ -120,7 +120,7 @@ where
         directory: &Path,
         dim: usize,
         advice: AdviceSetting,
-        populate: Option<bool>,
+        populate: Populate,
     ) -> OperationResult<Self> {
         fs_err::create_dir_all(directory)?;
         let status_path = Self::ensure_status_file(&fs, directory)?;
@@ -131,21 +131,21 @@ where
             OpenOptions {
                 writeable: true,
                 need_sequential: false,
-                populate: populate.map(Populate::from).unwrap_or_default(),
+                populate,
                 advice: AdviceSetting::Global,
             },
             Default::default(),
         )?;
 
-        let config = Self::ensure_config(&fs, directory, dim, populate)?;
-        let chunks = read_chunks(&fs, directory, advice, populate.unwrap_or_default(), true)?;
+        let config = Self::ensure_config(&fs, directory, dim, populate.to_bool::<S>())?;
+        let chunks = read_chunks(&fs, directory, advice, populate, true)?;
         let inner = ChunkedVectorsRead {
             config,
             len: status.len,
             chunks,
             directory: directory.to_owned(),
             advice,
-            populate: populate.unwrap_or_default(),
+            populate,
         };
         Ok(Self { inner, status, fs })
     }

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -275,7 +275,13 @@ pub fn open_appendable_memmap_vector_storage_impl<T: PrimitiveVectorElement>(
     let vectors_path = path.join(VECTORS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors = ChunkedVectors::open(MmapFs, &vectors_path, dim, madvise, Some(populate))?;
+    let vectors = ChunkedVectors::open(
+        MmapFs,
+        &vectors_path,
+        dim,
+        madvise,
+        Populate::from(populate),
+    )?;
 
     let deleted = BitvecFlags::new(
         MmapFs,

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -9,7 +9,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::mmap;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead};
 use fs_err::{File, OpenOptions};
 
 use crate::common::Flusher;
@@ -197,7 +197,13 @@ where
     let vectors_path = path.join(VECTORS_PATH);
     let deleted_path = path.join(DELETED_PATH);
 
-    let vectors = ImmutableDenseVectors::open(&fs, &vectors_path, &deleted_path, dim, populate)?;
+    let vectors = ImmutableDenseVectors::open(
+        &fs,
+        &vectors_path,
+        &deleted_path,
+        dim,
+        Populate::from(populate),
+    )?;
     let storage = DenseVectorStorageImpl {
         vectors_path,
         deleted_path,
@@ -278,7 +284,7 @@ where
             &self.vectors_path,
             &self.deleted_path,
             dim,
-            false, // No need to populate
+            Populate::No, // No need to populate
         )?);
 
         // Flush deleted flags into store

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -48,12 +48,12 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         fs: &S::Fs,
         vectors_path: &Path,
         dim: usize,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<Self> {
         let options = UniversalOpenOptions {
             writeable: false,
             need_sequential: true,
-            populate: Populate::from(populate),
+            populate,
             advice: AdviceSetting::Global,
         };
         let read_only =
@@ -217,7 +217,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
         vectors_path: &Path,
         deleted_path: &Path,
         dim: usize,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<Self> {
         // Allocate/open vectors file
         ensure_mmap_file_size(vectors_path, VECTORS_HEADER, None)

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -32,7 +32,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorSt
         path: &Path,
         dim: usize,
         distance: Distance,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<Self> {
         let vectors = ImmutableDenseVectorData::open(fs, &path.join(VECTORS_PATH), dim, populate)?;
         let deleted = open_deleted_flags::<S>(fs, &path.join(DELETED_PATH), vectors.num_vectors)?;

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
@@ -1,4 +1,4 @@
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::data_types::primitive::PrimitiveVectorElement;
@@ -21,7 +21,7 @@ pub struct ReadOnlyImmutableDenseVectorStorage<T: PrimitiveVectorElement, S: Uni
     deleted: InMemoryBitvecFlags,
     distance: Distance,
     /// Whether vector data is populated into RAM (drives `is_on_disk`).
-    populate: bool,
+    populate: Populate,
 }
 
 #[cfg(test)]
@@ -88,7 +88,7 @@ mod tests {
             dir.path(),
             DIM,
             Distance::Dot,
-            false,
+            Populate::No,
         )
         .unwrap();
 
@@ -141,7 +141,7 @@ mod tests {
             dir.path(),
             DIM,
             Distance::Dot,
-            false,
+            Populate::No,
         )
         .unwrap();
         assert_eq!(reader.deleted_vector_count(), 0);

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
@@ -41,7 +41,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn is_on_disk(&self) -> bool {
-        !self.populate
+        !self.populate.to_bool::<S>()
     }
 
     fn total_vector_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -24,15 +24,10 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStor
         dim: usize,
         distance: Distance,
         advice: AdviceSetting,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<Self> {
-        let vectors = ChunkedVectorsRead::open(
-            fs,
-            &path.join(VECTORS_DIR_PATH),
-            dim,
-            advice,
-            Some(populate),
-        )?;
+        let vectors =
+            ChunkedVectorsRead::open(fs, &path.join(VECTORS_DIR_PATH), dim, advice, populate)?;
 
         let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
 

--- a/lib/segment/src/vector_storage/dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/mod.rs
@@ -27,7 +27,7 @@ mod tests {
     use common::mmap::AdviceSetting;
     use common::sorted_slice::SortedSlice;
     use common::types::PointOffsetType;
-    use common::universal_io::{MmapFile, MmapFs};
+    use common::universal_io::{MmapFile, MmapFs, Populate};
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
@@ -87,7 +87,7 @@ mod tests {
             DIM,
             Distance::Dot,
             AdviceSetting::Global,
-            false,
+            Populate::No,
         )
         .unwrap();
 
@@ -144,7 +144,7 @@ mod tests {
             DIM,
             Distance::Dot,
             AdviceSetting::Global,
-            false,
+            Populate::No,
         )
         .unwrap();
         assert_eq!(reader.total_vector_count(), first.len());

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -576,8 +576,15 @@ pub fn open_appendable_memmap_multi_vector_storage_impl<T: PrimitiveVectorElemen
     let offsets_path = path.join(OFFSETS_DIR_PATH);
     let deleted_path = path.join(DELETED_DIR_PATH);
 
-    let vectors = ChunkedVectors::open(MmapFs, &vectors_path, dim, madvise, Some(populate))?;
-    let offsets = ChunkedVectors::open(MmapFs, &offsets_path, 1, madvise, Some(populate))?;
+    let vectors = ChunkedVectors::open(
+        MmapFs,
+        &vectors_path,
+        dim,
+        madvise,
+        Populate::from(populate),
+    )?;
+    let offsets =
+        ChunkedVectors::open(MmapFs, &offsets_path, 1, madvise, Populate::from(populate))?;
     // The offsets store is buffered so its durable state can never race ahead of
     // the durable `vectors` length, which would corrupt points on reload.
     let offsets = BufferedOffsets::new(offsets);

--- a/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
+++ b/lib/segment/src/vector_storage/multi_dense/buffered_offsets.rs
@@ -230,7 +230,7 @@ impl BufferedOffsets {
 mod tests {
     use common::generic_consts::Sequential;
     use common::mmap::AdviceSetting;
-    use common::universal_io::MmapFs;
+    use common::universal_io::{MmapFs, Populate};
     use tempfile::Builder;
 
     use super::*;
@@ -244,7 +244,7 @@ mod tests {
     }
 
     fn open_inner(dir: &std::path::Path) -> OffsetsStore {
-        ChunkedVectors::open(MmapFs, dir, 1, AdviceSetting::Global, Some(false)).unwrap()
+        ChunkedVectors::open(MmapFs, dir, 1, AdviceSetting::Global, Populate::No).unwrap()
     }
 
     /// The core property: a write that lands *after* a flusher is created must not

--- a/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -26,20 +26,15 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVecto
         distance: Distance,
         multi_vector_config: MultiVectorConfig,
         advice: AdviceSetting,
-        populate: bool,
+        populate: Populate,
     ) -> OperationResult<Self> {
-        let vectors = ChunkedVectorsRead::open(
-            fs,
-            &path.join(VECTORS_DIR_PATH),
-            dim,
-            advice,
-            Some(populate),
-        )?;
+        let vectors =
+            ChunkedVectorsRead::open(fs, &path.join(VECTORS_DIR_PATH), dim, advice, populate)?;
 
         // Offsets store one `MultivectorMmapOffset` element per point, so the
         // chunked storage dimensionality is 1.
         let offsets =
-            ChunkedVectorsRead::open(fs, &path.join(OFFSETS_DIR_PATH), 1, advice, Some(populate))?;
+            ChunkedVectorsRead::open(fs, &path.join(OFFSETS_DIR_PATH), 1, advice, populate)?;
 
         let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -64,7 +64,7 @@ mod tests {
     use common::generic_consts::Random;
     use common::mmap::AdviceSetting;
     use common::sorted_slice::SortedSlice;
-    use common::universal_io::{MmapFile, MmapFs};
+    use common::universal_io::{MmapFile, MmapFs, Populate};
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
@@ -138,7 +138,7 @@ mod tests {
             Distance::Dot,
             MultiVectorConfig::default(),
             AdviceSetting::Global,
-            false,
+            Populate::No,
         )
         .unwrap();
 
@@ -207,7 +207,7 @@ mod tests {
                 Distance::Dot,
                 MultiVectorConfig::default(),
                 AdviceSetting::Global,
-                false,
+                Populate::No,
             )
             .unwrap();
         assert_eq!(reader.total_vector_count(), first.len());

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -5,7 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -28,7 +28,7 @@ impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
             path,
             quantized_vector_size,
             AdviceSetting::Global,
-            None, // populate
+            Populate::No, // TODO(uio): consider `always_in_ram`?
         )?;
         Ok(Self { data })
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
@@ -5,7 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::mmap::{Advice, AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, UniversalWrite};
+use common::universal_io::{MmapFile, Populate, UniversalWrite};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -36,7 +36,7 @@ impl<S: UniversalWrite + Send + 'static> QuantizedChunkedStorage<S> {
             path,
             quantized_vector_size,
             advice,
-            Some(in_ram), // populate
+            Populate::from(in_ram),
         )?;
         Ok(Self { data })
     }
@@ -158,7 +158,7 @@ impl<S: UniversalWrite + Send + 'static> QuantizedChunkedStorageBuilder<S> {
             path,
             quantized_vector_size,
             advice,
-            Some(in_ram), // populate
+            Populate::from(in_ram),
         )?;
         Ok(Self {
             data,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -279,13 +279,7 @@ impl<S: UniversalWrite + Send + 'static> MultivectorOffsetsStorageChunked<S> {
         } else {
             AdviceSetting::Global
         };
-        let data = ChunkedVectors::open(
-            fs,
-            path,
-            1,
-            advice,
-            Some(in_ram), // populate
-        )?;
+        let data = ChunkedVectors::open(fs, path, 1, advice, Populate::from(in_ram))?;
         Ok(Self { data })
     }
 
@@ -376,7 +370,13 @@ pub struct MultivectorOffsetsStorageChunkedRead<S: UniversalRead> {
 
 impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
     pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
-        let data = ChunkedVectorsRead::open(fs, path, 1, AdviceSetting::Global, None)?;
+        let data = ChunkedVectorsRead::open(
+            fs,
+            path,
+            1,
+            AdviceSetting::Global,
+            Populate::No, // TODO(uio): consider `in_ram`?
+        )?;
         Ok(Self { data })
     }
 

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::{Advice, AdviceSetting};
-use common::universal_io::UniversalRead;
+use common::universal_io::{Populate, UniversalRead};
 
 use super::VectorStorageReadEnum;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -33,6 +33,11 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
             }
             // No on-disk data to open for these storage types: no-op.
             VectorStorageType::Memory | VectorStorageType::Empty => return Ok(None),
+        };
+
+        let populate = match populate {
+            true => Populate::PreferBackground,
+            false => Populate::No,
         };
 
         // Multivectors always use the appendable chunked layout.

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -116,7 +116,7 @@ pub fn open_appendable_turbo_multi_vector_storage(
         &path.join(OFFSETS_PATH),
         1,
         AdviceSetting::Global,
-        Some(in_ram),
+        populate,
     )?;
 
     let deleted = BitvecFlags::new(


### PR DESCRIPTION
This PR ensures we use `Populate::PreferBackground` when we want to populate a vector storage from a readonly segment.

