### PR TITLE
fix: avoid allocator abort on huge limit in random sample/scroll

### DIFF
--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -420,6 +420,15 @@ impl LocalShard {
         if availability.iter().all(|&count| count == 0) {
             return Ok(Vec::new());
         }
+        // The random sample holds at most `min(limit, total available points)`
+        // entries, so bound the pre-allocation by the points actually available.
+        // `limit` is a client-controlled request field that is unbounded by
+        // default (`StrictModeConfig::max_query_limit` is `None` unless an
+        // operator sets it), so `HashSet::with_capacity(limit)` would otherwise
+        // request an enormous up-front allocation that aborts the process
+        // (`handle_alloc_error`) on a single request.
+        let total_available: usize = availability.iter().sum();
+
         // Select points in a weighted fashion from each segment, depending on how many points each segment has.
         let distribution = WeightedIndex::new(availability).map_err(|err| {
             CollectionError::service_error(format!(
@@ -428,7 +437,7 @@ impl LocalShard {
         })?;
 
         let mut rng = rand::make_rng::<StdRng>();
-        let mut random_points = HashSet::with_capacity(limit);
+        let mut random_points = HashSet::with_capacity(limit.min(total_available));
 
         // Randomly sample points in two stages
         //

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -420,15 +420,8 @@ impl LocalShard {
         if availability.iter().all(|&count| count == 0) {
             return Ok(Vec::new());
         }
-        // The random sample can only ever contain the candidate points actually
-        // read into `segments_reads` (the loop below pops/iterates exclusively
-        // from it), so bound the pre-allocation by that filter-aware candidate
-        // count rather than the raw, filter-unaware segment sizes. `limit` is a
-        // client-controlled request field that is unbounded by default
-        // (`StrictModeConfig::max_query_limit` is `None` unless an operator sets
-        // it), so a plain `HashSet::with_capacity(limit)` would otherwise reserve
-        // an enormous buffer and abort the process (`handle_alloc_error`) on a
-        // single request.
+        // Cap HashSet capacity at filter-aware candidates in `segments_reads` (not segment sizes).
+        // Unbounded client `limit` would otherwise abort via `handle_alloc_error`.
         let candidate_count: usize = segments_reads.iter().map(|points| points.len()).sum();
 
         // Select points in a weighted fashion from each segment, depending on how many points each segment has.

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -420,14 +420,16 @@ impl LocalShard {
         if availability.iter().all(|&count| count == 0) {
             return Ok(Vec::new());
         }
-        // The random sample holds at most `min(limit, total available points)`
-        // entries, so bound the pre-allocation by the points actually available.
-        // `limit` is a client-controlled request field that is unbounded by
-        // default (`StrictModeConfig::max_query_limit` is `None` unless an
-        // operator sets it), so `HashSet::with_capacity(limit)` would otherwise
-        // request an enormous up-front allocation that aborts the process
-        // (`handle_alloc_error`) on a single request.
-        let total_available: usize = availability.iter().sum();
+        // The random sample can only ever contain the candidate points actually
+        // read into `segments_reads` (the loop below pops/iterates exclusively
+        // from it), so bound the pre-allocation by that filter-aware candidate
+        // count rather than the raw, filter-unaware segment sizes. `limit` is a
+        // client-controlled request field that is unbounded by default
+        // (`StrictModeConfig::max_query_limit` is `None` unless an operator sets
+        // it), so a plain `HashSet::with_capacity(limit)` would otherwise reserve
+        // an enormous buffer and abort the process (`handle_alloc_error`) on a
+        // single request.
+        let candidate_count: usize = segments_reads.iter().map(|points| points.len()).sum();
 
         // Select points in a weighted fashion from each segment, depending on how many points each segment has.
         let distribution = WeightedIndex::new(availability).map_err(|err| {
@@ -437,7 +439,7 @@ impl LocalShard {
         })?;
 
         let mut rng = rand::make_rng::<StdRng>();
-        let mut random_points = HashSet::with_capacity(limit.min(total_available));
+        let mut random_points = HashSet::with_capacity(limit.min(candidate_count));
 
         // Randomly sample points in two stages
         //

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -26,6 +26,7 @@ use segment::types::{
     PayloadFieldSchema, PayloadSchemaType, PointIdType, WithPayloadInterface,
 };
 use serde_json::Map;
+use shard::query::{SampleInternal, ScoringQuery, ShardQueryRequest};
 use tempfile::Builder;
 
 use crate::common::{N_SHARDS, load_local_collection, simple_collection_fixture};
@@ -953,4 +954,72 @@ async fn test_collection_local_load_initializing_not_stuck() {
             assert_eq!(replica_state, &ReplicaState::Active);
         }
     }
+}
+
+/// Regression test for an unauthenticated allocator-abort (SIGABRT) in
+/// `LocalShard::scroll_randomly`. The random-sample path pre-allocated
+/// `HashSet::with_capacity(limit)` directly from the client-supplied `limit`,
+/// which is unbounded by default. A huge `limit` made the up-front allocation
+/// fail and abort the whole process. The pre-allocation is now bounded by the
+/// number of points actually available, so the query returns those points.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_random_sample_huge_limit_does_not_abort() {
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+
+    // Single shard: avoids cross-shard undersampling, so the raw `limit` reaches
+    // `scroll_randomly` unchanged.
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let batch = BatchPersisted {
+        ids: vec![0, 1, 2].into_iter().map(u64::into).collect_vec(),
+        vectors: BatchVectorStructPersisted::Single(vec![
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0, 0.0],
+            vec![0.0, 0.0, 1.0, 0.0],
+        ]),
+        payloads: None,
+    };
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(batch),
+    ));
+    collection
+        .update_from_client_simple(
+            insert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    // Unbounded client limit: before the fix this aborted the process in
+    // `HashSet::with_capacity(limit)`.
+    let request = ShardQueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Sample(SampleInternal::Random)),
+        filter: None,
+        score_threshold: None,
+        limit: 1_000_000_000_000,
+        offset: 0,
+        params: None,
+        with_vector: false.into(),
+        with_payload: false.into(),
+    };
+
+    let result = collection
+        .query(
+            request,
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    // Bounded by the points actually available; the request completes instead of
+    // aborting.
+    assert_eq!(result.len(), 3);
 }


### PR DESCRIPTION
## Problem

`LocalShard::scroll_randomly` (the `sample: random` query path) pre-allocates its result set with `HashSet::with_capacity(limit)`, where `limit` comes straight from the request and has no default upper bound (`StrictModeConfig::max_query_limit` is `None` unless an operator configures it). A single request with a very large limit makes `with_capacity` try to allocate a huge amount up front; the allocation fails and aborts the process (`handle_alloc_error`), which cannot be caught and returned as an error response.

Reproduce on a collection with at least one point:

```
POST /collections/{collection}/points/query
{ "query": { "sample": "random" }, "limit": 1000000000000 }

-> memory allocation of N bytes failed
-> SIGABRT
```

This is the same class as #4321 / #4328 (search top-k) and the in-flight edge fix in #9374. `scroll_randomly` is the remaining `with_capacity(limit)` site.

## Fix

The sample loop inserts at most `min(limit, total points available across segments)` points, so the pre-allocation is bounded by what is actually available:

```rust
let total_available: usize = availability.iter().sum();
// ...
let mut random_points = HashSet::with_capacity(limit.min(total_available));
```

Capacity is unchanged for normal requests (`limit <= total_available`); only the pathological case is bounded. The returned result is identical.

## Tests

Added an integration test (`test_random_sample_huge_limit_does_not_abort`): a single-shard collection with a few points, queried with `sample: random` and a huge limit, returns the available points instead of aborting.

## AI disclosure (per CONTRIBUTING.md)

This change was developed with AI assistance (Claude).

Commits:
- `[AI] fix: bound random-sample pre-allocation by available point count`

Initial prompt:

> In qdrant `lib/collection/src/shards/local_shard/scroll.rs`, `scroll_randomly` pre-allocates `HashSet::with_capacity(limit)` from the client-supplied, unbounded `limit`; a huge limit causes an allocator abort (SIGABRT) on the unauthenticated `sample: random` query path. Bound the pre-allocation to the number of points actually available (the set can never hold more), keeping the existing pre-allocation for normal limits. Mirror the search-path fix (#4321/#4328) and the edge twin (#9374), and add a regression test.

## Checklist

- [x] Contributions target the `dev` branch
- [x] `cargo +nightly fmt` reports no changes
- [x] `cargo clippy -p collection --all-features --all-targets` passes with no warnings
- [x] The new regression test passes locally: `cargo test -p collection --test integration test_random_sample_huge_limit_does_not_abort`
