### PR TITLE
fix(optimizer): graceful OOD handling — skip instead of panic when disk is full

### DIFF
--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -737,7 +737,12 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
         return Ok(OptimizationResult { points_count: 0 });
     }
 
-    check_segments_size(optimizer_name, &input_segments, &paths.temp_path)?;
+    // Check disk space before starting optimization.
+    // If not enough space, skip optimization gracefully instead of failing.
+    if let Err(err) = check_segments_size(optimizer_name, &input_segments, &paths.temp_path) {
+        log::warn!("Skipping optimization due to insufficient disk space: {err}");
+        return Ok(OptimizationResult { points_count: 0 });
+    }
 
     check_process_stopped(stopped)?;
 


### PR DESCRIPTION
/claim #4297

## Problem
When the optimizer runs and there is not enough disk space to create a temporary segment, the current implementation propagates the error via `?` which causes the optimization to fail ungracefully. In the worst case, this leads to a panic (e.g. in `optimize_for_test` which calls `.unwrap()`).

## Solution
Changed `execute_optimization` to handle the disk space check result gracefully:
- Instead of `check_segments_size(...)?;` (which propagates the error), we now match on the result
- If disk space is insufficient, we log a warning and return `Ok(OptimizationResult { points_count: 0 })` — effectively skipping the optimization
- The rest of the system continues normally without crashing

This matches the existing pattern used for `all_segments_ok` check (line 736-738).

## Testing
- `cargo check -p shard` passes
- The change is minimal and follows existing code patterns for graceful degradation

Closes #4297