### PR TITLE
[UIO] Include file size in `UniversalReadFileOps::list_files`

### DIFF
--- a/lib/api/src/grpc/proto/storage_read_service.proto
+++ b/lib/api/src/grpc/proto/storage_read_service.proto
@@ -50,8 +50,13 @@ message FileExistsResponse {
   bool exists = 1;
 }
 
+message ListFilesEntry {
+  string path = 1;
+  uint64 size = 2;
+}
+
 message ListFilesResponse {
-  repeated string paths = 1;
+  repeated ListFilesEntry files = 1;
 }
 
 message FileLengthRequest {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -16083,9 +16083,17 @@ pub struct FileExistsResponse {
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListFilesEntry {
+    #[prost(string, tag = "1")]
+    pub path: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "2")]
+    pub size: u64,
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListFilesResponse {
-    #[prost(string, repeated, tag = "1")]
-    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "1")]
+    pub files: ::prost::alloc::vec::Vec<ListFilesEntry>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -91,7 +91,7 @@ impl UniversalReadFileOps for BlockCacheFs {
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -1,5 +1,5 @@
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use fs_err as fs;
@@ -7,8 +7,8 @@ use fs_err as fs;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    OpenOptions, Result, UniversalIoError, UniversalRead, UniversalReadFileOps, UniversalReadFs,
-    UserData, local_file_ops,
+    ListedFile, OpenOptions, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
+    UniversalReadFs, UserData, local_file_ops,
 };
 
 mod cached_slice;
@@ -91,7 +91,7 @@ impl UniversalReadFileOps for BlockCacheFs {
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -9,7 +9,7 @@ mod tests;
 use std::io::{self, Read as _, Seek as _};
 use std::ops::Range;
 use std::os::fd::AsRawFd as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use ::io_uring::types::Fd;
@@ -62,7 +62,7 @@ impl UniversalReadFileOps for IoUringFs {
         Ok(Self)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -62,7 +62,7 @@ impl UniversalReadFileOps for IoUringFs {
         Ok(Self)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/local_file_ops.rs
+++ b/lib/common/common/src/universal_io/local_file_ops.rs
@@ -29,7 +29,7 @@ pub fn local_atomic_save(path: &Path, bytes: &[u8]) -> crate::universal_io::Resu
     })
 }
 
-pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<PathBuf>> {
+pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<(PathBuf, u64)>> {
     let dir = prefix_path.parent().unwrap_or(Path::new("."));
     let file_prefix = prefix_path
         .file_name()
@@ -46,7 +46,10 @@ pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<P
             && name.starts_with(&file_prefix)
             && entry.file_type()?.is_file()
         {
-            results.push(dir.join(name));
+            let path = dir.join(name);
+            let size = entry.metadata()?.len();
+
+            results.push((path, size));
         }
     }
 

--- a/lib/common/common/src/universal_io/local_file_ops.rs
+++ b/lib/common/common/src/universal_io/local_file_ops.rs
@@ -1,9 +1,9 @@
 use std::io::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::fs::atomic_save;
 use crate::mmap::create_and_ensure_length;
-use crate::universal_io::UniversalIoError;
+use crate::universal_io::{ListedFile, UniversalIoError};
 
 pub fn local_create(path: &Path, expected_length: usize) -> crate::universal_io::Result<()> {
     create_and_ensure_length(path, expected_length)
@@ -29,7 +29,7 @@ pub fn local_atomic_save(path: &Path, bytes: &[u8]) -> crate::universal_io::Resu
     })
 }
 
-pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<(PathBuf, u64)>> {
+pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<ListedFile>> {
     let dir = prefix_path.parent().unwrap_or(Path::new("."));
     let file_prefix = prefix_path
         .file_name()
@@ -49,7 +49,7 @@ pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<(
             let path = dir.join(name);
             let size = entry.metadata()?.len();
 
-            results.push((path, size));
+            results.push(ListedFile { path, size });
         }
     }
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -28,7 +28,7 @@ impl UniversalReadFileOps for MmapFs {
         Ok(MmapFs)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -28,7 +28,7 @@ impl UniversalReadFileOps for MmapFs {
         Ok(MmapFs)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -25,7 +25,7 @@ pub use self::traits::{
     UniversalReadFs, UniversalWrite, UserData,
 };
 pub use self::types::{
-    ByteOffset, FileIndex, Flusher, OpenOptions, Populate, ReadBytesItem, ReadRange, Result,
-    UniversalKind, read_bin_via, read_json_via, read_whole_via,
+    ByteOffset, FileIndex, Flusher, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange,
+    Result, UniversalKind, read_bin_via, read_json_via, read_whole_via,
 };
 pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -78,7 +78,7 @@ where
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         self.remote_fs.list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use super::DiskCacheRemote;
@@ -7,8 +7,8 @@ use super::config::DiskCacheConfig;
 use super::file::{DiskCache, InitSource};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
-    OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError, UniversalRead,
-    UniversalReadFileOps, UniversalReadFs,
+    ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
+    UniversalRead, UniversalReadFileOps, UniversalReadFs,
 };
 
 /// Construction context for [`DiskCacheFs`]: carries the
@@ -78,7 +78,7 @@ where
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         self.remote_fs.list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -26,13 +26,14 @@ pub trait UniversalReadFileOps: Clone + Debug + Sized {
     /// Build a filesystem handle from its context.
     fn from_context(context: Self::ContextConfig) -> Result<Self>;
 
-    /// List files in the filesystem matching the given prefix.
+    /// List files in the filesystem matching the given prefix, alongside
+    /// their sizes in bytes.
     ///
     /// Example: `./gridstore/page_` should return
-    /// - `./gridstore/page_1.dat`
-    /// - `./gridstore/page_2.dat`
-    /// - `./gridstore/page_3.dat`
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>>;
+    /// - `./gridstore/page_1.dat` (size in bytes)
+    /// - `./gridstore/page_2.dat` (size in bytes)
+    /// - `./gridstore/page_3.dat` (size in bytes)
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>>;
 
     /// Check whether a file exists at the given path.
     fn exists(&self, path: &Path) -> Result<bool>;

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -1,9 +1,9 @@
 use std::fmt::Debug;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
-use crate::universal_io::{OpenOptions, Result};
+use crate::universal_io::{ListedFile, OpenOptions, Result};
 
 /// Filesystem-level handle.
 ///
@@ -33,7 +33,7 @@ pub trait UniversalReadFileOps: Clone + Debug + Sized {
     /// - `./gridstore/page_1.dat` (size in bytes)
     /// - `./gridstore/page_2.dat` (size in bytes)
     /// - `./gridstore/page_3.dat` (size in bytes)
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>>;
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>>;
 
     /// Check whether a file exists at the given path.
     fn exists(&self, path: &Path) -> Result<bool>;

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -178,6 +178,16 @@ pub struct ReadBytesItem<U: UserData> {
     pub align: usize,
 }
 
+/// A single file matched by [`UniversalReadFileOps::list_files`]: its path
+/// and size in bytes.
+///
+/// [`UniversalReadFileOps::list_files`]: super::UniversalReadFileOps::list_files
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ListedFile {
+    pub path: std::path::PathBuf,
+    pub size: u64,
+}
+
 pub type ByteOffset = u64;
 
 pub type FileIndex = usize;

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -43,7 +43,7 @@ impl<F: UniversalReadFileOps> UniversalReadFileOps for ReadOnlyFs<F> {
         Ok(ReadOnlyFs(F::from_context(ctx.0)?))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         self.0.list_files(prefix_path)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bytemuck::TransparentWrapper;
 
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalIoError, UniversalKind,
-    UniversalRead, UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalIoError,
+    UniversalKind, UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -43,7 +43,7 @@ impl<F: UniversalReadFileOps> UniversalReadFileOps for ReadOnlyFs<F> {
         Ok(ReadOnlyFs(F::from_context(ctx.0)?))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         self.0.list_files(prefix_path)
     }
 

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -130,7 +130,9 @@ mod tests {
     use std::ops::Range;
 
     use bytes::Bytes;
-    use common::universal_io::{OpenOptions, ReadRange, UniversalIoError, UniversalReadFs};
+    use common::universal_io::{
+        ListedFile, OpenOptions, ReadRange, UniversalIoError, UniversalReadFs,
+    };
     use futures::stream::{BoxStream, StreamExt};
 
     use super::*;
@@ -160,7 +162,7 @@ mod tests {
         fn list_files(
             &self,
             _prefix: &Path,
-        ) -> impl Future<Output = Result<Vec<(std::path::PathBuf, u64)>>> + Send + 'static {
+        ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
             std::future::ready(Ok(vec![]))
         }
 

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -160,7 +160,7 @@ mod tests {
         fn list_files(
             &self,
             _prefix: &Path,
-        ) -> impl Future<Output = Result<Vec<std::path::PathBuf>>> + Send + 'static {
+        ) -> impl Future<Output = Result<Vec<(std::path::PathBuf, u64)>>> + Send + 'static {
             std::future::ready(Ok(vec![]))
         }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -39,7 +39,7 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
         Ok(Self::new(A::open(&config)?, BridgeRuntime::global()))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<PathBuf>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
         self.runtime.block_on(self.inner.list_files(prefix_path))
     }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -1,7 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bytes::Bytes;
-use common::universal_io::{OpenOptions, Result, UniversalReadFileOps, UniversalReadFs};
+use common::universal_io::{
+    ListedFile, OpenOptions, Result, UniversalReadFileOps, UniversalReadFs,
+};
 
 use crate::{AsyncRead, BlobFile, BridgeRuntime};
 
@@ -39,7 +41,7 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
         Ok(Self::new(A::open(&config)?, BridgeRuntime::global()))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         self.runtime.block_on(self.inner.list_files(prefix_path))
     }
 

--- a/lib/common/io_bridge/src/read.rs
+++ b/lib/common/io_bridge/src/read.rs
@@ -1,9 +1,9 @@
 use std::future::Future;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bytes::Bytes;
-use common::universal_io::{Result, UniversalKind};
+use common::universal_io::{ListedFile, Result, UniversalKind};
 use futures::stream::BoxStream;
 
 /// Read-capable blob backend (S3, GCS, …). One impl per backend.
@@ -32,7 +32,7 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static;
+    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static;
 
     fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static;
 

--- a/lib/common/io_bridge/src/read.rs
+++ b/lib/common/io_bridge/src/read.rs
@@ -32,7 +32,7 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<PathBuf>>> + Send + 'static;
+    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static;
 
     fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static;
 

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -9,9 +9,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use bytes::Bytes;
 use common::generic_consts::Sequential;
 use common::universal_io::{
-    DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, OpenOptions, OwnedPipeline, Populate,
-    ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps,
-    UniversalReadFs,
+    DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, ListedFile, OpenOptions, OwnedPipeline,
+    Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead,
+    UniversalReadFileOps, UniversalReadFs,
 };
 use futures::stream::{BoxStream, StreamExt};
 
@@ -73,7 +73,7 @@ impl AsyncRead for CountingSource {
     fn list_files(
         &self,
         _prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
         std::future::ready(Ok(vec![]))
     }
 

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -73,7 +73,7 @@ impl AsyncRead for CountingSource {
     fn list_files(
         &self,
         _prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<PathBuf>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
         std::future::ready(Ok(vec![]))
     }
 

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -63,7 +63,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<PathBuf>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
         let store = self.0.clone();
         let prefix_path = prefix.to_path_buf();
         // object_store lists by whole path segment; emulate the byte-prefix
@@ -84,9 +84,12 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
             {
                 Ok(entries) => Ok(entries
                     .into_iter()
-                    .map(|e| e.location.to_string())
-                    .filter(|key| key.starts_with(&prefix_str))
-                    .map(PathBuf::from)
+                    .filter_map(|e| {
+                        let location = e.location.to_string();
+                        location
+                            .starts_with(&prefix_str)
+                            .then(|| (PathBuf::from(location), e.size))
+                    })
                     .collect()),
                 Err(object_store::Error::NotFound { .. }) => {
                     Err(UniversalIoError::NotFound { path: prefix_path })
@@ -379,14 +382,20 @@ mod tests {
             ],
         );
         let source = ObjectStoreSource::new(store);
-        let mut files: Vec<String> = runtime
+        let mut files: Vec<(String, u64)> = runtime
             .block_on(source.list_files(Path::new("dir/page_")))
             .expect("list_files")
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
+            .into_iter()
+            .map(|(p, size)| (p.to_string_lossy().into_owned(), size))
             .collect();
         files.sort();
-        assert_eq!(files, ["dir/page_0.dat", "dir/page_1.dat"]);
+        assert_eq!(
+            files,
+            [
+                ("dir/page_0.dat".to_string(), 1),
+                ("dir/page_1.dat".to_string(), 1),
+            ]
+        );
     }
 
     #[test]

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use common::universal_io::{Result, UniversalIoError, UniversalKind};
+use common::universal_io::{ListedFile, Result, UniversalIoError, UniversalKind};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use io_bridge::AsyncRead;
 use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt};
@@ -63,7 +63,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
         let store = self.0.clone();
         let prefix_path = prefix.to_path_buf();
         // object_store lists by whole path segment; emulate the byte-prefix
@@ -86,9 +86,10 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
                     .into_iter()
                     .filter_map(|e| {
                         let location = e.location.to_string();
-                        location
-                            .starts_with(&prefix_str)
-                            .then(|| (PathBuf::from(location), e.size))
+                        location.starts_with(&prefix_str).then(|| ListedFile {
+                            path: PathBuf::from(location),
+                            size: e.size,
+                        })
                     })
                     .collect()),
                 Err(object_store::Error::NotFound { .. }) => {
@@ -269,7 +270,7 @@ fn build_dir_prefix(path: &Path) -> object_store::path::Path {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use common::universal_io::{ReadRange, UniversalRead, UniversalReadFileOps};
+    use common::universal_io::{ListedFile, ReadRange, UniversalRead, UniversalReadFileOps};
     use io_bridge::{BlobFile, BlobFs, BridgeRuntime};
     use object_store::memory::InMemory;
 
@@ -386,7 +387,7 @@ mod tests {
             .block_on(source.list_files(Path::new("dir/page_")))
             .expect("list_files")
             .into_iter()
-            .map(|(p, size)| (p.to_string_lossy().into_owned(), size))
+            .map(|ListedFile { path, size }| (path.to_string_lossy().into_owned(), size))
             .collect();
         files.sort();
         assert_eq!(

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -130,7 +130,8 @@ fn test_list_files() {
         .block_on(store.list_files(Path::new("listed")))
         .expect("list_files");
     assert_eq!(files.len(), 3);
-    for f in &files {
-        assert!(f.to_string_lossy().starts_with("listed/"));
+    for (path, size) in &files {
+        assert!(path.to_string_lossy().starts_with("listed/"));
+        assert_eq!(*size, 1);
     }
 }

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -3,7 +3,7 @@
 use std::assert_matches;
 use std::path::Path;
 
-use common::universal_io::{ReadRange, UniversalIoError, UniversalRead};
+use common::universal_io::{ListedFile, ReadRange, UniversalIoError, UniversalRead};
 use io_bridge::{AsyncRead, BridgeRuntime};
 use object_store::aws::AmazonS3;
 
@@ -130,7 +130,7 @@ fn test_list_files() {
         .block_on(store.list_files(Path::new("listed")))
         .expect("list_files");
     assert_eq!(files.len(), 3);
-    for (path, size) in &files {
+    for ListedFile { path, size } in &files {
         assert!(path.to_string_lossy().starts_with("listed/"));
         assert_eq!(*size, 1);
     }

--- a/lib/common/io_bridge_uio_grpc/src/lib.rs
+++ b/lib/common/io_bridge_uio_grpc/src/lib.rs
@@ -39,11 +39,11 @@
 use std::future::Future;
 use std::io;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use common::universal_io::{Result, UniversalIoError, UniversalKind};
+use common::universal_io::{ListedFile, Result, UniversalIoError, UniversalKind};
 use futures::stream::{self, BoxStream, StreamExt as _};
 use io_bridge::{AsyncRead, BlobFile, BlobFs};
 use tokio::sync::OnceCell;
@@ -145,7 +145,7 @@ impl AsyncRead for UioGrpcSource {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
         let inner = self.inner.clone();
         let prefix = path_to_string(prefix);
         async move {

--- a/lib/common/io_bridge_uio_grpc/src/lib.rs
+++ b/lib/common/io_bridge_uio_grpc/src/lib.rs
@@ -145,7 +145,7 @@ impl AsyncRead for UioGrpcSource {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<PathBuf>>> + Send + 'static {
+    ) -> impl Future<Output = Result<Vec<(PathBuf, u64)>>> + Send + 'static {
         let inner = self.inner.clone();
         let prefix = path_to_string(prefix);
         async move {

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -58,7 +58,7 @@ impl<S: UniversalRead> Pages<S> {
         let page_files: HashSet<_> = fs
             .list_files(&dir.join("page_"))?
             .into_iter()
-            .map(|(path, _size)| path)
+            .map(|listed| listed.path)
             .collect();
 
         for page_id in 0.. {

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -55,7 +55,11 @@ impl<S: UniversalRead> Pages<S> {
     pub fn open(fs: &S::Fs, dir: &Path, writeable: bool, populate: Populate) -> Result<Self> {
         let mut pages = Self::new(dir.to_path_buf(), writeable);
 
-        let page_files: HashSet<_> = fs.list_files(&dir.join("page_"))?.into_iter().collect();
+        let page_files: HashSet<_> = fs
+            .list_files(&dir.join("page_"))?
+            .into_iter()
+            .map(|(path, _size)| path)
+            .collect();
 
         for page_id in 0.. {
             let page_path = pages.page_path(page_id);

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -41,7 +41,8 @@ pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
     // directory are never enumerated.
     let chunks_prefix = directory.join(MMAP_CHUNKS_PATTERN_START);
     let mut chunks_files: AHashMap<usize, _> = AHashMap::new();
-    for (path, _size) in fs.list_files(&chunks_prefix)? {
+    for listed in fs.list_files(&chunks_prefix)? {
+        let path = listed.path;
         let chunk_id = path
             .file_name()
             .and_then(|file_name| file_name.to_str())

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -41,7 +41,7 @@ pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
     // directory are never enumerated.
     let chunks_prefix = directory.join(MMAP_CHUNKS_PATTERN_START);
     let mut chunks_files: AHashMap<usize, _> = AHashMap::new();
-    for path in fs.list_files(&chunks_prefix)? {
+    for (path, _size) in fs.list_files(&chunks_prefix)? {
         let chunk_id = path
             .file_name()
             .and_then(|file_name| file_name.to_str())

--- a/lib/uio-grpc-client/proto/storage_read_service.proto
+++ b/lib/uio-grpc-client/proto/storage_read_service.proto
@@ -50,8 +50,13 @@ message FileExistsResponse {
   bool exists = 1;
 }
 
+message ListFilesEntry {
+  string path = 1;
+  uint64 size = 2;
+}
+
 message ListFilesResponse {
-  repeated string paths = 1;
+  repeated ListFilesEntry files = 1;
 }
 
 message FileLengthRequest {

--- a/lib/uio-grpc-client/src/generated/qdrant.rs
+++ b/lib/uio-grpc-client/src/generated/qdrant.rs
@@ -24,9 +24,16 @@ pub struct FileExistsResponse {
     pub exists: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListFilesEntry {
+    #[prost(string, tag = "1")]
+    pub path: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "2")]
+    pub size: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListFilesResponse {
-    #[prost(string, repeated, tag = "1")]
-    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "1")]
+    pub files: ::prost::alloc::vec::Vec<ListFilesEntry>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct FileLengthRequest {

--- a/lib/uio-grpc-client/src/read.rs
+++ b/lib/uio-grpc-client/src/read.rs
@@ -128,7 +128,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         prefix_path: &str,
-    ) -> Result<Vec<PathBuf>> {
+    ) -> Result<Vec<(PathBuf, u64)>> {
         let response = self
             .inner
             .clone()
@@ -142,9 +142,9 @@ impl Client {
 
         Ok(response
             .into_inner()
-            .paths
+            .files
             .into_iter()
-            .map(PathBuf::from)
+            .map(|entry| (PathBuf::from(entry.path), entry.size))
             .collect())
     }
 

--- a/lib/uio-grpc-client/src/read.rs
+++ b/lib/uio-grpc-client/src/read.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bytes::Bytes;
-use common::universal_io::{ReadRange, Result, UniversalIoError};
+use common::universal_io::{ListedFile, ReadRange, Result, UniversalIoError};
 use futures::StreamExt as _;
 use futures::stream::BoxStream;
 use tonic::codegen::InterceptedService;
@@ -128,7 +128,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         prefix_path: &str,
-    ) -> Result<Vec<(PathBuf, u64)>> {
+    ) -> Result<Vec<ListedFile>> {
         let response = self
             .inner
             .clone()
@@ -144,7 +144,10 @@ impl Client {
             .into_inner()
             .files
             .into_iter()
-            .map(|entry| (PathBuf::from(entry.path), entry.size))
+            .map(|entry| ListedFile {
+                path: PathBuf::from(entry.path),
+                size: entry.size,
+            })
             .collect())
     }
 

--- a/lib/uio-grpc-client/src/tests.rs
+++ b/lib/uio-grpc-client/src/tests.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use common::universal_io::ReadRange;
+use common::universal_io::{ListedFile, ReadRange};
 use tokio::net::TcpListener;
 use tonic::{Request, Response, Status};
 
@@ -203,8 +203,14 @@ async fn list_files() {
     assert_eq!(
         files,
         vec![
-            (PathBuf::from("data/a.bin"), 10),
-            (PathBuf::from("data/b.bin"), 10),
+            ListedFile {
+                path: PathBuf::from("data/a.bin"),
+                size: 10,
+            },
+            ListedFile {
+                path: PathBuf::from("data/b.bin"),
+                size: 10,
+            },
         ]
     );
 }

--- a/lib/uio-grpc-client/src/tests.rs
+++ b/lib/uio-grpc-client/src/tests.rs
@@ -36,14 +36,20 @@ impl StorageReadTrait for MockServer {
         request: Request<ListFilesRequest>,
     ) -> std::result::Result<Response<ListFilesResponse>, Status> {
         let req = request.into_inner();
-        let mut paths: Vec<String> = self
+        let mut files: Vec<ListFilesEntry> = self
             .files
-            .keys()
-            .filter(|(col, path)| col == &req.collection_name && path.starts_with(&req.prefix_path))
-            .map(|(_, path)| path.clone())
+            .iter()
+            .filter_map(|((col, path), data)| {
+                (col == &req.collection_name && path.starts_with(&req.prefix_path)).then(|| {
+                    ListFilesEntry {
+                        path: path.clone(),
+                        size: data.len() as u64,
+                    }
+                })
+            })
             .collect();
-        paths.sort();
-        Ok(Response::new(ListFilesResponse { paths }))
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(Response::new(ListFilesResponse { files }))
     }
 
     async fn file_exists(
@@ -192,11 +198,14 @@ fn test_files() -> HashMap<(String, String), Vec<u8>> {
 async fn list_files() {
     let url = start_mock(test_files()).await;
     let client = Client::connect(url, None).await.unwrap();
-    let mut paths = client.list_files("test-col", 0, "data/").await.unwrap();
-    paths.sort();
+    let mut files = client.list_files("test-col", 0, "data/").await.unwrap();
+    files.sort();
     assert_eq!(
-        paths,
-        vec![PathBuf::from("data/a.bin"), PathBuf::from("data/b.bin")]
+        files,
+        vec![
+            (PathBuf::from("data/a.bin"), 10),
+            (PathBuf::from("data/b.bin"), 10),
+        ]
     );
 }
 

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -11,7 +11,7 @@ use api::grpc::qdrant::{
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
-    MmapFile, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
+    ListedFile, MmapFile, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
     UniversalReadFileOps, UniversalReadFs,
 };
 use futures::Stream;
@@ -95,8 +95,8 @@ where
 
         let files = files
             .into_iter()
-            .filter_map(|(p, size)| {
-                p.strip_prefix(&base).ok().map(|rel| {
+            .filter_map(|ListedFile { path, size }| {
+                path.strip_prefix(&base).ok().map(|rel| {
                     // Always use forward slashes in gRPC responses regardless of OS.
                     let components = rel
                         .components()

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 
 use api::grpc::qdrant::storage_read_server::StorageRead;
 use api::grpc::qdrant::{
-    FileExistsRequest, FileExistsResponse, FileLengthRequest, FileLengthResponse, ListFilesRequest,
-    ListFilesResponse, ReadBatchRequest, ReadBatchResponse, ReadBytesRequest, ReadBytesResponse,
-    ReadBytesStreamRequest, ReadBytesStreamResponse, ReadWholeRequest, ReadWholeResponse,
+    FileExistsRequest, FileExistsResponse, FileLengthRequest, FileLengthResponse, ListFilesEntry,
+    ListFilesRequest, ListFilesResponse, ReadBatchRequest, ReadBatchResponse, ReadBytesRequest,
+    ReadBytesResponse, ReadBytesStreamRequest, ReadBytesStreamResponse, ReadWholeRequest,
+    ReadWholeResponse,
 };
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting};
@@ -87,28 +88,29 @@ where
         let prefix_path = Self::resolve_path(&base, &collections_root, &prefix_path)?;
 
         let fs = Arc::clone(&self.fs);
-        let paths = tokio::task::spawn_blocking(move || fs.list_files(&prefix_path))
+        let files = tokio::task::spawn_blocking(move || fs.list_files(&prefix_path))
             .await
             .map_err(|e| Status::internal(format!("Task join error: {e}")))?
             .map_err(io_error_to_status)?;
 
-        let relative_paths = paths
+        let files = files
             .into_iter()
-            .filter_map(|p| {
+            .filter_map(|(p, size)| {
                 p.strip_prefix(&base).ok().map(|rel| {
                     // Always use forward slashes in gRPC responses regardless of OS.
                     let components = rel
                         .components()
                         .filter_map(|c| c.as_os_str().to_str())
                         .collect::<Vec<_>>();
-                    components.join("/")
+                    ListFilesEntry {
+                        path: components.join("/"),
+                        size,
+                    }
                 })
             })
             .collect::<Vec<_>>();
 
-        Ok(Response::new(ListFilesResponse {
-            paths: relative_paths,
-        }))
+        Ok(Response::new(ListFilesResponse { files }))
     }
 
     // Get file length via UniversalRead::open() → .len().

--- a/src/tonic/api/storage_read_api/tests.rs
+++ b/src/tonic/api/storage_read_api/tests.rs
@@ -254,7 +254,7 @@ async fn list_files_returns_paths_relative_to_shard_dir() {
     write_shard_file(&shard_dir, "index/chunk_2.bin", b"456");
     write_shard_file(&shard_dir, "index/other.bin", b"789");
 
-    let mut paths = service
+    let mut files = service
         .list_files(Request::new(ListFilesRequest {
             collection_name: TEST_COLLECTION_NAME.to_string(),
             shard_id: TEST_SHARD_ID,
@@ -263,15 +263,21 @@ async fn list_files_returns_paths_relative_to_shard_dir() {
         .await
         .unwrap()
         .into_inner()
-        .paths;
+        .files;
 
-    paths.sort();
+    files.sort_by(|a, b| a.path.cmp(&b.path));
 
     assert_eq!(
-        paths,
+        files,
         vec![
-            "index/chunk_1.bin".to_string(),
-            "index/chunk_2.bin".to_string(),
+            ListFilesEntry {
+                path: "index/chunk_1.bin".to_string(),
+                size: 3,
+            },
+            ListFilesEntry {
+                path: "index/chunk_2.bin".to_string(),
+                size: 3,
+            },
         ]
     );
 


### PR DESCRIPTION
To be able to read all lengths at once, we can leverage that "list from prefix" operation already provides this information.

The first step for this is to make `size` part of the return type of `UniversalReadFileOps::list_files`