### PR TITLE
[DiskCache] refactor State into single enum

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -29,12 +29,10 @@ where
         }
 
         // SAFETY: self.ready tracks whether `state` is `State::Ready`, to make reads "lock-free".
-        match unsafe { &*self.state.data_ptr() } {
-            State::Ready { remote, local } => Ok(ReadyRef { remote, local }),
-            State::Uninit | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => {
-                unreachable!("the `ready` flag guarantees the `Ready` variant")
-            }
-        }
+        let State::Ready { remote, local } = (unsafe { &*self.state.data_ptr() }) else {
+            unreachable!("the `ready` flag guarantees the `Ready` variant")
+        };
+        Ok(ReadyRef { remote, local })
     }
 
     /// Whether the local mirror has been materialized. Cheap, lock-free; lets
@@ -60,10 +58,8 @@ where
             State::ReopenPrefill { pipeline, local } => {
                 self.init_from_reopen_prefill(pipeline, local)?
             }
-            // `state` and `ready` are published together under this lock, so the
-            // `!ready` we just observed rules out `Ready`.
             State::Ready { .. } => {
-                unreachable!("`!ready` under the lock rules out the `Ready` variant")
+                unreachable!("We just observed `!ready` while holding the mutex lock")
             }
         };
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -136,7 +136,7 @@ where
         }
 
         let mut state = self.state.lock();
