### PR TITLE
Trace-log "Missing request message." internal gRPC errors

### DIFF
--- a/src/tonic/logging.rs
+++ b/src/tonic/logging.rs
@@ -77,6 +77,18 @@ where
                                     elapsed_sec,
                                 );
                             }
+                            // A client dropping a unary call between HEADERS and DATA
+                            // surfaces as this internal error rather than `Cancelled`,
+                            // because hyper 1.x hides stream resets during request body
+                            // read (hyperium/hyper#3681). Cluster mode generates these
+                            // routinely by cancelling fanned-out read requests.
+                            Code::Internal
+                                if grpc_status.message() == "Missing request message." =>
+                            {
+                                log::trace!(
+                                    "gRPC cancelled before request message {method_name} {elapsed_sec:.6}"
+                                );
+                            }
                             Code::Internal
                             | Code::Unimplemented
                             | Code::Unavailable


### PR DESCRIPTION
## Problem

After upgrading production clusters to v1.18.2, logs fill with spurious ERROR lines:

```
ERROR qdrant::tonic::logging: gRPC /qdrant.PointsInternal/Get unexpectedly failed with Internal error "Missing request message." 0.000015
```

No API failures accompany them.

## Root cause

The status is generated inside tonic's server (`map_request_unary`): if a unary request's body stream ends before a message arrives, tonic returns `Internal "Missing request message."`. The underlying event is a peer node cancelling an in-flight internal request — read fan-out intentionally drops surplus replica requests once enough responses arrive, which sends `RST_STREAM(CANCEL)`.

Before v1.18.2 (tonic 0.11 / hyper 0.14) this surfaced as `Code::Cancelled`, which the logging middleware already trace-logs. The tonic 0.14.6 upgrade (#9139) moved the server onto hyper 1.x, which deliberately swallows client `RST_STREAM(CANCEL/NO_ERROR)` during request-body reads and reports clean end-of-stream instead (hyperium/hyper#3681). A cancellation landing between HEADERS and DATA now decodes as an empty body → `Internal "Missing request message."` → ERROR log. Same benign event, new disguise; the microsecond latencies in the log lines confirm the handler never ran.

## Fix

Tonic can't distinguish this from a genuinely empty request because hyper hides the reset, so handle it in our logging middleware: match `Code::Internal` with the `"Missing request message."` message and trace-log it, mirroring the existing `Cancelled` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)