### PR TITLE
Fix WAL replay for delete-by-filter operations

### DIFF
--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -267,8 +267,6 @@ impl Swarm {
     /// is just removing it from `FORCE_OFF`.
     //
     // Currently in `FORCE_OFF` (known-broken):
-    // - DeleteByFilter (3): WAL replay can resurrect filter-deleted points — post-reload count
-    //   mismatch. See https://github.com/qdrant/qdrant/issues/9575
     // - CreateVectorName / DeleteVectorName (22, 23): (1) proxy-segment schema race (optimizer-on)
     //   → "missing / Not existing vector name"; (2) DeleteVectorName vs. storage incoherence
     //   (fires without the optimizer too) — `delete_named_vector` updates `CollectionParams` but
@@ -316,7 +314,7 @@ impl Swarm {
     const FORCE_ON: [usize; 1] = [0]; // Upsert
 
     /// Indices kept disabled in every swarm config: known-broken ops (see `BASE`).
-    const FORCE_OFF: [usize; 3] = [3, 22, 23]; // DeleteByFilter, CreateVectorName, DeleteVectorName
+    const FORCE_OFF: [usize; 2] = [22, 23]; // CreateVectorName, DeleteVectorName
 
     /// Draw a per-run config: each non-forced op is included with probability 0.5 (keeping its
     /// base weight); omitted ops get weight 0.

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -10,9 +10,12 @@ use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
 use shard::count::CountRequestInternal;
+use shard::operations::CollectionUpdateOperations;
+use shard::operations::point_ops::PointOperations;
 use shard::retrieve::record_internal::RecordInternal;
 use shard::scroll::ScrollRequestInternal;
 use shard::search::CoreSearchRequestBatch;
+use shard::update::resolve_delete_points_by_filter;
 use tokio::sync::oneshot;
 use tokio::time::Instant;
 use tokio::time::error::Elapsed;
@@ -51,39 +54,57 @@ pub enum SubmitOutcome {
 }
 
 impl LocalShard {
-    /// Submit an update to the worker queue without waiting for completion.
-    ///
-    /// Holds locks only for the brief WAL write + channel send. The returned
-    /// [`SubmitOutcome::Submitted`] carries an owned `oneshot::Receiver` that
-    /// can be awaited via [`await_update_result`] after dropping any outer
-    /// read guards on the replica set.
-    pub async fn submit_update(
+    fn operation_needs_wal_resolution(operation: &CollectionUpdateOperations) -> bool {
+        matches!(
+            operation,
+            CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(_))
+        )
+    }
+
+    fn resolve_operation_for_wal(
+        &self,
+        operation: &mut OperationWithClockTag,
+        hw_measurement_acc: &HwMeasurementAcc,
+    ) -> CollectionResult<()> {
+        let CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
+            filter,
+        )) = &operation.operation
+        else {
+            return Ok(());
+        };
+
+        let filter = filter.clone();
+        let hw_counter = hw_measurement_acc.get_counter_cell();
+        let point_ids = {
+            let segments = self.segments.read();
+            resolve_delete_points_by_filter(&segments, &filter, &hw_counter)
+                .map_err(CollectionError::from)?
+        };
+
+        operation.operation =
+            CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+                ids: point_ids,
+            });
+
+        Ok(())
+    }
+
+    async fn wait_for_prior_updates(&self) -> CollectionResult<()> {
+        let plunger = self.plunge_async().await?;
+        plunger.await.map_err(|err| {
+            CollectionError::service_error(format!("Update plunger callback dropped: {err}"))
+        })
+    }
+
+    async fn write_and_queue_update(
         &self,
         mut operation: OperationWithClockTag,
         wait: WaitUntil,
+        pending_operations_count: usize,
+        callback_sender: Option<oneshot::Sender<CollectionResult<InternalUpdateResult>>>,
+        callback_receiver: Option<oneshot::Receiver<CollectionResult<InternalUpdateResult>>>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<SubmitOutcome> {
-        let (callback_sender, callback_receiver) = if wait.needs_callback() {
-            let (tx, rx) = oneshot::channel();
-            (Some(tx), Some(rx))
-        } else {
-            (None, None)
-        };
-
-        if self
-            .disk_usage_watcher
-            .is_disk_full()
-            .await?
-            .unwrap_or(false)
-        {
-            return Err(CollectionError::service_error(
-                "No space left on device: WAL buffer size exceeds available disk space".to_string(),
-            ));
-        }
-
-        let _update_lock = self.update_lock.read().await;
-        let pending_operations_count = self.update_queue_length();
-
         let update_sender = self.update_sender.load();
         let channel_permit = update_sender.reserve().await?;
 
@@ -122,6 +143,67 @@ impl LocalShard {
             receiver: callback_receiver,
             clock_tag,
         })
+    }
+
+    /// Submit an update to the worker queue without waiting for completion.
+    ///
+    /// Holds locks only for the brief WAL write + channel send. The returned
+    /// [`SubmitOutcome::Submitted`] carries an owned `oneshot::Receiver` that
+    /// can be awaited via [`await_update_result`] after dropping any outer
+    /// read guards on the replica set.
+    pub async fn submit_update(
+        &self,
+        mut operation: OperationWithClockTag,
+        wait: WaitUntil,
+        hw_measurement_acc: HwMeasurementAcc,
+    ) -> CollectionResult<SubmitOutcome> {
+        let (callback_sender, callback_receiver) = if wait.needs_callback() {
+            let (tx, rx) = oneshot::channel();
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+
+        if self
+            .disk_usage_watcher
+            .is_disk_full()
+            .await?
+            .unwrap_or(false)
+        {
+            return Err(CollectionError::service_error(
+                "No space left on device: WAL buffer size exceeds available disk space".to_string(),
+            ));
+        }
+
+        if Self::operation_needs_wal_resolution(&operation.operation) {
+            let _update_lock = self.update_lock.write().await;
+            self.wait_for_prior_updates().await?;
+            self.resolve_operation_for_wal(&mut operation, &hw_measurement_acc)?;
+            let pending_operations_count = self.update_queue_length();
+            return self
+                .write_and_queue_update(
+                    operation,
+                    wait,
+                    pending_operations_count,
+                    callback_sender,
+                    callback_receiver,
+                    hw_measurement_acc,
+                )
+                .await;
+        }
+
+        let _update_lock = self.update_lock.read().await;
+        let pending_operations_count = self.update_queue_length();
+
+        self.write_and_queue_update(
+            operation,
+            wait,
+            pending_operations_count,
+            callback_sender,
+            callback_receiver,
+            hw_measurement_acc,
+        )
+        .await
     }
 }
 

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -5,10 +5,15 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use segment::data_types::vectors::VectorStructInternal;
-use segment::types::{PayloadFieldSchema, PayloadSchemaType, WithPayload, WithVector};
+use segment::payload_json;
+use segment::types::{
+    Condition, FieldCondition, Filter, Match, PayloadFieldSchema, PayloadSchemaType, WithPayload,
+    WithVector,
+};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::point_ops::{
-    PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointOperations,
+    PointStructPersisted, UpdateMode,
 };
 use tempfile::Builder;
 use tokio::runtime::Handle;
