### PR TITLE
ci: fix edge-py-release version rewrite (SemVer, not PEP 440)

### DIFF
--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -52,23 +52,26 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set pre-release version
-        # Bump the patch component and append a `.dev<run_number>` suffix so
-        # the dev version sorts strictly ABOVE the latest published stable
-        # (e.g. Cargo.toml `0.7.2` -> wheel `0.7.3.dev137`). Combined with
-        # `pip install --pre`, this lets consumers pull "the current dev"
-        # without knowing the run number, and prevents pip from silently
-        # preferring the older stable release when both are visible.
+        # Bump the patch component and append a `-dev<run_number>` SemVer
+        # pre-release suffix so the dev version sorts strictly ABOVE the
+        # latest published stable (e.g. Cargo.toml `0.7.2` -> Cargo.toml
+        # `0.7.3-dev137` -> wheel `0.7.3.dev137`). Cargo rejects PEP 440
+        # syntax `.dev` because it isn't valid SemVer, so we write SemVer
+        # here and let maturin translate to PEP 440 when building the wheel.
+        # Combined with `pip install --pre`, this lets consumers pull "the
+        # current dev" without knowing the run number, and prevents pip
+        # from silently preferring the older stable release.
         if: github.event_name == 'push'
         shell: bash
         working-directory: lib/edge/python
         run: |
           awk -v run="${GITHUB_RUN_NUMBER}" '
             !patched && /^version = "/ {
-              # Assumes SemVer X.Y.Z inside the quotes; bump patch, append .devN.
+              # Assumes SemVer X.Y.Z inside the quotes; bump patch, append -devN.
               split($0, quoted, "\"")
               split(quoted[2], parts, ".")
               parts[3] = parts[3] + 1
-              print "version = \"" parts[1] "." parts[2] "." parts[3] ".dev" run "\""
+              print "version = \"" parts[1] "." parts[2] "." parts[3] "-dev" run "\""
               patched = 1
               next
             }


### PR DESCRIPTION
## Summary

Fixes the failing CI run on `dev` after #9647 merged: <https://github.com/qdrant/qdrant/actions/runs/28508449063>.

The version-rewrite step in `edge-py-release.yml` was writing PEP 440 syntax `0.7.3.dev<N>` into `Cargo.toml`, which Cargo rejects because it isn't valid SemVer:

```
error: unexpected character '.' after patch version number
 --> Cargo.toml:3:11
  |
3 | version = "0.7.3.dev54"
  |           ^^^^^^^^^^^^^
```

Cargo requires SemVer pre-release syntax (hyphen: `-devN`); PEP 440 uses period (`.devN`). maturin already translates SemVer pre-release identifiers to their PEP 440 equivalents when producing the wheel, so writing `0.7.3-dev137` to `Cargo.toml` results in the wheel filename `qdrant_edge_py-0.7.3.dev137-*.whl` — exactly the intent of the original change.

The awk step is now a one-character edit: `".dev"` → `"-dev"`.

## Verification

Locally reproduced with `Cargo.toml` at `0.7.3-dev54` and `maturin sdist`:

```
Built source distribution to /tmp/maturin-test/qdrant_edge_py-0.7.3.dev54.tar.gz
```

The published PEP 440 version is unchanged from what was intended in #9647.

## Test plan

- [ ] Merge, observe the auto-triggered run on `dev` complete without the "unexpected character '.'" error.
- [ ] Confirm wheels appear at `gs://qdrant-debug/edge-py-dev/wheels/` with filenames of the form `qdrant_edge_py-0.7.3.dev<N>-...whl`.
- [ ] From a fresh venv, verify `pip install --find-links <index-url> qdrant-edge-py --pre` picks the current dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)