### PR TITLE
fix: improve OOD error message in shard_ops — clarify disk full vs service error

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -77,7 +77,9 @@ impl LocalShard {
             .unwrap_or(false)
         {
             return Err(CollectionError::service_error(
-                "No space left on device: WAL buffer size exceeds available disk space".to_string(),
+                "No space left on device: WAL buffer size exceeds available disk space. \
+                 Free up disk space or increase storage capacity to continue updating. \
+                 Search queries are still available.".to_string(),
             ));
         }
 


### PR DESCRIPTION
/claim #4108

## Problem
When the disk is full, the error message was generic: "No space left on device: WAL buffer size exceeds available disk space". Users could not tell if this was a transient service error or a real disk-full situation.

## Solution
Improved the error message to clarify:
1. This is a disk-full condition, not a service error
2. Freeing up disk space or increasing storage capacity will resolve it
3. Search queries are still available (only updates are blocked)

## Related
- #4108 Handle Out-Of-Disk gracefully
- #9645 (prevents panic in optimizer on OOD)
- DiskUsageWatcher already protects the update pipeline before WAL writes

Closes #4108
