### PR TITLE
fix: resolve cancellation safety bug in queue_proxify_local

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -90,6 +90,27 @@ impl QueueProxyShard {
         }
     }
 
+    /// Create a queue proxy shard from prevalidated details.
+    ///
+    /// This is synchronous and cannot fail.
+    pub fn new_prevalidated(
+        wrapped_shard: LocalShard,
+        remote_shard: RemoteShard,
+        wal_keep_from: Arc<AtomicU64>,
+        version: u64,
+        progress: Arc<ParkingMutex<TransferTaskProgress>>,
+    ) -> Self {
+        Self {
+            inner: Some(Inner::new_from_version(
+                wrapped_shard,
+                remote_shard,
+                wal_keep_from,
+                version,
+                progress,
+            )),
+        }
+    }
+
     /// Queue proxy the given local shard and point to the remote shard, from a specific WAL version.
     ///
     /// This queues all (existing) updates from a specific WAL `version` and onwards. In other

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -13,6 +13,38 @@ use crate::shards::queue_proxy_shard::QueueProxyShard;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::Shard;
 use crate::shards::transfer::transfer_tasks_pool::TransferTaskProgress;
+use crate::shards::local_shard::LocalShard;
+
+// Whitebox hook for stopping in the cancellation window after `local.take()`.
+#[cfg(test)]
+static QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK: std::sync::Mutex<
+    Option<tokio::sync::oneshot::Sender<()>>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn notify_queue_proxify_local_after_take() {
+    if let Some(sender) = QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK
+        .lock()
+        .unwrap()
+        .take()
+    {
+        let _ = sender.send(());
+    }
+}
+
+struct TakenLocalShardGuard<'a> {
+    slot: &'a mut Option<Shard>,
+    local_shard: Option<LocalShard>,
+}
+
+impl Drop for TakenLocalShardGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(local_shard) = self.local_shard.take() {
+            log::warn!("Reverting taken local shard due to cancel or panic");
+            self.slot.get_or_insert(Shard::Local(local_shard));
+        }
+    }
+}
 
 impl ShardReplicaSet {
     /// Convert `Local` shard into `ForwardProxy`.
@@ -163,7 +195,7 @@ impl ShardReplicaSet {
             }
         };
 
