### PR TITLE
Explicit HNSW links residency: cold / cached / pinned

### DIFF
--- a/lib/segment/benches/fixture.rs
+++ b/lib/segment/benches/fixture.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::time::Duration;
 
 use common::types::PointOffsetType;
-use common::universal_io::Populate;
 use fs_err as fs;
 use rand::SeedableRng as _;
 use rand::rngs::StdRng;
@@ -11,7 +10,7 @@ use segment::fixtures::index_fixtures::TestRawScorerProducer;
 use segment::index::hnsw_index::HnswM;
 use segment::index::hnsw_index::graph_layers::GraphLayers;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
-use segment::index::hnsw_index::graph_links::GraphLinksFormatParam;
+use segment::index::hnsw_index::graph_links::{GraphLinksFormatParam, GraphLinksResidency};
 use segment::index::hnsw_index::hnsw::SINGLE_THREADED_HNSW_BUILD_THRESHOLD;
 use segment::spaces::metric::Metric;
 
@@ -55,7 +54,7 @@ where
         let updated_ago = updated_ago(&graph_layers_path).unwrap_or_else(|_| "???".to_string());
         eprintln!("Loading cached links (built {updated_ago} ago) from {graph_layers_path:?}.");
         eprintln!("Delete the directory above if code related to HNSW graph building is changed");
