### PR TITLE
Tidy up Debug impls

### DIFF
--- a/lib/common/common/src/mmap/mmap_readonly.rs
+++ b/lib/common/common/src/mmap/mmap_readonly.rs
@@ -73,8 +73,9 @@ where
 
 impl<T: ?Sized> fmt::Debug for MmapTypeReadOnly<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { mmap, r#type: _ } = self;
         f.debug_struct("MmapTypeReadOnly")
-            .field("mmap", &self.mmap)
+            .field("mmap", mmap)
             .finish_non_exhaustive()
     }
 }
@@ -299,9 +300,10 @@ where
 
 impl<T> fmt::Debug for MmapSliceReadOnly<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { mmap } = self;
         f.debug_struct("MmapSliceReadOnly")
-            .field("mmap", &self.mmap)
-            .finish_non_exhaustive()
+            .field("mmap", mmap)
+            .finish()
     }
 }
 

--- a/lib/common/common/src/mmap/mmap_rw.rs
+++ b/lib/common/common/src/mmap/mmap_rw.rs
@@ -78,8 +78,9 @@ where
 
 impl<T: ?Sized> fmt::Debug for MmapType<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { mmap, r#type: _ } = self;
         f.debug_struct("MmapType")
-            .field("mmap", &self.mmap)
+            .field("mmap", mmap)
             .finish_non_exhaustive()
     }
 }
@@ -236,9 +237,8 @@ where
 
 impl<T> fmt::Debug for MmapSlice<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MmapSlice")
-            .field("mmap", &self.mmap)
-            .finish_non_exhaustive()
+        let Self { mmap } = self;
+        f.debug_struct("MmapSlice").field("mmap", mmap).finish()
     }
 }
 

--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -41,8 +41,12 @@ struct Entry<'a, U: UserData, K: Key + ?Sized> {
 // buffers and key references that are not `Debug`.
 impl<U: std::fmt::Debug + UserData, K: Key + ?Sized> std::fmt::Debug for Entry<'_, U, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            user_data,
+            state: _,
+        } = self;
         f.debug_struct("Entry")
-            .field("user_data", &self.user_data)
+            .field("user_data", user_data)
             .finish_non_exhaustive()
     }
 }

--- a/lib/common/common/src/universal_io/oneshot.rs
+++ b/lib/common/common/src/universal_io/oneshot.rs
@@ -51,9 +51,8 @@ impl<S: UniversalRead> Deref for OneshotFile<S> {
 
 impl<S: UniversalRead> fmt::Debug for OneshotFile<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OneshotFile")
-            .field("inner", &self.inner)
-            .finish()
+        let Self { inner } = self;
+        f.debug_struct("OneshotFile").field("inner", inner).finish()
     }
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -72,12 +72,21 @@ where
     R: UniversalRead,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            remote_fs,
+            remote_path,
+            open_options,
+            local_path,
+            state,
+            remote_extra: _,
+            init_lock: _,
+        } = self;
         f.debug_struct("DiskCache")
-            .field("remote_fs", &self.remote_fs)
-            .field("remote_path", &self.remote_path)
-            .field("open_options", &self.open_options)
-            .field("local_path", &self.local_path)
-            .field("state", &self.state)
+            .field("remote_fs", remote_fs)
+            .field("remote_path", remote_path)
+            .field("open_options", open_options)
+            .field("local_path", local_path)
+            .field("state", state)
             .finish_non_exhaustive()
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -56,9 +56,10 @@ where
     R: UniversalRead,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { config, remote_fs } = self;
         f.debug_struct("DiskCacheFs")
-            .field("config", &self.config)
-            .field("remote_fs", &self.remote_fs)
+            .field("config", config)
+            .field("remote_fs", remote_fs)
             .finish()
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -26,9 +26,14 @@ struct RemoteMeta<File, U> {
 
 impl<File, U: fmt::Debug> fmt::Debug for RemoteMeta<File, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            scheduled_read,
+            user_data,
+            file: _,
+        } = self;
         f.debug_struct("RemoteMeta")
-            .field("scheduled_read", &self.scheduled_read)
-            .field("user_data", &self.user_data)
+            .field("scheduled_read", scheduled_read)
+            .field("user_data", user_data)
             .finish_non_exhaustive()
     }
 }

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -31,7 +31,8 @@ pub struct ReadOnlyFs<F>(F);
 
 impl<F: fmt::Debug> fmt::Debug for ReadOnlyFs<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ReadOnlyFs").field(&self.0).finish()
+        let Self(inner) = self;
+        f.debug_tuple("ReadOnlyFs").field(inner).finish()
     }
 }
 

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -27,8 +27,9 @@ pub struct TypedStorage<S, T> {
 
 impl<S: fmt::Debug, T> fmt::Debug for TypedStorage<S, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { inner, _phantom: _ } = self;
         f.debug_struct("TypedStorage")
-            .field("inner", &self.inner)
+            .field("inner", inner)
             .finish()
     }
 }

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -26,9 +26,14 @@ pub struct BlobFile<A: AsyncRead> {
 
 impl<A: AsyncRead> std::fmt::Debug for BlobFile<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            runtime,
+            path,
+            inner: _,
+        } = self;
         f.debug_struct("BlobFile")
