### PR TITLE
fix: unblock optimizer after deleting a named vector

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -80,6 +80,7 @@ mod tests {
                 .keys()
                 .map(|name| (name.clone(), SparseVectorOptimizerConfig { on_disk: None }))
                 .collect(),
+            live_vector_names: None,
         }
     }
 

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -70,6 +70,7 @@ mod tests {
             plain_sparse_vector_config: segment.segment_config.sparse_vector_data.clone(),
             dense_vector,
             sparse_vector: Default::default(),
+            live_vector_names: None,
         }
     }
 

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{Read, Write as _};
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::Path;
@@ -142,6 +142,22 @@ pub struct CollectionParams {
 impl CollectionParams {
     pub fn payload_storage_type(&self) -> PayloadStorageType {
         PayloadStorageType::from_on_disk_payload(self.on_disk_payload)
+    }
+
+    /// All vector names (dense and sparse) currently present in the collection schema.
+    ///
+    /// Covers both kinds because a segment's `vector_data` holds dense and sparse vectors
+    /// together; callers validating segment data against the schema (WAL-recovery name
+    /// stripping, the optimizer's live-schema read) need the full set. A dense-only set would
+    /// make a sparse vector look deleted.
+    pub fn vector_names(&self) -> HashSet<VectorNameBuf> {
+        let dense = self.vectors.params_iter().map(|(name, _)| name.to_owned());
+        let sparse = self
+            .sparse_vectors
+            .iter()
+            .flatten()
+            .map(|(name, _)| name.to_owned());
+        dense.chain(sparse).collect()
     }
 
     pub fn check_compatible(&self, other: &CollectionParams) -> CollectionResult<()> {

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
@@ -7,9 +6,7 @@ use common::types::PointOffsetType;
 use fs_err as fs;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use segment::types::{
-    HnswConfig, HnswGlobalConfig, QuantizationConfig, VectorNameBuf, VectorStorageDatatype,
-};
+use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig, VectorStorageDatatype};
 use serde::{Deserialize, Serialize};
 use shard::files::SEGMENTS_PATH;
 use shard::operations::optimization::OptimizerThresholds;
@@ -255,24 +252,6 @@ pub fn build_segment_optimizer_config(
     )
 }
 
-/// All vector names (dense and sparse) currently present in the collection schema.
-///
-/// Must cover both kinds: a segment's `vector_data` holds dense and sparse vectors together, so the
-/// optimizer merge consults this set for both. Dense-only here would make a freshly-created sparse
-/// vector look deleted and get wrongly pruned.
-fn collection_vector_names(params: &CollectionParams) -> HashSet<VectorNameBuf> {
-    let dense = params
-        .vectors
-        .params_iter()
-        .map(|(name, _)| name.to_owned());
-    let sparse = params
-        .sparse_vectors
-        .iter()
-        .flatten()
-        .map(|(name, _)| name.to_owned());
-    dense.chain(sparse).collect()
-}
-
 /// Build a [`LiveVectorNamesProvider`] that reads the collection's current vector names.
 ///
 /// The provider is invoked from the optimization worker (a `spawn_blocking` thread), so the
@@ -281,9 +260,7 @@ fn collection_vector_names(params: &CollectionParams) -> HashSet<VectorNameBuf> 
 fn live_vector_names_provider(
     collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
 ) -> LiveVectorNamesProvider {
-    LiveVectorNamesProvider::new(move || {
-        collection_vector_names(&collection_config.blocking_read().params)
-    })
+    LiveVectorNamesProvider::new(move || collection_config.blocking_read().params.vector_names())
 }
 
 pub fn build_optimizers(
@@ -357,7 +334,7 @@ mod tests {
     use crate::operations::vector_params_builder::VectorParamsBuilder;
 
     #[test]
-    fn collection_vector_names_includes_dense_and_sparse() {
+    fn live_vector_names_include_dense_and_sparse() {
         // A segment's `vector_data` holds dense and sparse vectors together, so the live set the
         // optimizer consults must enumerate both. A dense-only set would make a freshly-created
         // sparse vector look deleted and get wrongly pruned during the optimizer race.
@@ -376,7 +353,7 @@ mod tests {
             ..CollectionParams::empty()
         };
 
-        let names = collection_vector_names(&params);
+        let names = params.vector_names();
 
         assert!(
             names.contains("dense"),

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
@@ -6,24 +7,27 @@ use common::types::PointOffsetType;
 use fs_err as fs;
 use schemars::JsonSchema;
 use segment::common::anonymize::Anonymize;
-use segment::types::{HnswConfig, HnswGlobalConfig, QuantizationConfig, VectorStorageDatatype};
+use segment::types::{
+    HnswConfig, HnswGlobalConfig, QuantizationConfig, VectorNameBuf, VectorStorageDatatype,
+};
 use serde::{Deserialize, Serialize};
 use shard::files::SEGMENTS_PATH;
 use shard::operations::optimization::OptimizerThresholds;
 use shard::optimizers::config::{
     DEFAULT_DELETED_THRESHOLD, DEFAULT_VACUUM_MIN_VECTOR_NUMBER, DenseVectorOptimizerInput,
-    SegmentOptimizerConfig, SparseVectorOptimizerInput, TEMP_SEGMENTS_PATH,
-    get_deferred_points_threshold_bytes, get_indexing_threshold_kb, get_max_segment_size_kb,
-    get_number_segments,
+    LiveVectorNamesProvider, SegmentOptimizerConfig, SparseVectorOptimizerInput,
+    TEMP_SEGMENTS_PATH, get_deferred_points_threshold_bytes, get_indexing_threshold_kb,
+    get_max_segment_size_kb, get_number_segments,
 };
 use shard::optimizers::segment_optimizer::max_num_indexing_threads;
+use tokio::sync::RwLock as TokioRwLock;
 use validator::Validate;
 
 use crate::collection_manager::optimizers::config_mismatch_optimizer::ConfigMismatchOptimizer;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 use crate::collection_manager::optimizers::merge_optimizer::MergeOptimizer;
 use crate::collection_manager::optimizers::vacuum_optimizer::VacuumOptimizer;
-use crate::config::CollectionParams;
+use crate::config::{CollectionConfigInternal, CollectionParams};
 use crate::operations::config_diff::DiffConfig;
 use crate::operations::types::{SparseVectorParams, VectorParams};
 use crate::update_handler::Optimizer;
@@ -251,8 +255,40 @@ pub fn build_segment_optimizer_config(
     )
 }
 
+/// All vector names (dense and sparse) currently present in the collection schema.
+///
+/// Must cover both kinds: a segment's `vector_data` holds dense and sparse vectors together, so the
+/// optimizer merge consults this set for both. Dense-only here would make a freshly-created sparse
+/// vector look deleted and get wrongly pruned.
+fn collection_vector_names(params: &CollectionParams) -> HashSet<VectorNameBuf> {
+    let dense = params
+        .vectors
+        .params_iter()
+        .map(|(name, _)| name.to_owned());
+    let sparse = params
+        .sparse_vectors
+        .iter()
+        .flatten()
+        .map(|(name, _)| name.to_owned());
+    dense.chain(sparse).collect()
+}
+
+/// Build a [`LiveVectorNamesProvider`] that reads the collection's current vector names.
+///
+/// The provider is invoked from the optimization worker (a `spawn_blocking` thread), so the
+/// synchronous `blocking_read` is safe there. Optimizers use it to tell a deleted vector (to prune)
+/// from the CreateVectorName race (to cancel); see [`SegmentBuilder::set_live_vector_names`].
+fn live_vector_names_provider(
+    collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
+) -> LiveVectorNamesProvider {
+    LiveVectorNamesProvider::new(move || {
+        collection_vector_names(&collection_config.blocking_read().params)
+    })
+}
+
 pub fn build_optimizers(
     shard_path: &Path,
+    collection_config: Arc<TokioRwLock<CollectionConfigInternal>>,
     collection_params: &CollectionParams,
     optimizers_config: &OptimizersConfig,
     hnsw_config: &HnswConfig,
@@ -262,7 +298,8 @@ pub fn build_optimizers(
     let segments_path = shard_path.join(SEGMENTS_PATH);
     let temp_segments_path = shard_path.join(TEMP_SEGMENTS_PATH);
     let segment_config =
-        build_segment_optimizer_config(collection_params, hnsw_config, quantization_config);
+        build_segment_optimizer_config(collection_params, hnsw_config, quantization_config)
+            .with_live_vector_names(live_vector_names_provider(collection_config));
     let num_indexing_threads = max_num_indexing_threads(&segment_config);
     let threshold_config = optimizers_config.optimizer_thresholds(
         num_indexing_threads,
@@ -307,4 +344,47 @@ pub fn build_optimizers(
             hnsw_global_config.clone(),
         )),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use segment::types::Distance;
+
+    use super::*;
+    use crate::operations::types::{SparseVectorParams, VectorsConfig};
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+
+    #[test]
+    fn collection_vector_names_includes_dense_and_sparse() {
+        // A segment's `vector_data` holds dense and sparse vectors together, so the live set the
+        // optimizer consults must enumerate both. A dense-only set would make a freshly-created
+        // sparse vector look deleted and get wrongly pruned during the optimizer race.
+        let params = CollectionParams {
+            vectors: VectorsConfig::Multi(BTreeMap::from([(
+                "dense".to_owned(),
+                VectorParamsBuilder::new(4, Distance::Dot).build(),
+            )])),
+            sparse_vectors: Some(BTreeMap::from([(
+                "sparse".to_owned(),
+                SparseVectorParams {
+                    index: None,
+                    modifier: None,
+                },
+            )])),
+            ..CollectionParams::empty()
+        };
+
+        let names = collection_vector_names(&params);
+
+        assert!(
+            names.contains("dense"),
+            "dense vector name missing: {names:?}"
+        );
+        assert!(
+            names.contains("sparse"),
+            "sparse vector name missing: {names:?}",
+        );
+    }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -20,7 +20,7 @@ pub mod indexed_only;
 pub mod testing;
 mod wal_ops;
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
@@ -806,20 +806,7 @@ impl LocalShard {
         //
         // Seeded from the current config and grown as the replay re-applies `CreateVectorName`
         // operations, so a name that is created and used within the replay window stays valid.
-        let mut valid_vector_names: HashSet<_> = {
-            let params = &self.collection_config.read().await.params;
-            params
-                .vectors
-                .params_iter()
-                .map(|(name, _)| name.to_owned())
-                .chain(
-                    params
-                        .sparse_vectors
-                        .iter()
-                        .flat_map(|sparse| sparse.keys().cloned()),
-                )
-                .collect()
-        };
+        let mut valid_vector_names = self.collection_config.read().await.params.vector_names();
 
         for entry in wal.read_range(from..to) {
             let (op_num, mut update) = entry.map_err(|e| {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -490,6 +490,7 @@ impl LocalShard {
         clear_temp_segments(shard_path);
         let optimizers = build_optimizers(
             shard_path,
+            collection_config.clone(),
             &collection_config_read.params,
             &effective_optimizers_config,
             &collection_config_read.hnsw_config,
@@ -677,6 +678,7 @@ impl LocalShard {
 
         let optimizers = build_optimizers(
             shard_path,
+            collection_config.clone(),
             &config.params,
             &effective_optimizers_config,
             &config.hnsw_config,

--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -93,6 +93,7 @@ impl LocalShard {
 
         let new_optimizers = build_optimizers(
             &self.path,
+            self.collection_config.clone(),
             &config.params,
             &config.optimizer_config,
             &config.hnsw_config,

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -214,6 +214,7 @@ impl EdgeConfig {
             plain_sparse_vector_config,
             dense_vector,
             sparse_vector,
+            live_vector_names: None,
         }
     }
 

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -1,6 +1,6 @@
 //! Edge shard configuration: user-facing params and conversion to/from SegmentConfig.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use common::fs::{atomic_save_json, read_json};
@@ -175,6 +175,18 @@ impl EdgeConfig {
             sparse_vector_data,
             payload_storage_type,
         }
+    }
+
+    /// All vector names (dense and sparse) currently present in this config.
+    ///
+    /// Must cover both kinds: a segment's `vector_data` holds dense and sparse vectors together,
+    /// so the optimizer merge consults this set for both.
+    pub fn vector_names(&self) -> HashSet<VectorNameBuf> {
+        self.vectors
+            .keys()
+            .chain(self.sparse_vectors.keys())
+            .cloned()
+            .collect()
     }
 
     /// Build segment optimizer config from this config (for blocking optimizers).

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -52,7 +52,9 @@ use crate::config::shard::EDGE_CONFIG_FILE;
 #[derive(Debug)]
 pub struct EdgeShard {
     path: PathBuf,
-    config: SaveOnDisk<EdgeConfig>,
+    /// Shared so long-lived closures (e.g. the optimizer's live vector-name provider) can read the
+    /// current config after `&self` borrows expire.
+    config: Arc<SaveOnDisk<EdgeConfig>>,
     wal: Mutex<SerdeWal<CollectionUpdateOperations>>,
     segments: LockedSegmentHolder,
     /// Segment manifest (`segments/manifest.json`), kept in sync with the live segment set so a
@@ -89,8 +91,10 @@ impl EdgeShard {
         let search_pool = pool::build_search_pool(config.search_thread_count())?;
 
         let config_path = path.join(EDGE_CONFIG_FILE);
-        let config = SaveOnDisk::new(&config_path, config)
-            .map_err(|e| OperationError::service_error(e.to_string()))?;
+        let config = Arc::new(
+            SaveOnDisk::new(&config_path, config)
+                .map_err(|e| OperationError::service_error(e.to_string()))?,
+        );
 
         let segment_manifest = init_segment_manifest(path, &segments)?;
 
@@ -145,8 +149,10 @@ impl EdgeShard {
         let search_pool = pool::build_search_pool(config.search_thread_count())?;
 
         let config_path = path.join(EDGE_CONFIG_FILE);
-        let config = SaveOnDisk::new(&config_path, config)
-            .map_err(|e| OperationError::service_error(e.to_string()))?;
+        let config = Arc::new(
+            SaveOnDisk::new(&config_path, config)
+                .map_err(|e| OperationError::service_error(e.to_string()))?,
+        );
 
         let segment_manifest = init_segment_manifest(path, &segments)?;
 

--- a/lib/edge/src/optimize.rs
+++ b/lib/edge/src/optimize.rs
@@ -6,7 +6,8 @@ use common::progress_tracker::new_progress_tracker;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::HnswGlobalConfig;
 use shard::optimizers::config::{
-    DEFAULT_DELETED_THRESHOLD, DEFAULT_VACUUM_MIN_VECTOR_NUMBER, TEMP_SEGMENTS_PATH,
+    DEFAULT_DELETED_THRESHOLD, DEFAULT_VACUUM_MIN_VECTOR_NUMBER, LiveVectorNamesProvider,
+    TEMP_SEGMENTS_PATH,
 };
 use shard::optimizers::config_mismatch_optimizer::ConfigMismatchOptimizer;
 use shard::optimizers::indexing_optimizer::IndexingOptimizer;
@@ -85,7 +86,20 @@ impl EdgeShard {
         let temp_segments_path = self.path.join(TEMP_SEGMENTS_PATH);
 
         let cfg = self.config();
-        let segment_optimizer_config = cfg.segment_optimizer_config();
+        // Live read of the vector names so the merge can prune a vector deleted from the config
+        // (whose data still lingers in older segment files) instead of cancelling forever, while
+        // still cancelling on the CreateVectorName race. Safe here for the same reason as the
+        // server wiring: `update` holds the segments read guard across both the segment
+        // application and the config update, so any name a proxy-frozen source segment carries is
+        // already visible in this read. The provider uses a synchronous `parking_lot` read, fine
+        // on this blocking path.
+        let live_vector_names = {
+            let config = Arc::clone(&self.config);
+            LiveVectorNamesProvider::new(move || config.read().vector_names())
+        };
+        let segment_optimizer_config = cfg
+            .segment_optimizer_config()
+            .with_live_vector_names(live_vector_names);
         let global_hnsw_config = cfg.hnsw_config;
         let hnsw_global_config = HnswGlobalConfig::default();
         let num_indexing_threads = max_num_indexing_threads(&segment_optimizer_config);
@@ -149,10 +163,12 @@ mod tests {
     use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
     use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
     use shard::count::CountRequestInternal;
-    use shard::operations::CollectionUpdateOperations::PointOperation;
+    use shard::operations::CollectionUpdateOperations::{PointOperation, VectorNameOperation};
+    use shard::operations::VectorNameOperations;
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
     use shard::operations::point_ops::PointOperations::{DeletePoints, UpsertPoints};
     use shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
+    use shard::operations::vector_name_ops::DeleteVectorName;
     use shard::optimizers::config::default_segment_number;
     use uuid::Uuid;
 
@@ -686,6 +702,130 @@ mod tests {
         assert_points_retrievable_with_vectors(&reopened, &[251, 500, 750, 1000]);
     }
 
+    /// Regression test for the deleted-vector optimizer deadlock on edge.
+    ///
+    /// A vector name deleted from the config can still linger in older segment files: a
+    /// `DeleteVectorName` landing while a segment is proxy-frozen mid-optimization updates the
+    /// config and the proxy, but not the frozen source. This test recreates that persisted state
+    /// directly (config lacks the vector, segments still carry its data) and checks `optimize()`
+    /// prunes the stale data instead of cancelling every merge attempt (and, since edge propagates
+    /// the cancellation, erroring out of `optimize()` forever).
+    #[cfg_attr(target_os = "windows", ignore = "slow on Windows, not OS-specific")]
+    #[test]
+    fn optimize_prunes_vector_deleted_from_config() {
+        let target_count = default_segment_number() + 6;
+
+        let dir = tempfile::Builder::new()
+            .prefix("edge-opt-prune-deleted-vector")
+            .tempdir()
+            .unwrap();
+
+        let shard = EdgeShard::new(dir.path(), two_vector_config()).unwrap();
+        shard
+            .update(PointOperation(UpsertPoints(PointsList(vec![
+                two_vector_point(1),
+            ]))))
+            .unwrap();
+        drop(shard);
+
+        // Create excess segments so the merge optimizer has to rebuild them.
+        multiply_segments(dir.path(), target_count);
+
+        let reopened = EdgeShard::load(dir.path(), None).unwrap();
+
+        // Emulate the raced deletion: remove the vector from the config only, leaving its data in
+        // the on-disk segments, exactly what a mid-optimization `DeleteVectorName` leaves behind.
+        reopened
+            .config
+            .write(|cfg| {
+                cfg.vectors.remove(DROP_VECTOR_NAME);
+            })
+            .unwrap();
+
+        let optimized = reopened
+            .optimize()
+            .expect("optimize must prune the deleted vector data, not cancel the merge");
+        assert!(optimized, "excess segments should have been merged");
+
+        let info = reopened.info();
+        assert!(
+            info.segments_count <= default_segment_number() + 1,
+            "segments should be reduced after merge: got {} segments",
+            info.segments_count,
+        );
+
+        // No data loss on the surviving vector.
+        let results = reopened
+            .retrieve(
+                &[ExtendedPointId::NumId(1)],
+                Some(WithPayloadInterface::Bool(false)),
+                Some(WithVector::Bool(true)),
+            )
+            .unwrap();
+        assert_eq!(results.len(), 1, "point should survive the merge");
+        let vectors = match results[0]
+            .vector
+            .as_ref()
+            .expect("vector should be present")
+        {
+            VectorStructInternal::Named(named) => named,
+            other => panic!("expected Named vectors, got {other:?}"),
+        };
+        let keep = match vectors
+            .get(KEEP_VECTOR_NAME)
+            .expect("surviving vector should be present")
+        {
+            VectorInternal::Dense(v) => v,
+            other => panic!("expected Dense vector, got {other:?}"),
+        };
+        assert_eq!(keep, &vec![1.0], "surviving vector value mismatch");
+    }
+
+    /// The optimizers must observe vector-name deletions that land after they were built: the
+    /// live provider re-reads the config on every call rather than snapshotting it at build time.
+    /// A snapshot would wrongly prune a vector created between the snapshot and the merge.
+    #[test]
+    fn optimizers_read_live_vector_names() {
+        let dir = tempfile::Builder::new()
+            .prefix("edge-opt-live-vector-names")
+            .tempdir()
+            .unwrap();
+
+        let shard = EdgeShard::new(dir.path(), two_vector_config()).unwrap();
+        let optimizers = shard.build_blocking_optimizers();
+
+        for optimizer in &optimizers {
+            let names = optimizer
+                .segment_optimizer_config()
+                .live_vector_names()
+                .expect("live vector names must be wired into edge optimizers");
+            assert!(
+                names.contains(KEEP_VECTOR_NAME) && names.contains(DROP_VECTOR_NAME),
+                "both vector names should be live before the delete: {names:?}",
+            );
+        }
+
+        shard
+            .update(VectorNameOperation(VectorNameOperations::DeleteVectorName(
+                DeleteVectorName {
+                    vector_name: DROP_VECTOR_NAME.to_string(),
+                },
+            )))
+            .unwrap();
+
+        for optimizer in &optimizers {
+            let names = optimizer
+                .segment_optimizer_config()
+                .live_vector_names()
+                .expect("live vector names must be wired into edge optimizers");
+            assert!(names.contains(KEEP_VECTOR_NAME));
+            assert!(
+                !names.contains(DROP_VECTOR_NAME),
+                "a deletion after optimizer build must be visible to the live provider",
+            );
+        }
+    }
+
     /// Retrieve points by ID and verify each one is present with the correct
     /// vector value. Every test point was created with vector `[id as f32]`.
     fn assert_points_retrievable_with_vectors(shard: &EdgeShard, ids: &[u64]) {
@@ -746,6 +886,47 @@ mod tests {
             optimizers: Default::default(),
             wal_options: None,
             max_search_threads: None,
+        }
+    }
+
+    const KEEP_VECTOR_NAME: &str = "edge-keep-vector";
+    const DROP_VECTOR_NAME: &str = "edge-drop-vector";
+
+    /// Like [`test_config`], but with two dense vectors so one can be deleted.
+    fn two_vector_config() -> EdgeConfig {
+        let params = EdgeVectorParams {
+            size: 1,
+            distance: Distance::Dot,
+            quantization_config: None,
+            multivector_config: None,
+            datatype: None,
+            on_disk: None,
+            hnsw_config: None,
+        };
+        EdgeConfig {
+            vectors: HashMap::from([
+                (KEEP_VECTOR_NAME.to_string(), params.clone()),
+                (DROP_VECTOR_NAME.to_string(), params),
+            ]),
+            ..test_config()
+        }
+    }
+
+    /// A point populating both vectors of [`two_vector_config`]: keep = `[id]`, drop = `[-id]`.
+    fn two_vector_point(id: u64) -> PointStructPersisted {
+        PointStructPersisted {
+            id: ExtendedPointId::NumId(id),
+            vector: VectorStructPersisted::from(VectorStructInternal::Named(HashMap::from([
+                (
+                    KEEP_VECTOR_NAME.to_string(),
+                    VectorInternal::from(vec![id as f32]),
+                ),
+                (
+                    DROP_VECTOR_NAME.to_string(),
+                    VectorInternal::from(vec![-(id as f32)]),
+                ),
+            ]))),
+            payload: None,
         }
     }
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cmp;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::path::Path;
@@ -71,6 +71,13 @@ pub struct SegmentBuilder {
 
     // Payload key to defragment data to
     defragment_keys: Vec<PayloadKeyType>,
+
+    // Vector names that currently exist in the live collection schema. Used to decide what to do
+    // with a source vector name that is absent from this builder's (frozen) target schema:
+    // - present here (or `None`, i.e. unknown) => cancel the merge (the CreateVectorName race);
+    // - absent here => a previously deleted vector whose data still lingers in older segment
+    //   files, safe to prune. See the merge loop in `update`.
+    live_vector_names: Option<HashSet<VectorNameBuf>>,
 }
 
 struct VectorData {
@@ -138,11 +145,24 @@ impl SegmentBuilder {
             temp_dir,
             indexed_fields: Default::default(),
             defragment_keys: vec![],
+            live_vector_names: None,
         })
     }
 
     pub fn set_defragment_keys(&mut self, keys: Vec<PayloadKeyType>) {
         self.defragment_keys = keys;
+    }
+
+    /// Set the vector names that currently exist in the live collection schema.
+    ///
+    /// When set, [`SegmentBuilder::update`] prunes (rather than rejects) source vector names that
+    /// are absent from both the target schema and this set, i.e. vectors that were deleted from the
+    /// collection but whose data still lingers in older segment files. Source vector names that are
+    /// still present in the live schema keep cancelling the merge, since those signal the
+    /// CreateVectorName-vs-optimizer race rather than a genuine deletion. When unset, every
+    /// source-superset mismatch cancels (the conservative default).
+    pub fn set_live_vector_names(&mut self, names: HashSet<VectorNameBuf>) {
+        self.live_vector_names = Some(names);
     }
 
     pub fn remove_indexed_field(&mut self, field: &PayloadKeyType) {
@@ -322,24 +342,40 @@ impl SegmentBuilder {
 
         let vector_storages: Vec<_> = segments.iter().map(|i| &i.vector_data).collect();
 
-        // Every named vector present on any source segment must also be in the
-        // target schema. The merge loop below iterates `self.vector_data`
-        // (target) and would otherwise silently drop source vectors that
-        // aren't in target — the harm behind the optimizer-vs-CreateVectorName
-        // race: an optimizer launched with a pre-`CreateVectorName(V)` config
-        // would observe sources that gained V mid-flight and emit a merged
-        // segment without V at version >= V_opnum, breaking the next
-        // optimization round that uses the refreshed config (which has V).
+        // The merge loop below iterates `self.vector_data` (target), so any vector name present on
+        // a source segment but absent from the target schema is silently dropped. Whether that drop
+        // is correct depends on *why* the source carries a name the target lacks:
         //
-        // Use `Cancelled` rather than `ServiceError` so the optimization
-        // worker treats this as a recoverable cancellation (logged at debug,
-        // tracker marked Cancelled, no shard-level optimizer_errors set, no
-        // RED status). The follow-up `recreate_optimizers_blocking` will
-        // restart workers with a refreshed `target_config` that matches the
-        // sources, and the retry merges cleanly.
+        // - DeleteVectorName: the name was removed from the collection schema, but its data still
+        //   lives in older segment files. Pruning it on rebuild is the desired recovery.
+        // - CreateVectorName-vs-optimizer race: an optimizer launched with a pre-`CreateVectorName(V)`
+        //   config observes sources that gained V mid-flight. Dropping V here would emit a merged
+        //   segment without V at version >= V_opnum and break the next optimization round (whose
+        //   refreshed config has V). This must be cancelled and retried.
+        //
+        // We tell the two apart with the live collection schema (`live_vector_names`), which is
+        // authoritative because the schema is persisted before the op is applied to segments: a
+        // deleted name is gone from the live schema, a freshly created one is present. When the live
+        // schema is unknown (`None`) we conservatively cancel.
+        //
+        // Cancel via `Cancelled` rather than `ServiceError` so the optimization worker treats it as
+        // a recoverable cancellation (logged at debug, tracker marked Cancelled, no shard-level
+        // optimizer_errors, no RED status); the retry under the refreshed config merges cleanly.
         for vector_storage in &vector_storages {
             for source_vector_name in vector_storage.keys() {
-                if !self.vector_data.contains_key(source_vector_name) {
+                if self.vector_data.contains_key(source_vector_name) {
+                    continue;
+                }
+                let deleted_from_schema = self
+                    .live_vector_names
+                    .as_ref()
+                    .is_some_and(|live| !live.contains(source_vector_name));
+                if deleted_from_schema {
+                    log::debug!(
+                        "Dropping vector name {source_vector_name} from source segment during \
+                         optimization; it was deleted from the collection schema"
+                    );
+                } else {
                     return Err(OperationError::cancelled(format!(
                         "Cannot update from other segment because it has an extra \
                          vector name {source_vector_name} not in the target schema; \
@@ -529,6 +565,7 @@ impl SegmentBuilder {
                 temp_dir,
                 indexed_fields,
                 defragment_keys: _,
+                live_vector_names: _,
             } = self;
 
             let progress_quantization = progress_segment.subtask("quantization");

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -25,7 +25,7 @@ use segment::types::{
 };
 use serde_json::Value;
 use sparse::common::sparse_vector::SparseVector;
-use tempfile::Builder;
+use tempfile::{Builder, TempDir};
 use uuid::Uuid;
 
 use crate::fixtures::segment::{
@@ -584,21 +584,18 @@ fn test_segment_builder_rejects_target_with_extra_vector_name() {
     );
 }
 
-#[test]
-fn test_segment_builder_rejects_source_with_extra_vector_name() {
+/// Build a source segment that carries the default vector plus `extra_vector_name`, together with a
+/// target schema that lacks `extra_vector_name`. This is the shape both races produce: a source
+/// vector name absent from the optimizer's target. The returned [`TempDir`]s must be kept alive for
+/// the duration of the test.
+fn build_source_with_extra_vector(
+    extra_vector_name: &str,
+    hw_counter: &HardwareCounterCell,
+) -> (Segment, SegmentConfig, Vec<TempDir>) {
     use segment::segment_constructor::build_segment;
 
     let source_dir = Builder::new().prefix("segment_source").tempdir().unwrap();
-    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
 
-    let stopped = AtomicBool::new(false);
-    let hw_counter = HardwareCounterCell::new();
-
-    let extra_vector_name = "extra_vec";
-
-    // Build a source segment carrying both the default vector and an extra
-    // named vector — emulates a segment that received `CreateVectorName(V)`
-    // while an optimizer in flight was holding a `target_config` without V.
     let template = build_segment_1(source_dir.path());
     let mut source_config = template.segment_config.clone();
     source_config.vector_data.insert(
@@ -614,6 +611,7 @@ fn test_segment_builder_rejects_source_with_extra_vector_name() {
         },
     );
     drop(template);
+
     let source_dir2 = Builder::new().prefix("segment_source2").tempdir().unwrap();
     let (mut source, _) = build_segment(source_dir2.path(), &source_config, None, true).unwrap();
     for i in 0..3u64 {
@@ -622,13 +620,29 @@ fn test_segment_builder_rejects_source_with_extra_vector_name() {
             (extra_vector_name.to_owned(), vec![1.0, 1.0, 1.0, 1.0]),
         ]);
         source
-            .upsert_point(10 + i, (100 + i).into(), vectors, &hw_counter)
+            .upsert_point(10 + i, (100 + i).into(), vectors, hw_counter)
             .unwrap();
     }
 
-    // Target schema lacks the extra vector — the optimizer's pre-`CreateVectorName` view.
-    let mut target_config = source_config.clone();
+    // Target schema lacks the extra vector.
+    let mut target_config = source_config;
     target_config.vector_data.remove(extra_vector_name);
+
+    (source, target_config, vec![source_dir, source_dir2])
+}
+
+#[test]
+fn test_segment_builder_rejects_source_with_extra_vector_name() {
+    // Conservative default: without a live schema (`set_live_vector_names` not called), a source
+    // vector name absent from the target cancels the merge. This covers the
+    // CreateVectorName-vs-optimizer race, where dropping the vector would corrupt the next round.
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+    let extra_vector_name = "extra_vec";
+
+    let (source, target_config, _dirs) =
+        build_source_with_extra_vector(extra_vector_name, &hw_counter);
 
     let mut builder = SegmentBuilder::new(
         temp_dir.path(),
@@ -640,6 +654,80 @@ fn test_segment_builder_rejects_source_with_extra_vector_name() {
     let err = builder
         .update(&[&source], &stopped, &hw_counter)
         .expect_err("merge must reject a source carrying a vector not in target");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("extra vector name") && msg.contains(extra_vector_name),
+        "unexpected error message: {msg}",
+    );
+}
+
+#[test]
+fn test_segment_builder_drops_deleted_source_vector_name() {
+    // DeleteVectorName recovery: the extra vector is absent from the live collection schema, so the
+    // merge prunes the stale data and succeeds rather than cancelling forever.
+    let build_dir = Builder::new().prefix("segment_build").tempdir().unwrap();
+    let out_dir = Builder::new().prefix("segment_out").tempdir().unwrap();
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+    let extra_vector_name = "extra_vec";
+
+    let (source, target_config, _dirs) =
+        build_source_with_extra_vector(extra_vector_name, &hw_counter);
+
+    let mut builder = SegmentBuilder::new(
+        build_dir.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    // Live schema has only the default vector — the extra one was deleted from the collection.
+    builder.set_live_vector_names(HashSet::from([DEFAULT_VECTOR_NAME.to_owned()]));
+
+    builder
+        .update(&[&source], &stopped, &hw_counter)
+        .expect("merge should succeed by dropping the deleted source vector");
+
+    let built = builder.build_for_test(out_dir.path());
+    assert!(
+        !built.vector_data.contains_key(extra_vector_name),
+        "built segment must not contain the dropped vector {extra_vector_name}",
+    );
+    assert!(
+        built.vector_data.contains_key(DEFAULT_VECTOR_NAME),
+        "built segment must retain the default vector",
+    );
+}
+
+#[test]
+fn test_segment_builder_rejects_source_when_extra_vector_still_live() {
+    // CreateVectorName race: the extra vector is still present in the live collection schema (it was
+    // just created), only this optimizer's frozen target lags behind. Dropping it would corrupt the
+    // next round, so the merge must cancel even with a live schema set.
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+    let extra_vector_name = "extra_vec";
+
+    let (source, target_config, _dirs) =
+        build_source_with_extra_vector(extra_vector_name, &hw_counter);
+
+    let mut builder = SegmentBuilder::new(
+        temp_dir.path(),
+        &target_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    // Live schema still carries the extra vector.
+    builder.set_live_vector_names(HashSet::from([
+        DEFAULT_VECTOR_NAME.to_owned(),
+        extra_vector_name.to_owned(),
+    ]));
+
+    let err = builder
+        .update(&[&source], &stopped, &hw_counter)
+        .expect_err("merge must reject a source whose extra vector is still in the live schema");
     let msg = err.to_string();
     assert!(
         msg.contains("extra vector name") && msg.contains(extra_vector_name),

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -31,7 +31,7 @@ use segment::entry::{
 };
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::PointIdType;
+use segment::types::{PointIdType, VectorNameBuf};
 use uuid::Uuid;
 
 use crate::locked_segment::LockedSegment;
@@ -74,6 +74,14 @@ pub trait OptimizationStrategy: Send {
     /// Returns the segment together with the [`NewSegmentToken`] obliging the caller to register it
     /// in the manifest once it is published into the holder.
     fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)>;
+
+    /// Vector names currently present in the live collection schema, if a live source is wired in.
+    ///
+    /// `None` means the live schema is unknown, in which case the merge must treat a source vector
+    /// name absent from the target conservatively (cancel). When present, it lets the builder tell a
+    /// genuinely deleted vector (safe to prune) from the CreateVectorName-vs-optimizer race (must
+    /// cancel). See [`SegmentBuilder::set_live_vector_names`].
+    fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>>;
 }
 
 /// Restores original segments from proxies
@@ -256,6 +264,15 @@ fn build_new_segment<F: ?Sized + OptimizationStrategy>(
 
     if !defragmentation_keys.is_empty() {
         segment_builder.set_defragment_keys(defragmentation_keys.into_iter().collect());
+    }
+
+    // Wire in the live collection schema so the merge can distinguish a deleted vector (prune it)
+    // from the CreateVectorName race (cancel). Read here, after the proxy install froze the source
+    // segments: the schema is persisted before a vector-name op reaches the segments, so any name a
+    // frozen source carries is guaranteed visible in this read, and no concurrent create can be
+    // missed (which would otherwise cause a wrong prune).
+    if let Some(live_vector_names) = factory.live_vector_names() {
+        segment_builder.set_live_vector_names(live_vector_names);
     }
 
     {

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use segment::common::BYTES_IN_KB;
 use segment::data_types::modifier::Modifier;
@@ -30,6 +32,34 @@ pub struct SparseVectorOptimizerConfig {
     pub on_disk: Option<bool>,
 }
 
+/// Live read of the vector names currently present in the collection schema.
+///
+/// Unlike the rest of [`SegmentOptimizerConfig`], which is a frozen snapshot taken when the
+/// optimizer was built, this reads the *current* schema each time it is called. Optimization needs
+/// the live view to tell a vector name that was deleted from the collection (and should be pruned
+/// when rebuilding old segments) from one that was just created but is not yet in this optimizer's
+/// frozen target (the CreateVectorName race, which must cancel instead). Wrapped in a newtype so
+/// `SegmentOptimizerConfig` can keep deriving `Debug`.
+#[derive(Clone)]
+pub struct LiveVectorNamesProvider(Arc<dyn Fn() -> HashSet<VectorNameBuf> + Send + Sync>);
+
+impl LiveVectorNamesProvider {
+    pub fn new(read: impl Fn() -> HashSet<VectorNameBuf> + Send + Sync + 'static) -> Self {
+        Self(Arc::new(read))
+    }
+
+    pub fn get(&self) -> HashSet<VectorNameBuf> {
+        (self.0)()
+    }
+}
+
+impl fmt::Debug for LiveVectorNamesProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LiveVectorNamesProvider")
+            .finish_non_exhaustive()
+    }
+}
+
 /// This configuration contains all necessary information to build an optimized segment.
 #[derive(Debug, Clone)]
 pub struct SegmentOptimizerConfig {
@@ -44,6 +74,9 @@ pub struct SegmentOptimizerConfig {
     /// Extra configuration for sparse vectors, which _might_ be applied during optimization,
     /// depending on the segment state.
     pub sparse_vector: HashMap<VectorNameBuf, SparseVectorOptimizerConfig>,
+    /// Live read of the collection's vector names, when wired in via
+    /// [`SegmentOptimizerConfig::with_live_vector_names`]. `None` if no live source is available.
+    pub live_vector_names: Option<LiveVectorNamesProvider>,
 }
 
 impl SegmentOptimizerConfig {
@@ -125,7 +158,22 @@ impl SegmentOptimizerConfig {
             plain_sparse_vector_config,
             dense_vector,
             sparse_vector,
+            live_vector_names: None,
         }
+    }
+
+    /// Attach a live read of the collection's vector names (see [`LiveVectorNamesProvider`]).
+    #[must_use]
+    pub fn with_live_vector_names(mut self, provider: LiveVectorNamesProvider) -> Self {
+        self.live_vector_names = Some(provider);
+        self
+    }
+
+    /// The collection's current vector names, if a live source was wired in.
+    pub fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+        self.live_vector_names
+            .as_ref()
+            .map(LiveVectorNamesProvider::get)
     }
 }
 
@@ -201,4 +249,32 @@ pub fn get_deferred_points_threshold_bytes(
     (prevent_unoptimized == Some(true))
         .then(|| indexing_threshold_kb.saturating_mul(BYTES_IN_KB))
         .and_then(NonZeroUsize::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[test]
+    fn live_vector_names_provider_reads_current_state() {
+        // The provider must re-read the live source on every call rather than snapshot it once,
+        // otherwise a vector deleted (or created) after optimizer construction would be missed and
+        // the merge would make the wrong cancel/prune decision.
+        let source = Arc::new(Mutex::new(HashSet::from(["a".to_owned(), "b".to_owned()])));
+        let provider = {
+            let source = source.clone();
+            LiveVectorNamesProvider::new(move || source.lock().unwrap().clone())
+        };
+
+        assert_eq!(
+            provider.get(),
+            HashSet::from(["a".to_owned(), "b".to_owned()])
+        );
+
+        // Delete "b" from the live source: the provider must reflect it on the next read.
+        source.lock().unwrap().remove("b");
+        assert_eq!(provider.get(), HashSet::from(["a".to_owned()]));
+    }
 }

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -63,7 +63,9 @@ impl<O: SegmentOptimizer + ?Sized> OptimizationStrategy for ShardOptimizationStr
     }
 
     fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
-        self.optimizer.live_vector_names()
+        self.optimizer
+            .segment_optimizer_config()
+            .live_vector_names()
     }
 }
 
@@ -87,13 +89,6 @@ pub trait SegmentOptimizer: Sync {
 
     /// Get configuration for desired segment after optimization.
     fn segment_optimizer_config(&self) -> &SegmentOptimizerConfig;
-
-    /// Vector names currently present in the live collection schema, if a live source is wired into
-    /// the optimizer config. Used during merge to tell a deleted vector (prune) from the
-    /// CreateVectorName race (cancel); `None` means unknown and cancels conservatively.
-    fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
-        self.segment_optimizer_config().live_vector_names()
-    }
 
     /// Estimates how many indexing threads should be used for the optimization
     /// based on the configuration and available CPU cores.

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -16,7 +16,7 @@ use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{HnswGlobalConfig, Indexes, VectorStorageType};
+use segment::types::{HnswGlobalConfig, Indexes, VectorNameBuf, VectorStorageType};
 use uuid::Uuid;
 
 use super::config::SegmentOptimizerConfig;
@@ -61,6 +61,10 @@ impl<O: SegmentOptimizer + ?Sized> OptimizationStrategy for ShardOptimizationStr
     fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)> {
         self.optimizer.temp_segment(false)
     }
+
+    fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+        self.optimizer.live_vector_names()
+    }
 }
 
 /// SegmentOptimizer - trait implementing common functionality of the optimizers
@@ -83,6 +87,13 @@ pub trait SegmentOptimizer: Sync {
 
     /// Get configuration for desired segment after optimization.
     fn segment_optimizer_config(&self) -> &SegmentOptimizerConfig;
+
+    /// Vector names currently present in the live collection schema, if a live source is wired into
+    /// the optimizer config. Used during merge to tell a deleted vector (prune) from the
+    /// CreateVectorName race (cancel); `None` means unknown and cancels conservatively.
+    fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+        self.segment_optimizer_config().live_vector_names()
+    }
 
     /// Estimates how many indexing threads should be used for the optimization
     /// based on the configuration and available CPU cores.

--- a/tests/consensus_tests/test_named_vector_crud.py
+++ b/tests/consensus_tests/test_named_vector_crud.py
@@ -158,6 +158,140 @@ def test_create_vector_no_optimization(tmp_path: pathlib.Path):
         assert "new_sparse" in sparse, f"new_sparse not in sparse vectors config on {uri}"
 
 
+def update_collection_hnsw_m(peer_url, collection_name, m, timeout=30):
+    """Force a config-mismatch by changing the collection-wide HNSW `m`.
+
+    Returns immediately (wait happens via collection status); the config-mismatch
+    optimizer then rebuilds every already-indexed segment to apply the new value.
+    """
+    r = requests.patch(
+        f"{peer_url}/collections/{collection_name}?timeout={timeout}",
+        json={"hnsw_config": {"m": m}},
+    )
+    assert_http_ok(r)
+    return r.json()
+
+
+def test_delete_vector_keeps_optimizations_progressing(tmp_path: pathlib.Path):
+    """
+    Regression test for the deleted-vector optimizer deadlock.
+
+    Before the fix, deleting a named vector could permanently block the
+    config-mismatch optimizer: if a rebuilt source segment still carried the
+    deleted vector (a DeleteVectorName landing while that segment was mid-
+    optimization), `SegmentBuilder` cancelled the merge, and every retry
+    cancelled again — so no segment was ever rebuilt and any pending config
+    migration stalled forever (the collection never returns to green).
+
+    This drives a real server so the delete-vs-optimization race can occur
+    naturally. It is a stress/regression guard: it most reliably catches the
+    deadlock (the collection failing to return to green) and the data-loss
+    variant (points or the surviving vector disappearing); it also guards the
+    happy path of "delete a vector + run a config migration with data intact".
+
+    1. Create a collection with two dense vectors `keep` and `drop`, low
+       indexing threshold so segments get HNSW-indexed.
+    2. Upload points populating both, wait green.
+    3. Force a config-mismatch migration (bump HNSW `m`) and, while that
+       optimization is in flight, delete the `drop` vector — overlapping the
+       deletion with an active rebuild. Force a couple more migrations to keep
+       the optimizer churning while the schema settles.
+    4. Assert the collection returns to green (optimizations progress, not
+       stuck), all points survive, search on `keep` still works, and `drop` is
+       gone.
+    """
+    VECTOR_DIM = 32
+    N_POINTS = 1000
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    # Two dense vectors, low indexing threshold so the optimizer builds HNSW
+    # indexes — giving the config-mismatch optimizer segments to rebuild later.
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}?timeout=30",
+        json={
+            "vectors": {
+                "keep": {"size": VECTOR_DIM, "distance": "Cosine"},
+                "drop": {"size": VECTOR_DIM, "distance": "Dot"},
+            },
+            "shard_number": 1,
+            "replication_factor": 1,
+            "optimizers_config": {"indexing_threshold": 100},
+        },
+    )
+    assert_http_ok(r)
+
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris
+    )
+
+    # Upload N_POINTS points populating both vectors.
+    for i in range(N_POINTS // 100):
+        points = [
+            {
+                "id": i * 100 + j,
+                "vector": {
+                    "keep": [float((i + j + x) % 10) / 10 for x in range(VECTOR_DIM)],
+                    "drop": [float((i * j + x) % 7) / 10 for x in range(VECTOR_DIM)],
+                },
+                "payload": {"idx": i * 100 + j},
+            }
+            for j in range(100)
+        ]
+        r = requests.put(
+            f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points?wait=true",
+            json={"points": points},
+        )
+        assert_http_ok(r)
+
+    wait_collection_green(peer_api_uris[0], COLLECTION_NAME)
+    wait_collection_points_count(peer_api_uris[0], COLLECTION_NAME, N_POINTS)
+
+    # Kick off a config-mismatch rebuild of all indexed segments, then delete
+    # `drop` while that optimization is in flight — this is the race that used
+    # to wedge the optimizer forever. `wait=False` so the deletion overlaps the
+    # active rebuild rather than blocking until it has fully drained.
+    update_collection_hnsw_m(peer_api_uris[0], COLLECTION_NAME, 32)
+    delete_vector_name(peer_api_uris[0], COLLECTION_NAME, "drop", wait=False)
+
+    # Keep forcing fresh config mismatches so the optimizer must repeatedly
+    # rebuild the (now `drop`-less in schema) segments. Pre-fix, any segment
+    # still carrying `drop` would cancel each round and never converge.
+    update_collection_hnsw_m(peer_api_uris[0], COLLECTION_NAME, 48)
+    update_collection_hnsw_m(peer_api_uris[0], COLLECTION_NAME, 16)
+
+    # Key assertion: optimizations make progress and the collection returns to
+    # green. If the deleted-vector deadlock regresses, this times out.
+    wait_collection_green(peer_api_uris[0], COLLECTION_NAME)
+
+    # No data loss: every point still present.
+    wait_collection_points_count(peer_api_uris[0], COLLECTION_NAME, N_POINTS)
+
+    # `drop` is gone from the schema on all peers; `keep` remains.
+    for uri in peer_api_uris:
+        wait_for(
+            lambda u=uri: "drop" not in get_collection_vectors_config(u, COLLECTION_NAME)
+        )
+        vectors = get_collection_vectors_config(uri, COLLECTION_NAME)
+        assert "keep" in vectors, f"keep vector missing on {uri}"
+
+    # Search on the surviving vector still works.
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/search",
+        json={"vector": {"name": "keep", "vector": [0.1] * VECTOR_DIM}, "limit": 5},
+    )
+    assert_http_ok(r)
+    assert len(r.json()["result"]) > 0, "search on surviving vector returned nothing"
+
+    # Searching the deleted vector must fail (it no longer exists).
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/points/search",
+        json={"vector": {"name": "drop", "vector": [0.1] * VECTOR_DIM}, "limit": 5},
+    )
+    assert r.status_code != 200, "search on deleted vector should fail"
+
+
 def test_vector_crud_with_consensus_snapshot(tmp_path: pathlib.Path):
     """
     Test that named vector create/delete survives consensus snapshot recovery.


### PR DESCRIPTION
## Problem

Deleting a named vector can permanently block the optimizer.

When you call `DELETE /collections/{name}/vectors/{vector_name}`, the schema updates right away. The old segment files still hold the deleted vector until the optimizer rebuilds them.

PR #9110 added a safety check to `SegmentBuilder::update`. If a source segment has a vector name that is not in the target schema, the merge is cancelled. This protects the `CreateVectorName` race, where an in-flight optimizer would otherwise drop a freshly created vector.

The same check breaks the delete case. After a delete, the optimizer keeps seeing the leftover vector in old segments and cancels every time. The rebuild never succeeds. Any other pending config migration is blocked too, and `fail_count` climbs without bound.

## Why not just remove the check

Removing the check fixes delete but brings back data loss. During the `CreateVectorName` race, a freshly created vector could be silently dropped. From a segment alone, the two cases look identical.

## Fix

Use the live collection schema to tell the two cases apart.

For a source vector name that is missing from the optimizer target:

- If it is still in the live schema, it was just created. Cancel and retry.
- If it is gone from the live schema, it was deleted. Prune the stale data.

This is safe. The schema is always persisted before the op is applied to segments. The optimizer reads the live schema after the source segments are frozen by the proxy install. So a freshly created vector is always visible in that read and is never pruned by mistake.

The live set covers both dense and sparse vectors, because a segment stores both kinds together.

## Changes

- `SegmentBuilder` gains an optional live-schema set. The merge loop uses it to choose cancel vs prune.
- The live schema is wired from the collection config down to the optimizer through a small provider. The dense plus sparse name enumeration is shared with WAL recovery via `CollectionParams::vector_names`, so the two sets cannot drift.
- The edge crate wires the same provider from its own shard config (now shared behind an `Arc`). Edge was hit even harder by the deadlock: it propagates the cancellation as a hard error out of `optimize()`. The same safety argument holds there because `update` keeps the segments read guard across both the segment application and the config update.
- When no live source is wired in, the old conservative behavior (always cancel) is kept.

## Tests

- Unit tests for the three branches: cancel by default, prune when deleted, cancel when still live.
- Unit tests for the provider (it re-reads the live schema each call) and for dense plus sparse enumeration.
- A consensus test that deletes a vector during an active optimization and checks the collection returns to green with no data loss.
- Edge tests: a regression test that recreates the stale post-delete state (config without the vector, segments still carrying its data) and checks `optimize()` prunes it instead of failing, and a test that a delete landing after the optimizers were built is visible to the live provider (a build-time snapshot would fail it).

The "cancel when still live" unit test is the one that fails on the alternative approach in #9609.

## Relation to #9609

This is an alternative to #9609. It reaches the same goal, deleting a vector no longer blocks optimization, without the data-loss side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