-        GraphLayers::load(&path, Populate::Blocking, false).unwrap()
+        GraphLayers::load(&path, GraphLinksResidency::Cached, false).unwrap()
     } else {
         let mut graph_layers_builder =
             GraphLayersBuilder::new(num_vectors, HnswM::new2(m), ef_construct, 10, use_heuristic);

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -33,14 +33,14 @@ use std::sync::atomic::AtomicBool;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::fs::atomic_save;
 use common::types::{PointOffsetType, ScoredPointOffset};
-use common::universal_io::{MmapFs, Populate, UniversalReadFs, read_bin_via};
+use common::universal_io::{MmapFs, UniversalReadFs, read_bin_via};
 use fs_err as fs;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::HnswM;
 use super::entry_points::{EntryPoint, EntryPoints};
-use super::graph_links::{GraphLinks, GraphLinksFormat};
+use super::graph_links::{GraphLinks, GraphLinksFormat, GraphLinksResidency};
 use crate::common::operation_error::{
     CancellableResult, OperationError, OperationResult, check_process_stopped,
 };
@@ -620,16 +620,26 @@ impl GraphLayers {
     pub fn num_points(&self) -> usize {
         self.links.num_points()
     }
+
+    /// Heap RAM held by the graph links, in bytes.
+    /// Zero when the links are backed by a live (mmap-backed) file handle;
+    /// see [`GraphLinks::heap_size_bytes`].
+    pub fn links_heap_size_bytes(&self) -> usize {
+        self.links.heap_size_bytes()
+    }
 }
 
 impl GraphLayers {
     /// Load via local mmap, optionally converting the links to the compressed
     /// format first. Used by the (mutable) on-disk HNSW index.
     ///
-    /// `populate` fills the OS page cache for the links on open (e.g.
-    /// [`Populate::Blocking`] to keep them in RAM, [`Populate::No`] to keep them
-    /// lazily on disk).
-    pub fn load(dir: &Path, populate: Populate, compress: bool) -> OperationResult<Self> {
+    /// `residency` controls how the links reside in memory after loading;
+    /// see [`GraphLinksResidency`].
+    pub fn load(
+        dir: &Path,
+        residency: GraphLinksResidency,
+        compress: bool,
+    ) -> OperationResult<Self> {
         if compress {
             // `convert_to_compressed` writes data, and we don't have a
             // `UniversalWriteFs` yet, so it stays on local mmap IO. It is not
@@ -638,15 +648,19 @@ impl GraphLayers {
             Self::convert_to_compressed(dir, HnswM::new(graph_data.m, graph_data.m0))?;
         }
 
-        Self::load_universal(&MmapFs, dir, populate)
+        Self::load_universal(&MmapFs, dir, residency)
     }
 
     /// Load purely through universal IO, without the format conversion path of
     /// [`Self::load`]. Used by the read-only index.
     ///
-    /// `populate` fills the OS page cache for the links on open; see
-    /// [`Self::load`].
-    pub fn load_universal<Fs>(fs: &Fs, dir: &Path, populate: Populate) -> OperationResult<Self>
+    /// `residency` controls how the links reside in memory after loading;
+    /// see [`GraphLinksResidency`].
+    pub fn load_universal<Fs>(
+        fs: &Fs,
+        dir: &Path,
+        residency: GraphLinksResidency,
+    ) -> OperationResult<Self>
     where
         Fs: UniversalReadFs,
         Fs::File: 'static,
@@ -655,7 +669,7 @@ impl GraphLayers {
 
         Ok(Self {
             hnsw_m: HnswM::new(graph_data.m, graph_data.m0),
-            links: Self::load_links_universal(fs, dir, populate)?,
+            links: Self::load_links_universal(fs, dir, residency)?,
             entry_points: graph_data.entry_points.into_owned(),
             visited_pool: VisitedPool::new(),
         })
@@ -664,7 +678,7 @@ impl GraphLayers {
     fn load_links_universal<Fs>(
         fs: &Fs,
         dir: &Path,
-        populate: Populate,
+        residency: GraphLinksResidency,
     ) -> OperationResult<GraphLinks>
     where
         Fs: UniversalReadFs,
@@ -677,7 +691,7 @@ impl GraphLayers {
         ] {
             let path = GraphLayers::get_links_path(dir, format);
             if fs.exists(&path)? {
-                return GraphLinks::load_universal(fs, &path, format, populate);
+                return GraphLinks::load_universal(fs, &path, format, residency);
             }
         }
         Err(OperationError::service_error("No links file found"))
@@ -704,7 +718,7 @@ impl GraphLayers {
             &MmapFs,
             &plain_path,
             GraphLinksFormat::Plain,
-            Populate::No,
+            GraphLinksResidency::Cold,
         )?;
         let original_size = fs::metadata(&plain_path)?.len();
         atomic_save(&compressed_path, |writer| {
@@ -896,18 +910,38 @@ mod tests {
             )
             .unwrap();
         assert_eq!(graph1.links.format(), initial_format);
+        // The built graph must be mmap-backed, not pinned in heap.
+        assert_eq!(graph1.links.heap_size_bytes(), 0);
         let res1 = search_in_graph(&query, top, &vector_holder, &graph1);
         drop(graph1);
 
-        let graph2 = GraphLayers::load(dir.path(), Populate::Blocking, compress).unwrap();
+        let graph2 = GraphLayers::load(dir.path(), GraphLinksResidency::Cached, compress).unwrap();
         if compress {
             assert_eq!(graph2.links.format(), GraphLinksFormat::Compressed);
         } else {
             assert_eq!(graph2.links.format(), initial_format);
         }
+        // `Cached` residency keeps the links in the page cache, not in heap.
+        assert_eq!(graph2.links.heap_size_bytes(), 0);
         let res2 = search_in_graph(&query, top, &vector_holder, &graph2);
 
         assert_eq!(res1, res2)
+    }
+
+    /// A freshly built graph must have the same, single-copy residency as one
+    /// loaded from disk: mmap-backed for both `on_disk` values, never pinned
+    /// in heap.
+    #[rstest]
+    fn test_built_graph_is_not_pinned(#[values(false, true)] on_disk: bool) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let dir = Builder::new().prefix("graph_dir").tempdir().unwrap();
+
+        let (_vector_holder, graph_layers_builder) =
+            create_graph_layer_builder_fixture(100, M, 8, false, true, Distance::Cosine, &mut rng);
+        let graph = graph_layers_builder
+            .into_graph_layers(dir.path(), GraphLinksFormatParam::Compressed, on_disk)
+            .unwrap();
+        assert_eq!(graph.links.heap_size_bytes(), 0);
     }
 
     #[rstest]

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::cmp::{max, min};
-use std::io::Write;
 use std::ops::ControlFlow;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
@@ -10,7 +9,7 @@ use common::bitvec::BitSliceExt;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::fs::{atomic_save, atomic_save_bin};
 use common::types::{PointOffsetType, ScoredPointOffset};
-use common::universal_io::{MmapFs, Populate};
+use common::universal_io::MmapFs;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use rand::distr::Uniform;
 use rand::{Rng, RngExt};
@@ -24,7 +23,7 @@ use crate::index::hnsw_index::entry_points::EntryPoints;
 #[cfg(test)]
 use crate::index::hnsw_index::graph_layers::SearchAlgorithm;
 use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersBase};
-use crate::index::hnsw_index::graph_links::serialize_graph_links;
+use crate::index::hnsw_index::graph_links::{GraphLinksResidency, serialize_graph_links};
 use crate::index::hnsw_index::point_scorer::FilteredScorer;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 
@@ -220,25 +219,21 @@ impl GraphLayersBuilder {
         let links_path = GraphLayers::get_links_path(path, format_param.as_format());
 
         let edges = Self::links_layers_to_edges(self.links_layers);
-        let links;
-        if on_disk {
-            // Save memory by serializing directly to disk, then re-loading as mmap.
-            atomic_save(&links_path, |writer| {
-                serialize_graph_links(edges, format_param, self.hnsw_m, writer)
-            })?;
-            // On-disk build path: keep the links lazily on disk (no populate).
-            links = GraphLinks::load_universal(
-                &MmapFs,
-                &links_path,
-                format_param.as_format(),
-                Populate::No,
-            )?;
+        // Save memory by serializing directly to disk, then re-loading as mmap.
+        atomic_save(&links_path, |writer| {
+            serialize_graph_links(edges, format_param, self.hnsw_m, writer)
+        })?;
+        // Keep the links cold (lazily on disk) when configured so; otherwise
+        // pre-populate the page cache (cheap: the pages were just written).
+        // Never pin the links in heap here, so that the just-built index has
+        // the same, single-copy residency as one loaded from disk.
+        let residency = if on_disk {
+            GraphLinksResidency::Cold
         } else {
-            // Since we'll keep it in the RAM anyway, we can afford to build in the RAM too.
-            links = GraphLinks::new_from_edges(edges, format_param, self.hnsw_m)?;
-            let bytes = links.as_bytes()?;
-            atomic_save(&links_path, |writer| writer.write_all(bytes))?;
-        }
+            GraphLinksResidency::Cached
+        };
+        let links =
+            GraphLinks::load_universal(&MmapFs, &links_path, format_param.as_format(), residency)?;
 
         let entry_points = self.entry_points.into_inner();
 

--- a/lib/segment/src/index/hnsw_index/graph_links/links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/links.rs
@@ -62,6 +62,7 @@ impl GraphLinks {
         Fs::File: 'static,
     {
         let populate = match residency {
+            // Pin does not populate because we load into heap later
             GraphLinksResidency::Cold | GraphLinksResidency::Pinned => Populate::No,
             GraphLinksResidency::Cached => Populate::Blocking,
         };

--- a/lib/segment/src/index/hnsw_index/graph_links/links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/links.rs
@@ -30,24 +30,41 @@ self_cell::self_cell! {
     impl {Debug}
 }
 
+/// How the serialized links should reside in memory after loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphLinksResidency {
+    /// Mmap without populating: pages are faulted in on demand and remain
+    /// evictable by the OS. For graphs expected to stay on disk.
+    Cold,
+    /// Mmap with a blocking populate: the OS page cache is primed on load,
+    /// but the pages remain evictable under memory pressure.
+    Cached,
+    /// Materialize the links into an anonymous heap allocation, evicting
+    /// whatever the read left in the OS page cache. Not evictable by the OS.
+    Pinned,
+}
+
 impl GraphLinks {
-    /// Load the links through universal IO.
+    /// Load the links through universal IO with the requested [`GraphLinksResidency`].
     ///
-    /// `populate` controls how the OS page cache is primed on open (e.g.
-    /// [`Populate::Blocking`] to fill it eagerly, [`Populate::No`] to open
-    /// lazily). Borrowable (mmap-backed) backends keep their handle alive,
-    /// others are materialized into RAM; see
+    /// `Cold`/`Cached` require a borrowable (mmap-backed) backend to keep the
+    /// handle alive; non-borrowable backends (io_uring, remote object stores, …)
+    /// fall back to `Pinned`-like materialization into RAM; see
     /// [`GraphLinksEnum::from_storage`](super::storage).
     pub fn load_universal<Fs>(
         fs: &Fs,
         path: &Path,
         format: GraphLinksFormat,
-        populate: Populate,
+        residency: GraphLinksResidency,
     ) -> OperationResult<Self>
     where
         Fs: UniversalReadFs,
         Fs::File: 'static,
     {
+        let populate = match residency {
+            GraphLinksResidency::Cold | GraphLinksResidency::Pinned => Populate::No,
+            GraphLinksResidency::Cached => Populate::Blocking,
+        };
         let options = OpenOptions {
             writeable: false,
             need_sequential: false,
@@ -55,9 +72,13 @@ impl GraphLinks {
             advice: AdviceSetting::Advice(Advice::Random),
         };
         let storage = fs.open(path, options, Default::default())?;
-        Self::try_new(GraphLinksEnum::from_storage(storage)?, |x| {
-            GraphLinksView::load(x.as_bytes()?, format)
-        })
+        let owner = match residency {
+            GraphLinksResidency::Cold | GraphLinksResidency::Cached => {
+                GraphLinksEnum::from_storage(storage)?
+            }
+            GraphLinksResidency::Pinned => GraphLinksEnum::pinned_from_storage(storage)?,
+        };
+        Self::try_new(owner, |x| GraphLinksView::load(x.as_bytes()?, format))
     }
 
     pub fn new_from_edges(
@@ -80,6 +101,13 @@ impl GraphLinks {
 
     pub fn as_bytes(&self) -> OperationResult<&[u8]> {
         self.borrow_owner().as_bytes()
+    }
+
+    /// Heap RAM held by the serialized links, in bytes.
+    /// Zero when the links are backed by a live (mmap-backed) file handle;
+    /// see [`GraphLinksEnum::heap_size_bytes`].
+    pub fn heap_size_bytes(&self) -> usize {
+        self.borrow_owner().heap_size_bytes()
     }
 
     pub fn format(&self) -> GraphLinksFormat {

--- a/lib/segment/src/index/hnsw_index/graph_links/mod.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/mod.rs
@@ -86,7 +86,7 @@ mod view;
 mod tests;
 
 pub use format::{GraphLinksFormat, GraphLinksFormatParam};
-pub use links::GraphLinks;
+pub use links::{GraphLinks, GraphLinksResidency};
 pub use serializer::serialize_graph_links;
 pub use vectors::{GraphLinksVectors, GraphLinksVectorsLayout, StorageGraphLinksVectors};
 pub use view::LinksIterator;

--- a/lib/segment/src/index/hnsw_index/graph_links/storage.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/storage.rs
@@ -79,15 +79,38 @@ impl GraphLinksEnum {
         if S::kind().is_in_ram_or_mmap() {
             Ok(GraphLinksEnum::Universal(Box::new(storage)))
         } else {
-            let bytes = storage.read_whole::<u8>()?.into_owned();
-            Ok(GraphLinksEnum::Ram(bytes))
+            Self::pinned_from_storage(storage)
         }
+    }
+
+    /// Materialize the whole links blob into an anonymous heap allocation
+    /// ([`GraphLinksEnum::Ram`]), regardless of the backend.
+    pub(super) fn pinned_from_storage<S: UniversalRead>(storage: S) -> OperationResult<Self> {
+        let bytes = storage.read_whole::<u8>()?.into_owned();
+        // The heap copy is authoritative from here on: evict whatever the read
+        // left in the OS page cache or backend caches, so the links are not
+        // resident twice.
+        storage.clear_ram_cache()?;
+        Ok(GraphLinksEnum::Ram(bytes))
     }
 
     pub(super) fn as_bytes(&self) -> OperationResult<&[u8]> {
         match self {
             GraphLinksEnum::Ram(data) => Ok(data.as_slice()),
             GraphLinksEnum::Universal(storage) => storage.bytes(),
+        }
+    }
+
+    /// Heap RAM held by the links themselves, in bytes.
+    ///
+    /// Non-zero only for [`GraphLinksEnum::Ram`], i.e. freshly built links or
+    /// links materialized from a non-borrowable universal-IO backend. Storage
+    /// kept behind a live handle ([`GraphLinksEnum::Universal`]) is backed by
+    /// the OS page cache and reported via file residency instead.
+    pub(super) fn heap_size_bytes(&self) -> usize {
+        match self {
+            GraphLinksEnum::Ram(data) => data.len(),
+            GraphLinksEnum::Universal(_) => 0,
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links/tests.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/tests.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use common::fs::atomic_save;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFs, Populate};
+use common::universal_io::MmapFs;
 use rand::RngExt;
 use rstest::rstest;
 use tempfile::Builder;
@@ -155,7 +155,9 @@ fn test_save_load(
     })
     .unwrap();
 
-    let cmp_links = GraphLinks::load_universal(&MmapFs, &links_file, format, Populate::No).unwrap();
+    let cmp_links =
+        GraphLinks::load_universal(&MmapFs, &links_file, format, GraphLinksResidency::Cold)
+            .unwrap();
     check_links(links, &cmp_links, &vectors);
 }
 

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::{MmapFs, Populate};
+use common::universal_io::MmapFs;
 
 use self::telemetry::HNSWSearchesTelemetry;
 use crate::common::BYTES_IN_KB;
@@ -10,6 +10,7 @@ use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::types::HnswConfig;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
@@ -104,15 +105,15 @@ impl HNSWIndex {
 
         let is_on_disk = hnsw_config.on_disk.unwrap_or(false);
 
-        // Keep the links lazily on disk when configured so; otherwise populate
-        // them into RAM on load (blocking).
-        let populate = if is_on_disk {
-            Populate::No
+        // Keep the links cold (lazily on disk) when configured so; otherwise
+        // pre-populate them into the page cache on load.
+        let residency = if is_on_disk {
+            GraphLinksResidency::Cold
         } else {
-            Populate::Blocking
+            GraphLinksResidency::Cached
         };
 
-        let graph = GraphLayers::load(path, populate, do_convert)?;
+        let graph = GraphLayers::load(path, residency, do_convert)?;
 
         Ok(HNSWIndex {
             id_tracker,
@@ -129,6 +130,15 @@ impl HNSWIndex {
 
     pub fn is_on_disk(&self) -> bool {
         self.is_on_disk
+    }
+
+    /// Heap RAM held by the graph links, in bytes.
+    ///
+    /// Non-zero when the links are materialized in RAM rather than backed by
+    /// a live mmap handle (freshly built index, or a non-borrowable universal-IO
+    /// backend); such links are invisible to page-cache residency probes.
+    pub fn links_heap_size_bytes(&self) -> usize {
+        self.graph.links_heap_size_bytes()
     }
 
     #[cfg(test)]

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::Populate;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
@@ -15,6 +14,7 @@ use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
@@ -108,14 +108,15 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
 
         let is_on_disk = hnsw_config.on_disk.unwrap_or(false);
 
-        // Keep the graph lazily on disk when configured so; otherwise populate
-        // it into RAM on load (blocking).
-        let populate = if is_on_disk {
-            Populate::No
+        // Keep the graph cold (lazily on disk) when configured so; otherwise
+        // pre-populate it into the page cache on load. Note that non-borrowable
+        // backends materialize the links into heap RAM either way.
+        let residency = if is_on_disk {
+            GraphLinksResidency::Cold
         } else {
-            Populate::Blocking
+            GraphLinksResidency::Cached
         };
-        let graph = GraphLayers::load_universal(fs, path, populate)?;
+        let graph = GraphLayers::load_universal(fs, path, residency)?;
 
         Ok(Self {
             id_tracker,

--- a/lib/segment/src/index/memory_reporter.rs
+++ b/lib/segment/src/index/memory_reporter.rs
@@ -7,14 +7,28 @@ impl MemoryReporter for VectorIndexEnum {
             // Plain index: no files, no extra memory (searches storage directly)
             VectorIndexEnum::Plain(_) => ComponentMemoryUsage::empty(),
 
-            // HNSW: graph files, intent depends on on_disk config
+            // HNSW: graph files, intent depends on how the links are actually held
             VectorIndexEnum::Hnsw(index) => {
-                let intent = if index.is_on_disk() {
-                    FileStorageIntent::OnDisk
+                let links_heap_bytes = index.links_heap_size_bytes() as u64;
+                if links_heap_bytes > 0 {
+                    // Links are materialized in heap RAM (freshly built index,
+                    // or a non-borrowable universal-IO backend): files are
+                    // persistence only, not expected to be in page cache.
+                    ComponentMemoryUsage::from_files_and_ram(
+                        index.files(),
+                        FileStorageIntent::OnDisk,
+                        links_heap_bytes,
+                    )
                 } else {
-                    FileStorageIntent::Cached
-                };
-                ComponentMemoryUsage::from_files(index.files(), intent)
+                    // Links are backed by a live mmap handle: residency is
+                    // tracked via the page cache, intent depends on on_disk config.
+                    let intent = if index.is_on_disk() {
+                        FileStorageIntent::OnDisk
+                    } else {
+                        FileStorageIntent::Cached
+                    };
+                    ComponentMemoryUsage::from_files(index.files(), intent)
+                }
             }
 
             // Sparse RAM variants: inverted index is deserialized into heap.


### PR DESCRIPTION
Related PRs:

- https://github.com/qdrant/qdrant/pull/9214 - introduced pinning, we now revert
- https://github.com/qdrant/qdrant/pull/9427#issuecomment-4699775984 - (incorrect) reaction to make populate work


## What

Makes HNSW graph links memory residency an explicit choice (`GraphLinksResidency`) instead of a side effect of the IO backend:

- **`Cold`** — mmap without populate; pages fault in on demand, evictable (`on_disk: true`)
- **`Cached`** — mmap with blocking populate; page cache primed, still evictable (`on_disk: false`)
- **`Pinned`** — links materialized into anonymous heap, page cache evicted after the read. **Internal-only for now**: no production caller selects it explicitly; non-borrowable universal-IO backends (io_uring, object stores, uio-grpc) fall back to it by necessity. Reserved as the hook for a future config knob.

The `on_disk` HNSW config parameter now cleanly maps to cold vs cached page cache, for both the mutable and read-only index.

## Fixes along the way

1. **Freshly built `on_disk: false` indexes no longer pin links in heap.** The builder previously kept the heap `Vec` from `new_from_edges` until segment reload, alongside the freshly written links file in page cache — two resident copies. It now always serializes directly to disk (also lowering peak build memory) and re-loads as mmap with `Cold`/`Cached`, so a just-built index has the same single-copy residency as one loaded after restart. The `Cached` populate is nearly free: the just-written pages are still in page cache.

2. **Materializing fallbacks evict the page cache after copying to heap** (same hygiene as `read_whole_via`), so links backed by non-borrowable backends are never resident twice.

3. **Memory reporter sees heap-materialized links.** Previously the HNSW branch derived everything from the `on_disk` config flag, so pinned links reported `0` RAM, `0` cached, and their full size as "expected cache" — misleading on all axes. Heap-held links are now reported as RAM (via new `heap_size_bytes()` plumbing: `GraphLinksEnum` → `GraphLinks` → `GraphLayers` → `HNSWIndex`), with files marked persistence-only, mirroring the existing `QuantizedVectors` reporter.

## Tests

- `test_built_graph_is_not_pinned` (`on_disk` = false/true): built graph is mmap-backed, `heap_size_bytes() == 0`
- `test_save_and_load`: asserts both built and `Cached`-loaded graphs are not heap-pinned
- All existing HNSW/graph-links tests pass; clippy clean on all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)