### PR TITLE
model_testing: add QueryFusion op (prefetch + fusion coverage)

### DIFF
--- a/lib/collection/src/model_testing/apply/mod.rs
+++ b/lib/collection/src/model_testing/apply/mod.rs
@@ -161,6 +161,15 @@ pub(super) async fn apply(
         Op::ScrollPaged { limit, filter } => {
             reads::apply_scroll_paged(collection, model, *limit, filter).await
         }
+        Op::QueryFusion {
+            prefetches,
+            fusion,
+            limit,
+            filter_num,
+        } => {
+            reads::apply_query_fusion(collection, model, prefetches, *fusion, *limit, *filter_num)
+                .await
+        }
     }
 }
 

--- a/lib/collection/src/model_testing/apply/reads.rs
+++ b/lib/collection/src/model_testing/apply/reads.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use ahash::AHashSet;
 use api::rest::RecommendStrategy;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
 use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::order_by::{Direction, OrderBy, OrderByInterface, OrderValue};
 use segment::data_types::vectors::{
@@ -12,12 +13,13 @@ use segment::types::{
     PointIdType, SearchParams, VectorNameBuf, WithPayload, WithPayloadInterface, WithVector,
 };
 use shard::query::query_enum::QueryEnum;
-use shard::query::{ScoringQuery, ShardQueryRequest};
+use shard::query::{FusionInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest};
 use shard::scroll::ScrollRequestInternal;
 
 use super::super::op::{
-    NamedVectors, ScrollFilter, canonical_sparse, has_num, match_has_id_filter,
-    match_has_vector_filter, match_num_filter, match_tag_filter, num_matches, tag_matches,
+    FusionKind, NamedVectors, Prefetch, ScrollFilter, canonical_sparse, has_num,
+    match_has_id_filter, match_has_vector_filter, match_num_filter, match_tag_filter, num_matches,
+    tag_matches,
 };
 use super::super::{Model, VectorValue};
 use crate::collection::Collection;
@@ -643,6 +645,112 @@ pub(super) async fn apply_query(
     )
     .await;
     assert_nearest_results_valid(returned_ids, model, vector_name, filter_num, "query");
+}
+
+/// Coverage of the Query API's `prefetch` + fusion path (the plain `Query` op only does a top-level
+/// Nearest). Each prefetch is an independent Nearest source; the outer query fuses their union with
+/// RRF or DBSF, then the optional outer `num` filter applies on top.
+///
+/// Fusion ranking is score-based and approximate (and which points land in each prefetch's top-k is
+/// score-dependent), so the oracle is upper-bound only — like the approximate `Search`/`Query`
+/// path: every returned id must be some prefetch's candidate (its vector populated + that
+/// prefetch's filter) *and* pass the outer filter, and the result size can't exceed the
+/// outer-filtered union capped at `limit`. Scores and order are never checked.
+pub(super) async fn apply_query_fusion(
+    collection: &Collection,
+    model: &Model,
+    prefetches: &[Prefetch],
+    fusion: FusionKind,
+    limit: usize,
+    filter_num: Option<i64>,
+) {
+    let shard_prefetches = prefetches
+        .iter()
+        .map(|p| {
+            let named_query = NamedQuery::new(nearest_internal_query(&p.query), &p.vector_name);
+            ShardPrefetch {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(QueryEnum::Nearest(named_query))),
+                limit: p.limit,
+                params: None,
+                filter: p.filter_num.map(match_num_filter),
+                score_threshold: None,
+            }
+        })
+        .collect();
+    let fusion_internal = match fusion {
+        FusionKind::Rrf => FusionInternal::Rrf {
+            k: DEFAULT_RRF_K,
+            weights: None,
+        },
+        FusionKind::Dbsf => FusionInternal::Dbsf,
+    };
+    let returned_ids = collection
+        .query(
+            ShardQueryRequest {
+                prefetches: shard_prefetches,
+                query: Some(ScoringQuery::Fusion(fusion_internal)),
+                filter: filter_num.map(match_num_filter),
+                score_threshold: None,
+                limit,
+                offset: 0,
+                params: None,
+                with_vector: WithVector::Bool(false),
+                with_payload: WithPayloadInterface::Bool(false),
+            },
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("query fusion failed")
+        .iter()
+        .map(|r| r.id)
+        .collect::<AHashSet<PointIdType>>();
+
+    // Two independent upper bounds on the fused result, both narrowed by the outer `limit`:
+    // - it's a subset of the outer-filtered union of every prefetch's candidates;
+    // - it's no larger than the sum of per-prefetch caps (each prefetch returns at most
+    //   `min(p.limit, |its candidates|)` points, and fusion only dedups that union smaller).
+    // `nearest_candidates` hands back exactly that per-prefetch cap as its second element.
+    let mut union: AHashSet<PointIdType> = AHashSet::new();
+    let mut prefetch_cap = 0usize;
+    for p in prefetches {
+        let (candidates, cap) = nearest_candidates(model, &p.vector_name, p.filter_num, p.limit);
+        prefetch_cap += cap;
+        union.extend(candidates);
+    }
+    if let Some(n) = filter_num {
+        union.retain(|id| model.get(id).is_some_and(|e| num_matches(&e.payload, n)));
+    }
+    let expected_len = limit.min(union.len()).min(prefetch_cap);
+    assert!(
+        returned_ids.len() <= expected_len,
+        "query_fusion(fusion={fusion:?}, filter={filter_num:?}) returned {} points, expected at most {expected_len}",
+        returned_ids.len(),
+    );
+
+    for id in &returned_ids {
+        let entry = model
+            .get(id)
+            .unwrap_or_else(|| panic!("query_fusion returned unknown id {id:?}"));
+        let is_prefetch_candidate = prefetches.iter().any(|p| {
+            entry.vectors.contains_key(&p.vector_name)
+                && p.filter_num.is_none_or(|n| num_matches(&entry.payload, n))
+        });
+        assert!(
+            is_prefetch_candidate,
+            "query_fusion returned id {id:?} matching no prefetch source",
+        );
+        if let Some(n) = filter_num {
+            assert!(
+                num_matches(&entry.payload, n),
+                "query_fusion(outer filter num=={n}) returned id {id:?} that does not match",
+            );
+        }
+    }
 }
 
 pub(super) async fn apply_count_by_num(collection: &Collection, model: &Model, num: i64) {

--- a/lib/collection/src/model_testing/apply/reads.rs
+++ b/lib/collection/src/model_testing/apply/reads.rs
@@ -685,7 +685,7 @@ pub(super) async fn apply_query_fusion(
         },
         FusionKind::Dbsf => FusionInternal::Dbsf,
     };
