### PR TITLE
Add disk-resident id tracker

### DIFF
--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -69,6 +69,12 @@ impl FeatureFlags {
         self == FeatureFlags::default()
     }
 
+    /// Whether segments should be produced in a serverless-compatible way (e.g.
+    /// the disk-resident id-tracker format). See the field docs for implications.
+    pub fn serverless_compatible(self) -> bool {
+        self.serverless_compatible
+    }
+
     fn all() -> Self {
         Self {
             all: true,

--- a/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
@@ -48,7 +48,10 @@ pub trait DiskMappingsSource {
     /// A borrowed `(reader, deleted)` view for ordered/random iteration. Fails if
     /// the deleted set cannot be materialized.
     fn mappings_ref(&self) -> OperationResult<DiskMappingsRef<'_, Self::Backend>> {
-        Ok(DiskMappingsRef::new(self.mapping_reader(), self.deleted_bitslice()?))
+        Ok(DiskMappingsRef::new(
+            self.mapping_reader(),
+            self.deleted_bitslice()?,
+        ))
     }
 
     /// A `(reader, deleted)` view for the infallible `IdTrackerRead` boundary: on
@@ -62,7 +65,10 @@ pub trait DiskMappingsSource {
     }
 
     /// External→internal, excluding deleted points. Storage errors propagate.
-    fn resolve_internal(&self, external_id: PointIdType) -> OperationResult<Option<PointOffsetType>> {
+    fn resolve_internal(
+        &self,
+        external_id: PointIdType,
+    ) -> OperationResult<Option<PointOffsetType>> {
         let Some(offset) = self.mapping_reader().lookup(external_id)? else {
             return Ok(None);
         };
@@ -129,7 +135,11 @@ impl<'a, S: UniversalRead> DiskMappingsRef<'a, S> {
         self,
         external_id: Option<PointIdType>,
     ) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + 'a> {
-        Box::new(self.reader.iter_from(external_id).filter(live_filter(self.deleted)))
+        Box::new(
+            self.reader
+                .iter_from(external_id)
+                .filter(live_filter(self.deleted)),
+        )
     }
 
     pub fn iter_random(self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + 'a> {

--- a/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
@@ -1,0 +1,156 @@
+//! Shared mapping-read behaviour for the two disk-resident id trackers.
+//!
+//! [`DiskIdTracker`](super::DiskIdTracker) and
+//! [`ReadOnlyDiskIdTracker`](super::read_only::ReadOnlyDiskIdTracker) both hold a
+//! [`DiskMappingReader`] plus a deleted set; they differ only in how the deleted
+//! set is stored (a resident bitvec mutated in place vs a lazy `get_bit` over the
+//! on-disk file) and how versions are kept.
+//!
+//! Everything that depends purely on `(mapping reader, deleted set)` is written
+//! here once:
+//!
+//! - point lookups — [`resolve_internal`](DiskMappingsSource::resolve_internal) /
+//!   [`resolve_external`](DiskMappingsSource::resolve_external), shared via the
+//!   [`DiskMappingsSource`] trait each tracker implements;
+//! - ordered/random iteration — [`DiskMappingsRef`], a concrete `(reader, deleted)`
+//!   view held directly by [`PointMappingsRefEnum::Disk`], so there is no trait
+//!   object at the mapping boundary.
+//!
+//! [`PointMappingsRefEnum::Disk`]: crate::id_tracker::PointMappingsRefEnum::Disk
+
+use common::bitvec::{BitSlice, BitSliceExt as _};
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::reader::{self, DiskMappingReader};
+use crate::common::operation_error::OperationResult;
+use crate::types::PointIdType;
+
+/// The state a disk-resident mapping needs to answer reads: the lazy mapping
+/// reader and the deleted set. Each disk tracker implements it, gaining the
+/// shared point-lookup helpers and a uniform way to build a [`DiskMappingsRef`].
+pub trait DiskMappingsSource {
+    type Backend: UniversalRead;
+
+    /// The lazy mapping read core (`i2e`/`e2i`).
+    fn mapping_reader(&self) -> &DiskMappingReader<Self::Backend>;
+
+    /// Per-point deletion check. The writable tracker reads its resident bitvec
+    /// (infallible); the read-only tracker does a single lazy `get_bit` over the
+    /// on-disk file (no full-set load), whose storage error propagates here.
+    fn point_deleted(&self, offset: PointOffsetType) -> OperationResult<bool>;
+
+    /// The whole deleted set as a slice, used by iteration and vector search. The
+    /// read-only tracker materializes it lazily behind this call, so its storage
+    /// error propagates here.
+    fn deleted_bitslice(&self) -> OperationResult<&BitSlice>;
+
+    /// A borrowed `(reader, deleted)` view for ordered/random iteration. Fails if
+    /// the deleted set cannot be materialized.
+    fn mappings_ref(&self) -> OperationResult<DiskMappingsRef<'_, Self::Backend>> {
+        Ok(DiskMappingsRef::new(self.mapping_reader(), self.deleted_bitslice()?))
+    }
+
+    /// A `(reader, deleted)` view for the infallible `IdTrackerRead` boundary: on
+    /// a deleted-set load error, log and fall back to an empty deleted set (the
+    /// same best-effort behaviour as before the error surface was threaded in).
+    fn mappings_ref_lossy(&self) -> DiskMappingsRef<'_, Self::Backend> {
+        self.mappings_ref().unwrap_or_else(|err| {
+            log::error!("disk id tracker deleted set load failed: {err}");
+            DiskMappingsRef::new(self.mapping_reader(), BitSlice::empty())
+        })
+    }
+
+    /// External→internal, excluding deleted points. Storage errors propagate.
+    fn resolve_internal(&self, external_id: PointIdType) -> OperationResult<Option<PointOffsetType>> {
+        let Some(offset) = self.mapping_reader().lookup(external_id)? else {
+            return Ok(None);
+        };
+        // The immutable runs still carry points deleted after build; re-check.
+        Ok((!self.point_deleted(offset)?).then_some(offset))
+    }
+
+    /// Internal→external, excluding deleted points. Storage errors propagate.
+    fn resolve_external(&self, offset: PointOffsetType) -> OperationResult<Option<PointIdType>> {
+        if self.point_deleted(offset)? {
+            Ok(None)
+        } else {
+            self.mapping_reader().external_id(offset)
+        }
+    }
+}
+
+/// A borrowed view over a disk-resident mapping and its deleted set, providing
+/// the ordered/random iteration used by [`PointMappingsRefEnum`].
+///
+/// Held by value (it is two references) inside
+/// [`PointMappingsRefEnum::Disk`](crate::id_tracker::PointMappingsRefEnum::Disk),
+/// so the mapping is reached by static dispatch rather than a trait object.
+pub struct DiskMappingsRef<'a, S: UniversalRead> {
+    reader: &'a DiskMappingReader<S>,
+    deleted: &'a BitSlice,
+}
+
+// Hand-written so `Copy` doesn't require `S: Copy` (this only holds references).
+impl<S: UniversalRead> Clone for DiskMappingsRef<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S: UniversalRead> Copy for DiskMappingsRef<'_, S> {}
+
+impl<'a, S: UniversalRead> DiskMappingsRef<'a, S> {
+    pub fn new(reader: &'a DiskMappingReader<S>, deleted: &'a BitSlice) -> Self {
+        Self { reader, deleted }
+    }
+
+    pub fn deleted(self) -> &'a BitSlice {
+        self.deleted
+    }
+
+    pub fn iter_external(self) -> Box<dyn Iterator<Item = PointIdType> + 'a> {
+        Box::new(
+            self.reader
+                .iter_from(None)
+                .filter(live_filter(self.deleted))
+                .map(|(external_id, _)| external_id),
+        )
+    }
+
+    pub fn iter_internal(self) -> Box<dyn Iterator<Item = PointOffsetType> + 'a> {
+        let deleted = self.deleted;
+        let total = self.reader.total_point_count() as PointOffsetType;
+        Box::new(
+            (0..total).filter(move |&offset| !deleted.get_bit(offset as usize).unwrap_or(false)),
+        )
+    }
+
+    pub fn iter_from(
+        self,
+        external_id: Option<PointIdType>,
+    ) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + 'a> {
+        Box::new(self.reader.iter_from(external_id).filter(live_filter(self.deleted)))
+    }
+
+    pub fn iter_random(self) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + 'a> {
+        reader::iter_random(self.reader, self.deleted)
+    }
+}
+
+/// Predicate keeping only `(id, offset)` pairs whose offset is not deleted.
+fn live_filter(deleted: &BitSlice) -> impl Fn(&(PointIdType, PointOffsetType)) -> bool + '_ {
+    move |&(_, offset)| !deleted.get_bit(offset as usize).unwrap_or(false)
+}
+
+/// Swallow a disk lookup error at the [`IdTrackerRead`](crate::id_tracker::IdTrackerRead)
+/// boundary — whose methods must return `Option` — by logging it and yielding
+/// `None`. The fallible surface stops at [`DiskMappingsSource`]; this is the one
+/// place the error is dropped.
+///
+/// ToDo: this should be removed after we have a batch-read interface for id tracker lookups
+pub fn log_lookup_err<T>(result: OperationResult<Option<T>>) -> Option<T> {
+    result.unwrap_or_else(|err| {
+        log::error!("disk id tracker lookup failed: {err}");
+        None
+    })
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
@@ -38,8 +38,8 @@ use fs_err::File;
 
 pub use self::mappings::DiskMappingsSource;
 use self::mappings::log_lookup_err;
-pub use self::read_only::ReadOnlyDiskIdTracker;
 use self::on_disk_format::{e2i_path, i2e_path, store_e2i, store_i2e};
+pub use self::read_only::ReadOnlyDiskIdTracker;
 use self::reader::DiskMappingReader;
 use crate::common::Flusher;
 use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
@@ -161,7 +161,9 @@ where
         let deleted_filepath = deleted_path(path);
         create_and_ensure_length(
             &deleted_filepath,
-            total.div_ceil(u8::BITS as usize).next_multiple_of(size_of::<u64>()),
+            total
+                .div_ceil(u8::BITS as usize)
+                .next_multiple_of(size_of::<u64>()),
         )?;
         let mut deleted_storage = StoredBitSlice::open(
             fs,
@@ -191,7 +193,10 @@ where
         // Versions file: one `u64` per point.
         let version_filepath = version_mapping_path(path);
         let versions_count = internal_to_version.len().max(total);
-        create_and_ensure_length(&version_filepath, versions_count * size_of::<SeqNumberType>())?;
+        create_and_ensure_length(
+            &version_filepath,
+            versions_count * size_of::<SeqNumberType>(),
+        )?;
         let mut internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
             fs,
             &version_filepath,
@@ -381,7 +386,7 @@ impl<S: UniversalWrite + Debug + Send + Sync + 'static> IdTracker for DiskIdTrac
     fn clear_cache(&self) -> OperationResult<()> {
         let Self {
             path,
-            reader: _, // i2e/e2i mmap pages dropped via `mapping_files` below
+            reader: _,  // i2e/e2i mmap pages dropped via `mapping_files` below
             deleted: _, // kept in RAM
             deleted_wrapper,
             internal_to_version: _, // kept in RAM

--- a/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
@@ -1,0 +1,398 @@
+//! Disk-resident id tracker: keeps the point-id mapping on disk (the
+//! [on-disk format](on_disk_format) `i2e`/`e2i` files) instead of loading it into
+//! RAM, so resident memory does not scale with point count.
+//!
+//! Two trackers share the [`reader`] core:
+//!
+//! - [`DiskIdTracker`] — writable, deletion-only (non-appendable, R6): usable in a
+//!   regular [`Segment`](crate::segment::Segment) so ordinary deployments also
+//!   avoid the full RAM load. `deleted` and `versions` are kept resident (small,
+//!   mutated in place); only the mapping stays on disk.
+//! - [`ReadOnlyDiskIdTracker`](read_only::ReadOnlyDiskIdTracker) — read-only,
+//!   live-reload mirror for object-storage followers.
+//!
+//! Both are produced from the same on-disk files, written from a
+//! [`CompressedPointMappings`] at build time when `serverless_compatible` is set.
+
+pub mod mappings;
+pub mod on_disk_format;
+pub mod read_only;
+mod reader;
+
+#[cfg(test)]
+mod tests;
+
+use std::fmt::Debug;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use common::bitvec::{BitSlice, BitSliceExt as _, BitVec};
+use common::fs::clear_disk_cache;
+use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::stored_bitslice::StoredBitSlice;
+use common::types::{DeferredBehavior, PointOffsetType};
+use common::universal_io::{
+    OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage, UniversalWrite,
+};
+use fs_err::File;
+
+pub use self::mappings::DiskMappingsSource;
+use self::mappings::log_lookup_err;
+pub use self::read_only::ReadOnlyDiskIdTracker;
+use self::on_disk_format::{e2i_path, i2e_path, store_e2i, store_i2e};
+use self::reader::DiskMappingReader;
+use crate::common::Flusher;
+use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::id_tracker::compressed::versions_store::CompressedVersions;
+use crate::id_tracker::immutable_id_tracker::{deleted_path, version_mapping_path};
+use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
+use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum};
+use crate::types::{PointIdType, SeqNumberType};
+
+/// Writable, deletion-only disk-resident id tracker.
+///
+/// The mapping (`i2e`/`e2i`) is immutable and served from disk via
+/// [`DiskMappingReader`]; the `deleted` bitvec and `versions` are kept resident
+/// and mutated in place, mirroring [`ImmutableIdTracker`] minus the RAM mapping.
+///
+/// [`ImmutableIdTracker`]: crate::id_tracker::immutable_id_tracker::ImmutableIdTracker
+#[derive(Debug)]
+pub struct DiskIdTracker<S: UniversalWrite> {
+    path: PathBuf,
+
+    /// Lazy mapping read core (resident: headers + sparse index).
+    reader: DiskMappingReader<S>,
+
+    /// Resident deleted set (read source for lookups/search); persisted via the wrapper.
+    deleted: BitVec,
+    deleted_wrapper: BufferedUpdateBitSlice<S>,
+
+    /// Resident per-point versions; persisted via the wrapper.
+    internal_to_version: CompressedVersions,
+    internal_to_version_wrapper: SliceBufferedUpdateWrapper<S, SeqNumberType>,
+}
+
+impl<S> DiskIdTracker<S>
+where
+    S: UniversalWrite + Send + Sync + 'static,
+{
+    /// Approximate resident RAM: versions + deleted bitvec. The mapping stays on
+    /// disk and is not counted here.
+    pub fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            path: _,
+            reader: _, // headers + sparse index only; negligible, on-disk mapping not counted
+            deleted,
+            deleted_wrapper: _, // mmap-backed, accounted via files
+            internal_to_version,
+            internal_to_version_wrapper: _, // mmap-backed, accounted via files
+        } = self;
+        internal_to_version.ram_usage_bytes() + deleted.capacity().div_ceil(u8::BITS as usize)
+    }
+
+    pub fn from_in_memory_tracker(
+        fs: &S::Fs,
+        in_memory_tracker: InMemoryIdTracker,
+        path: &Path,
+    ) -> OperationResult<Self> {
+        let (internal_to_version, mappings) = in_memory_tracker.into_internal();
+        let compressed_mappings = CompressedPointMappings::from_mappings(mappings);
+        Self::new(fs, path, &internal_to_version, compressed_mappings)
+    }
+
+    /// Open an existing disk-resident id tracker: `deleted` and `versions` are
+    /// read into RAM (small, mutated in place), the mapping stays on disk.
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        let deleted_storage = StoredBitSlice::open(
+            fs,
+            deleted_path(segment_path),
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                populate: Populate::Blocking,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+        )?;
+        let mut deleted = BitVec::new();
+        deleted.extend_from_bitslice(deleted_storage.read_all()?.as_ref());
+        let deleted_wrapper = BufferedUpdateBitSlice::new(deleted_storage);
+
+        let internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
+            fs,
+            version_mapping_path(segment_path),
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                populate: Populate::Blocking,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+        )?;
+        let internal_to_version =
+            CompressedVersions::from_slice(&internal_to_version_file.read_whole()?);
+        let internal_to_version_wrapper =
+            SliceBufferedUpdateWrapper::new(internal_to_version_file.inner)?;
+
+        let reader = DiskMappingReader::open(fs, segment_path)?;
+
+        Ok(Self {
+            path: segment_path.to_path_buf(),
+            reader,
+            deleted,
+            deleted_wrapper,
+            internal_to_version,
+            internal_to_version_wrapper,
+        })
+    }
+
+    pub fn new(
+        fs: &S::Fs,
+        path: &Path,
+        internal_to_version: &[SeqNumberType],
+        mappings: CompressedPointMappings,
+    ) -> OperationResult<Self> {
+        let total = mappings.total_point_count();
+        debug_assert!(mappings.deleted().len() <= total);
+
+        // Deleted bitvec file: one bit per point, rounded up to a `u64` multiple.
+        let deleted_filepath = deleted_path(path);
+        create_and_ensure_length(
+            &deleted_filepath,
+            total.div_ceil(u8::BITS as usize).next_multiple_of(size_of::<u64>()),
+        )?;
+        let mut deleted_storage = StoredBitSlice::open(
+            fs,
+            &deleted_filepath,
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                populate: Populate::Auto,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+        )?;
+        deleted_storage.write_bitslice(mappings.deleted())?;
+        deleted_storage.set_ascending_bits_batch(
+            (mappings.deleted().len()..total).map(|i| (i as u64, true)),
+        )?;
+        deleted_storage.flusher()()?;
+
+        // Resident deleted mirror: same bits as on disk (trailing points beyond
+        // `mappings.deleted()` are deleted).
+        let mut deleted = BitVec::new();
+        deleted.extend_from_bitslice(mappings.deleted());
+        deleted.resize(total, true);
+
+        let deleted_wrapper = BufferedUpdateBitSlice::new(deleted_storage);
+
+        // Versions file: one `u64` per point.
+        let version_filepath = version_mapping_path(path);
+        let versions_count = internal_to_version.len().max(total);
+        create_and_ensure_length(&version_filepath, versions_count * size_of::<SeqNumberType>())?;
+        let mut internal_to_version_file = TypedStorage::<S, SeqNumberType>::open(
+            fs,
+            &version_filepath,
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                populate: Populate::No,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+        )?;
+        internal_to_version_file.write(0, internal_to_version)?;
+        let internal_to_version =
+            CompressedVersions::from_slice(&internal_to_version_file.read_whole()?);
+        debug_assert_eq!(internal_to_version.len(), versions_count);
+        let internal_to_version_wrapper =
+            SliceBufferedUpdateWrapper::new(internal_to_version_file.inner)?;
+
+        // Mapping files (immutable): i2e + e2i.
+        write_mapping_file(i2e_path(path), |writer| store_i2e(&mappings, writer))?;
+        write_mapping_file(e2i_path(path), |writer| store_e2i(&mappings, writer))?;
+
+        deleted_wrapper.flusher()()?;
+        internal_to_version_wrapper.flusher()()?;
+
+        let reader = DiskMappingReader::open(fs, path)?;
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            reader,
+            deleted,
+            deleted_wrapper,
+            internal_to_version,
+            internal_to_version_wrapper,
+        })
+    }
+
+    fn mapping_files(&self) -> Vec<PathBuf> {
+        vec![i2e_path(&self.path), e2i_path(&self.path)]
+    }
+}
+
+/// Create a mapping file and write it with an explicit fsync.
+fn write_mapping_file(
+    path: PathBuf,
+    write: impl FnOnce(&mut BufWriter<File>) -> OperationResult<()>,
+) -> OperationResult<()> {
+    let mut writer = BufWriter::new(File::create(path)?);
+    write(&mut writer)?;
+    writer.flush()?;
+    writer.into_inner().unwrap().sync_all()?;
+    Ok(())
+}
+
+impl<S: UniversalWrite + Send + Sync + 'static> DiskMappingsSource for DiskIdTracker<S> {
+    type Backend = S;
+
+    fn mapping_reader(&self) -> &DiskMappingReader<S> {
+        &self.reader
+    }
+
+    fn point_deleted(&self, offset: PointOffsetType) -> OperationResult<bool> {
+        // Resident bitvec, so this never fails; out-of-range offsets are treated
+        // as deleted (mirrors the in-RAM tracker).
+        Ok(self.deleted.get_bit(offset as usize).unwrap_or(true))
+    }
+
+    fn deleted_bitslice(&self) -> OperationResult<&BitSlice> {
+        // Resident bitvec, so this never fails.
+        Ok(&self.deleted)
+    }
+}
+
+impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for DiskIdTracker<S> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
+        PointMappingsRefEnum::Disk(self.mappings_ref_lossy())
+    }
+
+    fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
+        self.internal_to_version.get(internal_id)
+    }
+
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        _deferred_behavior: DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        log_lookup_err(self.resolve_internal(external_id))
+    }
+
+    fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
+        log_lookup_err(self.resolve_external(internal_id))
+    }
+
+    fn total_point_count(&self) -> usize {
+        self.reader.total_point_count() as usize
+    }
+
+    fn deleted_point_count(&self) -> usize {
+        self.deleted.count_ones()
+    }
+
+    fn deleted_point_bitslice(&self) -> &BitSlice {
+        &self.deleted
+    }
+
+    fn is_deleted_point(&self, key: PointOffsetType) -> bool {
+        // Resident bitvec, so this never actually errors.
+        self.point_deleted(key).unwrap_or(true)
+    }
+
+    fn name(&self) -> &'static str {
+        "disk id tracker"
+    }
+
+    fn iter_internal_versions(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PointOffsetType, SeqNumberType)> + '_> {
+        Box::new(self.internal_to_version.iter())
+    }
+}
+
+impl<S: UniversalWrite + Debug + Send + Sync + 'static> IdTracker for DiskIdTracker<S> {
+    fn set_internal_version(
+        &mut self,
+        internal_id: PointOffsetType,
+        version: SeqNumberType,
+    ) -> OperationResult<()> {
+        let has_version = self.internal_to_version.has(internal_id);
+        debug_assert!(has_version, "Can't extend version list in disk id tracker");
+        if has_version {
+            self.internal_to_version.set(internal_id, version);
+            self.internal_to_version_wrapper.set(internal_id, version);
+        }
+        Ok(())
+    }
+
+    fn set_link(
+        &mut self,
+        _external_id: PointIdType,
+        _internal_id: PointOffsetType,
+    ) -> OperationResult<()> {
+        panic!("Trying to call a mutating function (`set_link`) of a disk id tracker");
+    }
+
+    fn drop(&mut self, external_id: PointIdType) -> OperationResult<()> {
+        // Mutating path: propagate lookup/deletion-check errors instead of swallowing.
+        if let Some(internal_id) = self.reader.lookup(external_id)? {
+            if !self.point_deleted(internal_id)? {
+                self.deleted.set(internal_id as usize, true);
+                self.deleted_wrapper.set(internal_id as usize, true);
+                self.set_internal_version(internal_id, DELETED_POINT_VERSION)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn drop_internal(&mut self, internal_id: PointOffsetType) -> OperationResult<()> {
+        self.deleted.set(internal_id as usize, true);
+        self.deleted_wrapper.set(internal_id as usize, true);
+        self.set_internal_version(internal_id, DELETED_POINT_VERSION)?;
+        Ok(())
+    }
+
+    /// Only deletions are flushed; the mapping is immutable.
+    fn mapping_flusher(&self) -> Flusher {
+        self.deleted_wrapper.flusher()
+    }
+
+    fn versions_flusher(&self) -> Flusher {
+        let flusher = self.internal_to_version_wrapper.flusher();
+        Box::new(move || flusher().map_err(OperationError::from))
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        let mut files = vec![deleted_path(&self.path), version_mapping_path(&self.path)];
+        files.extend(self.mapping_files());
+        files
+    }
+
+    fn immutable_files(&self) -> Vec<PathBuf> {
+        self.mapping_files()
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        let Self {
+            path,
+            reader: _, // i2e/e2i mmap pages dropped via `mapping_files` below
+            deleted: _, // kept in RAM
+            deleted_wrapper,
+            internal_to_version: _, // kept in RAM
+            internal_to_version_wrapper,
+        } = self;
+        deleted_wrapper.clear_cache()?;
+        internal_to_version_wrapper.clear_cache()?;
+        for file in self.mapping_files() {
+            clear_disk_cache(&file)?;
+        }
+        let _ = path;
+        Ok(())
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
@@ -346,12 +346,12 @@ impl<S: UniversalWrite + Debug + Send + Sync + 'static> IdTracker for DiskIdTrac
 
     fn drop(&mut self, external_id: PointIdType) -> OperationResult<()> {
         // Mutating path: propagate lookup/deletion-check errors instead of swallowing.
-        if let Some(internal_id) = self.reader.lookup(external_id)? {
-            if !self.point_deleted(internal_id)? {
-                self.deleted.set(internal_id as usize, true);
-                self.deleted_wrapper.set(internal_id as usize, true);
-                self.set_internal_version(internal_id, DELETED_POINT_VERSION)?;
-            }
+        if let Some(internal_id) = self.reader.lookup(external_id)?
+            && !self.point_deleted(internal_id)?
+        {
+            self.deleted.set(internal_id as usize, true);
+            self.deleted_wrapper.set(internal_id as usize, true);
+            self.set_internal_version(internal_id, DELETED_POINT_VERSION)?;
         }
         Ok(())
     }

--- a/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
@@ -103,7 +103,10 @@ fn pack_bits(bits: &BitSlice) -> Vec<u8> {
 ///
 /// Layout: header, then `total` little-endian `u128` values in offset order,
 /// then the packed `is_uuid` bit array (`ceil(total / 8)` bytes).
-pub fn store_i2e<W: Write>(mappings: &CompressedPointMappings, mut writer: W) -> OperationResult<()> {
+pub fn store_i2e<W: Write>(
+    mappings: &CompressedPointMappings,
+    mut writer: W,
+) -> OperationResult<()> {
     let total = mappings.total_point_count();
 
     writer.write_u64::<Endian>(I2E_MAGIC)?;
@@ -128,7 +131,10 @@ pub fn store_i2e<W: Write>(mappings: &CompressedPointMappings, mut writer: W) ->
 /// Runs are taken from `mappings.iter_from(None)`, which yields live points in
 /// numeric-then-UUID order, each run internally sorted ascending — exactly the
 /// on-disk run order. Deleted-at-build points are already excluded there.
-pub fn store_e2i<W: Write>(mappings: &CompressedPointMappings, mut writer: W) -> OperationResult<()> {
+pub fn store_e2i<W: Write>(
+    mappings: &CompressedPointMappings,
+    mut writer: W,
+) -> OperationResult<()> {
     let mut num: Vec<(u64, PointOffsetType)> = Vec::new();
     let mut uuid: Vec<(u128, PointOffsetType)> = Vec::new();
     for (external_id, offset) in mappings.iter_from(None) {
@@ -240,7 +246,8 @@ pub struct E2iHeader {
 
 impl E2iHeader {
     pub fn num_blocks(&self) -> u64 {
-        self.num_count.div_ceil(u64::from(self.num_block_size).max(1))
+        self.num_count
+            .div_ceil(u64::from(self.num_block_size).max(1))
     }
 
     pub fn uuid_blocks(&self) -> u64 {

--- a/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
@@ -1,0 +1,331 @@
+//! On-disk mapping format for the disk-resident id tracker: a random-access
+//! layout that lets the tracker answer lookups without holding the mapping in
+//! RAM.
+//!
+//! Two files hold the mapping (alongside the reused `id_tracker.versions` and
+//! `id_tracker.deleted`):
+//!
+//! - [`I2E_FILE_NAME`] — internal→external as a fixed-width `u128` array plus an
+//!   `is_uuid` bit per slot (a direct transcription of
+//!   [`CompressedInternalToExternal`]). `external_id(offset)` is one 16-byte read.
+//! - [`E2I_FILE_NAME`] — external→internal as two sorted, fixed-width runs
+//!   (`(u64, u32)` for numeric ids, then `(u128, u32)` for UUIDs — the section
+//!   order encodes "any UUID sorts after any numeric id"), preceded by a sparse
+//!   block index (first key of every ~16 KiB block). A point lookup is an
+//!   in-RAM sparse-index search plus one data-block read.
+//!
+//! [`CompressedInternalToExternal`]:
+//!   crate::id_tracker::compressed::internal_to_external::CompressedInternalToExternal
+
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use common::bitvec::{BitSlice, BitSliceExt as _, BitVec};
+use common::types::PointOffsetType;
+use uuid::Uuid;
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::types::PointIdType;
+
+type Endian = LittleEndian;
+
+pub const I2E_FILE_NAME: &str = "id_tracker.i2e";
+pub const E2I_FILE_NAME: &str = "id_tracker.e2i";
+
+pub fn i2e_path(base: &Path) -> PathBuf {
+    base.join(I2E_FILE_NAME)
+}
+
+pub fn e2i_path(base: &Path) -> PathBuf {
+    base.join(E2I_FILE_NAME)
+}
+
+/// On-disk format version, stored in each file header for forward compatibility.
+pub const ON_DISK_FORMAT_VERSION: u32 = 1;
+
+const I2E_MAGIC: u64 = 0x5144_5F49_3245_0001;
+const E2I_MAGIC: u64 = 0x5144_5F45_3249_0001;
+
+/// Header size in bytes for the i2e file: magic(8) + version(4) + reserved(4) + total(8).
+pub const I2E_HEADER_SIZE: u64 = 24;
+/// Header size in bytes for the e2i file:
+/// magic(8) + version(4) + reserved(4) + num_count(8) + uuid_count(8) + num_bs(4) + uuid_bs(4).
+pub const E2I_HEADER_SIZE: u64 = 40;
+
+/// Byte width of one numeric run entry: `u64` key + `u32` offset.
+pub const NUM_ENTRY_SIZE: u64 = 12;
+/// Byte width of one UUID run entry: `u128` key + `u32` offset.
+pub const UUID_ENTRY_SIZE: u64 = 20;
+
+/// Entries per numeric block, chosen so a block is ~16 KiB (the `DiskCache` block
+/// size), i.e. one logical block ≈ one cache block ≈ one remote range read.
+pub const NUM_BLOCK_ENTRIES: u32 = 1365; // * 12 = 16380 bytes
+/// Entries per UUID block, same ~16 KiB target.
+pub const UUID_BLOCK_ENTRIES: u32 = 819; // * 20 = 16380 bytes
+
+/// Encode an external id into the `(u128, is_uuid)` representation shared with
+/// [`CompressedInternalToExternal`](crate::id_tracker::compressed::internal_to_external::CompressedInternalToExternal).
+fn encode_external(id: PointIdType) -> (u128, bool) {
+    match id {
+        PointIdType::NumId(num) => (u128::from(num), false),
+        PointIdType::Uuid(uuid) => (uuid.as_u128(), true),
+    }
+}
+
+/// Decode a `(u128, is_uuid)` slot back into a [`PointIdType`].
+fn decode_external(value: u128, is_uuid: bool) -> PointIdType {
+    if is_uuid {
+        PointIdType::Uuid(Uuid::from_u128(value))
+    } else {
+        debug_assert!(
+            value <= u128::from(u64::MAX),
+            "numeric external id does not fit into u64",
+        );
+        PointIdType::NumId(value as u64)
+    }
+}
+
+/// Pack a bit slice into bytes, LSB-first within each byte (bit `i` lives in byte
+/// `i / 8` at position `i % 8`). Matches the single-bit read in the reader.
+fn pack_bits(bits: &BitSlice) -> Vec<u8> {
+    let mut bytes = vec![0u8; bits.len().div_ceil(8)];
+    for i in 0..bits.len() {
+        if bits.get_bit(i).unwrap_or(false) {
+            bytes[i / 8] |= 1 << (i % 8);
+        }
+    }
+    bytes
+}
+
+/// Serialize the internal→external mapping (`id_tracker.i2e`).
+///
+/// Layout: header, then `total` little-endian `u128` values in offset order,
+/// then the packed `is_uuid` bit array (`ceil(total / 8)` bytes).
+pub fn store_i2e<W: Write>(mappings: &CompressedPointMappings, mut writer: W) -> OperationResult<()> {
+    let total = mappings.total_point_count();
+
+    writer.write_u64::<Endian>(I2E_MAGIC)?;
+    writer.write_u32::<Endian>(ON_DISK_FORMAT_VERSION)?;
+    writer.write_u32::<Endian>(0)?; // reserved
+    writer.write_u64::<Endian>(total as u64)?;
+
+    let mut is_uuid = BitVec::with_capacity(total);
+    for (offset, external_id) in mappings.iter_internal_raw() {
+        debug_assert_eq!(offset as usize, is_uuid.len(), "i2e entries out of order");
+        let (value, uuid_flag) = encode_external(external_id);
+        writer.write_u128::<Endian>(value)?;
+        is_uuid.push(uuid_flag);
+    }
+
+    writer.write_all(&pack_bits(&is_uuid))?;
+    Ok(())
+}
+
+/// Serialize the external→internal mapping (`id_tracker.e2i`).
+///
+/// Runs are taken from `mappings.iter_from(None)`, which yields live points in
+/// numeric-then-UUID order, each run internally sorted ascending — exactly the
+/// on-disk run order. Deleted-at-build points are already excluded there.
+pub fn store_e2i<W: Write>(mappings: &CompressedPointMappings, mut writer: W) -> OperationResult<()> {
+    let mut num: Vec<(u64, PointOffsetType)> = Vec::new();
+    let mut uuid: Vec<(u128, PointOffsetType)> = Vec::new();
+    for (external_id, offset) in mappings.iter_from(None) {
+        match external_id {
+            PointIdType::NumId(n) => num.push((n, offset)),
+            PointIdType::Uuid(u) => uuid.push((u.as_u128(), offset)),
+        }
+    }
+    debug_assert!(num.is_sorted_by_key(|(k, _)| *k), "numeric run not sorted");
+    debug_assert!(uuid.is_sorted_by_key(|(k, _)| *k), "uuid run not sorted");
+
+    writer.write_u64::<Endian>(E2I_MAGIC)?;
+    writer.write_u32::<Endian>(ON_DISK_FORMAT_VERSION)?;
+    writer.write_u32::<Endian>(0)?; // reserved
+    writer.write_u64::<Endian>(num.len() as u64)?;
+    writer.write_u64::<Endian>(uuid.len() as u64)?;
+    writer.write_u32::<Endian>(NUM_BLOCK_ENTRIES)?;
+    writer.write_u32::<Endian>(UUID_BLOCK_ENTRIES)?;
+
+    // Sparse block index: first key of every block, for each run.
+    for chunk in num.chunks(NUM_BLOCK_ENTRIES as usize) {
+        writer.write_u64::<Endian>(chunk[0].0)?;
+    }
+    for chunk in uuid.chunks(UUID_BLOCK_ENTRIES as usize) {
+        writer.write_u128::<Endian>(chunk[0].0)?;
+    }
+
+    // Runs.
+    for (key, offset) in &num {
+        writer.write_u64::<Endian>(*key)?;
+        writer.write_u32::<Endian>(*offset)?;
+    }
+    for (key, offset) in &uuid {
+        writer.write_u128::<Endian>(*key)?;
+        writer.write_u32::<Endian>(*offset)?;
+    }
+
+    Ok(())
+}
+
+fn inconsistent(msg: impl Into<String>) -> OperationError {
+    OperationError::inconsistent_storage(msg.into())
+}
+
+/// Parsed i2e header plus the byte offset where the `is_uuid` bit array begins.
+#[derive(Copy, Clone, Debug)]
+pub struct I2eHeader {
+    pub total: u64,
+    /// Byte offset of the `u128` data array (right after the header).
+    pub data_offset: u64,
+    /// Byte offset of the packed `is_uuid` bit array.
+    pub is_uuid_offset: u64,
+}
+
+impl I2eHeader {
+    pub fn parse(bytes: &[u8]) -> OperationResult<Self> {
+        let mut cursor = Cursor::new(bytes);
+        let magic = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
+        if magic != I2E_MAGIC {
+            return Err(inconsistent("i2e file has invalid magic"));
+        }
+        let version = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
+        if version != ON_DISK_FORMAT_VERSION {
+            return Err(inconsistent(format!(
+                "unsupported i2e on-disk format version {version}"
+            )));
+        }
+        let _reserved = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
+        let total = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
+
+        let data_offset = I2E_HEADER_SIZE;
+        let is_uuid_offset = data_offset + total * 16;
+        Ok(Self {
+            total,
+            data_offset,
+            is_uuid_offset,
+        })
+    }
+
+    /// Decode one `(u128, is_uuid)` slot from the raw 16 data bytes and the byte
+    /// holding this slot's `is_uuid` bit.
+    pub fn decode_slot(offset: PointOffsetType, data16: &[u8], is_uuid_byte: u8) -> PointIdType {
+        let value = u128::from_le_bytes(data16.try_into().expect("16 data bytes"));
+        let is_uuid = (is_uuid_byte >> (offset as usize % 8)) & 1 == 1;
+        decode_external(value, is_uuid)
+    }
+}
+
+/// Parsed e2i header plus the computed byte offsets of every section.
+#[derive(Clone, Debug)]
+pub struct E2iHeader {
+    pub num_count: u64,
+    pub uuid_count: u64,
+    pub num_block_size: u32,
+    pub uuid_block_size: u32,
+    pub num_sparse_offset: u64,
+    pub uuid_sparse_offset: u64,
+    pub num_run_offset: u64,
+    pub uuid_run_offset: u64,
+}
+
+impl E2iHeader {
+    pub fn num_blocks(&self) -> u64 {
+        self.num_count.div_ceil(u64::from(self.num_block_size).max(1))
+    }
+
+    pub fn uuid_blocks(&self) -> u64 {
+        self.uuid_count
+            .div_ceil(u64::from(self.uuid_block_size).max(1))
+    }
+
+    /// Byte offset where the sparse index (num + uuid) ends and runs begin.
+    pub fn index_end(&self) -> u64 {
+        self.num_run_offset
+    }
+
+    pub fn parse(bytes: &[u8]) -> OperationResult<Self> {
+        let mut cursor = Cursor::new(bytes);
+        let magic = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        if magic != E2I_MAGIC {
+            return Err(inconsistent("e2i file has invalid magic"));
+        }
+        let version = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        if version != ON_DISK_FORMAT_VERSION {
+            return Err(inconsistent(format!(
+                "unsupported e2i on-disk format version {version}"
+            )));
+        }
+        let _reserved = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        let num_count = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        let uuid_count = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        let num_block_size = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        let uuid_block_size = cursor
+            .read_u32::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+
+        if num_block_size == 0 || uuid_block_size == 0 {
+            return Err(inconsistent("e2i block size is zero"));
+        }
+
+        let mut header = Self {
+            num_count,
+            uuid_count,
+            num_block_size,
+            uuid_block_size,
+            num_sparse_offset: E2I_HEADER_SIZE,
+            uuid_sparse_offset: 0,
+            num_run_offset: 0,
+            uuid_run_offset: 0,
+        };
+        header.uuid_sparse_offset = header.num_sparse_offset + header.num_blocks() * 8;
+        header.num_run_offset = header.uuid_sparse_offset + header.uuid_blocks() * 16;
+        header.uuid_run_offset = header.num_run_offset + num_count * NUM_ENTRY_SIZE;
+        Ok(header)
+    }
+}
+
+/// Decode a numeric run block (`(u64 key, u32 offset)` entries) from raw bytes.
+pub fn decode_num_block(bytes: &[u8]) -> Vec<(u128, PointOffsetType)> {
+    bytes
+        .chunks_exact(NUM_ENTRY_SIZE as usize)
+        .map(|entry| {
+            let key = u64::from_le_bytes(entry[0..8].try_into().unwrap());
+            let offset = u32::from_le_bytes(entry[8..12].try_into().unwrap());
+            (u128::from(key), offset)
+        })
+        .collect()
+}
+
+/// Decode a UUID run block (`(u128 key, u32 offset)` entries) from raw bytes.
+pub fn decode_uuid_block(bytes: &[u8]) -> Vec<(u128, PointOffsetType)> {
+    bytes
+        .chunks_exact(UUID_ENTRY_SIZE as usize)
+        .map(|entry| {
+            let key = u128::from_le_bytes(entry[0..16].try_into().unwrap());
+            let offset = u32::from_le_bytes(entry[16..20].try_into().unwrap());
+            (key, offset)
+        })
+        .collect()
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/on_disk_format.rs
@@ -48,11 +48,25 @@ pub const ON_DISK_FORMAT_VERSION: u32 = 1;
 const I2E_MAGIC: u64 = 0x5144_5F49_3245_0001;
 const E2I_MAGIC: u64 = 0x5144_5F45_3249_0001;
 
-/// Header size in bytes for the i2e file: magic(8) + version(4) + reserved(4) + total(8).
-pub const I2E_HEADER_SIZE: u64 = 24;
+/// Header size in bytes for the i2e file:
+/// magic(8) + version(4) + reserved(4) + total(8) + reserved(8).
+///
+/// Headers and every section start are aligned to [`SECTION_ALIGN`] so the
+/// files stay transmute-friendly if we ever mmap them (`u128` needs 16-byte
+/// alignment in Rust).
+pub const I2E_HEADER_SIZE: u64 = 32;
 /// Header size in bytes for the e2i file:
-/// magic(8) + version(4) + reserved(4) + num_count(8) + uuid_count(8) + num_bs(4) + uuid_bs(4).
-pub const E2I_HEADER_SIZE: u64 = 40;
+/// magic(8) + version(4) + reserved(4) + num_count(8) + uuid_count(8) + num_bs(4) + uuid_bs(4)
+/// + reserved(8).
+pub const E2I_HEADER_SIZE: u64 = 48;
+
+/// Alignment (bytes) of headers and section starts within both files.
+pub const SECTION_ALIGN: u64 = 16;
+
+/// Round `offset` up to the next [`SECTION_ALIGN`] boundary.
+fn align_section(offset: u64) -> u64 {
+    offset.next_multiple_of(SECTION_ALIGN)
+}
 
 /// Byte width of one numeric run entry: `u64` key + `u32` offset.
 pub const NUM_ENTRY_SIZE: u64 = 12;
@@ -113,6 +127,7 @@ pub fn store_i2e<W: Write>(
     writer.write_u32::<Endian>(ON_DISK_FORMAT_VERSION)?;
     writer.write_u32::<Endian>(0)?; // reserved
     writer.write_u64::<Endian>(total as u64)?;
+    writer.write_u64::<Endian>(0)?; // reserved, pads header to SECTION_ALIGN
 
     let mut is_uuid = BitVec::with_capacity(total);
     for (offset, external_id) in mappings.iter_internal_raw() {
@@ -153,20 +168,36 @@ pub fn store_e2i<W: Write>(
     writer.write_u64::<Endian>(uuid.len() as u64)?;
     writer.write_u32::<Endian>(NUM_BLOCK_ENTRIES)?;
     writer.write_u32::<Endian>(UUID_BLOCK_ENTRIES)?;
+    writer.write_u64::<Endian>(0)?; // reserved, pads header to SECTION_ALIGN
+
+    // Sections are padded so each starts at a SECTION_ALIGN boundary; the pad
+    // sizes here must mirror the offsets computed in `E2iHeader::parse`.
+    let write_section_pad = |writer: &mut W, end: u64| -> OperationResult<()> {
+        writer.write_all(&vec![0u8; (align_section(end) - end) as usize])?;
+        Ok(())
+    };
 
     // Sparse block index: first key of every block, for each run.
     for chunk in num.chunks(NUM_BLOCK_ENTRIES as usize) {
         writer.write_u64::<Endian>(chunk[0].0)?;
     }
+    let num_sparse_end =
+        E2I_HEADER_SIZE + num.len().div_ceil(NUM_BLOCK_ENTRIES as usize) as u64 * 8;
+    write_section_pad(&mut writer, num_sparse_end)?;
     for chunk in uuid.chunks(UUID_BLOCK_ENTRIES as usize) {
         writer.write_u128::<Endian>(chunk[0].0)?;
     }
 
-    // Runs.
+    // Runs. The uuid sparse section ends SECTION_ALIGN-aligned (16-byte
+    // entries), so the numeric run needs no leading pad.
     for (key, offset) in &num {
         writer.write_u64::<Endian>(*key)?;
         writer.write_u32::<Endian>(*offset)?;
     }
+    let num_run_end = align_section(num_sparse_end)
+        + uuid.len().div_ceil(UUID_BLOCK_ENTRIES as usize) as u64 * 16
+        + num.len() as u64 * NUM_ENTRY_SIZE;
+    write_section_pad(&mut writer, num_run_end)?;
     for (key, offset) in &uuid {
         writer.write_u128::<Endian>(*key)?;
         writer.write_u32::<Endian>(*offset)?;
@@ -210,6 +241,9 @@ impl I2eHeader {
             .read_u32::<Endian>()
             .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
         let total = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
+        let _reserved2 = cursor
             .read_u64::<Endian>()
             .map_err(|e| inconsistent(format!("i2e header: {e}")))?;
 
@@ -291,11 +325,16 @@ impl E2iHeader {
         let uuid_block_size = cursor
             .read_u32::<Endian>()
             .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
+        let _reserved2 = cursor
+            .read_u64::<Endian>()
+            .map_err(|e| inconsistent(format!("e2i header: {e}")))?;
 
         if num_block_size == 0 || uuid_block_size == 0 {
             return Err(inconsistent("e2i block size is zero"));
         }
 
+        // Every section starts SECTION_ALIGN-aligned; must mirror the pads
+        // written in `store_e2i`.
         let mut header = Self {
             num_count,
             uuid_count,
@@ -306,9 +345,10 @@ impl E2iHeader {
             num_run_offset: 0,
             uuid_run_offset: 0,
         };
-        header.uuid_sparse_offset = header.num_sparse_offset + header.num_blocks() * 8;
+        header.uuid_sparse_offset =
+            align_section(header.num_sparse_offset + header.num_blocks() * 8);
         header.num_run_offset = header.uuid_sparse_offset + header.uuid_blocks() * 16;
-        header.uuid_run_offset = header.num_run_offset + num_count * NUM_ENTRY_SIZE;
+        header.uuid_run_offset = align_section(header.num_run_offset + num_count * NUM_ENTRY_SIZE);
         Ok(header)
     }
 }

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
@@ -1,0 +1,283 @@
+//! Disk-resident, read-only id tracker over the [on-disk format], for
+//! serverless / object-storage followers.
+//!
+//! Keeps only a small fixed index resident (via [`DiskMappingReader`]) and
+//! answers every lookup with at most one data-block read through the backing
+//! [`UniversalRead`] handle, so RAM usage does not scale with point count.
+//!
+//! Deletion status is checked per point via [`StoredBitSlice::get_bit`] on the hot
+//! read-by-id path (no full load). The whole deleted set is materialized lazily,
+//! once, only when a path that needs the entire slice runs — vector search
+//! ([`deleted_point_bitslice`](IdTrackerRead::deleted_point_bitslice)), scroll
+//! iteration, counts, or the [`live_reload`](Self::live_reload) diff baseline.
+//!
+//! [on-disk format]: super::on_disk_format
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use common::bitvec::{BitSlice, BitVec};
+use common::generic_consts::{Random, Sequential};
+use common::mmap::AdviceSetting;
+use common::stored_bitslice::StoredBitSlice;
+use common::types::{DeferredBehavior, PointOffsetType};
+use common::universal_io::{OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead};
+
+use super::mappings::{DiskMappingsSource, log_lookup_err};
+use super::on_disk_format::{e2i_path, i2e_path};
+use super::reader::DiskMappingReader;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::immutable_id_tracker::{deleted_path, version_mapping_path};
+use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
+use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
+use crate::types::{PointIdType, SeqNumberType};
+
+/// Read-only id tracker backed by the on-disk format files, streamed lazily
+/// through a [`UniversalRead`] backend.
+pub struct ReadOnlyDiskIdTracker<S: UniversalRead> {
+    path: PathBuf,
+
+    /// Lazy mapping read core (resident: headers + sparse index).
+    reader: DiskMappingReader<S>,
+
+    versions: TypedStorage<S, SeqNumberType>,
+    versions_len: u64,
+    /// Kept for per-point `get_bit` and for `live_reload` reopen.
+    deleted_file: StoredBitSlice<S>,
+
+    /// Full deleted set. NOT loaded on open or by point lookups. Materialized on
+    /// the first search/scroll/count/reload and reused; invalidated by `live_reload`.
+    deleted_full: OnceLock<BitVec>,
+}
+
+impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
+    /// Open a read-only disk id tracker at `segment_path`. Reads only the two
+    /// headers and the e2i sparse block index into RAM; all per-point data stays
+    /// on the backing store.
+    ///
+    /// Errors if the segment is not in the on-disk format; use
+    /// [`try_open`](Self::try_open) to probe without erroring.
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        Self::try_open(fs, segment_path)?.ok_or_else(|| {
+            OperationError::service_error(format!(
+                "on-disk id tracker not found in segment {}",
+                segment_path.display(),
+            ))
+        })
+    }
+
+    /// Like [`open`](Self::open), but returns `Ok(None)` when the segment is not
+    /// in the on-disk format (`i2e` absent). Probing happens by opening the
+    /// mapping directly, so no separate existence check is issued.
+    pub fn try_open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Option<Self>> {
+        let Some(reader) = DiskMappingReader::try_open(fs, segment_path)? else {
+            return Ok(None);
+        };
+
+        let options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Global,
+        };
+        let versions = TypedStorage::<S, SeqNumberType>::open(
+            fs,
+            version_mapping_path(segment_path),
+            options,
+            Default::default(),
+        )?;
+        let versions_len = versions.len()?;
+
+        let deleted_file =
+            StoredBitSlice::open(fs, deleted_path(segment_path), options, Default::default())?;
+
+        Ok(Some(Self {
+            path: segment_path.to_path_buf(),
+            reader,
+            versions,
+            versions_len,
+            deleted_file,
+            deleted_full: OnceLock::new(),
+        }))
+    }
+
+    pub fn files(&self) -> Vec<PathBuf> {
+        vec![
+            i2e_path(&self.path),
+            e2i_path(&self.path),
+            version_mapping_path(&self.path),
+            deleted_path(&self.path),
+        ]
+    }
+
+    /// Re-read the on-disk deleted bitslice and report points deleted since the
+    /// last reload. Mappings are immutable, so nothing is ever inserted.
+    ///
+    /// The full deleted set (`deleted_full`) doubles as the diff baseline: if it
+    /// was materialized (by a prior search/scroll/count/reload) we diff against
+    /// it; otherwise this is the first baseline and every currently-deleted
+    /// offset is reported (an idempotent replay downstream).
+    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
+        self.deleted_file.reopen()?;
+        let new: BitVec = self.deleted_file.read_all()?.into_owned();
+
+        let baseline = self.deleted_full.take();
+        let deleted: Vec<PointOffsetType> = match baseline {
+            Some(old) => new
+                .iter_ones()
+                .filter(|&i| !old.get(i).is_some_and(|b| *b))
+                .map(|i| i as PointOffsetType)
+                .collect(),
+            None => new.iter_ones().map(|i| i as PointOffsetType).collect(),
+        };
+        debug_assert!(deleted.is_sorted());
+
+        // `take` above emptied the cell, so this refreshes it to the new state
+        // and serves both the next search view and the next reload baseline.
+        let _ = self.deleted_full.set(new);
+
+        Ok(LiveReloadResult {
+            inserted: Vec::new(),
+            deleted,
+        })
+    }
+
+    /// Lazily materialize the full deleted set. Used only by paths that need the
+    /// whole slice (search / scroll / counts); never by point lookups. The read
+    /// error propagates instead of being swallowed here.
+    ///
+    /// Manual fallible init (std `OnceLock` has no stable `get_or_try_init`): on a
+    /// race both threads read the same on-disk state (`live_reload` needs `&mut`,
+    /// so it can't interleave), so the loser's `set` failing is harmless.
+    fn deleted_full(&self) -> OperationResult<&BitVec> {
+        if let Some(materialized) = self.deleted_full.get() {
+            return Ok(materialized);
+        }
+        let materialized = self.deleted_file.read_all()?.into_owned();
+        let _ = self.deleted_full.set(materialized);
+        Ok(self.deleted_full.get().expect("just set"))
+    }
+
+    /// Whether the full deleted set has been materialized. Test-only: used to
+    /// assert that read-by-id lookups do not trigger a full load.
+    #[cfg(test)]
+    pub(crate) fn deleted_full_materialized(&self) -> bool {
+        self.deleted_full.get().is_some()
+    }
+
+}
+
+impl<S: UniversalRead> DiskMappingsSource for ReadOnlyDiskIdTracker<S> {
+    type Backend = S;
+
+    fn mapping_reader(&self) -> &DiskMappingReader<S> {
+        &self.reader
+    }
+
+    /// A single lazy `get_bit` on the on-disk deleted file — no full-set load, so
+    /// read-by-id stays lazy. Out-of-range offsets are treated as deleted; storage
+    /// errors propagate.
+    fn point_deleted(&self, offset: PointOffsetType) -> OperationResult<bool> {
+        Ok(self.deleted_file.get_bit(u64::from(offset))?.unwrap_or(true))
+    }
+
+    fn deleted_bitslice(&self) -> OperationResult<&BitSlice> {
+        Ok(self.deleted_full()?.as_bitslice())
+    }
+}
+
+impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
+        PointMappingsRefEnum::Disk(self.mappings_ref_lossy())
+    }
+
+    fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
+        if u64::from(internal_id) >= self.versions_len {
+            return None;
+        }
+        match self.versions.read::<Random>(ReadRange {
+            byte_offset: u64::from(internal_id) * size_of::<SeqNumberType>() as u64,
+            length: 1,
+        }) {
+            Ok(values) => values.first().copied(),
+            Err(err) => {
+                log::error!("disk id tracker version read failed: {err}");
+                None
+            }
+        }
+    }
+
+    fn internal_id_with_behavior(
+        &self,
+        external_id: PointIdType,
+        _deferred_behavior: DeferredBehavior,
+    ) -> Option<PointOffsetType> {
+        log_lookup_err(self.resolve_internal(external_id))
+    }
+
+    fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
+        log_lookup_err(self.resolve_external(internal_id))
+    }
+
+    fn total_point_count(&self) -> usize {
+        self.reader.total_point_count() as usize
+    }
+
+    fn deleted_point_count(&self) -> usize {
+        self.mappings_ref_lossy().deleted().count_ones()
+    }
+
+    fn deleted_point_bitslice(&self) -> &BitSlice {
+        self.mappings_ref_lossy().deleted()
+    }
+
+    fn is_deleted_point(&self, internal_id: PointOffsetType) -> bool {
+        // Fail-safe on a storage error: treat the point as deleted (hide it).
+        self.point_deleted(internal_id).unwrap_or_else(|err| {
+            log::error!("disk id tracker deleted check failed: {err}");
+            true
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "read-only disk id tracker"
+    }
+
+    fn iter_internal_versions(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PointOffsetType, SeqNumberType)> + '_> {
+        let ranges = ReadRange {
+            byte_offset: 0,
+            length: self.versions_len,
+        }
+        .iter_autochunks::<SeqNumberType>()
+        .map(|range| ((), range));
+
+        match self.versions.read_iter::<Sequential, ()>(ranges) {
+            Ok(iter) => {
+                let mut offset: PointOffsetType = 0;
+                Box::new(iter.flat_map(move |result| {
+                    let chunk = match result {
+                        Ok((_, cow)) => cow.into_owned(),
+                        Err(err) => {
+                            log::error!("disk id tracker versions stream failed: {err}");
+                            Vec::new()
+                        }
+                    };
+                    let start = offset;
+                    offset += chunk.len() as PointOffsetType;
+                    chunk
+                        .into_iter()
+                        .enumerate()
+                        .map(move |(i, version)| (start + i as PointOffsetType, version))
+                }))
+            }
+            Err(err) => {
+                log::error!("disk id tracker versions read_iter failed: {err}");
+                Box::new(std::iter::empty())
+            }
+        }
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
@@ -164,7 +164,6 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     pub(crate) fn deleted_full_materialized(&self) -> bool {
         self.deleted_full.get().is_some()
     }
-
 }
 
 impl<S: UniversalRead> DiskMappingsSource for ReadOnlyDiskIdTracker<S> {
@@ -178,7 +177,10 @@ impl<S: UniversalRead> DiskMappingsSource for ReadOnlyDiskIdTracker<S> {
     /// read-by-id stays lazy. Out-of-range offsets are treated as deleted; storage
     /// errors propagate.
     fn point_deleted(&self, offset: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.deleted_file.get_bit(u64::from(offset))?.unwrap_or(true))
+        Ok(self
+            .deleted_file
+            .get_bit(u64::from(offset))?
+            .unwrap_or(true))
     }
 
     fn deleted_bitslice(&self) -> OperationResult<&BitSlice> {

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
@@ -104,6 +104,8 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         for _ in 0..e2i_header.num_blocks() {
             num_sparse.push(cursor.read_u64::<Endian>()?);
         }
+        // Skip the alignment pad between the numeric and UUID sparse sections.
+        cursor.set_position(e2i_header.uuid_sparse_offset - E2I_HEADER_SIZE);
         let mut uuid_sparse = Vec::with_capacity(e2i_header.uuid_blocks() as usize);
         for _ in 0..e2i_header.uuid_blocks() {
             uuid_sparse.push(cursor.read_u128::<Endian>()?);

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
@@ -128,10 +128,12 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         let bs = u64::from(self.e2i_header.num_block_size);
         let start = block * bs;
         let count = (self.e2i_header.num_count - start).min(bs);
-        let bytes = self.e2i.read::<common::generic_consts::Random, u8>(ReadRange {
-            byte_offset: self.e2i_header.num_run_offset + start * NUM_ENTRY_SIZE,
-            length: count * NUM_ENTRY_SIZE,
-        })?;
+        let bytes = self
+            .e2i
+            .read::<common::generic_consts::Random, u8>(ReadRange {
+                byte_offset: self.e2i_header.num_run_offset + start * NUM_ENTRY_SIZE,
+                length: count * NUM_ENTRY_SIZE,
+            })?;
         Ok(decode_num_block(bytes.as_ref()))
     }
 
@@ -139,10 +141,12 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         let bs = u64::from(self.e2i_header.uuid_block_size);
         let start = block * bs;
         let count = (self.e2i_header.uuid_count - start).min(bs);
-        let bytes = self.e2i.read::<common::generic_consts::Random, u8>(ReadRange {
-            byte_offset: self.e2i_header.uuid_run_offset + start * UUID_ENTRY_SIZE,
-            length: count * UUID_ENTRY_SIZE,
-        })?;
+        let bytes = self
+            .e2i
+            .read::<common::generic_consts::Random, u8>(ReadRange {
+                byte_offset: self.e2i_header.uuid_run_offset + start * UUID_ENTRY_SIZE,
+                length: count * UUID_ENTRY_SIZE,
+            })?;
         Ok(decode_uuid_block(bytes.as_ref()))
     }
 
@@ -196,14 +200,18 @@ impl<S: UniversalRead> DiskMappingReader<S> {
 
     fn read_external_id(&self, offset: PointOffsetType) -> OperationResult<PointIdType> {
         let data_offset = self.i2e_header.data_offset + u64::from(offset) * 16;
-        let data = self.i2e.read::<common::generic_consts::Random, u8>(ReadRange {
-            byte_offset: data_offset,
-            length: 16,
-        })?;
-        let is_uuid_byte = self.i2e.read::<common::generic_consts::Random, u8>(ReadRange {
-            byte_offset: self.i2e_header.is_uuid_offset + u64::from(offset) / 8,
-            length: 1,
-        })?;
+        let data = self
+            .i2e
+            .read::<common::generic_consts::Random, u8>(ReadRange {
+                byte_offset: data_offset,
+                length: 16,
+            })?;
+        let is_uuid_byte = self
+            .i2e
+            .read::<common::generic_consts::Random, u8>(ReadRange {
+                byte_offset: self.i2e_header.is_uuid_offset + u64::from(offset) / 8,
+                length: 1,
+            })?;
         Ok(I2eHeader::decode_slot(
             offset,
             data.as_ref(),

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
@@ -1,0 +1,399 @@
+//! Shared lazy read core over the [on-disk format](super::on_disk_format)
+//! mapping files (`i2e` + `e2i`).
+//!
+//! Holds only the two headers and the e2i sparse block index in RAM; every
+//! lookup reads at most one data block through the backing [`UniversalRead`]
+//! handle. Both the writable [`DiskIdTracker`](super::DiskIdTracker) and the
+//! read-only [`ReadOnlyDiskIdTracker`](super::read_only::ReadOnlyDiskIdTracker)
+//! embed this and layer their own deletion/version handling on top.
+//!
+//! Deletion is deliberately NOT applied here: `lookup`/`external_id`/`iter_from`
+//! return build-time-live entries, and each tracker filters with its own deleted
+//! source (a resident bitvec for the writable tracker, a lazy `get_bit` for the
+//! reader).
+
+use std::io::Cursor;
+use std::path::Path;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+use common::bitvec::{BitSlice, BitSliceExt as _};
+use common::mmap::AdviceSetting;
+use common::types::PointOffsetType;
+use common::universal_io::{
+    OkNotFound, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFs,
+};
+use itertools::Itertools as _;
+use rand::distr::{Distribution as _, Uniform};
+use uuid::Uuid;
+
+use super::on_disk_format::{
+    E2I_HEADER_SIZE, E2iHeader, I2E_HEADER_SIZE, I2eHeader, NUM_ENTRY_SIZE, UUID_ENTRY_SIZE,
+    decode_num_block, decode_uuid_block, e2i_path, i2e_path,
+};
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::types::PointIdType;
+
+type Endian = LittleEndian;
+
+/// Lazy read core over the `i2e`/`e2i` files.
+#[derive(Debug)]
+pub struct DiskMappingReader<S: UniversalRead> {
+    i2e: S,
+    e2i: S,
+    i2e_header: I2eHeader,
+    e2i_header: E2iHeader,
+    /// First numeric key of every numeric block.
+    num_sparse: Vec<u64>,
+    /// First UUID key (`as_u128`) of every UUID block.
+    uuid_sparse: Vec<u128>,
+}
+
+impl<S: UniversalRead> DiskMappingReader<S> {
+    /// Open the `i2e`/`e2i` handles and read the headers + sparse index. No
+    /// per-point data is read.
+    ///
+    /// Errors if the segment is not in the on-disk format (`i2e` absent). Use
+    /// [`try_open`](Self::try_open) to probe without erroring.
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        Self::try_open(fs, segment_path)?.ok_or_else(|| {
+            OperationError::service_error(format!(
+                "on-disk id tracker mapping ({}) not found",
+                i2e_path(segment_path).display(),
+            ))
+        })
+    }
+
+    /// Like [`open`](Self::open), but returns `Ok(None)` when the defining `i2e`
+    /// file is absent — i.e. the segment is not in the on-disk format. Any other
+    /// missing/corrupt file is a hard error. Opening the `i2e` handle also serves
+    /// as the format probe, so no separate existence check is issued.
+    pub fn try_open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Option<Self>> {
+        let options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Global,
+        };
+
+        let Some(i2e) = fs
+            .open(i2e_path(segment_path), options, Default::default())
+            .ok_not_found()?
+        else {
+            return Ok(None);
+        };
+        let i2e_header_bytes = i2e.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: 0,
+            length: I2E_HEADER_SIZE,
+        })?;
+        let i2e_header = I2eHeader::parse(i2e_header_bytes.as_ref())?;
+
+        let e2i = fs.open(e2i_path(segment_path), options, Default::default())?;
+        let e2i_header_bytes = e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: 0,
+            length: E2I_HEADER_SIZE,
+        })?;
+        let e2i_header = E2iHeader::parse(e2i_header_bytes.as_ref())?;
+
+        // Read the whole sparse index (numeric then UUID) in a single range.
+        let index_bytes = e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: E2I_HEADER_SIZE,
+            length: e2i_header.index_end() - E2I_HEADER_SIZE,
+        })?;
+        let mut cursor = Cursor::new(index_bytes.as_ref());
+        let mut num_sparse = Vec::with_capacity(e2i_header.num_blocks() as usize);
+        for _ in 0..e2i_header.num_blocks() {
+            num_sparse.push(cursor.read_u64::<Endian>()?);
+        }
+        let mut uuid_sparse = Vec::with_capacity(e2i_header.uuid_blocks() as usize);
+        for _ in 0..e2i_header.uuid_blocks() {
+            uuid_sparse.push(cursor.read_u128::<Endian>()?);
+        }
+
+        Ok(Some(Self {
+            i2e,
+            e2i,
+            i2e_header,
+            e2i_header,
+            num_sparse,
+            uuid_sparse,
+        }))
+    }
+
+    /// Total number of internal ids (including build-time-deleted slots).
+    pub fn total_point_count(&self) -> u64 {
+        self.i2e_header.total
+    }
+
+    fn read_num_block(&self, block: u64) -> OperationResult<Vec<(u128, PointOffsetType)>> {
+        let bs = u64::from(self.e2i_header.num_block_size);
+        let start = block * bs;
+        let count = (self.e2i_header.num_count - start).min(bs);
+        let bytes = self.e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: self.e2i_header.num_run_offset + start * NUM_ENTRY_SIZE,
+            length: count * NUM_ENTRY_SIZE,
+        })?;
+        Ok(decode_num_block(bytes.as_ref()))
+    }
+
+    fn read_uuid_block(&self, block: u64) -> OperationResult<Vec<(u128, PointOffsetType)>> {
+        let bs = u64::from(self.e2i_header.uuid_block_size);
+        let start = block * bs;
+        let count = (self.e2i_header.uuid_count - start).min(bs);
+        let bytes = self.e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: self.e2i_header.uuid_run_offset + start * UUID_ENTRY_SIZE,
+            length: count * UUID_ENTRY_SIZE,
+        })?;
+        Ok(decode_uuid_block(bytes.as_ref()))
+    }
+
+    fn lookup_num(&self, key: u64) -> OperationResult<Option<PointOffsetType>> {
+        if self.e2i_header.num_count == 0 {
+            return Ok(None);
+        }
+        let block = self
+            .num_sparse
+            .partition_point(|&first| first <= key)
+            .saturating_sub(1) as u64;
+        let entries = self.read_num_block(block)?;
+        Ok(entries
+            .binary_search_by_key(&u128::from(key), |(k, _)| *k)
+            .ok()
+            .map(|idx| entries[idx].1))
+    }
+
+    fn lookup_uuid(&self, key: u128) -> OperationResult<Option<PointOffsetType>> {
+        if self.e2i_header.uuid_count == 0 {
+            return Ok(None);
+        }
+        let block = self
+            .uuid_sparse
+            .partition_point(|&first| first <= key)
+            .saturating_sub(1) as u64;
+        let entries = self.read_uuid_block(block)?;
+        Ok(entries
+            .binary_search_by_key(&key, |(k, _)| *k)
+            .ok()
+            .map(|idx| entries[idx].1))
+    }
+
+    /// External→internal lookup ignoring deletion (the caller applies its own
+    /// deleted source). `Ok(None)` if the id is absent; storage errors propagate.
+    pub fn lookup(&self, external_id: PointIdType) -> OperationResult<Option<PointOffsetType>> {
+        match external_id {
+            PointIdType::NumId(num) => self.lookup_num(num),
+            PointIdType::Uuid(uuid) => self.lookup_uuid(uuid.as_u128()),
+        }
+    }
+
+    /// Internal→external lookup ignoring deletion. `Ok(None)` for out-of-range
+    /// offsets; storage errors propagate.
+    pub fn external_id(&self, offset: PointOffsetType) -> OperationResult<Option<PointIdType>> {
+        if u64::from(offset) >= self.i2e_header.total {
+            return Ok(None);
+        }
+        self.read_external_id(offset).map(Some)
+    }
+
+    fn read_external_id(&self, offset: PointOffsetType) -> OperationResult<PointIdType> {
+        let data_offset = self.i2e_header.data_offset + u64::from(offset) * 16;
+        let data = self.i2e.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: data_offset,
+            length: 16,
+        })?;
+        let is_uuid_byte = self.i2e.read::<common::generic_consts::Random, u8>(ReadRange {
+            byte_offset: self.i2e_header.is_uuid_offset + u64::from(offset) / 8,
+            length: 1,
+        })?;
+        Ok(I2eHeader::decode_slot(
+            offset,
+            data.as_ref(),
+            is_uuid_byte.as_ref()[0],
+        ))
+    }
+
+    /// Start index (within the numeric run) of the first key `>= key`.
+    fn num_start_index(&self, key: u64) -> OperationResult<u64> {
+        if self.e2i_header.num_count == 0 {
+            return Ok(0);
+        }
+        let block = self
+            .num_sparse
+            .partition_point(|&first| first <= key)
+            .saturating_sub(1) as u64;
+        let entries = self.read_num_block(block)?;
+        let within = entries.partition_point(|(k, _)| *k < u128::from(key)) as u64;
+        Ok(block * u64::from(self.e2i_header.num_block_size) + within)
+    }
+
+    /// Start index (within the UUID run) of the first key `>= key`.
+    fn uuid_start_index(&self, key: u128) -> OperationResult<u64> {
+        if self.e2i_header.uuid_count == 0 {
+            return Ok(0);
+        }
+        let block = self
+            .uuid_sparse
+            .partition_point(|&first| first <= key)
+            .saturating_sub(1) as u64;
+        let entries = self.read_uuid_block(block)?;
+        let within = entries.partition_point(|(k, _)| *k < key) as u64;
+        Ok(block * u64::from(self.e2i_header.uuid_block_size) + within)
+    }
+
+    /// Ordered iterator over the e2i runs starting at `external_id`, yielding
+    /// build-time-live points. Deletion is applied by the caller.
+    pub fn iter_from(&self, external_id: Option<PointIdType>) -> E2iIter<'_, S> {
+        E2iIter::new(self, external_id)
+    }
+}
+
+/// Random-order iterator over live `(external_id, offset)` pairs, mirroring
+/// [`CompressedPointMappings::iter_random`]: random internal offsets are drawn
+/// (rejection-sampled and deduplicated so each is visited at most once), the
+/// `deleted` set is applied, and the external id for each surviving offset is
+/// read lazily from `i2e`.
+///
+/// Like the in-RAM reference, this is aimed at small `take(limit)` sampling; a
+/// full drain pays coupon-collector cost (and one `i2e` read per yielded point).
+/// `deleted` is passed in because the writable and read-only trackers hold their
+/// deleted set differently.
+///
+/// [`CompressedPointMappings::iter_random`]:
+///   crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings::iter_random
+pub fn iter_random<'a, S: UniversalRead>(
+    reader: &'a DiskMappingReader<S>,
+    deleted: &'a BitSlice,
+) -> Box<dyn Iterator<Item = (PointIdType, PointOffsetType)> + 'a> {
+    let total = reader.total_point_count() as usize;
+    if total == 0 {
+        return Box::new(std::iter::empty());
+    }
+
+    let uniform = Uniform::new(0, total).expect("total point count is non-zero");
+    let sampled = uniform.sample_iter(rand::rng()).unique().take(total);
+    Box::new(sampled.filter_map(move |offset| {
+        if deleted.get_bit(offset).unwrap_or(false) {
+            return None;
+        }
+        let offset = offset as PointOffsetType;
+        // Sampling iteration stays best-effort: log and skip on a storage error.
+        match reader.external_id(offset) {
+            Ok(external_id) => external_id.map(|external_id| (external_id, offset)),
+            Err(err) => {
+                log::error!("disk id tracker random iteration lookup failed: {err}");
+                None
+            }
+        }
+    }))
+}
+
+/// Which run the [`E2iIter`] is currently walking.
+enum Phase {
+    Num,
+    Uuid,
+    Done,
+}
+
+/// Lazy, block-streaming iterator over the e2i runs (numeric then UUID).
+pub struct E2iIter<'a, S: UniversalRead> {
+    reader: &'a DiskMappingReader<S>,
+    phase: Phase,
+    /// Index within the current run.
+    index: u64,
+    buffer: Vec<(u128, PointOffsetType)>,
+    buffer_block: Option<u64>,
+}
+
+impl<'a, S: UniversalRead> E2iIter<'a, S> {
+    fn new(reader: &'a DiskMappingReader<S>, external_id: Option<PointIdType>) -> Self {
+        let (phase, index) = match external_id {
+            None => (Phase::Num, 0),
+            Some(PointIdType::NumId(key)) => match reader.num_start_index(key) {
+                Ok(index) => (Phase::Num, index),
+                Err(err) => {
+                    log::error!("disk id tracker iter_from(num) failed: {err}");
+                    (Phase::Done, 0)
+                }
+            },
+            Some(PointIdType::Uuid(uuid)) => match reader.uuid_start_index(uuid.as_u128()) {
+                Ok(index) => (Phase::Uuid, index),
+                Err(err) => {
+                    log::error!("disk id tracker iter_from(uuid) failed: {err}");
+                    (Phase::Done, 0)
+                }
+            },
+        };
+        Self {
+            reader,
+            phase,
+            index,
+            buffer: Vec::new(),
+            buffer_block: None,
+        }
+    }
+
+    /// Ensure `self.buffer` holds `block`, reading it if needed.
+    fn ensure_block(
+        &mut self,
+        block: u64,
+        read: impl Fn(&DiskMappingReader<S>, u64) -> OperationResult<Vec<(u128, PointOffsetType)>>,
+    ) -> bool {
+        if self.buffer_block == Some(block) {
+            return true;
+        }
+        match read(self.reader, block) {
+            Ok(entries) => {
+                self.buffer = entries;
+                self.buffer_block = Some(block);
+                true
+            }
+            Err(err) => {
+                log::error!("disk id tracker block read failed: {err}");
+                false
+            }
+        }
+    }
+}
+
+impl<S: UniversalRead> Iterator for E2iIter<'_, S> {
+    type Item = (PointIdType, PointOffsetType);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.phase {
+                Phase::Num => {
+                    if self.index >= self.reader.e2i_header.num_count {
+                        self.phase = Phase::Uuid;
+                        self.index = 0;
+                        self.buffer_block = None;
+                        continue;
+                    }
+                    let bs = u64::from(self.reader.e2i_header.num_block_size);
+                    let block = self.index / bs;
+                    if !self.ensure_block(block, DiskMappingReader::read_num_block) {
+                        self.phase = Phase::Done;
+                        return None;
+                    }
+                    let (key, offset) = self.buffer[(self.index - block * bs) as usize];
+                    self.index += 1;
+                    return Some((PointIdType::NumId(key as u64), offset));
+                }
+                Phase::Uuid => {
+                    if self.index >= self.reader.e2i_header.uuid_count {
+                        self.phase = Phase::Done;
+                        return None;
+                    }
+                    let bs = u64::from(self.reader.e2i_header.uuid_block_size);
+                    let block = self.index / bs;
+                    if !self.ensure_block(block, DiskMappingReader::read_uuid_block) {
+                        self.phase = Phase::Done;
+                        return None;
+                    }
+                    let (key, offset) = self.buffer[(self.index - block * bs) as usize];
+                    self.index += 1;
+                    return Some((PointIdType::Uuid(Uuid::from_u128(key)), offset));
+                }
+                Phase::Done => return None,
+            }
+        }
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -261,3 +261,52 @@ fn deletion_and_live_reload() {
         assert_eq!(read_only.external_id(*offset), None);
     }
 }
