### PR TITLE
fix: treat missing field as count 0 for values_count filter

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -138,11 +138,17 @@ impl ValueChecker for FieldCondition {
             geo_radius: _,
             geo_bounding_box: _,
             geo_polygon: _,
-            values_count: _,
+            values_count,
             key: _,
             is_empty,
             is_null,
         } = self;
+        // A missing field is treated as having a value count of 0, so the
+        // `values_count` bounds must be evaluated against 0 instead of being
+        // skipped (which would incorrectly never match missing fields).
+        if let Some(values_count) = values_count {
+            return values_count.check_empty();
+        }
         if let Some(is_empty) = is_empty {
             return *is_empty;
         }
@@ -405,6 +411,62 @@ mod tests {
             lte: None,
         };
         assert!(gte_two_countries_query.check(&countries));
+    }
+
+    #[test]
+    fn test_value_count_missing_field() {
+        // A missing payload field must be treated as a value count of 0 by
+        // `values_count` filters (regression for
+        // https://github.com/qdrant/qdrant/issues/9586).
+        let key = JsonPath::new("tags");
+
+        let field_condition = |values_count: ValuesCount| FieldCondition {
+            r#match: None,
+            range: None,
+            geo_radius: None,
+            geo_bounding_box: None,
+            geo_polygon: None,
+            values_count: Some(values_count),
+            key: key.clone(),
+            is_empty: None,
+            is_null: None,
+        };
+
+        let lt_one = field_condition(ValuesCount {
+            lt: Some(1),
+            gt: None,
+            gte: None,
+            lte: None,
+        });
+        // 0 < 1 -> a missing field matches
+        assert!(lt_one.check_empty());
+
+        let gte_zero = field_condition(ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(0),
+            lte: None,
+        });
+        // 0 >= 0 -> a missing field matches
+        assert!(gte_zero.check_empty());
+
+        let lte_zero = field_condition(ValuesCount {
+            lt: None,
+            gt: None,
+            gte: None,
+            lte: Some(0),
+        });
+        // 0 <= 0 -> a missing field matches
+        assert!(lte_zero.check_empty());
+
+        let gte_one = field_condition(ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(1),
+            lte: None,
+        });
+        // 0 >= 1 is false -> a missing field does not match
+        assert!(!gte_one.check_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes the `values_count` filter so a point whose payload field is **missing** is treated as having a value count of `0`, instead of never matching.

Targets the regression-test branch `test/values-count-missing-field-9586` (the test added there currently fails against `master`).

## Root cause

`FieldCondition::check_empty()` in `lib/segment/src/payload_storage/condition_checker.rs` ignored the `values_count` field. When a point has no value for the queried key, `check_field_condition()` short-circuits to `check_empty()`, which returned `false` — so `values_count` bounds were never evaluated for missing fields.

## Fix

Forward the empty check to the already-existing `ValuesCount::check_empty()` (which evaluates the bounds against a count of `0`). Now:

- `{"lt": 1}` matches a missing field (`0 < 1`)
- `{"gte": 0}` matches a missing field (`0 >= 0`)
- `{"lte": 0}` matches a missing field (`0 <= 0`)
- `{"gte": 1}` does **not** match a missing field (`0 >= 1` is false)

## Tests

- Added `test_value_count_missing_field` unit test in `condition_checker.rs`.
- Makes the openapi regression test `test_filter_values_count_missing_field.py` (added on the base branch) pass.

Fixes #9586

🤖 Generated with [Claude Code](https://claude.com/claude-code)