### PR TITLE
fix: bound GroupsAggregator allocations by client limit and group_size (#8406)

### DIFF
--- a/lib/collection/src/grouping/aggregator.rs
+++ b/lib/collection/src/grouping/aggregator.rs
@@ -11,6 +11,11 @@ use serde_json::Value;
 
 use super::types::{AggregatorError, Group};
 
+/// Avoid excessive memory allocation and allocation failures when a client supplies a huge
+/// `limit` (number of groups) or `group_size`. Mirrors `SearchResultAggregator` and
+/// `FixedLengthPriorityQueue`. See issue #8406.
+const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
+
 type Hits = AHashMap<PointIdType, ScoredPoint>;
 pub(super) struct GroupsAggregator {
     groups: AHashMap<GroupId, Hits>,
@@ -30,14 +35,24 @@ impl GroupsAggregator {
         grouped_by: JsonPath,
         order: Option<Order>,
     ) -> Self {
+        // Cap the eagerly reserved capacity: `groups` and `group_size` come straight from the
+        // client request and are otherwise unbounded, so reserving on the raw values can abort
+        // the process (allocation failure) or trigger a capacity-overflow panic. `group_size`
+        // is multiplied with `saturating_mul` to avoid the multiply itself wrapping.
         Self {
-            groups: AHashMap::with_capacity(groups),
+            groups: AHashMap::with_capacity(groups.min(LARGEST_REASONABLE_ALLOCATION_SIZE)),
             max_group_size: group_size,
             grouped_by,
             max_groups: groups,
-            full_groups: AHashSet::with_capacity(groups),
-            group_best_scores: AHashMap::with_capacity(groups),
-            all_ids: AHashSet::with_capacity(groups * group_size),
+            full_groups: AHashSet::with_capacity(groups.min(LARGEST_REASONABLE_ALLOCATION_SIZE)),
+            group_best_scores: AHashMap::with_capacity(
+                groups.min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+            ),
+            all_ids: AHashSet::with_capacity(
+                groups
+                    .saturating_mul(group_size)
+                    .min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+            ),
             order,
         }
     }
@@ -70,10 +85,9 @@ impl GroupsAggregator {
             .map_err(|_| AggregatorError::BadKeyType)?;
 
         for group_key in unique_group_keys {
-            let group = self
-                .groups
-                .entry(group_key.clone())
-                .or_insert_with(|| AHashMap::with_capacity(self.max_group_size));
+            let group = self.groups.entry(group_key.clone()).or_insert_with(|| {
+                AHashMap::with_capacity(self.max_group_size.min(LARGEST_REASONABLE_ALLOCATION_SIZE))
+            });
 
             let entry = group.entry(point.id);
 
@@ -452,5 +466,22 @@ mod unit_tests {
             let group_id_score: Vec<_> = group.hits.into_iter().map(|x| (x.id, x.score)).collect();
             assert_eq!(expected_id_score, group_id_score);
         }
+    }
+
+    /// Regression test for issue #8406: a client-supplied huge `limit` (number of groups) and
+    /// `group_size` must not abort the process or panic through an oversized `with_capacity`
+    /// reservation, both when constructing the aggregator and when the first point creates a
+    /// per-group map.
+    #[test]
+    fn test_large_groups_and_group_size_do_not_panic() {
+        let mut aggregator = GroupsAggregator::new(
+            usize::MAX,
+            usize::MAX,
+            "docId".parse().unwrap(),
+            Some(Order::LargeBetter),
+        );
+
+        // Also exercise the per-group allocation path in `add_point`.
+        aggregator.add_point(&point(1, 0.5, json!("a"))).unwrap();
     }
 }


### PR DESCRIPTION
Fixes #8406.

Point group search reserves hash map and hash set capacity in `GroupsAggregator` directly from the request `limit` (number of groups) and `group_size`. Those fields are only validated with `min = 1` and there is no default query-limit cap, so a large value makes `with_capacity` reserve a very large table before any point is fetched. That aborts the process on allocation failure or panics with a capacity overflow instead of returning an error.

This caps each eager reservation in `GroupsAggregator` at `LARGEST_REASONABLE_ALLOCATION_SIZE` (1048576), the same constant and approach already used in `SearchResultAggregator` and `FixedLengthPriorityQueue`, and uses `saturating_mul` for the `groups * group_size` reservation so the multiply itself cannot wrap. The group and group-size limits are unchanged, so a real result set above the cap still grows on demand and legitimate queries behave exactly as before.

A previous PR (#8431) proposed the same cap but was closed before it was retargeted to `dev`. This redoes the fix on `dev` and adds a regression test that constructs the aggregator with `usize::MAX` for both parameters and adds a point.

### Commits
- [AI] fix: bound GroupsAggregator allocations by client limit and group_size (#8406)

### Disclosed initial prompt (AI assistance)
> In lib/collection/src/grouping/aggregator.rs, GroupsAggregator::new and add_point size their with_capacity reservations directly from the client-supplied number of groups (limit) and group_size, which can abort or OOM the process on huge values (issue #8406). Cap each reserved capacity at LARGEST_REASONABLE_ALLOCATION_SIZE = 1_048_576, mirroring SearchResultAggregator and FixedLengthPriorityQueue; use saturating_mul for groups * group_size; leave max_groups and max_group_size semantics unchanged; and add a regression test constructing the aggregator with usize::MAX for both and adding one point.

### All Submissions
- [x] My PR targets the `dev` branch and my branch was created from `dev`.
- [x] I have followed the guidelines in the Contributing document.
- [x] I have checked that there is no other open PR for the same change.

### Changes to Core Features
- [x] Explanation of the change is included above.
- [x] New regression test added.
- [x] Ran tests locally: `cargo test -p collection --lib grouping::aggregator` (passes), `cargo +nightly fmt --all` (clean), `cargo clippy -p collection --all-features --all-targets` (clean).
