### PR TITLE
fix: reject out-of-range f64 values in value_to_integer (Fixes #9584)

### DIFF
--- a/lib/segment/src/index/field_index/utils.rs
+++ b/lib/segment/src/index/field_index/utils.rs
@@ -24,9 +24,16 @@ where
 pub fn value_to_integer(value: &Value) -> Option<i64> {
     value.as_i64().or_else(|| {
         value.as_f64().and_then(|v| {
-            let int = v as i64;
-            // This covers fractions, ranges, infinity and NaN cases
-            (int as f64 == v).then_some(int)
+            // Reject NaN, infinity, and values outside i64 range.
+            // Without the range check, out-of-range f64 values saturate during
+            // the `v as i64` cast and then pass the round-trip equality test
+            // (e.g. 9223372036854775808.0 → i64::MAX → 9223372036854775808.0).
+            if v.is_finite() && v >= (i64::MIN as f64) && v < (i64::MAX as f64) {
+                let int = v as i64;
+                (int as f64 == v).then_some(int)
+            } else {
+                None
+            }
         })
     })
 }


### PR DESCRIPTION
Fixes #9584

## Problem
`value_to_integer()` in `lib/segment/src/index/field_index/utils.rs` converts f64 to i64 using `v as i64` and checks round-trip equality `(int as f64 == v)`. However, `i64::MAX as f64` rounds up to `9223372036854775808.0` (2^63), so the value `9223372036854775808.0` saturates to `i64::MAX` during the cast, then passes the round-trip check — allowing an out-of-range float to match `i64::MAX`.

This causes the non-indexed integer match path to accept values that the indexed path correctly rejects.

## Solution
Added explicit `v.is_finite() && v >= (i64::MIN as f64) && v < (i64::MAX as f64)` range checks before the cast. Out-of-range, NaN, and infinity values are now correctly rejected with `None`.

## Verification
- The fix is structurally equivalent to the CodeRabbit-reviewed version from the original PR
- The change is a single function in `utils.rs` — no other callers affected
- The strict inequality `v < (i64::MAX as f64)` correctly rejects `9223372036854775808.0`

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-30 | Recreated targeting dev branch (was #9605); fixed utils.rs only since number_to_integer was refactored out | rtmalikian |

### Files Changed
- lib/segment/src/index/field_index/utils.rs — Added f64 range boundary validation in `value_to_integer()`

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek-v4** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
