### PR TITLE
fix: return error for missing point IDs in Query API recommend (Fixes #9390)

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -243,7 +243,7 @@ impl VectorQuery<VectorInputInternal> {
                     ids_to_vectors,
                     lookup_vector_name,
                     lookup_collection,
-                );
+                )?;
                 Ok(VectorQuery::RecommendAverageVector(RecoQuery::new(
                     positives, negatives,
                 )))
@@ -254,7 +254,7 @@ impl VectorQuery<VectorInputInternal> {
                     ids_to_vectors,
                     lookup_vector_name,
                     lookup_collection,
-                );
+                )?;
                 Ok(VectorQuery::RecommendBestScore(RecoQuery::new(
                     positives, negatives,
                 )))
@@ -265,7 +265,7 @@ impl VectorQuery<VectorInputInternal> {
                     ids_to_vectors,
                     lookup_vector_name,
                     lookup_collection,
-                );
+                )?;
                 Ok(VectorQuery::RecommendSumScores(RecoQuery::new(
                     positives, negatives,
                 )))
@@ -363,35 +363,36 @@ impl VectorQuery<VectorInputInternal> {
     }
 
     /// Resolves the references in the RecoQuery into actual vectors.
+    /// Returns an error if any referenced point ID cannot be resolved.
     fn resolve_reco_reference(
         reco_query: RecoQuery<VectorInputInternal>,
         ids_to_vectors: &ReferencedVectors,
         lookup_vector_name: &VectorName,
         lookup_collection: Option<&String>,
-    ) -> (Vec<VectorInternal>, Vec<VectorInternal>) {
-        let positives = reco_query
+    ) -> CollectionResult<(Vec<VectorInternal>, Vec<VectorInternal>)> {
+        let positives: Vec<VectorInternal> = reco_query
             .positives
             .into_iter()
-            .filter_map(|vector_input| {
+            .map(|vector_input| {
                 ids_to_vectors.resolve_reference(
                     lookup_collection,
                     lookup_vector_name,
                     vector_input,
-                )
+                ).ok_or_else(|| vector_not_found_error(lookup_vector_name))
             })
-            .collect();
-        let negatives = reco_query
+            .collect::<CollectionResult<_>>()?;
+        let negatives: Vec<VectorInternal> = reco_query
             .negatives
             .into_iter()
-            .filter_map(|vector_input| {
+            .map(|vector_input| {
                 ids_to_vectors.resolve_reference(
                     lookup_collection,
                     lookup_vector_name,
                     vector_input,
-                )
+                ).ok_or_else(|| vector_not_found_error(lookup_vector_name))
             })
-            .collect();
-        (positives, negatives)
+            .collect::<CollectionResult<_>>()?;
+        Ok((positives, negatives))
     }
 }
 


### PR DESCRIPTION
Fixes #9390

## Problem
The Query API's `/collections/{name}/points/query` endpoint with a `recommend` query silently ignores missing point IDs in `positive` or `negative` arrays, returning a successful response even when referenced points do not exist. This differs from the legacy `/points/recommend` API, which correctly rejects such requests with a `PointNotFound` error.

## Root Cause
`resolve_reco_reference()` in `collection_query.rs` used `.filter_map()` to resolve vector references. When a point ID could not be found, `ReferencedVectors.resolve_reference()` returned `None`, which was silently dropped by `filter_map` — the remaining (successfully resolved) vectors were still returned, masking the error.

All other query types (`Nearest`, `Discover`, `Context`, `Feedback`) use `.ok_or_else(|| ...)?` to propagate resolution failures as errors.

## Solution
Changed `resolve_reco_reference()` to return `CollectionResult<(Vec<VectorInternal>, Vec<VectorInternal>)>` and replaced `.filter_map()` with `.map()` + `.ok_or_else(|| vector_not_found_error(...))` + `collect::<CollectionResult<_>>()?`. This matches the error-propagation pattern used by all other query types in the same file.

## Verification
- All 3 recommend strategy variants (AverageVector, BestScore, SumScores) now propagate the error
- Follows the identical pattern established by `Discover`, `Context`, and `Feedback` in the same file
- Existing tests continue to pass
- Legacy `/points/recommend` API behavior is preserved as the reference

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-29 | Replace `filter_map` with error propagation in `resolve_reco_reference` | rtmalikian |

### Files Changed
- `lib/collection/src/operations/universal_query/collection_query.rs` — Changed `resolve_reco_reference` return type and implementation

### Verification
- The fix mirrors the `.ok_or_else()` pattern used by all other query types in `ids_into_vectors`
- Error matches the same `vector_not_found_error` function used by `Nearest`, `Discover`, `Context`, and `Feedback`

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek v4** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
