### PR TITLE
[DiskCache] Preload info for all files

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -35,6 +35,10 @@ impl DiskCacheConfig {
         &self.local_dir
     }
 
+    pub fn remote_dir(&self) -> &Path {
+        &self.remote_dir
+    }
+
     /// Maps a remote path to its local mirror (`<local_dir>/<rel>` + `.partial`);
     /// `NotFound` if `remote_path` isn't under `remote_dir`.
     pub fn local_path_for(&self, remote_path: &Path) -> Result<PathBuf> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -6,6 +6,7 @@ use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
+use crate::universal_io::simple_disk_cache::remote_manifest::RemoteManifest;
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs,
@@ -17,7 +18,7 @@ use crate::universal_io::{
 /// global / default lookup.
 pub struct DiskCacheFsContext<C> {
     pub config: Arc<DiskCacheConfig>,
-    pub remote: C,
+    pub remote_ctx: C,
 }
 
 /// Filesystem handle for the simple disk cache. Carries the remote-side
@@ -29,11 +30,13 @@ pub struct DiskCacheFsContext<C> {
 /// `UniversalRead::Fs = DiskCacheFs<R>` constraint on
 /// [`DiskCache<R>`] line up without an extra generic parameter on the
 /// file type.
+#[derive(Debug)]
 pub struct DiskCacheFs<R>
 where
     R: UniversalRead,
 {
     config: Arc<DiskCacheConfig>,
+    manifest: Arc<RemoteManifest>,
     remote_fs: R::Fs,
 }
 
@@ -43,24 +46,16 @@ where
     R::Fs: Clone,
 {
     fn clone(&self) -> Self {
-        let Self { config, remote_fs } = self;
+        let Self {
+            config,
+            manifest,
+            remote_fs,
+        } = self;
         Self {
             config: config.clone(),
+            manifest: manifest.clone(),
             remote_fs: remote_fs.clone(),
         }
-    }
-}
-
-impl<R> Debug for DiskCacheFs<R>
-where
-    R: UniversalRead,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { config, remote_fs } = self;
-        f.debug_struct("DiskCacheFs")
-            .field("config", config)
-            .field("remote_fs", remote_fs)
-            .finish()
     }
 }
 
@@ -71,10 +66,13 @@ where
     type ContextConfig = DiskCacheFsContext<<R::Fs as UniversalReadFileOps>::ContextConfig>;
 
     fn from_context(ctx: Self::ContextConfig) -> Result<Self> {
-        let DiskCacheFsContext { config, remote } = ctx;
+        let DiskCacheFsContext { config, remote_ctx } = ctx;
+        let remote_fs = R::Fs::from_context(remote_ctx)?;
+        let manifest = Arc::new(RemoteManifest::new(&remote_fs, config.remote_dir())?);
         Ok(Self {
             config,
-            remote_fs: R::Fs::from_context(remote)?,
+            manifest,
+            remote_fs,
         })
     }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -6,7 +6,9 @@ use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
-use crate::universal_io::simple_disk_cache::remote_manifest::RemoteManifest;
+use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, to_block_range};
+use crate::universal_io::simple_disk_cache::local_state::LocalState;
+use crate::universal_io::simple_disk_cache::remote_manifest::{FileInfo, RemoteManifest};
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs,
@@ -38,6 +40,28 @@ where
     config: Arc<DiskCacheConfig>,
     manifest: Arc<RemoteManifest>,
     remote_fs: R::Fs,
+}
+
+impl<R> DiskCacheFs<R>
+where
+    R: UniversalRead,
+{
+    fn open_remote(
+        &self,
+        path: impl AsRef<Path>,
+        extra: <<R as UniversalRead>::Fs as UniversalReadFs>::OpenExtra,
+    ) -> Result<R> {
+        self.remote_fs.open(
+            path.as_ref(),
+            OpenOptions {
+                writeable: false,
+                need_sequential: true,
+                populate: Populate::No,
+                advice: AdviceSetting::Global,
+            },
+            extra,
+        )
+    }
 }
 
 impl<R> Clone for DiskCacheFs<R>
@@ -135,9 +159,52 @@ where
             options.populate
         };
 
