### PR TITLE
ci: also bump patch + use SemVer -dev on macOS and Windows

### DIFF
--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -123,12 +123,21 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set pre-release version
+        # See the identical step on the Linux job for the rationale (SemVer
+        # `-dev<N>` + patch bump so maturin emits PEP 440 `X.Y.(Z+1).dev<N>`).
         if: github.event_name == 'push'
         shell: bash
         working-directory: lib/edge/python
         run: |
           awk -v run="${GITHUB_RUN_NUMBER}" '
-            !patched && /^version = "/ { sub(/"$/, ".dev" run "\""); patched = 1 }
+            !patched && /^version = "/ {
+              split($0, quoted, "\"")
+              split(quoted[2], parts, ".")
+              parts[3] = parts[3] + 1
+              print "version = \"" parts[1] "." parts[2] "." parts[3] "-dev" run "\""
+              patched = 1
+              next
+            }
             { print }
           ' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
@@ -176,12 +185,21 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set pre-release version
+        # See the identical step on the Linux job for the rationale (SemVer
+        # `-dev<N>` + patch bump so maturin emits PEP 440 `X.Y.(Z+1).dev<N>`).
         if: github.event_name == 'push'
         shell: bash
         working-directory: lib/edge/python
         run: |
           awk -v run="${GITHUB_RUN_NUMBER}" '
-            !patched && /^version = "/ { sub(/"$/, ".dev" run "\""); patched = 1 }
+            !patched && /^version = "/ {
+              split($0, quoted, "\"")
+              split(quoted[2], parts, ".")
+              parts[3] = parts[3] + 1
+              print "version = \"" parts[1] "." parts[2] "." parts[3] "-dev" run "\""
+              patched = 1
+              next
+            }
             { print }
           ' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml


### PR DESCRIPTION
## Summary

Follow-up fix. #9648 corrected the Linux job's version-rewrite step but left the macOS and Windows blocks untouched, so the auto-triggered publish after that merge failed on both non-Linux runners: <https://github.com/qdrant/qdrant/actions/runs/28509950366>.

The macOS and Windows jobs were still writing `version = "0.7.2.dev55"` — the pre-#9648 form (PEP 440 `.dev`, no patch bump), so Cargo rejected the manifest with the same error #9648 was meant to fix:

```
error: unexpected character '.' after patch version number
 --> Cargo.toml:3:11
  |
3 | version = "0.7.2.dev55"
  |           ^^^^^^^^^^^^^
```

### Root cause of the miss

My previous `replace_all` edit matched a step that included a longer explanatory comment that only the Linux block ever had. macOS and Windows blocks had a shorter form that didn't match the search string, so they were silently skipped.

## Fix

Bring both blocks in line with Linux: patch-component bump and SemVer `-dev<run_number>` suffix, so maturin emits PEP 440 `X.Y.(Z+1).dev<N>` for the wheel.

## Verification

- `grep -c 'parts\[3\] = parts\[3\] + 1'` on the workflow now returns 3 (Linux + macOS + Windows).
- `grep -c 'sub(/"$/, ".dev"'` returns 0 (no leftovers of the old awk).

## Test plan

- [ ] Merge, watch the auto-triggered dev run complete on all three OSes (`edge-py-linux`, `edge-py-macos`, `edge-py-windows`).
- [ ] Confirm wheels appear at `gs://qdrant-debug/edge-py-dev/wheels/` for every matrix combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)