### PR TITLE
Fix/deleted vector bug

### DIFF
--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -322,29 +322,25 @@ impl SegmentBuilder {
 
         let vector_storages: Vec<_> = segments.iter().map(|i| &i.vector_data).collect();
 
-        // Every named vector present on any source segment must also be in the
-        // target schema. The merge loop below iterates `self.vector_data`
-        // (target) and would otherwise silently drop source vectors that
-        // aren't in target — the harm behind the optimizer-vs-CreateVectorName
-        // race: an optimizer launched with a pre-`CreateVectorName(V)` config
-        // would observe sources that gained V mid-flight and emit a merged
-        // segment without V at version >= V_opnum, breaking the next
-        // optimization round that uses the refreshed config (which has V).
+        // The merge loop below iterates `self.vector_data` (target), so any
+        // vector names present in source segments but absent from the target
+        // schema are silently dropped. This is the correct behaviour for the
+        // DeleteVectorName case: a vector that was removed from the collection
+        // schema may still live in older segment files; rebuilding those
+        // segments should naturally prune the stale data.
         //
-        // Use `Cancelled` rather than `ServiceError` so the optimization
-        // worker treats this as a recoverable cancellation (logged at debug,
-        // tracker marked Cancelled, no shard-level optimizer_errors set, no
-        // RED status). The follow-up `recreate_optimizers_blocking` will
-        // restart workers with a refreshed `target_config` that matches the
-        // sources, and the retry merges cleanly.
+        // The CreateVectorName race (an optimizer built with a pre-CreateVectorName
+        // config would miss the new vector) is prevented upstream by serialising
+        // the proxy-install step against shard updates, so there is no need to
+        // cancel here.
         for vector_storage in &vector_storages {
             for source_vector_name in vector_storage.keys() {
                 if !self.vector_data.contains_key(source_vector_name) {
-                    return Err(OperationError::cancelled(format!(
-                        "Cannot update from other segment because it has an extra \
-                         vector name {source_vector_name} not in the target schema; \
-                         retry after optimizer config refresh"
-                    )));
+                    log::debug!(
+                        "Dropping vector name {source_vector_name} from source segment \
+                         during optimization; it is absent from the target schema \
+                         (likely a previously deleted vector name)"
+                    );
                 }
             }
         }

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -585,20 +585,24 @@ fn test_segment_builder_rejects_target_with_extra_vector_name() {
 }
 
 #[test]
-fn test_segment_builder_rejects_source_with_extra_vector_name() {
+fn test_segment_builder_drops_extra_source_vector_name() {
+    // Verifies that when a source segment carries a vector name absent from
+    // the target schema (the DeleteVectorName case — a vector was removed from
+    // the collection schema but old segment files still contain the data),
+    // the builder silently drops the stale data and succeeds rather than
+    // cancelling.  The CreateVectorName race is prevented upstream by
+    // serialising the proxy-install step, so this check is not needed there.
     use segment::segment_constructor::build_segment;
 
     let source_dir = Builder::new().prefix("segment_source").tempdir().unwrap();
-    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+    let build_dir = Builder::new().prefix("segment_build").tempdir().unwrap();
+    let out_dir = Builder::new().prefix("segment_out").tempdir().unwrap();
 
     let stopped = AtomicBool::new(false);
     let hw_counter = HardwareCounterCell::new();
 
     let extra_vector_name = "extra_vec";
 
-    // Build a source segment carrying both the default vector and an extra
-    // named vector — emulates a segment that received `CreateVectorName(V)`
-    // while an optimizer in flight was holding a `target_config` without V.
     let template = build_segment_1(source_dir.path());
     let mut source_config = template.segment_config.clone();
     source_config.vector_data.insert(
@@ -626,24 +630,32 @@ fn test_segment_builder_rejects_source_with_extra_vector_name() {
             .unwrap();
     }
 
-    // Target schema lacks the extra vector — the optimizer's pre-`CreateVectorName` view.
+    // Target schema lacks the extra vector — emulates a post-DeleteVectorName config.
     let mut target_config = source_config.clone();
     target_config.vector_data.remove(extra_vector_name);
 
     let mut builder = SegmentBuilder::new(
-        temp_dir.path(),
+        build_dir.path(),
         &target_config,
         &HnswGlobalConfig::default(),
     )
     .unwrap();
 
-    let err = builder
+    // Should succeed: the extra vector is silently dropped.
+    builder
         .update(&[&source], &stopped, &hw_counter)
-        .expect_err("merge must reject a source carrying a vector not in target");
-    let msg = err.to_string();
+        .expect("merge should succeed by dropping the extra source vector");
+
+    // The resulting segment must not carry the deleted vector name.
+    let built = builder.build_for_test(out_dir.path());
     assert!(
-        msg.contains("extra vector name") && msg.contains(extra_vector_name),
-        "unexpected error message: {msg}",
+        !built.vector_data.contains_key(extra_vector_name),
+        "built segment must not contain the dropped vector {extra_vector_name}",
+    );
+    // But the default vector must still be present.
+    assert!(
+        built.vector_data.contains_key(DEFAULT_VECTOR_NAME),
+        "built segment must retain the default vector",
     );
 }
 


### PR DESCRIPTION
The bug was encountered after using the new feature for deleting vectors from existing collections. After performing that, all optimizations got blocked, and changes to other vectors were no longer working. 

I used Claude to debug, formulate the fix, and write the below description.

# Problem
When a vector name is deleted from a collection (DELETE /collections/{name}/vectors/{vector_name}), the schema is updated immediately but the actual segment files are not rewritten — that is left to the config-mismatch optimizer on its next pass.

PR #9110 added a safety check to SegmentBuilder::update: if any source segment carries a vector name that is absent from the target schema, the operation is cancelled with:

"Cannot update from other segment because it has an extra vector name {V} not in the target schema; retry after optimizer config refresh"

This check was designed for the CreateVectorName race — an optimizer launched with a pre-CreateVectorName(V) config would silently drop V from its output, corrupting the next optimization round. For that race, cancelling and retrying after a config refresh is correct.

However, this same check fatally breaks the DeleteVectorName recovery path. After deleting a vector name from the schema:

The config-mismatch optimizer selects segments to rebuild (e.g. to migrate a sparse index from ImmutableRam → Mmap).
The SegmentBuilder encounters the deleted vector name still present in the source segment files and cancels.
On the next optimizer tick the same segments are selected again.
recreate_optimizers_blocking (the intended recovery) recreates optimizers with the current schema, which still doesn't include the deleted vector — so the cancellation repeats indefinitely.
The result: no segment is ever successfully rebuilt. Any other pending config migration (e.g. on_disk changes) is permanently blocked, and optimizer_status stays ok (cancelled != error) while fail_count climbs without bound.

# Root cause
The CreateVectorName race that motivated the check in #9110 is already prevented by the serialized proxy-install step introduced in the same PR (the write lock is held across UnsyncedProxySegment::new and segment holder insertion, so no CreateVectorName can sneak into source segments between the config snapshot and the proxy wrap). The cancel check is therefore redundant for that race and actively harmful for DeleteVectorName.

# Fix
Remove the cancellation. Replace it with a debug! log and let the merge loop's natural iteration over self.vector_data (the target schema) silently drop any vector name present in a source segment but absent from the target. This is the correct and desired behavior: a segment rebuild after DeleteVectorName should prune the stale vector data.

The companion test test_segment_builder_rejects_source_with_extra_vector_name is updated to assert the new behavior: the merge succeeds, the deleted vector is absent from the output segment, and all retained vectors are intact.