-    let returned_ids = collection
+    let returned = collection
         .query(
             ShardQueryRequest {
                 prefetches: shard_prefetches,
@@ -705,10 +705,16 @@ pub(super) async fn apply_query_fusion(
             HwMeasurementAcc::new(),
         )
         .await
-        .expect("query fusion failed")
-        .iter()
-        .map(|r| r.id)
-        .collect::<AHashSet<PointIdType>>();
+        .expect("query fusion failed");
+    // Collect ids as a Vec first so we can assert fusion actually deduplicated overlapping prefetch
+    // hits — collapsing straight into a set would silently hide an engine returning a point twice.
+    let returned_vec: Vec<PointIdType> = returned.iter().map(|r| r.id).collect();
+    let returned_ids: AHashSet<PointIdType> = returned_vec.iter().copied().collect();
+    assert_eq!(
+        returned_vec.len(),
+        returned_ids.len(),
+        "query_fusion(fusion={fusion:?}, filter={filter_num:?}) returned duplicate ids",
+    );
 
     // Two independent upper bounds on the fused result, both narrowed by the outer `limit`:
     // - it's a subset of the outer-filtered union of every prefetch's candidates;

--- a/lib/collection/src/model_testing/op/generators.rs
+++ b/lib/collection/src/model_testing/op/generators.rs
@@ -14,7 +14,7 @@ use serde_json::{Map, Value};
 use sparse::common::sparse_vector::SparseVector;
 
 use super::super::{Model, VectorKind, VectorValue, kind_of};
-use super::{NamedVectors, Op, ScrollFilter, canonical_sparse};
+use super::{NamedVectors, Op, Prefetch, ScrollFilter, canonical_sparse};
 use crate::operations::point_ops::UpdateMode;
 
 // ───── payload value pools ────────────────────────────────────────────────
@@ -271,6 +271,19 @@ pub(super) fn random_vector_name(
 /// Build a search query appropriate for the chosen vector name.
 pub(super) fn random_query_for_name(rng: &mut impl Rng, name: &str) -> VectorValue {
     random_vector_for_name(rng, name)
+}
+
+/// A single prefetch source for `QueryFusion`: a Nearest sub-query over a random active vector
+/// name, with its own limit and optional `num` filter.
+pub(super) fn random_prefetch(rng: &mut impl Rng, active: &BTreeSet<VectorNameBuf>) -> Prefetch {
+    let vector_name = random_vector_name(rng, active);
+    let query = random_query_for_name(rng, &vector_name);
+    Prefetch {
+        vector_name,
+        query,
+        limit: rng.random_range(1..=10),
+        filter_num: rng.random_bool(0.5).then(|| random_num(rng)),
+    }
 }
 
 pub(super) fn random_payload(rng: &mut impl Rng) -> Payload {

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -7,9 +7,9 @@ use api::rest::RecommendStrategy;
 use generators::{
     random_direction, random_distinct_ids, random_distinct_points, random_existing_ids, random_num,
     random_partial_named_vectors, random_payload, random_payload_key, random_payload_keys,
-    random_point, random_query_for_name, random_recommend_strategy, random_scroll_filter,
-    random_tag, random_update_mode, random_vector_name, random_vector_name_subset,
-    random_with_payload, random_with_vector, upsert_fallback,
+    random_point, random_prefetch, random_query_for_name, random_recommend_strategy,
+    random_scroll_filter, random_tag, random_update_mode, random_vector_name,
+    random_vector_name_subset, random_with_payload, random_with_vector, upsert_fallback,
 };
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::Distribution;
@@ -187,6 +187,37 @@ pub(super) enum Op {
         limit: usize,
         filter: ScrollFilter,
     },
+    /// Verification op: a fused multi-source Query (`prefetch` + RRF/DBSF fusion) — the query-API
+    /// shape the plain `Query` op never reaches. Each prefetch is an independent Nearest source
+    /// (its own vector name, limit and optional `num` filter); the outer query fuses their union
+    /// and an optional outer `num` filter applies on top. Fusion ranking is score-based and
+    /// approximate, so — like `Search`/`Query` — we check only id membership (every result is some
+    /// prefetch's candidate and passes the outer filter) and a result-size upper bound, never
+    /// scores or order. One prefetch level only (no nesting).
+    QueryFusion {
+        prefetches: Vec<Prefetch>,
+        fusion: FusionKind,
+        limit: usize,
+        filter_num: Option<i64>,
+    },
+}
+
+/// A single prefetch source for `QueryFusion`: a Nearest sub-query over one vector name, with its
+/// own limit and optional `num` filter.
+#[derive(Debug, Clone)]
+pub(super) struct Prefetch {
+    pub(super) vector_name: VectorNameBuf,
+    pub(super) query: VectorValue,
+    pub(super) limit: usize,
+    pub(super) filter_num: Option<i64>,
+}
+
+/// Fusion method for `QueryFusion` (the engine's `api::rest::Fusion` isn't `Clone`, which `Op`
+/// requires). Maps to `FusionInternal` at apply time.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum FusionKind {
+    Rrf,
+    Dbsf,
 }
 
 /// Filter selector for `ScrollPaged`. Beyond the payload filters the other scroll verifiers
@@ -221,7 +252,7 @@ pub(super) struct Swarm {
 }
 
 impl Swarm {
-    const N: usize = 34;
+    const N: usize = 35;
 
     /// Op names, aligned 1:1 with `BASE` and the `match` arms in `Op::random`.
     const NAMES: [&'static str; Self::N] = [
@@ -259,6 +290,7 @@ impl Swarm {
         "RetrieveSelective",
         "ScrollPaged",
         "Query",
+        "QueryFusion",
     ];
 
     /// Each op's *natural* relative weight — the default distribution before swarm masking.
@@ -309,6 +341,7 @@ impl Swarm {
         4,  // RetrieveSelective
         4,  // ScrollPaged
         6,  // Query
+        5,  // QueryFusion
     ];
 
     /// Indices kept enabled in every swarm config: without a way to insert points the run can't
@@ -591,6 +624,26 @@ impl Op {
                     filter_num: rng.random_bool(0.5).then(|| random_num(rng)),
                 }
             }
+            34 => {
+                // 1-3 independent Nearest prefetch sources, fused by RRF or DBSF. Vector names are
+                // drawn per prefetch so sources can mix metrics/kinds; an optional outer filter
+                // applies on top of the fused union.
+                let n_prefetch = rng.random_range(1..=3);
+                let prefetches = (0..n_prefetch)
+                    .map(|_| random_prefetch(rng, active))
+                    .collect();
+                let fusion = if rng.random_bool(0.5) {
+                    FusionKind::Rrf
+                } else {
+                    FusionKind::Dbsf
+                };
+                Op::QueryFusion {
+                    prefetches,
+                    fusion,
+                    limit: rng.random_range(1..=10),
+                    filter_num: rng.random_bool(0.5).then(|| random_num(rng)),
+                }
+            }
             n => panic!("unexpected op index {n}"),
         }
     }
@@ -633,6 +686,7 @@ impl Op {
             Op::SetPayloadByKey { .. } => "SetPayloadByKey",
             Op::RetrieveSelective { .. } => "RetrieveSelective",
             Op::ScrollPaged { .. } => "ScrollPaged",
+            Op::QueryFusion { .. } => "QueryFusion",
         }
     }
 }

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -305,6 +305,17 @@ fn op_payload(op: &Op) -> Value {
             "limit": limit,
             "filter": format!("{filter:?}"),
         }),
