### PR TITLE
fix: bound TopK reservation by client search limit

### DIFF
--- a/lib/common/common/src/top_k.rs
+++ b/lib/common/common/src/top_k.rs
@@ -4,6 +4,9 @@ use ordered_float::Float;
 
 use crate::types::{ScoreType, ScoredPointOffset};
 
+/// Avoid excessive memory allocation and allocation failures on huge limits
+const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
+
 /// TopK implementation following the median algorithm described in
 /// <https://quickwit.io/blog/top-k-complexity>.
 ///
@@ -19,7 +22,9 @@ impl TopK {
     pub fn new(k: usize) -> Self {
         TopK {
             k,
-            elements: Vec::with_capacity(2 * k),
+            elements: Vec::with_capacity(
+                k.saturating_mul(2).min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+            ),
             threshold: ScoreType::min_value(),
         }
     }
@@ -69,6 +74,21 @@ mod test {
         assert_eq!(top_k.len(), 0);
         assert_eq!(top_k.elements.capacity(), 2 * 3);
         assert_eq!(top_k.threshold(), ScoreType::MIN);
+    }
+
+    #[test]
+    fn huge_k_does_not_allocate_unbounded() {
+        // `k` is the client-supplied search limit and flows straight into the
+        // initial reservation. Without a bound, a huge value reserves a buffer
+        // large enough to abort the process on allocation failure before any
+        // point is scored. The reservation is capped; a legitimate result set
+        // larger than the cap still grows the buffer on demand.
+        let top_k = TopK::new(usize::MAX);
+        assert_eq!(top_k.len(), 0);
+        assert_eq!(
+            top_k.elements.capacity(),
+            LARGEST_REASONABLE_ALLOCATION_SIZE
+        );
     }
 
     #[test]

--- a/lib/common/common/src/top_k.rs
+++ b/lib/common/common/src/top_k.rs
@@ -49,7 +49,7 @@ impl TopK {
         if element.score > self.threshold {
             self.elements.push(Reverse(element));
             // check if full
-            if self.elements.len() == self.k * 2 {
+            if self.elements.len() == self.k.saturating_mul(2) {
                 let (_, median_el, _) = self.elements.select_nth_unstable(self.k - 1);
                 self.threshold = median_el.0.score;
                 self.elements.truncate(self.k);
@@ -77,18 +77,25 @@ mod test {
     }
 
     #[test]
-    fn huge_k_does_not_allocate_unbounded() {
-        // `k` is the client-supplied search limit and flows straight into the
-        // initial reservation. Without a bound, a huge value reserves a buffer
-        // large enough to abort the process on allocation failure before any
-        // point is scored. The reservation is capped; a legitimate result set
-        // larger than the cap still grows the buffer on demand.
-        let top_k = TopK::new(usize::MAX);
+    fn huge_k_does_not_panic() {
+        // `k` is the client-supplied search limit. A huge value must not abort
+        // on the initial reservation (capped below), and must not overflow the
+        // `2 * k` push threshold once scoring starts.
+        let mut top_k = TopK::new(usize::MAX);
         assert_eq!(top_k.len(), 0);
         assert_eq!(
             top_k.elements.capacity(),
             LARGEST_REASONABLE_ALLOCATION_SIZE
         );
+
+        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
+        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
+        assert_eq!(top_k.len(), 2);
+
+        let res = top_k.into_vec();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].score, 2.0);
+        assert_eq!(res[1].score, 1.0);
     }
 
     #[test]


### PR DESCRIPTION
Sparse vector search reserves the `TopK` result buffer directly from the request `limit`. `TopK::new` does `Vec::with_capacity(2 * k)`, where `k` is the client-supplied limit that flows in through `SearchContext::new` with no default cap (request validation enforces only `min = 1`, and strict-mode `max_query_limit` is unset by default). A large limit makes this reserve a very large buffer before any point is scored, which aborts the process on allocation failure rather than returning an error, and the `2 * k` doubling overflows for a limit near `usize::MAX`.

This caps the reservation at `LARGEST_REASONABLE_ALLOCATION_SIZE` (1,048,576), the same constant and approach already used in `SearchResultAggregator` and `FixedLengthPriorityQueue`, and uses `saturating_mul` for the doubling so it cannot wrap. `k` itself is unchanged, so a result set larger than the cap still grows the buffer on demand and legitimate queries behave exactly as before.

This is the same eager `with_capacity`-from-limit class fixed for the dense aggregator in #4328 ("Huge limit now does not crash") and recently for random sample/scroll in #9604 and grouped search in #9610. The sparse `TopK` path was not covered by those, so it is addressed here.

### AI assistance disclosure
This change was prepared with AI assistance. Per CONTRIBUTING the commit is tagged `[AI]` and the initial prompt is disclosed below; this description was written by me.

Initial prompt:
> In lib/common/common/src/top_k.rs, TopK::new sizes its Vec::with_capacity reservation as `2 * k` directly from the client-supplied search limit `k`, which can abort or OOM the process on huge values and overflow the doubling near usize::MAX. Cap the reserved capacity at LARGEST_REASONABLE_ALLOCATION_SIZE = 1_048_576, mirroring SearchResultAggregator and FixedLengthPriorityQueue; use saturating_mul for the `2 * k` doubling; leave k unchanged; and add a regression test constructing TopK with usize::MAX.

### Checklist
- [x] Targets `dev`, branch created from `dev`
- [x] Formatted with `cargo +nightly fmt`
- [x] `cargo clippy -p common --all-features --all-targets` clean (CI runs the full workspace)
- [x] Regression test added and passing locally