-        if matches!(&*state, State::Uninit) {
+        if state.is_uninit() {
             // Use the remote's `schedule_whole` to avoid an extra `len` call.
             let mut pipeline = OwnedPipeline::new(self.open_remote()?)?;
             pipeline.schedule_whole((), 0)?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -1,182 +1,150 @@
 //! Lazy first-use initialization of a [`DiskCache`]'s [`State`].
-//!
-//! A freshly opened `DiskCache` has no [`State`] yet — only an [`InitSource`]
-//! describing *how* the local mirror should be brought to life. The first
-//! operation that actually needs the mirror ([`DiskCache::state`], or an
-//! explicit prefill from [`super::reopen`]) takes `init_lock` and runs
-//! [`DiskCache::init_state`] exactly once, consuming the `InitSource` and
-//! publishing a populated `State` into the `OnceLock`.
+
+use std::sync::atomic::Ordering;
 
 use super::{DiskCache, State};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
-use crate::universal_io::{OwnedPipeline, Result, UniversalRead};
+use crate::universal_io::{OwnedPipeline, Result};
 
-/// Where a [`DiskCache`]'s [`State`] comes from the first time it is needed.
+/// A borrowed view of a materialized [`State::Ready`]: the live `remote` handle
+/// paired with its local mmap mirror.
 ///
-/// `FromScratch` is *lazy*: it needs only the remote's **length** and faults
-/// blocks in on demand. `Prefiller` is *eager*: it holds an in-flight whole-object
-/// read and fills the mirror from those **bytes** at once.
-///
-/// ```text
-/// Populate::No | Auto    →  FromScratch          →  remote.len(); empty mmap; blocks faulted in on read
-/// Populate::Blocking|Pref →  Prefiller(pipeline) →  pipeline.wait(); mmap sized to bytes; all written
-/// ```
-pub(crate) enum InitSource<R>
-where
-    R: UniversalRead + 'static,
-{
-    /// Lazy: build an empty local mmap (sized from the remote length) and let
-    /// reads fill blocks on demand. Chosen for `Populate::No` / `Populate::Auto`.
-    FromScratch,
-    /// Eager: an in-flight whole-object read scheduled at open time; init waits
-    /// on it and writes the whole mirror. For `Populate::Blocking` / `PreferBackground`.
-    Prefiller(OwnedPipeline<R, ()>),
-    /// The reopen-time counterpart of [`Prefiller`](Self::Prefiller): an in-flight
-    /// read of just the appended tail (block-aligned old length → new EOF). Init
-    /// resizes the mirror and writes only that suffix. See [`super::reopen`].
-    PartialPrefiller {
-        prefiller: OwnedPipeline<R, u64>,
-        local_state: LocalState,
-    },
-}
-
-impl<R> std::fmt::Debug for InitSource<R>
-where
-    R: UniversalRead,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InitSource::FromScratch => write!(f, "FromScratch"),
-            InitSource::Prefiller(_) => write!(f, "Prefiller"),
-            InitSource::PartialPrefiller { .. } => write!(f, "PartialPrefiller"),
-        }
-    }
+/// Both references are valid for as long as the borrow of the `DiskCache` that
+/// produced them — see [`DiskCache::state`] for why that holds even though the
+/// backing enum lives behind a lock.
+pub(crate) struct ReadyRef<'a, R> {
+    pub remote: &'a R,
+    pub local: &'a LocalState,
 }
 
 impl<R> DiskCache<R>
 where
     R: DiskCacheRemote,
 {
-    /// Return the cached [`State`], initializing it on first call.
-    pub(crate) fn state(&self) -> Result<&State<R>> {
-        if let Some(state) = self.state.get() {
-            return Ok(state);
+    /// Return the materialized [`State::Ready`], initializing it on first call.
+    pub(crate) fn state(&self) -> Result<ReadyRef<'_, R>> {
+        if !self.is_ready() {
+            self.init_state()?;
         }
 
-        let mut init_guard = self.init_lock.lock();
-
-        // Try again now that we have the lock, in case another thread initialized it first.
-        if self.state.get().is_none() {
-            self.init_state(&mut init_guard, true)?;
+        // SAFETY: self.ready tracks whether `state` is `State::Ready`, to make reads "lock-free".
+        match unsafe { &*self.state.data_ptr() } {
+            State::Ready { remote, local } => Ok(ReadyRef { remote, local }),
+            State::Uninit | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => {
+                unreachable!("the `ready` flag guarantees the `Ready` variant")
+            }
         }
-
-        Ok(self.state.get().expect("just initialized"))
     }
 
-    /// Initialize the local state depending on `InitSource`
-    ///
-    /// If `allow_from_scratch` is false, this method will avoid initializing if `InitSource::FromScratch` is set.
-    /// This is helpful for [`Self::reopen`] scenario where we can avoid work if no reads have taken place.
-    pub(crate) fn init_state(
-        &self,
-        init_guard: &mut InitSource<R>,
-        allow_from_scratch: bool,
-    ) -> Result<()> {
-        let state = match std::mem::replace(init_guard, InitSource::FromScratch) {
-            InitSource::FromScratch => {
-                if !allow_from_scratch {
-                    return Ok(());
-                }
-                self.new_state_from_scratch(self.open_remote()?)?
+    /// Whether the local mirror has been materialized. Cheap, lock-free; lets
+    /// callers act on an already-live mirror without forcing initialization.
+    pub(crate) fn is_ready(&self) -> bool {
+        self.is_ready.load(Ordering::Acquire)
+    }
+
+    /// Drive `state` to [`State::Ready`] under the lock, consuming whichever
+    /// pre-init variant is staged. Idempotent: a no-op once `ready` is set.
+    pub(super) fn init_state(&self) -> Result<()> {
+        let mut state = self.state.lock();
+
+        // Another thread may have materialized while we waited for the lock.
+        // Prevent using `mem::replace` if it is already initialized.
+        if self.is_ready() {
+            return Ok(());
+        }
+
+        let (remote, local) = match std::mem::replace(&mut *state, State::Uninit) {
+            State::Uninit => self.init_from_scratch(self.open_remote()?)?,
+            State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
+            State::ReopenPrefill { pipeline, local } => {
+                self.init_from_reopen_prefill(pipeline, local)?
             }
-            InitSource::Prefiller(mut prefiller) => {
-                match prefiller.wait()? {
-                    Some((_, bytes)) => {
-                        let local = LocalState::new(
-                            &self.local_path,
-                            // bytes length is the length of the remote file
-                            bytes.len() as u64,
-                            self.open_options,
-                        )?;
-                        let blocks_range = to_block_range(0..bytes.len() as u64);
-                        unsafe { local.write_mmap_bytes(&bytes, blocks_range) };
-                        State {
-                            local,
-                            remote: prefiller.into_inner(),
-                        }
-                    }
-                    None => {
-                        debug_assert!(
-                            false,
-                            "Looks like the request for prefill bytes was incorrect"
-                        );
-                        if !allow_from_scratch {
-                            return Ok(());
-                        }
-                        // init from scratch
-                        self.new_state_from_scratch(prefiller.into_inner())?
-                    }
-                }
-            }
-            InitSource::PartialPrefiller {
-                mut prefiller,
-                mut local_state,
-            } => {
-                match prefiller.wait()? {
-                    Some((start, bytes)) if !bytes.is_empty() => {
-                        let end = start + bytes.len() as u64;
-
-                        local_state.resize(&self.local_path, end)?;
-
-                        let blocks_range = to_block_range(start..end);
-                        unsafe { local_state.write_mmap_bytes(&bytes, blocks_range) }
-                    }
-                    // `None`: nothing was scheduled. `Some(_, empty)`: the
-                    // open-ended tail read from our block-aligned offset came back
-                    // empty, i.e. the remote didn't grow past it. Either way there
-                    // is nothing to apply — and we must not `resize` down to the
-                    // offset, which would truncate the local mirror.
-                    // TODO: double check that the remote didn't shrink?
-                    Some(_) | None => {}
-                };
-
-                let remote = prefiller.into_inner();
-
-                State {
-                    remote,
-                    local: local_state,
-                }
+            // `state` and `ready` are published together under this lock, so the
+            // `!ready` we just observed rules out `Ready`.
+            State::Ready { .. } => {
+                unreachable!("`!ready` under the lock rules out the `Ready` variant")
             }
         };
 
-        self.state
-            .set(state)
-            .expect("OnceLock::set must succeed while holding init_lock");
+        *state = State::Ready { remote, local };
+        self.is_ready.store(true, Ordering::Release);
 
         Ok(())
     }
 
-    fn new_state_from_scratch(&self, remote: R) -> Result<State<R>> {
+    /// Build an empty local mmap sized from the remote length; reads fault blocks
+    /// in on demand. The lazy cold-start path ([`State::Uninit`]).
+    fn init_from_scratch(&self, remote: R) -> Result<(R, LocalState)> {
         let len = remote.len::<u8>()?;
         let local = LocalState::new(&self.local_path, len, self.open_options)?;
-        Ok(State { remote, local })
+        Ok((remote, local))
     }
 
-    /// Set up [`InitSource::Prefiller`] when the cache is cold
-    /// (not initialized and `InitSource::FromScratch`)
-    pub(super) fn prefill_if_uninit(&self) -> Result<()> {
-        if self.state.get().is_none() {
-            let mut init_guard = self.init_lock.lock();
-            if self.state.get().is_none() {
-                // Cold cache: use the remote's `schedule_whole` to prevent an
-                // additional `len` call to remote.
-                if matches!(&*init_guard, InitSource::FromScratch) {
-                    let mut pipeline = OwnedPipeline::new(self.open_remote()?)?;
-                    pipeline.schedule_whole((), 0)?;
-                    *init_guard = InitSource::Prefiller(pipeline);
-                }
+    /// Resolve an [`State::OpenPrefill`] whole-object read into a fully-written
+    /// local mirror. Falls back to a cold start if no bytes were scheduled.
+    pub(super) fn init_from_open_prefill(
+        &self,
+        mut pipeline: OwnedPipeline<R, ()>,
+    ) -> Result<(R, LocalState)> {
+        match pipeline.wait()? {
+            Some((_, bytes)) => {
+                // `bytes` covers the whole file, so its length is the remote length.
+                let local =
+                    LocalState::new(&self.local_path, bytes.len() as u64, self.open_options)?;
+                let blocks_range = to_block_range(0..bytes.len() as u64);
+                // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
+                // is immutable, so the mmap is filled once with correct data.
+                unsafe { local.write_mmap_bytes(&bytes, blocks_range) };
+                Ok((pipeline.into_inner(), local))
             }
+            // `None` means the whole-object read scheduled nothing — the remote
+            // is empty (`schedule_whole` from offset 0 against EOF 0). Fall back
+            // to a from-scratch, zero-length mirror.
+            None => self.init_from_scratch(pipeline.into_inner()),
+        }
+    }
+
+    /// Resolve a [`State::ReopenPrefill`] tail read: resize the mirror and write
+    /// only the appended suffix. See [`super::reopen`].
+    pub(super) fn init_from_reopen_prefill(
+        &self,
+        mut pipeline: OwnedPipeline<R, u64>,
+        mut local: LocalState,
+    ) -> Result<(R, LocalState)> {
+        match pipeline.wait()? {
+            Some((start, bytes)) if !bytes.is_empty() => {
+                let end = start + bytes.len() as u64;
+                local.resize(&self.local_path, end)?;
+                let blocks_range = to_block_range(start..end);
+                // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
+                // is immutable, so the mmap suffix is filled once with correct data.
+                unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
+            }
+            // There is nothing to apply.
+            // TODO: double check that the remote didn't shrink?
+            Some(_) | None => {}
+        }
+
+        Ok((pipeline.into_inner(), local))
+    }
+
+    /// Stage a [`State::OpenPrefill`] when the cache is still cold ([`State::Uninit`]),
+    /// so that a subsequent [`read_whole`] reads the whole object in one access
+    /// instead of a separate `len` call followed by lazy faulting.
+    ///
+    /// [`read_whole`]: crate::universal_io::UniversalRead::read_whole
+    pub(super) fn prefill_if_uninit(&self) -> Result<()> {
+        if self.is_ready() {
+            return Ok(());
+        }
+
+        let mut state = self.state.lock();
+        if matches!(&*state, State::Uninit) {
+            // Use the remote's `schedule_whole` to avoid an extra `len` call.
+            let mut pipeline = OwnedPipeline::new(self.open_remote()?)?;
+            pipeline.schedule_whole((), 0)?;
+            *state = State::OpenPrefill { pipeline };
         }
 
         Ok(())

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -1,31 +1,20 @@
 //! [`DiskCache`]: a lazily-populated local mirror of an immutable remote file.
-//!
-//! The implementation is split across this module's submodules:
-//!
-//! - this file — the [`DiskCache`] type, its backing [`State`], and the cheap
-//!   constructors ([`DiskCache::new`], [`DiskCache::open_remote`]).
-//! - [`init`] — how the mirror is brought to life on first use: the
-//!   [`InitSource`] state machine and [`DiskCache::init_state`]. **Start here**
-//!   to understand cold-start vs. eager-prefill behavior.
-//! - [`reopen`] — refreshing the mirror after the (append-only) remote grew.
-//! - [`read`] — the [`UniversalRead`] implementation (the public read surface).
 
-use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::AtomicBool;
 
 use parking_lot::Mutex;
 
 use super::DiskCacheRemote;
 use super::local_state::LocalState;
 use crate::mmap::AdviceSetting;
-use crate::universal_io::{OpenOptions, Populate, Result, UniversalRead, UniversalReadFs};
+use crate::universal_io::{
+    OpenOptions, OwnedPipeline, Populate, Result, UniversalRead, UniversalReadFs,
+};
 
 mod init;
 mod read;
 mod reopen;
-
-pub(crate) use init::InitSource;
 
 /// A lazily-populated local mirror of an immutable remote file.
 ///
@@ -38,6 +27,7 @@ pub(crate) use init::InitSource;
 ///
 /// WARN: There should be only a single instance of DiskCache per path.
 /// Initializing multiple instances will try to re-read from remote.
+#[derive(Debug)]
 pub struct DiskCache<R>
 where
     R: UniversalRead + 'static,
@@ -52,43 +42,31 @@ where
     pub(super) open_options: OpenOptions,
     /// Path to the local mmap file.
     pub(super) local_path: PathBuf,
-    /// Lazily-initialized mirror.
-    // We could switch to LazyLock, but there is no fallible initialization
-    pub(super) state: OnceLock<State<R>>,
-    /// Guards initialization of `local` and carries the source of init.
-    pub(super) init_lock: Arc<Mutex<InitSource<R>>>,
+    /// The cache's lifecycle state, initialized lazily on first use.
+    pub(super) state: Mutex<State<R>>,
+    /// Fast-path gate: `true` when `state` is [`State::Ready`].
+    pub(super) is_ready: AtomicBool,
 }
 
-/// The materialized mirror: the opened `remote` handle paired with its local
-/// mmap mirror. Created exactly once, lazily, by [`DiskCache::init_state`].
+/// The lifecycle of a [`DiskCache`]'s local mirror, from "not yet materialized"
+/// through to the live [`Ready`](Self::Ready) mirror.
 #[derive(Debug)]
-pub(crate) struct State<R> {
-    pub remote: R,
-    pub local: LocalState,
-}
-
-impl<R> Debug for DiskCache<R>
-where
-    R: UniversalRead,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            remote_fs,
-            remote_path,
-            open_options,
-            local_path,
-            state,
-            remote_extra: _,
-            init_lock: _,
-        } = self;
-        f.debug_struct("DiskCache")
-            .field("remote_fs", remote_fs)
-            .field("remote_path", remote_path)
-            .field("open_options", open_options)
-            .field("local_path", local_path)
-            .field("state", state)
-            .finish_non_exhaustive()
-    }
+pub(crate) enum State<R: UniversalRead + 'static> {
+    /// Uninitialized start. Chosen for `Populate::No` / `Auto`.
+    Uninit,
+    /// The live mirror: the opened `remote` handle paired with its local mmap.
+    Ready { remote: R, local: LocalState },
+    /// Eager open-time prefill: an in-flight whole-object read scheduled at open;
+    /// init waits on it and writes the whole mirror. For `Populate::Blocking` /
+    /// `PreferBackground`.
+    OpenPrefill { pipeline: OwnedPipeline<R, ()> },
+    /// The reopen-time counterpart of [`OpenPrefill`](Self::OpenPrefill): an
+    /// in-flight read of just the appended tail (block-aligned old length → new
+    /// EOF). Init resizes the mirror and writes only that suffix. See [`reopen`].
+    ReopenPrefill {
+        pipeline: OwnedPipeline<R, u64>,
+        local: LocalState,
+    },
 }
 
 impl<R> DiskCache<R>
@@ -101,16 +79,17 @@ where
         remote_path: impl AsRef<Path>,
         local_path: PathBuf,
         options: OpenOptions,
-        init_source: InitSource<R>,
+        state: State<R>,
     ) -> Self {
+        let is_ready = matches!(state, State::Ready { .. });
         Self {
             remote_fs,
             remote_extra,
             remote_path: remote_path.as_ref().to_owned(),
             open_options: options,
             local_path,
-            state: OnceLock::new(),
-            init_lock: Arc::new(Mutex::new(init_source)),
+            state: Mutex::new(state),
+            is_ready: AtomicBool::new(is_ready),
         }
     }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -69,6 +69,24 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     },
 }
 
+impl<R: UniversalRead + 'static> State<R> {
+    #[inline]
+    pub fn is_ready(&self) -> bool {
+        match self {
+            State::Ready { .. } => true,
+            State::Uninit | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_uninit(&self) -> bool {
+        match self {
+            State::Uninit => true,
+            State::Ready { .. } | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => false,
+        }
+    }
+}
+
 impl<R> DiskCache<R>
 where
     R: DiskCacheRemote,
@@ -81,7 +99,7 @@ where
         options: OpenOptions,
         state: State<R>,
     ) -> Self {
-        let is_ready = matches!(state, State::Ready { .. });
+        let is_ready = state.is_ready();
         Self {
             remote_fs,
             remote_extra,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -87,8 +87,10 @@ where
     }
 
     fn clear_ram_cache(&self) -> Result<()> {
-        if let Some(state) = self.state.get() {
-            state.local.mmap().clear_ram_cache()?;
+        // Only touch an already-live mirror; don't force initialization just to
+        // clear a cache that may not exist yet.
+        if self.is_ready() {
+            self.state()?.local.mmap().clear_ram_cache()?;
         }
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -1,17 +1,10 @@
-//! Refreshing the local mirror after the (append-only) remote has grown.
-//!
-//! The remote is immutable except that it may be *appended to*. [`reopen`] picks
-//! up that growth: for the lazy populate modes it just resizes the mirror and
-//! lets later reads fault the new blocks in; for the eager modes it schedules a
-//! tail read of the appended suffix and stages it as an
-//! [`InitSource::PartialPrefiller`](super::InitSource::PartialPrefiller).
+//! [`Reopen`] the local mirror after the (append-only) remote has grown.
 //!
 //! [`reopen`]: crate::universal_io::UniversalRead::reopen
 
-use std::assert_matches;
 use std::io::{self, ErrorKind};
 
-use super::{DiskCache, InitSource, State};
+use super::{DiskCache, State};
 use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
 use crate::universal_io::{OwnedPipeline, Populate, Result, UniversalIoError, UniversalRead};
 
@@ -21,22 +14,20 @@ where
 {
     /// Body of [`UniversalRead::reopen`](crate::universal_io::UniversalRead::reopen).
     pub(super) fn reopen_impl(&mut self) -> Result<()> {
-        // Wait for InitSource::Prefill, if set.
-        let mut init_guard = self.init_lock.lock();
-        self.init_state(&mut init_guard, false)?;
-
-        let Some(state) = self.state.take() else {
-            // If `self.state` didn't initialize after `init_state`, we are not populating
-            // and we haven't made any reads.
-            //
-            // The first read will take care of initializing to the remote length.
-            return Ok(());
+        // `&mut self` gives exclusive access, so we can transition `state`
+        // directly without locking or touching the `ready` gate concurrently.
+        //
+        // Resolve any in-flight prefill so we hold a concrete mirror.
+        let (mut remote, mut local) = match std::mem::replace(self.state.get_mut(), State::Uninit) {
+            // If it is still `Uninit`, we can let the first read initialize it later.
+            State::Uninit => return Ok(()),
+            State::Ready { remote, local } => (remote, local),
+            State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
+            State::ReopenPrefill { pipeline, local } => {
+                self.init_from_reopen_prefill(pipeline, local)?
+            }
         };
-
-        let State {
-            mut remote,
-            mut local,
-        } = state;
+        *self.is_ready.get_mut() = false;
 
         // Reopen remote so it reflects current length
         remote.reopen()?;
@@ -59,34 +50,24 @@ where
                 // Make the new length visible; new blocks will be filled lazily on read.
                 local.resize(&self.local_path, remote_len)?;
 
-                // return the updated local state and remote
-                self.state
-                    .set(State { remote, local })
-                    .expect("we just take()'d it");
+                *self.state.get_mut() = State::Ready { remote, local };
+                *self.is_ready.get_mut() = true;
             }
             Populate::Blocking | Populate::PreferBackground => {
                 // Re-fetch from the start of the (possibly partial) tail block so
                 // we still make an page-aligned read.
                 let from = local_len.saturating_sub(local_len % BLOCK_SIZE as u64);
 
-                let mut remote_pipeline = OwnedPipeline::new(remote)?;
+                let mut pipeline = OwnedPipeline::new(remote)?;
 
                 // FIXME: check can_schedule in a loop?
-                remote_pipeline.schedule_whole(from, from)?;
+                pipeline.schedule_whole(from, from)?;
 
-                assert_matches!(
-                    *init_guard,
-                    InitSource::FromScratch,
-                    "by this point, InitSource must be FromScratch"
-                );
-                *init_guard = InitSource::PartialPrefiller {
-                    prefiller: remote_pipeline,
-                    local_state: local,
-                };
+                *self.state.get_mut() = State::ReopenPrefill { pipeline, local };
 
                 // For blocking, resolve the prefill now instead of on first read.
                 if matches!(self.open_options.populate, Populate::Blocking) {
-                    self.init_state(&mut init_guard, false)?;
+                    self.init_state()?;
                 }
             }
         }

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
-use super::file::{DiskCache, InitSource};
+use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
     OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError, UniversalRead,
@@ -137,8 +137,8 @@ where
             options.populate
         };
 
-        let init_source = match populate {
-            Populate::Auto | Populate::No => InitSource::FromScratch,
+        let state = match populate {
+            Populate::Auto | Populate::No => State::Uninit,
             Populate::Blocking | Populate::PreferBackground => {
                 let remote = self.remote_fs.open(
                     path.as_ref(),
@@ -156,7 +156,7 @@ where
                 // FIXME: check `can_schedule` in a loop first
                 pipeline.schedule_whole((), 0)?;
 
-                InitSource::Prefiller(pipeline)
+                State::OpenPrefill { pipeline }
             }
         };
 
@@ -166,7 +166,7 @@ where
             path.as_ref(),
             local_path,
             options,
-            init_source,
+            state,
         );
 
         if matches!(populate, Populate::Blocking) {

--- a/lib/common/common/src/universal_io/simple_disk_cache/local_state.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/local_state.rs
@@ -94,7 +94,7 @@ impl LocalState {
 
         mmap.reopen()?;
 
-        self.fully_populated.store(false, Ordering::Release);
+        *self.fully_populated.get_mut() = false;
 
         // The previous tail block may have been only partially populated (its
         // fetch was clamped to the old EOF). `set_len` zero-filled the bytes

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -121,7 +121,7 @@ where
     if range.is_empty() {
         return Ok(&[]);
     }
-    let local = &file.state()?.local;
+    let local = file.state()?.local;
     if is_sequential {
         unsafe { local.read_mmap_bytes::<Sequential>(range) }
     } else {
@@ -146,19 +146,13 @@ where
         read_range,
     } = scheduled_read;
 
-    let state = if let Some(state) = file.state.get() {
-        state
-    } else {
-        let mut init_guard = file.init_lock.lock();
-        if file.state.get().is_none() {
-            file.init_state(&mut init_guard, true)?;
-        }
-        file.state.get().expect("just initialized")
-    };
+    // The mirror is already materialized: scheduling this remote read went
+    // through `file.state()` (see `schedule`), which forces initialization.
+    let local = file.state()?.local;
 
     unsafe {
-        state.local.write_mmap_bytes(bytes, blocks_range);
-        state.local.read_mmap_bytes::<Random>(read_range)
+        local.write_mmap_bytes(bytes, blocks_range);
+        local.read_mmap_bytes::<Random>(read_range)
     }
 }
 
@@ -223,7 +217,7 @@ where
         _align: usize,
     ) -> universal_io::Result<()> {
         let state = file.state()?;
-        match pick_source::<P>(&state.local, range.clone())? {
+        match pick_source::<P>(state.local, range.clone())? {
             Source::Local {
                 range,
                 is_sequential,
@@ -247,7 +241,7 @@ where
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
                 remote_pipeline.schedule::<P>(
                     remote_meta,
-                    &state.remote,
+                    state.remote,
                     blocks_byte_range,
                     REMOTE_READ_ALIGNMENT,
                 )?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -140,6 +140,21 @@ mod tests_mod {
         assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
     }
 
+    /// `read_whole` on a zero-length remote must return an empty slice, not
+    /// panic. The whole-object prefill schedules nothing for an empty file, so
+    /// `init_from_open_prefill` resolves to `None` and falls back to a
+    /// zero-length mirror (on io_uring `schedule_whole` returns without
+    /// scheduling; on mmap it yields an empty read).
+    #[test]
+    fn read_whole_empty_remote_returns_empty() {
+        let scn = Scenario::new(0);
+        let file = scn.open::<R>(PREFILL);
+
+        let bytes = file.read_whole::<u8>().unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(file.len::<u8>().unwrap(), 0);
+    }
+
     #[test]
     fn read_spanning_multiple_blocks_is_contiguous() {
         let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
@@ -244,7 +259,7 @@ mod tests_mod {
 
         // In both Populate::No and Populate::PreferBackground, we still
         // have local marked as uninitialized at this point
-        assert!(cache.state.get().is_none());
+        assert!(!cache.is_ready());
     }
 
     /// Reopen on an unchanged remote must not resize, repopulate, or mutate
@@ -262,11 +277,7 @@ mod tests_mod {
             .unwrap();
 
         let (len_before, populated_before, fetched_before) = {
-            let local = &cache
-                .state
-                .get()
-                .expect("local initialized after read")
-                .local;
+            let local = cache.state().expect("local initialized after read").local;
             (
                 local.mmap().len::<u8>().unwrap(),
                 local.fully_populated.load(Ordering::Acquire),
@@ -279,14 +290,12 @@ mod tests_mod {
         let local = if PREFILL {
             // in case of Populate::PreferBackground, we need to await for
             // completion to get the local_state back.
-            &cache.state().unwrap().local
+            cache.state().unwrap().local
         } else {
             // in case of Populate::No, local_state should still be there
-            &cache
-                .state
-                .get()
-                .expect("local must still be initialized")
-                .local
+            // without forcing (re)initialization.
+            assert!(cache.is_ready(), "local must still be initialized");
+            cache.state().unwrap().local
         };
 
         assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 /// Per-call backend extras for [`UniversalReadFs::open`].
 ///
 /// Marker trait for the value passed to
@@ -7,7 +9,7 @@
 ///
 /// `Default` is required so callers can construct a neutral extras value
 /// (e.g. `<Fs::OpenExtra>::default()`) and then chain typed setters.
-pub trait OpenExtra: Default {
+pub trait OpenExtra: Default + Debug {
     /// Hint that the open should bypass the OS page cache. Backends that
     /// support it (e.g. `io_uring` via `O_DIRECT`) honor the flag; backends
     /// where it's meaningless (mmap, block-cache) treat this as a no-op.

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -23,6 +23,7 @@
 //! outlives all in-flight operations.
 
 use std::borrow::Cow;
+use std::fmt::Debug;
 use std::mem::ManuallyDrop;
 use std::ops::Range;
 
@@ -109,6 +110,18 @@ where
     // file must be wrapped in Box, to provide *stable address* for safe
     // self-referential borrows
     file: ManuallyDrop<Box<R>>,
+}
+
+impl<R, U> Debug for OwnedPipeline<R, U>
+where
+    R: UniversalRead,
+    U: UserData,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OwnedPipeline")
+            .field("file", &self.file)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<R, U> OwnedPipeline<R, U>


### PR DESCRIPTION
Previously, we handled initialization state with a `OnceLock` + a `Mutex<InitSource>` enum. This encapsulated the state in two distinct fields. 

What this PR proposes (thanks to @ffuugoo's suggestion) is to keep a single enum for `State`, like so:

```rust
enum State<R: UniversalRead + 'static> {
    Uninit,
    Ready { remote: R, local: LocalState },
    OpenPrefill { pipeline: OwnedPipeline<R, ()> },
    ReopenPrefill {
        pipeline: OwnedPipeline<R, u64>,
        local: LocalState,
    },
}
```

So that the fields on `DiskCache<R>` become like this:

```diff
// instead of
-    /// Lazily-initialized mirror.
-    // We could switch to LazyLock, but there is no fallible initialization
-    pub(super) state: OnceLock<State<R>>,
-    /// Guards initialization of `local` and carries the source of init.
-    pub(super) init_lock: Arc<Mutex<InitSource<R>>>,

// we now have this
+    /// The cache's lifecycle state, initialized lazily on first use.
+    pub(super) state: Mutex<State<R>>,
+    /// Fast-path gate: `true` when `state` is [`State::Ready`].
+    pub(super) ready: AtomicBool,
```

This way, we can use the `ready` bool to signal that we can skip the mutex through `Mutex::data_ptr` unsafe operation, and keeping the "lock-free" read semantics, if it is already initialized.