-        // Get `max_ack_version` without "taking" local shard (to maintain cancel safety)
+        // Get `wal_keep_from` and start `version` without "taking" local shard (to maintain cancel safety)
         let local_shard = match local.deref() {
             Some(Shard::Local(local)) => local,
             Some(Shard::ForwardProxy(proxy)) => &proxy.wrapped_shard,
@@ -177,45 +209,58 @@ impl ShardReplicaSet {
             .wal_keep_from
             .clone();
 
+        let version = match from_version {
+            None => {
+                let wal = local_shard.wal.wal.clone();
+                wal.lock().await.last_index() + 1
+            }
+            Some(version) => {
+                let wal = local_shard.wal.wal.clone();
+                let wal_lock = wal.lock().await;
+
+                // If start version is not in current WAL bounds [first_idx, last_idx + 1], we cannot reliably transfer WAL
+                // Allow it to be one higher than the last index to only send new updates
+                let (first_idx, last_idx) = (wal_lock.first_closed_index(), wal_lock.last_index());
+                if !(first_idx..=last_idx + 1).contains(&version) {
+                    return Err(CollectionError::service_error(format!(
+                        "Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})",
+                    )));
+                }
+                version
+            }
+        };
+
         // Proxify local shard
-        //
-        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
         let local_shard = match local.take() {
             Some(Shard::Local(local)) => local,
             Some(Shard::ForwardProxy(proxy)) => proxy.wrapped_shard,
             _ => unreachable!(),
         };
 
-        // Try to queue proxify with or without version
-        let proxy_shard = match from_version {
-            None => {
-                Ok(QueueProxyShard::new(local_shard, remote_shard, wal_keep_from, progress).await)
-            }
-            Some(from_version) => {
-                QueueProxyShard::new_from_version(
-                    local_shard,
-                    remote_shard,
-                    wal_keep_from,
-                    from_version,
-                    progress,
-                )
-                .await
-            }
+        // Guard to restore local shard in case of cancellation or panic while we construct the proxy
+        let mut guard = TakenLocalShardGuard {
+            slot: &mut local,
+            local_shard: Some(local_shard),
         };
 
-        // Insert queue proxy shard on success or revert to local shard on failure
-        match proxy_shard {
-            // All good, insert queue proxy shard
-            Ok(proxy_shard) => {
-                let _ = local.insert(Shard::QueueProxy(proxy_shard));
-                Ok(())
-            }
-            Err((local_shard, err)) => {
-                log::warn!("Failed to queue proxify shard, reverting to local shard: {err}");
-                let _ = local.insert(Shard::Local(local_shard));
-                Err(err)
-            }
-        }
+        #[cfg(test)]
+        notify_queue_proxify_local_after_take();
+
+        #[cfg(test)]
+        // Yield to allow the test to cancel us while the shard is taken and the guard is active
+        tokio::task::yield_now().await;
+
+        let proxy_shard = QueueProxyShard::new_prevalidated(
+            guard.local_shard.take().unwrap(),
+            remote_shard,
+            wal_keep_from,
+            version,
+            progress,
+        );
+
+        let _ = guard.slot.insert(Shard::QueueProxy(proxy_shard));
+
+        Ok(())
     }
 
     /// Un-proxify local shard wrapped as `ForwardProxy` or `QueueProxy`.
@@ -522,5 +567,147 @@ impl ShardReplicaSet {
         };
 
         local_shard.wal_version().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+
+    use common::budget::ResourceBudget;
+    use common::save_on_disk::SaveOnDisk;
+    use segment::types::Distance;
+    use tempfile::{Builder, TempDir};
+    use tokio::runtime::Handle;
+    use tokio::sync::{RwLock, oneshot};
+
+    use super::*;
+    use crate::collection::payload_index_schema::PayloadIndexSchema;
+    use crate::common::adaptive_handle::AdaptiveSearchHandle;
+    use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+    use crate::operations::shared_storage_config::SharedStorageConfig;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::optimizers_builder::OptimizersConfig;
+    use crate::shards::channel_service::ChannelService;
+    use crate::shards::replica_set::replica_set_state::ReplicaState;
+    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cancel_queue_proxify_after_local_take_drops_local_shard() {
+        let collection_dir = Builder::new()
+            .prefix("queue-proxy-cancel")
+            .tempdir()
+            .unwrap();
+        let replica_set = new_shard_replica_set(&collection_dir).await;
+
+        let (after_take_tx, after_take_rx) = oneshot::channel();
+        install_queue_proxify_local_after_take_hook(after_take_tx);
+
+        let remote_shard = RemoteShard::new(
+            replica_set.shard_id,
+            replica_set.collection_id.clone(),
+            2,
+            ChannelService::default(),
+        );
+        let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
+        let cancel = cancel::CancellationToken::new();
+
+        let queue_proxify = replica_set.queue_proxify_local(remote_shard, None, progress);
+        let cancelable_queue_proxify =
+            cancel::future::cancel_on_token(cancel.clone(), queue_proxify);
+        tokio::pin!(cancelable_queue_proxify);
+
+        tokio::select! {
+            _ = after_take_rx => {}
+            result = &mut cancelable_queue_proxify => {
+                panic!("queue proxification completed before the cancellation window: {result:?}");
+            }
+        }
+
+        cancel.cancel();
+        let result = cancelable_queue_proxify.await;
+        assert!(matches!(result, Err(cancel::Error::Cancelled)));
+
+        assert!(
+            replica_set.has_local_shard().await,
+            "queue_proxification cancellation must not drop the local shard slot"
+        );
+    }
+
+    fn install_queue_proxify_local_after_take_hook(sender: oneshot::Sender<()>) {
+        let mut hook = QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK.lock().unwrap();
+        assert!(hook.is_none(), "queue-proxify test hook is already installed");
+        *hook = Some(sender);
+    }
+
+    async fn new_shard_replica_set(collection_dir: &TempDir) -> ShardReplicaSet {
+        let update_runtime = Handle::current();
+        let search_runtime = AdaptiveSearchHandle::current_for_tests();
+
+        let wal_config = WalConfig {
+            wal_capacity_mb: 1,
+            wal_segments_ahead: 0,
+            wal_retain_closed: 1,
+        };
+
+        let collection_params = CollectionParams {
+            vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+            shard_number: NonZeroU32::new(1).unwrap(),
+            replication_factor: NonZeroU32::new(1).unwrap(),
+            write_consistency_factor: NonZeroU32::new(1).unwrap(),
+            ..CollectionParams::empty()
+        };
+
+        let optimizers_config = OptimizersConfig::fixture();
+        let config = CollectionConfigInternal {
+            params: collection_params,
+            optimizer_config: optimizers_config.clone(),
+            wal_config,
+            hnsw_config: Default::default(),
+            quantization_config: None,
+            strict_mode_config: None,
+            uuid: None,
+            metadata: None,
+        };
+
+        let payload_index_schema_file = collection_dir.path().join("payload-schema.json");
+        let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> = Arc::new(
+            SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap(),
+        );
+        let shared_config = Arc::new(RwLock::new(config));
+
+        ShardReplicaSet::build(
+            1,
+            None,
+            "test_collection".to_string(),
+            1,
+            true,
+            HashSet::from([2]),
+            dummy_on_replica_failure(),
+            dummy_abort_shard_transfer(),
+            collection_dir.path(),
+            shared_config,
+            optimizers_config,
+            Arc::new(SharedStorageConfig::default()),
+            payload_index_schema,
+            ChannelService::default(),
+            update_runtime,
+            search_runtime,
+            ResourceBudget::default(),
+            Some(ReplicaState::Active),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn dummy_on_replica_failure() -> ChangePeerFromState {
+        Arc::new(move |_peer_id, _shard_id, _from_state| {})
+    }
+
+    fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+        Arc::new(|_shard_transfer, _reason| {})
     }
 }

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -8,12 +8,12 @@ use super::ShardReplicaSet;
 use crate::hash_ring::HashRingRouter;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::forward_proxy_shard::{ForwardProxyShard, PreparedTransferBatch};
+use crate::shards::local_shard::LocalShard;
 use crate::shards::local_shard::clock_map::RecoveryPoint;
 use crate::shards::queue_proxy_shard::QueueProxyShard;
 use crate::shards::remote_shard::RemoteShard;
 use crate::shards::shard::Shard;
 use crate::shards::transfer::transfer_tasks_pool::TransferTaskProgress;
-use crate::shards::local_shard::LocalShard;
 
 // Whitebox hook for stopping in the cancellation window after `local.take()`.
 #[cfg(test)]
@@ -23,11 +23,7 @@ static QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK: std::sync::Mutex<
 
 #[cfg(test)]
 fn notify_queue_proxify_local_after_take() {
-    if let Some(sender) = QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK
-        .lock()
-        .unwrap()
-        .take()
-    {
+    if let Some(sender) = QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK.lock().unwrap().take() {
         let _ = sender.send(());
     }
 }
@@ -220,7 +216,8 @@ impl ShardReplicaSet {
             Some(version) => {
                 // If start version is not in current WAL bounds [first_idx, last_idx + 1], we cannot reliably transfer WAL
                 // Allow it to be one higher than the last index to only send new updates
-                let (first_idx, last_idx) = (_wal_lock.first_closed_index(), _wal_lock.last_index());
+                let (first_idx, last_idx) =
+                    (_wal_lock.first_closed_index(), _wal_lock.last_index());
                 if !(first_idx..=last_idx + 1).contains(&version) {
                     return Err(CollectionError::service_error(format!(
                         "Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})",
@@ -712,7 +709,10 @@ mod tests {
 
     fn install_queue_proxify_local_after_take_hook(sender: oneshot::Sender<()>) {
         let mut hook = QUEUE_PROXIFY_LOCAL_AFTER_TAKE_HOOK.lock().unwrap();
-        assert!(hook.is_none(), "queue-proxify test hook is already installed");
+        assert!(
+            hook.is_none(),
+            "queue-proxify test hook is already installed"
+        );
         *hook = Some(sender);
     }
 
@@ -747,9 +747,8 @@ mod tests {
         };
 
         let payload_index_schema_file = collection_dir.path().join("payload-schema.json");
-        let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> = Arc::new(
-            SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap(),
-        );
+        let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
+            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
         let shared_config = Arc::new(RwLock::new(config));
 
         ShardReplicaSet::build(

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -34,14 +34,14 @@ fn notify_queue_proxify_local_after_take() {
 
 struct TakenLocalShardGuard<'a> {
     slot: &'a mut Option<Shard>,
-    local_shard: Option<LocalShard>,
+    original_shard: Option<Shard>,
 }
 
 impl Drop for TakenLocalShardGuard<'_> {
     fn drop(&mut self) {
-        if let Some(local_shard) = self.local_shard.take() {
-            log::warn!("Reverting taken local shard due to cancel or panic");
-            self.slot.get_or_insert(Shard::Local(local_shard));
+        if let Some(original_shard) = self.original_shard.take() {
+            log::warn!("Reverting taken shard due to cancel or panic");
+            self.slot.get_or_insert(original_shard);
         }
     }
 }
@@ -199,7 +199,10 @@ impl ShardReplicaSet {
         let local_shard = match local.deref() {
             Some(Shard::Local(local)) => local,
             Some(Shard::ForwardProxy(proxy)) => &proxy.wrapped_shard,
-            _ => unreachable!(),
+            Some(Shard::Proxy(_)) => unreachable!(),
+            Some(Shard::QueueProxy(_)) => unreachable!(),
+            Some(Shard::Dummy(_)) => unreachable!(),
+            None => unreachable!(),
         };
 
         let wal_keep_from = local_shard
@@ -209,18 +212,15 @@ impl ShardReplicaSet {
             .wal_keep_from
             .clone();
 
-        let version = match from_version {
-            None => {
-                let wal = local_shard.wal.wal.clone();
-                wal.lock().await.last_index() + 1
-            }
-            Some(version) => {
-                let wal = local_shard.wal.wal.clone();
-                let wal_lock = wal.lock().await;
+        let wal = local_shard.wal.wal.clone();
+        let _wal_lock = wal.lock().await;
 
+        let version = match from_version {
+            None => _wal_lock.last_index() + 1,
+            Some(version) => {
                 // If start version is not in current WAL bounds [first_idx, last_idx + 1], we cannot reliably transfer WAL
                 // Allow it to be one higher than the last index to only send new updates
-                let (first_idx, last_idx) = (wal_lock.first_closed_index(), wal_lock.last_index());
+                let (first_idx, last_idx) = (_wal_lock.first_closed_index(), _wal_lock.last_index());
                 if !(first_idx..=last_idx + 1).contains(&version) {
                     return Err(CollectionError::service_error(format!(
                         "Cannot create queue proxy shard from version {version} because it is out of WAL bounds ({first_idx}..={last_idx})",
@@ -231,16 +231,19 @@ impl ShardReplicaSet {
         };
 
         // Proxify local shard
-        let local_shard = match local.take() {
-            Some(Shard::Local(local)) => local,
-            Some(Shard::ForwardProxy(proxy)) => proxy.wrapped_shard,
-            _ => unreachable!(),
+        let original_shard = match local.take() {
+            Some(shard @ Shard::Local(_)) => shard,
+            Some(shard @ Shard::ForwardProxy(_)) => shard,
+            Some(Shard::Proxy(_)) => unreachable!(),
+            Some(Shard::QueueProxy(_)) => unreachable!(),
+            Some(Shard::Dummy(_)) => unreachable!(),
+            None => unreachable!(),
         };
 
         // Guard to restore local shard in case of cancellation or panic while we construct the proxy
         let mut guard = TakenLocalShardGuard {
             slot: &mut local,
-            local_shard: Some(local_shard),
+            original_shard: Some(original_shard),
         };
 
         #[cfg(test)]
@@ -250,8 +253,17 @@ impl ShardReplicaSet {
         // Yield to allow the test to cancel us while the shard is taken and the guard is active
         tokio::task::yield_now().await;
 
+        let original_shard = guard.original_shard.take().unwrap();
+        let local_shard = match original_shard {
+            Shard::Local(local) => local,
+            Shard::ForwardProxy(proxy) => proxy.wrapped_shard,
+            Shard::Proxy(_) => unreachable!(),
+            Shard::QueueProxy(_) => unreachable!(),
+            Shard::Dummy(_) => unreachable!(),
+        };
+
         let proxy_shard = QueueProxyShard::new_prevalidated(
-            guard.local_shard.take().unwrap(),
+            local_shard,
             remote_shard,
             wal_keep_from,
             version,
@@ -635,6 +647,67 @@ mod tests {
             replica_set.has_local_shard().await,
             "queue_proxification cancellation must not drop the local shard slot"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cancel_queue_proxify_from_forward_proxy_restores_forward_proxy() {
+        let collection_dir = Builder::new()
+            .prefix("queue-proxy-cancel-fp")
+            .tempdir()
+            .unwrap();
+        let replica_set = new_shard_replica_set(&collection_dir).await;
+
+        let remote_shard = RemoteShard::new(
+            replica_set.shard_id,
+            replica_set.collection_id.clone(),
+            2,
+            ChannelService::default(),
+        );
+
+        // Turn local shard into ForwardProxy first
+        replica_set
+            .proxify_local(remote_shard.clone(), None, None)
+            .await
+            .unwrap();
+
+        // Verify it is a ForwardProxy now
+        {
+            let local = replica_set.local.read().await;
+            assert!(matches!(local.deref(), Some(Shard::ForwardProxy(_))));
+        }
+
+        let (after_take_tx, after_take_rx) = oneshot::channel();
+        install_queue_proxify_local_after_take_hook(after_take_tx);
+
+        let progress = Arc::new(Mutex::new(TransferTaskProgress::new()));
+        let cancel = cancel::CancellationToken::new();
+
+        let queue_proxify = replica_set.queue_proxify_local(remote_shard, None, progress);
+        let cancelable_queue_proxify =
+            cancel::future::cancel_on_token(cancel.clone(), queue_proxify);
+        tokio::pin!(cancelable_queue_proxify);
+
+        tokio::select! {
+            _ = after_take_rx => {}
+            result = &mut cancelable_queue_proxify => {
+                panic!("queue proxification completed before the cancellation window: {result:?}");
+            }
+        }
+
+        cancel.cancel();
+        let result = cancelable_queue_proxify.await;
+        assert!(matches!(result, Err(cancel::Error::Cancelled)));
+
+        // Verify that the shard was restored specifically as a ForwardProxy (and not Local or None)
+        let local = replica_set.local.read().await;
+        match local.deref() {
+            Some(Shard::ForwardProxy(_)) => {}
+            Some(Shard::Local(_)) => panic!("Restored as Local instead of ForwardProxy"),
+            Some(Shard::Proxy(_)) => panic!("Restored as Proxy"),
+            Some(Shard::QueueProxy(_)) => panic!("Restored as QueueProxy"),
+            Some(Shard::Dummy(_)) => panic!("Restored as Dummy"),
+            None => panic!("Restored as None"),
+        }
     }
 
     fn install_queue_proxify_local_after_take_hook(sender: oneshot::Sender<()>) {


### PR DESCRIPTION
## Fixes: #9665 
Avoid awaiting while local shard is temporarily removed from `self.local`.
- Perform all async WAL/version checks before calling `local.take()`.
- Add `QueueProxyShard::new_prevalidated()` synchronous constructor.
- Introduce `TakenLocalShardGuard` to restore `Shard::Local` on drop.
- Add a regression test to verify cancel safety.

### Detailed Description

**Background & Root Cause:**
As detailed in the issue, `ShardReplicaSet::queue_proxify_local` contained a cancellation window vulnerability. The function temporarily removed the current local shard from `self.local` with `local.take()`, making the slot `None`. Following this, it awaited `QueueProxyShard::new(...)` or `new_from_version(...)`—which awaits the WAL lock—before reinserting either the new `Shard::QueueProxy` or reverting to the original `Shard::Local`.

If shard transfers were cancelled at this exact `await` boundary, the in-progress future was dropped by the transfer driver's cancellation token. Consequently:
- `self.local` remained set to `None`.
- The taken `LocalShard` was owned only by the cancelled future and was permanently dropped.
- The replica set was left in an unrecoverable state where `has_local_shard() == false`, causing an observable in-memory state-machine gap.

**Implemented Fixes:**
To guarantee absolute cancel safety across this transition, this PR implements the following changes:

1. **Shifted Async Checks Before `local.take()`:**
   Instead of taking the shard first, we borrow the local shard to perform all async operations and version bounds checks (`update_handler.lock().await` and `wal.lock().await`) while the local shard is still safely present in `self.local`.

2. **Synchronous Queue Proxy Construction:**
   Introduced a new synchronous constructor `QueueProxyShard::new_prevalidated()`. This constructor builds the proxy shard using the pre-calculated, validated WAL start version without any `.await` calls.

3. **`TakenLocalShardGuard` (RAII Recovery):**
   Added a small drop guard (`TakenLocalShardGuard`) that wraps the taken local shard during the critical section. If the task panics or gets dropped unexpectedly between `local.take()` and the final proxy insertion, the guard’s `Drop` implementation will seamlessly revert `self.local` back to `Shard::Local`.

4. **Whitebox Regression Testing:**
   Appended `test_cancel_queue_proxify_after_local_take_drops_local_shard` to verify the fix. The test utilizes a synchronous test hook (`notify_queue_proxify_local_after_take`) combined with `tokio::task::yield_now().await` to artificially create a cancellation point precisely inside the take-and-insert window. When cancelled at this yield point, the test asserts that `has_local_shard().await == true`, verifying that the RAII guard successfully prevents the loss of the local shard.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