@@ -21,6 +26,70 @@ use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
 use crate::update_workers::applied_seq::{APPLIED_SEQ_SAVE_INTERVAL, AppliedSeqHandler};
+
+fn num_point(id: u64, num: i64) -> PointStructPersisted {
+    PointStructPersisted {
+        id: id.into(),
+        vector: VectorStructInternal::from(vec![id as f32, 2.0, 3.0, 4.0]).into(),
+        payload: Some(payload_json! {"num": num}),
+    }
+}
+
+fn upsert_num_point_operation(id: u64, num: i64) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(vec![num_point(id, num)]),
+    ))
+}
+
+fn insert_only_num_point_operation(id: u64, num: i64) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsConditional(
+        ConditionalInsertOperationInternal {
+            points_op: PointInsertOperationsInternal::PointsList(vec![num_point(id, num)]),
+            condition: match_num_filter(num),
+            update_mode: Some(UpdateMode::InsertOnly),
+        },
+    ))
+}
+
+fn delete_num_filter_operation(num: i64) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
+        match_num_filter(num),
+    ))
+}
+
+fn match_num_filter(num: i64) -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_match(
+        "num".parse().unwrap(),
+        Match::from(num),
+    )))
+}
+
+async fn retrieve_point_count(
+    shard: &LocalShard,
+    id: u64,
+    current_runtime: &AdaptiveSearchHandle,
+    hw_acc: HwMeasurementAcc,
+) -> usize {
+    let request = Arc::new(PointRequestInternal {
+        ids: vec![id.into()],
+        with_payload: None,
+        with_vector: WithVector::Bool(false),
+    });
+
+    shard
+        .retrieve(
+            request,
+            &WithPayload::from(false),
+            &WithVector::Bool(false),
+            current_runtime,
+            None,
+            hw_acc,
+            DeferredBehavior::VisibleOnly,
+        )
+        .await
+        .unwrap()
+        .len()
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_delete_from_indexed_payload() {
@@ -265,6 +334,108 @@ async fn test_partial_flush_recovery() {
         .points;
 
     assert_eq!(number_of_indexed_points_after_load, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_replay_delete_by_filter_after_insert_only() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Keep all WAL records for the reload below while still flushing the post-delete
+    // segment state to disk manually.
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    shard
+        .update(
+            upsert_num_point_operation(1, 1).into(),
+            WaitUntil::Visible,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .unwrap();
+
+    // Live execution should skip this insert because point 1 already exists.
+    shard
+        .update(
+            insert_only_num_point_operation(1, 2).into(),
+            WaitUntil::Visible,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .unwrap();
+
+    shard
+        .update(
+            delete_num_filter_operation(1).into(),
+            WaitUntil::Visible,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        retrieve_point_count(&shard, 1, &current_runtime, hw_acc.clone()).await,
+        0,
+        "point should be deleted before reload"
+    );
+
+    shard.full_flush();
+    shard.stop_gracefully().await;
+
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        true,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        retrieve_point_count(&shard, 1, &current_runtime, hw_acc).await,
+        0,
+        "WAL replay must not resurrect a point deleted by filter"
+    );
+
+    shard.stop_gracefully().await;
 }
 
 /// Test that truncate_unapplied_wal correctly drops unapplied records from a non-empty WAL

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -366,6 +366,12 @@ pub fn delete_points(
         }
     }
 
+    if ids.is_empty() {
+        // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
+        // If we don't do this, startup might take up a lot of time in some scenarios because of recovering these no-op operations.
+        segments.bump_max_segment_version_overwrite(op_num);
+    }
+
     Ok(total_deleted_points)
 }
 
@@ -413,6 +419,82 @@ fn deferred_points_to_exclude_by_filter(
     }
 
     to_exclude
+}
+
+fn latest_filter_matched_point_ids(
+    segments: &SegmentHolder,
+    per_segment_points: &AHashMap<SegmentId, Vec<PointIdType>>,
+) -> AHashSet<PointIdType> {
+    let mut max_matched_versions: AHashMap<PointIdType, SeqNumberType> = Default::default();
+
+    for (segment_id, point_ids) in per_segment_points {
+        let segment = segments.get(*segment_id).unwrap().get().read();
+        for point_id in point_ids {
+            let Some(version) = segment.point_version(*point_id) else {
+                continue;
+            };
+            max_matched_versions
+                .entry(*point_id)
+                .and_modify(|current| *current = (*current).max(version))
+                .or_insert(version);
+        }
+    }
+
+    let matched_point_ids: Vec<_> = max_matched_versions.keys().copied().collect();
+    let mut latest_versions = max_matched_versions.clone();
+
+    for (_segment_id, segment) in segments.iter() {
+        let segment = segment.get().read();
+        for point_id in &matched_point_ids {
+            let Some(version) = segment.point_version(*point_id) else {
+                continue;
+            };
+            latest_versions
+                .entry(*point_id)
+                .and_modify(|current| *current = (*current).max(version))
+                .or_insert(version);
+        }
+    }
+
+    max_matched_versions
+        .into_iter()
+        .filter_map(|(point_id, max_matched_version)| {
+            let latest_version = latest_versions[&point_id];
+            (max_matched_version >= latest_version).then_some(point_id)
+        })
+        .collect()
+}
+
+pub fn resolve_delete_points_by_filter(
+    segments: &SegmentHolder,
+    filter: &Filter,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<Vec<PointIdType>> {
+    // we don’t want to cancel this filtered read
+    let is_stopped = AtomicBool::new(false);
+    let per_segment_points: AHashMap<SegmentId, Vec<PointIdType>> = segments
+        .iter()
+        .map(|(segment_id, segment)| {
+            let segment = segment.get().read();
+            let point_ids = segment.read_filtered(
+                None,
+                None,
+                Some(filter),
+                &is_stopped,
+                hw_counter,
+                // Include deferred points when resolving the logical delete set.
+                DeferredBehavior::WithDeferred,
+            )?;
+            Ok((segment_id, point_ids))
+        })
+        .collect::<OperationResult<_>>()?;
+
+    let mut point_ids: Vec<_> = latest_filter_matched_point_ids(segments, &per_segment_points)
+        .into_iter()
+        .collect();
+    point_ids.sort_unstable();
+
+    Ok(point_ids)
 }
 
 /// Deletes points from all segments matching the given filter


### PR DESCRIPTION
Fixes #9575.

This makes `DeletePointsByFilter` deterministic in the WAL. Before writing the operation to WAL, local shards now resolve the filter against the current segment state and persist the resulting `DeletePoints { ids }` operation instead.

This avoids replaying the same filter against a later state, where a preceding conditional insert can change whether the filter matches and resurrect a point that was deleted during live execution.

The resolver keeps the existing deferred-point semantics by only selecting IDs whose latest version matched the filter, and it sorts the IDs before writing them to WAL for stable records.

I also added a WAL recovery regression test for the `InsertOnly` + `DeletePointsByFilter` replay scenario and re-enabled `DeleteByFilter` in model testing.

### All Submissions:

- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

Verification:
- `PROTOC=/tmp/qdrant-protoc-34.1/bin/protoc cargo +nightly-2026-05-06 test -p collection test_wal_replay_delete_by_filter_after_insert_only --features testing -- --nocapture`
- `PROTOC=/tmp/qdrant-protoc-34.1/bin/protoc cargo +nightly-2026-05-06 test -p collection test_delete_by_filter_with_deferred_points --features testing -- --nocapture`
- `PROTOC=/tmp/qdrant-protoc-34.1/bin/protoc cargo +nightly-2026-05-06 test -p shard test_delete_by_filter -- --nocapture`
- `PROTOC=/tmp/qdrant-protoc-34.1/bin/protoc cargo +nightly-2026-05-06 test -p collection model_testing::tests::harness_no_optimizer_restarts --features testing -- --nocapture`
- `cargo +nightly-2026-05-06 fmt --check`

Not run:
- Full workspace test suite
- `cargo clippy --workspace --all-features`

AI disclosure:
- Commit `87931f11c` was prepared with AI assistance in Codex and reviewed locally through the tests above.
- Initial prompt: “Fix qdrant/qdrant#9575 locally first and do not submit a PR yet.”