+
+/// The on-disk layout must keep headers and every section start aligned to
+/// `SECTION_ALIGN`, so the files stay mmap+transmute-friendly (`u128` requires
+/// 16-byte alignment). Also pins the store/parse padding agreement: parsed
+/// offsets must land exactly at the section ends implied by the written bytes.
+#[test]
+fn on_disk_sections_are_aligned() {
+    use super::on_disk_format::{
+        E2I_HEADER_SIZE, E2iHeader, I2E_HEADER_SIZE, I2eHeader, NUM_ENTRY_SIZE, SECTION_ALIGN,
+        UUID_ENTRY_SIZE, store_e2i, store_i2e,
+    };
+
+    assert_eq!(I2E_HEADER_SIZE % SECTION_ALIGN, 0);
+    assert_eq!(E2I_HEADER_SIZE % SECTION_ALIGN, 0);
+
+    // Several seeds so both runs hit block-count/entry-count parities that
+    // require actual padding bytes.
+    for seed in [1, 2, 3] {
+        let (_versions, mappings) = make_data(seed);
+
+        let mut i2e_bytes = Vec::new();
+        store_i2e(&mappings, &mut i2e_bytes).unwrap();
+        let i2e = I2eHeader::parse(&i2e_bytes).unwrap();
+        assert_eq!(i2e.data_offset % SECTION_ALIGN, 0);
+        assert_eq!(i2e.is_uuid_offset % SECTION_ALIGN, 0);
+        assert_eq!(
+            i2e_bytes.len() as u64,
+            i2e.is_uuid_offset + i2e.total.div_ceil(8),
+            "i2e file length must match the parsed layout",
+        );
+
+        let mut e2i_bytes = Vec::new();
+        store_e2i(&mappings, &mut e2i_bytes).unwrap();
+        let e2i = E2iHeader::parse(&e2i_bytes).unwrap();
+        assert_eq!(e2i.num_sparse_offset % SECTION_ALIGN, 0);
+        assert_eq!(e2i.uuid_sparse_offset % SECTION_ALIGN, 0);
+        assert_eq!(e2i.num_run_offset % SECTION_ALIGN, 0);
+        assert_eq!(e2i.uuid_run_offset % SECTION_ALIGN, 0);
+        assert_eq!(
+            e2i_bytes.len() as u64,
+            e2i.uuid_run_offset + e2i.uuid_count * UUID_ENTRY_SIZE,
+            "e2i file length must match the parsed layout",
+        );
+        // The parsed offsets must also cover the written sections exactly.
+        assert!(e2i.uuid_sparse_offset >= e2i.num_sparse_offset + e2i.num_blocks() * 8);
+        assert!(e2i.num_run_offset >= e2i.uuid_sparse_offset + e2i.uuid_blocks() * 16);
+        assert!(e2i.uuid_run_offset >= e2i.num_run_offset + e2i.num_count * NUM_ENTRY_SIZE);
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -20,7 +20,10 @@ fn make_data(seed: u64) -> (Vec<SeqNumberType>, CompressedPointMappings) {
     (versions, CompressedPointMappings::from_mappings(mappings))
 }
 
-fn build_immutable(versions: &[SeqNumberType], mappings: CompressedPointMappings) -> ImmutableIdTracker<MmapFile> {
+fn build_immutable(
+    versions: &[SeqNumberType],
+    mappings: CompressedPointMappings,
+) -> ImmutableIdTracker<MmapFile> {
     let dir = Builder::new().prefix("imm").tempdir().unwrap();
     let tracker = ImmutableIdTracker::new(&MmapFs, dir.path(), versions, mappings).unwrap();
     // Keep the dir alive for the tracker's lifetime by leaking it (test-only).
@@ -32,7 +35,10 @@ fn build_immutable(versions: &[SeqNumberType], mappings: CompressedPointMappings
 /// same data.
 fn assert_read_parity<A: IdTrackerRead, B: IdTrackerRead>(reference: &A, candidate: &B) {
     assert_eq!(reference.total_point_count(), candidate.total_point_count());
-    assert_eq!(reference.deleted_point_count(), candidate.deleted_point_count());
+    assert_eq!(
+        reference.deleted_point_count(),
+        candidate.deleted_point_count()
+    );
     assert_eq!(
         reference.available_point_count(),
         candidate.available_point_count()
@@ -123,9 +129,10 @@ fn detect_and_load_selects_disk_format() {
 
     // A disk-format segment.
     let disk_dir = Builder::new().prefix("disk").tempdir().unwrap();
-    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, disk_dir.path(), &versions, mappings).unwrap();
-    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, disk_dir.path(), None)
-        .unwrap();
+    let _disk =
+        DiskIdTracker::<MmapFile>::new(&MmapFs, disk_dir.path(), &versions, mappings).unwrap();
+    let loaded =
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, disk_dir.path(), None).unwrap();
     assert_eq!(loaded.name(), "read-only disk id tracker");
     assert_read_parity(&immutable, &loaded);
 
@@ -134,14 +141,15 @@ fn detect_and_load_selects_disk_format() {
     let imm_dir = Builder::new().prefix("imm").tempdir().unwrap();
     let _imm = ImmutableIdTracker::<MmapFile>::new(&MmapFs, imm_dir.path(), &versions2, mappings2)
         .unwrap();
-    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, imm_dir.path(), None)
-        .unwrap();
+    let loaded =
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, imm_dir.path(), None).unwrap();
     assert_eq!(loaded.name(), "read-only immutable id tracker");
 
     // An empty segment (no mapping files) falls back to the appendable reader.
     let empty_dir = Builder::new().prefix("empty").tempdir().unwrap();
     let loaded =
-        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, empty_dir.path(), None).unwrap();
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, empty_dir.path(), None)
+            .unwrap();
     assert_eq!(loaded.name(), "read-only appendable id tracker");
 }
 
@@ -160,7 +168,11 @@ fn iter_random_yields_all_live_points() {
     // A random-order full drain must cover exactly the live set, once each.
     let random: Vec<(PointIdType, u32)> = disk.point_mappings().iter_random_visible().collect();
     let random_set: HashSet<(PointIdType, u32)> = random.iter().copied().collect();
-    assert_eq!(random.len(), random_set.len(), "iter_random yielded duplicates");
+    assert_eq!(
+        random.len(),
+        random_set.len(),
+        "iter_random yielded duplicates"
+    );
     assert_eq!(random_set, expected, "iter_random must cover the live set");
     // It should genuinely be reordered, not the sorted iter_from sequence.
     let ordered: Vec<(PointIdType, u32)> = disk.point_mappings().iter_from(None).collect();
@@ -172,7 +184,8 @@ fn read_by_id_does_not_materialize_deleted_set() {
     let (versions, mappings) = make_data(4);
     let dir = Builder::new().prefix("disk").tempdir().unwrap();
     let live: Vec<_> = {
-        let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+        let disk =
+            DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
         disk.point_mappings().iter_from(None).collect()
     };
 

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -1,0 +1,250 @@
+use common::types::DeferredBehavior;
+use common::universal_io::{MmapFile, MmapFs};
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
+use tempfile::Builder;
+
+use super::{DiskIdTracker, ReadOnlyDiskIdTracker};
+use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
+use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
+use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
+use crate::id_tracker::{IdTracker, IdTrackerRead};
+use crate::types::{PointIdType, SeqNumberType};
+
+/// Random data source shared by both trackers so parity can be asserted.
+fn make_data(seed: u64) -> (Vec<SeqNumberType>, CompressedPointMappings) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let in_memory = InMemoryIdTracker::random(&mut rng, 5_000, 4_200, 32);
+    let (versions, mappings) = in_memory.into_internal();
+    (versions, CompressedPointMappings::from_mappings(mappings))
+}
+
+fn build_immutable(versions: &[SeqNumberType], mappings: CompressedPointMappings) -> ImmutableIdTracker<MmapFile> {
+    let dir = Builder::new().prefix("imm").tempdir().unwrap();
+    let tracker = ImmutableIdTracker::new(&MmapFs, dir.path(), versions, mappings).unwrap();
+    // Keep the dir alive for the tracker's lifetime by leaking it (test-only).
+    std::mem::forget(dir);
+    tracker
+}
+
+/// Assert every read-path method agrees between two trackers built from the
+/// same data.
+fn assert_read_parity<A: IdTrackerRead, B: IdTrackerRead>(reference: &A, candidate: &B) {
+    assert_eq!(reference.total_point_count(), candidate.total_point_count());
+    assert_eq!(reference.deleted_point_count(), candidate.deleted_point_count());
+    assert_eq!(
+        reference.available_point_count(),
+        candidate.available_point_count()
+    );
+
+    let reference_iter: Vec<_> = reference.point_mappings().iter_from(None).collect();
+    let candidate_iter: Vec<_> = candidate.point_mappings().iter_from(None).collect();
+    assert_eq!(reference_iter, candidate_iter, "iter_from(None) mismatch");
+
+    for (external_id, offset) in &reference_iter {
+        assert_eq!(
+            candidate.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            Some(*offset),
+        );
+        assert_eq!(candidate.external_id(*offset), Some(*external_id));
+    }
+
+    // Cover every offset, including build-deleted ones.
+    for offset in 0..reference.total_point_count() as u32 {
+        assert_eq!(
+            reference.external_id(offset),
+            candidate.external_id(offset),
+            "external_id mismatch at {offset}",
+        );
+        assert_eq!(
+            reference.is_deleted_point(offset),
+            candidate.is_deleted_point(offset),
+            "is_deleted mismatch at {offset}",
+        );
+        assert_eq!(
+            reference.internal_version(offset),
+            candidate.internal_version(offset),
+            "version mismatch at {offset}",
+        );
+    }
+}
+
+#[test]
+fn disk_matches_immutable() {
+    let (versions, mappings) = make_data(1);
+    let immutable = build_immutable(&versions, mappings.clone());
+
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    assert_read_parity(&immutable, &disk);
+}
+
+#[test]
+fn read_only_matches_immutable() {
+    let (versions, mappings) = make_data(2);
+    let immutable = build_immutable(&versions, mappings.clone());
+
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    // Writing the files also validates the on-disk format round-trips.
+    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    assert_read_parity(&immutable, &read_only);
+}
+
+#[test]
+fn iter_from_boundaries() {
+    let (versions, mappings) = make_data(3);
+    let immutable = build_immutable(&versions, mappings.clone());
+
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    let starts = [
+        None,
+        Some(PointIdType::NumId(0)),
+        Some(PointIdType::NumId(u64::MAX)),
+        Some(PointIdType::Uuid(uuid::Uuid::from_u128(0))),
+        Some(PointIdType::Uuid(uuid::Uuid::from_u128(u128::MAX))),
+    ];
+    for start in starts {
+        let expected: Vec<_> = immutable.point_mappings().iter_from(start).collect();
+        let actual: Vec<_> = disk.point_mappings().iter_from(start).collect();
+        assert_eq!(expected, actual, "iter_from({start:?}) mismatch");
+    }
+}
+
+#[test]
+fn detect_and_load_selects_disk_format() {
+    let (versions, mappings) = make_data(6);
+    let immutable = build_immutable(&versions, mappings.clone());
+
+    // A disk-format segment.
+    let disk_dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, disk_dir.path(), &versions, mappings).unwrap();
+    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, disk_dir.path(), None)
+        .unwrap();
+    assert_eq!(loaded.name(), "read-only disk id tracker");
+    assert_read_parity(&immutable, &loaded);
+
+    // An immutable-format segment loads as the immutable reader.
+    let (versions2, mappings2) = make_data(7);
+    let imm_dir = Builder::new().prefix("imm").tempdir().unwrap();
+    let _imm = ImmutableIdTracker::<MmapFile>::new(&MmapFs, imm_dir.path(), &versions2, mappings2)
+        .unwrap();
+    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, imm_dir.path(), None)
+        .unwrap();
+    assert_eq!(loaded.name(), "read-only immutable id tracker");
+
+    // An empty segment (no mapping files) falls back to the appendable reader.
+    let empty_dir = Builder::new().prefix("empty").tempdir().unwrap();
+    let loaded =
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, empty_dir.path(), None).unwrap();
+    assert_eq!(loaded.name(), "read-only appendable id tracker");
+}
+
+#[test]
+fn iter_random_yields_all_live_points() {
+    use std::collections::HashSet;
+
+    let (versions, mappings) = make_data(9);
+    let immutable = build_immutable(&versions, mappings.clone());
+    let expected: HashSet<(PointIdType, u32)> =
+        immutable.point_mappings().iter_from(None).collect();
+
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    // A random-order full drain must cover exactly the live set, once each.
+    let random: Vec<(PointIdType, u32)> = disk.point_mappings().iter_random_visible().collect();
+    let random_set: HashSet<(PointIdType, u32)> = random.iter().copied().collect();
+    assert_eq!(random.len(), random_set.len(), "iter_random yielded duplicates");
+    assert_eq!(random_set, expected, "iter_random must cover the live set");
+    // It should genuinely be reordered, not the sorted iter_from sequence.
+    let ordered: Vec<(PointIdType, u32)> = disk.point_mappings().iter_from(None).collect();
+    assert_ne!(random, ordered, "iter_random should not be in sorted order");
+}
+
+#[test]
+fn read_by_id_does_not_materialize_deleted_set() {
+    let (versions, mappings) = make_data(4);
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let live: Vec<_> = {
+        let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+        disk.point_mappings().iter_from(None).collect()
+    };
+
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+
+    // Point lookups must not trigger the full deleted-set materialization.
+    for (external_id, offset) in live.iter().take(200) {
+        assert_eq!(
+            read_only.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            Some(*offset),
+        );
+        assert_eq!(read_only.external_id(*offset), Some(*external_id));
+        let _ = read_only.internal_version(*offset);
+        let _ = read_only.is_deleted_point(*offset);
+    }
+    assert!(
+        !read_only.deleted_full_materialized(),
+        "read-by-id lookups must not materialize the full deleted set",
+    );
+
+    // A search-style call (whole-slice access) does materialize it.
+    let _ = read_only.deleted_point_bitslice();
+    assert!(read_only.deleted_full_materialized());
+}
+
+#[test]
+fn deletion_and_live_reload() {
+    let (versions, mappings) = make_data(5);
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let mut disk =
+        DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    // A reader opened before the deletions; it will pick them up via live_reload.
+    let mut read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    // Establish the diff baseline (a search-style access) so the next reload
+    // reports only the incremental deletions, not every build-time deletion.
+    let _ = read_only.deleted_point_bitslice();
+
+    let to_delete: Vec<(PointIdType, u32)> =
+        disk.point_mappings().iter_from(None).take(50).collect();
+
+    for (external_id, _) in &to_delete {
+        disk.drop(*external_id).unwrap();
+    }
+    // Writable tracker: deletions are hidden immediately.
+    for (external_id, offset) in &to_delete {
+        assert_eq!(
+            disk.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+        assert!(disk.is_deleted_point(*offset));
+        assert_eq!(disk.external_id(*offset), None);
+    }
+    // Persist deletions so the reader can observe them.
+    disk.mapping_flusher()().unwrap();
+    disk.versions_flusher()().unwrap();
+
+    let result = read_only.live_reload().unwrap();
+    let mut reported = result.deleted.clone();
+    reported.sort_unstable();
+    let mut expected: Vec<u32> = to_delete.iter().map(|(_, offset)| *offset).collect();
+    expected.sort_unstable();
+    assert_eq!(reported, expected, "live_reload delta mismatch");
+    assert!(result.inserted.is_empty());
+
+    // After reload, the reader hides the deleted points on every path.
+    for (external_id, offset) in &to_delete {
+        assert_eq!(
+            read_only.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+        assert!(read_only.is_deleted_point(*offset));
+        assert_eq!(read_only.external_id(*offset), None);
+    }
+}

--- a/lib/segment/src/id_tracker/format_detection.rs
+++ b/lib/segment/src/id_tracker/format_detection.rs
@@ -1,0 +1,57 @@
+//! Single source of truth for detecting which on-disk id-tracker format a
+//! *local* segment is persisted in (used by the writable segment loader).
+//!
+//! The read-only / object-storage path does not detect by file name — it uses
+//! [`ReadOnlyIdTrackerEnum::detect_and_load`](crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum::detect_and_load),
+//! which loads by *attempting* each format and avoids per-file `exists` round-trips.
+
+use std::path::Path;
+
+use crate::id_tracker::disk_id_tracker::on_disk_format::i2e_path;
+use crate::id_tracker::immutable_id_tracker::mappings_path;
+
+/// The on-disk id-tracker format a segment uses.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum IdTrackerFormat {
+    /// Appendable / mutable format (append-only mapping + version logs).
+    Mutable,
+    /// Immutable format: a single sequential `id_tracker.mappings` file, loaded
+    /// fully into RAM.
+    Immutable,
+    /// Disk-resident format: `id_tracker.i2e` + `id_tracker.e2i`, served lazily.
+    Disk,
+}
+
+impl IdTrackerFormat {
+    /// Resolve the format from the segment's appendability and the presence of
+    /// the immutable/disk mapping files.
+    ///
+    /// An appendable segment is always mutable. A non-appendable segment uses the
+    /// disk format when its `i2e` file is present, the immutable format when the
+    /// v1 `mappings` file is present, and otherwise defaults to mutable (a fresh
+    /// segment with no mapping file written yet).
+    fn from_presence(is_appendable: bool, has_mappings: bool, has_disk: bool) -> Self {
+        if is_appendable {
+            Self::Mutable
+        } else if has_disk {
+            Self::Disk
+        } else if has_mappings {
+            Self::Immutable
+        } else {
+            Self::Mutable
+        }
+    }
+
+    /// Detect the format using the local filesystem.
+    pub fn detect_local(segment_path: &Path, is_appendable: bool) -> Self {
+        Self::from_presence(
+            is_appendable,
+            mappings_path(segment_path).is_file(),
+            i2e_path(segment_path).is_file(),
+        )
+    }
+
+    pub fn is_mutable(self) -> bool {
+        matches!(self, Self::Mutable)
+    }
+}

--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -1,11 +1,13 @@
 use atomic_refcell::AtomicRef;
 use common::bitvec::{BitSlice, BitSliceExt as _};
 use common::types::{DeferredBehavior, PointOffsetType};
+use common::universal_io::{MmapFile, UniversalRead};
 use itertools::Either;
 use self_cell::self_cell;
 
 use super::tracker_enum::IdTrackerEnum;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::id_tracker::disk_id_tracker::mappings::DiskMappingsRef;
 use crate::id_tracker::point_mappings::PointMappings;
 use crate::types::PointIdType;
 
@@ -13,20 +15,35 @@ use crate::types::PointIdType;
 ///
 /// Provides iteration methods over external/internal IDs without requiring
 /// the `IdTracker` trait to return boxed iterators.
-#[derive(Clone, Copy)]
-pub enum PointMappingsRefEnum<'a> {
+///
+/// Generic over the disk-resident tracker's read backend `S`
+/// ([`IdTrackerRead::Backend`](super::trait_def::IdTrackerRead::Backend)); the
+/// [`Disk`](Self::Disk) variant holds a concrete [`DiskMappingsRef`] rather than a
+/// trait object, so the mapping is reached by static dispatch. `S` is unused by
+/// the `Plain`/`Compressed` variants.
+pub enum PointMappingsRefEnum<'a, S: UniversalRead> {
     Plain(&'a PointMappings),
     Compressed(&'a CompressedPointMappings),
+    Disk(DiskMappingsRef<'a, S>),
 }
 
-impl<'a> PointMappingsRefEnum<'a> {
+// Hand-written so `Copy` doesn't require `S: Copy` (every variant is references).
+impl<S: UniversalRead> Clone for PointMappingsRefEnum<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S: UniversalRead> Copy for PointMappingsRefEnum<'_, S> {}
+
+impl<'a, S: UniversalRead> PointMappingsRefEnum<'a, S> {
     /// Iterate over all external IDs.
     ///
     /// Excludes soft deleted points.
     pub fn iter_external(self) -> impl Iterator<Item = PointIdType> + 'a {
         match self {
             PointMappingsRefEnum::Plain(m) => Either::Left(m.iter_external()),
-            PointMappingsRefEnum::Compressed(m) => Either::Right(m.iter_external()),
+            PointMappingsRefEnum::Compressed(m) => Either::Right(Either::Left(m.iter_external())),
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_external())),
         }
     }
 
@@ -36,7 +53,8 @@ impl<'a> PointMappingsRefEnum<'a> {
     pub fn iter_internal(self) -> impl Iterator<Item = PointOffsetType> + 'a {
         match self {
             PointMappingsRefEnum::Plain(m) => Either::Left(m.iter_internal()),
-            PointMappingsRefEnum::Compressed(m) => Either::Right(m.iter_internal()),
+            PointMappingsRefEnum::Compressed(m) => Either::Right(Either::Left(m.iter_internal())),
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_internal())),
         }
     }
 