+        Op::QueryFusion {
+            prefetches,
+            fusion,
+            limit,
+            filter_num,
+        } => json!({
+            "fusion": format!("{fusion:?}"),
+            "limit": limit,
+            "filter_num": filter_num,
+            "prefetch_names": prefetches.iter().map(|p| p.vector_name.as_str()).collect::<Vec<_>>(),
+        }),
     }
 }
 

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -314,7 +314,14 @@ fn op_payload(op: &Op) -> Value {
             "fusion": format!("{fusion:?}"),
             "limit": limit,
             "filter_num": filter_num,
-            "prefetch_names": prefetches.iter().map(|p| p.vector_name.as_str()).collect::<Vec<_>>(),
+            "prefetches": prefetches
+                .iter()
+                .map(|p| json!({
+                    "vector_name": p.vector_name.as_str(),
+                    "limit": p.limit,
+                    "filter_num": p.filter_num,
+                }))
+                .collect::<Vec<_>>(),
         }),
     }
 }


### PR DESCRIPTION
Adds a `QueryFusion` op to the `model_testing` harness, covering the Query API's **prefetch + fusion** path — the plain `Query` op only issues a top-level Nearest.

**Generates:** 1–3 independent Nearest prefetch sources (each with its own vector name, limit, and optional `num` filter), fused with RRF or DBSF, plus an optional outer `num` filter.

**Oracle** (upper-bound only, since fusion ranking is score-based/approximate — same convention as `Search`/`Query`):
- every returned id is some prefetch's candidate (vector populated + that prefetch's filter) and passes the outer filter;
- result size ≤ the outer-filtered candidate union, capped at `limit`.

Scores and order are never compared.

**Not covered:** nested prefetch (single level only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)