### PR TITLE
[UIO] Split UniversalReadFileOps into read and write traits

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -8,7 +8,7 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     ListedFile, OpenOptions, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
-    UniversalReadFs, UserData, local_file_ops,
+    UniversalReadFs, UniversalWriteFileOps, UserData, local_file_ops,
 };
 
 mod cached_slice;
@@ -98,7 +98,9 @@ impl UniversalReadFileOps for BlockCacheFs {
     fn exists(&self, path: &Path) -> Result<bool> {
         fs::exists(path).map_err(UniversalIoError::from)
     }
+}
 
+impl UniversalWriteFileOps for BlockCacheFs {
     fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
         local_file_ops::local_create(path, expected_length)
     }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -21,7 +21,7 @@ use self::error::*;
 use self::pipeline::IoUringPipeline;
 use self::pool::*;
 use self::runtime::*;
-use super::traits::{OpenExtra, UniversalReadFileOps, UniversalReadFs};
+use super::traits::{OpenExtra, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
 use super::*;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
@@ -69,7 +69,9 @@ impl UniversalReadFileOps for IoUringFs {
     fn exists(&self, path: &Path) -> Result<bool> {
         fs::exists(path).map_err(UniversalIoError::from)
     }
+}
 
+impl UniversalWriteFileOps for IoUringFs {
     fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
         local_file_ops::local_create(path, expected_length)
     }

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -11,7 +11,7 @@ use memmap2::MmapRaw;
 use parking_lot::Mutex;
 
 use self::pipeline::MmapReadPipeline;
-use super::traits::{UniversalReadFileOps, UniversalReadFs};
+use super::traits::{UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
 use super::*;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
@@ -35,7 +35,9 @@ impl UniversalReadFileOps for MmapFs {
     fn exists(&self, path: &Path) -> Result<bool> {
         fs_err::exists(path).map_err(UniversalIoError::from)
     }
+}
 
+impl UniversalWriteFileOps for MmapFs {
     fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
         local_file_ops::local_create(path, expected_length)
     }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -22,7 +22,7 @@ pub use self::simple_disk_cache::{
 };
 pub use self::traits::{
     Item, OpenExtra, OwnedPipeline, ReadPipeline, UniversalRead, UniversalReadFileOps,
-    UniversalReadFs, UniversalWrite, UserData,
+    UniversalReadFs, UniversalWrite, UniversalWriteFileOps, UserData,
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange,

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -8,7 +8,7 @@ use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
-    UniversalRead, UniversalReadFileOps, UniversalReadFs,
+    UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
 };
 
 /// Construction context for [`DiskCacheFs`]: carries the
@@ -85,7 +85,13 @@ where
     fn exists(&self, path: &Path) -> Result<bool> {
         self.remote_fs.exists(path)
     }
+}
 
+impl<R> UniversalWriteFileOps for DiskCacheFs<R>
+where
+    R: UniversalRead,
+    R::Fs: UniversalWriteFileOps,
+{
     fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
         self.remote_fs.create(path, expected_length)
     }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -5,7 +5,7 @@ use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
 use crate::universal_io::{ListedFile, OpenOptions, Result};
 
-/// Filesystem-level handle.
+/// Filesystem-level handle for read-only operations.
 ///
 /// Constructed once per backend instance from a
 /// [`Self::ContextConfig`] (e.g. a bucket name + credentials for S3, an
@@ -15,7 +15,10 @@ use crate::universal_io::{ListedFile, OpenOptions, Result};
 /// Deliberately does NOT depend on [`UniversalRead`] or `UniversalWrite`:
 /// a backend can implement this trait to expose metadata-style operations
 /// without ever opening file handles. The "open files" capability lives on
-/// the [`UniversalReadFs`] subtrait.
+/// the [`UniversalReadFs`] subtrait, and mutating operations live on the
+/// [`UniversalWriteFileOps`] subtrait.
+///
+/// [`UniversalWrite`]: super::UniversalWrite
 pub trait UniversalReadFileOps: Clone + Debug + Sized {
     /// Implementation-specific construction config. Backends are free to
     /// require explicit construction; callers that want to opt into the
@@ -38,6 +41,17 @@ pub trait UniversalReadFileOps: Clone + Debug + Sized {
     /// Check whether a file exists at the given path.
     fn exists(&self, path: &Path) -> Result<bool>;
 
+    // When adding provided methods, don't forget to update impls in
+    // `crate::universal_io::wrappers::*`.
+}
+
+/// Filesystem-level handle for mutating operations.
+///
+/// Extends [`UniversalReadFileOps`] with create/remove/save operations.
+/// Read-only backends (e.g. `ReadOnlyFs`) implement only the read side,
+/// making the absence of write support a compile-time property instead of
+/// a runtime error.
+pub trait UniversalWriteFileOps: UniversalReadFileOps {
     /// Create or truncate a file at the given path.
     ///
     /// Local backends use `expected_length` to pre-size the file. Backends

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -6,7 +6,7 @@ mod write;
 
 use std::fmt;
 
-pub use file_ops::{UniversalReadFileOps, UniversalReadFs};
+pub use file_ops::{UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
 pub use open_extra::OpenExtra;
 pub use pipeline::{OwnedPipeline, ReadPipeline};
 pub use read::UniversalRead;

--- a/lib/common/common/src/universal_io/traits/write.rs
+++ b/lib/common/common/src/universal_io/traits/write.rs
@@ -1,7 +1,12 @@
-use super::UniversalRead;
+use super::{UniversalRead, UniversalWriteFileOps};
 use crate::universal_io::{ByteOffset, FileIndex, Flusher, Result, UniversalIoError};
 
-pub trait UniversalWrite: UniversalRead {
+/// A writeable file handle.
+///
+/// Requires the backing filesystem to support mutating file operations
+/// ([`UniversalWriteFileOps`]): a backend that can open files for writing
+/// must also be able to create and remove them.
+pub trait UniversalWrite: UniversalRead<Fs: UniversalWriteFileOps> {
     fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()>;
 
     fn write_batch<'a, T: bytemuck::Pod>(

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalIoError,
-    UniversalKind, UniversalRead, UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalKind, UniversalRead,
+    UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -51,35 +51,8 @@ impl<F: UniversalReadFileOps> UniversalReadFileOps for ReadOnlyFs<F> {
         self.0.exists(path)
     }
 
-    fn create(&self, _path: &Path, _expected_length: usize) -> Result<()> {
-        Err(UniversalIoError::uninitialized(
-            "ReadOnlyFs does not support creating files",
-        ))
-    }
-
-    fn create_dir(&self, _path: &Path) -> Result<()> {
-        Err(UniversalIoError::uninitialized(
-            "ReadOnlyFs does not support creating directories",
-        ))
-    }
-
-    fn remove(&self, _path: &Path) -> Result<()> {
-        Err(UniversalIoError::uninitialized(
-            "ReadOnlyFs does not support removing files",
-        ))
-    }
-
-    fn remove_dir(&self, _path: &Path) -> Result<()> {
-        Err(UniversalIoError::uninitialized(
-            "ReadOnlyFs does not support removing directories",
-        ))
-    }
-
-    fn atomic_save(&self, _path: &Path, _bytes: &[u8]) -> Result<()> {
-        Err(UniversalIoError::uninitialized(
-            "ReadOnlyFs does not support atomic saves",
-        ))
-    }
+    // Deliberately no `UniversalWriteFileOps` impl: read-only is a
+    // compile-time property of this wrapper.
 }
 
 impl<F: UniversalReadFs> UniversalReadFs for ReadOnlyFs<F> {

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -170,26 +170,6 @@ mod tests {
             std::future::ready(Ok(true))
         }
 
-        fn create(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-            std::future::ready(Ok(()))
-        }
-
-        fn remove(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-            std::future::ready(Ok(()))
-        }
-
-        fn remove_dir(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-            std::future::ready(Ok(()))
-        }
-
-        fn atomic_save(
-            &self,
-            _path: &Path,
-            _bytes: Bytes,
-        ) -> impl Future<Output = Result<()>> + Send + 'static {
-            std::future::ready(Ok(()))
-        }
-
         fn read_range(
             &self,
             _path: &Path,

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use bytes::Bytes;
 use common::universal_io::{
     ListedFile, OpenOptions, Result, UniversalReadFileOps, UniversalReadFs,
 };
@@ -49,26 +48,8 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
         self.runtime.block_on(self.inner.exists(path))
     }
 
-    fn create(&self, path: &Path, _expected_length: usize) -> Result<()> {
-        self.runtime.block_on(self.inner.create(path))
-    }
-
-    fn create_dir(&self, _path: &Path) -> Result<()> {
-        Ok(())
-    }
-
-    fn remove(&self, path: &Path) -> Result<()> {
-        self.runtime.block_on(self.inner.remove(path))
-    }
-
-    fn remove_dir(&self, path: &Path) -> Result<()> {
-        self.runtime.block_on(self.inner.remove_dir(path))
-    }
-
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
-        self.runtime
-            .block_on(self.inner.atomic_save(path, Bytes::copy_from_slice(bytes)))
-    }
+    // Deliberately no `UniversalWriteFileOps` impl: blob backends are
+    // read-only; a future `AsyncWrite` trait is the place for mutations.
 }
 
 impl<A: AsyncRead + Clone> UniversalReadFs for BlobFs<A> {

--- a/lib/common/io_bridge/src/read.rs
+++ b/lib/common/io_bridge/src/read.rs
@@ -36,22 +36,6 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
 
     fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static;
 
-    /// Create or truncate an empty object at `path`.
-    fn create(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static;
-
-    /// Remove the object at `path`.
-    fn remove(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static;
-
-    /// Remove all objects matching the directory prefix at `path`.
-    fn remove_dir(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static;
-
-    /// Save bytes by overwriting the full object at `path`.
-    fn atomic_save(
-        &self,
-        path: &Path,
-        bytes: Bytes,
-    ) -> impl Future<Output = Result<()>> + Send + 'static;
-
     /// Fetch `range` from `path` as a stream of byte chunks.
     ///
     /// The returned future resolves once the request has been initiated and the

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -81,26 +81,6 @@ impl AsyncRead for CountingSource {
         std::future::ready(Ok(true))
     }
 
-    fn create(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Ok(()))
-    }
-
-    fn remove(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Ok(()))
-    }
-
-    fn remove_dir(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Ok(()))
-    }
-
-    fn atomic_save(
-        &self,
-        _path: &Path,
-        _bytes: Bytes,
-    ) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Ok(()))
-    }
-
     fn read_range(
         &self,
         _path: &Path,

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -113,73 +113,6 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         }
     }
 
-    fn create(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        let store = self.0.clone();
-        let key = build_key(path);
-
-        async move {
-            store
-                .put(&key, Bytes::new().into())
-                .await
-                .map(drop)
-                .map_err(UniversalIoError::s3)
-        }
-    }
-
-    fn remove(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        let store = self.0.clone();
-        let key = build_key(path);
-
-        async move {
-            store.delete(&key).await.map_err(|err| match err {
-                object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                    path: PathBuf::from(key.to_string()),
-                },
-                err => UniversalIoError::s3(err),
-            })
-        }
-    }
-
-    fn remove_dir(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        let store = self.0.clone();
-        let prefix_path = path.to_path_buf();
-        let prefix = build_dir_prefix(path);
-
-        async move {
-            let mut objects = store.list(Some(&prefix));
-            while let Some(meta) = objects.try_next().await.map_err(|err| match err {
-                object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                    path: prefix_path.clone(),
-                },
-                other => UniversalIoError::s3(other),
-            })? {
-                match store.delete(&meta.location).await {
-                    Ok(()) | Err(object_store::Error::NotFound { .. }) => {}
-                    Err(other) => return Err(UniversalIoError::s3(other)),
-                }
-            }
-
-            Ok(())
-        }
-    }
-
-    fn atomic_save(
-        &self,
-        path: &Path,
-        bytes: Bytes,
-    ) -> impl Future<Output = Result<()>> + Send + 'static {
-        let store = self.0.clone();
-        let key = build_key(path);
-
-        async move {
-            store
-                .put(&key, bytes.into())
-                .await
-                .map(drop)
-                .map_err(UniversalIoError::s3)
-        }
-    }
-
     fn read_range(
         &self,
         path: &Path,
@@ -270,8 +203,8 @@ fn build_dir_prefix(path: &Path) -> object_store::path::Path {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use common::universal_io::{ListedFile, ReadRange, UniversalRead, UniversalReadFileOps};
-    use io_bridge::{BlobFile, BlobFs, BridgeRuntime};
+    use common::universal_io::{ListedFile, ReadRange, UniversalRead};
+    use io_bridge::{BlobFile, BridgeRuntime};
     use object_store::memory::InMemory;
 
     use super::*;
@@ -415,32 +348,6 @@ mod tests {
         let file = make_file(runtime, store, "obj");
         let len: u64 = <BlobFile<InMemorySource> as UniversalRead>::len::<u16>(&file).unwrap();
         assert_eq!(len, 2);
-    }
-
-    #[test]
-    fn fs_create_writes_empty_object_and_create_dir_is_noop() {
-        let runtime = BridgeRuntime::global();
-        let store = Arc::new(InMemory::new());
-        let fs = BlobFs::new(ObjectStoreSource::new(store.clone()), runtime.clone());
-
-        fs.create_dir(Path::new("prefix")).unwrap();
-        fs.create(Path::new("prefix/empty"), 1024).unwrap();
-        fs.create(Path::new("prefix/nested/empty"), 1024).unwrap();
-        fs.create(Path::new("prefix-sibling/empty"), 1024).unwrap();
-        fs.atomic_save(Path::new("prefix/saved"), b"saved").unwrap();
-
-        assert!(fs.exists(Path::new("prefix/empty")).unwrap());
-        let len = runtime.block_on(store.head(&object_store::path::Path::from("prefix/empty")));
-        assert_eq!(len.unwrap().size, 0);
-        let len = runtime.block_on(store.head(&object_store::path::Path::from("prefix/saved")));
-        assert_eq!(len.unwrap().size, 5);
-
-        fs.remove(Path::new("prefix/empty")).unwrap();
-        fs.remove_dir(Path::new("prefix")).unwrap();
-        assert!(!fs.exists(Path::new("prefix/empty")).unwrap());
-        assert!(!fs.exists(Path::new("prefix/nested/empty")).unwrap());
-        assert!(!fs.exists(Path::new("prefix/saved")).unwrap());
-        assert!(fs.exists(Path::new("prefix-sibling/empty")).unwrap());
     }
 
     #[test]

--- a/lib/common/io_bridge_uio_grpc/src/lib.rs
+++ b/lib/common/io_bridge_uio_grpc/src/lib.rs
@@ -29,21 +29,18 @@
 //!
 //! # Read-only
 //!
-//! `StorageRead` is a read-only service. The mutating [`AsyncRead`] methods
-//! ([`create`](AsyncRead::create), [`remove`](AsyncRead::remove),
-//! [`remove_dir`](AsyncRead::remove_dir), [`atomic_save`](AsyncRead::atomic_save))
-//! therefore return an `Unsupported` IO error; wrap a [`UioGrpcFile`] in
+//! `StorageRead` is a read-only service, matching the read-only [`AsyncRead`]
+//! trait; wrap a [`UioGrpcFile`] in
 //! [`ReadOnly`](common::universal_io::ReadOnly) when a read-only handle is what
 //! the caller expects.
 
 use std::future::Future;
-use std::io;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use common::universal_io::{ListedFile, Result, UniversalIoError, UniversalKind};
+use common::universal_io::{ListedFile, Result, UniversalKind};
 use futures::stream::{self, BoxStream, StreamExt as _};
 use io_bridge::{AsyncRead, BlobFile, BlobFs};
 use tokio::sync::OnceCell;
@@ -123,13 +120,6 @@ fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
-fn read_only_error(op: &str) -> UniversalIoError {
-    UniversalIoError::Io(io::Error::new(
-        io::ErrorKind::Unsupported,
-        format!("uio-grpc StorageRead backend is read-only: {op} is not supported"),
-    ))
-}
-
 impl AsyncRead for UioGrpcSource {
     type Config = UioGrpcConfig;
 
@@ -165,26 +155,6 @@ impl AsyncRead for UioGrpcSource {
                 .file_exists(&inner.collection, inner.shard_id, &path)
                 .await
         }
-    }
-
-    fn create(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Err(read_only_error("create")))
-    }
-
-    fn remove(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Err(read_only_error("remove")))
-    }
-
-    fn remove_dir(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Err(read_only_error("remove_dir")))
-    }
-
-    fn atomic_save(
-        &self,
-        _path: &Path,
-        _bytes: Bytes,
-    ) -> impl Future<Output = Result<()>> + Send + 'static {
-        std::future::ready(Err(read_only_error("atomic_save")))
     }
 
     fn read_range(
@@ -263,9 +233,6 @@ pub type UioGrpcFs = BlobFs<UioGrpcSource>;
 
 #[cfg(test)]
 mod tests {
-    use common::universal_io::UniversalReadFileOps;
-    use io_bridge::BridgeRuntime;
-
     use super::*;
 
     fn offline_source() -> UioGrpcSource {
@@ -288,25 +255,5 @@ mod tests {
         // `open` must not touch the network or a runtime (the endpoint here is
         // unreachable, and we are not inside a Tokio runtime).
         let _source = offline_source();
-    }
-
-    #[test]
-    fn writes_are_unsupported() {
-        let fs = UioGrpcFs::new(offline_source(), BridgeRuntime::global());
-
-        // Mutating ops resolve to a ready `Unsupported` error without any IO, so
-        // they can be checked offline.
-        let err = fs
-            .create(Path::new("f"), 0)
-            .expect_err("create is read-only");
-        assert!(matches!(err, UniversalIoError::Io(e) if e.kind() == io::ErrorKind::Unsupported));
-
-        let err = fs
-            .atomic_save(Path::new("f"), b"x")
-            .expect_err("atomic_save is read-only");
-        assert!(matches!(err, UniversalIoError::Io(e) if e.kind() == io::ErrorKind::Unsupported));
-
-        let err = fs.remove(Path::new("f")).expect_err("remove is read-only");
-        assert!(matches!(err, UniversalIoError::Io(e) if e.kind() == io::ErrorKind::Unsupported));
     }
 }

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -14,7 +14,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::is_alive_lock::IsAliveLock;
-use common::universal_io::{MmapFile, Populate, UniversalReadFileOps, UniversalWrite, UserData};
+use common::universal_io::{MmapFile, Populate, UniversalWrite, UniversalWriteFileOps, UserData};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use reader::CONFIG_FILENAME;


### PR DESCRIPTION
## What

`UniversalReadFileOps` mixed read-side operations (`from_context`, `list_files`, `exists`) with mutating ones (`create`, `create_dir`, `remove`, `remove_dir`, `atomic_save`). This splits the mutating operations into a new `UniversalWriteFileOps: UniversalReadFileOps` subtrait, mirroring the existing `UniversalRead`/`UniversalWrite` naming.

## Changes

- **`UniversalWriteFileOps`** holds `create`/`create_dir`/`remove`/`remove_dir`/`atomic_save`; implemented by the local backends (`MmapFs`, `IoUringFs`, `BlockCacheFs`).
- **`UniversalWrite`** now requires `Fs: UniversalWriteFileOps` — a backend that opens files for writing must also be able to create/remove them. Generic consumers (gridstore) keep reaching write ops through `S::Fs` unchanged.
- **`ReadOnlyFs`** drops its five runtime-erroring write stubs: read-only is now a compile-time property.
- **`DiskCacheFs<R>`** implements the write side only when the remote fs does (forwarding to remote).
- **`BlobFs` / async `AsyncRead`** are read-only: the async write methods are removed from `AsyncRead` and its backends (`ObjectStoreSource`, `UioGrpcSource`), along with the tests that exercised them (`fs_create_writes_empty_object_and_create_dir_is_noop`, `writes_are_unsupported`). A future `AsyncWrite` trait is the place for blob mutations, as the `AsyncRead` docs already stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)