@@ -49,7 +67,10 @@ impl<'a> PointMappingsRefEnum<'a> {
     ) -> impl Iterator<Item = (PointIdType, PointOffsetType)> + 'a {
         match self {
             PointMappingsRefEnum::Plain(m) => Either::Left(m.iter_from(external_id)),
-            PointMappingsRefEnum::Compressed(m) => Either::Right(m.iter_from(external_id)),
+            PointMappingsRefEnum::Compressed(m) => {
+                Either::Right(Either::Left(m.iter_from(external_id)))
+            }
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_from(external_id))),
         }
     }
 
@@ -91,8 +112,10 @@ impl<'a> PointMappingsRefEnum<'a> {
                 // they can't have deferred points,
                 // so we can only pull visible points
                 // and ignore the parameter
-                Either::Right(m.iter_internal())
+                Either::Right(Either::Left(m.iter_internal()))
             }
+            // Disk mappings are immutable too; ignore the deferred parameter.
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_internal())),
         }
     }
 
@@ -152,7 +175,10 @@ impl<'a> PointMappingsRefEnum<'a> {
             PointMappingsRefEnum::Plain(m) => {
                 Either::Left(m.iter_from_with_behavior(external_id, deferred_behavior))
             }
-            PointMappingsRefEnum::Compressed(m) => Either::Right(m.iter_from(external_id)),
+            PointMappingsRefEnum::Compressed(m) => {
+                Either::Right(Either::Left(m.iter_from(external_id)))
+            }
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_from(external_id))),
         }
     }
 
