### PR TITLE
debug logging of the s3 connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,6 +3784,7 @@ dependencies = [
  "bytes",
  "common",
  "futures",
+ "log",
  "slab",
  "tempfile",
  "tokio",

--- a/lib/common/io_bridge/Cargo.toml
+++ b/lib/common/io_bridge/Cargo.toml
@@ -14,6 +14,7 @@ futures = { workspace = true }
 slab = { workspace = true }
 tokio = { workspace = true }
 aligned-vec = "0.6.4"
+log = { workspace = true }
 
 [dev-dependencies]
 common = { path = "../common", features = ["testing"] }

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -85,18 +85,22 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
     }
 
     fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
-        let start_time = std::time::Instant::now();
+        let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
+        let start_time = enabled.then(std::time::Instant::now);
         let buf = self
             .runtime
             .block_on(read_into_byte_buffer::<A>(self, range.clone(), align))?;
 
-        log::warn!(
-            "read_bytes({}, {:?}) took {:?} and returned {} bytes",
-            self.path.display(),
-            range,
-            start_time.elapsed(),
-            buf.len()
-        );
+        if let Some(start_time) = start_time {
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
+                "read_bytes({}, {:?}) took {:?} and returned {} bytes",
+                self.path.display(),
+                range,
+                start_time.elapsed(),
+                buf.len()
+            );
+        }
         Ok(ACow::Owned(buf))
     }
 
@@ -110,18 +114,22 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
     }
 
     fn len<T>(&self) -> Result<u64> {
-        let start_time = std::time::Instant::now();
+        let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
+        let start_time = enabled.then(std::time::Instant::now);
         let item_size = size_of::<T>() as u64;
         let len = self.runtime.block_on(self.inner.len(&self.path))?;
         debug_assert_eq!(len % item_size, 0);
 
-        log::warn!(
-            "len::<{}>({}) took {:?} and returned {} items",
-            std::any::type_name::<T>(),
-            self.path.display(),
-            start_time.elapsed(),
-            len / item_size
-        );
+        if let Some(start_time) = start_time {
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
+                "len::<{}>({}) took {:?} and measured {} bytes",
+                std::any::type_name::<T>(),
+                self.path.display(),
+                start_time.elapsed(),
+                len
+            );
+        }
         Ok(len / item_size)
     }
 

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -85,9 +85,18 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
     }
 
     fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+        let start_time = std::time::Instant::now();
         let buf = self
             .runtime
-            .block_on(read_into_byte_buffer::<A>(self, range, align))?;
+            .block_on(read_into_byte_buffer::<A>(self, range.clone(), align))?;
+
+        log::warn!(
+            "read_bytes({}, {:?}) took {:?} and returned {} bytes",
+            self.path.display(),
+            range,
+            start_time.elapsed(),
+            buf.len()
+        );
         Ok(ACow::Owned(buf))
     }
 
@@ -101,9 +110,18 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
     }
 
     fn len<T>(&self) -> Result<u64> {
+        let start_time = std::time::Instant::now();
         let item_size = size_of::<T>() as u64;
         let len = self.runtime.block_on(self.inner.len(&self.path))?;
         debug_assert_eq!(len % item_size, 0);
+
+        log::warn!(
+            "len::<{}>({}) took {:?} and returned {} items",
+            std::any::type_name::<T>(),
+            self.path.display(),
+            start_time.elapsed(),
+            len / item_size
+        );
         Ok(len / item_size)
     }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -41,13 +41,33 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
     }
 
     fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
-        self.runtime.block_on(self.inner.list_files(prefix_path))
+        let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
+        let start_time = enabled.then(std::time::Instant::now);
+        let result = self.runtime.block_on(self.inner.list_files(prefix_path));
+        if let Some(start_time) = start_time {
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
+                "list_files({}) took {:?} and returned {} files",
+                prefix_path.display(),
+                start_time.elapsed(),
+                result.as_ref().map_or(0, |files| files.len()),
+            );
+        }
+        result
     }
 
     fn exists(&self, path: &Path) -> Result<bool> {
-        let start_time = std::time::Instant::now();
+        let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
+        let start_time = enabled.then(std::time::Instant::now);
         let result = self.runtime.block_on(self.inner.exists(path));
-        log::warn!("exists({}) took {:?}", path.display(), start_time.elapsed());
+        if let Some(start_time) = start_time {
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
+                "exists({}) took {:?}",
+                path.display(),
+                start_time.elapsed(),
+            );
+        }
         result
     }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -45,7 +45,10 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
     }
 
     fn exists(&self, path: &Path) -> Result<bool> {
-        self.runtime.block_on(self.inner.exists(path))
+        let start_time = std::time::Instant::now();
+        let result = self.runtime.block_on(self.inner.exists(path));
+        log::warn!("exists({}) took {:?}", path.display(), start_time.elapsed());
+        result
     }
 
     // Deliberately no `UniversalWriteFileOps` impl: blob backends are

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -105,6 +105,13 @@ mod pipeline;
 mod read;
 mod runtime;
 