-            .field("runtime", &self.runtime)
-            .field("path", &self.path)
+            .field("runtime", runtime)
+            .field("path", path)
             .finish_non_exhaustive()
     }
 }

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -17,8 +17,9 @@ pub struct BlobFs<A: AsyncRead> {
 
 impl<A: AsyncRead> std::fmt::Debug for BlobFs<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { runtime, inner: _ } = self;
         f.debug_struct("BlobFs")
-            .field("runtime", &self.runtime)
+            .field("runtime", runtime)
             .finish_non_exhaustive()
     }
 }

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -70,11 +70,16 @@ pub struct DynamicStoredFlags<S> {
 
 impl<S: fmt::Debug> fmt::Debug for DynamicStoredFlags<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DynamicMmapFlags")
-            .field("flags", &self.flags)
-            .field("status", &self.status)
-            .field("directory", &self.directory)
-            .finish_non_exhaustive()
+        let Self {
+            flags,
+            status,
+            directory,
+        } = self;
+        f.debug_struct("DynamicStoredFlags")
+            .field("flags", flags)
+            .field("status", status)
+            .field("directory", directory)
+            .finish()
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -46,13 +46,22 @@ pub struct VolatileMultiDenseVectorStorage<T: PrimitiveVectorElement> {
 
 impl<T: fmt::Debug + PrimitiveVectorElement> fmt::Debug for VolatileMultiDenseVectorStorage<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            dim,
+            distance,
+            multi_vector_config,
+            vectors,
+            vectors_metadata,
+            deleted_count,
+            deleted: _,
+        } = self;
         f.debug_struct("VolatileMultiDenseVectorStorage")
-            .field("dim", &self.dim)
-            .field("distance", &self.distance)
-            .field("multi_vector_config", &self.multi_vector_config)
-            .field("vectors", &self.vectors)
-            .field("vectors_metadata", &self.vectors_metadata)
-            .field("deleted_count", &self.deleted_count)
+            .field("dim", dim)
+            .field("distance", distance)
+            .field("multi_vector_config", multi_vector_config)
+            .field("vectors", vectors)
+            .field("vectors_metadata", vectors_metadata)
+            .field("deleted_count", deleted_count)
             .finish_non_exhaustive()
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/config.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/config.rs
@@ -27,8 +27,13 @@ pub struct QuantizedVectorsConfig {
 
 impl fmt::Debug for QuantizedVectorsConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            quantization_config,
+            vector_parameters: _,
+            storage_type: _,
+        } = self;
         f.debug_struct("QuantizedVectorsConfig")
-            .field("quantization_config", &self.quantization_config)
+            .field("quantization_config", quantization_config)
             .finish_non_exhaustive()
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/storage.rs
@@ -107,7 +107,8 @@ pub enum ReadOnlyQuantizedVectorStorage<S: UniversalRead = MmapFile> {
 
 impl<S: UniversalRead> fmt::Debug for ReadOnlyQuantizedVectorStorage<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ReadOnlyQuantizedVectorStorage").finish()
+        f.debug_tuple("ReadOnlyQuantizedVectorStorage")
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/storage.rs
@@ -172,7 +172,8 @@ impl QuantizedVectorStorage {
 
 impl fmt::Debug for QuantizedVectorStorage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("QuantizedVectorStorage").finish()
+        f.debug_tuple("QuantizedVectorStorage")
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -187,11 +187,20 @@ impl TurboVectorStorage {
 
 impl std::fmt::Debug for TurboVectorStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            dim,
+            distance,
+            storage,
+            deleted_count,
+            quantizer: _,
+            deleted: _,
+            quantization_buffer: _,
+        } = self;
         f.debug_struct("TurboVectorStorage")
-            .field("dim", &self.dim)
-            .field("distance", &self.distance)
-            .field("total_vector_count", &self.storage.vectors_count())
-            .field("deleted_count", &self.deleted_count)
+            .field("dim", dim)
+            .field("distance", distance)
+            .field("total_vector_count", &storage.vectors_count())
+            .field("deleted_count", deleted_count)
             .finish_non_exhaustive()
     }
 }

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -74,11 +74,22 @@ pub struct TurboMultiVectorStorage {
 
 impl std::fmt::Debug for TurboMultiVectorStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            dim,
+            distance,
+            offsets,
+            deleted_count,
+            storage: _,
+            quantizer: _,
+            deleted: _,
+            multi_vector_config: _,
+            quantization_buffer: _,
+        } = self;
         f.debug_struct("TurboMultiVectorStorage")
-            .field("dim", &self.dim)
-            .field("distance", &self.distance)
-            .field("total_vector_count", &self.offsets.len())
-            .field("deleted_count", &self.deleted_count)
+            .field("dim", dim)
+            .field("distance", distance)
+            .field("total_vector_count", &offsets.len())
+            .field("deleted_count", deleted_count)
             .finish_non_exhaustive()
     }
 }

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -65,9 +65,14 @@ struct DeferredAction {
 
 impl std::fmt::Debug for DeferredAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            ready_at,
+            ack_pin,
+            action: _,
+        } = self;
         f.debug_struct("DeferredAction")