@@ -169,7 +195,8 @@ impl<'a> PointMappingsRefEnum<'a> {
             PointMappingsRefEnum::Plain(m) => {
                 Either::Left(m.iter_random_with_behavior(deferred_behavior))
             }
-            PointMappingsRefEnum::Compressed(m) => Either::Right(m.iter_random()),
+            PointMappingsRefEnum::Compressed(m) => Either::Right(Either::Left(m.iter_random())),
+            PointMappingsRefEnum::Disk(m) => Either::Right(Either::Right(m.iter_random())),
         }
     }
 
@@ -201,7 +228,7 @@ impl<'a> PointMappingsRefEnum<'a> {
     fn deferred_internal_id(self) -> Option<PointOffsetType> {
         match self {
             PointMappingsRefEnum::Plain(m) => m.deferred_internal_id(),
-            PointMappingsRefEnum::Compressed(_) => None,
+            PointMappingsRefEnum::Compressed(_) | PointMappingsRefEnum::Disk(_) => None,
         }
     }
 
@@ -210,18 +237,25 @@ impl<'a> PointMappingsRefEnum<'a> {
         match self {
             PointMappingsRefEnum::Plain(m) => m.deleted(),
             PointMappingsRefEnum::Compressed(m) => m.deleted(),
+            PointMappingsRefEnum::Disk(m) => m.deleted(),
         }
     }
 
-    /// Shadowed-active bitslice for this mapping. Empty for compressed
+    /// Shadowed-active bitslice for this mapping. Empty for compressed and disk
     /// mappings (immutable trackers can't carry deferred mutations).
     fn shadowed(self) -> &'a BitSlice {
         match self {
             PointMappingsRefEnum::Plain(m) => m.shadowed_bitslice(),
-            PointMappingsRefEnum::Compressed(_) => BitSlice::empty(),
+            PointMappingsRefEnum::Compressed(_) | PointMappingsRefEnum::Disk(_) => {
+                BitSlice::empty()
+            }
         }
     }
 }
