### PR TITLE
[UIO] Simplify `DiskCache::read_whole`

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -163,43 +163,21 @@ where
         Ok(State { remote, local })
     }
 
-    /// Fill the local mirror from one whole-object read when the cache is cold
-    /// (`InitSource::FromScratch`); other init sources fall back to the normal
-    /// initialization.
-    pub(super) fn ensure_whole_local(&self) -> Result<()> {
-        if self.state.get().is_some() {
-            return Ok(());
+    /// Set up [`InitSource::Prefiller`] when the cache is cold
+    /// (not initialized and `InitSource::FromScratch`)
+    pub(super) fn prefill_if_uninit(&self) -> Result<()> {
+        if self.state.get().is_none() {
+            let mut init_guard = self.init_lock.lock();
+            if self.state.get().is_none() {
+                // Cold cache: use the remote's `schedule_whole` to prevent an
+                // additional `len` call to remote.
+                if matches!(&*init_guard, InitSource::FromScratch) {
+                    let mut pipeline = OwnedPipeline::new(self.open_remote()?)?;
+                    pipeline.schedule_whole((), 0)?;
+                    *init_guard = InitSource::Prefiller(pipeline);
+                }
+            }
         }
-
-        let mut init_guard = self.init_lock.lock();
-        if self.state.get().is_some() {
-            return Ok(());
-        }
-
-        // Only a cold cache (`FromScratch`) gets the dedicated whole-object fill
-        // below. If a prefill is already in flight (eager populate, or a reopen
-        // tail read), resolve it through the normal initialization path instead.
-        let from_scratch = match &*init_guard {
-            InitSource::FromScratch => true,
-            InitSource::Prefiller(_) => false,
-            InitSource::PartialPrefiller { .. } => false,
-        };
-        if !from_scratch {
-            return self.init_state(&mut init_guard, true);
-        }
-
-        let remote = self.open_remote()?;
-        let bytes = remote.read_whole::<u8>()?;
-        let len = bytes.len() as u64;
-        let local = LocalState::new(&self.local_path, len, self.open_options)?;
-        if len > 0 {
-            // SAFETY: `bytes` covers the whole file `0..len` and the remote is
-            // immutable, so the mmap is filled exactly once with correct data.
-            unsafe { local.write_mmap_bytes(&bytes, to_block_range(0..len)) };
-        }
-        self.state
-            .set(State { remote, local })
-            .expect("OnceLock::set must succeed while holding init_lock");
 
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -66,7 +66,7 @@ where
     }
 
     fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
-        self.ensure_whole_local()?;
+        self.prefill_if_uninit()?;
         let length = self.len::<T>()?;
         self.read::<Sequential, T>(ReadRange {
             byte_offset: 0,


### PR DESCRIPTION
Simplify the implementation by relying on the existing initialization logic when prefilling for `read_whole`.