### PR TITLE
[AI] Speed up TurboQuant Hadamard rotation by ~3x

### DIFF
--- a/lib/quantization/src/turboquant/permutation.rs
+++ b/lib/quantization/src/turboquant/permutation.rs
@@ -16,6 +16,8 @@ impl ReversibleLcg {
     /// Knuth's MMIX increment.
     const C: u64 = 1_442_695_040_888_963_407;
     /// Modular multiplicative inverse of A mod 2^64: A * A_INV ≡ 1 (mod 2^64).
+    /// Only the test-only reverse pass steps backward.
+    #[cfg(test)]
     const A_INV: u64 = 13_877_824_140_714_322_085;
 
     fn new(seed: u64) -> Self {
@@ -33,6 +35,7 @@ impl Iterator for ReversibleLcg {
     }
 }
 
+#[cfg(test)]
 impl DoubleEndedIterator for ReversibleLcg {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -53,15 +56,20 @@ pub struct Permutation {
     seed: u64,
     count: usize,
     /// LCG state after all forward-pass random draws, used as starting
-    /// point for the reverse pass.
+    /// point for the reverse pass. Only the test-only reverse path reads it.
+    #[cfg(test)]
     end_state: Option<u64>,
 }
 
 impl Permutation {
     /// Create a new permutation for `count` elements seeded by `seed`.
     ///
-    /// Unlike [`Self::new_one_way`], the result supports [`Self::unpermute`].
+    /// Unlike [`Self::new_one_way`], the result supports `unpermute`.
     /// Both constructors produce identical output from [`Self::permute`] for the same seed.
+    ///
+    /// Test-only: production code inverts a materialized index map instead of
+    /// replaying the shuffle backward (see `HadamardRotation::new`).
+    #[cfg(test)]
     pub fn new_reversible(seed: u64, count: usize) -> Self {
         Self {
             seed,
@@ -70,6 +78,7 @@ impl Permutation {
         }
     }
 
+    #[cfg(test)]
     fn calculate_end_state(seed: u64, count: usize) -> u64 {
         let mut rng = ReversibleLcg::new(seed);
 
@@ -81,20 +90,22 @@ impl Permutation {
     }
 
     /// Create a forward-only permutation. Skips the O(`count`) LCG warm-up
-    /// that [`Self::new_reversible`] does to record `end_state`. Intended for
-    /// [`Self::permute`]; calling [`Self::unpermute`] still works but pays the
-    /// warm-up lazily (and trips a `debug_assert` to flag the mismatch).
+    /// that `new_reversible` does to record `end_state`. Intended for
+    /// [`Self::permute`]; calling the test-only `unpermute` still works but
+    /// pays the warm-up lazily (and trips a `debug_assert` to flag the
+    /// mismatch).
     #[inline]
     pub fn new_one_way(seed: u64, count: usize) -> Self {
         Self {
             seed,
             count,
+            #[cfg(test)]
             end_state: None,
         }
     }
 
     /// Apply the forward permutation in-place (Fisher-Yates replay).
-    pub fn permute(&self, arr: &mut [f64]) {
+    pub fn permute<T>(&self, arr: &mut [T]) {
         debug_assert_eq!(arr.len(), self.count);
         let rng = ReversibleLcg::new(self.seed);
         for (i, rand) in ((1..self.count).rev()).zip(rng) {
@@ -108,6 +119,9 @@ impl Permutation {
     /// If this permutation was created with [`Self::new_one_way`], the missing
     /// `end_state` is recomputed on demand at O(`count`) extra cost. A
     /// `debug_assert` flags the unexpected path in debug builds.
+    ///
+    /// Test-only; see [`Self::new_reversible`].
+    #[cfg(test)]
     pub fn unpermute(&self, arr: &mut [f64]) {
         debug_assert_eq!(arr.len(), self.count);
 

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -67,12 +67,14 @@ impl HadamardRotation {
     }
 
     pub fn apply(&self, x: &mut [f64]) {
-        debug_assert_eq!(x.len(), self.dim);
+        // Hard assert: fail fast before the WHT mutates a wrong-length slice
+        // (the gather's own hard asserts would only fire after that).
+        assert_eq!(x.len(), self.dim);
         wht_and_gather_rounds(x, self.forward_maps.iter());
     }
 
     pub fn apply_inverse(&self, y: &mut [f64]) {
-        debug_assert_eq!(y.len(), self.dim);
+        assert_eq!(y.len(), self.dim);
         wht_and_gather_rounds(y, self.backward_maps.iter().rev());
     }
 }

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -95,15 +95,23 @@ thread_local! {
 fn wht_and_gather_rounds<'a>(x: &mut [f64], maps: impl Iterator<Item = &'a Vec<u32>>) {
     GATHER_SCRATCH.with(|cell| {
         let mut scratch = cell.borrow_mut();
-        scratch.resize(x.len(), 0.0);
+        // Grow-only: every gather fully overwrites its destination, so the
+        // zero-fill only matters for capacity. Shrinking here would force a
+        // re-zeroing regrow on every call when a thread alternates between
+        // dims.
+        if scratch.len() < x.len() {
+            scratch.resize(x.len(), 0.0);
+        }
 
         wht_normalized_chunks(x);
 
         let mut src: &mut [f64] = x;
-        let mut dst: &mut [f64] = scratch.as_mut_slice();
+        let mut dst: &mut [f64] = &mut scratch[..src.len()];
         let mut rounds = 0;
         for map in maps {
-            gather_permuted(dst, src, map);
+            // SAFETY: `map` comes from `HadamardRotation::new`, which builds
+            // it as a permutation of `0..dim`.
+            unsafe { gather_permuted(dst, src, map) };
             wht_normalized_chunks(dst);
             std::mem::swap(&mut src, &mut dst);
             rounds += 1;
@@ -120,16 +128,21 @@ fn wht_and_gather_rounds<'a>(x: &mut [f64], maps: impl Iterator<Item = &'a Vec<u
 
 /// Out-of-place gather `dst[k] = src[map[k]]`: the materialized form of one
 /// permutation pass.
-fn gather_permuted(dst: &mut [f64], src: &[f64], map: &[u32]) {
+///
+/// # Safety
+/// `map` must only contain indices in `0..map.len()` (it is a permutation in
+/// practice); the length asserts inside then guarantee every index is in
+/// bounds for `src`.
+unsafe fn gather_permuted(dst: &mut [f64], src: &[f64], map: &[u32]) {
     // Hard asserts: the unchecked gather below would otherwise turn a
     // length-mismatched call into an out-of-bounds read.
     assert_eq!(dst.len(), src.len());
     assert_eq!(dst.len(), map.len());
     for (d, &s) in dst.iter_mut().zip(map) {
         debug_assert!((s as usize) < src.len());
-        // SAFETY: `map` is a permutation of `0..map.len()` built in
-        // `HadamardRotation::new`, and `src.len() == map.len()` is asserted
-        // above, so every index is in bounds.
+        // SAFETY: `map` only holds indices in `0..map.len()` (caller
+        // contract), and `src.len() == map.len()` is asserted above, so every
+        // index is in bounds.
         *d = unsafe { *src.get_unchecked(s as usize) };
     }
 }
@@ -393,10 +406,12 @@ mod test {
     /// `random_vector_rotation_inverse`) matches the struct API bit-for-bit
     /// and is its own inverse. Without this, a wrong seed index, a forgotten
     /// `.rev()`, or a swapped helper in either free function would slip past
-    /// `hadamard_roundtrip` (which only exercises the struct).
+    /// `hadamard_roundtrip` (which only exercises the struct). Small dims
+    /// (5, 50) pin the map path where the chunk split degenerates into
+    /// several tiny power-of-two chunks.
     #[test]
     fn static_rotation_matches_struct_and_roundtrips() {
-        for &dim in &[128, 300, 1024, 1536] {
+        for &dim in &[5, 50, 128, 300, 1024, 1536] {
             let mut rng = StdRng::seed_from_u64(7);
             let input: Vec<f64> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
 

--- a/lib/quantization/src/turboquant/rotation.rs
+++ b/lib/quantization/src/turboquant/rotation.rs
@@ -10,9 +10,20 @@ const N_PERMUTATIONS: usize = 3;
 const PERMUTATION_SEEDS: [u64; 3] = [654605292835415893, 8636605637963351413, 1775280196666917949];
 
 /// Hadamard rotation implementation customized for TurboQuant.
+///
+/// Materializes the shared random permutations as index maps at construction
+/// time, so `apply`/`apply_inverse` replace the serial Fisher-Yates swap
+/// replay (one LCG step plus a 64-bit `%` per element) with a flat gather
+/// pass. Output stays bit-identical to the replay-based test-only oracle
+/// (`random_vector_rotation` / `random_vector_rotation_inverse`): the
+/// maps move the exact same values to the exact same positions.
 pub struct HadamardRotation {
-    /// Random (but shared) permutations.
-    permutations: [Permutation; N_PERMUTATIONS],
+    /// `forward_maps[p][k]` is the source index whose value lands at `k`
+    /// when applying permutation `p` (same shuffle as [`Permutation::permute`]).
+    forward_maps: [Vec<u32>; N_PERMUTATIONS],
+
+    /// Inverse of `forward_maps`, matching [`Permutation::unpermute`].
+    backward_maps: [Vec<u32>; N_PERMUTATIONS],
 
     /// Original dimension.
     dim: usize,
@@ -20,10 +31,34 @@ pub struct HadamardRotation {
 
 impl HadamardRotation {
     pub fn new(dim: usize) -> Self {
-        let permutations: [_; N_PERMUTATIONS] =
-            std::array::from_fn(|index| Permutation::new_reversible(PERMUTATION_SEEDS[index], dim));
+        // The index maps store u32; larger dims would silently wrap.
+        assert!(
+            u32::try_from(dim).is_ok(),
+            "HadamardRotation dim {dim} must fit in u32",
+        );
 
-        Self { permutations, dim }
+        let forward_maps: [_; N_PERMUTATIONS] = std::array::from_fn(|index| {
+            // `new_one_way` is enough: the backward map is derived by
+            // inverting the forward one, no reverse LCG replay needed.
+            let permutation = Permutation::new_one_way(PERMUTATION_SEEDS[index], dim);
+            let mut map: Vec<u32> = (0..dim as u32).collect();
+            permutation.permute(&mut map);
+            map
+        });
+
+        let backward_maps = std::array::from_fn(|index| {
+            let mut inverse = vec![0u32; dim];
+            for (position, &source) in forward_maps[index].iter().enumerate() {
+                inverse[source as usize] = position as u32;
+            }
+            inverse
+        });
+
+        Self {
+            forward_maps,
+            backward_maps,
+            dim,
+        }
     }
 
     /// Number of coordinates this rotation spans.
@@ -33,12 +68,69 @@ impl HadamardRotation {
 
     pub fn apply(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.dim);
-        apply_rotation_with_permutations(x, &self.permutations);
+        wht_and_gather_rounds(x, self.forward_maps.iter());
     }
 
     pub fn apply_inverse(&self, y: &mut [f64]) {
         debug_assert_eq!(y.len(), self.dim);
-        apply_inverse_rotation_with_permutations(y, &self.permutations);
+        wht_and_gather_rounds(y, self.backward_maps.iter().rev());
+    }
+}
+
+thread_local! {
+    /// Reusable buffer for the gather ping-pong in [`wht_and_gather_rounds`],
+    /// avoiding a heap allocation per `apply`/`apply_inverse` call on the
+    /// encode/decode hot paths.
+    static GATHER_SCRATCH: std::cell::RefCell<Vec<f64>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// WHT+normalize `x`, then for each map apply the permutation and
+/// WHT+normalize again.
+///
+/// Each permutation is one out-of-place gather that ping-pongs the live data
+/// between `x` and a scratch buffer instead of an in-place pass, avoiding a
+/// full copy per permutation; after an odd number of rounds a single copy
+/// moves the result from the scratch buffer back into `x`.
+fn wht_and_gather_rounds<'a>(x: &mut [f64], maps: impl Iterator<Item = &'a Vec<u32>>) {
+    GATHER_SCRATCH.with(|cell| {
+        let mut scratch = cell.borrow_mut();
+        scratch.resize(x.len(), 0.0);
+
+        wht_normalized_chunks(x);
+
+        let mut src: &mut [f64] = x;
+        let mut dst: &mut [f64] = scratch.as_mut_slice();
+        let mut rounds = 0;
+        for map in maps {
+            gather_permuted(dst, src, map);
+            wht_normalized_chunks(dst);
+            std::mem::swap(&mut src, &mut dst);
+            rounds += 1;
+        }
+
+        // After an odd number of rounds (`src` and `dst` swapped an odd
+        // number of times) the live data sits in the scratch buffer, now
+        // `src`, while `dst` is `x` again.
+        if rounds % 2 == 1 {
+            dst.copy_from_slice(src);
+        }
+    });
+}
+
+/// Out-of-place gather `dst[k] = src[map[k]]`: the materialized form of one
+/// permutation pass.
+fn gather_permuted(dst: &mut [f64], src: &[f64], map: &[u32]) {
+    // Hard asserts: the unchecked gather below would otherwise turn a
+    // length-mismatched call into an out-of-bounds read.
+    assert_eq!(dst.len(), src.len());
+    assert_eq!(dst.len(), map.len());
+    for (d, &s) in dst.iter_mut().zip(map) {
+        debug_assert!((s as usize) < src.len());
+        // SAFETY: `map` is a permutation of `0..map.len()` built in
+        // `HadamardRotation::new`, and `src.len() == map.len()` is asserted
+        // above, so every index is in bounds.
+        *d = unsafe { *src.get_unchecked(s as usize) };
     }
 }
 
@@ -67,6 +159,11 @@ pub fn in_place_walsh_hadamard_transform(x: &mut [f64]) {
 
 /// Randomly rotates `x` in place. Produces bit-identical output to
 /// [`HadamardRotation::apply`]; invert with [`HadamardRotation::apply_inverse`].
+///
+/// Test-only: replays the Fisher-Yates shuffle instead of materializing index
+/// maps, serving as the independent parity oracle that pins
+/// [`HadamardRotation`]'s output to the historical replay behavior.
+#[cfg(test)]
 pub fn random_vector_rotation(x: &mut [f64]) {
     let dim = x.len();
 
@@ -79,6 +176,9 @@ pub fn random_vector_rotation(x: &mut [f64]) {
 
 /// Inverts the rotated `y` back. Produces bit-identical output to
 /// [`HadamardRotation::apply_inverse`].
+///
+/// Test-only parity oracle; see [`random_vector_rotation`].
+#[cfg(test)]
 pub fn random_vector_rotation_inverse(y: &mut [f64]) {
     let dim = y.len();
 
@@ -120,6 +220,7 @@ fn compute_chunk_sizes(dim: usize) -> impl Iterator<Item = usize> {
 }
 
 /// Apply a Hadamard rotation to `x` using the given `permutations`.
+#[cfg(test)]
 fn apply_rotation_with_permutations(x: &mut [f64], permutations: &[Permutation; N_PERMUTATIONS]) {
     // Apply WHT + normalize to each variable-size chunk.
     wht_normalized_chunks(x);
@@ -132,6 +233,7 @@ fn apply_rotation_with_permutations(x: &mut [f64], permutations: &[Permutation; 
 }
 
 /// Apply the inverse of a Hadamard rotation to `y` using the given `permutations`.
+#[cfg(test)]
 fn apply_inverse_rotation_with_permutations(
     y: &mut [f64],
     permutations: &[Permutation; N_PERMUTATIONS],
@@ -146,19 +248,17 @@ fn apply_inverse_rotation_with_permutations(
     }
 }
 
-/// Apply WHT + normalization to variable-size chunks.
+/// Apply WHT + normalization to variable-size chunks. The normalization
+/// multiply is fused into the transform's final stage where a SIMD path
+/// exists (bit-equal to a separate multiply pass).
 fn wht_normalized_chunks(buf: &mut [f64]) {
     let mut offset = 0;
 
     for size in compute_chunk_sizes(buf.len()) {
         let chunk = &mut buf[offset..offset + size];
 
-        simd::hadamard::wht_dispatch(chunk);
-
         let norm = 1.0 / (size as f64).sqrt();
-        for v in chunk.iter_mut() {
-            *v *= norm;
-        }
+        simd::hadamard::wht_dispatch_scaled(chunk, norm);
 
         offset += size;
     }

--- a/lib/quantization/src/turboquant/simd/hadamard.rs
+++ b/lib/quantization/src/turboquant/simd/hadamard.rs
@@ -102,11 +102,17 @@ pub mod simd_x86 {
     /// vs 4–7 and `(r0..r1, r2..r3)` is 0–7 vs 8–15) — bit-equal output to
     /// the scalar reference.
     ///
+    /// With `SCALED`, every output is multiplied by `scale` before the store.
+    /// Only valid when h=8 is the transform's final stage (n = 16): fusing
+    /// the external normalization multiply into the final-stage store keeps
+    /// the same per-element op sequence (single add/sub, then one multiply),
+    /// so the result stays bit-equal to WHT-then-normalize.
+    ///
     /// # Safety
     /// `p` must point to ≥ 16 writable f64. CPU must support `avx,avx2`.
     #[inline]
     #[target_feature(enable = "avx,avx2")]
-    unsafe fn radix16_block(p: *mut f64) {
+    unsafe fn radix16_block<const SCALED: bool>(p: *mut f64, scale: __m256d) {
         unsafe {
             let r0 = _mm256_loadu_pd(p);
             let r1 = _mm256_loadu_pd(p.add(4));
@@ -130,10 +136,17 @@ pub mod simd_x86 {
             // Stage h=8: register-to-register butterflies between (s0,s2) and
             // (s1,s3). Maintains scalar pair order: positions [0..7] paired
             // with [8..15].
-            let t0 = _mm256_add_pd(s0, s2);
-            let t1 = _mm256_add_pd(s1, s3);
-            let t2 = _mm256_sub_pd(s0, s2);
-            let t3 = _mm256_sub_pd(s1, s3);
+            let mut t0 = _mm256_add_pd(s0, s2);
+            let mut t1 = _mm256_add_pd(s1, s3);
+            let mut t2 = _mm256_sub_pd(s0, s2);
+            let mut t3 = _mm256_sub_pd(s1, s3);
+
+            if SCALED {
+                t0 = _mm256_mul_pd(t0, scale);
+                t1 = _mm256_mul_pd(t1, scale);
+                t2 = _mm256_mul_pd(t2, scale);
+                t3 = _mm256_mul_pd(t3, scale);
+            }
 
             _mm256_storeu_pd(p, t0);
             _mm256_storeu_pd(p.add(4), t1);
@@ -176,55 +189,275 @@ pub mod simd_x86 {
         }
     }
 
-    /// 4× hand-unrolled outer butterfly loop. Inner iteration processes 16
-    /// doubles (4 YMM pairs) — 8 in-flight loads, 4 adds, 4 subs, 8 stores per
-    /// iteration. At `h = 16` the unrolled body covers the whole stage in one
-    /// iteration with no loop. At larger h it improves ILP by giving the OoO
-    /// engine four independent dep chains.
+    /// One 4×-unrolled butterfly pass for a single stage `h`. Inner iteration
+    /// processes 16 doubles (4 YMM pairs): 8 in-flight loads, 4 adds, 4
+    /// subs, 8 stores per iteration. At `h = 16` the unrolled body covers a
+    /// whole block in one iteration with no loop. At larger h it improves ILP
+    /// by giving the OoO engine four independent dep chains.
+    ///
+    /// With `SCALED`, every output is multiplied by `scale` before the store.
+    /// Only valid when `h` is the transform's final stage (h = n/2): fusing
+    /// the external normalization multiply into the final-stage store keeps
+    /// the same per-element op sequence, so the result stays bit-equal to
+    /// WHT-then-normalize.
     ///
     /// # Safety
-    /// CPU must support `avx,avx2`. `start_h` must be ≥ 16 and a power of two,
-    /// `x.len()` must be a power of two ≥ 2·`start_h`. Caller guarantees h is
-    /// always a multiple of 16 inside the inner loop, so no scalar tail.
+    /// CPU must support `avx,avx2`. `h` must be ≥ 16 and a power of two (so
+    /// always a multiple of 16, no scalar tail), `x.len()` must be a power of
+    /// two ≥ 2·`h`.
     #[inline]
     #[target_feature(enable = "avx,avx2")]
-    unsafe fn outer_butterfly_stages_4x(x: &mut [f64], start_h: usize) {
+    unsafe fn outer_stage_pass_4x<const SCALED: bool>(x: &mut [f64], h: usize, scale: __m256d) {
         unsafe {
             let n = x.len();
-            let mut h = start_h;
-            while h < n {
-                let stride = 2 * h;
-                let mut block = 0;
-                while block < n {
-                    let mut j = 0;
-                    while j < h {
-                        let p = x.as_mut_ptr().add(block + j);
-                        let q = p.add(h);
+            let stride = 2 * h;
+            let mut block = 0;
+            while block < n {
+                let mut j = 0;
+                while j < h {
+                    let p = x.as_mut_ptr().add(block + j);
+                    let q = p.add(h);
 
-                        let a0 = _mm256_loadu_pd(p);
-                        let a1 = _mm256_loadu_pd(p.add(4));
-                        let a2 = _mm256_loadu_pd(p.add(8));
-                        let a3 = _mm256_loadu_pd(p.add(12));
-                        let b0 = _mm256_loadu_pd(q);
-                        let b1 = _mm256_loadu_pd(q.add(4));
-                        let b2 = _mm256_loadu_pd(q.add(8));
-                        let b3 = _mm256_loadu_pd(q.add(12));
+                    let a0 = _mm256_loadu_pd(p);
+                    let a1 = _mm256_loadu_pd(p.add(4));
+                    let a2 = _mm256_loadu_pd(p.add(8));
+                    let a3 = _mm256_loadu_pd(p.add(12));
+                    let b0 = _mm256_loadu_pd(q);
+                    let b1 = _mm256_loadu_pd(q.add(4));
+                    let b2 = _mm256_loadu_pd(q.add(8));
+                    let b3 = _mm256_loadu_pd(q.add(12));
 
-                        _mm256_storeu_pd(p, _mm256_add_pd(a0, b0));
-                        _mm256_storeu_pd(p.add(4), _mm256_add_pd(a1, b1));
-                        _mm256_storeu_pd(p.add(8), _mm256_add_pd(a2, b2));
-                        _mm256_storeu_pd(p.add(12), _mm256_add_pd(a3, b3));
-                        _mm256_storeu_pd(q, _mm256_sub_pd(a0, b0));
-                        _mm256_storeu_pd(q.add(4), _mm256_sub_pd(a1, b1));
-                        _mm256_storeu_pd(q.add(8), _mm256_sub_pd(a2, b2));
-                        _mm256_storeu_pd(q.add(12), _mm256_sub_pd(a3, b3));
+                    let mut s0 = _mm256_add_pd(a0, b0);
+                    let mut s1 = _mm256_add_pd(a1, b1);
+                    let mut s2 = _mm256_add_pd(a2, b2);
+                    let mut s3 = _mm256_add_pd(a3, b3);
+                    let mut d0 = _mm256_sub_pd(a0, b0);
+                    let mut d1 = _mm256_sub_pd(a1, b1);
+                    let mut d2 = _mm256_sub_pd(a2, b2);
+                    let mut d3 = _mm256_sub_pd(a3, b3);
 
-                        j += 16;
+                    if SCALED {
+                        s0 = _mm256_mul_pd(s0, scale);
+                        s1 = _mm256_mul_pd(s1, scale);
+                        s2 = _mm256_mul_pd(s2, scale);
+                        s3 = _mm256_mul_pd(s3, scale);
+                        d0 = _mm256_mul_pd(d0, scale);
+                        d1 = _mm256_mul_pd(d1, scale);
+                        d2 = _mm256_mul_pd(d2, scale);
+                        d3 = _mm256_mul_pd(d3, scale);
                     }
-                    block += stride;
+
+                    _mm256_storeu_pd(p, s0);
+                    _mm256_storeu_pd(p.add(4), s1);
+                    _mm256_storeu_pd(p.add(8), s2);
+                    _mm256_storeu_pd(p.add(12), s3);
+                    _mm256_storeu_pd(q, d0);
+                    _mm256_storeu_pd(q.add(4), d1);
+                    _mm256_storeu_pd(q.add(8), d2);
+                    _mm256_storeu_pd(q.add(12), d3);
+
+                    j += 16;
                 }
-                h *= 2;
+                block += stride;
             }
+        }
+    }
+
+    /// One fused double-stage outer butterfly pass: applies stages h and 2h
+    /// in a single pass over the array, halving memory traffic versus two
+    /// separate stage passes. Each inner iteration loads the 4 stripes `(j,
+    /// j+h, j+2h, j+3h)`, applies the stage-h butterflies `(a,b)` and
+    /// `(c,d)`, then the stage-2h butterflies `(u,w)` and `(v,z)` on the
+    /// results, and stores. Every butterfly is still a single add/sub on the
+    /// same operands in the same direction as the scalar reference, so the
+    /// output is bit-equal.
+    ///
+    /// With `SCALED`, every output is multiplied by `scale` before the store.
+    /// Only valid when 2h is the transform's final stage (2h = n/2); see
+    /// [`outer_stage_pass_4x`].
+    ///
+    /// # Safety
+    /// CPU must support `avx,avx2`. `h` must be ≥ 16 and a power of two,
+    /// `x.len()` must be a power of two ≥ 4·`h`.
+    #[inline]
+    #[target_feature(enable = "avx,avx2")]
+    unsafe fn outer_stage_pass_fused_4x<const SCALED: bool>(
+        x: &mut [f64],
+        h: usize,
+        scale: __m256d,
+    ) {
+        unsafe {
+            let n = x.len();
+            let stride = 4 * h;
+            let mut block = 0;
+            while block < n {
+                let mut j = 0;
+                while j < h {
+                    let pa = x.as_mut_ptr().add(block + j);
+                    let pb = pa.add(h);
+                    let pc = pa.add(2 * h);
+                    let pd = pa.add(3 * h);
+
+                    let a0 = _mm256_loadu_pd(pa);
+                    let a1 = _mm256_loadu_pd(pa.add(4));
+                    let b0 = _mm256_loadu_pd(pb);
+                    let b1 = _mm256_loadu_pd(pb.add(4));
+                    let c0 = _mm256_loadu_pd(pc);
+                    let c1 = _mm256_loadu_pd(pc.add(4));
+                    let d0 = _mm256_loadu_pd(pd);
+                    let d1 = _mm256_loadu_pd(pd.add(4));
+
+                    // Stage h: butterflies (a,b) and (c,d).
+                    let u0 = _mm256_add_pd(a0, b0);
+                    let u1 = _mm256_add_pd(a1, b1);
+                    let v0 = _mm256_sub_pd(a0, b0);
+                    let v1 = _mm256_sub_pd(a1, b1);
+                    let w0 = _mm256_add_pd(c0, d0);
+                    let w1 = _mm256_add_pd(c1, d1);
+                    let z0 = _mm256_sub_pd(c0, d0);
+                    let z1 = _mm256_sub_pd(c1, d1);
+
+                    // Stage 2h: butterflies (u,w) and (v,z).
+                    let mut r0 = _mm256_add_pd(u0, w0);
+                    let mut r1 = _mm256_add_pd(u1, w1);
+                    let mut r2 = _mm256_add_pd(v0, z0);
+                    let mut r3 = _mm256_add_pd(v1, z1);
+                    let mut r4 = _mm256_sub_pd(u0, w0);
+                    let mut r5 = _mm256_sub_pd(u1, w1);
+                    let mut r6 = _mm256_sub_pd(v0, z0);
+                    let mut r7 = _mm256_sub_pd(v1, z1);
+
+                    if SCALED {
+                        r0 = _mm256_mul_pd(r0, scale);
+                        r1 = _mm256_mul_pd(r1, scale);
+                        r2 = _mm256_mul_pd(r2, scale);
+                        r3 = _mm256_mul_pd(r3, scale);
+                        r4 = _mm256_mul_pd(r4, scale);
+                        r5 = _mm256_mul_pd(r5, scale);
+                        r6 = _mm256_mul_pd(r6, scale);
+                        r7 = _mm256_mul_pd(r7, scale);
+                    }
+
+                    _mm256_storeu_pd(pa, r0);
+                    _mm256_storeu_pd(pa.add(4), r1);
+                    _mm256_storeu_pd(pb, r2);
+                    _mm256_storeu_pd(pb.add(4), r3);
+                    _mm256_storeu_pd(pc, r4);
+                    _mm256_storeu_pd(pc.add(4), r5);
+                    _mm256_storeu_pd(pd, r6);
+                    _mm256_storeu_pd(pd.add(4), r7);
+
+                    j += 8;
+                }
+                block += stride;
+            }
+        }
+    }
+
+    /// Run all outer butterfly stages h = `start_h`, 2·`start_h`, …, n/2,
+    /// fusing stage pairs into single passes via [`outer_stage_pass_fused_4x`].
+    /// An odd stage count leaves the final (largest-h) stage unfused; it is
+    /// handled by one [`outer_stage_pass_4x`] pass.
+    ///
+    /// With `SCALED`, whichever pass writes the final stage multiplies its
+    /// outputs by `scale`, fusing the external normalization pass into the
+    /// transform. Bit-equal to WHT-then-normalize (same per-element op
+    /// sequence). Callers must ensure at least one stage fires (n > start_h),
+    /// otherwise the scale would be silently skipped.
+    ///
+    /// # Safety
+    /// CPU must support `avx,avx2`. `start_h` must be ≥ 16 and a power of
+    /// two, `x.len()` must be a power of two ≥ 2·`start_h`.
+    #[inline]
+    #[target_feature(enable = "avx,avx2")]
+    unsafe fn outer_butterfly_stages_fused_4x<const SCALED: bool>(
+        x: &mut [f64],
+        start_h: usize,
+        scale: __m256d,
+    ) {
+        unsafe {
+            let n = x.len();
+            debug_assert!(!SCALED || n > start_h);
+            let mut h = start_h;
+            // Both stage h and stage 2h must exist to fuse them. This fused
+            // pass writes the final stage iff 4h = n.
+            while 2 * h < n {
+                if SCALED && 4 * h == n {
+                    outer_stage_pass_fused_4x::<true>(x, h, scale);
+                } else {
+                    outer_stage_pass_fused_4x::<false>(x, h, scale);
+                }
+                h *= 4;
+            }
+
+            // Leftover unfused final stage (no-op when h ≥ n).
+            if h < n {
+                if SCALED {
+                    outer_stage_pass_4x::<true>(x, h, scale);
+                } else {
+                    outer_stage_pass_4x::<false>(x, h, scale);
+                }
+            }
+        }
+    }
+
+    /// Shared body of [`wht_avx2_radix16_4x`] / [`wht_avx2_radix16_4x_scaled`].
+    /// With `SCALED`, the pass writing each element's final value multiplies
+    /// it by `scale` before the store, fusing the external normalization pass
+    /// into the transform at zero extra memory traffic. Bit-equal to
+    /// WHT-then-normalize: every element still sees the same op sequence
+    /// (single add/sub per butterfly, then one multiply).
+    ///
+    /// # Safety
+    /// CPU must support `avx` and `avx2`. Length must be a power of two.
+    #[target_feature(enable = "avx,avx2")]
+    unsafe fn wht_avx2_radix16_4x_impl<const SCALED: bool>(x: &mut [f64], scale: f64) {
+        let n = x.len();
+        debug_assert!(n.is_power_of_two(), "WHT requires power-of-2 length");
+
+        if n < 8 {
+            scalar_wht(x);
+            if SCALED {
+                for v in x.iter_mut() {
+                    *v *= scale;
+                }
+            }
+            return;
+        }
+
+        unsafe {
+            let vscale = _mm256_set1_pd(scale);
+
+            if n == 8 {
+                let p = x.as_mut_ptr();
+                let v0 = wht_h1h2_in_ymm(_mm256_loadu_pd(p));
+                let v1 = wht_h1h2_in_ymm(_mm256_loadu_pd(p.add(4)));
+                let mut lo = _mm256_add_pd(v0, v1);
+                let mut hi = _mm256_sub_pd(v0, v1);
+                if SCALED {
+                    lo = _mm256_mul_pd(lo, vscale);
+                    hi = _mm256_mul_pd(hi, vscale);
+                }
+                _mm256_storeu_pd(p, lo);
+                _mm256_storeu_pd(p.add(4), hi);
+                return;
+            }
+
+            if n == 16 {
+                // h=8 is the final stage: the radix-16 block applies the scale.
+                radix16_block::<SCALED>(x.as_mut_ptr(), vscale);
+                return;
+            }
+
+            let mut i = 0;
+            while i + 16 <= n {
+                radix16_block::<false>(x.as_mut_ptr().add(i), vscale);
+                i += 16;
+            }
+
+            // n ≥ 32: outer stages start at h=16, always a multiple of 16,
+            // and at least one fires, so the scale is always applied.
+            outer_butterfly_stages_fused_4x::<SCALED>(x, 16, vscale);
         }
     }
 
@@ -235,34 +468,19 @@ pub mod simd_x86 {
     /// CPU must support `avx` and `avx2`. Length must be a power of two.
     #[target_feature(enable = "avx,avx2")]
     pub unsafe fn wht_avx2_radix16_4x(x: &mut [f64]) {
-        let n = x.len();
-        debug_assert!(n.is_power_of_two(), "WHT requires power-of-2 length");
+        unsafe { wht_avx2_radix16_4x_impl::<false>(x, 1.0) }
+    }
 
-        if n < 8 {
-            scalar_wht(x);
-            return;
-        }
-
-        unsafe {
-            if n == 8 {
-                let p = x.as_mut_ptr();
-                let v0 = wht_h1h2_in_ymm(_mm256_loadu_pd(p));
-                let v1 = wht_h1h2_in_ymm(_mm256_loadu_pd(p.add(4)));
-                _mm256_storeu_pd(p, _mm256_add_pd(v0, v1));
-                _mm256_storeu_pd(p.add(4), _mm256_sub_pd(v0, v1));
-                return;
-            }
-
-            let mut i = 0;
-            while i + 16 <= n {
-                radix16_block(x.as_mut_ptr().add(i));
-                i += 16;
-            }
-
-            // n ≥ 16: outer stages start at h=16, always a multiple of 16.
-            // n=16 has no outer stages (h=16 is == n, loop doesn't fire).
-            outer_butterfly_stages_4x(x, 16);
-        }
+    /// [`wht_avx2_radix16_4x`] followed by an elementwise multiply by
+    /// `scale`, with the multiply fused into the final-stage stores.
+    /// Bit-equal to running the WHT and then multiplying each element by
+    /// `scale` as a separate pass.
+    ///
+    /// # Safety
+    /// CPU must support `avx` and `avx2`. Length must be a power of two.
+    #[target_feature(enable = "avx,avx2")]
+    pub unsafe fn wht_avx2_radix16_4x_scaled(x: &mut [f64], scale: f64) {
+        unsafe { wht_avx2_radix16_4x_impl::<true>(x, scale) }
     }
 }
 
@@ -604,6 +822,27 @@ pub fn wht_dispatch(x: &mut [f64]) {
     scalar_wht(x);
 }
 
+/// Safe in-place WHT followed by an elementwise multiply by `scale`, with the
+/// multiply fused into the transform's final-stage stores where a fused SIMD
+/// path exists (currently AVX2). Bit-equal on every path to [`wht_dispatch`]
+/// plus a separate `*v *= scale` pass: each element still sees the same op
+/// sequence (single add/sub per butterfly, then one multiply).
+#[inline]
+pub fn wht_dispatch_scaled(x: &mut [f64], scale: f64) {
+    #[cfg(target_arch = "x86_64")]
+    if std::is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 confirmed by runtime detection above.
+        unsafe { simd_x86::wht_avx2_radix16_4x_scaled(x, scale) };
+        return;
+    }
+
+    // Fallbacks (scalar, NEON) keep the separate multiply pass.
+    wht_dispatch(x);
+    for v in x.iter_mut() {
+        *v *= scale;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand::prelude::StdRng;
@@ -769,6 +1008,38 @@ mod tests {
             wht_dispatch(&mut dispatched);
 
             assert_bit_equal(&scalar, &dispatched, &format!("wht_dispatch at n={n}"));
+        }
+    }
+
+    /// Scaled-WHT parity: `wht_dispatch_scaled` (and through it the fused
+    /// AVX2 final-stage multiply) must be bit-equal to the scalar reference
+    /// followed by a separate elementwise multiply, for every size and for
+    /// scales of different magnitudes. Covers every dispatch path: n < 8
+    /// scalar fallback, n = 8, n = 16 (radix-16 block applies the scale),
+    /// n = 32 (unfused leftover stage applies it), n ≥ 64 (fused or leftover
+    /// pass depending on stage-count parity).
+    #[test]
+    fn wht_dispatch_scaled_matches_scalar_then_multiply() {
+        for &scale in &[1.0, 0.5, 1.0 / 3.0_f64.sqrt(), 1e-160, 1e160] {
+            let mut rng = StdRng::seed_from_u64(0xA5CA1E);
+            for &n in SIZES {
+                let input: Vec<f64> = (0..n).map(|_| rng.random_range(-1.0f64..1.0)).collect();
+
+                let mut reference = input.clone();
+                in_place_walsh_hadamard_transform(&mut reference);
+                for v in reference.iter_mut() {
+                    *v *= scale;
+                }
+
+                let mut fused = input.clone();
+                wht_dispatch_scaled(&mut fused, scale);
+
+                assert_bit_equal(
+                    &reference,
+                    &fused,
+                    &format!("wht_dispatch_scaled at n={n}, scale={scale:e}"),
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## What

`HadamardRotation::apply`/`apply_inverse` are on the TurboQuant encode and decode hot paths (every vector goes through them at encoding time and at rescoring/decode time). 

Profiling `apply_inverse` showed only 23% of cycles in the WHT kernel itself; 44% went to replaying the Fisher-Yates shuffle on every call (one serial LCG step plus a 64-bit `%` by a variable bound per element), and another ~12% to the separate normalization pass and buffer copies.

## How

1. **Materialized permutation maps.** `HadamardRotation::new` now builds forward/backward index maps (`[Vec<u32>; 3]` each, 24 bytes per dimension) once, so each permutation at apply time is a flat gather pass instead of a serial swap replay. The gathers ping-pong between the vector and a thread-local scratch buffer (no per-call allocation), with a single copy back at the end.
2. **Fused WHT outer stages (AVX2).** Consecutive butterfly stage pairs (h, 2h) are applied in one pass over the array instead of two, halving memory traffic for all stages h >= 16.
3. **Fused normalization.** `wht_dispatch_scaled` multiplies by the chunk norm in the transform's final-stage stores (via `const SCALED: bool` threaded through the AVX2 kernels), removing the separate read-modify-write normalize pass.
4. The old replay-based implementation (`random_vector_rotation*`, `Permutation::new_reversible`/`unpermute`, reverse LCG) is kept under `#[cfg(test)]` as the parity oracle, leaving a single production path.

## Bit-equality

The permutation seeds are baked into every stored quantized vector, so output must not change by even one ulp. 

All three changes preserve exact op sequences: maps move the same values to the same positions, fused butterflies are the same single add/sub per pair, and the fused norm is still "final add/sub, then one multiply" per element. This is enforced by:

* `static_rotation_matches_struct_and_roundtrips` pins the new map-based path bit-for-bit to the historical replay implementation.
* The existing SIMD-vs-scalar bit-equal tests (all sizes 1 to 8192, random and edge-value inputs).
* New `wht_dispatch_scaled_matches_scalar_then_multiply` covers every dispatch path (n < 8, 8, 16, 32, >= 64) with scales from 1e-160 to 1e160.

## Results

Criterion `hadamard` bench, Zen 5, paired same-session runs (2.8-3.7x):

| dim | `apply` | `apply_inverse` |
|---|---|---|
| 128 | 820ns -> 247ns (3.3x) | 819ns -> 236ns (3.5x) |
| 384 | 2.58µs -> 0.70µs (3.7x) | 2.26µs -> 0.70µs (3.2x) |
| 768 | 5.32µs -> 1.44µs (3.7x) | 4.45µs -> 1.47µs (3.0x) |
| 1024 | 6.98µs -> 2.03µs (3.4x) | 6.10µs -> 2.05µs (3.0x) |
| 1536 | 10.14µs -> 2.97µs (3.4x) | 9.01µs -> 3.08µs (2.9x) |
| 4096 | 27.2µs -> 9.19µs (3.0x) | 25.2µs -> 9.10µs (2.8x) |

## Notes

* NEON is unchanged: it keeps the per-stage outer loop and the separate normalize pass, byte-for-byte the previous behavior (could not benchmark ARM locally). Porting the fused stages and norm fusion is a possible follow-up.
* `HadamardRotation::new` asserts `dim <= u32::MAX` (index maps store u32), and the unchecked gather hard-asserts length equality, so API misuse panics rather than reading out of bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)