### PR TITLE
Restart consensus thread on failure instead of stopping permanently

### DIFF
--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -51,6 +51,9 @@ pub enum ClusterOperations {
     /// Introduce artificial delay to a node
     #[cfg(feature = "staging")]
     TestSlowDown(TestSlowDownOperation),
+    /// Simulate a transient consensus failure on a node
+    #[cfg(feature = "staging")]
+    TestTransientError(TestTransientErrorOperation),
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone)]
@@ -130,6 +133,8 @@ impl Validate for ClusterOperations {
             ClusterOperations::ReplicatePoints(op) => op.validate(),
             #[cfg(feature = "staging")]
             ClusterOperations::TestSlowDown(op) => op.validate(),
+            #[cfg(feature = "staging")]
+            ClusterOperations::TestTransientError(op) => op.validate(),
         }
     }
 }
@@ -361,4 +366,6 @@ pub struct FinishResharding {}
 pub struct AbortResharding {}
 
 #[cfg(feature = "staging")]
-pub use super::staging::{TestSlowDown, TestSlowDownOperation};
+pub use super::staging::{
+    TestSlowDown, TestSlowDownOperation, TestTransientError, TestTransientErrorOperation,
+};

--- a/lib/collection/src/operations/staging.rs
+++ b/lib/collection/src/operations/staging.rs
@@ -29,3 +29,30 @@ pub struct TestSlowDown {
     #[validate(range(min = 0.0, max = 300.0))]
     pub duration: f64,
 }
+
+fn default_test_transient_error_probability() -> f64 {
+    0.5
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct TestTransientErrorOperation {
+    #[validate(nested)]
+    pub test_transient_error: TestTransientError,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
+pub struct TestTransientError {
+    /// Target peer ID to fail on.
+    /// If not specified, the operation will be executed on all peers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<PeerId>,
+    /// Probability that applying the operation fails on each targeted peer,
+    /// stopping its consensus thread with a service error (default: 0.5, max: 1.0).
+    ///
+    /// A failed peer re-applies the operation when its consensus thread restarts,
+    /// rolling the probability again. Probability 1.0 therefore simulates a
+    /// permanently failing consensus operation.
+    #[serde(default = "default_test_transient_error_probability")]
+    #[validate(range(min = 0.0, max = 1.0))]
+    pub failure_probability: f64,
+}

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -25,7 +25,7 @@ use validator::Validate;
 
 // Re-export staging types when the feature is enabled
 #[cfg(feature = "staging")]
-pub use super::staging::TestSlowDown;
+pub use super::staging::{TestSlowDown, TestTransientError};
 use crate::content_manager::errors::{StorageError, StorageResult};
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
 
@@ -472,6 +472,9 @@ pub enum CollectionMetaOperations {
     /// Introduce artificial delay to a specific peer node
     #[cfg(feature = "staging")]
     TestSlowDown(TestSlowDown),
+    /// Simulate a transient consensus failure on a specific peer node
+    #[cfg(feature = "staging")]
+    TestTransientError(TestTransientError),
 }
 
 /// Use config of the existing collection to generate a create collection operation

--- a/lib/storage/src/content_manager/staging.rs
+++ b/lib/storage/src/content_manager/staging.rs
@@ -5,6 +5,8 @@
 use collection::shards::shard::PeerId;
 use serde::{Deserialize, Serialize};
 
+use crate::content_manager::errors::StorageError;
+
 /// Introduce artificial delay to a specific peer node.
 /// If no peer provided, execute on all peers.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
@@ -24,6 +26,43 @@ impl TestSlowDown {
             log::debug!("TestSlowDown: sleeping for {duration_ms}ms on peer {this_peer_id}");
             tokio::time::sleep(std::time::Duration::from_millis(self.duration_ms)).await;
             log::debug!("TestSlowDown: finished sleeping on peer {this_peer_id}");
+        }
+    }
+}
+
+/// Simulate a transient consensus failure: applying this operation fails with the given
+/// probability, which stops the consensus thread with a service error. The peer re-applies
+/// the operation when its consensus thread restarts, rolling the probability again.
+/// If no peer provided, execute on all peers.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
+pub struct TestTransientError {
+    pub peer_id: Option<PeerId>,
+    /// Probability, in percent (0-100), that applying this operation fails
+    pub failure_probability_percent: u8,
+}
+
+impl TestTransientError {
+    pub fn should_execute_on(&self, peer_id: PeerId) -> bool {
+        self.peer_id.is_none_or(|target| target == peer_id)
+    }
+
+    pub fn execute(&self, this_peer_id: PeerId) -> Result<(), StorageError> {
+        if !self.should_execute_on(this_peer_id) {
+            return Ok(());
+        }
+        let failure_probability_percent = self.failure_probability_percent;
+        let roll = rand::random_range(0..100u8);
+        if roll < failure_probability_percent {
+            Err(StorageError::service_error(format!(
+                "TestTransientError: simulated transient consensus error on peer {this_peer_id} \
+                 (failure probability {failure_probability_percent}%, roll {roll})"
+            )))
+        } else {
+            log::debug!(
+                "TestTransientError: applied without failure on peer {this_peer_id} \
+                 (failure probability {failure_probability_percent}%, roll {roll})"
+            );
+            Ok(())
         }
     }
 }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -139,6 +139,12 @@ impl TableOfContent {
                 test_slow_down.execute(self.this_peer_id).await;
                 Ok(true)
             }
