### PR TITLE
fix: evaluate values_count query condition on missing fields

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -131,6 +131,10 @@ impl ValueChecker for FieldCondition {
         }
     }
 
+    /// Check condition in case of empty payload value (missing or null field).
+    ///
+    /// For `values_count` conditions, a missing field has a value count of 0,
+    /// so we delegate to the values count checker with 0.
     fn check_empty(&self) -> bool {
         let FieldCondition {
             r#match: _,
@@ -138,7 +142,7 @@ impl ValueChecker for FieldCondition {
             geo_radius: _,
             geo_bounding_box: _,
             geo_polygon: _,
-            values_count: _,
+            values_count,
             key: _,
             is_empty,
             is_null,
@@ -148,6 +152,12 @@ impl ValueChecker for FieldCondition {
         }
         if let Some(is_null) = is_null {
             return !*is_null;
+        }
+        if let Some(values_count) = values_count {
+            // If the field is missing/empty, its value count is logically 0.
+            // Delegate the evaluation to the values_count condition handler with a count of 0
+            // to check if bounds conditions (such as lt: 1, gte: 0, lte: 0) are satisfied.
+            return values_count.check_empty();
         }
         false
     }
@@ -504,4 +514,39 @@ mod tests {
         assert!(is_not_null.check(&number));
         assert!(is_not_null.check(&bool));
     }
+
+    #[test]
+    fn test_values_count_missing_key_matches_lte_zero() {
+        let lte_zero = ValuesCount {
+            lt: None,
+            gt: None,
+            gte: None,
+            lte: Some(0),
+        };
+        assert!(lte_zero.check_empty());
+
+        let eq_zero = ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(0),
+            lte: Some(0),
+        };
+        assert!(eq_zero.check_empty());
+
+        let lte_zero_field = FieldCondition {
+            r#match: None,
+            range: None,
+            geo_radius: None,
+            geo_bounding_box: None,
+            geo_polygon: None,
+            values_count: Some(lte_zero),
+            key: JsonPath::new("comments"),
+            is_empty: None,
+            is_null: None,
+        };
+        assert!(lte_zero_field.check_empty());
+        assert!(!lte_zero_field.check(&json!(["one"])));
+        assert!(lte_zero_field.check(&json!([])));
+    }
 }
+

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -336,6 +336,7 @@ mod tests {
     };
 
     #[test]
+    /// Tests condition checker logic including missing/empty values_count cases.
     fn test_condition_checker() {
         let payload = payload_json! {
             "location": {
@@ -490,6 +491,47 @@ mod tests {
                 },
             )));
         assert!(payload_checker.check(0, &few_value_count_condition));
+
+        // Verify that values_count conditions are correctly evaluated on non-existent fields.
+        // A missing field has logically 0 values, so it must satisfy filters such as:
+        // - lt: 1 (0 < 1 is true)
+        // - gte: 0 (0 >= 0 is true)
+        // - lte: 0 (0 <= 0 is true)
+        let missing_value_count_condition =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("non_existent_field"),
+                ValuesCount {
+                    lt: Some(1),
+                    gt: None,
+                    gte: None,
+                    lte: None,
+                },
+            )));
+        assert!(payload_checker.check(0, &missing_value_count_condition));
+
+        let missing_value_count_condition_gte =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("non_existent_field"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: Some(0),
+                    lte: None,
+                },
+            )));
+        assert!(payload_checker.check(0, &missing_value_count_condition_gte));
+
+        let missing_value_count_condition_lte =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("non_existent_field"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: None,
+                    lte: Some(0),
+                },
+            )));
+        assert!(payload_checker.check(0, &missing_value_count_condition_lte));
 
         let in_berlin = Condition::Field(FieldCondition::new_geo_bounding_box(
             JsonPath::new("location"),

--- a/tests/openapi/test_filter_values_count.py
+++ b/tests/openapi/test_filter_values_count.py
@@ -89,3 +89,31 @@ def test_filter_values_count(collection_name):
     json = response.json()
     assert len(json['result']) == 3
     assert json['result'][0]['id'] == 1
+
+
+def test_values_count_lte_zero_matches_missing_key(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {
+                "must": [
+                    {
+                        "key": "city",
+                        "values_count": {
+                            "lte": 0
+                        }
+                    }
+                ]
+            },
+            "limit": 10,
+            "with_payload": True,
+        }
+    )
+    assert response.ok
+    ids = sorted(p['id'] for p in response.json()['result']['points'])
+    # Points 5 and 6 (missing key), 7 (null value), 8 and 10 (empty array []) should match
+    assert ids == [5, 6, 7, 8, 10]
+
+


### PR DESCRIPTION
### Summary
Fixes a bug where `values_count` filter queries returned incorrect results when evaluating points that were missing the target payload field.

### Issue: #9586 & #9065

### Problem
Previously, when a query condition evaluated a payload field that did not exist on a point (e.g. `tags` on a point with no `tags` field), the query engine fell back to calling `check_empty()` on the `FieldCondition`. 

In `FieldCondition::check_empty()`, the `values_count` check was completely ignored (using a wildcard pattern `values_count: _`), causing it to default to `false`. This meant conditions like `values_count` with `lt: 1`, `lte: 0`, or `gte: 0` (which should match a point missing the field since its value count is `0`) incorrectly returned `false`.

### Solution
1. Updated `FieldCondition::check_empty()` in `lib/segment/src/payload_storage/condition_checker.rs` to evaluate the `values_count` check (if present) by calling `values_count.check_empty()`. This successfully checks conditions against a count of `0`.
2. Added unit tests in `lib/segment/src/payload_storage/query_checker.rs` to cover these scenarios:
   - `values_count` check with `lt: 1` matching a missing field (value count of `0`).
   - `values_count` check with `gte: 0` matching a missing field.
   - `values_count` check with `lte: 0` matching a missing field.

`[Drafted by Claude Code (Opus 4.8)]`