+
+/// The `PointMappingsRefEnum` produced by an [`IdTrackerEnum`], whose backend is
+/// always [`MmapFile`] (all its variants are local, `MmapFile`-backed trackers).
+type IdTrackerEnumMappingsRef<'a> = PointMappingsRefEnum<'a, MmapFile>;
 
 self_cell! {
     /// Wrapper around `PointMappingsRefEnum` that only exposes external ID iteration.
@@ -232,6 +266,6 @@ self_cell! {
         owner: AtomicRef<'a, IdTrackerEnum>,
 
         #[covariant]
-        dependent: PointMappingsRefEnum,
+        dependent: IdTrackerEnumMappingsRef,
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -141,9 +141,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deleted_point_bitslice(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deleted_point_bitslice(),
-            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
-                id_tracker.deleted_point_bitslice()
-            }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.deleted_point_bitslice(),
         }
     }
 
@@ -175,9 +173,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.iter_internal_versions(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.iter_internal_versions(),
-            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
-                id_tracker.iter_internal_versions()
-            }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.iter_internal_versions(),
         }
     }
 
@@ -193,9 +189,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deferred_deleted_count(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deferred_deleted_count(),
-            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
-                id_tracker.deferred_deleted_count()
-            }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.deferred_deleted_count(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -5,6 +5,7 @@ use common::types::PointOffsetType;
 use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
+use crate::id_tracker::disk_id_tracker::ReadOnlyDiskIdTracker;
 use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::read_only::{
     LiveReloadResult, ReadOnlyAppendableIdTracker,
@@ -15,28 +16,40 @@ use crate::types::{PointIdType, SeqNumberType};
 pub enum ReadOnlyIdTrackerEnum<S: UniversalRead> {
     Appendable(ReadOnlyAppendableIdTracker<S>),
     Immutable(ReadOnlyImmutableIdTracker<S>),
+    DiskResident(ReadOnlyDiskIdTracker<S>),
 }
 
 impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
-    /// Open the read-only ID tracker, mirroring the writable `create_segment_id_tracker` selection.
-    pub fn open(
+    /// Detect the persisted id-tracker format and load it, by *attempting* each
+    /// format's open rather than probing file names one by one.
+    ///
+    /// This avoids the separate `exists` round-trips that a name-based detector
+    /// would issue — costly on object storage (S3/GCS/Azure), where each is a
+    /// remote request. Each candidate's open reads its own defining file, so a
+    /// not-found there simply means "not this format" and we fall through.
+    ///
+    /// Order: disk-resident (the serverless/object-storage format) first, then
+    /// the in-RAM immutable format, then the appendable/mutable format (whose
+    /// open tolerates absent files, i.e. a fresh or empty segment).
+    ///
+    /// The attempts are sequential for now; they are independent and can be
+    /// issued concurrently later (the slow-path being remote opens).
+    pub fn detect_and_load(
         fs: &S::Fs,
         segment_path: &Path,
-        use_appendable: bool,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
-        if use_appendable {
-            Ok(Self::Appendable(ReadOnlyAppendableIdTracker::open(
-                fs,
-                segment_path,
-                deferred_internal_id,
-            )?))
-        } else {
-            Ok(Self::Immutable(ReadOnlyImmutableIdTracker::open(
-                fs,
-                segment_path,
-            )?))
+        if let Some(tracker) = ReadOnlyDiskIdTracker::try_open(fs, segment_path)? {
+            return Ok(Self::DiskResident(tracker));
         }
+        if let Some(tracker) = ReadOnlyImmutableIdTracker::try_open(fs, segment_path)? {
+            return Ok(Self::Immutable(tracker));
+        }
+        Ok(Self::Appendable(ReadOnlyAppendableIdTracker::open(
+            fs,
+            segment_path,
+            deferred_internal_id,
+        )?))
     }
 
     /// Reload externally-applied changes, dispatching to the active variant.
@@ -44,15 +57,19 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
         match self {
             Self::Appendable(id_tracker) => id_tracker.live_reload(),
             Self::Immutable(id_tracker) => id_tracker.live_reload(),
+            Self::DiskResident(id_tracker) => id_tracker.live_reload(),
         }
     }
 }
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.point_mappings(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.point_mappings(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.point_mappings(),
         }
     }
 
@@ -62,6 +79,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
                 id_tracker.internal_version(internal_id)
             }
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => {
+                id_tracker.internal_version(internal_id)
+            }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
                 id_tracker.internal_version(internal_id)
             }
         }