-            .field("ready_at", &self.ready_at)
-            .field("ack_pin", &self.ack_pin)
+            .field("ready_at", ready_at)
+            .field("ack_pin", ack_pin)
             .finish_non_exhaustive()
     }
 }

--- a/lib/wal/src/lib.rs
+++ b/lib/wal/src/lib.rs
@@ -557,19 +557,24 @@ impl Wal {
 
 impl fmt::Debug for Wal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let start_index = self
-            .closed_segments
+        let Self {
+            open_segment,
+            closed_segments,
+            path,
+            creator: _,
+            retain_closed: _,
+            dir: _,
+            flush: _,
+        } = self;
+        let start_index = closed_segments
             .first()
             .map_or(0, |segment| segment.start_index);
-        let end_index = self.open_segment_start_index() + self.open_segment.segment.len() as u64;
-        write!(
-            f,
-            "Wal {{ path: {:?}, segment-count: {}, entries: [{}, {})  }}",
-            &self.path,
-            self.closed_segments.len() + 1,
-            start_index,
-            end_index
-        )
+        let end_index = self.open_segment_start_index() + open_segment.segment.len() as u64;
+        f.debug_struct("Wal")
+            .field("path", path)
+            .field("segment-count", &(closed_segments.len() + 1))
+            .field("entries", &format_args!("[{start_index}, {end_index})"))
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/wal/src/mmap_view_sync.rs
+++ b/lib/wal/src/mmap_view_sync.rs
@@ -174,11 +174,15 @@ impl From<MmapMut> for MmapViewSync {
 
 impl fmt::Debug for MmapViewSync {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "MmapViewSync {{ offset: {}, len: {} }}",
-            self.offset, self.len
-        )
+        let Self {
+            offset,
+            len,
+            inner: _,
+        } = self;
+        f.debug_struct("MmapViewSync")
+            .field("offset", offset)
+            .field("len", len)
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/wal/src/segment.rs
+++ b/lib/wal/src/segment.rs
@@ -38,7 +38,8 @@ impl Deref for Entry {
 
 impl fmt::Debug for Entry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Entry {{ len: {} }}", self.view.len())
+        let Self { view } = self;
+        f.debug_struct("Entry").field("len", &view.len()).finish()
     }
 }
 
@@ -680,15 +681,22 @@ impl Segment {
 
 impl fmt::Debug for Segment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Segment {{ path: {:?}, flush_offset: {}, entries: {}, space: ({}/{}) }}",
-            &self.path,
-            self.flush_offset,
-            self.len(),
-            self.size(),
-            self.capacity()
-        )
+        let Self {
+            path,
+            flush_offset,
+            mmap: _,
+            index: _,
+            crc: _,
+        } = self;
+        f.debug_struct("Segment")
+            .field("path", path)
+            .field("flush_offset", flush_offset)
+            .field("entries", &self.len())
+            .field(
+                "space",
+                &format_args!("({}/{})", self.size(), self.capacity()),
+            )
+            .finish_non_exhaustive()
     }
 }
 

--- a/lib/wal/src/test_utils.rs
+++ b/lib/wal/src/test_utils.rs
@@ -79,11 +79,16 @@ impl Iterator for EntryGenerator {
 
 impl fmt::Debug for EntryGenerator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "EntryGenerator {{ seed: {}, remaining_size: {} }}",
-            self.seed, self.remaining_size
-        )
+        let Self {
+            seed,
+            remaining_size,
+            rng: _,
+            dist: _,
+        } = self;
+        f.debug_struct("EntryGenerator")
+            .field("seed", seed)
+            .field("remaining_size", remaining_size)
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
A proper debug impl should:                                                     
- Use `.debug_tuple`/`.debug_struct` or similar methods, not `write!()`.
- Destructure self (via `let Self { foo, bar, baz: _ } = self;` or `match`) instead of using `&self.foo`.
- For partial formatters: `.finish_non_exhaustive()` should be used.
- Non-partial formatters: `.finish()`.
- Excluded fields ignored explicitly (`Self { foo, bar: _ }`), not `..` (`Self { foo, .. }`).
                                                                                                               
Exception: impls that print simple identifiers (without arguments/etc) can use `..` and `write!`: `match self { Something::Whatever{..} => write!("Something::Whatever"), … }`.
