### PR TITLE
feat(snapshots): set S3 user-agent on snapshot uploads

### DIFF
--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -5,8 +5,8 @@ use common::tempfile_ext::MaybeTempPath;
 use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use http::HeaderValue;
-use object_store::ClientOptions;
 use object_store::aws::AmazonS3Builder;
+use object_store::{ClientOptions, ObjectStoreExt};
 use serde::Deserialize;
 use tempfile::TempPath;
 use tokio::io::AsyncWriteExt;
@@ -483,14 +483,12 @@ impl SnapshotStorageCloud {
     ) -> CollectionResult<SnapshotStream> {
         let snapshot_path = snapshot_storage_ops::trim_dot_slash(snapshot_path)?;
         #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
-        let download = object_store::ObjectStoreExt::get(self.client.as_ref(), &snapshot_path)
-            .await
-            .map_err(|e| match e {
-                object_store::Error::NotFound { path, source } => {
-                    CollectionError::not_found(format!("Snapshot {path} does not exist: {source}"))
-                }
-                _ => CollectionError::service_error(format!("Failed to get {snapshot_path}: {e}")),
-            })?;
+        let download = self.client.get(&snapshot_path).await.map_err(|e| match e {
+            object_store::Error::NotFound { path, source } => {
+                CollectionError::not_found(format!("Snapshot {path} does not exist: {source}"))
+            }
+            _ => CollectionError::service_error(format!("Failed to get {snapshot_path}: {e}")),
+        })?;
         Ok(SnapshotStream::new_stream(download.into_stream(), None))
     }
 }

--- a/lib/collection/src/common/snapshots_manager.rs
+++ b/lib/collection/src/common/snapshots_manager.rs
@@ -1,9 +1,11 @@
 use std::path::{Path, PathBuf};
 
+use common::defaults::APP_USER_AGENT;
 use common::tempfile_ext::MaybeTempPath;
 use fs_err as fs;
 use fs_err::tokio as tokio_fs;
-use object_store::ObjectStoreExt;
+use http::HeaderValue;
+use object_store::ClientOptions;
 use object_store::aws::AmazonS3Builder;
 use serde::Deserialize;
 use tempfile::TempPath;
@@ -57,6 +59,10 @@ pub enum SnapshotStorageManager {
 }
 
 impl SnapshotStorageManager {
+    /// Create a snapshot storage manager from the configured backend.
+    ///
+    /// S3-compatible storage clients identify themselves with the Qdrant user
+    /// agent so object-store providers can attribute snapshot traffic.
     pub fn new(snapshots_config: &SnapshotsConfig) -> CollectionResult<Self> {
         match snapshots_config.snapshots_storage {
             SnapshotsStorageConfig::Local => {
@@ -64,6 +70,11 @@ impl SnapshotStorageManager {
             }
             SnapshotsStorageConfig::S3 => {
                 let mut builder = AmazonS3Builder::from_env();
+                // Identify Qdrant to Amazon S3 and other S3-compatible backends.
+                if let Ok(user_agent) = HeaderValue::from_str(APP_USER_AGENT.as_str()) {
+                    builder = builder
+                        .with_client_options(ClientOptions::new().with_user_agent(user_agent));
+                }
                 if let Some(s3_config) = &snapshots_config.s3_config {
                     builder = builder.with_bucket_name(&s3_config.bucket);
 
@@ -472,12 +483,14 @@ impl SnapshotStorageCloud {
     ) -> CollectionResult<SnapshotStream> {
         let snapshot_path = snapshot_storage_ops::trim_dot_slash(snapshot_path)?;
         #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
-        let download = self.client.get(&snapshot_path).await.map_err(|e| match e {
-            object_store::Error::NotFound { path, source } => {
-                CollectionError::not_found(format!("Snapshot {path} does not exist: {source}"))
-            }
-            _ => CollectionError::service_error(format!("Failed to get {snapshot_path}: {e}")),
-        })?;
+        let download = object_store::ObjectStoreExt::get(self.client.as_ref(), &snapshot_path)
+            .await
+            .map_err(|e| match e {
+                object_store::Error::NotFound { path, source } => {
+                    CollectionError::not_found(format!("Snapshot {path} does not exist: {source}"))
+                }
+                _ => CollectionError::service_error(format!("Failed to get {snapshot_path}: {e}")),
+            })?;
         Ok(SnapshotStream::new_stream(download.into_stream(), None))
     }
 }


### PR DESCRIPTION
## Summary

When Qdrant stores snapshots in S3-compatible object storage, the S3 client currently sends requests without a user-agent that identifies Qdrant. Every other outbound HTTP client in Qdrant (telemetry, error reporting, the shared `http_client`, and inference) already sets `APP_USER_AGENT` (`Qdrant/<version>`). This change extends that same convention to the snapshot S3 client so requests to Amazon S3 and any other S3-compatible backend (for example Backblaze B2, Cloudflare R2, or MinIO) carry a `User-Agent: Qdrant/<version>` header.

The change is minimal and additive: 8 lines in one file (`lib/collection/src/common/snapshots_manager.rs`), no config surface, no behavior change to the upload logic itself.

## Motivation

Object storage providers surface the client user-agent in request logs and analytics. A stable `Qdrant/<version>` string lets operators and providers attribute snapshot traffic to Qdrant instead of an anonymous `object_store`/`reqwest` default, which helps with debugging, support, and capacity planning on the storage side. The value reuses the existing `common::defaults::APP_USER_AGENT` constant, so it stays in lockstep with the crate version and matches the header Qdrant already sends elsewhere. It is vendor-neutral: it names Qdrant and its version, nothing provider-specific.

## What changed

- In `SnapshotStorageManager::new`, for the `S3` storage config, set a user-agent on the `AmazonS3Builder` via `ClientOptions::with_user_agent`, using `APP_USER_AGENT`.
- The header is applied only when it parses as a valid `HeaderValue` (`if let Ok(...)`), so a malformed value can never break snapshot uploads. This mirrors the fallible-but-non-fatal pattern used for the other clients.
- No new dependencies: `object_store::ClientOptions` and `http::HeaderValue` are already in the dependency tree.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? (see Summary and Motivation above)
* [ ] Have you written new tests for your core changes, as applicable? (see Testing note below)
* [x] Have you successfully ran tests with your changes locally?

## Testing

- `cargo +nightly fmt --all`
- `cargo clippy --workspace --all-features`
- Built the `collection` crate and ran its existing test suite locally; the snapshot storage manager continues to build and pass.

I did not add a dedicated unit test. The header is set through the `object_store` builder and is not exposed on the resulting `ObjectStore` trait object, so asserting on it would require intercepting outbound HTTP, which the existing snapshot tests do not do. I verified the header on the wire manually against an S3-compatible endpoint (observed `User-Agent: Qdrant/<version>` in the request log). Happy to add coverage if you would prefer a specific approach, for example a small helper that returns the configured `ClientOptions` so it can be asserted directly.

## AI assistance disclosure

Per the Contributing guide's "Contributing with AI" section: this PR description was written by me. An AI coding assistant was used to help locate where the S3 client is constructed and to draft the one-file diff; I reviewed the change, confirmed it follows the existing `APP_USER_AGENT` usage, and ran the checks above. There is a single commit, and it is the AI-assisted change:

- [AI] feat(snapshots): set S3 user-agent on snapshot uploads

The original intent given to the tool: "In the S3 snapshot storage path, set the Qdrant user-agent (the existing `APP_USER_AGENT`) on the `object_store` S3 client, the same way the other HTTP clients do, without changing any other behavior."
