### PR TITLE
Fix reinit failing with "removed all voters" on a removed peer

### DIFF
--- a/lib/storage/src/content_manager/consensus/consensus_wal.rs
+++ b/lib/storage/src/content_manager/consensus/consensus_wal.rs
@@ -309,6 +309,40 @@ impl ConsensusOpWal {
         Ok(())
     }
 
+    /// Drop all entries with a Raft index strictly greater than `raft_index`.
+    ///
+    /// Used during consensus re-initialization to discard committed-but-unapplied
+    /// entries inherited from the previous cluster (e.g. a `RemoveNode` conf-change
+    /// for this very peer, if it was removed from consensus before reinit).
+    pub fn truncate_after(&mut self, raft_index: u64) -> Result<(), StorageError> {
+        // Empty WAL - nothing to drop
+        let Some(offset) = self.index_offset_impl()? else {
+            return Ok(());
+        };
+
+        // First Raft index we want to drop, mapped to a WAL index. If it's below the
+        // first physical entry, the whole (remaining) WAL is beyond the cut point.
+        let from_wal_index = offset
+            .try_raft_to_wal(raft_index + 1)
+            .unwrap_or(offset.wal_index);
+
+        // Exclusive upper bound of physical WAL indices
+        let end_wal_index = offset.wal_index + self.wal.num_entries();
+        if from_wal_index >= end_wal_index {
+            // Nothing past the cut point
+            return Ok(());
+        }
+
+        log::debug!(
+            "Truncating consensus WAL after Raft index {raft_index} (from WAL index {from_wal_index})",
+        );
+
+        self.wal.truncate(from_wal_index)?;
+        self.wal.flush_open_segment()?;
+
+        Ok(())
+    }
+
     pub fn index_offset(&self) -> raft::Result<IndexOffset> {
         let res = self.index_offset_impl();
         into_raft_result(res)

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -885,6 +885,33 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         self.wal.lock().clear()
     }
 