@@ -79,6 +99,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
             ReadOnlyIdTrackerEnum::Immutable(t) => {
                 t.internal_id_with_behavior(external_id, deferred_behavior)
             }
+            ReadOnlyIdTrackerEnum::DiskResident(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
         }
     }
 
@@ -86,6 +109,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.external_id(internal_id),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.external_id(internal_id),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.external_id(internal_id),
         }
     }
 
@@ -93,6 +117,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.total_point_count(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.total_point_count(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.total_point_count(),
         }
     }
 
@@ -100,6 +125,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.available_point_count(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.available_point_count(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.available_point_count(),
         }
     }
 
@@ -107,6 +133,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deleted_point_count(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deleted_point_count(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.deleted_point_count(),
         }
     }
 
@@ -114,6 +141,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deleted_point_bitslice(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deleted_point_bitslice(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
+                id_tracker.deleted_point_bitslice()
+            }
         }
     }
 
@@ -125,6 +155,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => {
                 id_tracker.is_deleted_point(internal_id)
             }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
+                id_tracker.is_deleted_point(internal_id)
+            }
         }
     }
 
@@ -132,6 +165,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.name(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.name(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.name(),
         }
     }
 
@@ -141,6 +175,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.iter_internal_versions(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.iter_internal_versions(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
+                id_tracker.iter_internal_versions()
+            }
         }
     }
 
