### PR TITLE
Add serverless mode for Gridstore backend

### DIFF
--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -222,6 +222,12 @@ impl UniversalWrite for IoUringFile {
         Ok(())
     }
 
+    fn write_grow<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
+        // `write_all_at` (pwrite) extends the file when writing past its end, so
+        // growing and writing are already a single operation here.
+        self.write(byte_offset, items)
+    }
+
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         items: impl IntoIterator<Item = (ByteOffset, &'a [T])>,

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -298,6 +298,20 @@ impl UniversalWrite for MmapFile {
         Ok(())
     }
 
+    fn write_grow<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
+        let needed = byte_offset as usize + size_of_val(items);
+        if needed > self.len {
+            // The mmap backend cannot grow and write in a single syscall, so
+            // emulate an append: resize the backing file and remap before
+            // writing. The gap (if any) is zero-filled by `set_len`.
+            local_file_ops::local_create(self.path(), needed)?;
+            self.reopen()?;
+        }
+        let mmap = self.as_bytes_mut();
+        write(mmap, byte_offset, items)?;
+        Ok(())
+    }
+
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
@@ -487,4 +501,97 @@ where
     mmap.copy_from_slice(bytes);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generic_consts::Random;
+
+    fn open_writable(path: &Path) -> MmapFile {
+        MmapFs.open(path, OpenOptions::new_for_test(), ()).unwrap()
+    }
+
+    #[test]
+    fn test_write_grow_extends_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("page.dat");
+
+        // Start from an empty (zero-length) file, like an append-only page.
+        MmapFs.create(&path, 0).unwrap();
+        let mut file = open_writable(&path);
+        assert_eq!(file.len::<u8>().unwrap(), 0);
+
+        // A plain `write` would be out of bounds; `write_grow` extends the file.
+        let data: [u8; 5] = [1, 2, 3, 4, 5];
+        file.write_grow(0, &data).unwrap();
+
+        assert_eq!(file.len::<u8>().unwrap(), 5);
+        let read = file
+            .read_bytes::<Random>(0..5, 1)
+            .unwrap()
+            .as_ref()
+            .to_vec();
+        assert_eq!(read, data);
+    }
+
+    #[test]
+    fn test_write_grow_appends_and_keeps_existing_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("page.dat");
+
+        MmapFs.create(&path, 0).unwrap();
+        let mut file = open_writable(&path);
+
+        file.write_grow(0, &[1u8, 2, 3]).unwrap();
+        file.write_grow(3, &[4u8, 5, 6]).unwrap();
+
+        assert_eq!(file.len::<u8>().unwrap(), 6);
+        let read = file
+            .read_bytes::<Random>(0..6, 1)
+            .unwrap()
+            .as_ref()
+            .to_vec();
+        assert_eq!(read, [1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn test_write_grow_gap_reads_as_zeros() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("page.dat");
+
+        MmapFs.create(&path, 0).unwrap();
+        let mut file = open_writable(&path);
+
+        // Write past the current end: the gap [0..4) must read back as zeros.
+        file.write_grow(4, &[9u8, 9]).unwrap();
+
+        assert_eq!(file.len::<u8>().unwrap(), 6);
+        let read = file
+            .read_bytes::<Random>(0..6, 1)
+            .unwrap()
+            .as_ref()
+            .to_vec();
+        assert_eq!(read, [0, 0, 0, 0, 9, 9]);
+    }
+
+    #[test]
+    fn test_write_grow_within_bounds_does_not_grow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("page.dat");
+
+        // Pre-sized file (like a dynamic page); writing within it must not resize.
+        MmapFs.create(&path, 8).unwrap();
+        let mut file = open_writable(&path);
+
+        file.write_grow(2, &[7u8, 7]).unwrap();
+
+        assert_eq!(file.len::<u8>().unwrap(), 8);
+        let read = file
+            .read_bytes::<Random>(0..8, 1)
+            .unwrap()
+            .as_ref()
+            .to_vec();
+        assert_eq!(read, [0, 0, 7, 7, 0, 0, 0, 0]);
+    }
 }