+            #[cfg(feature = "staging")]
+            CollectionMetaOperations::TestTransientError(test_transient_error) => {
+                test_transient_error
+                    .execute(self.this_peer_id)
+                    .map(|()| true)
+            }
         }
     }
 

--- a/lib/storage/src/dispatcher.rs
+++ b/lib/storage/src/dispatcher.rs
@@ -154,7 +154,8 @@ impl Dispatcher {
                 | CollectionMetaOperations::DeleteNamedVector(_)
                 | CollectionMetaOperations::Nop { .. } => operation,
                 #[cfg(feature = "staging")]
-                CollectionMetaOperations::TestSlowDown(_) => operation,
+                CollectionMetaOperations::TestSlowDown(_)
+                | CollectionMetaOperations::TestTransientError(_) => operation,
             };
 
             let operation_awaiter =
@@ -199,7 +200,8 @@ impl Dispatcher {
                 | CollectionMetaOperations::Nop { .. } => false,
 
                 #[cfg(feature = "staging")]
-                CollectionMetaOperations::TestSlowDown(_) => false,
+                CollectionMetaOperations::TestSlowDown(_)
+                | CollectionMetaOperations::TestTransientError(_) => false,
             };
 
             // During creation of a shard key, we must ensure that all replicas are ready to accept

--- a/lib/storage/src/rbac/auditable_operation.rs
+++ b/lib/storage/src/rbac/auditable_operation.rs
@@ -31,7 +31,8 @@ impl AuditableOperation for CollectionMetaOperations {
             CollectionMetaOperations::DeleteNamedVector(_) => "delete_named_vector",
             CollectionMetaOperations::Nop { .. } => "nop",
             #[cfg(feature = "staging")]
-            CollectionMetaOperations::TestSlowDown(_) => "debug",
+            CollectionMetaOperations::TestSlowDown(_)
+            | CollectionMetaOperations::TestTransientError(_) => "debug",
         }
     }
 }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -81,7 +81,8 @@ impl Access {
             }
             CollectionMetaOperations::Nop { token: _ } => (),
             #[cfg(feature = "staging")]
-            CollectionMetaOperations::TestSlowDown(_) => {
+            CollectionMetaOperations::TestSlowDown(_)
+            | CollectionMetaOperations::TestTransientError(_) => {
                 self.check_global_access(AccessRequirements::new().manage())?;
             }
         }

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -8,13 +8,13 @@ use api::rest::models::{
     CollectionDescription, CollectionsResponse, ShardKeyDescription, ShardKeysResponse,
 };
 use collection::config::ShardingMethod;
-#[cfg(feature = "staging")]
-use collection::operations::cluster_ops::{TestSlowDownOperation, TestTransientErrorOperation};
 use collection::operations::cluster_ops::{
     AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShardOperation,
     ReplicatePoints, ReplicatePointsOperation, ReplicateShardOperation, ReshardingDirection,
     RestartTransfer, RestartTransferOperation, StartResharding,
 };