@@ -148,6 +185,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deferred_internal_id(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deferred_internal_id(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => id_tracker.deferred_internal_id(),
         }
     }
 
@@ -155,6 +193,9 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyIdTrackerEnum<S> {
         match self {
             ReadOnlyIdTrackerEnum::Appendable(id_tracker) => id_tracker.deferred_deleted_count(),
             ReadOnlyIdTrackerEnum::Immutable(id_tracker) => id_tracker.deferred_deleted_count(),
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
+                id_tracker.deferred_deleted_count()
+            }
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -8,6 +8,7 @@ use super::point_mappings_ref::PointMappingsRefEnum;
 use super::trait_def::{IdTracker, IdTrackerRead};
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::id_tracker::disk_id_tracker::DiskIdTracker;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
@@ -18,6 +19,7 @@ pub enum IdTrackerEnum {
     MutableIdTracker(MutableIdTracker),
     ImmutableIdTracker(ImmutableIdTracker<MmapFile>),
     InMemoryIdTracker(InMemoryIdTracker),
+    DiskIdTracker(DiskIdTracker<MmapFile>),
 }
 
 impl IdTrackerRead for IdTrackerEnum {
@@ -28,6 +30,9 @@ impl IdTrackerRead for IdTrackerEnum {
                 id_tracker.internal_version(internal_id)
             }
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
+                id_tracker.internal_version(internal_id)
+            }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => {
                 id_tracker.internal_version(internal_id)
             }
         }
@@ -48,6 +53,9 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(t) => {
                 t.internal_id_with_behavior(external_id, deferred_behavior)
             }
+            IdTrackerEnum::DiskIdTracker(t) => {
+                t.internal_id_with_behavior(external_id, deferred_behavior)
+            }
         }
     }
 
@@ -56,14 +64,18 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.external_id(internal_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.external_id(internal_id),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.external_id(internal_id),
         }
     }
 
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = MmapFile;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         match self {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.point_mappings(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.point_mappings(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.point_mappings(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.point_mappings(),
         }
     }
 
@@ -72,6 +84,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.total_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.total_point_count(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.total_point_count(),
         }
     }
 
@@ -80,6 +93,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_count(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.deleted_point_count(),
         }
     }
 
@@ -88,6 +102,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.deleted_point_bitslice(),
         }
     }
 
@@ -100,6 +115,9 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.is_deleted_point(internal_id)
             }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => {
+                id_tracker.is_deleted_point(internal_id)
+            }
         }
     }
 
@@ -108,6 +126,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.name(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.name(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.name(),
         }
     }
 
@@ -118,6 +137,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.iter_internal_versions(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.iter_internal_versions(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.iter_internal_versions(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.iter_internal_versions(),
         }
     }
 
@@ -126,6 +146,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.deferred_internal_id(),
         }
     }
 
@@ -134,6 +155,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.deferred_deleted_count(),
         }
     }
 }
@@ -154,6 +176,9 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_internal_version(internal_id, version)
             }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => {
+                id_tracker.set_internal_version(internal_id, version)
+            }
         }
     }
 
@@ -172,6 +197,9 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.set_link(external_id, internal_id)
             }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => {
+                id_tracker.set_link(external_id, internal_id)
+            }
         }
     }
 
@@ -180,6 +208,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.drop(external_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.drop(external_id),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.drop(external_id),
         }
     }
 
@@ -188,6 +217,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.drop_internal(internal_id),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.drop_internal(internal_id),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.drop_internal(internal_id),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.drop_internal(internal_id),
         }
     }
 
@@ -196,6 +226,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.mapping_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.mapping_flusher(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.mapping_flusher(),
         }
     }
 
@@ -204,6 +235,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.versions_flusher(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.versions_flusher(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.versions_flusher(),
         }
     }
 
@@ -212,6 +244,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
         }
     }
 
@@ -220,6 +253,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.files(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.files(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.files(),
         }
     }
 
@@ -228,6 +262,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.immutable_files(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.immutable_files(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.immutable_files(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.immutable_files(),
         }
     }
 
@@ -236,6 +271,7 @@ impl IdTracker for IdTrackerEnum {
             IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.clear_cache(),
             IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.clear_cache(),
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.clear_cache(),
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.clear_cache(),
         }
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -32,9 +32,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.internal_version(internal_id)
             }
-            IdTrackerEnum::DiskIdTracker(id_tracker) => {
-                id_tracker.internal_version(internal_id)
-            }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.internal_version(internal_id),
         }
     }
 
@@ -115,9 +113,7 @@ impl IdTrackerRead for IdTrackerEnum {
             IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
                 id_tracker.is_deleted_point(internal_id)
             }