+/// Dedicated log target for the blob-backend latency traces emitted across this
+/// crate. All of them are `trace!` under this single target, so they are silent
+/// by default and can be toggled as one group at runtime without a rebuild — e.g.
+/// `POST /logger {"log_level": "io_bridge::latency=trace"}` or
+/// `RUST_LOG=io_bridge::latency=trace`.
+pub(crate) const LATENCY_LOG_TARGET: &str = "io_bridge::latency";
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/common/io_bridge/src/pipeline/inner.rs
+++ b/lib/common/io_bridge/src/pipeline/inner.rs
@@ -10,6 +10,10 @@ use tokio::sync::mpsc;
 use super::BLOB_PIPELINE_CAPACITY;
 use crate::runtime::{BridgeResponse, BridgeRuntime};
 
+/// A completed read drained from a pipeline: the caller `user_data`, the
+/// destination buffer, and the time the read took (see [`BridgeResponse::duration`]).
+type CompletedRead<U> = (U, AVec<u8, RuntimeAlign>, std::time::Duration);
+
 /// Best-effort extraction of a human-readable message from a caught panic
 /// payload. `panic!` payloads are most commonly `&'static str` or `String`;
 /// anything else is reported generically.
@@ -116,6 +120,12 @@ where
         // pipeline capacity, so the send never blocks on backpressure — the
         // only `send` error is the pipeline being dropped before collecting,
         // in which case discarding the buffer is correct.
+        // Stamp the request at enqueue time so the measured latency spans the
+        // full life of the request — including any time it waits for a free
+        // runtime worker — not just the read future's execution. This matters
+        // when a caller schedules a burst of reads at once (e.g. a batched
+        // scroll), where queueing delay is part of the real per-request cost.
+        let started = std::time::Instant::now();
         let reply_tx = self.tx.clone();
         runtime.handle().spawn(async move {
             // Catch a panic in the read future and turn it into an error reply,
@@ -129,12 +139,17 @@ where
                 Ok(result) => result,
                 Err(panic) => Err(UniversalIoError::TaskPanicked(panic_message(&*panic))),
             };
-            let _ = reply_tx.send(BridgeResponse::new(slot, result)).await;
+            let duration = started.elapsed();
+            let _ = reply_tx
+                .send(BridgeResponse::new(slot, result, duration))
+                .await;
         });
         Ok(())
     }
 
-    pub(crate) fn wait(&mut self) -> Result<Option<(U, AVec<u8, RuntimeAlign>)>> {
+    /// Block until any in-flight read completes, returning its caller
+    /// `user_data`, destination buffer, and the time the read itself took.
+    pub(crate) fn wait(&mut self) -> Result<Option<CompletedRead<U>>> {
         if self.slots.is_empty() {
             return Ok(None);
         }
@@ -146,8 +161,9 @@ where
             .slots
             .try_remove(response.slot)
             .expect("response slot must be in pending");
+        let duration = response.duration;
         let buf = response.result?;
-        Ok(Some((user_data, buf)))
+        Ok(Some((user_data, buf, duration)))
     }
 }
 
@@ -196,7 +212,7 @@ mod tests {
         inner
             .schedule(&runtime, 111, async { Ok(avec(b"hello")) })
             .expect("schedule");
-        let (user, bytes) = inner.wait().expect("wait ok").expect("some");
+        let (user, bytes, _took) = inner.wait().expect("wait ok").expect("some");
         assert_eq!(user, 111);
         assert_eq!(&bytes[..], b"hello");
     }
@@ -217,7 +233,7 @@ mod tests {
         }
         let mut seen = std::collections::HashSet::new();
         for _ in 0..3 {
-            let (user, _bytes) = inner.wait().unwrap().unwrap();
+            let (user, _bytes, _took) = inner.wait().unwrap().unwrap();
             assert!(seen.insert(user), "user_data {user} seen twice");
         }
         assert_eq!(seen, [0u32, 1, 2].into_iter().collect());
@@ -256,7 +272,7 @@ mod tests {
         inner.schedule(&rt_b, 2, async { Ok(avec(b"BB")) }).unwrap();
         let mut seen: AHashMap<u32, Vec<u8>> = AHashMap::new();
         for _ in 0..2 {
-            let (user, bytes) = inner.wait().unwrap().unwrap();
+            let (user, bytes, _took) = inner.wait().unwrap().unwrap();
             seen.insert(user, bytes.to_vec());
         }
         assert_eq!(seen[&1], b"AAAA");

--- a/lib/common/io_bridge/src/pipeline/mod.rs
+++ b/lib/common/io_bridge/src/pipeline/mod.rs
@@ -67,6 +67,11 @@ where
             let (tx, rx) = PipelineInner::<U>::default_channel();
             PipelineInner::new(tx, rx)
         });
