### PR TITLE
feat: require UserData to implement Debug

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -38,6 +38,17 @@ struct Entry<'a, U: UserData, K: Key + ?Sized> {
     state: State<'a, K>,
 }
 
+// Manual `Debug` impl: `Entry` is used as user data for the read pipeline, so it
+// must be `Debug` (via `UserData`). Only `user_data` is printed; `state` carries
+// buffers and key references that are not `Debug`.
+impl<U: std::fmt::Debug + UserData, K: Key + ?Sized> std::fmt::Debug for Entry<'_, U, K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Entry")
+            .field("user_data", &self.user_data)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Lifecycle:
 ///
 /// - [`Request::Offset`]             →             [`State::ReadingEntry`]

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -18,6 +18,19 @@ struct RemoteMeta<File, U> {
     user_data: U,
 }
 
+// Manual `Debug` impl: `RemoteMeta` is used as user data for the remote
+// pipeline, so it must be `Debug` (via `UserData`). `file` can be a
+// `&DiskCache<R>`, which is not `Debug`, so it is omitted from the output.
+impl<File, U: std::fmt::Debug> std::fmt::Debug for RemoteMeta<File, U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteMeta")
+            .field("scheduled_read", &self.scheduled_read)
+            .field("user_data", &self.user_data)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 enum ScheduledRead {
     Range {
         blocks_range: Range<u32>,
@@ -192,6 +205,7 @@ where
 impl<'file, R, U> BorrowedReadPipeline<'file, U> for DiskCachePipeline<'file, R, U>
 where
     R: DiskCacheRemote + 'file,
+    U: UserData,
 {
     type File = DiskCache<R>;
 
@@ -312,6 +326,7 @@ where
 impl<R, U> OwnedReadPipeline<U> for OwnedDiskCachePipeline<R, U>
 where
     R: DiskCacheRemote,
+    U: UserData,
 {
     type File = DiskCache<R>;
 

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -4,6 +4,8 @@ mod pipeline;
 mod read;
 mod write;
 
+use std::fmt::Debug;
+
 pub use file_ops::{UniversalReadFileOps, UniversalReadFs};
 pub use open_extra::OpenExtra;
 pub use pipeline::{BorrowedReadPipeline, OwnedReadPipeline};
@@ -20,8 +22,8 @@ pub use write::UniversalWrite;
 /// `u64`.
 ///
 /// This trait exists for documentation/code navigation purposes only.
-pub trait UserData {}
-impl<T> UserData for T {}
+pub trait UserData: Debug {}
+impl<T: Debug> UserData for T {}
 
 /// Element type read from or written to a universal I/O storage.
 ///

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -14,7 +14,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::is_alive_lock::IsAliveLock;
-use common::universal_io::{MmapFile, Populate, UniversalReadFileOps, UniversalWrite};
+use common::universal_io::{MmapFile, Populate, UniversalReadFileOps, UniversalWrite, UserData};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use reader::CONFIG_FILENAME;
@@ -405,6 +405,7 @@ where
     ) -> Result<(), E>
     where
         P: AccessPattern,
+        U: UserData,
         E: From<GridstoreError>,
     {
         self.with_view(|view| {

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -5,7 +5,7 @@ use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs, read_json_via};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs, UserData, read_json_via};
 
 use super::view::GridstoreView;
 use crate::Result;
@@ -135,6 +135,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     ) -> Result<(), E>
     where
         P: AccessPattern,
+        U: UserData,
         E: From<GridstoreError>,
     {
         self.view().read_values::<P, _, _>(

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -9,7 +9,7 @@ use common::maybe_uninit::assume_init_vec;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
     FileIndex, Flusher, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFileOps,
-    UniversalReadFs, UniversalWrite,
+    UniversalReadFs, UniversalWrite, UserData,
 };
 use itertools::Either;
 
@@ -246,6 +246,7 @@ impl<S: UniversalRead> Pages<S> {
     ) -> Result<bool, E>
     where
         P: AccessPattern,
+        U: UserData,
         E: From<GridstoreError>,
     {
         struct Progress<U> {
@@ -255,6 +256,7 @@ impl<S: UniversalRead> Pages<S> {
             user_data: U,
         }
 
+        #[derive(Debug)]
         struct ReadMeta<U> {
             value_idx: usize,
             buffer_offset: usize,

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -140,7 +140,7 @@ pub trait PayloadIndexRead {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload>;
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_ids: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -169,7 +169,7 @@ impl PayloadIndexRead for PlainPayloadIndex {
         unreachable!()
     }
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
         _callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -292,7 +292,7 @@ where
         self.payload.borrow().get_sequential(point_id, hw_counter)
     }
 
-    fn read_payloads<AP: AccessPattern, U>(
+    fn read_payloads<AP: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_ids: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -58,7 +58,7 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
         Ok(())
     }
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -42,7 +42,7 @@ pub trait PayloadStorageRead {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<OwnedPayloadRef<'_>>;
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -88,7 +88,7 @@ impl PayloadStorageRead for PayloadStorageEnum {
         }
     }
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/payload_storage/payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/payload_storage_impl.rs
@@ -124,7 +124,7 @@ where
         Ok(OwnedPayloadRef::from(payload))
     }
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -43,7 +43,7 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
         Ok(OwnedPayloadRef::from(payload))
     }
 
-    fn read_payloads<P: AccessPattern, U>(
+    fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/segment/read_view/payload.rs
+++ b/lib/segment/src/segment/read_view/payload.rs
@@ -19,7 +19,7 @@ where
     TPS: PayloadStorageRead,
     TVD: VectorDataRead,
 {
-    pub fn read_payloads<P: AccessPattern, U>(
+    pub fn read_payloads<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,

--- a/lib/segment/src/segment/read_view/vectors.rs
+++ b/lib/segment/src/segment/read_view/vectors.rs
@@ -49,7 +49,7 @@ where
     /// parallel input array without keeping a separate `offset → ...` lookup
     /// table. Deleted points are filtered out lazily — entries with deleted
     /// vectors or deleted points are simply not delivered to the callback.
-    pub fn vectors_by_offsets<U: Copy>(
+    pub fn vectors_by_offsets<U: Copy + common::universal_io::UserData>(
         &self,
         vector_name: &VectorName,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,

--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, Populate};
+use common::universal_io::{MmapFile, MmapFs, Populate, UserData};
 use fs_err as fs;
 
 use crate::common::Flusher;
@@ -143,7 +143,7 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorS
             .expect("Vector not found")
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::data_types::named_vectors::CowVector;
@@ -55,7 +55,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
             .expect("Vector not found")
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead, UserData};
 use fs_err as fs;
 
 use super::buffered_offsets::BufferedOffsets;
@@ -328,7 +328,7 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
         self.get_vector_opt::<P>(key).expect("vector not found")
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -32,6 +32,7 @@ pub fn iter_vectors<'a, P, T, U, S>(
 where
     P: AccessPattern,
     T: PrimitiveVectorElement,
+    U: UserData,
     S: UniversalRead,
 {
     let point_offsets = keys

--- a/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use common::bitvec::BitSlice;
 use common::generic_consts::{AccessPattern, Sequential};
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
@@ -98,7 +98,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
         self.get_vector_opt::<P>(key).expect("vector not found")
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -1,7 +1,7 @@
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::VectorStorageReadEnum;
 use crate::data_types::named_vectors::CowVector;
@@ -103,7 +103,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
         }
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, Populate};
+use common::universal_io::{MmapFile, MmapFs, Populate, UserData};
 use fs_err as fs;
 use gridstore::Gridstore;
 use gridstore::config::{Compression, StorageOptions};
@@ -283,7 +283,7 @@ impl VectorStorageRead for MmapSparseVectorStorage {
             .unwrap_or_else(CowVector::default_sparse)
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
@@ -2,7 +2,7 @@ use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 use sparse::common::sparse_vector::SparseVector;
 
 use super::ReadOnlySparseVectorStorage;
@@ -80,7 +80,7 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
             .unwrap_or_else(CowVector::default_sparse)
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -11,6 +11,7 @@ use common::generic_consts::{AccessPattern, Random};
 use common::types::PointOffsetType;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
+use common::universal_io::UserData;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::dense_vector_storage::DenseVectorStorageImpl;
@@ -99,7 +100,7 @@ pub trait VectorStorageRead {
     /// straight back to the callback alongside its offset and vector, so
     /// callers can map results into a parallel input array without keeping a
     /// separate `offset → ...` lookup table.
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
@@ -931,7 +932,7 @@ impl VectorStorageRead for VectorStorageEnum {
         }
     }
 
-    fn read_vectors<P: AccessPattern, U: Copy>(
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, PointOffsetType, CowVector<'_>),


### PR DESCRIPTION
## What

Adds a `Debug` supertrait bound to the `UserData` marker trait in `universal_io` and propagates the bound through the read pipelines and the read APIs built on them.

```rust
pub trait UserData: Debug {}
impl<T: Debug> UserData for T {}
```

## Why

Pipeline user-data (request ids, point ids, internal read metadata) needs to be formattable for diagnostics — e.g. per-request logging/latency tracing in the edge S3 tooling. Requiring `Debug` on `UserData` lets that data be printed wherever it flows.

## Changes

- `UserData: Debug` bound + blanket impl restricted to `T: Debug`.
- `Debug` impls for the wrapper types that carry user data through the pipelines: `RemoteMeta` (simple_disk_cache), gridstore `ReadMeta`, hashmap `Entry`. These skip non-`Debug` internal fields (file handles, buffers) and print only the user data.
- The `U: UserData` bound threaded through `read_vectors` / `read_payloads` / `read_values` / `iter_vectors` and their implementors across `common`, `gridstore`, and `segment`.

Mechanical bound propagation + a few manual `Debug` impls; no behavioral change.

## Notes

- Draft: opening for early review. The actual `log::warn!` instrumentation that motivated this (per-request latency tracing in `io_bridge_object_store`) is kept on the branch but **not** included in this PR yet.
- Also carries a pre-existing CI commit (`ci: build edge-s3-scroll among the debug tools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)