+    /// Discard committed-but-unapplied Raft log entries inherited from a previous
+    /// cluster during first-peer consensus re-initialization (`--reinit`).
+    ///
+    /// `--reinit` resets this peer's `conf_state` to a single voter (itself) but
+    /// leaves the Raft log untouched. If this peer had been removed from consensus
+    /// before reinit, its log still holds a committed `RemoveNode(self)` conf-change
+    /// (and possibly other topology changes from the old cluster). Replaying those on
+    /// top of the reset single-voter config makes Raft abort with "removed all voters".
+    ///
+    /// Drop that tail: physically truncate the WAL to the last applied index, pin
+    /// `commit` to it and clear the apply-progress queue, so a fresh single-node
+    /// leader has nothing stale left to re-commit and re-apply.
+    pub fn clear_unapplied_entries_on_reinit(&self) -> Result<(), StorageError> {
+        let last_applied = self.persistent.read().last_applied_entry().unwrap_or(0);
+
+        // Physically drop entries beyond the applied index
+        self.wal.lock().truncate_after(last_applied)?;
+
+        // Align persisted commit index and apply-progress queue with the truncated log
+        let mut persistent = self.persistent.write();
+        persistent.apply_state_update(|state| state.hard_state.commit = last_applied)?;
+        // Empty queue that still reports `last_applied` as the last applied entry
+        persistent.set_unapplied_entries(last_applied + 1, last_applied)?;
+
+        Ok(())
+    }
+
     pub fn compact_wal(&self, min_entries_to_compact: u64) -> Result<bool, StorageError> {
         if min_entries_to_compact == 0 {
             return Ok(false);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -191,7 +191,8 @@ impl Consensus {
         // from re-playing consensus WAL operations, as they should already have them applied.
         // Do ensure that we are forcing compacting WAL on the first re-initialized peer,
         // which should trigger snapshot transferring instead of replaying WAL.
-        let force_compact_wal = reinit && bootstrap_peer.is_none();
+        let reinit_first_peer = reinit && bootstrap_peer.is_none();
+        let force_compact_wal = reinit_first_peer;
 
         // On the bootstrap-ed peers during reinit of the consensus
         // we want to make sure only the bootstrap peer will hold the true state
@@ -201,6 +202,16 @@ impl Consensus {
         if clear_wal {
             log::debug!("Clearing WAL on the bootstrap peer to force snapshot transfer");
             state_ref.clear_wal()?;
+        }
+
+        // On the first peer during reinit, `conf_state` has been reset to a single voter
+        // (this peer), but the Raft log still holds committed-but-unapplied entries from the
+        // previous cluster. Replaying them - most notably a `RemoveNode` for this very peer,
+        // if it was removed from consensus before reinit - would abort with "removed all
+        // voters". Drop that tail before the log is replayed below.
+        if reinit_first_peer {
+            log::debug!("Discarding unapplied consensus entries from the previous cluster");
+            state_ref.clear_unapplied_entries_on_reinit()?;
         }
 
         // raft will not return entries to the application smaller or equal to `applied`

--- a/tests/consensus_tests/test_reinit_removed_peer.py
+++ b/tests/consensus_tests/test_reinit_removed_peer.py
@@ -1,0 +1,66 @@
+import pathlib
+
+from .utils import *
+
+N_PEERS = 2
+
+
+def test_reinit_removed_peer(tmp_path: pathlib.Path):
+    """
+    Regression test for reinitializing a peer that was previously *removed from
+    consensus*.
+
+    When a peer is removed, its Raft log gains a committed `RemoveNode(self)`
+    conf-change. `--reinit` resets the peer's `conf_state` to a single voter
+    (itself), but leaves the Raft log untouched. Without dropping that stale
+    entry it gets replayed on top of the reset single-voter config on startup,
+    and consensus initialization panics with "removed all voters", so the node
+    can never come back.
+    """
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    # The peer we are going to remove from consensus and later reinitialize.
+    removed_peer_uri = peer_api_uris[1]
+    removed_peer_dir = peer_dirs[1]
+    removed_peer_id = get_cluster_info(removed_peer_uri)["peer_id"]
+
+    # Gracefully remove the still-alive peer. In a 2-node cluster the removal
+    # can only be committed once the removed peer itself acks it, which
+    # guarantees the `RemoveNode(self)` entry lands in its own WAL. (There are
+    # no collections, so the peer holds no shards and can be removed cleanly.)
+    res = requests.delete(f"{peer_api_uris[0]}/cluster/peer/{removed_peer_id}?timeout=60")
+    assert_http_ok(res)
+
+    # The first peer is now a single-node cluster - which also confirms the
+    # removal was committed (and therefore persisted on the removed peer).
+    wait_for(check_cluster_size, peer_api_uris[0], 1)
+
+    # Stop the removed peer (its consensus already stopped on self-removal).
+    removed_peer_process = processes[1]
+    removed_peer_process.kill()
+    processes.remove(removed_peer_process)
+
+    # Reinitialize the removed peer as a fresh first peer, reusing its data
+    # directory. Before the fix this panicked on startup with:
+    #   Can't initialize consensus: Failed to apply configuration change entry
+    #   Caused by: Error in Raft consensus: removed all voters
+    reinit_api_uri, reinit_bootstrap_uri = start_first_peer(
+        removed_peer_dir, "removed_peer_reinit.log", reinit=True,
+    )
+
+    # It must come online and elect itself leader of the new single-voter
+    # cluster (reaching this point already proves consensus initialized without
+    # the "removed all voters" panic).
+    wait_for_peer_online(reinit_api_uri)
+    wait_for(leader_is_defined, reinit_api_uri)
+    leader = get_leader(reinit_api_uri)
+
+    # It must also still be usable as a cluster seed: a fresh peer can bootstrap
+    # onto it, which requires the reinitialized peer to serve a snapshot (the
+    # entry at the commit index is kept as the snapshot anchor by the fix).
+    new_peer_dir = make_peer_folder(tmp_path, N_PEERS)
+    new_peer_uri = start_peer(new_peer_dir, "new_peer.log", reinit_bootstrap_uri)
+    wait_for_peer_online(new_peer_uri)
+    wait_for(check_leader, new_peer_uri, leader)


### PR DESCRIPTION
## Problem

Running `--reinit` on a peer that had previously been **removed from consensus** panics on startup and the node can never come back:

```
ERROR qdrant::startup: Panic occurred ... Can't initialize consensus: Failed to apply configuration change entry
Caused by:
    Service internal error: Error in Raft consensus: removed all voters
```

## Root cause

On the first peer, `--reinit` resets `conf_state` to a single voter (this peer), but leaves the Raft log untouched. If this peer had been removed from consensus before reinit, its log still holds a committed `RemoveNode(self)` conf-change. On startup that entry is replayed on top of the freshly reset single-voter config, and raft-rs aborts with `removed all voters`.

Resetting only the apply-progress queue is not enough: a fresh single-node leader re-commits and re-applies any log entries still physically present beyond `commit`, re-triggering the failure. The stale tail has to be physically dropped from the WAL.

## Fix

On the first-peer reinit path, discard committed-but-unapplied entries inherited from the previous cluster:

- `ConsensusOpWal::truncate_after(raft_index)` — physically drop WAL entries with a Raft index `> raft_index` (reuses the existing `Wal::truncate` primitive).
- `ConsensusState::clear_unapplied_entries_on_reinit()` — truncate the WAL to the last applied index, pin `hard_state.commit` to it, and clear the apply-progress queue.
- `Consensus::new` calls it on the first-peer reinit path (`reinit && bootstrap_peer.is_none()`), before the log is replayed.

The entry **at** `commit` is retained as the snapshot anchor, so the first peer can still serve snapshots to bootstrapping peers (unlike a full WAL clear, which would break `term(commit)` / snapshot construction). Bootstrap peers were already handled — they clear their WAL and re-request a snapshot.

## Behavior note

This discards the committed-but-unapplied tail on the first peer. For a peer that was removed from consensus that tail is stale/unreachable, and it mirrors what bootstrap peers already do (discard everything and re-sync). Reinit is a disaster-recovery/migration operation where this peer's current applied state is declared the source of truth.

## Tests

Added `tests/consensus_tests/test_reinit_removed_peer.py`: starts a 2-node cluster, gracefully removes the second peer from consensus (so it commits `RemoveNode(self)` into its own WAL), then reinitializes it as a fresh first peer and asserts it comes back online, elects itself leader, and can still seed a fresh bootstrapping peer.

Verified the test **fails against the pre-fix binary** with exactly the reported panic (`Failed to apply configuration change entry` / `removed all voters`) and **passes with the fix**. The existing `test_reinit_consensus.py` (reinit of a healthy cluster) was unaffected — it never produced the `RemoveNode(self)` entry that triggers the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)