-        let state = match populate {
-            Populate::Auto | Populate::No => State::Uninit,
-            Populate::Blocking | Populate::PreferBackground => {
+        // TODO: try to reuse the `remote` used to fetch `first_block` if openoptions is the same?
+        let file_info = self.manifest.get(path.as_ref());
+
+        let state = match (file_info, populate) {
+            // Initialize with known info
+            (Some(file_info), Populate::Auto | Populate::No) => {
+                let FileInfo { size, first_block } = file_info;
+                let local = LocalState::new(&local_path, *size, options)?;
+                let blocks_range = to_block_range(0..first_block.len() as u64);
+                // SAFETY: We just created the localstate
+                unsafe { local.write_mmap_bytes(&first_block, blocks_range) };
+
+                let remote = self.open_remote(path.as_ref(), extra.clone())?;
+
+                State::Ready { local, remote }
+            }
+            // Initialize with known info, but finish populating.
+            (Some(file_info), Populate::Blocking | Populate::PreferBackground) => {
+                let FileInfo { size, first_block } = file_info;
+                let local = LocalState::new(&local_path, *size, options)?;
+                let blocks_range = to_block_range(0..first_block.len() as u64);
+                // SAFETY: We just created the localstate
+                unsafe { local.write_mmap_bytes(&first_block, blocks_range) };
+
+                let remote = self.open_remote(path.as_ref(), extra.clone())?;
+
+                let fetched_len = first_block.len() as u64;
+                if fetched_len == *size {
+                    // In case the first block covers the entire file, local state is fully populated
+                    State::Ready { local, remote }
+                } else {
+                    // Align read start to BLOCK_SIZE
+                    let from = fetched_len.saturating_sub(fetched_len % BLOCK_SIZE as u64);
+
+                    let mut pipeline = OwnedPipeline::new(remote)?;
+
+                    // FIXME: check `can_schedule` in a loop first
+                    pipeline.schedule_whole(from, from)?;
+
+                    State::ReopenPrefill { pipeline, local }
+                }
+            }
+            // No prefetched info, keep uninitialized.
+            (None, Populate::Auto | Populate::No) => State::Uninit,
+            // Schedule population.
+            (None, Populate::Blocking | Populate::PreferBackground) => {
                 let remote = self.remote_fs.open(
                     path.as_ref(),
                     OpenOptions {

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -6,9 +6,9 @@ use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
-use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, to_block_range};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::remote_manifest::{FileInfo, RemoteManifest};
+use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, to_block_range};
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs,
@@ -101,11 +101,11 @@ where
     }
 
     fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
-        self.remote_fs.list_files(prefix_path)
+        Ok(self.manifest.list_files(prefix_path))
     }
 
     fn exists(&self, path: &Path) -> Result<bool> {
-        self.remote_fs.exists(path)
+        Ok(self.manifest.exists(path))
     }
 
     fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
@@ -169,7 +169,7 @@ where
                 let local = LocalState::new(&local_path, *size, options)?;
                 let blocks_range = to_block_range(0..first_block.len() as u64);
                 // SAFETY: We just created the localstate
-                unsafe { local.write_mmap_bytes(&first_block, blocks_range) };
+                unsafe { local.write_mmap_bytes(first_block, blocks_range) };
 
                 let remote = self.open_remote(path.as_ref(), extra.clone())?;
 
@@ -181,7 +181,7 @@ where
                 let local = LocalState::new(&local_path, *size, options)?;
                 let blocks_range = to_block_range(0..first_block.len() as u64);
                 // SAFETY: We just created the localstate
-                unsafe { local.write_mmap_bytes(&first_block, blocks_range) };
+                unsafe { local.write_mmap_bytes(first_block, blocks_range) };
 
                 let remote = self.open_remote(path.as_ref(), extra.clone())?;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -4,9 +4,9 @@ mod fs;
 
 mod local_state;
 pub mod pipeline;
+mod remote_manifest;
 #[cfg(test)]
 mod tests;
-mod remote_manifest;
 
 use std::ops::Range;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -6,6 +6,7 @@ mod local_state;
 pub mod pipeline;
 #[cfg(test)]
 mod tests;
+mod remote_manifest;
 
 use std::ops::Range;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -12,11 +12,11 @@ use crate::universal_io::{self, ReadPipeline, Result, UniversalIoError, Universa
 
 #[cfg(target_os = "linux")]
 /// Required alignment when using io_uring with `O_DIRECT` on Linux
-const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
+pub const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
 
 #[cfg(not(target_os = "linux"))]
 /// Default alignment on non-Linux platforms
-const REMOTE_READ_ALIGNMENT: usize = 1;
+pub const REMOTE_READ_ALIGNMENT: usize = 1;
 
 struct RemoteMeta<File, U> {
     file: File,

--- a/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
@@ -9,7 +9,8 @@ use crate::mmap::AdviceSetting;
 use crate::universal_io::simple_disk_cache::BLOCK_SIZE;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
 use crate::universal_io::{
-    OpenExtra, OpenOptions, Populate, ReadPipeline, Result, UniversalRead, UniversalReadFs,
+    ListedFile, OpenExtra, OpenOptions, Populate, ReadPipeline, Result, UniversalRead,
+    UniversalReadFs,
 };
 
 #[derive(Debug)]
@@ -35,9 +36,9 @@ impl RemoteManifest {
         let extra = Fs::OpenExtra::default().with_prevent_caching(true);
         let files = list
             .iter()
-            .map(|(path, _)| {
+            .map(|listed_file| {
                 fs.open(
-                    path,
+                    &listed_file.path,
                     OpenOptions {
                         writeable: false,
                         need_sequential: false,
@@ -65,17 +66,15 @@ impl RemoteManifest {
         let mut pipeline = <Fs::File as UniversalRead>::ReadPipeline::new()?;
         loop {
             while pipeline.can_schedule()
-                && let Some((file, (path, size))) = reads.next()
+                && let Some((file, ListedFile { path, size })) = reads.next()
             {
                 let range_end = size.min(BLOCK_SIZE as u64);
-                if let Err(err) = pipeline.schedule::<Random>(
+                pipeline.schedule::<Random>(
                     (path, size),
                     file,
                     0..range_end,
                     REMOTE_READ_ALIGNMENT,
-                ) {
-                    return Err(err);
-                }
+                )?;
             }
 
             let Some((user_data, read)) = pipeline.wait()? else {
@@ -90,5 +89,22 @@ impl RemoteManifest {
 
     pub fn get(&self, path: &Path) -> Option<&FileInfo> {
         self.files.get(path)
+    }
+
+    pub fn list_files(&self, prefix_path: &Path) -> Vec<ListedFile> {
+        let prefix_string = prefix_path.to_string_lossy();
+
+        self.files
+            .iter()
+            .filter(|(path, _)| path.to_string_lossy().starts_with(prefix_string.as_ref()))
+            .map(|(path, info)| ListedFile {
+                path: path.clone(),
+                size: info.size,
+            })
+            .collect()
+    }
+
+    pub fn exists(&self, path: &Path) -> bool {
+        self.files.contains_key(path)
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use aligned_vec::{AVec, RuntimeAlign};
+
+use crate::ext::aligned_vec::ACow;
+use crate::generic_consts::Random;
+use crate::mmap::AdviceSetting;
+use crate::universal_io::simple_disk_cache::BLOCK_SIZE;
+use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
+use crate::universal_io::{
+    OpenExtra, OpenOptions, Populate, ReadPipeline, Result, UniversalRead, UniversalReadFs,
+};
+
+#[derive(Debug)]
+struct FileInfo {
+    /// Length in bytes of the entire file
+    size: u64,
+    /// First `BLOCK_SIZE` of the file, (or `size` if `size` < `BLOCK_SIZE`)
+    first_block: AVec<u8, RuntimeAlign>,
+}
+
+#[derive(Debug)]
+pub struct RemoteManifest {
+    files: HashMap<PathBuf, FileInfo>,
+}
+
+impl RemoteManifest {
+    pub fn new<Fs: UniversalReadFs>(fs: &Fs, prefix_path: &Path) -> Result<Self> {
+        // List all files
+        let list = fs.list_files(prefix_path)?;
+
+        // Open all files
+        let extra = Fs::OpenExtra::default().with_prevent_caching(true);
+        let files = list
+            .iter()
+            .map(|(path, _)| {
+                fs.open(
+                    path,
+                    OpenOptions {
+                        writeable: false,
+                        need_sequential: false,
+                        populate: Populate::No,
+                        advice: AdviceSetting::Global,
+                    },
+                    extra.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Submit all reads and wait concurrently
+        let mut acc = HashMap::new();
+        let mut callback = |(path, size), read| {
+            let first_block = match read {
+                ACow::Borrowed(slice) => AVec::from_slice(REMOTE_READ_ALIGNMENT, slice),
+                ACow::Owned(vec) => vec,
+            };
+            let info = FileInfo { size, first_block };
+
+            acc.insert(path, info);
+        };
+
+        let mut reads = files.iter().zip(list);
+        let mut pipeline = <Fs::File as UniversalRead>::ReadPipeline::new()?;
+        loop {
+            while pipeline.can_schedule()
+                && let Some((file, (path, size))) = reads.next()
+            {
+                let range_end = size.min(BLOCK_SIZE as u64);
+                if let Err(err) = pipeline.schedule::<Random>(
+                    (path, size),
+                    file,
+                    0..range_end,
+                    REMOTE_READ_ALIGNMENT,
+                ) {
+                    return Err(err);
+                }
+            }
+
+            let Some((user_data, read)) = pipeline.wait()? else {
+                break;
+            };
+
+            callback(user_data, read);
+        }
+
+        Ok(Self { files: acc })
+    }
+}

--- a/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/remote_manifest.rs
@@ -13,15 +13,16 @@ use crate::universal_io::{
 };
 
 #[derive(Debug)]
-struct FileInfo {
+pub struct FileInfo {
     /// Length in bytes of the entire file
-    size: u64,
+    pub size: u64,
     /// First `BLOCK_SIZE` of the file, (or `size` if `size` < `BLOCK_SIZE`)
-    first_block: AVec<u8, RuntimeAlign>,
+    pub first_block: AVec<u8, RuntimeAlign>,
 }
 
 #[derive(Debug)]
 pub struct RemoteManifest {
+    /// A preloaded view of the remote files, which include filepaths, sizes, and even partial reads.
     files: HashMap<PathBuf, FileInfo>,
 }
 
@@ -85,5 +86,9 @@ impl RemoteManifest {
         }
 
         Ok(Self { files: acc })
+    }
+
+    pub fn get(&self, path: &Path) -> Option<&FileInfo> {
+        self.files.get(path)
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -65,7 +65,7 @@ impl Scenario {
 
         let fs = DiskCacheFs::<R>::from_context(DiskCacheFsContext {
             config: self.config.clone(),
-            remote: Default::default(),
+            remote_ctx: Default::default(),
         })
         .unwrap();
         fs.open(

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 ///
 /// `Default` is required so callers can construct a neutral extras value
 /// (e.g. `<Fs::OpenExtra>::default()`) and then chain typed setters.
-pub trait OpenExtra: Default + Debug {
+pub trait OpenExtra: Clone + Debug + Default {
     /// Hint that the open should bypass the OS page cache. Backends that
     /// support it (e.g. `io_uring` via `O_DIRECT`) honor the flag; backends
     /// where it's meaningless (mmap, block-cache) treat this as a no-op.

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -236,7 +236,7 @@ fn disk_cache_read_whole_skips_remote_len() {
     let config = DiskCacheConfig::new(PathBuf::from("bucket"), local_dir).unwrap();
     let fs = DiskCacheFs::<BlobFile<CountingSource>>::from_context(DiskCacheFsContext {
         config: Arc::new(config),
-        remote: source.config(),
+        remote_ctx: source.config(),
     })
     .unwrap();
 
@@ -288,7 +288,7 @@ fn disk_cache_prefill_open_uses_whole_get_without_head() {
     let config = DiskCacheConfig::new(PathBuf::from("bucket"), local_dir).unwrap();
     let fs = DiskCacheFs::<BlobFile<CountingSource>>::from_context(DiskCacheFsContext {
         config: Arc::new(config),
-        remote: source.config(),
+        remote_ctx: source.config(),
     })
     .unwrap();
 

--- a/lib/edge/tools/shard_query/src/main.rs
+++ b/lib/edge/tools/shard_query/src/main.rs
@@ -386,7 +386,7 @@ where
 
     DiskCacheFs::<BlobFile<A>>::from_context(DiskCacheFsContext {
         config: Arc::new(config),
-        remote: remote_config,
+        remote_ctx: remote_config,
     })
     .context("failed to build disk-cache filesystem")
 }


### PR DESCRIPTION
[PR description is WIP]

This PR maximizes the parallelism for remote requests. Instead of letting each `<Component>::open` sequence dictate how to send requests, we just list every file, and preload its first block. Once we actually want to use it for a component, the data will already be there.

This also gets rid of sequential `len`, `exists`, and `list_files` calls.