+        log::warn!(
+            "schedule read for {user_data:?} of {} range {:?}",
+            file.path.display(),
+            range
+        );
         let future = read_into_byte_buffer::<A>(file, range, align);
         inner.schedule(&file.runtime, user_data, future)
     }
@@ -81,6 +86,11 @@ where
             let (tx, rx) = PipelineInner::<U>::default_channel();
             PipelineInner::new(tx, rx)
         });
+        log::warn!(
+            "schedule_whole read of {} from {}",
+            file.path.display(),
+            from
+        );
 
         let future = read_from_into_byte_buffer::<A>(file, from, 1);
         inner.schedule(&file.runtime, user_data, future)
@@ -90,6 +100,18 @@ where
         let Some(inner) = self.inner.as_mut() else {
             return Ok(None);
         };
-        Ok(inner.wait()?.map(|(u, v)| (u, ACow::Owned(v))))
+
+        let res = inner.wait()?;
+
+        if let Some((u, v, took)) = res {
+            log::warn!(
+                "awaited read for {u:?} returned {} bytes in {took:?}",
+                v.len(),
+            );
+            Ok(Some((u, ACow::Owned(v))))
+        } else {
+            log::warn!("awaited read returned None");
+            Ok(None)
+        }
     }
 }

--- a/lib/common/io_bridge/src/pipeline/mod.rs
+++ b/lib/common/io_bridge/src/pipeline/mod.rs
@@ -67,7 +67,8 @@ where
             let (tx, rx) = PipelineInner::<U>::default_channel();
             PipelineInner::new(tx, rx)
         });
-        log::warn!(
+        log::trace!(
+            target: crate::LATENCY_LOG_TARGET,
             "schedule read for {user_data:?} of {} range {:?}",
             file.path.display(),
             range
@@ -86,7 +87,8 @@ where
             let (tx, rx) = PipelineInner::<U>::default_channel();
             PipelineInner::new(tx, rx)
         });
-        log::warn!(
+        log::trace!(
+            target: crate::LATENCY_LOG_TARGET,
             "schedule_whole read of {} from {}",
             file.path.display(),
             from
@@ -104,13 +106,14 @@ where
         let res = inner.wait()?;
 
         if let Some((u, v, took)) = res {
-            log::warn!(
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
                 "awaited read for {u:?} returned {} bytes in {took:?}",
                 v.len(),
             );
             Ok(Some((u, ACow::Owned(v))))
         } else {
-            log::warn!("awaited read returned None");
+            log::trace!(target: crate::LATENCY_LOG_TARGET, "awaited read returned None");
             Ok(None)
         }
     }

--- a/lib/common/io_bridge/src/runtime.rs
+++ b/lib/common/io_bridge/src/runtime.rs
@@ -11,17 +11,26 @@ use common::universal_io::UniversalIoError;
 pub(crate) struct BridgeResponse {
     pub slot: usize,
     pub result: Result<AVec<u8, RuntimeAlign>, UniversalIoError>,
+    /// Wall-clock time the read future itself took to resolve (measured on the
+    /// worker thread, so it reflects the actual I/O latency of this request
+    /// regardless of how the caller interleaves `schedule`/`wait`).
+    pub duration: std::time::Duration,
 }
 
 impl BridgeResponse {
-    /// Build a reply for the given slot with the future's output. Provided so
-    /// the spawned task doesn't have to reach into the struct layout when
-    /// constructing the response.
+    /// Build a reply for the given slot with the future's output and the time
+    /// it took. Provided so the spawned task doesn't have to reach into the
+    /// struct layout when constructing the response.
     pub(crate) fn new(
         slot: usize,
         result: Result<AVec<u8, RuntimeAlign>, UniversalIoError>,
+        duration: std::time::Duration,
     ) -> Self {
-        Self { slot, result }
+        Self {
+            slot,
+            result,
+            duration,
+        }
     }
 }
 

--- a/lib/edge/tools/shard_query/src/main.rs
+++ b/lib/edge/tools/shard_query/src/main.rs
@@ -552,7 +552,9 @@ where
 }
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .init();
 
     let cli = Cli::parse();
     let conn = &cli.connection;


### PR DESCRIPTION
The command I use for debug:

```
time env RUST_LOG='info,io_bridge::latency=trace' cargo run -p edge-shard-query -- \
    --backend aws \
    --bucket qdrant-benchmark-snapshots \
    --endpoint https://storage.googleapis.com \
    --region auto \
    --access-key GOOG1xxxxxxxxxxxxxxxxxxxxxxxxxxx \
    --secret-key 6X3xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
    --prefix serverless/shard-100k \
    --search-threads 1 \
    scroll \
    --filter '{"must": {"key": "a", "match": {"value": "keyword_1"}}}' \
    --limit 20
```