-            IdTrackerEnum::DiskIdTracker(id_tracker) => {
-                id_tracker.is_deleted_point(internal_id)
-            }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.is_deleted_point(internal_id),
         }
     }
 

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use common::bitvec::{BitSlice, BitSliceExt as _};
 use common::types::{DeferredBehavior, PointOffsetType};
+use common::universal_io::UniversalRead;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
@@ -124,8 +125,14 @@ pub trait IdTracker: IdTrackerRead + fmt::Debug {
 }
 
 pub trait IdTrackerRead {
+    /// Read backend of the disk-resident mapping, if any. Trackers that keep
+    /// their mapping in RAM (all but the disk-resident ones) set this to a
+    /// placeholder [`MmapFile`](common::universal_io::MmapFile) — the
+    /// `Plain`/`Compressed` mapping variants do not use it.
+    type Backend: UniversalRead;
+
     /// Get a reference to the point mappings, which provides iteration methods.
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_>;
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend>;
 
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType>;
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -24,11 +24,12 @@ use common::universal_io::{
 use fs_err::File;
 
 pub use self::deleted_storage::DELETED_FILE_NAME;
-use self::deleted_storage::deleted_path;
+pub(crate) use self::deleted_storage::deleted_path;
 pub use self::mappings_storage::{MAPPINGS_FILE_NAME, mappings_path};
 use self::mappings_storage::{load_mapping, store_mapping};
 pub use self::versions_storage::VERSION_MAPPING_FILE_NAME;
-use self::versions_storage::{mmap_size, version_mapping_path};
+use self::versions_storage::mmap_size;
+pub(crate) use self::versions_storage::version_mapping_path;
 use crate::common::Flusher;
 use crate::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -251,7 +252,9 @@ impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for ImmutableIdTra
         self.mappings.external_id(internal_id)
     }
 
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         PointMappingsRefEnum::Compressed(&self.mappings)
     }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
@@ -7,7 +7,9 @@ use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyImmutableIdTracker<S> {
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         PointMappingsRefEnum::Compressed(&self.mappings)
     }
 

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -6,7 +6,7 @@ use common::generic_consts::Sequential;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::universal_io::{
-    OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalReadFs,
+    OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalReadFs,
 };
 
 use super::ReadOnlyImmutableIdTracker;
@@ -25,6 +25,28 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
     /// mappings are immutable and read once into memory.
     ///
     /// [`ImmutableIdTracker::open`]: crate::id_tracker::immutable_id_tracker::ImmutableIdTracker::open
+    ///
+    /// Returns `Ok(None)` when the defining `id_tracker.mappings` file is absent
+    /// (i.e. the segment is not in the immutable format). The probe reuses the
+    /// existing `open` flow, so no separate existence check is issued.
+    pub fn try_open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Option<Self>> {
+        // Probe the defining mappings file without a separate `exists` call.
+        let probe_options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::No,
+            advice: AdviceSetting::Global,
+        };
+        if fs
+            .open(mappings_path(segment_path), probe_options, Default::default())
+            .ok_not_found()?
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(Self::open(fs, segment_path)?))
+    }
+
     pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
         let options = OpenOptions {
             writeable: false,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -38,7 +38,11 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
             advice: AdviceSetting::Global,
         };
         if fs
-            .open(mappings_path(segment_path), probe_options, Default::default())
+            .open(
+                mappings_path(segment_path),
+                probe_options,
+                Default::default(),
+            )
             .ok_not_found()?
             .is_none()
         {

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -77,7 +77,9 @@ impl IdTrackerRead for InMemoryIdTracker {
         self.mappings.external_id(internal_id)
     }
 
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = common::universal_io::MmapFile;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         PointMappingsRefEnum::Plain(&self.mappings)
     }
 

--- a/lib/segment/src/id_tracker/memory_reporter.rs
+++ b/lib/segment/src/id_tracker/memory_reporter.rs
@@ -26,6 +26,14 @@ impl MemoryReporter for IdTrackerEnum {
                 // Purely in-memory, no files.
                 ComponentMemoryUsage::ram_only(tracker.ram_usage_bytes() as u64)
             }
+            IdTrackerEnum::DiskIdTracker(tracker) => {
+                // Mapping stays on disk; only versions + the deleted bitvec are resident.
+                ComponentMemoryUsage::from_files_and_ram(
+                    tracker.files(),
+                    FileStorageIntent::OnDisk,
+                    tracker.ram_usage_bytes() as u64,
+                )
+            }
         }
     }
 }

--- a/lib/segment/src/id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mod.rs
@@ -1,4 +1,6 @@
 pub mod compressed;
+pub mod disk_id_tracker;
+pub mod format_detection;
 pub mod id_tracker_base;
 pub mod immutable_id_tracker;
 pub mod in_memory_id_tracker;
@@ -7,6 +9,7 @@ pub mod mutable_id_tracker;
 pub mod point_mappings;
 
 use common::types::PointOffsetType;
+pub use format_detection::IdTrackerFormat;
 pub use id_tracker_base::*;
 use itertools::Itertools as _;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -188,7 +188,9 @@ impl IdTrackerRead for MutableIdTracker {
         self.mappings.external_id(internal_id)
     }
 
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = common::universal_io::MmapFile;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         PointMappingsRefEnum::Plain(&self.mappings)
     }
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
@@ -7,7 +7,9 @@ use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyAppendableIdTracker<S> {
-    fn point_mappings(&self) -> PointMappingsRefEnum<'_> {
+    type Backend = S;
+
+    fn point_mappings(&self) -> PointMappingsRefEnum<'_, Self::Backend> {
         PointMappingsRefEnum::Plain(&self.mappings)
     }
 

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -947,7 +947,8 @@ mod set_link_shadow_tests {
         m.set_link(ext(8), 3);
         m.set_link(ext(9), 8);
 
-        let r = PointMappingsRefEnum::Plain(&m);
+        // Backend is irrelevant for the Plain variant; pick a concrete one.
+        let r = PointMappingsRefEnum::<common::universal_io::MmapFile>::Plain(&m);
         let candidates: Vec<PointOffsetType> = vec![2, 3, 7, 8];
 
         // VisibleOnly: visible-only path — drops everything above cutoff.

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -5,12 +5,11 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{Populate, UniversalReadFileOps, read_json_via};
+use common::universal_io::{Populate, read_json_via};
 use uuid::Uuid;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::id_tracker::immutable_id_tracker;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::UniversalReadExt;
 use crate::index::read_only::{ReadOnlyVectorIndexOpenArgs, VectorIndexReadEnum};
@@ -64,13 +63,11 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             payload_populate,
         )?));
 
-        // Appendable (mutable-format) segments have no immutable mappings file.
-        let use_appendable_id_tracker =
-            is_appendable || !fs.exists(&immutable_id_tracker::mappings_path(segment_path))?;
-        let id_tracker = Arc::new(AtomicRefCell::new(ReadOnlyIdTrackerEnum::open(
+        // Detect the persisted format by attempting each format's open (no
+        // per-file `exists` round-trips — important for object-storage backends).
+        let id_tracker = Arc::new(AtomicRefCell::new(ReadOnlyIdTrackerEnum::detect_and_load(
             fs,
             segment_path,
-            use_appendable_id_tracker,
             deferred_internal_id,
         )?));
 

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -33,6 +33,7 @@ use crate::common::error_logging::LogError;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::entry::entry_point::StorageSegmentEntry as _;
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::id_tracker::disk_id_tracker::DiskIdTracker;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use crate::id_tracker::{IdTracker, IdTrackerEnum, IdTrackerRead, for_each_unique_point};
@@ -551,19 +552,33 @@ impl SegmentBuilder {
 
             let id_tracker = match id_tracker {
                 IdTrackerEnum::InMemoryIdTracker(in_memory_id_tracker) => {
-                    let (versions, mappings) = in_memory_id_tracker.into_internal();
-                    let compressed_mapping = CompressedPointMappings::from_mappings(mappings);
-                    let immutable_id_tracker = ImmutableIdTracker::new(
-                        &MmapFs,
-                        temp_dir.path(),
-                        &versions,
-                        compressed_mapping,
-                    )?;
-                    IdTrackerEnum::ImmutableIdTracker(immutable_id_tracker)
+                    // Serverless-compatible builds produce the disk-resident tracker
+                    // (mapping stays on disk); otherwise the in-RAM immutable tracker.
+                    if feature_flags().serverless_compatible() {
+                        let disk_id_tracker = DiskIdTracker::from_in_memory_tracker(
+                            &MmapFs,
+                            in_memory_id_tracker,
+                            temp_dir.path(),
+                        )?;
+                        IdTrackerEnum::DiskIdTracker(disk_id_tracker)
+                    } else {
+                        let (versions, mappings) = in_memory_id_tracker.into_internal();
+                        let compressed_mapping = CompressedPointMappings::from_mappings(mappings);
+                        let immutable_id_tracker = ImmutableIdTracker::new(
+                            &MmapFs,
+                            temp_dir.path(),
+                            &versions,
+                            compressed_mapping,
+                        )?;
+                        IdTrackerEnum::ImmutableIdTracker(immutable_id_tracker)
+                    }
                 }
                 IdTrackerEnum::MutableIdTracker(_) => id_tracker,
                 IdTrackerEnum::ImmutableIdTracker(_) => {
                     unreachable!("ImmutableIdTracker should not be used for building segment")
+                }
+                IdTrackerEnum::DiskIdTracker(_) => {
+                    unreachable!("DiskIdTracker should not be used for building segment")
                 }
             };
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
@@ -20,7 +20,7 @@ use super::sparse_vector_index::open_or_create_sparse_vector_index;
 use super::vector_index::{VectorIndexOpenArgs, open_vector_index};
 use super::vector_storage::{create_sparse_vector_storage, open_vector_storage};
 use crate::common::operation_error::{OperationResult, check_process_stopped};
-use crate::id_tracker::{IdTrackerEnum, IdTrackerRead, immutable_id_tracker};
+use crate::id_tracker::{IdTrackerEnum, IdTrackerFormat, IdTrackerRead};
 use crate::index::VectorIndexEnum;
 use crate::index::sparse_index::sparse_vector_index::SparseVectorIndexOpenArgs;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -57,11 +57,10 @@ pub(super) fn create_segment(
     // Limit deferred segment feature to appendable segments.
     let deferred_internal_id = deferred_internal_id.filter(|_| appendable_flag);
 
-    let use_mutable_id_tracker =
-        appendable_flag || !immutable_id_tracker::mappings_path(segment_path).is_file();
+    let id_tracker_format = IdTrackerFormat::detect_local(segment_path, appendable_flag);
     let started = Instant::now();
     let id_tracker =
-        create_segment_id_tracker(use_mutable_id_tracker, segment_path, deferred_internal_id)?;
+        create_segment_id_tracker(id_tracker_format, segment_path, deferred_internal_id)?;
     log_load_timing(segment_path, "id_tracker", started);
 
     let mut vector_storages = HashMap::new();

--- a/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
@@ -25,12 +25,10 @@ pub(crate) fn create_segment_id_tracker(
     deferred_internal_id: Option<PointOffsetType>,
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
     let id_tracker = match format {
-        IdTrackerFormat::Mutable => {
-            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
-                segment_path,
-                deferred_internal_id,
-            )?)
-        }
+        IdTrackerFormat::Mutable => IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
+            segment_path,
+            deferred_internal_id,
+        )?),
         IdTrackerFormat::Immutable => {
             IdTrackerEnum::ImmutableIdTracker(ImmutableIdTracker::open(&MmapFs, segment_path)?)
         }

--- a/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
@@ -7,9 +7,10 @@ use common::universal_io::MmapFs;
 
 use super::sp;
 use crate::common::operation_error::OperationResult;
-use crate::id_tracker::IdTrackerEnum;
+use crate::id_tracker::disk_id_tracker::DiskIdTracker;
 use crate::id_tracker::immutable_id_tracker::ImmutableIdTracker;
 use crate::id_tracker::mutable_id_tracker::MutableIdTracker;
+use crate::id_tracker::{IdTrackerEnum, IdTrackerFormat};
 
 pub(crate) fn create_mutable_id_tracker(
     segment_path: &Path,
@@ -19,17 +20,23 @@ pub(crate) fn create_mutable_id_tracker(
 }
 
 pub(crate) fn create_segment_id_tracker(
-    mutable_id_tracker: bool,
+    format: IdTrackerFormat,
     segment_path: &Path,
     deferred_internal_id: Option<PointOffsetType>,
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
-    if !mutable_id_tracker {
-        return Ok(sp(IdTrackerEnum::ImmutableIdTracker(
-            ImmutableIdTracker::open(&MmapFs, segment_path)?,
-        )));
-    }
-
-    Ok(sp(IdTrackerEnum::MutableIdTracker(
-        create_mutable_id_tracker(segment_path, deferred_internal_id)?,
-    )))
+    let id_tracker = match format {
+        IdTrackerFormat::Mutable => {
+            IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
+                segment_path,
+                deferred_internal_id,
+            )?)
+        }
+        IdTrackerFormat::Immutable => {
+            IdTrackerEnum::ImmutableIdTracker(ImmutableIdTracker::open(&MmapFs, segment_path)?)
+        }
+        IdTrackerFormat::Disk => {
+            IdTrackerEnum::DiskIdTracker(DiskIdTracker::open(&MmapFs, segment_path)?)
+        }
+    };
+    Ok(sp(id_tracker))
 }


### PR DESCRIPTION
## Summary

Introduces a **disk-resident id tracker** family that keeps the point-id mapping on disk instead of loading it into RAM, so resident memory no longer scales with total point count. This removes the last segment component that forced a full RAM load — enabling object-storage / edge followers, and cutting RAM for regular deployments that opt in.

## What's included

**New on-disk mapping format** (`disk_id_tracker/on_disk_format.rs`) — random-access, replacing the sequential `id_tracker.mappings` for serverless segments:
- `id_tracker.i2e` — internal→external as a fixed-width `u128` array + `is_uuid` bits.
- `id_tracker.e2i` — external→internal as sorted numeric/uuid runs (section order encodes "any UUID > any numeric id") with a small resident sparse block index.
- `id_tracker.versions` / `id_tracker.deleted` are reused unchanged.

A point lookup is an in-RAM sparse-index search plus one ~16 KiB block read.

**Two trackers** sharing a lazy `DiskMappingReader` core and a `DiskMappingsSource` trait:
- **`DiskIdTracker`** — writable, deletion-only; a new `IdTrackerEnum` variant used by regular segments, so ordinary deployments also avoid the RAM mapping load. `deleted`+`versions` stay resident; the mapping stays on disk.
- **`ReadOnlyDiskIdTracker`** — read-only live-reload mirror for object-storage followers. Read-by-id uses a per-point `get_bit` deletion check; the full deleted set is materialized lazily only for search/scroll/counts.

**Selection & detection:**
- Created when the `serverless_compatible` feature flag is set (in `segment_builder`).
- Loaded via `ReadOnlyIdTrackerEnum::detect_and_load`, which *attempts* each format's open instead of probing file names — avoiding per-file `exists` round-trips that are costly on object storage.
- File-presence detection unified in `IdTrackerFormat` for the local/writable path.

**Design notes:**
- `PointMappingsRefEnum` is now generic over the read backend, so the disk variant is a concrete `DiskMappingsRef` (no trait object at the mapping boundary).
- The `DiskMappingsSource` read surface returns `OperationResult`; storage errors are only swallowed at the infallible `IdTrackerRead` boundary.
- `ImmutableIdTracker` is untouched — it remains the in-RAM format.

## Testing

New tests in `disk_id_tracker/tests.rs`: read-path parity of `DiskIdTracker` and `ReadOnlyDiskIdTracker` against `ImmutableIdTracker` over identical data; `iter_from` boundary cases; deletion + live-reload delta; format `detect_and_load` selection; `iter_random` coverage; and an assertion that read-by-id does **not** materialize the full deleted set. Full `id_tracker` suite and `collection`/`edge`/`shard` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)