+#[cfg(feature = "staging")]
+use collection::operations::cluster_ops::{TestSlowDownOperation, TestTransientErrorOperation};
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::snapshot_ops::SnapshotDescription;
 use collection::operations::types::{
@@ -32,12 +32,12 @@ use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use rand::seq::IteratorRandom;
 use storage::content_manager::collection_meta_ops::ShardTransferOperations::{Abort, Start};
-#[cfg(feature = "staging")]
-use storage::content_manager::collection_meta_ops::{TestSlowDown, TestTransientError};
 use storage::content_manager::collection_meta_ops::{
     CollectionMetaOperations, CreateShardKey, DropShardKey, ReshardingOperation,
     SetShardReplicaState, ShardTransferOperations, UpdateCollectionOperation,
 };
+#[cfg(feature = "staging")]
+use storage::content_manager::collection_meta_ops::{TestSlowDown, TestTransientError};
 use storage::content_manager::errors::StorageError;
 use storage::content_manager::toc::TableOfContent;
 use storage::dispatcher::Dispatcher;

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -9,7 +9,7 @@ use api::rest::models::{
 };
 use collection::config::ShardingMethod;
 #[cfg(feature = "staging")]
-use collection::operations::cluster_ops::TestSlowDownOperation;
+use collection::operations::cluster_ops::{TestSlowDownOperation, TestTransientErrorOperation};
 use collection::operations::cluster_ops::{
     AbortTransferOperation, ClusterOperations, DropReplicaOperation, MoveShardOperation,
     ReplicatePoints, ReplicatePointsOperation, ReplicateShardOperation, ReshardingDirection,
@@ -33,7 +33,7 @@ use rand::prelude::SliceRandom;
 use rand::seq::IteratorRandom;
 use storage::content_manager::collection_meta_ops::ShardTransferOperations::{Abort, Start};
 #[cfg(feature = "staging")]
-use storage::content_manager::collection_meta_ops::TestSlowDown;
+use storage::content_manager::collection_meta_ops::{TestSlowDown, TestTransientError};
 use storage::content_manager::collection_meta_ops::{
     CollectionMetaOperations, CreateShardKey, DropShardKey, ReshardingOperation,
     SetShardReplicaState, ShardTransferOperations, UpdateCollectionOperation,
@@ -966,6 +966,30 @@ pub async fn do_update_collection_cluster(
                     CollectionMetaOperations::TestSlowDown(TestSlowDown {
                         peer_id: test_slow_down.peer_id,
                         duration_ms,
+                    }),
+                    auth,
+                    wait_timeout,
+                )
+                .await
+        }
+
+        #[cfg(feature = "staging")]
+        ClusterOperations::TestTransientError(TestTransientErrorOperation {
+            test_transient_error,
+        }) => {
+            if let Some(peer_id) = test_transient_error.peer_id {
+                validate_peer_exists(peer_id)?;
+            }
+
+            // Convert probability (f64, 0.0-1.0) to percent (u8, 0-100)
+            let failure_probability_percent =
+                (test_transient_error.failure_probability * 100.0) as u8;
+
+            dispatcher
+                .submit_collection_meta_op(
+                    CollectionMetaOperations::TestTransientError(TestTransientError {
+                        peer_id: test_transient_error.peer_id,
+                        failure_probability_percent,
                     }),
                     auth,
                     wait_timeout,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -38,6 +38,16 @@ type Node = RawNode<ConsensusStateRef>;
 const RECOVERY_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 const RECOVERY_MAX_RETRY_COUNT: usize = 3;
 
+/// Initial delay before restarting the consensus thread after a failure
+const CONSENSUS_RESTART_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Maximum delay between consensus thread restart attempts
+const CONSENSUS_RESTART_MAX_BACKOFF: Duration = Duration::from_secs(300);
+
+/// If the consensus thread was working for at least this long before failing,
+/// consider the previous failure resolved and start restart backoff from scratch
+const CONSENSUS_RESTART_BACKOFF_RESET_UPTIME: Duration = Duration::from_secs(300);
+
 pub enum Message {
     FromClient(ConsensusOperations),
     FromPeer(Box<RaftMessage>),
@@ -48,8 +58,6 @@ pub enum Message {
 pub struct Consensus {
     /// Raft structure which handles raft-related state
     node: Node,
-    /// Receives proposals from peers and client for applying in consensus
-    receiver: Receiver<Message>,
     /// Runtime for async message sending
     runtime: Handle,
     /// Uri to some other known peer, used to join the consensus
@@ -82,20 +90,35 @@ impl Consensus {
         let p2p_port = settings.cluster.p2p.port.expect("P2P port is not set");
         let config = settings.cluster.consensus.clone();
 
-        let (mut consensus, message_sender) = Self::new(
+        // Bounded channel for backpressure.
+        //
+        // The channel is created here, outside of `Consensus` itself, so it survives consensus
+        // thread restarts: internal gRPC handlers and the forward-proposals thread keep their
+        // senders across restarts, and messages accumulated while consensus is down are drained
+        // once it is rebuilt.
+        let (message_sender, message_receiver) =
+            tokio::sync::mpsc::channel(config.max_message_queue_size);
+
+        // The first construction is fail-fast: if consensus cannot be initialized on startup
+        // (including bootstrap and `reinit`), Qdrant fails to start. Only failures of an already
+        // running consensus are retried by the restart loop below.
+        let mut consensus = Self::new(
             logger,
             state_ref.clone(),
-            bootstrap_peer,
-            uri,
+            bootstrap_peer.clone(),
+            uri.clone(),
             p2p_port,
-            config,
-            tls_client_config,
-            channel_service,
+            config.clone(),
+            tls_client_config.clone(),
+            channel_service.clone(),
             runtime.clone(),
             reinit,
         )?;
 
+        let logger_clone = logger.clone();
         let state_ref_clone = state_ref.clone();
+        let channel_service_clone = channel_service.clone();
+        let runtime_clone = runtime.clone();
         thread::Builder::new()
             .name("consensus".to_string())
             .spawn(move || {
@@ -108,12 +131,83 @@ impl Consensus {
                     );
                 }
 
-                if let Err(err) = consensus.start() {
+                let mut receiver = message_receiver;
+                let mut backoff = CONSENSUS_RESTART_INITIAL_BACKOFF;
+                let mut restart_attempt = 0u32;
+
+                loop {
+                    let started_at = Instant::now();
+
+                    let err = match consensus.start(&mut receiver) {
+                        Ok(()) => {
+                            log::info!("Consensus stopped");
+                            state_ref_clone.on_consensus_stopped();
+                            return;
+                        }
+                        Err(err) => err,
+                    };
+
                     log::error!("Consensus stopped with error: {err:#}");
-                    state_ref_clone.on_consensus_thread_err(err);
-                } else {
-                    log::info!("Consensus stopped");
-                    state_ref_clone.on_consensus_stopped();
+
+                    // If consensus was working for a while before failing, consider the previous
+                    // failure resolved and start backoff from scratch
+                    if started_at.elapsed() >= CONSENSUS_RESTART_BACKOFF_RESET_UPTIME {
+                        backoff = CONSENSUS_RESTART_INITIAL_BACKOFF;
+                        restart_attempt = 0;
+                    }
+
+                    // After a failure the in-memory Raft state may be ahead of the persisted
+                    // state, so it is not safe to reuse. Drop the failed instance and rebuild
+                    // from persisted state, exactly like a process restart would.
+                    drop(consensus);
+
+                    let mut last_err = err;
+
+                    consensus = loop {
+                        restart_attempt += 1;
+
+                        state_ref_clone.on_consensus_thread_err(format!(
+                            "{last_err:#}; \
+                             restarting consensus thread \
+                             (attempt {restart_attempt}, next attempt in {} sec)",
+                            backoff.as_secs(),
+                        ));
+
+                        log::info!(
+                            "Restarting consensus thread in {} sec (attempt {restart_attempt})",
+                            backoff.as_secs(),
+                        );
+
+                        thread::sleep(backoff);
+                        backoff = cmp::min(backoff * 2, CONSENSUS_RESTART_MAX_BACKOFF);
+
+                        // Rebuilding from persisted state is equivalent to a process restart,
+                        // except `reinit` is never repeated: WAL clearing/compaction on reinit
+                        // must happen at most once per process start.
+                        let rebuilt = Self::new(
+                            &logger_clone,
+                            state_ref_clone.clone(),
+                            bootstrap_peer.clone(),
+                            uri.clone(),
+                            p2p_port,
+                            config.clone(),
+                            tls_client_config.clone(),
+                            channel_service_clone.clone(),
+                            runtime_clone.clone(),
+                            false,
+                        );
+
+                        match rebuilt {
+                            Ok(consensus) => break consensus,
+                            Err(err) => {
+                                log::error!("Failed to restart consensus: {err:#}");
+                                last_err = err;
+                            }
+                        }
+                    };
+
+                    log::info!("Consensus thread restarted after failure");
+                    state_ref_clone.record_consensus_working();
                 }
             })?;
 
@@ -186,7 +280,7 @@ impl Consensus {
         channel_service: ChannelService,
         runtime: Handle,
         reinit: bool,
-    ) -> anyhow::Result<(Self, Sender<Message>)> {
+    ) -> anyhow::Result<Self> {
         // If we want to re-initialize consensus, we need to prevent other peers
         // from re-playing consensus WAL operations, as they should already have them applied.
         // Do ensure that we are forcing compacting WAL on the first re-initialized peer,
@@ -211,8 +305,6 @@ impl Consensus {
             ..Default::default()
         };
         raft_config.validate()?;
-        // bounded channel for backpressure
-        let (sender, receiver) = tokio::sync::mpsc::channel(config.max_message_queue_size);
         // State might be initialized but the node might be shutdown without actually syncing or committing anything.
         if state_ref.is_new_deployment() || reinit {
             let leader_established_in_ms =
@@ -273,7 +365,6 @@ impl Consensus {
 
         let consensus = Self {
             node,
-            receiver,
             runtime,
             config,
             broker,
@@ -284,7 +375,7 @@ impl Consensus {
             state_ref.recover_first_voter()?;
         }
 
-        Ok((consensus, sender))
+        Ok(consensus)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -478,7 +569,7 @@ impl Consensus {
         Ok(())
     }
 
-    pub fn start(&mut self) -> anyhow::Result<()> {
+    pub fn start(&mut self, receiver: &mut Receiver<Message>) -> anyhow::Result<()> {
         // If this is the only peer in the cluster, tick Raft node a few times to instantly
         // self-elect itself as Raft leader
         if self.node.store().peer_count() == 1 {
@@ -498,7 +589,7 @@ impl Consensus {
 
         loop {
             // Wait (for up to `tick_period`) for incoming client requests and Raft messages
-            let raft_messages = self.advance_node(tick_period)?;
+            let raft_messages = self.advance_node(receiver, tick_period)?;
 
             // Calculate how many ticks passed since the last one
             let elapsed_ticks = previous_tick.elapsed().div_duration_f32(tick_period) as u32;
@@ -561,7 +652,11 @@ impl Consensus {
         }
     }
 
-    fn advance_node(&mut self, tick_period: Duration) -> anyhow::Result<usize> {
+    fn advance_node(
+        &mut self,
+        receiver: &mut Receiver<Message>,
+        tick_period: Duration,
+    ) -> anyhow::Result<usize> {
         if self
             .try_promote_learner()
             .context("failed to promote learner")?
@@ -590,7 +685,7 @@ impl Consensus {
         let mut raft_messages = 0;
 
         loop {
-            let Ok(message) = self.recv_update(timeout_at) else {
+            let Ok(message) = self.recv_update(receiver, timeout_at) else {
                 break;
             };
 
@@ -630,11 +725,15 @@ impl Consensus {
         Ok(raft_messages)
     }
 
-    fn recv_update(&mut self, timeout_at: Instant) -> Result<Message, TryRecvUpdateError> {
+    fn recv_update(
+        &self,
+        receiver: &mut Receiver<Message>,
+        timeout_at: Instant,
+    ) -> Result<Message, TryRecvUpdateError> {
         self.runtime.block_on(async {
             tokio::select! {
                 biased;
-                message = self.receiver.recv() => message.ok_or(TryRecvUpdateError::Closed),
+                message = receiver.recv() => message.ok_or(TryRecvUpdateError::Closed),
                 _ = tokio::time::sleep_until(timeout_at.into()) => Err(TryRecvUpdateError::Timeout),
             }
         })
@@ -1523,13 +1622,16 @@ mod tests {
         let dispatcher =
             Dispatcher::new(toc_arc.clone()).with_consensus(consensus_state.clone(), true);
         let slog_logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), slog::o!());
-        let (mut consensus, message_sender) = Consensus::new(
+        let consensus_config = ConsensusConfig::default();
+        let (message_sender, mut message_receiver) =
+            tokio::sync::mpsc::channel(consensus_config.max_message_queue_size);
+        let mut consensus = Consensus::new(
             &slog_logger,
             consensus_state.clone(),
             None,
             Some("http://127.0.0.1:6335".parse().unwrap()),
             6335,
-            ConsensusConfig::default(),
+            consensus_config,
             None,
             ChannelService::new(
                 settings.service.http_port,
@@ -1543,7 +1645,7 @@ mod tests {
         .unwrap();
 
         let is_leader_established = consensus_state.is_leader_established.clone();
-        thread::spawn(move || consensus.start().unwrap());
+        thread::spawn(move || consensus.start(&mut message_receiver).unwrap());
         thread::spawn(move || {
             while let Ok(entry) = propose_receiver.recv() {
                 if message_sender

--- a/tests/consensus_tests/test_consensus_restart_on_transient_error.py
+++ b/tests/consensus_tests/test_consensus_restart_on_transient_error.py
@@ -1,0 +1,134 @@
+"""
+Test that the consensus thread automatically restarts after a transient error
+while applying a committed operation.
+
+Uses the staging-only `test_transient_error` cluster operation, which fails with the
+given probability when applied on the targeted peer, stopping its consensus thread
+with a service error. Requires the `staging` cargo feature to be enabled in the
+qdrant binary under test.
+"""
+
+import pathlib
+
+import pytest
+
+from .fixtures import create_collection
+from .utils import *
+
+COLLECTION_NAME = "test_collection"
+
+# Failure probability of a single roll. Applying the poisoned entry is retried on every
+# consensus thread restart (with exponential backoff between attempts), so higher values
+# make the test slower: the entry has to pass the roll for the peer to recover.
+FAILURE_PROBABILITY = 0.3
+
+# P(no failure triggered) = (1 - FAILURE_PROBABILITY) ^ MAX_PROPOSALS ~= 0.01%
+MAX_PROPOSALS = 25
+
+# Recovery requires the poisoned entry to pass its rolls; with backoff doubling from 1s
+# this covers ~9 consecutive failed restart attempts (P < 0.5%)
+RECOVERY_TIMEOUT_SEC = 600
+
+
+def propose_transient_error(peer_api_uri: str, target_peer_id: int) -> requests.Response:
+    return requests.post(
+        f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster?timeout=20",
+        json={
+            "test_transient_error": {
+                "peer_id": target_peer_id,
+                "failure_probability": FAILURE_PROBABILITY,
+            }
+        },
+    )
+
+
+def consensus_status(peer_api_uri: str) -> dict:
+    return get_cluster_info(peer_api_uri)["consensus_thread_status"]
+
+
+def check_consensus_restarting(peer_api_uri: str) -> bool:
+    status = consensus_status(peer_api_uri)
+    return "restarting consensus thread" in status.get("err", "")
+
+
+def check_peer_recovered(peer_api_uris: list, target_uri: str) -> bool:
+    if consensus_status(target_uri)["consensus_thread_status"] != "working":
+        return False
+    commits = set()
+    for uri in peer_api_uris:
+        info = get_cluster_info(uri)
+        commits.add(info["raft_info"]["commit"])
+        if info["raft_info"]["pending_operations"] != 0:
+            return False
+    return len(commits) == 1
+
+
+def test_consensus_restart_on_transient_error(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_api_uris, _peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 3)
+
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=3)
+    wait_for_uniform_collection_existence(COLLECTION_NAME, peer_api_uris)
+
+    # Target a follower, so the rest of the cluster keeps a quorum while it is down.
+    # Propose through the target itself: when the roll fails on the proposing peer,
+    # the API returns the simulated error, so the failure is detected deterministically.
+    leader = get_leader(peer_api_uris[0])
+    target_uri = next(
+        uri for uri in peer_api_uris if get_cluster_info(uri)["peer_id"] != leader
+    )
+    target_peer_id = get_cluster_info(target_uri)["peer_id"]
+    healthy_uris = [uri for uri in peer_api_uris if uri != target_uri]
+
+    triggered = False
+    for i in range(MAX_PROPOSALS):
+        resp = propose_transient_error(target_uri, target_peer_id)
+
+        # `ClusterOperations` is an untagged enum, unsupported operations are reported
+        # as not matching any variant
+        if resp.status_code == 400 and "did not match any variant" in resp.text:
+            pytest.skip("qdrant is built without the `staging` feature")
+
+        if resp.ok:
+            # Applied without failure on the target, roll again
+            continue
+
+        assert "TestTransientError" in resp.text, resp.text
+        print(f"Triggered transient consensus error after {i + 1} proposals")
+        triggered = True
+        break
+
+    assert triggered, f"No transient error triggered in {MAX_PROPOSALS} proposals"
+
+    # The target peer must report the restart loop being engaged
+    wait_for(check_consensus_restarting, target_uri, wait_for_timeout=5)
+
+    # The rest of the cluster keeps working while the target peer is down
+    create_collection(
+        healthy_uris[0],
+        collection="collection_during_outage",
+        shard_number=1,
+        replication_factor=2,
+    )
+    for uri in healthy_uris:
+        wait_for_collection(uri, "collection_during_outage")
+
+    # The target peer eventually re-applies the poisoned entry successfully,
+    # recovers its consensus thread and catches up with the cluster
+    wait_for(
+        check_peer_recovered,
+        peer_api_uris,
+        target_uri,
+        wait_for_timeout=RECOVERY_TIMEOUT_SEC,
+        wait_for_interval=1,
+    )
+
+    # Consensus operations propagate to the recovered peer again
+    create_collection(
+        peer_api_uris[0],
+        collection="collection_after_recovery",
+        shard_number=1,
+        replication_factor=3,
+    )
+    wait_for_uniform_collection_existence("collection_after_recovery", peer_api_uris)


### PR DESCRIPTION
## Problem

If the consensus loop fails (e.g. a transient I/O error such as running out of disk space), the consensus thread stops permanently. Even after the underlying issue is resolved (disk extended), the only way to recover is a full service restart, causing avoidable downtime.

## Changes

**Supervisor loop around the consensus thread.** When `Consensus::start()` returns an error, the thread drops the failed instance and rebuilds it from persisted state, retrying with exponential backoff: 1s initial, doubled up to a 5-minute cap, retrying indefinitely. If consensus ran for at least 5 minutes before failing, backoff starts from scratch again. A graceful stop (peer removal) still exits the thread for good.

**Safety.** The in-memory Raft node is never resumed after a failure — it may be ahead of persisted state (e.g. `append_entries` succeeded but `set_hard_state` failed). Each attempt reconstructs the node from WAL + persisted hard state and re-applies unapplied committed entries, which is exactly what a process restart does today. So retrying introduces no failure modes that a crash-restart doesn't already have. The `reinit` logic (WAL clearing/forced compaction) is never repeated on restart attempts, and initial startup remains fail-fast: if consensus can't be initialized on boot, Qdrant fails to start as before.

**Message channel survives restarts.** The consensus mpsc channel is now created in `Consensus::run()` rather than inside `Consensus::new()`, and the receiver is passed to `start()` instead of being owned by `Consensus`. Internal gRPC handlers and the forward-proposals thread keep their senders across restarts, and messages buffered during the outage (bounded by `max_message_queue_size`) are drained after recovery.

**Status reporting.** While in restart backoff, the node reports the existing `StoppedWithErr` cluster status with the original error plus `restarting consensus thread (attempt N, next attempt in X sec)` appended, and flips back to `Working` after a successful restart. `/metrics` shows `cluster_working_state{state="stopped"}` during the outage, so existing alerting keeps firing. No REST/gRPC schema changes; a dedicated `Restarting` status variant could be a follow-up if we want it machine-readable.

Side effect: errors from `try_promote_learner` previously killed consensus permanently; they now also go through the restart path.

## Testing

- `cargo test --bin qdrant` — 150/150 pass (the existing `collection_creation_passes_consensus` test exercises the new channel/receiver plumbing end to end)
- clippy clean
- Failure path covered by a new staging-only `test_transient_error` cluster operation (mirroring `test_slow_down`): applying it fails with the given probability on the targeted peer, stopping its consensus thread. The new `test_consensus_restart_on_transient_error` integration test poisons a follower in a 3-peer cluster and asserts the restart loop engages, the remaining peers keep a working quorum, and the failed peer recovers and catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