--- a/lib/common/common/src/universal_io/traits/write.rs
+++ b/lib/common/common/src/universal_io/traits/write.rs
@@ -4,6 +4,16 @@ use crate::universal_io::{ByteOffset, FileIndex, Flusher, Result, UniversalIoErr
 pub trait UniversalWrite: UniversalRead {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()>;
 
+    /// Write `data` at `byte_offset`, extending the file if the write reaches
+    /// past its current end.
+    ///
+    /// Unlike [`Self::write`] — which requires the file to already be large
+    /// enough — growing the file and writing the data happen as a single append
+    /// operation. This is what append-only backends (e.g. object stores) need:
+    /// they cannot resize a file separately from writing to it. Any gap between
+    /// the old end of the file and `byte_offset` reads back as zeros.
+    fn write_grow<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()>;
+
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
@@ -27,6 +37,28 @@ pub trait UniversalWrite: UniversalRead {
                 })?;
 
             file.write(offset, data)?;
+        }
+
+        Ok(())
+    }
+
+    /// Like [`Self::write_multi`], but each write may extend its target file as
+    /// a single append operation (see [`Self::write_grow`]).
+    fn write_multi_grow<'a, T: bytemuck::Pod>(
+        files: &mut [Self],
+        writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
+    ) -> Result<()> {
+        let files_len = files.len();
+
+        for (file_index, offset, data) in writes {
+            let file = files
+                .get_mut(file_index)
+                .ok_or(UniversalIoError::InvalidFileIndex {
+                    file_index,
+                    files: files_len,
+                })?;
+
+            file.write_grow(offset, data)?;
         }
 
         Ok(())

--- a/lib/gridstore/benches/bustle_bench/payload_storage.rs
+++ b/lib/gridstore/benches/bustle_bench/payload_storage.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bustle::Collection;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
+use gridstore::Mode;
 use gridstore::fixtures::{Payload, empty_storage};
 use parking_lot::RwLock;
 
@@ -13,7 +14,7 @@ impl Collection for ArcStorage<PayloadStorage> {
     type Handle = Self;
 
     fn with_capacity(_capacity: usize) -> Self {
-        let (dir, storage) = empty_storage();
+        let (dir, storage) = empty_storage(Mode::default());
 
         let proxy = StorageProxy::new(storage);
         ArcStorage {

--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
+use gridstore::Mode;
 use gridstore::fixtures::{empty_storage, random_payload};
 use rand::RngExt;
 
@@ -14,7 +15,7 @@ pub fn flush_bench(c: &mut Criterion) {
 
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records
-            let (_dir, mut storage) = empty_storage();
+            let (_dir, mut storage) = empty_storage(Mode::default());
             let mut rng = rand::rng();
             let hw_counter = HardwareCounterCell::new();
             let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -52,7 +53,7 @@ pub fn flush_bench(c: &mut Criterion) {
 
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records
-            let (_dir, mut storage) = empty_storage();
+            let (_dir, mut storage) = empty_storage(Mode::default());
             let mut rng = rand::rng();
             let hw_counter = HardwareCounterCell::new();
             let hw_counter_ref = hw_counter.ref_payload_io_write_counter();

--- a/lib/gridstore/benches/random_data_bench.rs
+++ b/lib/gridstore/benches/random_data_bench.rs
@@ -1,13 +1,14 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use gridstore::Mode;
 use gridstore::fixtures::{empty_storage, random_payload};
 
 /// sized similarly to the real dataset for a fair comparison
 const PAYLOAD_COUNT: u32 = 100_000;
 
 pub fn random_data_bench(c: &mut Criterion) {
-    let (_dir, mut storage) = empty_storage();
+    let (_dir, mut storage) = empty_storage(Mode::default());
     let mut rng = rand::rng();
     c.bench_function("write random payload", |b| {
         let hw_counter = HardwareCounterCell::new();

--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -7,6 +7,7 @@ use common::generic_consts::Random;
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
 use fs_err::File;
+use gridstore::Mode;
 use gridstore::fixtures::{HM_FIELDS, Payload, empty_storage};
 use rand::RngExt;
 use serde_json::Value;
@@ -52,7 +53,7 @@ fn compute_folder_size_mb<P: AsRef<Path>>(path: P) -> u64 {
 }
 
 pub fn real_data_data_bench(c: &mut Criterion) {
-    let (dir, mut storage) = empty_storage();
+    let (dir, mut storage) = empty_storage(Mode::default());
     let csv_path = dataset::Dataset::HMArticles
         .download()
         .expect("download should succeed");

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use crate::Result;
 use crate::config::StorageConfig;
 use crate::error::GridstoreError;
-use crate::tracker::{BlockOffset, PageId};
+use crate::tracker::{BlockOffset, PageId, ValuePointer};
 
 const BITMASK_NAME: &str = "bitmask.dat";
 
@@ -111,30 +111,31 @@ impl<S: UniversalWrite> Bitmask<S> {
         })
     }
 
-    /// Create a bitmask covering `num_pages` pages with every block marked used,
-    /// resetting any stale bitmask/gaps files.
-    ///
-    /// Used when opening in dynamic mode a storage whose bitmask is missing or
-    /// stale (e.g. created/extended in serverless mode). Over-marking is fully
-    /// crash-safe; the cost is unreclaimed spare capacity until a rebuild.
-    pub(crate) fn create_all_used(
+    /// Rebuild the bitmask over `num_pages` from the live `mappings`: blocks a
+    /// mapping occupies are used, the rest free. Resets stale bitmask/gaps files.
+    /// Callers must pad the pages to full size first, so free blocks are writable.
+    pub(crate) fn create_from_mappings(
         fs: &S::Fs,
         dir: &Path,
         config: StorageConfig,
         num_pages: usize,
+        mappings: impl Iterator<Item = ValuePointer>,
     ) -> Result<Self> {
         debug_assert!(num_pages >= 1, "storage always has at least one page");
 
-        // Fresh single-page bitmask, then grow it to cover every page.
+        // Fresh all-free bitmask covering every page.
         let mut bitmask = Self::create(fs, dir, config.clone())?;
         for _ in 1..num_pages {
             bitmask.cover_new_page()?;
         }
 
-        // Mark every block used; `mark_blocks` recomputes the region gaps too.
-        let blocks_per_page = (config.page_size_bytes / config.block_size_bytes) as u32;
-        for page_id in 0..num_pages as PageId {
-            bitmask.mark_blocks(page_id, 0, blocks_per_page, true)?;
+        // Mark each mapping's blocks used (also recomputes region gaps).
+        let block_size = config.block_size_bytes;
+        for pointer in mappings {
+            let num_blocks = (pointer.length as usize).div_ceil(block_size) as u32;
+            if num_blocks > 0 {
+                bitmask.mark_blocks(pointer.page_id, pointer.block_offset, num_blocks, true)?;
+            }
         }
 
         // Persist so a later open doesn't reconstruct from a half-written file.

--- a/lib/gridstore/src/bitmask/mod.rs
+++ b/lib/gridstore/src/bitmask/mod.rs
@@ -111,6 +111,38 @@ impl<S: UniversalWrite> Bitmask<S> {
         })
     }
 
+    /// Create a bitmask covering `num_pages` pages with every block marked used,
+    /// resetting any stale bitmask/gaps files.
+    ///
+    /// Used when opening in dynamic mode a storage whose bitmask is missing or
+    /// stale (e.g. created/extended in serverless mode). Over-marking is fully
+    /// crash-safe; the cost is unreclaimed spare capacity until a rebuild.
+    pub(crate) fn create_all_used(
+        fs: &S::Fs,
+        dir: &Path,
+        config: StorageConfig,
+        num_pages: usize,
+    ) -> Result<Self> {
+        debug_assert!(num_pages >= 1, "storage always has at least one page");
+
+        // Fresh single-page bitmask, then grow it to cover every page.
+        let mut bitmask = Self::create(fs, dir, config.clone())?;
+        for _ in 1..num_pages {
+            bitmask.cover_new_page()?;
+        }
+
+        // Mark every block used; `mark_blocks` recomputes the region gaps too.
+        let blocks_per_page = (config.page_size_bytes / config.block_size_bytes) as u32;
+        for page_id in 0..num_pages as PageId {
+            bitmask.mark_blocks(page_id, 0, blocks_per_page, true)?;
+        }
+
+        // Persist so a later open doesn't reconstruct from a half-written file.
+        bitmask.flusher()()?;
+
+        Ok(bitmask)
+    }
+
     pub(crate) fn open(fs: &S::Fs, dir: &Path, config: StorageConfig) -> Result<Self> {
         debug_assert!(
             config
@@ -150,6 +182,11 @@ impl<S: UniversalWrite> Bitmask<S> {
 
     fn bitmask_path(dir: &Path) -> PathBuf {
         dir.join(BITMASK_NAME)
+    }
+
+    /// Whether a bitmask file exists in `dir` (false for serverless storage).
+    pub(crate) fn exists(dir: &Path) -> bool {
+        Self::bitmask_path(dir).exists()
     }
 
     pub fn flusher(&self) -> impl FnOnce() -> Result<()> + Send + use<S> {
@@ -194,6 +231,12 @@ impl<S: UniversalWrite> Bitmask<S> {
         let bits = self.bitslice.bit_len() as usize;
         let covered_bytes = bits * self.config.block_size_bytes;
         covered_bytes.div_euclid(self.config.page_size_bytes)
+    }
+
+    /// Number of blocks the bitmask covers (one bit per block). Exact, unlike
+    /// [`Self::infer_num_pages`] which rounds down to whole pages.
+    pub(crate) fn covered_blocks(&self) -> usize {
+        self.bitslice.bit_len() as usize
     }
 
     /// Extend the bitslice to cover another page

--- a/lib/gridstore/src/fixtures.rs
+++ b/lib/gridstore/src/fixtures.rs
@@ -28,32 +28,19 @@ impl Blob for Payload {
     }
 }
 
-/// Create an empty storage with the default configuration
-pub fn empty_storage() -> (TempDir, Gridstore<Payload>) {
-    empty_storage_in_mode(Mode::default())
-}
-
 /// Create an empty storage with the default configuration in a specific mode.
 ///
 /// Tests that assert dynamic-mode invariants (bitmask, block reuse,
 /// block-rounded sizes) should use [`Mode::Regular`].
-pub fn empty_storage_in_mode(mode: Mode) -> (TempDir, Gridstore<Payload>) {
+pub fn empty_storage(mode: Mode) -> (TempDir, Gridstore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
     let storage =
         Gridstore::new(MmapFs, dir.path().to_path_buf(), Default::default(), mode).unwrap();
     (dir, storage)
 }
 
-/// Create an empty storage with a specific page size
-pub fn empty_storage_sized(
-    page_size: usize,
-    compression: Compression,
-) -> (TempDir, Gridstore<Payload>) {
-    empty_storage_sized_in_mode(page_size, compression, Mode::default())
-}
-
 /// Create an empty storage with a specific page size in a specific mode.
-pub fn empty_storage_sized_in_mode(
+pub fn empty_storage_sized(
     page_size: usize,
     compression: Compression,
     mode: Mode,

--- a/lib/gridstore/src/fixtures.rs
+++ b/lib/gridstore/src/fixtures.rs
@@ -6,6 +6,7 @@ use serde_json::Map;
 use tempfile::{Builder, TempDir};
 
 use crate::config::{Compression, StorageOptions};
+use crate::gridstore::Mode;
 use crate::{Blob, Gridstore};
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -29,8 +30,17 @@ impl Blob for Payload {
 
 /// Create an empty storage with the default configuration
 pub fn empty_storage() -> (TempDir, Gridstore<Payload>) {
+    empty_storage_in_mode(Mode::default())
+}
+
+/// Create an empty storage with the default configuration in a specific mode.
+///
+/// Tests that assert dynamic-mode invariants (bitmask, block reuse,
+/// block-rounded sizes) should use [`Mode::Regular`].
+pub fn empty_storage_in_mode(mode: Mode) -> (TempDir, Gridstore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
-    let storage = Gridstore::new(MmapFs, dir.path().to_path_buf(), Default::default()).unwrap();
+    let storage =
+        Gridstore::new(MmapFs, dir.path().to_path_buf(), Default::default(), mode).unwrap();
     (dir, storage)
 }
 
@@ -39,13 +49,22 @@ pub fn empty_storage_sized(
     page_size: usize,
     compression: Compression,
 ) -> (TempDir, Gridstore<Payload>) {
+    empty_storage_sized_in_mode(page_size, compression, Mode::default())
+}
+
+/// Create an empty storage with a specific page size in a specific mode.
+pub fn empty_storage_sized_in_mode(
+    page_size: usize,
+    compression: Compression,
+    mode: Mode,
+) -> (TempDir, Gridstore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
     let options = StorageOptions {
         page_size_bytes: Some(page_size),
         compression: Some(compression),
         ..Default::default()
     };
-    let storage = Gridstore::new(MmapFs, dir.path().to_path_buf(), options).unwrap();
+    let storage = Gridstore::new(MmapFs, dir.path().to_path_buf(), options, mode).unwrap();
     (dir, storage)
 }
 

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -189,7 +189,13 @@ where
     /// the page count purely from the page files (like [`GridstoreReader`]).
     pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate, mode: Mode) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
-        let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
+        let (config, mut tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
+
+        // Serverless strictly appends at the end of the tracker file: drop any
+        // zero padding a dynamic-mode pre-allocation left after the mappings.
+        if mode.is_serverless() {
+            tracker = tracker.truncate_padding(&fs)?;
+        }
 
         let mut pages = Pages::open(&fs, &base_path, true, populate)?;
         let loaded_pages = pages.num_pages();

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -14,6 +14,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::is_alive_lock::IsAliveLock;
+use common::mmap::create_and_ensure_length;
 use common::universal_io::{MmapFile, Populate, UniversalReadFileOps, UniversalWrite, UserData};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -185,26 +186,24 @@ where
         // Writable store: open pages and tracker writable so it can append.
         let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
 
-        let pages = Pages::open(&fs, &base_path, true, populate)?;
+        let mut pages = Pages::open(&fs, &base_path, true, populate)?;
         let loaded_pages = pages.num_pages();
 
         let storage_engine = match mode {
             Mode::Regular => {
-                // The bitmask needs one flag per block, `pages * blocks_per_page`
-                // bits. Compare that to what it covers: a storage created or
-                // extended in serverless mode has no bitmask, or a stale one
-                // covering too few blocks. Either way, reconstruct all-used.
+                // Reuse the bitmask only if it exists and is the right length
+                // (`pages * blocks_per_page` bits); serverless keeps none, or a
+                // shorter one.
                 let blocks_per_page = config.page_size_bytes / config.block_size_bytes;
                 let expected_blocks = loaded_pages * blocks_per_page;
-                let bitmask = if Bitmask::<S>::exists(&base_path) {
+                let reuse = if Bitmask::<S>::exists(&base_path) {
                     let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
                     let covered_blocks = bitmask.covered_blocks();
                     if covered_blocks == expected_blocks {
-                        bitmask
+                        Some(bitmask)
                     } else if covered_blocks < expected_blocks {
-                        // Missing flags for serverless-appended blocks; rebuild.
-                        drop(bitmask);
-                        Bitmask::create_all_used(&fs, &base_path, config.clone(), loaded_pages)?
+                        drop(bitmask); // stale, reconstruct below
+                        None
                     } else {
                         // More blocks than pages hold: corruption, not a mode switch.
                         return Err(GridstoreError::service_error(format!(
@@ -212,8 +211,37 @@ where
                         )));
                     }
                 } else {
-                    // No bitmask: created in serverless mode.
-                    Bitmask::create_all_used(&fs, &base_path, config.clone(), loaded_pages)?
+                    None
+                };
+                let bitmask = match reuse {
+                    Some(bitmask) => bitmask,
+                    None => {
+                        // Pad pages to full size (dynamic writes don't grow pages,
+                        // so reclaimed free blocks must be writable), then rebuild
+                        // the flags from the live mappings.
+                        drop(pages);
+                        for page_id in 0..loaded_pages as PageId {
+                            create_and_ensure_length(
+                                &page_path(&base_path, page_id),
+                                config.page_size_bytes,
+                            )?;
+                        }
+                        pages = Pages::open(&fs, &base_path, true, populate)?;
+
+                        let mut mappings = Vec::with_capacity(tracker.pointer_count() as usize);
+                        for point_offset in 0..tracker.pointer_count() {
+                            if let Some(pointer) = tracker.get(point_offset)? {
+                                mappings.push(pointer);
+                            }
+                        }
+                        Bitmask::create_from_mappings(
+                            &fs,
+                            &base_path,
+                            config.clone(),
+                            loaded_pages,
+                            mappings.into_iter(),
+                        )?
+                    }
                 };
                 debug_assert_eq!(bitmask.covered_blocks(), expected_blocks);
                 StorageEngine::Dynamic {

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -806,7 +806,7 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
     fn flusher_serverless(&self) -> Flusher {
         debug_assert!(
             self.mode.is_serverless(),
-            "flusher_dynamic may only be called in serverless mode",
+            "flusher_serverless may only be called in serverless mode",
         );
 
         let pending_updates = self.tracker.read().pending_updates.clone();

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -153,7 +153,12 @@ where
 
         let storage = Self {
             mode,
-            tracker: Arc::new(RwLock::new(Tracker::new(&fs, &base_path, None)?)),
+            tracker: Arc::new(RwLock::new(Tracker::new(
+                &fs,
+                &base_path,
+                None,
+                mode.is_serverless(),
+            )?)),
             pages: Arc::new(RwLock::new(Pages::new(base_path.clone(), true))),
             storage_engine,
             base_path,

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -31,6 +31,22 @@ use crate::tracker::{BlockOffset, PageId, PointOffset, PointerUpdates, Tracker, 
 
 pub type Flusher = Box<dyn FnOnce() -> std::result::Result<(), GridstoreError> + Send>;
 
+#[derive(Debug)]
+enum StorageEngine<S = MmapFile>
+where
+    S: UniversalWrite + 'static,
+{
+    Dynamic {
+        /// MmapBitmask to represent which "blocks" of data in the pages are used and which are free.
+        /// Only used in dynamic storage engine where we want to reuse freed blocks in the middle of
+        /// pages.
+        ///
+        /// 0 is free, 1 is used.
+        bitmask: Arc<RwLock<Bitmask<S>>>,
+    },
+    Serverless {},
+}
+
 /// Read-write storage for values of type `V`.
 ///
 /// Uses `Arc<RwLock<...>>` for pages and tracker to support concurrent flushing.
@@ -41,13 +57,11 @@ where
     S: UniversalWrite + 'static,
 {
     pub(super) fs: S::Fs,
+    mode: Mode,
     pub(super) config: StorageConfig,
     pub(super) tracker: Arc<RwLock<Tracker<S>>>,
     pub(super) pages: Arc<RwLock<Pages<S>>>,
-    /// MmapBitmask to represent which "blocks" of data in the pages are used and which are free.
-    ///
-    /// 0 is free, 1 is used.
-    pub(super) bitmask: Arc<RwLock<Bitmask<S>>>,
+    storage_engine: StorageEngine<S>,
     pub(super) base_path: PathBuf,
     pub(super) _value_type: std::marker::PhantomData<V>,
     /// Lock to prevent concurrent flushes and used for waiting for ongoing flushes to finish.
@@ -80,8 +94,13 @@ where
             paths.push(pages.page_path(page_id));
         }
         paths.push(self.base_path.join(CONFIG_FILENAME));
-        for bitmask_file in self.bitmask.read().files() {
-            paths.push(bitmask_file);
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => {
+                for bitmask_file in bitmask.read().files() {
+                    paths.push(bitmask_file);
+                }
+            }
+            StorageEngine::Serverless {} => {}
         }
         paths
     }
@@ -99,13 +118,14 @@ where
         base_path: PathBuf,
         create_options: StorageOptions,
         populate: Populate,
+        mode: Mode,
     ) -> Result<Self> {
         let config_path = base_path.join(CONFIG_FILENAME);
         if config_path.exists() {
-            Self::open(fs, base_path, populate)
+            Self::open(fs, base_path, populate, mode)
         } else {
             fs.create_dir(&base_path)?;
-            Self::new(fs, base_path, create_options)
+            Self::new(fs, base_path, create_options, mode)
         }
     }
 
@@ -113,21 +133,33 @@ where
     ///
     /// `base_path` is the directory where the storage files will be stored.
     /// It should exist already.
-    pub fn new(fs: S::Fs, base_path: PathBuf, options: StorageOptions) -> Result<Self> {
+    pub fn new(fs: S::Fs, base_path: PathBuf, options: StorageOptions, mode: Mode) -> Result<Self> {
         let config = StorageConfig::try_from(options).map_err(GridstoreError::service_error)?;
         let config_path = base_path.join(CONFIG_FILENAME);
 
-        let bitmask = Bitmask::create(&fs, &base_path, config.clone())?;
+        // Serverless storage is append-only and has no bitmask, so don't create
+        // its files.
+        let storage_engine = match mode {
+            Mode::Regular => StorageEngine::Dynamic {
+                bitmask: Arc::new(RwLock::new(Bitmask::create(
+                    &fs,
+                    &base_path,
+                    config.clone(),
+                )?)),
+            },
+            Mode::Serverless => StorageEngine::Serverless {},
+        };
 
         let storage = Self {
+            mode,
             tracker: Arc::new(RwLock::new(Tracker::new(&fs, &base_path, None)?)),
             pages: Arc::new(RwLock::new(Pages::new(base_path.clone(), true))),
+            storage_engine,
             base_path,
             config,
-            fs,
             _value_type: std::marker::PhantomData,
-            bitmask: Arc::new(RwLock::new(bitmask)),
             is_alive_flush_lock: IsAliveLock::new(),
+            fs,
         };
 
         let new_page_id = storage.next_page_id();
@@ -146,28 +178,39 @@ where
 
     /// Open an existing storage at the given path.
     ///
-    /// Uses the bitmask to infer page count for consistency with the write path.
-    pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
+    /// In dynamic mode the bitmask infers the page count, which is cross-checked
+    /// against the page files on disk. Serverless mode has no bitmask and infers
+    /// the page count purely from the page files (like [`GridstoreReader`]).
+    pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate, mode: Mode) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
         let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
-        let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
-        let num_pages = bitmask.infer_num_pages();
 
         let pages = Pages::open(&fs, &base_path, true, populate)?;
         let loaded_pages = pages.num_pages();
 
-        if loaded_pages != num_pages {
-            return Err(GridstoreError::service_error(format!(
-                "Inconsistent number of gridstore pages at {base_path:?}: expected {num_pages}, but found {loaded_pages}",
-            )));
-        }
+        let storage_engine = match mode {
+            Mode::Regular => {
+                let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+                let num_pages = bitmask.infer_num_pages();
+                if loaded_pages != num_pages {
+                    return Err(GridstoreError::service_error(format!(
+                        "Inconsistent number of gridstore pages at {base_path:?}: expected {num_pages}, but found {loaded_pages}",
+                    )));
+                }
+                StorageEngine::Dynamic {
+                    bitmask: Arc::new(RwLock::new(bitmask)),
+                }
+            }
+            Mode::Serverless => StorageEngine::Serverless {},
+        };
 
         Ok(Self {
             fs,
+            mode,
             config,
             tracker: Arc::new(RwLock::new(tracker)),
             pages: Arc::new(RwLock::new(pages)),
-            bitmask: Arc::new(RwLock::new(bitmask)),
+            storage_engine,
             base_path,
             _value_type: std::marker::PhantomData,
             is_alive_flush_lock: IsAliveLock::new(),
@@ -184,13 +227,27 @@ where
             .write()
             .attach_page(&self.fs, &path, Populate::No)?;
 
-        self.bitmask.write().cover_new_page()?;
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => {
+                bitmask.write().cover_new_page()?;
+            }
+            StorageEngine::Serverless {} => {}
+        }
 
         Ok(new_page_id)
     }
 
     fn create_page_file(&self, path: &std::path::Path) -> Result<()> {
-        self.fs.create(path, self.config.page_size_bytes)?;
+        // Serverless pages are created empty and grown as data is appended, so
+        // their byte length reflects actual data (see `next_append_block`).
+        // Dynamic pages are pre-sized to the full page so the bitmask can use
+        // any block within them.
+        let expected_length = if self.mode.is_serverless() {
+            0
+        } else {
+            self.config.page_size_bytes
+        };
+        self.fs.create(path, expected_length)?;
         Ok(())
     }
 
@@ -199,8 +256,21 @@ where
         num_blocks: u32,
     ) -> Result<(PageId, BlockOffset)> {
         debug_assert!(num_blocks > 0, "num_blocks must be greater than 0");
+        debug_assert!(
+            !self.mode.is_serverless(),
+            "must not use find_or_create_available_blocks in serverless mode",
+        );
 
-        let bitmask_guard = self.bitmask.read();
+        let bitmask = match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => Arc::clone(bitmask),
+            StorageEngine::Serverless {} => {
+                unreachable!(
+                    "find_or_create_available_blocks should not be called in serverless mode"
+                );
+            }
+        };
+
+        let bitmask_guard = bitmask.read();
         if let Some((page_id, block_offset)) = bitmask_guard.find_available_blocks(num_blocks)? {
             return Ok((page_id, block_offset));
         }
@@ -216,8 +286,7 @@ where
             self.create_new_page()?;
         }
 
-        let available = self
-            .bitmask
+        let available = bitmask
             .read()
             .find_available_blocks(num_blocks)?
             .expect("New page has just been created");
@@ -225,7 +294,72 @@ where
         Ok(available)
     }
 
-    /// Write value into a new cell, considering that it can span more than one page.
+    /// Find the next block to write to if we're only appending to storage.
+    ///
+    /// Append-only storage has no bitmask, so the cursor is derived from the
+    /// byte length of the last page: because values are packed from the front
+    /// and occupy whole blocks starting on a block boundary, the number of used
+    /// blocks in the last page is `ceil(byte_len / block_size)`. The last page's
+    /// byte length captures exactly the bytes spilled into it, for both
+    /// single-page and page-spanning values.
+    ///
+    /// This only computes the position; it must never create new pages. Use
+    /// [`Self::ensure_append_pages`] to materialize the page files the value
+    /// needs.
+    fn next_append_block(&self, num_blocks: u32) -> Result<(PageId, BlockOffset)> {
+        debug_assert!(num_blocks > 0, "num_blocks must be greater than 0");
+
+        let blocks_per_page = (self.config.page_size_bytes / self.config.block_size_bytes) as u64;
+
+        let pages = self.pages.read();
+        let num_pages = pages.num_pages();
+        debug_assert!(num_pages > 0, "storage always has at least one page");
+        let used_in_last = pages
+            .last_page_len()?
+            .div_ceil(self.config.block_size_bytes as u64);
+        drop(pages);
+
+        // Global block index of the append cursor. When the last page is exactly
+        // full (used == blocks_per_page) this rolls over to a fresh page start.
+        let start_global = (num_pages as u64 - 1) * blocks_per_page + used_in_last;
+        let start_page = (start_global / blocks_per_page) as PageId;
+        let start_offset = (start_global % blocks_per_page) as BlockOffset;
+
+        Ok((start_page, start_offset))
+    }
+
+    /// Ensure the page files backing an append of `num_blocks` blocks starting
+    /// at the position returned by [`Self::next_append_block`] exist (are
+    /// created empty and attached).
+    ///
+    /// Serverless storage is append-only and does not pre-size pages: the
+    /// page files are created empty here, and the write itself grows each one
+    /// by exactly the bytes it appends (see [`Self::write_into_pages`] /
+    /// [`Pages::write_to_pages_grow`]). This only materializes the files; it
+    /// must not size them.
+    fn ensure_append_pages(
+        &mut self,
+        start_page_id: PageId,
+        block_offset: BlockOffset,
+        num_blocks: u32,
+    ) -> Result<()> {
+        let blocks_per_page = (self.config.page_size_bytes / self.config.block_size_bytes) as u64;
+        let start_global = u64::from(start_page_id) * blocks_per_page + u64::from(block_offset);
+        let pages_required =
+            (start_global + u64::from(num_blocks)).div_ceil(blocks_per_page) as usize;
+        while self.pages.read().num_pages() < pages_required {
+            self.create_new_page()?;
+        }
+        Ok(())
+    }
+
+    /// Write a value into a cell, considering that it can span more than one
+    /// page.
+    ///
+    /// In serverless (append-only) mode the write grows each page file by
+    /// exactly the appended bytes as a single operation, so the pages must not
+    /// be pre-sized. In dynamic mode the pages are already allocated to their
+    /// full size and are written in place.
     #[allow(clippy::needless_pass_by_ref_mut)]
     fn write_into_pages(
         &mut self,
@@ -234,9 +368,12 @@ where
         block_offset: BlockOffset,
     ) -> Result<()> {
         let pointer = ValuePointer::new(start_page_id, block_offset, value.len() as u32);
-        self.pages
-            .write()
-            .write_to_pages(pointer, value, &self.config)
+        let mut pages = self.pages.write();
+        if self.mode.is_serverless() {
+            pages.write_to_pages_grow(pointer, value, &self.config)
+        } else {
+            pages.write_to_pages(pointer, value, &self.config)
+        }
     }
 
     /// Put a value in the storage.
@@ -303,14 +440,29 @@ where
         hw_counter.incr_delta(value_size);
 
         let required_blocks = Self::blocks_for_value(value_size, self.config.block_size_bytes);
-        let (start_page_id, block_offset) =
-            self.find_or_create_available_blocks(required_blocks)?;
+
+        let (start_page_id, block_offset) = if self.mode.is_serverless() {
+            // Append-only: derive the position, then ensure the (empty) page
+            // files exist. The write itself grows each page by appending. Page
+            // creation is intentionally kept out of `next_append_block`.
+            let (page_id, block_offset) = self.next_append_block(required_blocks)?;
+            self.ensure_append_pages(page_id, block_offset, required_blocks)?;
+            (page_id, block_offset)
+        } else {
+            self.find_or_create_available_blocks(required_blocks)?
+        };
 
         self.write_into_pages(&comp_value, start_page_id, block_offset)?;
 
-        self.bitmask
-            .write()
-            .mark_blocks(start_page_id, block_offset, required_blocks, true)?;
+        // We only mark used blocks in dynamic mode
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => {
+                bitmask
+                    .write()
+                    .mark_blocks(start_page_id, block_offset, required_blocks, true)?;
+            }
+            StorageEngine::Serverless {} => {}
+        }
 
         let mut tracker_guard = self.tracker.write();
         let is_update = tracker_guard.has_pointer(point_offset)?;
@@ -353,6 +505,7 @@ where
             self.fs.clone(),
             self.base_path.clone(),
             StorageOptions::from(&self.config),
+            self.mode,
         )?;
 
         Ok(())
@@ -365,9 +518,10 @@ where
     pub fn wipe(self) -> Result<()> {
         let Self {
             fs,
+            mode: _,
             tracker,
             pages,
-            bitmask,
+            storage_engine,
             base_path,
             config: _,
             _value_type,
@@ -375,7 +529,7 @@ where
         } = self;
 
         is_alive_flush_lock.blocking_mark_dead();
-        drop((tracker, pages, bitmask));
+        drop((tracker, pages, storage_engine));
 
         fs.remove_dir(&base_path)?;
         Ok(())
@@ -383,7 +537,16 @@ where
 
     /// Return the storage size in bytes (precise, based on bitmask occupancy).
     pub fn get_storage_size_bytes(&self) -> Result<usize> {
-        self.bitmask.read().get_storage_size_bytes()
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => bitmask.read().get_storage_size_bytes(),
+            StorageEngine::Serverless {} => {
+                let mut total = 0;
+                for page in &self.pages.read().pages {
+                    total += page.len::<u8>()? as usize;
+                }
+                Ok(total)
+            }
+        }
     }
 
     pub fn get_value<P: AccessPattern>(
@@ -493,6 +656,16 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
         self.pages.read().num_pages() as PageId
     }
 
+    /// Test-only access to the dynamic-mode bitmask. Panics in serverless mode,
+    /// which has no bitmask.
+    #[cfg(test)]
+    pub(crate) fn bitmask_for_test(&self) -> &Arc<RwLock<Bitmask<S>>> {
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => bitmask,
+            StorageEngine::Serverless {} => panic!("no bitmask in serverless mode"),
+        }
+    }
+
     #[inline]
     fn blocks_for_value(value_size: usize, block_size: usize) -> u32 {
         value_size.div_ceil(block_size).try_into().unwrap()
@@ -500,11 +673,24 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
 
     /// Create flusher that durably persists all pending changes when invoked.
     pub fn flusher(&self) -> Flusher {
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => self.flusher_dynamic(bitmask),
+            StorageEngine::Serverless {} => self.flusher_serverless(),
+        }
+    }
+
+    /// Create flusher that durably persists all pending changes when invoked.
+    fn flusher_dynamic(&self, bitmask: &Arc<RwLock<Bitmask<S>>>) -> Flusher {
+        debug_assert!(
+            !self.mode.is_serverless(),
+            "flusher_dynamic must only be called in dynamic mode",
+        );
+
         let pending_updates = self.tracker.read().pending_updates.clone();
 
         let pages = Arc::downgrade(&self.pages);
         let tracker = Arc::downgrade(&self.tracker);
-        let bitmask = Arc::downgrade(&self.bitmask);
+        let bitmask = Arc::downgrade(bitmask);
         let block_size_bytes = self.config.block_size_bytes;
 
         let is_alive_flush_lock = self.is_alive_flush_lock.handle();
@@ -533,6 +719,43 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
             }
 
             Self::flush_free_blocks(&bitmask, old_pointers, block_size_bytes)?;
+
+            drop(is_alive_flush_guard);
+
+            Ok(())
+        })
+    }
+
+    /// Create flusher that durably persists all pending changes when invoked.
+    fn flusher_serverless(&self) -> Flusher {
+        debug_assert!(
+            self.mode.is_serverless(),
+            "flusher_dynamic may only be called in serverless mode",
+        );
+
+        let pending_updates = self.tracker.read().pending_updates.clone();
+
+        let pages = Arc::downgrade(&self.pages);
+        let tracker = Arc::downgrade(&self.tracker);
+        let _block_size_bytes = self.config.block_size_bytes;
+
+        let is_alive_flush_lock = self.is_alive_flush_lock.handle();
+
+        Box::new(move || {
+            let (Some(is_alive_flush_guard), Some(pages), Some(tracker)) = (
+                is_alive_flush_lock.lock_if_alive(),
+                pages.upgrade(),
+                tracker.upgrade(),
+            ) else {
+                log::trace!("Gridstore was cleared, cancelling flush");
+                return Err(GridstoreError::FlushCancelled);
+            };
+
+            let pages_flusher = pages.read().flusher();
+            pages_flusher()?;
+
+            // In serverless we don't clean up old points
+            let _old_pointers = Self::flush_tracker(&tracker, pending_updates)?;
 
             drop(is_alive_flush_guard);
 
@@ -584,7 +807,12 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
     pub fn populate(&self) -> Result<()> {
         self.pages.read().populate()?;
         self.tracker.read().populate()?;
-        self.bitmask.read().populate()?;
+        match &self.storage_engine {
+            StorageEngine::Dynamic { bitmask } => {
+                bitmask.read().populate()?;
+            }
+            StorageEngine::Serverless {} => {}
+        }
         Ok(())
     }
 
@@ -592,16 +820,41 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
     pub fn clear_cache(&self) -> crate::Result<()> {
         let Self {
             fs: _,
+            mode: _,
             config: _,
             tracker: _,
             pages,
-            bitmask,
+            storage_engine,
             base_path: _,
             _value_type,
             is_alive_flush_lock: _,
         } = self;
         pages.read().clear_cache()?;
-        bitmask.read().clear_cache()?;
+
+        match storage_engine {
+            StorageEngine::Dynamic { bitmask } => {
+                bitmask.read().clear_cache()?;
+            }
+            StorageEngine::Serverless {} => {}
+        }
+
         Ok(())
+    }
+}
+
+/// Operating mode
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub enum Mode {
+    #[default]
+    Regular,
+    Serverless,
+}
+
+impl Mode {
+    pub fn is_serverless(self) -> bool {
+        match self {
+            Self::Regular => false,
+            Self::Serverless => true,
+        }
     }
 }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -190,13 +190,32 @@ where
 
         let storage_engine = match mode {
             Mode::Regular => {
-                let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
-                let num_pages = bitmask.infer_num_pages();
-                if loaded_pages != num_pages {
-                    return Err(GridstoreError::service_error(format!(
-                        "Inconsistent number of gridstore pages at {base_path:?}: expected {num_pages}, but found {loaded_pages}",
-                    )));
-                }
+                // The bitmask needs one flag per block, `pages * blocks_per_page`
+                // bits. Compare that to what it covers: a storage created or
+                // extended in serverless mode has no bitmask, or a stale one
+                // covering too few blocks. Either way, reconstruct all-used.
+                let blocks_per_page = config.page_size_bytes / config.block_size_bytes;
+                let expected_blocks = loaded_pages * blocks_per_page;
+                let bitmask = if Bitmask::<S>::exists(&base_path) {
+                    let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+                    let covered_blocks = bitmask.covered_blocks();
+                    if covered_blocks == expected_blocks {
+                        bitmask
+                    } else if covered_blocks < expected_blocks {
+                        // Missing flags for serverless-appended blocks; rebuild.
+                        drop(bitmask);
+                        Bitmask::create_all_used(&fs, &base_path, config.clone(), loaded_pages)?
+                    } else {
+                        // More blocks than pages hold: corruption, not a mode switch.
+                        return Err(GridstoreError::service_error(format!(
+                            "Inconsistent gridstore blocks at {base_path:?}: bitmask covers {covered_blocks}, but pages hold {expected_blocks}",
+                        )));
+                    }
+                } else {
+                    // No bitmask: created in serverless mode.
+                    Bitmask::create_all_used(&fs, &base_path, config.clone(), loaded_pages)?
+                };
+                debug_assert_eq!(bitmask.covered_blocks(), expected_blocks);
                 StorageEngine::Dynamic {
                     bitmask: Arc::new(RwLock::new(bitmask)),
                 }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -239,7 +239,8 @@ where
 
     fn create_page_file(&self, path: &std::path::Path) -> Result<()> {
         // Serverless pages are created empty and grown as data is appended, so
-        // their byte length reflects actual data (see `next_append_block`).
+        // their byte length reflects the appended data, block-aligned (see
+        // `write_into_pages` and `next_append_block`).
         // Dynamic pages are pre-sized to the full page so the bitmask can use
         // any block within them.
         let expected_length = if self.mode.is_serverless() {
@@ -297,11 +298,11 @@ where
     /// Find the next block to write to if we're only appending to storage.
     ///
     /// Append-only storage has no bitmask, so the cursor is derived from the
-    /// byte length of the last page: because values are packed from the front
-    /// and occupy whole blocks starting on a block boundary, the number of used
-    /// blocks in the last page is `ceil(byte_len / block_size)`. The last page's
-    /// byte length captures exactly the bytes spilled into it, for both
-    /// single-page and page-spanning values.
+    /// byte length of the last page: because every value is padded to whole
+    /// blocks on write (see [`Self::write_into_pages`]), each page's byte length
+    /// is a block multiple and the number of used blocks in the last page is
+    /// `last_page_len / block_size` (computed as `ceil` to stay robust). This
+    /// holds for both single-page and page-spanning values.
     ///
     /// This only computes the position; it must never create new pages. Use
     /// [`Self::ensure_append_pages`] to materialize the page files the value
@@ -334,9 +335,9 @@ where
     ///
     /// Serverless storage is append-only and does not pre-size pages: the
     /// page files are created empty here, and the write itself grows each one
-    /// by exactly the bytes it appends (see [`Self::write_into_pages`] /
-    /// [`Pages::write_to_pages_grow`]). This only materializes the files; it
-    /// must not size them.
+    /// by the appended bytes, padded to a whole number of blocks (see
+    /// [`Self::write_into_pages`] / [`Pages::write_to_pages_grow`]). This only
+    /// materializes the files; it must not size them.
     fn ensure_append_pages(
         &mut self,
         start_page_id: PageId,
@@ -356,10 +357,16 @@ where
     /// Write a value into a cell, considering that it can span more than one
     /// page.
     ///
-    /// In serverless (append-only) mode the write grows each page file by
-    /// exactly the appended bytes as a single operation, so the pages must not
-    /// be pre-sized. In dynamic mode the pages are already allocated to their
-    /// full size and are written in place.
+    /// In serverless (append-only) mode the write grows each page file as a
+    /// single operation, so the pages must not be pre-sized. The appended bytes
+    /// are padded with zeroes up to a whole number of blocks, so every value
+    /// occupies whole blocks and the next append starts on a block boundary —
+    /// matching the block-aligned, pre-sized pages of dynamic mode. In dynamic
+    /// mode the pages are already allocated to their full size and are written
+    /// in place.
+    ///
+    /// The padding is physical only: the tracker still stores the value's exact
+    /// (unpadded) length, so reads return just the value bytes.
     #[allow(clippy::needless_pass_by_ref_mut)]
     fn write_into_pages(
         &mut self,
@@ -367,11 +374,22 @@ where
         start_page_id: PageId,
         block_offset: BlockOffset,
     ) -> Result<()> {
-        let pointer = ValuePointer::new(start_page_id, block_offset, value.len() as u32);
         let mut pages = self.pages.write();
         if self.mode.is_serverless() {
-            pages.write_to_pages_grow(pointer, value, &self.config)
+            // Append-only pages grow per write, so pad with zeroes up to the
+            // block boundary to keep every value block-aligned.
+            let padded_len = value.len().next_multiple_of(self.config.block_size_bytes);
+            let pointer = ValuePointer::new(start_page_id, block_offset, padded_len as u32);
+            if padded_len == value.len() {
+                pages.write_to_pages_grow(pointer, value, &self.config)
+            } else {
+                let mut padded = Vec::with_capacity(padded_len);
+                padded.extend_from_slice(value);
+                padded.resize(padded_len, 0);
+                pages.write_to_pages_grow(pointer, &padded, &self.config)
+            }
         } else {
+            let pointer = ValuePointer::new(start_page_id, block_offset, value.len() as u32);
             pages.write_to_pages(pointer, value, &self.config)
         }
     }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -777,7 +777,7 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
             let pages_flusher = pages.read().flusher();
             pages_flusher()?;
 
-            let old_pointers = Self::flush_tracker(&tracker, pending_updates)?;
+            let old_pointers = Self::flush_tracker(&tracker, pending_updates, false)?;
 
             if old_pointers.is_empty() {
                 return Ok(());
@@ -820,7 +820,7 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
             pages_flusher()?;
 
             // In serverless we don't clean up old points
-            let _old_pointers = Self::flush_tracker(&tracker, pending_updates)?;
+            let _old_pointers = Self::flush_tracker(&tracker, pending_updates, true)?;
 
             drop(is_alive_flush_guard);
 
@@ -832,10 +832,11 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
     fn flush_tracker(
         tracker: &Arc<RwLock<Tracker<S>>>,
         pending_updates: AHashMap<PointOffset, PointerUpdates>,
+        append_only: bool,
     ) -> crate::Result<Vec<ValuePointer>> {
         let (old_pointers, tracker_flusher) = {
             let mut guard = tracker.write();
-            let old_pointers = guard.write_pending(pending_updates)?;
+            let old_pointers = guard.write_pending(pending_updates, append_only)?;
             let flusher = guard.flusher();
             (old_pointers, flusher)
         };

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -7,6 +7,7 @@ use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
 use common::universal_io::{Populate, UniversalRead, UniversalReadFs, UserData, read_json_via};
 
+use super::Mode;
 use super::view::GridstoreView;
 use crate::Result;
 use crate::blob::Blob;
@@ -30,6 +31,9 @@ pub struct GridstoreReader<V, S: UniversalRead> {
     pub(super) _value_type: std::marker::PhantomData<V>,
     /// How to populate new attached pages
     populate: Populate,
+    /// Storage engine mode this reader was opened with, mirroring
+    /// [`super::Gridstore`].
+    mode: Mode,
 }
 
 impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
@@ -61,7 +65,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// Open an existing read-only storage at the given path.
     ///
     /// Infers page count by scanning for page files on disk.
-    pub fn open(fs: &S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
+    pub fn open(fs: &S::Fs, base_path: PathBuf, populate: Populate, mode: Mode) -> Result<Self> {
         // A reader only reads, so open pages and tracker non-writable. This
         // lets the backend be write-enforced (e.g. `ReadOnly<MmapFile>`); the
         // writable `Gridstore` opens these same files writable instead.
@@ -75,12 +79,18 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
             pages,
             base_path,
             populate,
+            mode,
             _value_type: std::marker::PhantomData,
         })
     }
 
     pub(super) fn page_path(&self, page_id: u32) -> PathBuf {
         self.base_path.join(format!("page_{page_id}.dat"))
+    }
+
+    /// Storage engine mode this reader was opened with.
+    pub fn mode(&self) -> Mode {
+        self.mode
     }
 
     pub fn get_value<P: AccessPattern>(
@@ -192,6 +202,7 @@ impl<V, S: UniversalRead> GridstoreReader<V, S> {
             pages,
             base_path: _,
             populate: _,
+            mode: _,
             _value_type,
         } = self;
         pages.clear_cache()?;

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -176,7 +176,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     ///
     pub fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
-        let has_new_data = self.tracker.live_reload()?;
+        let has_new_data = self.tracker.live_reload(self.mode.is_serverless())?;
 
         if !has_new_data {
             return Ok(());

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -989,7 +989,9 @@ fn test_different_block_sizes(
 /// - data is only written to disk when closure is invoked
 #[rstest]
 fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: asserts block reuse / storage size across flushes.
+    // The deferred-flush read semantics are identical in both modes. The block
+    // offsets differ: dynamic mode reuses blocks freed by earlier flushes, while
+    // serverless mode is append-only and keeps assigning the next block.
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1053,8 +1055,13 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     flusher().unwrap();
     assert_eq!(get_payload(&storage), "value 4");
 
-    // We flushed and freed blocks 0 and 1, we expect to reuse block 0
-    put_payload(&mut storage, "value 5", 0);
+    // Dynamic mode: flush and free block 0 and 1, reuse block 0
+    // Serverless mode: append-only and use next block
+    put_payload(
+        &mut storage,
+        "value 5",
+        if mode.is_serverless() { 4 } else { 0 },
+    );
     assert_eq!(get_payload(&mut storage), "value 5");
 
     // Reopen gridstore
@@ -1065,16 +1072,29 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // On reopen, we expect to read the data at the time the flusher was created
     assert_eq!(get_payload(&storage), "value 3");
 
-    // Bitslice is not buffered and can be flushed by the kernel, expect to reuse block 1
-    // It means that we might lose unoccupied storage, but it can only happen on crash and the
-    // optimizer will eventually take care of this when building a fresh segment
-    put_payload(&mut storage, "value 6", 1);
+    // Dynamic mode: the bitslice is not buffered and can be flushed by the kernel, so we
+    // expect to reuse block 1. It means that we might lose unoccupied storage, but it can
+    // only happen on crash and the optimizer will eventually take care of this when building
+    // a fresh segment. Serverless mode keeps appending monotonically (blocks 5, 6, 7).
+    put_payload(
+        &mut storage,
+        "value 6",
+        if mode.is_serverless() { 5 } else { 1 },
+    );
     assert_eq!(get_payload(&storage), "value 6");
 
-    put_payload(&mut storage, "value 7", 4);
+    put_payload(
+        &mut storage,
+        "value 7",
+        if mode.is_serverless() { 6 } else { 4 },
+    );
     assert_eq!(get_payload(&storage), "value 7");
 
-    put_payload(&mut storage, "value 8", 5);
+    put_payload(
+        &mut storage,
+        "value 8",
+        if mode.is_serverless() { 7 } else { 5 },
+    );
     assert_eq!(get_payload(&storage), "value 8");
 }
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -2498,3 +2498,80 @@ fn test_serverless_unmap_leaves_mapping_in_place() {
         Some(&payload_1),
     );
 }
+
+/// A serverless append past the end of the file pads the write with zeroed
+/// (unmapped) slots so the mapping lands at its correct place.
+#[test]
+fn test_serverless_tracker_pads_mapping_gap_with_zeroes() {
+    const HEADER_SIZE: usize = size_of::<u32>();
+    const SLOT_SIZE: usize = size_of::<u32>() + size_of::<ValuePointer>();
+
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    // Write points 0 and 3, skipping 1 and 2.
+    let payload_0 = random_payload(rng, 1);
+    let payload_3 = random_payload(rng, 1);
+    storage.put_value(0, &payload_0, hw_counter_ref).unwrap();
+    storage.put_value(3, &payload_3, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    // The file covers slots 0..=3 exactly; the skipped slots are zero.
+    let bytes = fs::read(dir.path().join("tracker.dat")).unwrap();
+    assert_eq!(bytes.len(), HEADER_SIZE + 4 * SLOT_SIZE);
+    assert!(
+        bytes[HEADER_SIZE + SLOT_SIZE..HEADER_SIZE + 3 * SLOT_SIZE]
+            .iter()
+            .all(|&b| b == 0),
+        "skipped slots must be zero-padded",
+    );
+
+    // The skipped points read as missing; the mapped ones round-trip.
+    assert!(
+        storage
+            .get_value::<Random>(1, &hw_counter)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        storage
+            .get_value::<Random>(2, &hw_counter)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_0),
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(3, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_3),
+    );
+
+    // Same after reopen; the count is derived from the last mapping.
+    let path = dir.path().to_path_buf();
+    drop(storage);
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Serverless).unwrap();
+    assert_eq!(storage.max_point_offset(), 4);
+    assert!(
+        storage
+            .get_value::<Random>(1, &hw_counter)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(3, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_3),
+    );
+}

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1001,9 +1001,8 @@ fn test_different_block_sizes(
 /// - data is only written to disk when closure is invoked
 #[rstest]
 fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // The deferred-flush read semantics are identical in both modes. The block
-    // offsets differ: dynamic mode reuses blocks freed by earlier flushes, while
-    // serverless mode is append-only and keeps assigning the next block.
+    // Read semantics match in both modes; only block offsets differ: dynamic
+    // reuses freed blocks, serverless appends the next.
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1084,10 +1083,8 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // On reopen, we expect to read the data at the time the flusher was created
     assert_eq!(get_payload(&storage), "value 3");
 
-    // Dynamic mode: the bitslice is not buffered and can be flushed by the kernel, so we
-    // expect to reuse block 1. It means that we might lose unoccupied storage, but it can
-    // only happen on crash and the optimizer will eventually take care of this when building
-    // a fresh segment. Serverless mode keeps appending monotonically (blocks 5, 6, 7).
+    // Dynamic reuses block 1 (kernel may flush the bitslice; a crash can lose
+    // unoccupied storage, which the optimizer later rebuilds). Serverless appends.
     put_payload(
         &mut storage,
         "value 6",
@@ -1113,11 +1110,9 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
 /// Similar to [`test_deferred_flush`] but more complex, including multiple flushers and deletes
 #[rstest]
 fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // The deferred-flush read semantics (including deletes) are identical in both
-    // modes. The block offsets differ: dynamic mode reuses blocks freed after a
-    // delete or flush, while serverless mode is append-only and keeps assigning
-    // the next block. Deletes only touch the tracker, so they don't consume a
-    // block in serverless mode.
+    // Read semantics (incl. deletes) match in both modes; only block offsets
+    // differ: dynamic reuses freed blocks, serverless appends. Deletes touch only
+    // the tracker, so consume no block in serverless.
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1503,9 +1498,7 @@ fn test_skip_deferred_flush_after_clear(#[values(Mode::Regular, Mode::Serverless
     // call the flusher. This allows us to trigger broken flush behavior in old versions.
     // The same is possible without cloning these arcs, but it would require specific timing
     // conditions. Cloning arcs here is much more reliable for this test case.
-    // Serverless mode has no bitmask, so only its pages and tracker arcs are kept alive; those
-    // are exactly the arcs its flusher upgrades, so the flush can only be cancelled by the
-    // is-alive lock that `clear` marks dead.
+    // Serverless keeps only pages+tracker arcs (its flusher upgrades no bitmask).
     let storage_arcs = (
         Arc::clone(&storage.pages),
         Arc::clone(&storage.tracker),
@@ -1741,8 +1734,8 @@ fn read_only_reader_over_write_enforced_backend(
     let stored = reader.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(stored, Some(payload));
 }
-/// Serverless storage must only ever append to its page files: writing new data grows the page,
-/// but never rewrites bytes that were already persisted.
+
+/// Serverless writes only append: they grow page files, never rewriting existing bytes.
 #[test]
 fn test_serverless_writes_only_append() {
     let (dir, mut storage) = empty_storage(Mode::Serverless);
@@ -1768,8 +1761,7 @@ fn test_serverless_writes_only_append() {
     let snapshot = fs::read(&page_path).unwrap();
     assert!(!snapshot.is_empty(), "page must hold the first value");
 
-    // Appending more values (including an update of point 0) must only extend
-    // the page; the previously written prefix must stay byte-for-byte identical.
+    // Appending more (incl. an update of point 0) must only extend the page.
     put(&mut storage, 1, "second value");
     put(&mut storage, 0, "updated first value");
     storage.flusher()().unwrap();
@@ -1807,20 +1799,17 @@ fn test_serverless_initial_page_is_empty() {
     );
 }
 
-/// When a serverless write crosses a page border, the first page must be filled to exactly the
-/// page size, and the new page must hold only the blocks that spilled over (partial,
-/// block-aligned).
+/// A write crossing a page border fills the first page exactly and puts only the
+/// spilled blocks in the next.
 #[test]
 fn test_serverless_write_across_page_border_fills_page() {
-    // Use a small page so we don't allocate huge files.
+    // Small page (and no compression) so the value predictably crosses the border.
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
     let (dir, mut storage) = empty_storage_sized(page_size, Compression::None, Mode::Serverless);
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
 
-    // A value whose (uncompressed) size exceeds one page, so it fills page 0 and
-    // spills into page 1. Compression is disabled so the stored size is
-    // predictable.
+    // Larger than one page, so it fills page 0 and spills into page 1.
     let big = "x".repeat(page_size + page_size / 2);
     let mut payload = Payload::default();
     payload
@@ -1874,8 +1863,8 @@ fn test_serverless_write_across_page_border_fills_page() {
     assert_eq!(read, payload);
 }
 
-/// Every serverless write is block-aligned: page files stay a whole multiple of the block size,
-/// and each value occupies exactly its padded whole-block span (no sub-block packing).
+/// Serverless writes are block-aligned: page files stay block multiples and each
+/// value occupies exactly its padded whole-block span.
 #[test]
 fn test_serverless_writes_are_block_aligned() {
     let (dir, mut storage) = empty_storage(Mode::Serverless);
@@ -1890,8 +1879,7 @@ fn test_serverless_writes_are_block_aligned() {
             .put_value(point_offset, &payload, hw_counter_ref)
             .unwrap();
 
-        // After every write, all page files must be block-aligned in length,
-        // i.e. every append ended exactly on a block boundary.
+        // Every append must end on a block boundary.
         let num_pages = storage.pages.read().num_pages();
         for page_id in 0..num_pages {
             let len = fs::metadata(dir.path().join(format!("page_{page_id}.dat")))
@@ -1906,9 +1894,7 @@ fn test_serverless_writes_are_block_aligned() {
     }
     storage.flusher()().unwrap();
 
-    // The total bytes on disk must equal the sum of every value padded up to a
-    // whole number of blocks: append-only + block-aligned means no gaps and no
-    // packing.
+    // Total bytes on disk == sum of each value padded to whole blocks (no gaps).
     let num_pages = storage.pages.read().num_pages();
     let total_page_bytes: u64 = (0..num_pages)
         .map(|page_id| {
@@ -1929,8 +1915,7 @@ fn test_serverless_writes_are_block_aligned() {
     );
 }
 
-/// Serverless mode has no block-usage bitmask: the `bitmask.dat` / `gaps.dat` files must never be
-/// created, nor reported by `files()`.
+/// Serverless mode never creates or reports `bitmask.dat` / `gaps.dat`.
 #[test]
 fn test_serverless_has_no_block_flag_files() {
     let (dir, mut storage) = empty_storage(Mode::Serverless);
@@ -1971,8 +1956,7 @@ fn test_serverless_has_no_block_flag_files() {
     );
 }
 
-/// A storage created in dynamic mode can be reopened in serverless mode and all of its data read
-/// back.
+/// A dynamic-created storage reopens in serverless mode with all data intact.
 #[test]
 fn test_open_dynamic_storage_in_serverless_mode() {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1101,7 +1101,11 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
 /// Similar to [`test_deferred_flush`] but more complex, including multiple flushers and deletes
 #[rstest]
 fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: asserts block reuse (reused offsets after delete).
+    // The deferred-flush read semantics (including deletes) are identical in both
+    // modes. The block offsets differ: dynamic mode reuses blocks freed after a
+    // delete or flush, while serverless mode is append-only and keeps assigning
+    // the next block. Deletes only touch the tracker, so they don't consume a
+    // block in serverless mode.
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1187,7 +1191,13 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
     // On reopen, delete was flushed this time, expect point to be missing
     assert!(get_payload(&storage).is_none());
 
-    put_payload(&mut storage, "value 4", 0);
+    // Dynamic mode: reuse block 0
+    // Serverless mode: append
+    put_payload(
+        &mut storage,
+        "value 4",
+        if mode.is_serverless() { 3 } else { 0 },
+    );
     assert_eq!(get_payload(&storage).unwrap(), "value 4");
 
     assert_eq!(
@@ -1212,7 +1222,11 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
     // On reopen, value 4 was flushed, expect to read it
     assert_eq!(get_payload(&storage).unwrap(), "value 4");
 
-    put_payload(&mut storage, "value 5", 1);
+    put_payload(
+        &mut storage,
+        "value 5",
+        if mode.is_serverless() { 4 } else { 1 },
+    );
     assert_eq!(get_payload(&storage).unwrap(), "value 5");
 
     let flusher_1_value_5 = storage.flusher();
@@ -1222,12 +1236,20 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
 
     let flusher_2_delete = storage.flusher();
 
-    put_payload(&mut storage, "value 6", 3);
+    put_payload(
+        &mut storage,
+        "value 6",
+        if mode.is_serverless() { 5 } else { 3 },
+    );
     assert_eq!(get_payload(&storage).unwrap(), "value 6");
 
     let flusher_3_value_6 = storage.flusher();
 
-    put_payload(&mut storage, "value 7", 4);
+    put_payload(
+        &mut storage,
+        "value 7",
+        if mode.is_serverless() { 6 } else { 4 },
+    );
     assert_eq!(get_payload(&storage).unwrap(), "value 7");
 
     // Not flushed, still expect to read value 4

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -254,8 +254,6 @@ fn test_update_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: M
 #[rstest]
 fn test_write_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-    // Dynamic mode: writes directly to a pre-sized page via the low-level
-    // `write_to_pages`, bypassing the append/grow path.
     let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None, mode);
     let config = StorageConfig {
         page_size_bytes: page_size,
@@ -278,11 +276,18 @@ fn test_write_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode
     let block_offset = (DEFAULT_REGION_SIZE_BLOCKS - 10) as u32;
     let pointer = ValuePointer::new(0, block_offset, value_len as u32);
 
-    storage
-        .pages
-        .write()
-        .write_to_pages(pointer, &value, &config)
-        .unwrap();
+    // Write via the mode's low-level page-write path (as `write_into_pages`
+    // does): dynamic pages are pre-sized and written in place, while serverless
+    // pages are created empty and grown by the write itself (the skipped gap
+    // reads back as zeros).
+    {
+        let mut pages = storage.pages.write();
+        if mode.is_serverless() {
+            pages.write_to_pages_grow(pointer, &value, &config).unwrap();
+        } else {
+            pages.write_to_pages(pointer, &value, &config).unwrap();
+        }
+    }
 
     let read_value = storage
         .with_view(|view| {

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -220,7 +220,6 @@ fn test_delete_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: M
 
 #[rstest]
 fn test_update_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: asserts block reuse on update.
     let (_dir, mut storage) = empty_storage(mode);
 
     let hw_counter = HardwareCounterCell::new();
@@ -255,8 +254,13 @@ fn test_update_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: M
 
     storage.flusher()().unwrap();
 
-    // First block offset should be available again, so we can reuse it
-    put_payload(&mut storage, "updated after flush", 0);
+    // Dynamic mode: reuse blocks freed by flush
+    // Serverless: append
+    put_payload(
+        &mut storage,
+        "updated after flush",
+        if mode.is_serverless() { 3 } else { 0 },
+    );
 }
 
 #[rstest]

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -729,7 +729,6 @@ fn test_behave_like_hashmap(
 
 #[rstest]
 fn test_handle_huge_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: inspects the bitmask and asserts block-level free space.
     let (_dir, mut storage) = empty_storage(mode);
     assert_eq!(storage.pages.read().num_pages(), 1);
 
@@ -757,7 +756,8 @@ fn test_handle_huge_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mod
     assert!(stored_payload.is_some());
     assert_eq!(stored_payload.unwrap(), payload);
 
-    {
+    // Finding free blocks is only done in dynamic mode
+    if !mode.is_serverless() {
         // the fitting page should be 64MB, so we should still have about 14MB of free space
         let free_blocks = storage
             .bitmask_for_test()

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -21,7 +21,10 @@ use crate::blob::Blob;
 use crate::config::{
     Compression, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS,
 };
-use crate::fixtures::{HM_FIELDS, Payload, empty_storage, empty_storage_sized, random_payload};
+use crate::fixtures::{
+    HM_FIELDS, Payload, empty_storage, empty_storage_in_mode, empty_storage_sized,
+    empty_storage_sized_in_mode, random_payload,
+};
 
 #[test]
 fn test_empty_payload_storage() {
@@ -34,7 +37,8 @@ fn test_empty_payload_storage() {
 
 #[test]
 fn test_put_single_empty_value() {
-    let (_dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block-rounded storage size.
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter = hw_counter.ref_payload_io_write_counter();
@@ -57,7 +61,8 @@ fn test_put_single_empty_value() {
 
 #[test]
 fn test_put_single_payload() {
-    let (_dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block-rounded storage size.
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -88,7 +93,8 @@ fn test_put_single_payload() {
 
 #[test]
 fn test_storage_files() {
-    let (dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts presence of bitmask files.
+    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -157,7 +163,8 @@ fn test_put_payload(#[case] num_payloads: u32, #[case] payload_size_factor: usiz
 
 #[test]
 fn test_delete_single_payload() {
-    let (_dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block-rounded storage size and block reuse.
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -195,7 +202,8 @@ fn test_delete_single_payload() {
 
 #[test]
 fn test_update_single_payload() {
-    let (_dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block reuse on update.
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -236,7 +244,10 @@ fn test_update_single_payload() {
 #[test]
 fn test_write_across_pages() {
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-    let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None);
+    // Dynamic mode: writes directly to a pre-sized page via the low-level
+    // `write_to_pages`, bypassing the append/grow path.
+    let (_dir, mut storage) =
+        empty_storage_sized_in_mode(page_size, Compression::None, Mode::Regular);
     let config = StorageConfig {
         page_size_bytes: page_size,
         block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
@@ -272,6 +283,106 @@ fn test_write_across_pages() {
         .unwrap();
 
     assert_eq!(value, read_value);
+}
+
+/// Serverless storage is append-only: writing a value grows the page file by
+/// exactly the value's byte length, with no block- or page-rounding.
+#[test]
+fn test_serverless_append_grows_page_by_exact_bytes() {
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Serverless);
+
+    let mut payload = Payload::default();
+    payload.0.insert(
+        "key".to_string(),
+        serde_json::Value::String("value".to_string()),
+    );
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    storage.put_value(0, &payload, hw_counter_ref).unwrap();
+
+    // The page file holds exactly the bytes written (the pointer length), unlike
+    // dynamic mode where the page is pre-sized to a full page.
+    let pointer = storage.get_pointer(0).unwrap();
+    assert_eq!(
+        storage.pages.read().last_page_len().unwrap(),
+        u64::from(pointer.length),
+    );
+    assert_eq!(
+        storage.get_storage_size_bytes().unwrap(),
+        pointer.length as usize,
+    );
+}
+
+/// Serverless append-only storage grows onto new pages as values spill over
+/// page boundaries, and reads correctly both before and after reopening.
+#[test]
+fn test_serverless_append_spans_pages_and_reopens() {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    // Smallest valid page (block_size * region_size) so a handful of values
+    // already spill across page boundaries.
+    let options = StorageOptions {
+        page_size_bytes: Some(512),
+        block_size_bytes: Some(128),
+        region_size_blocks: Some(4),
+        compression: Some(Compression::None),
+    };
+    let mut storage =
+        Gridstore::<Payload>::new(MmapFs, path.clone(), options, Mode::Serverless).unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    // Deterministic payloads of varying size, some larger than a block, so the
+    // appended stream crosses page boundaries.
+    let make = |i: u32| {
+        let mut payload = Payload::default();
+        payload.0.insert(
+            "key".to_string(),
+            serde_json::Value::String("x".repeat(40 + (i as usize % 7) * 20)),
+        );
+        payload
+    };
+    let payloads: Vec<_> = (0..40).map(|i| (i, make(i))).collect();
+
+    for (offset, payload) in &payloads {
+        storage.put_value(*offset, payload, hw_counter_ref).unwrap();
+    }
+
+    // Appending must have grown the storage onto multiple pages.
+    assert!(
+        storage.pages.read().num_pages() > 1,
+        "expected the appended value stream to span multiple pages",
+    );
+
+    // Read back (including page-spanning values) before flushing.
+    for (offset, payload) in &payloads {
+        assert_eq!(
+            storage
+                .get_value::<Random>(*offset, &hw_counter)
+                .unwrap()
+                .as_ref(),
+            Some(payload),
+        );
+    }
+
+    storage.flusher()().unwrap();
+    drop(storage);
+
+    // Reopen serverless storage (no bitmask, page count inferred from files) and
+    // confirm every value survives.
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Serverless).unwrap();
+    for (offset, payload) in &payloads {
+        assert_eq!(
+            storage
+                .get_value::<Random>(*offset, &hw_counter)
+                .unwrap()
+                .as_ref(),
+            Some(payload),
+        );
+    }
 }
 
 enum Operation {
@@ -543,8 +654,13 @@ fn test_behave_like_hashmap(
     drop(storage);
 
     // reopen storage
-    let storage =
-        Gridstore::<Payload>::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
+    let storage = Gridstore::<Payload>::open(
+        MmapFs,
+        dir.path().to_path_buf(),
+        Populate::No,
+        Mode::default(),
+    )
+    .unwrap();
     // assert same size
     assert_eq!(storage.get_storage_size_bytes().unwrap(), before_size);
     // assert same length
@@ -578,7 +694,8 @@ fn test_behave_like_hashmap(
 
 #[test]
 fn test_handle_huge_payload() {
-    let (_dir, mut storage) = empty_storage();
+    // Dynamic mode: inspects the bitmask and asserts block-level free space.
+    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let mut payload = Payload::default();
@@ -607,7 +724,11 @@ fn test_handle_huge_payload() {
 
     {
         // the fitting page should be 64MB, so we should still have about 14MB of free space
-        let free_blocks = storage.bitmask.read().free_blocks_for_page(1).unwrap();
+        let free_blocks = storage
+            .bitmask_for_test()
+            .read()
+            .free_blocks_for_page(1)
+            .unwrap();
         let min_expected = 1024 * 1024 * 13 / DEFAULT_BLOCK_SIZE_BYTES;
         let max_expected = 1024 * 1024 * 15 / DEFAULT_BLOCK_SIZE_BYTES;
         assert!((min_expected..max_expected).contains(&free_blocks));
@@ -642,7 +763,8 @@ fn test_storage_persistence_basic() {
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
     {
-        let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), Default::default()).unwrap();
+        let mut storage =
+            Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), Mode::default()).unwrap();
         storage.put_value(0, &payload, hw_counter_ref).unwrap();
         assert_eq!(storage.pages.read().num_pages(), 1);
 
@@ -659,7 +781,7 @@ fn test_storage_persistence_basic() {
     }
 
     // reopen storage
-    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::default()).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let stored_payload = storage.get_value::<Random>(0, &hw_counter).unwrap();
@@ -752,7 +874,13 @@ fn test_with_real_hm_data() {
     storage.flusher()().unwrap();
     drop(storage);
 
-    let mut storage = Gridstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
+    let mut storage = Gridstore::open(
+        MmapFs,
+        dir.path().to_path_buf(),
+        Populate::No,
+        Mode::default(),
+    )
+    .unwrap();
     assert_eq!(point_offset, EXPECTED_LEN as u32 * 2);
     assert_eq!(storage.pages.read().num_pages(), 4);
     assert_eq!(
@@ -812,7 +940,8 @@ fn test_different_block_sizes(#[case] block_size_bytes: usize) {
         block_size_bytes: Some(block_size_bytes),
         ..Default::default()
     };
-    let mut storage = Gridstore::<_>::new(MmapFs, dir.path().to_path_buf(), options).unwrap();
+    let mut storage =
+        Gridstore::<_>::new(MmapFs, dir.path().to_path_buf(), options, Mode::default()).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -840,7 +969,8 @@ fn test_different_block_sizes(#[case] block_size_bytes: usize) {
 /// - data is only written to disk when closure is invoked
 #[test]
 fn test_deferred_flush() {
-    let (dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block reuse / storage size across flushes.
+    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -909,7 +1039,8 @@ fn test_deferred_flush() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Regular).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, we expect to read the data at the time the flusher was created
@@ -931,7 +1062,8 @@ fn test_deferred_flush() {
 /// Similar to [`test_deferred_flush`] but more complex, including multiple flushers and deletes
 #[test]
 fn test_deferred_flush_with_delete() {
-    let (dir, mut storage) = empty_storage();
+    // Dynamic mode: asserts block reuse (reused offsets after delete).
+    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -991,7 +1123,8 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let flusher = storage.flusher();
@@ -1010,7 +1143,8 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, delete was flushed this time, expect point to be missing
@@ -1035,7 +1169,8 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, value 4 was flushed, expect to read it
@@ -1061,28 +1196,32 @@ fn test_deferred_flush_with_delete() {
 
     // Not flushed, still expect to read value 4
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+        let tmp_storage =
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 4");
     }
 
     // First flusher flushed, expect to read value 5 if we load from disk
     flusher_1_value_5().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+        let tmp_storage =
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 5");
     }
 
     // Second flusher flushed, expect point to be missing if we load from disk
     flusher_2_delete().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+        let tmp_storage =
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
         assert!(get_payload(&tmp_storage).is_none());
     }
 
     // Third flusher flushed, expect to read value 6 if we load from disk
     flusher_3_value_6().unwrap();
     {
-        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No).unwrap();
+        let tmp_storage =
+            Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Regular).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 6");
     }
 
@@ -1122,7 +1261,8 @@ fn test_live_reload() {
     };
 
     // Step 1: Write initial data and flush
-    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), Default::default()).unwrap();
+    let mut storage =
+        Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), Mode::default()).unwrap();
 
     let payload_0 = make_payload("key", "value_0");
     let payload_1 = make_payload("key", "value_1");
@@ -1131,8 +1271,13 @@ fn test_live_reload() {
     storage.flusher()().unwrap();
 
     // Step 2: Open a reader
-    let mut reader =
-        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
+    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
+        &MmapFs,
+        path.clone(),
+        Populate::No,
+        Mode::default(),
+    )
+    .unwrap();
     assert_eq!(reader.max_point_offset(), 2);
 
     // Step 3: Verify reader sees initial data
@@ -1193,7 +1338,7 @@ fn test_live_reload_across_pages() {
         page_size_bytes: Some(page_size),
         ..Default::default()
     };
-    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), options).unwrap();
+    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), options, Mode::default()).unwrap();
 
     let payload = minimal_payload();
 
@@ -1208,8 +1353,13 @@ fn test_live_reload_across_pages() {
     let initial_pages = storage.pages.read().num_pages();
 
     // Open reader
-    let mut reader =
-        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
+    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
+        &MmapFs,
+        path.clone(),
+        Populate::No,
+        Mode::default(),
+    )
+    .unwrap();
     assert_eq!(reader.max_point_offset(), first_batch);
 
     // Verify reader can read all initial data
@@ -1252,7 +1402,8 @@ fn test_live_reload_across_pages() {
 ///   something else
 #[test]
 fn test_skip_deferred_flush_after_clear() {
-    let (dir, mut storage) = empty_storage();
+    // Dynamic mode: inspects the bitmask via `bitmask_for_test`.
+    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -1296,7 +1447,7 @@ fn test_skip_deferred_flush_after_clear() {
     let storage_arcs = (
         Arc::clone(&storage.pages),
         Arc::clone(&storage.tracker),
-        Arc::clone(&storage.bitmask),
+        Arc::clone(storage.bitmask_for_test()),
     );
 
     // We clear the storage, pending flusher must not write anything anymore
@@ -1313,7 +1464,8 @@ fn test_skip_deferred_flush_after_clear() {
 
     // If we reopen the storage it must still be empty
     drop(storage);
-    let storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No).unwrap();
+    let storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
     assert!(storage.get_pointer(0).is_none(), "point must not exist");
     assert_eq!(storage.max_point_offset(), 0, "must have zero points");
@@ -1513,6 +1665,7 @@ fn read_only_reader_over_write_enforced_backend() {
         &fs,
         dir.path().to_path_buf(),
         Populate::No,
+        Mode::Regular,
     )
     .unwrap();
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1741,3 +1741,271 @@ fn read_only_reader_over_write_enforced_backend(
     let stored = reader.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(stored, Some(payload));
 }
+/// Serverless storage must only ever append to its page files: writing new data grows the page,
+/// but never rewrites bytes that were already persisted.
+#[test]
+fn test_serverless_writes_only_append() {
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let put = |storage: &mut Gridstore<Payload>, point_offset: u32, value: &str| {
+        let mut payload = Payload::default();
+        payload.0.insert(
+            "key".to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+        storage
+            .put_value(point_offset, &payload, hw_counter_ref)
+            .unwrap();
+    };
+
+    let page_path = dir.path().join("page_0.dat");
+
+    // Write, flush, and snapshot the raw page bytes.
+    put(&mut storage, 0, "first value");
+    storage.flusher()().unwrap();
+    let snapshot = fs::read(&page_path).unwrap();
+    assert!(!snapshot.is_empty(), "page must hold the first value");
+
+    // Appending more values (including an update of point 0) must only extend
+    // the page; the previously written prefix must stay byte-for-byte identical.
+    put(&mut storage, 1, "second value");
+    put(&mut storage, 0, "updated first value");
+    storage.flusher()().unwrap();
+    let grown = fs::read(&page_path).unwrap();
+
+    assert!(
+        grown.len() > snapshot.len(),
+        "append-only writes must grow the page ({} -> {})",
+        snapshot.len(),
+        grown.len(),
+    );
+    assert_eq!(
+        &grown[..snapshot.len()],
+        &snapshot[..],
+        "previously written bytes must be untouched (append-only)",
+    );
+}
+
+/// A freshly created serverless storage must have a single, empty page.
+#[test]
+fn test_serverless_initial_page_is_empty() {
+    let (dir, storage) = empty_storage(Mode::Serverless);
+
+    assert_eq!(storage.pages.read().num_pages(), 1);
+    assert_eq!(
+        storage.pages.read().last_page_len().unwrap(),
+        0,
+        "the initial serverless page must be empty",
+    );
+    let page_path = dir.path().join("page_0.dat");
+    assert_eq!(
+        fs::metadata(&page_path).unwrap().len(),
+        0,
+        "the initial serverless page file must be zero-length on disk",
+    );
+}
+
+/// When a serverless write crosses a page border, the first page must be filled to exactly the
+/// page size, and the new page must hold only the blocks that spilled over (partial,
+/// block-aligned).
+#[test]
+fn test_serverless_write_across_page_border_fills_page() {
+    // Use a small page so we don't allocate huge files.
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let (dir, mut storage) = empty_storage_sized(page_size, Compression::None, Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    // A value whose (uncompressed) size exceeds one page, so it fills page 0 and
+    // spills into page 1. Compression is disabled so the stored size is
+    // predictable.
+    let big = "x".repeat(page_size + page_size / 2);
+    let mut payload = Payload::default();
+    payload
+        .0
+        .insert("key".to_string(), serde_json::Value::String(big));
+    storage.put_value(0, &payload, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    assert_eq!(
+        storage.pages.read().num_pages(),
+        2,
+        "the value must span two pages",
+    );
+
+    let length = storage.get_pointer(0).unwrap().length as usize;
+    let padded_total = length.next_multiple_of(DEFAULT_BLOCK_SIZE_BYTES);
+    assert!(
+        padded_total > page_size,
+        "the value must actually cross the page border",
+    );
+
+    let page0_len = fs::metadata(dir.path().join("page_0.dat")).unwrap().len() as usize;
+    let page1_len = fs::metadata(dir.path().join("page_1.dat")).unwrap().len() as usize;
+
+    // First page is complete and exactly the page size.
+    assert_eq!(
+        page0_len, page_size,
+        "the crossed page must be exactly full",
+    );
+    // Second page is partial: only the spilled-over blocks, block-aligned.
+    assert_eq!(
+        page1_len,
+        padded_total - page_size,
+        "the new page must hold only the spilled-over blocks",
+    );
+    assert!(
+        page1_len > 0 && page1_len < page_size,
+        "the new page must be partial",
+    );
+    assert_eq!(
+        page1_len % DEFAULT_BLOCK_SIZE_BYTES,
+        0,
+        "the new page must be block-aligned",
+    );
+
+    // And the value round-trips across the border.
+    let read = storage
+        .get_value::<Random>(0, &hw_counter)
+        .unwrap()
+        .unwrap();
+    assert_eq!(read, payload);
+}
+
+/// Every serverless write is block-aligned: page files stay a whole multiple of the block size,
+/// and each value occupies exactly its padded whole-block span (no sub-block packing).
+#[test]
+fn test_serverless_writes_are_block_aligned() {
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    let num_values = 64u32;
+    for point_offset in 0..num_values {
+        let payload = random_payload(rng, (point_offset % 4) as usize + 1);
+        storage
+            .put_value(point_offset, &payload, hw_counter_ref)
+            .unwrap();
+
+        // After every write, all page files must be block-aligned in length,
+        // i.e. every append ended exactly on a block boundary.
+        let num_pages = storage.pages.read().num_pages();
+        for page_id in 0..num_pages {
+            let len = fs::metadata(dir.path().join(format!("page_{page_id}.dat")))
+                .unwrap()
+                .len();
+            assert_eq!(
+                len % DEFAULT_BLOCK_SIZE_BYTES as u64,
+                0,
+                "page {page_id} length {len} is not block-aligned",
+            );
+        }
+    }
+    storage.flusher()().unwrap();
+
+    // The total bytes on disk must equal the sum of every value padded up to a
+    // whole number of blocks: append-only + block-aligned means no gaps and no
+    // packing.
+    let num_pages = storage.pages.read().num_pages();
+    let total_page_bytes: u64 = (0..num_pages)
+        .map(|page_id| {
+            fs::metadata(dir.path().join(format!("page_{page_id}.dat")))
+                .unwrap()
+                .len()
+        })
+        .sum();
+    let expected_bytes: u64 = (0..num_values)
+        .map(|point_offset| {
+            let length = storage.get_pointer(point_offset).unwrap().length as usize;
+            length.next_multiple_of(DEFAULT_BLOCK_SIZE_BYTES) as u64
+        })
+        .sum();
+    assert_eq!(
+        total_page_bytes, expected_bytes,
+        "each value must occupy exactly its padded whole-block span",
+    );
+}
+
+/// Serverless mode has no block-usage bitmask: the `bitmask.dat` / `gaps.dat` files must never be
+/// created, nor reported by `files()`.
+#[test]
+fn test_serverless_has_no_block_flag_files() {
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    for point_offset in 0..32u32 {
+        storage
+            .put_value(point_offset, &random_payload(rng, 2), hw_counter_ref)
+            .unwrap();
+    }
+    storage.flusher()().unwrap();
+
+    // Not on disk...
+    let on_disk: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !on_disk
+            .iter()
+            .any(|name| name == "bitmask.dat" || name == "gaps.dat"),
+        "serverless mode must not create block-flag files, found {on_disk:?}",
+    );
+
+    // ...and not reported by files().
+    let reported: Vec<String> = storage
+        .files()
+        .into_iter()
+        .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !reported
+            .iter()
+            .any(|name| name == "bitmask.dat" || name == "gaps.dat"),
+        "files() must not report block-flag files, got {reported:?}",
+    );
+}
+
+/// A storage created in dynamic mode can be reopened in serverless mode and all of its data read
+/// back.
+#[test]
+fn test_open_dynamic_storage_in_serverless_mode() {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    let payloads: Vec<Payload> = (0..40).map(|_| random_payload(rng, 3)).collect();
+
+    // Create and populate in dynamic mode.
+    {
+        let mut storage =
+            Gridstore::<Payload>::new(MmapFs, path.clone(), Default::default(), Mode::Regular)
+                .unwrap();
+        for (point_offset, payload) in payloads.iter().enumerate() {
+            storage
+                .put_value(point_offset as u32, payload, hw_counter_ref)
+                .unwrap();
+        }
+        storage.flusher()().unwrap();
+    }
+
+    // Reopen in serverless mode and read everything back.
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Serverless).unwrap();
+    for (point_offset, payload) in payloads.iter().enumerate() {
+        let got = storage
+            .get_value::<Random>(point_offset as u32, &hw_counter)
+            .unwrap();
+        assert_eq!(
+            got.as_ref(),
+            Some(payload),
+            "point {point_offset} mismatch after opening dynamic storage in serverless mode",
+        );
+    }
+}

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -2045,13 +2045,17 @@ fn test_open_serverless_storage_in_dynamic_mode() {
         "gaps.dat must be created when opening in dynamic mode",
     );
 
-    // ...and every block is marked used (used size == full page capacity).
-    let num_pages = storage.pages.read().num_pages();
-    let used_bytes = storage.get_storage_size_bytes().unwrap();
+    // ...and the flags mark exactly the live blocks (all points are live here).
+    let expected_used: usize = (0..40u32)
+        .map(|point_offset| {
+            let length = storage.get_pointer(point_offset).unwrap().length as usize;
+            length.div_ceil(DEFAULT_BLOCK_SIZE_BYTES) * DEFAULT_BLOCK_SIZE_BYTES
+        })
+        .sum();
     assert_eq!(
-        used_bytes,
-        num_pages * DEFAULT_PAGE_SIZE_BYTES,
-        "the reconstructed bitmask must mark every block of every page as used",
+        storage.get_storage_size_bytes().unwrap(),
+        expected_used,
+        "the reconstructed bitmask must mark exactly the live mapping blocks used",
     );
 
     // Reconstructed store is usable: a new write lands in fresh space, old data intact.
@@ -2224,12 +2228,17 @@ fn test_dynamic_reopen_after_serverless_appends_blocks() {
         assert_eq!(got.as_ref(), Some(payload), "point {point_offset} lost");
     }
 
-    // Every block of every page is now marked used.
-    let num_pages = storage.pages.read().num_pages();
+    // Only the live mapping blocks are marked used (all values here are live).
+    let expected_used: usize = (0..expected.len() as u32)
+        .map(|point_offset| {
+            let length = storage.get_pointer(point_offset).unwrap().length as usize;
+            length.div_ceil(DEFAULT_BLOCK_SIZE_BYTES) * DEFAULT_BLOCK_SIZE_BYTES
+        })
+        .sum();
     assert_eq!(
         storage.get_storage_size_bytes().unwrap(),
-        num_pages * page_size,
-        "reconstructed bitmask must mark every block used",
+        expected_used,
+        "reconstructed bitmask must mark exactly the live mapping blocks used",
     );
 
     // Reconstructed store is usable: a new write lands in fresh space, old data intact.
@@ -2248,5 +2257,93 @@ fn test_dynamic_reopen_after_serverless_appends_blocks() {
             .unwrap()
             .as_ref(),
         Some(&expected[0]),
+    );
+}
+
+/// Rebuilding flags from mappings reclaims serverless dead space: blocks left
+/// stale by overwrites/deletes are freed, so used size reflects only live values.
+#[test]
+fn test_reconstruct_flags_reclaims_stale_serverless_blocks() {
+    let block_size = DEFAULT_BLOCK_SIZE_BYTES;
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    // Distinct multi-block values (no compression, so sizes are predictable).
+    let make = |c: char| -> Payload {
+        let mut payload = Payload::default();
+        payload.0.insert(
+            "key".to_string(),
+            serde_json::Value::String(std::iter::repeat_n(c, block_size * 3).collect::<String>()),
+        );
+        payload
+    };
+    let c = make('c');
+    let d = make('d');
+
+    // Serverless: overwrite point 0 and delete point 1, leaving stale blocks.
+    let total_written_bytes = {
+        let options = StorageOptions {
+            compression: Some(Compression::None),
+            ..Default::default()
+        };
+        let mut storage =
+            Gridstore::<Payload>::new(MmapFs, path.clone(), options, Mode::Serverless).unwrap();
+        storage.put_value(0, &make('a'), hw_counter_ref).unwrap();
+        storage.put_value(1, &make('b'), hw_counter_ref).unwrap();
+        storage.put_value(2, &c, hw_counter_ref).unwrap();
+        storage.put_value(0, &d, hw_counter_ref).unwrap(); // overwrite -> 'a' stale
+        storage.delete_value(1).unwrap(); // -> 'b' stale
+        storage.flusher()().unwrap();
+
+        let num_pages = storage.pages.read().num_pages();
+        (0..num_pages)
+            .map(|id| {
+                fs::metadata(dir.path().join(format!("page_{id}.dat")))
+                    .unwrap()
+                    .len() as usize
+            })
+            .sum::<usize>()
+    };
+
+    // Reopen in dynamic mode: flags reconstructed from the live mappings only.
+    let storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+
+    // Live data is correct; the deleted point is gone.
+    assert_eq!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&d),
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(2, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&c),
+    );
+    assert!(
+        storage
+            .get_value::<Random>(1, &hw_counter)
+            .unwrap()
+            .is_none()
+    );
+
+    // Used size covers only the two live values; the stale blocks were reclaimed.
+    let live_used: usize = [0u32, 2]
+        .iter()
+        .map(|&point_offset| {
+            let length = storage.get_pointer(point_offset).unwrap().length as usize;
+            length.div_ceil(block_size) * block_size
+        })
+        .sum();
+    assert_eq!(storage.get_storage_size_bytes().unwrap(), live_used);
+    assert!(
+        live_used < total_written_bytes,
+        "stale blocks must be reclaimed: live {live_used} vs written {total_written_bytes}",
     );
 }

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -276,9 +276,9 @@ fn test_write_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode
 
     storage.create_new_page().unwrap();
 
-    let value_len = 1000;
+    let value_len = DEFAULT_BLOCK_SIZE_BYTES * 12;
 
-    // Value should span 8 blocks
+    // Value should span 12 blocks, crossing from the last 10 blocks into the next page.
     let value = (0..)
         .map(|i| (i % 24) as u8)
         .take(value_len)

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -164,7 +164,8 @@ fn test_put_payload(
 
 #[rstest]
 fn test_delete_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: asserts block-rounded storage size and block reuse.
+    // Both modes store block-rounded sizes. They differ on delete: dynamic mode
+    // frees the block, while serverless is append-only and keeps it on disk.
     let (_dir, mut storage) = empty_storage(mode);
 
     let mut payload = Payload::default();
@@ -198,7 +199,15 @@ fn test_delete_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: M
     let stored_payload = storage.get_value::<Random>(0, &hw_counter).unwrap();
     assert!(stored_payload.is_none());
     storage.flusher()().unwrap();
-    assert_eq!(storage.get_storage_size_bytes().unwrap(), 0);
+
+    // Dynamic mode frees the block on delete; serverless is append-only and keeps
+    // the block-aligned bytes on disk.
+    let expected_size = if mode.is_serverless() {
+        DEFAULT_BLOCK_SIZE_BYTES
+    } else {
+        0
+    };
+    assert_eq!(storage.get_storage_size_bytes().unwrap(), expected_size);
 }
 
 #[rstest]
@@ -286,9 +295,10 @@ fn test_write_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode
 }
 
 /// Serverless storage is append-only: writing a value grows the page file by
-/// exactly the value's byte length, with no block- or page-rounding.
+/// the value's byte length padded up to a whole number of blocks, so every
+/// value stays block-aligned (like the pre-sized pages in dynamic mode).
 #[test]
-fn test_serverless_append_grows_page_by_exact_bytes() {
+fn test_serverless_append_grows_page_block_aligned() {
     let (_dir, mut storage) = empty_storage(Mode::Serverless);
 
     let mut payload = Payload::default();
@@ -301,16 +311,28 @@ fn test_serverless_append_grows_page_by_exact_bytes() {
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
     storage.put_value(0, &payload, hw_counter_ref).unwrap();
 
-    // The page file holds exactly the bytes written (the pointer length), unlike
-    // dynamic mode where the page is pre-sized to a full page.
+    // The tracker keeps the exact (unpadded) value length; this small value
+    // fits within a single block.
     let pointer = storage.get_pointer(0).unwrap();
+    assert!(
+        u64::from(pointer.length) < DEFAULT_BLOCK_SIZE_BYTES as u64,
+        "test assumes the value is smaller than a single block",
+    );
+
+    // But the page file (and storage size) grows by the block-aligned length:
+    // the value bytes followed by zero padding up to the block boundary.
+    let block_aligned = (pointer.length as usize).next_multiple_of(DEFAULT_BLOCK_SIZE_BYTES);
+    assert_eq!(block_aligned, DEFAULT_BLOCK_SIZE_BYTES);
     assert_eq!(
         storage.pages.read().last_page_len().unwrap(),
-        u64::from(pointer.length),
+        block_aligned as u64,
     );
+    assert_eq!(storage.get_storage_size_bytes().unwrap(), block_aligned);
+
+    // The padding is physical only: the value still reads back intact.
     assert_eq!(
-        storage.get_storage_size_bytes().unwrap(),
-        pointer.length as usize,
+        storage.get_value::<Random>(0, &hw_counter).unwrap(),
+        Some(payload),
     );
 }
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1450,7 +1450,6 @@ fn test_live_reload_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode
 ///   something else
 #[rstest]
 fn test_skip_deferred_flush_after_clear(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Dynamic mode: inspects the bitmask via `bitmask_for_test`.
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1492,10 +1491,13 @@ fn test_skip_deferred_flush_after_clear(#[values(Mode::Regular, Mode::Serverless
     // call the flusher. This allows us to trigger broken flush behavior in old versions.
     // The same is possible without cloning these arcs, but it would require specific timing
     // conditions. Cloning arcs here is much more reliable for this test case.
+    // Serverless mode has no bitmask, so only its pages and tracker arcs are kept alive; those
+    // are exactly the arcs its flusher upgrades, so the flush can only be cancelled by the
+    // is-alive lock that `clear` marks dead.
     let storage_arcs = (
         Arc::clone(&storage.pages),
         Arc::clone(&storage.tracker),
-        Arc::clone(storage.bitmask_for_test()),
+        (!mode.is_serverless()).then(|| Arc::clone(storage.bitmask_for_test())),
     );
 
     // We clear the storage, pending flusher must not write anything anymore

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -113,12 +113,20 @@ fn test_storage_files(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
         actual_files.len(),
         files.len()
     );
-    assert_eq!(files.len(), 5, "Expected 5 files, got {files:?}");
-    assert_eq!(files[0].file_name().unwrap(), "tracker.dat");
-    assert_eq!(files[1].file_name().unwrap(), "page_0.dat");
-    assert_eq!(files[2].file_name().unwrap(), "config.json");
-    assert_eq!(files[3].file_name().unwrap(), "bitmask.dat");
-    assert_eq!(files[4].file_name().unwrap(), "gaps.dat");
+
+    let mut expected_files = vec!["tracker.dat", "page_0.dat", "config.json"];
+    if !mode.is_serverless() {
+        expected_files.extend(["bitmask.dat", "gaps.dat"]);
+    }
+    assert_eq!(
+        files.len(),
+        expected_files.len(),
+        "Expected {} files, got {files:?}",
+        expected_files.len(),
+    );
+    for (file, &expected) in files.iter().zip(expected_files.iter()) {
+        assert_eq!(file.file_name().unwrap(), expected);
+    }
 }
 
 #[rstest]

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -521,8 +521,21 @@ fn test_behave_like_hashmap(
     let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
 
     let mut model_hashmap = AHashMap::with_capacity(max_point_offset as usize);
+    let mut monotonic_offsets = 0..;
+    let operations = (0..operation_count).map(|_| {
+        let mut op = Operation::random(rng, max_point_offset);
 
-    let operations = (0..operation_count).map(|_| Operation::random(rng, max_point_offset));
+        // Serverless flushes are append-only, remap puts and deletes to use monotonic offsets
+        if mode.is_serverless() {
+            if let Operation::Put(offset, _) = &mut op {
+                *offset = monotonic_offsets.next().unwrap();
+            } else if let Operation::Delete(offset) = op {
+                op = Operation::Get(offset);
+            }
+        }
+
+        op
+    });
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -1108,11 +1121,10 @@ fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
 }
 
 /// Similar to [`test_deferred_flush`] but more complex, including multiple flushers and deletes
-#[rstest]
-fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
-    // Read semantics (incl. deletes) match in both modes; only block offsets
-    // differ: dynamic reuses freed blocks, serverless appends. Deletes touch only
-    // the tracker, so consume no block in serverless.
+#[test]
+fn test_deferred_flush_with_delete() {
+    // Dynamic-only: flush deletes/updates of persisted points, which serverless mode rejects
+    let mode = Mode::Regular;
     let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
@@ -1198,13 +1210,8 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
     // On reopen, delete was flushed this time, expect point to be missing
     assert!(get_payload(&storage).is_none());
 
-    // Dynamic mode: reuse block 0
-    // Serverless mode: append
-    put_payload(
-        &mut storage,
-        "value 4",
-        if mode.is_serverless() { 3 } else { 0 },
-    );
+    // Block 0 was freed by the flushed delete, so it is reused
+    put_payload(&mut storage, "value 4", 0);
     assert_eq!(get_payload(&storage).unwrap(), "value 4");
 
     assert_eq!(
@@ -1229,11 +1236,7 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
     // On reopen, value 4 was flushed, expect to read it
     assert_eq!(get_payload(&storage).unwrap(), "value 4");
 
-    put_payload(
-        &mut storage,
-        "value 5",
-        if mode.is_serverless() { 4 } else { 1 },
-    );
+    put_payload(&mut storage, "value 5", 1);
     assert_eq!(get_payload(&storage).unwrap(), "value 5");
 
     let flusher_1_value_5 = storage.flusher();
@@ -1243,20 +1246,12 @@ fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mo
 
     let flusher_2_delete = storage.flusher();
 
-    put_payload(
-        &mut storage,
-        "value 6",
-        if mode.is_serverless() { 5 } else { 3 },
-    );
+    put_payload(&mut storage, "value 6", 3);
     assert_eq!(get_payload(&storage).unwrap(), "value 6");
 
     let flusher_3_value_6 = storage.flusher();
 
-    put_payload(
-        &mut storage,
-        "value 7",
-        if mode.is_serverless() { 6 } else { 4 },
-    );
+    put_payload(&mut storage, "value 7", 4);
     assert_eq!(get_payload(&storage).unwrap(), "value 7");
 
     // Not flushed, still expect to read value 4
@@ -1761,9 +1756,9 @@ fn test_serverless_writes_only_append() {
     let snapshot = fs::read(&page_path).unwrap();
     assert!(!snapshot.is_empty(), "page must hold the first value");
 
-    // Appending more (incl. an update of point 0) must only extend the page.
+    // Appending more values must only extend the page.
     put(&mut storage, 1, "second value");
-    put(&mut storage, 0, "updated first value");
+    put(&mut storage, 2, "third value");
     storage.flusher()().unwrap();
     let grown = fs::read(&page_path).unwrap();
 
@@ -2136,10 +2131,19 @@ fn test_open_back_and_forth_between_modes() {
             expected.insert(next_point, payload);
             next_point += 1;
         }
-        // Update an existing point too.
+
+        // Dynamic mode: update any point offset
+        // Serverless mode: only append new point offset
+        let point_offset = if mode.is_serverless() {
+            next_point
+        } else {
+            rng.random_range(0..next_point)
+        };
         let updated = random_payload(rng, 2);
-        storage.put_value(0, &updated, hw_counter_ref).unwrap();
-        expected.insert(0, updated);
+        storage
+            .put_value(point_offset, &updated, hw_counter_ref)
+            .unwrap();
+        expected.insert(point_offset, updated);
 
         storage.flusher()().unwrap();
     }

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -2351,3 +2351,86 @@ fn test_reconstruct_flags_reclaims_stale_serverless_blocks() {
         "stale blocks must be reclaimed: live {live_used} vs written {total_written_bytes}",
     );
 }
+
+/// Serverless flushes append new mappings at the very end of the tracker file;
+/// persisted mapping bytes stay untouched.
+#[test]
+fn test_serverless_tracker_appends_new_mappings_at_end() {
+    // Tracker layout: u32 header, then a (u32 tag + ValuePointer) slot per point;
+    // unwritten slots are zeros.
+    const HEADER_SIZE: usize = size_of::<u32>();
+    const SLOT_SIZE: usize = size_of::<u32>() + size_of::<ValuePointer>();
+
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+    let tracker_path = dir.path().join("tracker.dat");
+
+    let first_batch = 10u32;
+    let second_batch = 25u32;
+
+    for point_offset in 0..first_batch {
+        storage
+            .put_value(point_offset, &random_payload(rng, 1), hw_counter_ref)
+            .unwrap();
+    }
+    storage.flusher()().unwrap();
+
+    let before = fs::read(&tracker_path).unwrap();
+    let first_end = HEADER_SIZE + first_batch as usize * SLOT_SIZE;
+    assert!(
+        before[first_end..].iter().all(|&b| b == 0),
+        "no data may exist past the last mapping",
+    );
+
+    for point_offset in first_batch..second_batch {
+        storage
+            .put_value(point_offset, &random_payload(rng, 1), hw_counter_ref)
+            .unwrap();
+    }
+    storage.flusher()().unwrap();
+
+    let after = fs::read(&tracker_path).unwrap();
+    let second_end = HEADER_SIZE + second_batch as usize * SLOT_SIZE;
+
+    assert!(after.len() >= before.len(), "tracker file must not shrink");
+    // Header is excluded: it tracks the mapping count.
+    assert_eq!(
+        after[HEADER_SIZE..first_end],
+        before[HEADER_SIZE..first_end],
+        "persisted mappings must stay untouched",
+    );
+    assert!(
+        after[first_end..second_end]
+            .chunks(SLOT_SIZE)
+            .all(|slot| slot.iter().any(|&b| b != 0)),
+        "new mappings must fill the slots right after the existing ones",
+    );
+    assert!(
+        after[second_end..].iter().all(|&b| b == 0),
+        "no data may exist past the last mapping",
+    );
+}
+
+/// The serverless flush path rejects changing a persisted mapping.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "append-only tracker flush")]
+fn test_serverless_flush_rejects_changing_persisted_mapping() {
+    let (_dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    storage
+        .put_value(0, &random_payload(rng, 1), hw_counter_ref)
+        .unwrap();
+    storage.flusher()().unwrap();
+
+    // Updating a persisted point and flushing must trip the debug assertion.
+    storage
+        .put_value(0, &random_payload(rng, 1), hw_counter_ref)
+        .unwrap();
+    storage.flusher()().unwrap();
+}

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -2379,9 +2379,10 @@ fn test_serverless_tracker_appends_new_mappings_at_end() {
 
     let before = fs::read(&tracker_path).unwrap();
     let first_end = HEADER_SIZE + first_batch as usize * SLOT_SIZE;
-    assert!(
-        before[first_end..].iter().all(|&b| b == 0),
-        "no data may exist past the last mapping",
+    assert_eq!(
+        before.len(),
+        first_end,
+        "file must grow to exactly the appended mappings",
     );
 
     for point_offset in first_batch..second_batch {
@@ -2393,23 +2394,23 @@ fn test_serverless_tracker_appends_new_mappings_at_end() {
 
     let after = fs::read(&tracker_path).unwrap();
     let second_end = HEADER_SIZE + second_batch as usize * SLOT_SIZE;
-
-    assert!(after.len() >= before.len(), "tracker file must not shrink");
-    // Header is excluded: it tracks the mapping count.
     assert_eq!(
-        after[HEADER_SIZE..first_end],
-        before[HEADER_SIZE..first_end],
-        "persisted mappings must stay untouched",
+        after.len(),
+        second_end,
+        "file must grow to exactly the appended mappings",
+    );
+
+    // The full prefix, header included, must be byte-for-byte untouched.
+    assert_eq!(
+        after[..first_end],
+        before[..first_end],
+        "existing bytes must stay untouched",
     );
     assert!(
-        after[first_end..second_end]
+        after[first_end..]
             .chunks(SLOT_SIZE)
             .all(|slot| slot.iter().any(|&b| b != 0)),
         "new mappings must fill the slots right after the existing ones",
-    );
-    assert!(
-        after[second_end..].iter().all(|&b| b == 0),
-        "no data may exist past the last mapping",
     );
 }
 
@@ -2433,4 +2434,67 @@ fn test_serverless_flush_rejects_changing_persisted_mapping() {
         .put_value(0, &random_payload(rng, 1), hw_counter_ref)
         .unwrap();
     storage.flusher()().unwrap();
+}
+
+/// Serverless unmaps leave the persisted mapping in place: the tracker file is
+/// not touched, in-session reads see the delete, and the value resurrects on
+/// reopen (accepted trade-off of append-only storage).
+#[test]
+fn test_serverless_unmap_leaves_mapping_in_place() {
+    let (dir, mut storage) = empty_storage(Mode::Serverless);
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+    let tracker_path = dir.path().join("tracker.dat");
+
+    let payload_0 = random_payload(rng, 1);
+    let payload_1 = random_payload(rng, 1);
+    storage.put_value(0, &payload_0, hw_counter_ref).unwrap();
+    storage.put_value(1, &payload_1, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+    let before = fs::read(&tracker_path).unwrap();
+
+    // Unmap a persisted point and flush: the tracker file must be untouched.
+    let deleted = storage.delete_value(0).unwrap();
+    assert_eq!(deleted, Some(payload_0.clone()));
+    storage.flusher()().unwrap();
+    assert_eq!(
+        fs::read(&tracker_path).unwrap(),
+        before,
+        "unmapping must not write to the tracker file",
+    );
+
+    // In-session reads keep seeing the delete.
+    assert!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(1, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_1),
+    );
+
+    // On reopen the mapping is still in place, so the value resurrects.
+    let path = dir.path().to_path_buf();
+    drop(storage);
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Serverless).unwrap();
+    assert_eq!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_0),
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(1, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payload_1),
+    );
 }

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -21,24 +21,21 @@ use crate::blob::Blob;
 use crate::config::{
     Compression, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS,
 };
-use crate::fixtures::{
-    HM_FIELDS, Payload, empty_storage, empty_storage_in_mode, empty_storage_sized,
-    empty_storage_sized_in_mode, random_payload,
-};
+use crate::fixtures::{HM_FIELDS, Payload, empty_storage, empty_storage_sized, random_payload};
 
-#[test]
-fn test_empty_payload_storage() {
+#[rstest]
+fn test_empty_payload_storage(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     let hw_counter = HardwareCounterCell::new();
-    let (_dir, storage) = empty_storage();
+    let (_dir, storage) = empty_storage(mode);
     let payload = storage.get_value::<Random>(0, &hw_counter).unwrap();
     assert!(payload.is_none());
     assert_eq!(storage.get_storage_size_bytes().unwrap(), 0);
 }
 
-#[test]
-fn test_put_single_empty_value() {
+#[rstest]
+fn test_put_single_empty_value(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block-rounded storage size.
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (_dir, mut storage) = empty_storage(mode);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter = hw_counter.ref_payload_io_write_counter();
@@ -59,10 +56,10 @@ fn test_put_single_empty_value() {
     );
 }
 
-#[test]
-fn test_put_single_payload() {
+#[rstest]
+fn test_put_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block-rounded storage size.
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (_dir, mut storage) = empty_storage(mode);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -91,10 +88,10 @@ fn test_put_single_payload() {
     );
 }
 
-#[test]
-fn test_storage_files() {
+#[rstest]
+fn test_storage_files(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts presence of bitmask files.
-    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (dir, mut storage) = empty_storage(mode);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -127,8 +124,12 @@ fn test_storage_files() {
 #[rstest]
 #[case(50000, 2)]
 #[case(100, 2000)]
-fn test_put_payload(#[case] num_payloads: u32, #[case] payload_size_factor: usize) {
-    let (_dir, mut storage) = empty_storage();
+fn test_put_payload(
+    #[case] num_payloads: u32,
+    #[case] payload_size_factor: usize,
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
+    let (_dir, mut storage) = empty_storage(mode);
 
     let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
 
@@ -161,10 +162,10 @@ fn test_put_payload(#[case] num_payloads: u32, #[case] payload_size_factor: usiz
     }
 }
 
-#[test]
-fn test_delete_single_payload() {
+#[rstest]
+fn test_delete_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block-rounded storage size and block reuse.
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (_dir, mut storage) = empty_storage(mode);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -185,7 +186,7 @@ fn test_delete_single_payload() {
     assert_eq!(stored_payload, Some(payload));
     assert_eq!(
         storage.get_storage_size_bytes().unwrap(),
-        DEFAULT_BLOCK_SIZE_BYTES
+        DEFAULT_BLOCK_SIZE_BYTES,
     );
 
     // delete payload
@@ -200,10 +201,10 @@ fn test_delete_single_payload() {
     assert_eq!(storage.get_storage_size_bytes().unwrap(), 0);
 }
 
-#[test]
-fn test_update_single_payload() {
+#[rstest]
+fn test_update_single_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block reuse on update.
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (_dir, mut storage) = empty_storage(mode);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -241,13 +242,12 @@ fn test_update_single_payload() {
     put_payload(&mut storage, "updated after flush", 0);
 }
 
-#[test]
-fn test_write_across_pages() {
+#[rstest]
+fn test_write_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
     // Dynamic mode: writes directly to a pre-sized page via the low-level
     // `write_to_pages`, bypassing the append/grow path.
-    let (_dir, mut storage) =
-        empty_storage_sized_in_mode(page_size, Compression::None, Mode::Regular);
+    let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None, mode);
     let config = StorageConfig {
         page_size_bytes: page_size,
         block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
@@ -289,7 +289,7 @@ fn test_write_across_pages() {
 /// exactly the value's byte length, with no block- or page-rounding.
 #[test]
 fn test_serverless_append_grows_page_by_exact_bytes() {
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Serverless);
+    let (_dir, mut storage) = empty_storage(Mode::Serverless);
 
     let mut payload = Payload::default();
     payload.0.insert(
@@ -465,6 +465,7 @@ impl Operation {
 fn test_behave_like_hashmap(
     #[values(1_048_576, 2_097_152, DEFAULT_PAGE_SIZE_BYTES)] page_size: usize,
     #[values(Compression::None, Compression::LZ4)] compression: Compression,
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
 ) {
     use ahash::AHashMap;
 
@@ -476,7 +477,7 @@ fn test_behave_like_hashmap(
 
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let (dir, mut storage) = empty_storage_sized(page_size, compression);
+    let (dir, mut storage) = empty_storage_sized(page_size, compression, mode);
 
     let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
 
@@ -654,13 +655,8 @@ fn test_behave_like_hashmap(
     drop(storage);
 
     // reopen storage
-    let storage = Gridstore::<Payload>::open(
-        MmapFs,
-        dir.path().to_path_buf(),
-        Populate::No,
-        Mode::default(),
-    )
-    .unwrap();
+    let storage =
+        Gridstore::<Payload>::open(MmapFs, dir.path().to_path_buf(), Populate::No, mode).unwrap();
     // assert same size
     assert_eq!(storage.get_storage_size_bytes().unwrap(), before_size);
     // assert same length
@@ -692,10 +688,10 @@ fn test_behave_like_hashmap(
     );
 }
 
-#[test]
-fn test_handle_huge_payload() {
+#[rstest]
+fn test_handle_huge_payload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: inspects the bitmask and asserts block-level free space.
-    let (_dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (_dir, mut storage) = empty_storage(mode);
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let mut payload = Payload::default();
@@ -749,8 +745,8 @@ fn test_handle_huge_payload() {
     }
 }
 
-#[test]
-fn test_storage_persistence_basic() {
+#[rstest]
+fn test_storage_persistence_basic(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
     let path = dir.path().to_path_buf();
 
@@ -764,7 +760,7 @@ fn test_storage_persistence_basic() {
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
     {
         let mut storage =
-            Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), Mode::default()).unwrap();
+            Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), mode).unwrap();
         storage.put_value(0, &payload, hw_counter_ref).unwrap();
         assert_eq!(storage.pages.read().num_pages(), 1);
 
@@ -781,7 +777,7 @@ fn test_storage_persistence_basic() {
     }
 
     // reopen storage
-    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::default()).unwrap();
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let stored_payload = storage.get_value::<Random>(0, &hw_counter).unwrap();
@@ -789,9 +785,9 @@ fn test_storage_persistence_basic() {
     assert_eq!(stored_payload.unwrap(), payload);
 }
 
-#[test]
+#[rstest]
 #[ignore = "this test is too slow for ci, and has similar coverage to the hashmap tests"]
-fn test_with_real_hm_data() {
+fn test_with_real_hm_data(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     const EXPECTED_LEN: usize = 105_542;
 
     fn write_data(storage: &mut Gridstore<Payload>, init_offset: u32) -> u32 {
@@ -855,7 +851,7 @@ fn test_with_real_hm_data() {
         }
     }
 
-    let (dir, mut storage) = empty_storage();
+    let (dir, mut storage) = empty_storage(mode);
     let point_offset = write_data(&mut storage, 0);
     assert_eq!(point_offset, EXPECTED_LEN as u32);
     assert_eq!(storage.tracker.read().mapping_len().unwrap(), EXPECTED_LEN);
@@ -874,13 +870,8 @@ fn test_with_real_hm_data() {
     storage.flusher()().unwrap();
     drop(storage);
 
-    let mut storage = Gridstore::open(
-        MmapFs,
-        dir.path().to_path_buf(),
-        Populate::No,
-        Mode::default(),
-    )
-    .unwrap();
+    let mut storage =
+        Gridstore::open(MmapFs, dir.path().to_path_buf(), Populate::No, mode).unwrap();
     assert_eq!(point_offset, EXPECTED_LEN as u32 * 2);
     assert_eq!(storage.pages.read().num_pages(), 4);
     assert_eq!(
@@ -931,7 +922,10 @@ fn test_payload_compression() {
 #[case(128)]
 #[case(256)]
 #[case(512)]
-fn test_different_block_sizes(#[case] block_size_bytes: usize) {
+fn test_different_block_sizes(
+    #[case] block_size_bytes: usize,
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
     use crate::fixtures::minimal_payload;
 
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
@@ -940,8 +934,7 @@ fn test_different_block_sizes(#[case] block_size_bytes: usize) {
         block_size_bytes: Some(block_size_bytes),
         ..Default::default()
     };
-    let mut storage =
-        Gridstore::<_>::new(MmapFs, dir.path().to_path_buf(), options, Mode::default()).unwrap();
+    let mut storage = Gridstore::<_>::new(MmapFs, dir.path().to_path_buf(), options, mode).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -967,10 +960,10 @@ fn test_different_block_sizes(#[case] block_size_bytes: usize) {
 /// Specifically:
 /// - version of data we write to disk is that of when the flusher was created
 /// - data is only written to disk when closure is invoked
-#[test]
-fn test_deferred_flush() {
+#[rstest]
+fn test_deferred_flush(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block reuse / storage size across flushes.
-    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -1039,8 +1032,7 @@ fn test_deferred_flush() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage =
-        Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Regular).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, we expect to read the data at the time the flusher was created
@@ -1060,10 +1052,10 @@ fn test_deferred_flush() {
 }
 
 /// Similar to [`test_deferred_flush`] but more complex, including multiple flushers and deletes
-#[test]
-fn test_deferred_flush_with_delete() {
+#[rstest]
+fn test_deferred_flush_with_delete(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: asserts block reuse (reused offsets after delete).
-    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -1123,8 +1115,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage =
-        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     let flusher = storage.flusher();
@@ -1143,8 +1134,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage =
-        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, delete was flushed this time, expect point to be missing
@@ -1169,8 +1159,7 @@ fn test_deferred_flush_with_delete() {
 
     // Reopen gridstore
     drop(storage);
-    let mut storage =
-        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+    let mut storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
 
     // On reopen, value 4 was flushed, expect to read it
@@ -1197,7 +1186,7 @@ fn test_deferred_flush_with_delete() {
     // Not flushed, still expect to read value 4
     {
         let tmp_storage =
-            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 4");
     }
 
@@ -1205,7 +1194,7 @@ fn test_deferred_flush_with_delete() {
     flusher_1_value_5().unwrap();
     {
         let tmp_storage =
-            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 5");
     }
 
@@ -1213,15 +1202,14 @@ fn test_deferred_flush_with_delete() {
     flusher_2_delete().unwrap();
     {
         let tmp_storage =
-            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
         assert!(get_payload(&tmp_storage).is_none());
     }
 
     // Third flusher flushed, expect to read value 6 if we load from disk
     flusher_3_value_6().unwrap();
     {
-        let tmp_storage =
-            Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Regular).unwrap();
+        let tmp_storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, mode).unwrap();
         assert_eq!(get_payload(&tmp_storage).unwrap(), "value 6");
     }
 
@@ -1243,8 +1231,8 @@ fn test_deferred_flush_with_delete() {
 /// 4. Write more data via Gridstore, flush.
 /// 5. Call `live_reload` on reader, verify it sees new data.
 /// 6. Also test that live_reload is a no-op when nothing changed.
-#[test]
-fn test_live_reload() {
+#[rstest]
+fn test_live_reload(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
     let path = dir.path().to_path_buf();
 
@@ -1261,8 +1249,7 @@ fn test_live_reload() {
     };
 
     // Step 1: Write initial data and flush
-    let mut storage =
-        Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), Mode::default()).unwrap();
+    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), Default::default(), mode).unwrap();
 
     let payload_0 = make_payload("key", "value_0");
     let payload_1 = make_payload("key", "value_1");
@@ -1271,13 +1258,9 @@ fn test_live_reload() {
     storage.flusher()().unwrap();
 
     // Step 2: Open a reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
-        &MmapFs,
-        path.clone(),
-        Populate::No,
-        Mode::default(),
-    )
-    .unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No, mode)
+            .unwrap();
     assert_eq!(reader.max_point_offset(), 2);
 
     // Step 3: Verify reader sees initial data
@@ -1321,8 +1304,8 @@ fn test_live_reload() {
 ///
 /// Writes enough data to fill pages, then writes more data that creates new pages,
 /// and verifies that live_reload picks up the new pages too.
-#[test]
-fn test_live_reload_across_pages() {
+#[rstest]
+fn test_live_reload_across_pages(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     use crate::config::DEFAULT_BLOCK_SIZE_BYTES;
     use crate::fixtures::minimal_payload;
 
@@ -1338,7 +1321,7 @@ fn test_live_reload_across_pages() {
         page_size_bytes: Some(page_size),
         ..Default::default()
     };
-    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), options, Mode::default()).unwrap();
+    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), options, mode).unwrap();
 
     let payload = minimal_payload();
 
@@ -1353,13 +1336,9 @@ fn test_live_reload_across_pages() {
     let initial_pages = storage.pages.read().num_pages();
 
     // Open reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
-        &MmapFs,
-        path.clone(),
-        Populate::No,
-        Mode::default(),
-    )
-    .unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No, mode)
+            .unwrap();
     assert_eq!(reader.max_point_offset(), first_batch);
 
     // Verify reader can read all initial data
@@ -1400,10 +1379,10 @@ fn test_live_reload_across_pages() {
 /// Specifically:
 /// - ensure that 'late' flushers don't write any data if already invalidated by a clear or
 ///   something else
-#[test]
-fn test_skip_deferred_flush_after_clear() {
+#[rstest]
+fn test_skip_deferred_flush_after_clear(#[values(Mode::Regular, Mode::Serverless)] mode: Mode) {
     // Dynamic mode: inspects the bitmask via `bitmask_for_test`.
-    let (dir, mut storage) = empty_storage_in_mode(Mode::Regular);
+    let (dir, mut storage) = empty_storage(mode);
     let path = dir.path().to_path_buf();
 
     let hw_counter = HardwareCounterCell::new();
@@ -1464,8 +1443,7 @@ fn test_skip_deferred_flush_after_clear() {
 
     // If we reopen the storage it must still be empty
     drop(storage);
-    let storage =
-        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+    let storage = Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
     assert_eq!(storage.pages.read().num_pages(), 1);
     assert!(storage.get_pointer(0).is_none(), "point must not exist");
     assert_eq!(storage.max_point_offset(), 0, "must have zero points");
@@ -1474,11 +1452,13 @@ fn test_skip_deferred_flush_after_clear() {
 /// `Pages::read_batch_from_pages` must yield the same bytes as calling
 /// `read_from_pages` for each pointer individually. Covers the small/multi-page mix
 /// and synthetic zero-length pointers.
-#[test]
-fn test_read_batch_from_pages_congruent_with_read_from_pages() {
+#[rstest]
+fn test_read_batch_from_pages_congruent_with_read_from_pages(
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
     // Use small pages so larger payloads span multiple pages.
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-    let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None);
+    let (_dir, mut storage) = empty_storage_sized(page_size, Compression::None, mode);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -1542,9 +1522,11 @@ fn test_read_batch_from_pages_congruent_with_read_from_pages() {
 /// `GridstoreView::for_each_in_batch` must yield the same values as calling
 /// `get_value` per offset, including missing/out-of-range offsets that should be
 /// silently skipped (matching `get_value`'s `Ok(None)`).
-#[test]
-fn test_for_each_in_batch_congruent_with_get_value() {
-    let (_dir, mut storage) = empty_storage();
+#[rstest]
+fn test_for_each_in_batch_congruent_with_get_value(
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
+    let (_dir, mut storage) = empty_storage(mode);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
@@ -1598,9 +1580,11 @@ fn test_for_each_in_batch_congruent_with_get_value() {
 /// `get_value` path and the batched `read_values` path. The batched tracker lookup used to skip
 /// the `pending.current == None` case and fall through to the stale persisted pointer, so
 /// `read_values` resurrected the old value while `get_value` correctly reported it gone.
-#[test]
-fn test_batch_read_honors_pending_unset_of_flushed_value() {
-    let (_dir, mut storage) = empty_storage();
+#[rstest]
+fn test_batch_read_honors_pending_unset_of_flushed_value(
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
+    let (_dir, mut storage) = empty_storage(mode);
 
     let hw_counter = HardwareCounterCell::new();
     let hw_write = hw_counter.ref_payload_io_write_counter();
@@ -1640,14 +1624,16 @@ fn test_batch_read_honors_pending_unset_of_flushed_value() {
 /// only reads. Backing it with the write-enforced `ReadOnly<MmapFile>` (which
 /// `debug_assert!`s every open is non-writable) only succeeds if the reader
 /// opens its pages and tracker read-only.
-#[test]
-fn read_only_reader_over_write_enforced_backend() {
+#[rstest]
+fn read_only_reader_over_write_enforced_backend(
+    #[values(Mode::Regular, Mode::Serverless)] mode: Mode,
+) {
     use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
 
     let hw_counter = HardwareCounterCell::new();
 
     // Build a writable gridstore, write one value, flush, then drop it.
-    let (dir, mut storage) = empty_storage();
+    let (dir, mut storage) = empty_storage(mode);
     let mut payload = Payload::default();
     payload
         .0
@@ -1665,7 +1651,7 @@ fn read_only_reader_over_write_enforced_backend() {
         &fs,
         dir.path().to_path_buf(),
         Populate::No,
-        Mode::Regular,
+        mode,
     )
     .unwrap();
 

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -2009,3 +2009,260 @@ fn test_open_dynamic_storage_in_serverless_mode() {
         );
     }
 }
+
+/// A serverless-created storage reopens in dynamic mode, reconstructing
+/// `bitmask.dat` / `gaps.dat` with every block marked used.
+#[test]
+fn test_open_serverless_storage_in_dynamic_mode() {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    let payloads: Vec<Payload> = (0..40).map(|_| random_payload(rng, 3)).collect();
+
+    // Create and populate in serverless mode.
+    {
+        let mut storage =
+            Gridstore::<Payload>::new(MmapFs, path.clone(), Default::default(), Mode::Serverless)
+                .unwrap();
+        for (point_offset, payload) in payloads.iter().enumerate() {
+            storage
+                .put_value(point_offset as u32, payload, hw_counter_ref)
+                .unwrap();
+        }
+        storage.flusher()().unwrap();
+
+        // Serverless storage has no block-flag files.
+        assert!(!dir.path().join("bitmask.dat").exists());
+        assert!(!dir.path().join("gaps.dat").exists());
+    }
+
+    // Reopen in dynamic mode: this must reconstruct the bitmask.
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+
+    // All data still reads back unchanged.
+    for (point_offset, payload) in payloads.iter().enumerate() {
+        let got = storage
+            .get_value::<Random>(point_offset as u32, &hw_counter)
+            .unwrap();
+        assert_eq!(got.as_ref(), Some(payload), "point {point_offset} mismatch");
+    }
+
+    // The block-flag files now exist...
+    assert!(
+        dir.path().join("bitmask.dat").exists(),
+        "bitmask.dat must be created when opening in dynamic mode",
+    );
+    assert!(
+        dir.path().join("gaps.dat").exists(),
+        "gaps.dat must be created when opening in dynamic mode",
+    );
+
+    // ...and every block is marked used (used size == full page capacity).
+    let num_pages = storage.pages.read().num_pages();
+    let used_bytes = storage.get_storage_size_bytes().unwrap();
+    assert_eq!(
+        used_bytes,
+        num_pages * DEFAULT_PAGE_SIZE_BYTES,
+        "the reconstructed bitmask must mark every block of every page as used",
+    );
+
+    // Reconstructed store is usable: a new write lands in fresh space, old data intact.
+    let extra = random_payload(rng, 3);
+    storage.put_value(40, &extra, hw_counter_ref).unwrap();
+    assert_eq!(
+        storage
+            .get_value::<Random>(40, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&extra),
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&payloads[0]),
+    );
+}
+
+/// Reopening back and forth between dynamic and serverless preserves all data,
+/// including data written in each mode.
+#[test]
+fn test_open_back_and_forth_between_modes() {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+
+    // The latest expected value for every point written so far.
+    let mut expected: std::collections::HashMap<u32, Payload> = std::collections::HashMap::new();
+    let mut next_point = 0u32;
+
+    // Start in dynamic mode with an initial batch.
+    let mut mode = Mode::Regular;
+    {
+        let mut storage =
+            Gridstore::<Payload>::new(MmapFs, path.clone(), Default::default(), mode).unwrap();
+        for _ in 0..20 {
+            let payload = random_payload(rng, 2);
+            storage
+                .put_value(next_point, &payload, hw_counter_ref)
+                .unwrap();
+            expected.insert(next_point, payload);
+            next_point += 1;
+        }
+        storage.flusher()().unwrap();
+    }
+
+    // Flip modes each round: read all back, then write more and update a point.
+    for round in 0..4 {
+        mode = if mode.is_serverless() {
+            Mode::Regular
+        } else {
+            Mode::Serverless
+        };
+        let mut storage =
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, mode).unwrap();
+
+        for (point_offset, payload) in &expected {
+            let got = storage
+                .get_value::<Random>(*point_offset, &hw_counter)
+                .unwrap();
+            assert_eq!(
+                got.as_ref(),
+                Some(payload),
+                "point {point_offset} corrupted in round {round} (mode {mode:?})",
+            );
+        }
+
+        for _ in 0..10 {
+            let payload = random_payload(rng, 2);
+            storage
+                .put_value(next_point, &payload, hw_counter_ref)
+                .unwrap();
+            expected.insert(next_point, payload);
+            next_point += 1;
+        }
+        // Update an existing point too.
+        let updated = random_payload(rng, 2);
+        storage.put_value(0, &updated, hw_counter_ref).unwrap();
+        expected.insert(0, updated);
+
+        storage.flusher()().unwrap();
+    }
+
+    // Final verification, back in dynamic mode.
+    let storage = Gridstore::<Payload>::open(MmapFs, path, Populate::No, Mode::Regular).unwrap();
+    for (point_offset, payload) in &expected {
+        let got = storage
+            .get_value::<Random>(*point_offset, &hw_counter)
+            .unwrap();
+        assert_eq!(
+            got.as_ref(),
+            Some(payload),
+            "point {point_offset} corrupted at final check",
+        );
+    }
+}
+
+/// Reopening in dynamic mode after serverless appends grew the pages rebuilds the
+/// stale bitmask (it now covers too few blocks), marking the new blocks used.
+#[test]
+fn test_dynamic_reopen_after_serverless_appends_blocks() {
+    // Small pages (and no compression) so a few large values create extra pages.
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let make_big = |c: char| -> Payload {
+        let mut payload = Payload::default();
+        payload.0.insert(
+            "key".to_string(),
+            serde_json::Value::String(std::iter::repeat_n(c, page_size / 3).collect::<String>()),
+        );
+        payload
+    };
+
+    let mut expected: Vec<Payload> = Vec::new();
+
+    // 1. Dynamic mode, one value: bitmask covers one page.
+    {
+        let options = StorageOptions {
+            page_size_bytes: Some(page_size),
+            compression: Some(Compression::None),
+            ..Default::default()
+        };
+        let mut storage =
+            Gridstore::<Payload>::new(MmapFs, path.clone(), options, Mode::Regular).unwrap();
+        let payload = make_big('a');
+        storage.put_value(0, &payload, hw_counter_ref).unwrap();
+        expected.push(payload);
+        storage.flusher()().unwrap();
+        assert_eq!(storage.pages.read().num_pages(), 1);
+        assert!(dir.path().join("bitmask.dat").exists());
+    }
+
+    // 2. Serverless: append until the pages grow; the bitmask is left stale.
+    {
+        let mut storage =
+            Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Serverless)
+                .unwrap();
+        for (i, c) in ['b', 'c', 'd'].into_iter().enumerate() {
+            let payload = make_big(c);
+            storage
+                .put_value(1 + i as u32, &payload, hw_counter_ref)
+                .unwrap();
+            expected.push(payload);
+        }
+        storage.flusher()().unwrap();
+        assert!(
+            storage.pages.read().num_pages() >= 2,
+            "serverless appends must have grown the pages",
+        );
+    }
+
+    // 3. Dynamic: the stale bitmask covers too few blocks, so it's rebuilt all-used.
+    let mut storage =
+        Gridstore::<Payload>::open(MmapFs, path.clone(), Populate::No, Mode::Regular).unwrap();
+
+    // All data survives the reconstruction.
+    for (point_offset, payload) in expected.iter().enumerate() {
+        let got = storage
+            .get_value::<Random>(point_offset as u32, &hw_counter)
+            .unwrap();
+        assert_eq!(got.as_ref(), Some(payload), "point {point_offset} lost");
+    }
+
+    // Every block of every page is now marked used.
+    let num_pages = storage.pages.read().num_pages();
+    assert_eq!(
+        storage.get_storage_size_bytes().unwrap(),
+        num_pages * page_size,
+        "reconstructed bitmask must mark every block used",
+    );
+
+    // Reconstructed store is usable: a new write lands in fresh space, old data intact.
+    let extra = make_big('e');
+    storage.put_value(99, &extra, hw_counter_ref).unwrap();
+    assert_eq!(
+        storage
+            .get_value::<Random>(99, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&extra),
+    );
+    assert_eq!(
+        storage
+            .get_value::<Random>(0, &hw_counter)
+            .unwrap()
+            .as_ref(),
+        Some(&expected[0]),
+    );
+}

--- a/lib/gridstore/src/lib.rs
+++ b/lib/gridstore/src/lib.rs
@@ -8,7 +8,7 @@ mod pages;
 mod tracker;
 
 pub use blob::Blob;
-pub use gridstore::{Gridstore, GridstoreReader, GridstoreView};
+pub use gridstore::{Gridstore, GridstoreReader, GridstoreView, Mode};
 
 use crate::error::GridstoreError;
 

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -25,7 +25,8 @@ pub fn page_path(base_path: &Path, page_id: PageId) -> PathBuf {
 #[derive(Debug)]
 pub(crate) struct Pages<S> {
     base_path: PathBuf,
-    pages: Vec<S>,
+    // TODO: don't use pub(super) here?
+    pub(super) pages: Vec<S>,
     /// Whether attached pages are opened writable. The writable [`Gridstore`]
     /// opens writable so it can append; a read-only [`GridstoreReader`] opens
     /// non-writable so it can sit on a write-enforced backend (e.g.
@@ -84,6 +85,16 @@ impl<S: UniversalRead> Pages<S> {
 
     pub fn num_pages(&self) -> usize {
         self.pages.len()
+    }
+
+    /// Byte length of the last (active) page. Used by append-only storage to
+    /// derive the next free block without a bitmask.
+    pub fn last_page_len(&self) -> Result<u64> {
+        let page = self
+            .pages
+            .last()
+            .expect("storage always has at least one page");
+        Ok(page.len::<u8>()?)
     }
 
     pub fn page_path(&self, page_id: PageId) -> PathBuf {
@@ -444,22 +455,45 @@ impl<S: UniversalRead> Pages<S> {
 }
 
 impl<S: UniversalWrite> Pages<S> {
+    /// Write a value into pre-sized pages (dynamic storage): the pages must
+    /// already be large enough to hold the value.
     pub fn write_to_pages(
         &mut self,
         pointer: ValuePointer,
         value: &[u8],
         config: &StorageConfig,
     ) -> Result<()> {
-        let writes =
-            Self::get_page_value_ranges(pointer, config).map(|(buf_offset, page, range)| {
-                let data = &value[buf_offset..buf_offset + range.length as usize];
-                (page as FileIndex, range.byte_offset, data)
-            });
-
+        let writes = Self::value_page_writes(pointer, value, config);
         // Execute writes (mutable borrow of self.pages)
         S::write_multi(self.pages.as_mut_slice(), writes)?;
-
         Ok(())
+    }
+
+    /// Append a value into pages (append-only / serverless storage): each page
+    /// is grown to fit by the write itself, as a single append operation. The
+    /// pages must already exist (be attached), but need not be pre-sized.
+    pub fn write_to_pages_grow(
+        &mut self,
+        pointer: ValuePointer,
+        value: &[u8],
+        config: &StorageConfig,
+    ) -> Result<()> {
+        let writes = Self::value_page_writes(pointer, value, config);
+        // Execute writes (mutable borrow of self.pages)
+        S::write_multi_grow(self.pages.as_mut_slice(), writes)?;
+        Ok(())
+    }
+
+    /// Split a value into per-page `(page, byte_offset, data)` write tuples.
+    fn value_page_writes<'a>(
+        pointer: ValuePointer,
+        value: &'a [u8],
+        config: &StorageConfig,
+    ) -> impl Iterator<Item = (FileIndex, u64, &'a [u8])> {
+        Self::get_page_value_ranges(pointer, config).map(|(buf_offset, page, range)| {
+            let data = &value[buf_offset..buf_offset + range.length as usize];
+            (page as FileIndex, range.byte_offset, data)
+        })
     }
 
     pub fn flusher(&self) -> Flusher {

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -605,6 +605,48 @@ where
         Ok(())
     }
 
+    /// Truncate zero padding after the last mapping, e.g. from a dynamic-mode
+    /// pre-allocation, so append-only writes land at the very end of the file.
+    ///
+    /// Call when opening in serverless mode. Only ever removes zero bytes: every
+    /// slot past the scanned pointer count is unmapped. Consumes and reopens the
+    /// tracker, since a mapped file cannot shrink in place.
+    pub fn truncate_padding(self, fs: &S::Fs) -> Result<Self> {
+        let Self {
+            path,
+            header,
+            storage,
+            pending_updates,
+            next_pointer_offset,
+        } = self;
+
+        let expected_len = (size_of::<TrackerHeader>()
+            + next_pointer_offset as usize * size_of::<OptionalPointer>())
+            as u64;
+        if storage.len::<u8>()? <= expected_len {
+            return Ok(Self {
+                path,
+                header,
+                storage,
+                pending_updates,
+                next_pointer_offset,
+            });
+        }
+
+        storage.flusher()()?;
+        drop(storage);
+        create_and_ensure_length(&path, expected_len as usize)?;
+        let storage = Self::open_storage(fs, &path, true)?;
+
+        Ok(Self {
+            path,
+            header,
+            storage,
+            pending_updates,
+            next_pointer_offset,
+        })
+    }
+
     /// Append a mapping at the given offset, growing the file by exactly the
     /// written slot (no pre-allocation). Gaps read back as zeros (None).
     fn persist_pointer_append(

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -614,6 +614,14 @@ where
     ) -> Result<()> {
         let start_offset =
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
+
+        // Strictly append: the slot must be at the very end of the file, never
+        // replacing existing bytes - not even zero padding.
+        debug_assert!(
+            start_offset as u64 >= self.storage.len::<u8>()?,
+            "append-only tracker flush must write at the very end of the file, point {point_offset} lands within it",
+        );
+
         self.storage
             .write_grow(start_offset as u64, &[OptionalPointer::some(pointer)])?;
         Ok(())

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -661,13 +661,14 @@ where
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
         let file_len = self.storage.len::<u8>()? as usize;
 
-        // Strictly append: the slot must be at the very end of the file, never
-        // replacing existing bytes - not even zero padding.
-        debug_assert!(
-            start_offset >= file_len,
-            "append-only tracker flush must write at the very end of the file, point {point_offset} lands within it",
-        );
-
+        // Strictly append: the slot must be at or past the current end of the file.
+        // If it lands within the existing file, we'd overwrite bytes, which is not allowed
+        // for append-only (serverless) storage.
+        if start_offset < file_len {
+            return Err(GridstoreError::service_error(format!(
+                "append-only tracker flush must not overwrite existing bytes for point {point_offset}"
+            )));
+        }
         let slot = OptionalPointer::some(pointer);
         let gap_bytes = start_offset.saturating_sub(file_len);
         if gap_bytes == 0 {

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -433,14 +433,21 @@ where
     /// processed.
     ///
     /// Returns the old pointers that were overwritten, so that they can be freed in the bitmask.
+    ///
+    /// `append_only` (serverless): debug-asserts that no existing mapping is changed.
     #[must_use = "The old pointers need to be freed in the bitmask"]
     pub fn write_pending(
         &mut self,
         pending_updates: AHashMap<PointOffset, PointerUpdates>,
+        append_only: bool,
     ) -> Result<Vec<ValuePointer>> {
         let mut old_pointers = Vec::new();
 
         for (point_offset, updates) in pending_updates {
+            debug_assert!(
+                !append_only || self.get_raw(point_offset)?.is_none(),
+                "append-only tracker flush must not change persisted mapping for point {point_offset}",
+            );
             match updates.current {
                 // Write to store a new pointer
                 Some(new_pointer) => {

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 use std::path::{Path, PathBuf};
 
 use ahash::{AHashMap, AHashSet};
-use common::generic_consts::Random;
+use common::generic_consts::{Random, Sequential};
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::universal_io::{
     OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
@@ -279,14 +279,43 @@ impl<S: UniversalRead> Tracker<S> {
         let path = Self::tracker_file_name(path);
         let storage = Self::open_storage(fs, &path, writeable)?;
         let header: TrackerHeader = Self::read_header(&storage)?;
+        let next_pointer_offset = Self::scan_pointer_count(&storage, header.next_pointer_offset)?;
         let pending_updates = AHashMap::new();
         Ok(Self {
-            next_pointer_offset: header.next_pointer_offset,
             path,
             header,
             storage,
             pending_updates,
+            next_pointer_offset,
         })
+    }
+
+    /// Derive the pointer count: the last mapped slot + 1, or the header count if
+    /// that is higher (trailing deleted points in dynamic mode).
+    ///
+    /// Append-only (serverless) flushes never rewrite the header, so mappings may
+    /// exist beyond its count; scan for them from there.
+    fn scan_pointer_count(storage: &S, header_count: PointOffset) -> Result<PointOffset> {
+        const HEADER_SIZE: u64 = size_of::<TrackerHeader>() as u64;
+        const SLOT_SIZE: u64 = size_of::<OptionalPointer>() as u64;
+
+        let slots_in_file = storage.len::<u8>()?.saturating_sub(HEADER_SIZE) / SLOT_SIZE;
+        let scan_range = ReadRange::new(
+            HEADER_SIZE + u64::from(header_count) * SLOT_SIZE,
+            slots_in_file.saturating_sub(u64::from(header_count)),
+        );
+
+        let mut count = header_count;
+        for chunk in scan_range.iter_autochunks::<OptionalPointer>() {
+            let first_slot = (chunk.byte_offset - HEADER_SIZE) / SLOT_SIZE;
+            let slots = storage.read::<Sequential, OptionalPointer>(chunk)?;
+            for (index, slot) in slots.iter().enumerate() {
+                if slot.to_option().is_some() {
+                    count = (first_slot + index as u64 + 1) as PointOffset;
+                }
+            }
+        }
+        Ok(count)
     }
 
     fn read_header(storage: &S) -> Result<TrackerHeader> {
@@ -316,10 +345,23 @@ impl<S: UniversalRead> Tracker<S> {
     ///
     /// - Should only be called on read-only instances of the tracker.
     /// - Only appending new pointers is supported, not modifications of existing pointers.
-    /// - Partial writes are possible, but ignored. Header is a source of truth.
+    /// - Partial writes are possible, but ignored. Header is a source of truth,
+    ///   except in append-only (serverless) mode where the slots themselves are.
     ///
     /// Returns `true` if there are new changes, `false` if the tracker is already up to date.
-    pub fn live_reload(&mut self) -> Result<bool> {
+    pub fn live_reload(&mut self, append_only: bool) -> Result<bool> {
+        // Append-only flushes never rewrite the header; reopen (the file may have
+        // grown) and rescan for appended mappings instead.
+        if append_only {
+            self.storage.reopen()?;
+            let new_count = Self::scan_pointer_count(&self.storage, self.next_pointer_offset)?;
+            if new_count == self.next_pointer_offset {
+                return Ok(false);
+            }
+            self.next_pointer_offset = new_count;
+            return Ok(true);
+        }
+
         let new_header = Self::read_header(&self.storage)?;
 
         if new_header.next_pointer_offset < self.next_pointer_offset {
@@ -402,13 +444,26 @@ where
 
     /// Create a new PageTracker at the given dir path
     /// The file is created with the default size if no size hint is given
-    pub fn new(fs: &S::Fs, path: &Path, size_hint: Option<usize>) -> Result<Self> {
+    ///
+    /// `append_only` (serverless): the file holds just the header and grows per
+    /// appended mapping, rather than being pre-allocated.
+    pub fn new(
+        fs: &S::Fs,
+        path: &Path,
+        size_hint: Option<usize>,
+        append_only: bool,
+    ) -> Result<Self> {
         let path = Self::tracker_file_name(path);
-        let size = size_hint.unwrap_or(Self::DEFAULT_SIZE).next_power_of_two();
-        assert!(
-            size > std::mem::size_of::<TrackerHeader>(),
-            "Size hint is too small"
-        );
+        let size = if append_only {
+            std::mem::size_of::<TrackerHeader>()
+        } else {
+            let size = size_hint.unwrap_or(Self::DEFAULT_SIZE).next_power_of_two();
+            assert!(
+                size > std::mem::size_of::<TrackerHeader>(),
+                "Size hint is too small"
+            );
+            size
+        };
         create_and_ensure_length(&path, size)?;
         let storage = fs.open(&path, tracker_open_options(true), Default::default())?;
         let header = TrackerHeader::default();
@@ -434,7 +489,9 @@ where
     ///
     /// Returns the old pointers that were overwritten, so that they can be freed in the bitmask.
     ///
-    /// `append_only` (serverless): debug-asserts that no existing mapping is changed.
+    /// `append_only` (serverless): only appends new mappings — unmapped points
+    /// stay in place on disk (the unset stays pending) and the header is not
+    /// rewritten; the count is rescanned on open.
     #[must_use = "The old pointers need to be freed in the bitmask"]
     pub fn write_pending(
         &mut self,
@@ -443,21 +500,40 @@ where
     ) -> Result<Vec<ValuePointer>> {
         let mut old_pointers = Vec::new();
 
+        // Append-only: persist in ascending order so the file only grows at the end
+        let mut pending_updates: Vec<_> = pending_updates.into_iter().collect();
+        if append_only {
+            pending_updates.sort_unstable_by_key(|(point_offset, _)| *point_offset);
+        }
+
         for (point_offset, updates) in pending_updates {
-            debug_assert!(
-                !append_only || self.get_raw(point_offset)?.is_none(),
-                "append-only tracker flush must not change persisted mapping for point {point_offset}",
-            );
             match updates.current {
                 // Write to store a new pointer
                 Some(new_pointer) => {
                     // Mark any existing pointer for removal to free its blocks
-                    if let Some(old_pointer) = self.get_raw(point_offset)? {
+                    let existing = self.get_raw(point_offset)?;
+                    debug_assert_ne!(
+                        existing,
+                        Some(new_pointer),
+                        "pointer is always expected to change"
+                    );
+                    debug_assert!(
+                        !append_only || existing.is_none(),
+                        "append-only tracker flush must not change persisted mapping for point {point_offset}",
+                    );
+                    if let Some(old_pointer) = existing {
                         old_pointers.push(old_pointer);
                     }
 
-                    self.persist_pointer(point_offset, Some(new_pointer))?;
+                    if append_only {
+                        self.persist_pointer_append(point_offset, new_pointer)?;
+                    } else {
+                        self.persist_pointer(point_offset, Some(new_pointer))?;
+                    }
                 }
+                // Append-only leaves unmapped points in place. Keep the unset
+                // pending so reads keep seeing the delete; it resurrects on reopen.
+                None if append_only => continue,
                 // Write to empty the pointer
                 None => self.persist_pointer(point_offset, None)?,
             }
@@ -473,15 +549,18 @@ where
                     if let Some(prev) = prev {
                         debug_assert!(
                             prev.is_empty(),
-                            "remove pending element should be empty but got {prev:?}"
+                            "remove pending element should be empty but got {prev:?}",
                         );
                     }
                 }
             }
         }
 
-        // Increment header count if necessary
-        self.write_pointer_count()?;
+        // Increment header count if necessary. Append-only never rewrites the
+        // header; the count is rescanned on open.
+        if !append_only {
+            self.write_pointer_count()?;
+        }
 
         Ok(old_pointers)
     }
@@ -523,6 +602,20 @@ where
 
         let pointer = OptionalPointer::from(pointer);
         self.storage.write(start_offset as u64, &[pointer])?;
+        Ok(())
+    }
+
+    /// Append a mapping at the given offset, growing the file by exactly the
+    /// written slot (no pre-allocation). Gaps read back as zeros (None).
+    fn persist_pointer_append(
+        &mut self,
+        point_offset: PointOffset,
+        pointer: ValuePointer,
+    ) -> Result<()> {
+        let start_offset =
+            size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
+        self.storage
+            .write_grow(start_offset as u64, &[OptionalPointer::some(pointer)])?;
         Ok(())
     }
 

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -648,7 +648,10 @@ where
     }
 
     /// Append a mapping at the given offset, growing the file by exactly the
-    /// written slot (no pre-allocation). Gaps read back as zeros (None).
+    /// written slot (no pre-allocation).
+    ///
+    /// If the slot lands past the end of the file, the write is padded with
+    /// zeroes (unmapped slots) so it is one contiguous append.
     fn persist_pointer_append(
         &mut self,
         point_offset: PointOffset,
@@ -656,16 +659,26 @@ where
     ) -> Result<()> {
         let start_offset =
             size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
+        let file_len = self.storage.len::<u8>()? as usize;
 
         // Strictly append: the slot must be at the very end of the file, never
         // replacing existing bytes - not even zero padding.
         debug_assert!(
-            start_offset as u64 >= self.storage.len::<u8>()?,
+            start_offset >= file_len,
             "append-only tracker flush must write at the very end of the file, point {point_offset} lands within it",
         );
 
-        self.storage
-            .write_grow(start_offset as u64, &[OptionalPointer::some(pointer)])?;
+        let slot = OptionalPointer::some(pointer);
+        let gap_bytes = start_offset.saturating_sub(file_len);
+        if gap_bytes == 0 {
+            self.storage.write_grow(start_offset as u64, &[slot])?;
+        } else {
+            // Pad the write with zeroes so the mapping lands in the correct
+            // place, appended at the end of the file as one write.
+            let mut buffer = vec![0u8; gap_bytes + size_of::<OptionalPointer>()];
+            buffer[gap_bytes..].copy_from_slice(bytemuck::bytes_of(&slot));
+            self.storage.write_grow(file_len as u64, &buffer)?;
+        }
         Ok(())
     }
 

--- a/lib/gridstore/src/tracker/tests.rs
+++ b/lib/gridstore/src/tracker/tests.rs
@@ -54,7 +54,7 @@ fn test_file_name() {
 fn test_page_tracker_files() {
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
-    let tracker = TestTracker::new(&MmapFs, path, None).unwrap();
+    let tracker = TestTracker::new(&MmapFs, path, None, false).unwrap();
     let files = tracker.files();
     assert_eq!(files.len(), 1);
     assert_eq!(files[0], path.join(TestTracker::FILE_NAME));
@@ -64,7 +64,7 @@ fn test_page_tracker_files() {
 fn test_new_tracker() {
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
-    let tracker = TestTracker::new(&MmapFs, path, None).unwrap();
+    let tracker = TestTracker::new(&MmapFs, path, None, false).unwrap();
     assert!(tracker.is_empty());
     assert_eq!(tracker.mapping_len().unwrap(), 0);
     assert_eq!(tracker.pointer_count(), 0);
@@ -77,7 +77,7 @@ fn test_new_tracker() {
 fn test_mapping_len_tracker(#[case] initial_tracker_size: usize) {
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
-    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size)).unwrap();
+    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size), false).unwrap();
     assert!(tracker.is_empty());
     tracker.set(0, ValuePointer::new(1, 1, 1));
 
@@ -101,7 +101,7 @@ fn test_mapping_len_tracker(#[case] initial_tracker_size: usize) {
 fn test_set_get_clear_tracker(#[case] initial_tracker_size: usize) {
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
-    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size)).unwrap();
+    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size), false).unwrap();
     tracker.set(0, ValuePointer::new(1, 1, 1));
     tracker.set(1, ValuePointer::new(2, 2, 2));
     tracker.set(2, ValuePointer::new(3, 3, 3));
@@ -162,7 +162,7 @@ fn test_persist_and_open_tracker(#[case] initial_tracker_size: usize) {
 
     let value_count: usize = 1000;
 
-    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size)).unwrap();
+    let mut tracker = TestTracker::new(&MmapFs, path, Some(initial_tracker_size), false).unwrap();
 
     for i in 0..value_count {
         // save only half of the values
@@ -208,7 +208,7 @@ fn test_page_tracker_resize(
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
 
-    let mut tracker = TestTracker::new(&MmapFs, path, Some(desired_tracker_size)).unwrap();
+    let mut tracker = TestTracker::new(&MmapFs, path, Some(desired_tracker_size), false).unwrap();
     assert_eq!(tracker.mapping_len().unwrap(), 0);
     assert_eq!(tracker.mmap_file_size().unwrap(), actual_tracker_size);
 
@@ -227,7 +227,7 @@ fn test_track_non_sequential_large_offset() {
     let file = Builder::new().prefix("test-tracker").tempdir().unwrap();
     let path = file.path();
 
-    let mut tracker = TestTracker::new(&MmapFs, path, None).unwrap();
+    let mut tracker = TestTracker::new(&MmapFs, path, None, false).unwrap();
     assert_eq!(tracker.mapping_len().unwrap(), 0);
 
     let page_pointer = ValuePointer::new(1, 1, 1);

--- a/lib/gridstore/src/tracker/tests.rs
+++ b/lib/gridstore/src/tracker/tests.rs
@@ -37,7 +37,7 @@ impl TestTracker {
 
     pub fn write_pending_and_flush_internal(&mut self) -> Result<Vec<ValuePointer>> {
         let pending_updates = std::mem::take(&mut self.pending_updates);
-        let res = self.write_pending(pending_updates)?;
+        let res = self.write_pending(pending_updates, false)?;
         self.storage.flusher()()?;
         Ok(res)
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Populate};
-use gridstore::Gridstore;
+use gridstore::{Gridstore, Mode};
 use itertools::Itertools;
 
 use super::super::FullTextIndex;
@@ -30,15 +30,20 @@ impl MutableFullTextIndex {
         create_if_missing: bool,
     ) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
-            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS, Populate::Blocking).map_err(
-                |err| {
-                    OperationError::service_error(format!(
-                        "failed to open mutable full text index on gridstore: {err}"
-                    ))
-                },
-            )?
+            Gridstore::open_or_create(
+                MmapFs,
+                path,
+                GRIDSTORE_OPTIONS,
+                Populate::Blocking,
+                Mode::default(),
+            )
+            .map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to open mutable full text index on gridstore: {err}"
+                ))
+            })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking, Mode::default()).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable full text index on gridstore: {err}"
                 ))
@@ -67,7 +72,7 @@ impl MutableFullTextIndex {
             )
             .map_err(|err| {
                 OperationError::service_error(format!(
-                    "Failed to load mutable full text index from gridstore: {err}"
+                    "Failed to load mutable full text index from gridstore: {err}",
                 ))
             })?;
 
@@ -84,16 +89,14 @@ impl MutableFullTextIndex {
     #[inline]
     pub(in super::super) fn init(&mut self) -> OperationResult<()> {
         self.storage.clear().map_err(|err| {
-            OperationError::service_error(
-                format!("Failed to clear mutable full text index: {err}",),
-            )
+            OperationError::service_error(format!("Failed to clear mutable full text index: {err}"))
         })
     }
 
     #[inline]
     pub(in super::super) fn wipe(self) -> OperationResult<()> {
         self.storage.wipe().map_err(|err| {
-            OperationError::service_error(format!("Failed to wipe mutable full text index: {err}",))
+            OperationError::service_error(format!("Failed to wipe mutable full text index: {err}"))
         })
     }
 
@@ -106,7 +109,7 @@ impl MutableFullTextIndex {
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.storage.clear_cache().map_err(|err| {
             OperationError::service_error(format!(
-                "Failed to clear mutable full text index gridstore cache: {err}"
+                "Failed to clear mutable full text index gridstore cache: {err}",
             ))
         })
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{OkNotFound, Populate, UniversalRead};
-use gridstore::GridstoreReader;
+use gridstore::{GridstoreReader, Mode};
 
 use super::super::inner::MutableFullTextIndexInner;
 use super::ReadOnlyAppendableFullTextIndex;
@@ -35,7 +35,8 @@ impl<S: UniversalRead> ReadOnlyAppendableFullTextIndex<S> {
         config: TextIndexParams,
     ) -> OperationResult<Option<Self>> {
         let Some(storage) =
-            GridstoreReader::<Vec<u8>, S>::open(fs, path, Populate::Blocking).ok_not_found()?
+            GridstoreReader::<Vec<u8>, S>::open(fs, path, Populate::Blocking, Mode::default())
+                .ok_not_found()?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/lifecycle.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Populate};
-use gridstore::Gridstore;
 use gridstore::config::StorageOptions;
+use gridstore::{Gridstore, Mode};
 
 use super::MutableGeoIndex;
 use super::inner::InMemoryGeoIndex;
@@ -31,15 +31,20 @@ impl MutableGeoIndex {
     /// loaded.
     pub fn open(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
-            Gridstore::open_or_create(MmapFs, path, GRIDSTORE_OPTIONS, Populate::Blocking).map_err(
-                |err| {
-                    OperationError::service_error(format!(
-                        "failed to open mutable geo index on gridstore: {err}"
-                    ))
-                },
-            )?
+            Gridstore::open_or_create(
+                MmapFs,
+                path,
+                GRIDSTORE_OPTIONS,
+                Populate::Blocking,
+                Mode::default(),
+            )
+            .map_err(|err| {
+                OperationError::service_error(format!(
+                    "failed to open mutable geo index on gridstore: {err}"
+                ))
+            })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking, Mode::default()).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable geo index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{OkNotFound, Populate, UniversalRead};
-use gridstore::GridstoreReader;
+use gridstore::{GridstoreReader, Mode};
 
 use super::super::inner::InMemoryGeoIndex;
 use super::ReadOnlyAppendableGeoIndex;
@@ -26,9 +26,13 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoIndex<S> {
     ///
     /// [1]: super::super::MutableGeoIndex::open_gridstore
     pub fn open(fs: &S::Fs, path: PathBuf) -> OperationResult<Option<Self>> {
-        let Some(storage) =
-            GridstoreReader::<Vec<RawGeoPoint>, S>::open(fs, path, Populate::Blocking)
-                .ok_not_found()?
+        let Some(storage) = GridstoreReader::<Vec<RawGeoPoint>, S>::open(
+            fs,
+            path,
+            Populate::Blocking,
+            Mode::default(),
+        )
+        .ok_not_found()?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/lifecycle.rs
@@ -5,7 +5,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Populate};
 use gridstore::config::StorageOptions;
 use gridstore::error::GridstoreError;
-use gridstore::{Blob, Gridstore};
+use gridstore::{Blob, Gridstore, Mode};
 
 use super::super::MapIndexKey;
 use super::MutableMapIndex;
@@ -36,13 +36,14 @@ where
     pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
             let options = default_gridstore_options(N::gridstore_block_size());
-            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking).map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to open mutable map index on gridstore: {err}"
-                ))
-            })?
+            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking, Mode::default())
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable map index on gridstore: {err}"
+                    ))
+                })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking, Mode::default()).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable map index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{OkNotFound, Populate, UniversalRead};
 use gridstore::error::GridstoreError;
-use gridstore::{Blob, GridstoreReader};
+use gridstore::{Blob, GridstoreReader, Mode};
 
 use super::super::MapIndexKey;
 use super::super::in_memory::InMemoryMapIndex;
@@ -34,6 +34,7 @@ where
             fs,
             path,
             Populate::Blocking,
+            Mode::default(),
         )
         .ok_not_found()?
         else {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/lifecycle.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Populate, UniversalRead};
 use gridstore::error::GridstoreError;
-use gridstore::{Blob, Gridstore};
+use gridstore::{Blob, Gridstore, Mode};
 
 use super::super::Encodable;
 use super::super::lifecycle::{HISTOGRAM_MAX_BUCKET_SIZE, HISTOGRAM_PRECISION};
@@ -157,13 +157,14 @@ where
     pub fn open_gridstore(path: PathBuf, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let store = if create_if_missing {
             let options = default_gridstore_options::<T>();
-            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking).map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to open mutable numeric index on gridstore: {err}"
-                ))
-            })?
+            Gridstore::open_or_create(MmapFs, path, options, Populate::Blocking, Mode::default())
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "failed to open mutable numeric index on gridstore: {err}"
+                    ))
+                })?
         } else if path.exists() {
-            Gridstore::open(MmapFs, path, Populate::Blocking).map_err(|err| {
+            Gridstore::open(MmapFs, path, Populate::Blocking, Mode::default()).map_err(|err| {
                 OperationError::service_error(format!(
                     "failed to open mutable numeric index on gridstore: {err}"
                 ))

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{OkNotFound, Populate, UniversalRead};
-use gridstore::{Blob, GridstoreReader};
+use gridstore::{Blob, GridstoreReader, Mode};
 
 use super::super::InMemoryNumericIndex;
 use super::ReadOnlyAppendableNumericIndex;
@@ -32,7 +32,8 @@ where
     /// [1]: super::super::MutableNumericIndex::open_gridstore
     pub fn open(fs: &S::Fs, path: PathBuf) -> OperationResult<Option<Self>> {
         let Some(storage) =
-            GridstoreReader::<Vec<T>, S>::open(fs, path, Populate::Blocking).ok_not_found()?
+            GridstoreReader::<Vec<T>, S>::open(fs, path, Populate::Blocking, Mode::default())
+                .ok_not_found()?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/payload_storage/payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/payload_storage_impl.rs
@@ -6,7 +6,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, Populate, UniversalWrite};
 use fs_err as fs;
 use gridstore::config::StorageOptions;
-use gridstore::{Blob, Gridstore};
+use gridstore::{Blob, Gridstore, Mode};
 use serde_json::Value;
 
 use crate::common::Flusher;
@@ -53,16 +53,26 @@ where
 
     fn open(path: PathBuf, populate: bool) -> OperationResult<Self> {
         // TODO(uio): use Populate as argument and propagate in callers
-        let storage =
-            Gridstore::open(S::Fs::default(), path, Populate::from(populate)).map_err(|err| {
-                OperationError::service_error(format!("Failed to open mmap payload storage: {err}"))
-            })?;
+        let storage = Gridstore::open(
+            S::Fs::default(),
+            path,
+            Populate::from(populate),
+            Mode::default(),
+        )
+        .map_err(|err| {
+            OperationError::service_error(format!("Failed to open mmap payload storage: {err}"))
+        })?;
 
         Ok(Self { storage, populate })
     }
 
     fn new(path: PathBuf, populate: bool) -> OperationResult<Self> {
-        let storage = Gridstore::new(S::Fs::default(), path, StorageOptions::default())?;
+        let storage = Gridstore::new(
+            S::Fs::default(),
+            path,
+            StorageOptions::default(),
+            Mode::default(),
+        )?;
 
         if populate {
             storage.populate()?;

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::universal_io::{Populate, UniversalRead};
-use gridstore::GridstoreReader;
+use gridstore::{GridstoreReader, Mode};
 
 use super::ReadOnlyPayloadStorage;
 use crate::common::operation_error::OperationResult;
@@ -15,7 +15,7 @@ impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
     /// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl::open_or_create
     pub fn open(fs: &S::Fs, path: PathBuf, populate: Populate) -> OperationResult<Self> {
         let path = storage_dir(path);
-        let storage = GridstoreReader::<Payload, S>::open(fs, path, populate)?;
+        let storage = GridstoreReader::<Payload, S>::open(fs, path, populate, Mode::default())?;
 
         Ok(Self { storage })
     }

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -10,8 +10,8 @@ use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, MmapFs, Populate, UserData};
 use fs_err as fs;
-use gridstore::Gridstore;
 use gridstore::config::{Compression, StorageOptions};
+use gridstore::{Gridstore, Mode};
 use sparse::common::sparse_vector::SparseVector;
 
 use crate::common::flags::bitvec_flags::BitvecFlags;
@@ -61,11 +61,12 @@ impl MmapSparseVectorStorage {
 
         // Storage
         let storage_dir = path.join(STORAGE_DIRNAME);
-        let storage = Gridstore::open(MmapFs, storage_dir, populate).map_err(|err| {
-            OperationError::service_error(format!(
-                "Failed to open mmap sparse vector storage: {err}"
-            ))
-        })?;
+        let storage =
+            Gridstore::open(MmapFs, storage_dir, populate, Mode::default()).map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to open mmap sparse vector storage: {err}"
+                ))
+            })?;
 
         // Deleted flags
         let deleted_path = path.join(DELETED_DIRNAME);
@@ -101,11 +102,12 @@ impl MmapSparseVectorStorage {
             ..Default::default()
         };
 
-        let storage = Gridstore::new(MmapFs, storage_dir, storage_config).map_err(|err| {
-            OperationError::service_error(format!(
-                "Failed to create storage for mmap sparse vectors: {err}"
-            ))
-        })?;
+        let storage = Gridstore::new(MmapFs, storage_dir, storage_config, Mode::default())
+            .map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to create storage for mmap sparse vectors: {err}"
+                ))
+            })?;
 
         // Payload storage does not need to be populated
         // as it is not required in the index search step

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::universal_io::{Populate, UniversalRead};
-use gridstore::GridstoreReader;
+use gridstore::{GridstoreReader, Mode};
 
 use super::ReadOnlySparseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -22,6 +22,7 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
             fs,
             path.join(STORAGE_DIRNAME),
             populate,
+            Mode::default(),
         )
         .map_err(|err| {
             OperationError::service_error(format!(


### PR DESCRIPTION
Add selectable serverless mode to the Gridstore storage backend.

Large PR, much of it tests. I can split code and test changes if desired, though they're currently interleaved.

A regular Gridstore instance modifies files in place to reuse free blocks. In a serverless deployment we can only append to files, which completely changes write behavior. Both implementations are kept since each is optimal for its domain, and the mode is runtime-selectable: dynamic or serverless (append-only).

The core concepts are unchanged: data is stored in blocks, blocks live in pages, and we map where each point's data is stored.

**Requirements:**

- File compatibility in both directions
- Regular: keep existing behavior, reuse free blocks
- Serverless: append only (new data and point mappings)

**Regular mode:**

- Writes find free blocks and change files in place
- Used blocks tracked via flags and gaps (`bitmask.dat`, `gaps.dat`)
- If the flag file is invalid, reconstruct it from mappings
- Pages allocated in full; blocks changed in place
- Any point mapping may change

**Serverless mode:**

- Writes always append blocks to the end of a page
- Used blocks not tracked; `bitmask.dat` and `gaps.dat` untouched
- Pages start empty and grow as blocks are appended
- Point mappings set in monotonic offset order, handled by an ID tracker

Regular mode needs the used-block flags, which serverless doesn't create. Starting in regular mode reconstructs missing or invalid-length flags, deriving all flags from mappings. Skipping flag and gap handling in serverless is beneficial since file IO is very expensive there.

Out of scope:

- End-to-end integration; a separate binary will handle updates using serverless mode

### TODO

- [x] Make tracker append-only compatible
- [ ] Describe new tracker behavior

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
