### PR TITLE
Add unified `memory: cold|cached|pinned` placement parameter for collection components

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7453,9 +7453,21 @@
             "nullable": true
           },
           "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
+            "description": "Deprecated: use `payload.memory` instead. If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
             "default": true,
+            "deprecated": true,
             "type": "boolean"
+          },
+          "payload": {
+            "description": "Configuration of the payload storage",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PayloadStorageParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "sparse_vectors": {
             "description": "Configuration of the sparse vector storage",
@@ -7521,9 +7533,21 @@
             ]
           },
           "on_disk": {
-            "description": "If true, vectors are served from disk, improving RAM usage at the cost of latency Default: false",
+            "description": "Deprecated: use `memory` instead. If true, vectors are served from disk, improving RAM usage at the cost of latency Default: false",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the original vector storage. Overrides the deprecated `on_disk` flag if both are set. `pinned` is not supported for dense vector storage. Default: `cached` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "datatype": {
             "description": "Defines which datatype should be used to represent vectors in the storage. Choosing different datatypes allows to optimize memory usage and performance vs accuracy.\n\n- For `float32` datatype - vectors are stored as single-precision floating point numbers, 4 bytes. - For `float16` datatype - vectors are stored as half-precision floating point numbers, 2 bytes. - For `uint8` datatype - vectors are stored as unsigned 8-bit integers, 1 byte. It expects vector elements to be in range `[0, 255]`. - For `turbo4` datatype - vectors are quantized to 4 bits per element using the TurboQuant algorithm.",
@@ -7590,9 +7614,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false",
+            "description": "Deprecated: use `memory` instead. Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the HNSW graph. Overrides the deprecated `on_disk` flag if both are set. Default: `cached` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "payload_m": {
             "description": "Custom M param for additional payload-aware HNSW links. If not set, default M will be used.",
@@ -7607,6 +7643,32 @@
             "nullable": true
           }
         }
+      },
+      "Memory": {
+        "description": "Memory placement of a component's data.\n\nData is always persisted on disk regardless of this setting; it only controls how the data is held in RAM.",
+        "oneOf": [
+          {
+            "description": "Data is not pre-loaded from disk to RAM. Preferred for rarely queried components or components larger than RAM size. First request might be slow, but data is cached with usage.",
+            "type": "string",
+            "enum": [
+              "cold"
+            ]
+          },
+          {
+            "description": "Data is pre-loaded into disk-cache RAM on start. First request is fast, but data may be evicted if there is not enough memory and some other component's data is used more frequently.",
+            "type": "string",
+            "enum": [
+              "cached"
+            ]
+          },
+          {
+            "description": "Data is loaded in RAM and never evicted. First request is fast, but the component must fit in RAM at all times. Recommended for frequently queried small components like quantized vectors or primary indexes.",
+            "type": "string",
+            "enum": [
+              "pinned"
+            ]
+          }
+        ]
       },
       "QuantizationConfig": {
         "anyOf": [
@@ -7653,9 +7715,21 @@
             "nullable": true
           },
           "always_ram": {
-            "description": "If true - quantized vectors always will be stored in RAM, ignoring the config of main storage",
+            "description": "Deprecated: use `memory` instead. If true - quantized vectors always will be stored in RAM, ignoring the config of main storage",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if both are set. Default: follow the memory placement of the original vector storage.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -7686,8 +7760,21 @@
             "$ref": "#/components/schemas/CompressionRatio"
           },
           "always_ram": {
+            "description": "Deprecated: use `memory` instead.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if both are set. Default: follow the memory placement of the original vector storage.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -7716,8 +7803,21 @@
         "type": "object",
         "properties": {
           "always_ram": {
+            "description": "Deprecated: use `memory` instead.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if both are set. Default: follow the memory placement of the original vector storage.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "encoding": {
             "anyOf": [
@@ -7774,8 +7874,21 @@
         "type": "object",
         "properties": {
           "always_ram": {
+            "description": "Deprecated: use `memory` instead.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if both are set. Default: follow the memory placement of the original vector storage.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "bits": {
             "anyOf": [
@@ -7831,6 +7944,23 @@
           "custom"
         ]
       },
+      "PayloadStorageParams": {
+        "description": "Params of the payload storage",
+        "type": "object",
+        "properties": {
+          "memory": {
+            "description": "Memory placement of the payload storage. Overrides the deprecated `on_disk_payload` flag if both are set. `pinned` is not supported for payload storage. Default: `cold` (`cached` if `on_disk_payload` is set to false).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        }
+      },
       "SparseVectorParams": {
         "description": "Params of single sparse vector data storage",
         "type": "object",
@@ -7871,9 +8001,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "Store index on disk. If set to false, the index will be stored in RAM. Default: false",
+            "description": "Deprecated: use `memory` instead. Store index on disk. If set to false, the index will be stored in RAM. Default: false",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "datatype": {
             "description": "Defines which datatype should be used for the index. Choosing different datatypes allows to optimize memory usage and performance vs accuracy.\n\n- For `float32` datatype - vectors are stored as single-precision floating point numbers, 4 bytes. - For `float16` datatype - vectors are stored as half-precision floating point numbers, 2 bytes. - For `uint8` datatype - vectors are quantized to unsigned 8-bit integers, 1 byte. Quantization to fit byte range `[0, 255]` happens during indexing automatically, so the actual vector data does not need to conform to this range.",
@@ -7931,9 +8073,21 @@
             "minimum": 0
           },
           "on_disk": {
-            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
+            "description": "Deprecated: use `memory` instead. Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the HNSW graph. Overrides the deprecated `on_disk` flag if both are set. Default: `cached` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "payload_m": {
             "description": "Custom M param for hnsw graph built for payload index. If not set, default M will be used.",
@@ -8341,9 +8495,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8388,9 +8554,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false. Default is false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8420,9 +8598,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8447,9 +8637,21 @@
             "$ref": "#/components/schemas/GeoIndexType"
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8517,9 +8719,21 @@
             ]
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "stemmer": {
             "description": "Algorithm for stemming. Default: disabled.",
@@ -8707,9 +8921,21 @@
             "$ref": "#/components/schemas/BoolIndexType"
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8739,9 +8965,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -8771,9 +9009,21 @@
             "nullable": true
           },
           "on_disk": {
-            "description": "If true, store the index on disk. Default: false.",
+            "description": "Deprecated: use `memory` instead. If true, store the index on disk. Default: false.",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set. Default: `pinned` (`cold` if `on_disk` is set to true).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "enable_hnsw": {
             "description": "Enable HNSW graph building for this payload field. If true, builds additional HNSW links (Need payload_m > 0). Default: true.",
@@ -10559,10 +10809,23 @@
             "nullable": true
           },
           "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
+            "description": "Deprecated: use `payload.memory` instead. If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.\n\nDefault: true",
             "default": null,
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "payload": {
+            "description": "Configuration of the payload storage",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PayloadStorageParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "hnsw_config": {
             "description": "Custom params for HNSW index. If none - values from service configuration file are used.",
@@ -11081,9 +11344,21 @@
             ]
           },
           "on_disk": {
-            "description": "If true, vectors are served from disk, improving RAM usage at the cost of latency",
+            "description": "Deprecated: use `memory` instead. If true, vectors are served from disk, improving RAM usage at the cost of latency",
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "memory": {
+            "description": "Memory placement of the original vector storage. Overrides the deprecated `on_disk` flag if both are set. `pinned` is not supported for dense vector storage.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -11144,10 +11419,22 @@
             "nullable": true
           },
           "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
+            "description": "Deprecated: use `payload.memory` instead. If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
             "default": null,
+            "deprecated": true,
             "type": "boolean",
             "nullable": true
+          },
+          "payload": {
+            "description": "Update params of the payload storage. If none - it is left unchanged.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PayloadStorageParams"
+              },
+              {
+                "nullable": true
+              }
+            ]
           }
         }
       },
@@ -13609,6 +13896,17 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/VectorStorageDatatype"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "memory": {
+            "description": "Requested memory placement of the index.\n\nThe structural decision is carried by `index_type`; this field additionally distinguishes `cold` from `cached` for the mmap index variant.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Memory"
               },
               {
                 "nullable": true

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr as _;
 use std::time::Instant;
@@ -32,7 +36,7 @@ use super::qdrant::{
     BinaryQuantization, BoolIndexParams, CompressionRatio, DatetimeIndexParams, DatetimeRange,
     Direction, FacetHit, FacetHitInternal, FacetValue, FacetValueInternal, FieldType,
     FloatIndexParams, GeoIndexParams, GeoLineString, GroupId, HardwareUsage, HasVectorCondition,
-    KeywordIndexParams, KeywordPrefixParams, LookupLocation, MaxOptimizationThreads,
+    KeywordIndexParams, KeywordPrefixParams, LookupLocation, MaxOptimizationThreads, Memory,
     MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
     RecommendStrategy, RetrievedPoint, SearchMatrixPair, SearchPointGroups, SearchPoints,
     ShardKeySelector, StartFrom, StrictModeMultivector, StrictModeMultivectorConfig,
@@ -193,12 +197,53 @@ impl From<segment::data_types::index::TokenizerType> for TokenizerType {
     }
 }
 
+impl From<segment::types::Memory> for Memory {
+    fn from(memory: segment::types::Memory) -> Self {
+        match memory {
+            segment::types::Memory::Cold => Memory::Cold,
+            segment::types::Memory::Cached => Memory::Cached,
+            segment::types::Memory::Pinned => Memory::Pinned,
+        }
+    }
+}
+
+/// Convert an optional proto `Memory` enum value into the segment memory placement.
+/// The `MemoryUnknown` sentinel maps to `None`.
+pub fn convert_memory_from_proto(
+    memory: Option<i32>,
+) -> Result<Option<segment::types::Memory>, Status> {
+    let Some(memory_int) = memory else {
+        return Ok(None);
+    };
+    let grpc_memory = Memory::try_from(memory_int).map_err(|_| {
+        Status::invalid_argument(format!("Cannot convert memory placement: {memory_int}"))
+    })?;
+    Ok(match grpc_memory {
+        Memory::Unknown => None,
+        Memory::Cold => Some(segment::types::Memory::Cold),
+        Memory::Cached => Some(segment::types::Memory::Cached),
+        Memory::Pinned => Some(segment::types::Memory::Pinned),
+    })
+}
+
+/// Convert an optional segment memory placement into the proto enum value.
+pub fn convert_memory_to_proto(memory: Option<segment::types::Memory>) -> Option<i32> {
+    memory.map(|memory| Memory::from(memory) as i32)
+}
+
+/// Infallible variant of [`convert_memory_from_proto`] for `From` conversions that cannot
+/// fail: invalid values are silently converted to `None`.
+pub fn convert_memory_from_proto_lossy(memory: Option<i32>) -> Option<segment::types::Memory> {
+    convert_memory_from_proto(memory).ok().flatten()
+}
+
 impl From<segment::data_types::index::KeywordIndexParams> for PayloadIndexParams {
     fn from(params: segment::data_types::index::KeywordIndexParams) -> Self {
         let segment::data_types::index::KeywordIndexParams {
             r#type: _,
             is_tenant,
             on_disk,
+            memory,
             enable_hnsw,
             prefix,
         } = params;
@@ -208,6 +253,7 @@ impl From<segment::data_types::index::KeywordIndexParams> for PayloadIndexParams
                 on_disk,
                 enable_hnsw,
                 prefix: prefix.unwrap_or_default().then_some(KeywordPrefixParams {}),
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -220,6 +266,7 @@ impl From<segment::data_types::index::IntegerIndexParams> for PayloadIndexParams
             lookup,
             range,
             on_disk,
+            memory,
             is_principal,
             enable_hnsw,
         } = params;
@@ -230,6 +277,7 @@ impl From<segment::data_types::index::IntegerIndexParams> for PayloadIndexParams
                 is_principal,
                 on_disk,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -240,6 +288,7 @@ impl From<segment::data_types::index::FloatIndexParams> for PayloadIndexParams {
         let segment::data_types::index::FloatIndexParams {
             r#type: _,
             on_disk,
+            memory,
             is_principal,
             enable_hnsw,
         } = params;
@@ -248,6 +297,7 @@ impl From<segment::data_types::index::FloatIndexParams> for PayloadIndexParams {
                 on_disk,
                 is_principal,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -258,12 +308,14 @@ impl From<segment::data_types::index::GeoIndexParams> for PayloadIndexParams {
         let segment::data_types::index::GeoIndexParams {
             r#type: _,
             on_disk,
+            memory,
             enable_hnsw,
         } = params;
         PayloadIndexParams {
             index_params: Some(IndexParams::GeoIndexParams(GeoIndexParams {
                 on_disk,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -280,6 +332,7 @@ impl From<segment::data_types::index::TextIndexParams> for PayloadIndexParams {
             ascii_folding,
             phrase_matching,
             on_disk,
+            memory,
             stopwords,
             stemmer,
             enable_hnsw,
@@ -303,6 +356,7 @@ impl From<segment::data_types::index::TextIndexParams> for PayloadIndexParams {
                 stopwords: stopwords_set,
                 stemmer: stemming_algo,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -313,12 +367,14 @@ impl From<segment::data_types::index::BoolIndexParams> for PayloadIndexParams {
         let segment::data_types::index::BoolIndexParams {
             r#type: _,
             on_disk,
+            memory,
             enable_hnsw,
         } = params;
         PayloadIndexParams {
             index_params: Some(IndexParams::BoolIndexParams(BoolIndexParams {
                 on_disk,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -330,6 +386,7 @@ impl From<segment::data_types::index::UuidIndexParams> for PayloadIndexParams {
             r#type: _,
             is_tenant,
             on_disk,
+            memory,
             enable_hnsw,
         } = params;
         PayloadIndexParams {
@@ -337,6 +394,7 @@ impl From<segment::data_types::index::UuidIndexParams> for PayloadIndexParams {
                 is_tenant,
                 on_disk,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -347,6 +405,7 @@ impl From<segment::data_types::index::DatetimeIndexParams> for PayloadIndexParam
         let segment::data_types::index::DatetimeIndexParams {
             r#type: _,
             on_disk,
+            memory,
             is_principal,
             enable_hnsw,
         } = params;
@@ -355,6 +414,7 @@ impl From<segment::data_types::index::DatetimeIndexParams> for PayloadIndexParam
                 on_disk,
                 is_principal,
                 enable_hnsw,
+                memory: convert_memory_to_proto(memory),
             })),
         }
     }
@@ -495,11 +555,13 @@ impl TryFrom<KeywordIndexParams> for segment::data_types::index::KeywordIndexPar
             on_disk,
             enable_hnsw,
             prefix,
+            memory,
         } = params;
         Ok(segment::data_types::index::KeywordIndexParams {
             r#type: KeywordIndexType::Keyword,
             is_tenant,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             enable_hnsw,
             // Presence of the (currently empty) message enables prefix
             // matching.
@@ -517,6 +579,7 @@ impl TryFrom<IntegerIndexParams> for segment::data_types::index::IntegerIndexPar
             is_principal,
             on_disk,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::IntegerIndexParams {
             r#type: IntegerIndexType::Integer,
@@ -524,6 +587,7 @@ impl TryFrom<IntegerIndexParams> for segment::data_types::index::IntegerIndexPar
             range,
             is_principal,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             enable_hnsw,
         })
     }
@@ -536,10 +600,12 @@ impl TryFrom<FloatIndexParams> for segment::data_types::index::FloatIndexParams 
             on_disk,
             is_principal,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::FloatIndexParams {
             r#type: FloatIndexType::Float,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             is_principal,
             enable_hnsw,
         })
@@ -552,10 +618,12 @@ impl TryFrom<GeoIndexParams> for segment::data_types::index::GeoIndexParams {
         let GeoIndexParams {
             on_disk,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::GeoIndexParams {
             r#type: GeoIndexType::Geo,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             enable_hnsw,
         })
     }
@@ -602,6 +670,7 @@ impl TryFrom<TextIndexParams> for segment::data_types::index::TextIndexParams {
             stopwords,
             stemmer,
             enable_hnsw,
+            memory,
         } = params;
 
         // Convert stopwords if present
@@ -629,6 +698,7 @@ impl TryFrom<TextIndexParams> for segment::data_types::index::TextIndexParams {
             max_token_len: max_token_len.map(|x| x as usize),
             phrase_matching,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             stopwords: stopwords_converted,
             stemmer,
             enable_hnsw,
@@ -669,10 +739,12 @@ impl TryFrom<BoolIndexParams> for segment::data_types::index::BoolIndexParams {
         let BoolIndexParams {
             on_disk,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::BoolIndexParams {
             r#type: BoolIndexType::Bool,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             enable_hnsw,
         })
     }
@@ -685,10 +757,12 @@ impl TryFrom<DatetimeIndexParams> for segment::data_types::index::DatetimeIndexP
             on_disk,
             is_principal,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::DatetimeIndexParams {
             r#type: DatetimeIndexType::Datetime,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             is_principal,
             enable_hnsw,
         })
@@ -702,11 +776,13 @@ impl TryFrom<UuidIndexParams> for segment::data_types::index::UuidIndexParams {
             is_tenant,
             on_disk,
             enable_hnsw,
+            memory,
         } = params;
         Ok(segment::data_types::index::UuidIndexParams {
             r#type: UuidIndexType::Uuid,
             is_tenant,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             enable_hnsw,
         })
     }
@@ -1204,6 +1280,7 @@ impl From<segment::types::ScalarQuantization> for ScalarQuantization {
             },
             quantile: config.quantile,
             always_ram: config.always_ram,
+            memory: convert_memory_to_proto(config.memory),
         }
     }
 }
@@ -1216,6 +1293,7 @@ impl TryFrom<ScalarQuantization> for segment::types::ScalarQuantization {
             r#type,
             quantile,
             always_ram,
+            memory,
         } = value;
         Ok(segment::types::ScalarQuantization {
             scalar: segment::types::ScalarQuantizationConfig {
@@ -1227,6 +1305,7 @@ impl TryFrom<ScalarQuantization> for segment::types::ScalarQuantization {
                 },
                 quantile,
                 always_ram,
+                memory: convert_memory_from_proto(memory)?,
             },
         })
     }
@@ -1238,6 +1317,7 @@ impl From<segment::types::ProductQuantization> for ProductQuantization {
         let segment::types::ProductQuantizationConfig {
             compression,
             always_ram,
+            memory,
         } = product;
         ProductQuantization {
             compression: match compression {
@@ -1248,6 +1328,7 @@ impl From<segment::types::ProductQuantization> for ProductQuantization {
                 segment::types::CompressionRatio::X64 => CompressionRatio::X64 as i32,
             },
             always_ram,
+            memory: convert_memory_to_proto(memory),
         }
     }
 }
@@ -1259,6 +1340,7 @@ impl TryFrom<ProductQuantization> for segment::types::ProductQuantization {
         let ProductQuantization {
             compression,
             always_ram,
+            memory,
         } = value;
         Ok(segment::types::ProductQuantization {
             product: segment::types::ProductQuantizationConfig {
@@ -1275,6 +1357,7 @@ impl TryFrom<ProductQuantization> for segment::types::ProductQuantization {
                     Ok(CompressionRatio::X64) => segment::types::CompressionRatio::X64,
                 },
                 always_ram,
+                memory: convert_memory_from_proto(memory)?,
             },
         })
     }
@@ -1317,6 +1400,7 @@ impl From<segment::types::BinaryQuantization> for BinaryQuantization {
         let segment::types::BinaryQuantization { binary } = value;
         let segment::types::BinaryQuantizationConfig {
             always_ram,
+            memory,
             encoding,
             query_encoding,
         } = binary;
@@ -1325,6 +1409,7 @@ impl From<segment::types::BinaryQuantization> for BinaryQuantization {
             encoding: encoding
                 .map(|encoding| i32::from(BinaryQuantizationEncoding::from(encoding))),
             query_encoding: query_encoding.map(BinaryQuantizationQueryEncoding::from),
+            memory: convert_memory_to_proto(memory),
         }
     }
 }
@@ -1337,6 +1422,7 @@ impl TryFrom<BinaryQuantization> for segment::types::BinaryQuantization {
             always_ram,
             encoding,
             query_encoding,
+            memory,
         } = value;
         let encoding = encoding
             .map(BinaryQuantizationEncoding::try_from)
@@ -1345,6 +1431,7 @@ impl TryFrom<BinaryQuantization> for segment::types::BinaryQuantization {
         Ok(segment::types::BinaryQuantization {
             binary: segment::types::BinaryQuantizationConfig {
                 always_ram,
+                memory: convert_memory_from_proto(memory)?,
                 encoding: encoding.map(segment::types::BinaryQuantizationEncoding::from),
                 query_encoding: query_encoding
                     .map(segment::types::BinaryQuantizationQueryEncoding::try_from)
@@ -1382,11 +1469,16 @@ fn turbo_quant_bit_size_from_i32(value: i32) -> Result<segment::types::TurboQuan
 impl From<segment::types::TurboQuantization> for TurboQuantization {
     fn from(value: segment::types::TurboQuantization) -> Self {
         let segment::types::TurboQuantization { turbo } = value;
-        let segment::types::TurboQuantQuantizationConfig { always_ram, bits } = turbo;
+        let segment::types::TurboQuantQuantizationConfig {
+            always_ram,
+            memory,
+            bits,
+        } = turbo;
 
         TurboQuantization {
             always_ram,
             bits: bits.map(|b| i32::from(TurboQuantBitSize::from(b))),
+            memory: convert_memory_to_proto(memory),
         }
     }
 }
@@ -1395,11 +1487,19 @@ impl TryFrom<TurboQuantization> for segment::types::TurboQuantization {
     type Error = Status;
 
     fn try_from(value: TurboQuantization) -> Result<Self, Self::Error> {
-        let TurboQuantization { always_ram, bits } = value;
+        let TurboQuantization {
+            always_ram,
+            bits,
+            memory,
+        } = value;
         let bits = bits.map(turbo_quant_bit_size_from_i32).transpose()?;
 
         Ok(segment::types::TurboQuantization {
-            turbo: segment::types::TurboQuantQuantizationConfig { always_ram, bits },
+            turbo: segment::types::TurboQuantQuantizationConfig {
+                always_ram,
+                memory: convert_memory_from_proto(memory)?,
+                bits,
+            },
         })
     }
 }
@@ -2343,6 +2443,7 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = hnsw_config;
@@ -2352,6 +2453,7 @@ impl From<HnswConfigDiff> for segment::types::HnswConfig {
             full_scan_threshold: full_scan_threshold.unwrap_or_default() as usize,
             max_indexing_threads: max_indexing_threads.unwrap_or_default() as usize,
             on_disk,
+            memory: convert_memory_from_proto_lossy(memory),
             payload_m: payload_m.map(|x| x as usize),
             inline_storage,
         }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -14,6 +14,19 @@ enum Datatype {
   Turbo4 = 4;
 }
 
+// Memory placement of a component's data.
+// Data is always persisted on disk regardless of this setting;
+// it only controls how the data is held in RAM.
+enum Memory {
+  MemoryUnknown = 0;
+  // Data is not pre-loaded from disk to RAM; cached with usage.
+  Cold = 1;
+  // Data is pre-loaded into disk-cache RAM on start, but may be evicted under memory pressure.
+  Cached = 2;
+  // Data is loaded in RAM and never evicted.
+  Pinned = 3;
+}
+
 // ---------------------------------------------
 // ------------- Collection Config -------------
 // ---------------------------------------------
@@ -29,13 +42,18 @@ message VectorParams {
   // Configuration of vector quantization config.
   // If omitted - the collection configuration will be used
   optional QuantizationConfig quantization_config = 4;
+  // Deprecated: use `memory` instead.
   // If true - serve vectors from disk.
   // If set to false, the vectors will be loaded in RAM.
-  optional bool on_disk = 5;
+  optional bool on_disk = 5 [deprecated = true];
   // Data type of the vectors
   optional Datatype datatype = 6;
   // Configuration for multi-vector search
   optional MultiVectorConfig multivector_config = 7;
+  // Memory placement of the original vector storage.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  // `Pinned` is not supported for dense vector storage.
+  optional Memory memory = 8;
 }
 
 message VectorParamsDiff {
@@ -44,9 +62,14 @@ message VectorParamsDiff {
   optional HnswConfigDiff hnsw_config = 1;
   // Update quantization params. If none - it is left unchanged.
   optional QuantizationConfigDiff quantization_config = 2;
+  // Deprecated: use `memory` instead.
   // If true - serve vectors from disk.
   // If set to false, the vectors will be loaded in RAM.
-  optional bool on_disk = 3;
+  optional bool on_disk = 3 [deprecated = true];
+  // Memory placement of the original vector storage.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  // `Pinned` is not supported for dense vector storage.
+  optional Memory memory = 4;
 }
 
 message VectorParamsMap {
@@ -219,8 +242,9 @@ message HnswConfigDiff {
   // Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
   // On small CPUs, less threads are used.
   optional uint64 max_indexing_threads = 4;
+  // Deprecated: use `memory` instead.
   // Store HNSW index on disk. If set to false, the index will be stored in RAM.
-  optional bool on_disk = 5;
+  optional bool on_disk = 5 [deprecated = true];
   // Number of additional payload-aware links per node in the index graph.
   // If not set - regular M parameter will be used.
   optional uint64 payload_m = 6;
@@ -229,16 +253,23 @@ message HnswConfigDiff {
   // random seeks during the search.
   // Requires quantized vectors to be enabled. Multi-vectors are not supported.
   optional bool inline_storage = 7;
+  // Memory placement of the HNSW graph.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 8;
 }
 
 message SparseIndexConfig {
   // Prefer a full scan search upto (excluding) this number of vectors.
   // Note: this is number of vectors, not KiloBytes.
   optional uint64 full_scan_threshold = 1;
+  // Deprecated: use `memory` instead.
   // Store inverted index on disk. If set to false, the index will be stored in RAM.
-  optional bool on_disk = 2;
+  optional bool on_disk = 2 [deprecated = true];
   // Datatype used to store weights in the index.
   optional Datatype datatype = 3;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message WalConfigDiff {
@@ -325,15 +356,23 @@ message ScalarQuantization {
   QuantizationType type = 1;
   // Number of bits to use for quantization
   optional float quantile = 2;
+  // Deprecated: use `memory` instead.
   // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
-  optional bool always_ram = 3;
+  optional bool always_ram = 3 [deprecated = true];
+  // Memory placement of quantized vectors.
+  // Overrides the deprecated `always_ram` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message ProductQuantization {
   // Compression ratio
   CompressionRatio compression = 1;
+  // Deprecated: use `memory` instead.
   // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
-  optional bool always_ram = 2;
+  optional bool always_ram = 2 [deprecated = true];
+  // Memory placement of quantized vectors.
+  // Overrides the deprecated `always_ram` flag if both are set.
+  optional Memory memory = 3;
 }
 
 enum BinaryQuantizationEncoding {
@@ -356,19 +395,27 @@ message BinaryQuantizationQueryEncoding {
 }
 
 message BinaryQuantization {
+  // Deprecated: use `memory` instead.
   // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
-  optional bool always_ram = 1;
+  optional bool always_ram = 1 [deprecated = true];
   // Binary quantization encoding method
   optional BinaryQuantizationEncoding encoding = 2;
   // Asymmetric quantization configuration allows a query to have different
   // quantization than stored vectors.
   // It can increase the accuracy of search at the cost of performance.
   optional BinaryQuantizationQueryEncoding query_encoding = 3;
+  // Memory placement of quantized vectors.
+  // Overrides the deprecated `always_ram` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message TurboQuantization{
-  optional bool always_ram = 1;
+  // Deprecated: use `memory` instead.
+  optional bool always_ram = 1 [deprecated = true];
   optional TurboQuantBitSize bits = 2;
+  // Memory placement of quantized vectors.
+  // Overrides the deprecated `always_ram` flag if both are set.
+  optional Memory memory = 3;
 }
 
 enum TurboQuantBitSize{
@@ -473,6 +520,14 @@ message StrictModeMultivector {
   optional uint64 max_vectors = 1;
 }
 
+// Params of the payload storage
+message PayloadStorageParams {
+  // Memory placement of the payload storage.
+  // Overrides the deprecated `on_disk_payload` flag if both are set.
+  // `Pinned` is not supported for payload storage.
+  optional Memory memory = 1;
+}
+
 message CreateCollection {
   // Name of the collection
   string collection_name = 1;
@@ -489,8 +544,9 @@ message CreateCollection {
   // Number of shards in the collection, default is 1 for standalone, otherwise
   // equal to the number of nodes. Minimum is 1
   optional uint32 shard_number = 7;
+  // Deprecated: use `payload.memory` instead.
   // If true - point's payload will not be stored in memory
-  optional bool on_disk_payload = 8;
+  optional bool on_disk_payload = 8 [deprecated = true];
   // Wait timeout for operation commit in seconds, if not specified - default
   // value will be supplied
   optional uint64 timeout = 9;
@@ -512,6 +568,8 @@ message CreateCollection {
   optional StrictModeConfig strict_mode_config = 17;
   // Arbitrary JSON metadata for the collection
   map<string, Value> metadata = 18;
+  // Configuration of the payload storage
+  optional PayloadStorageParams payload = 19;
 }
 
 message UpdateCollection {
@@ -563,8 +621,9 @@ message CollectionParams {
   reserved 2;
   // Number of shards in collection
   uint32 shard_number = 3;
+  // Deprecated: use `payload.memory` instead.
   // If true - point's payload will not be stored in memory
-  bool on_disk_payload = 4;
+  bool on_disk_payload = 4 [deprecated = true];
   // Configuration for vectors
   optional VectorsConfig vectors_config = 5;
   // Number of replicas of each shard that network tries to maintain
@@ -579,6 +638,8 @@ message CollectionParams {
   optional SparseVectorConfig sparse_vectors_config = 10;
   // Define number of milliseconds to wait before attempting to read from another replica.
   optional uint64 read_fan_out_delay_ms = 11;
+  // Configuration of the payload storage
+  optional PayloadStorageParams payload = 12;
 }
 
 message CollectionParamsDiff {
@@ -586,12 +647,15 @@ message CollectionParamsDiff {
   optional uint32 replication_factor = 1;
   // How many replicas should apply the operation for us to consider it successful
   optional uint32 write_consistency_factor = 2;
+  // Deprecated: use `payload.memory` instead.
   // If true - point's payload will not be stored in memory
-  optional bool on_disk_payload = 3;
+  optional bool on_disk_payload = 3 [deprecated = true];
   // Fan-out every read request to these many additional remote nodes (and return first available response)
   optional uint32 read_fan_out_factor = 4;
   // Define number of milliseconds to wait before attempting to read from another replica.
   optional uint64 read_fan_out_delay_ms = 5;
+  // Update params of the payload storage
+  optional PayloadStorageParams payload = 6;
 }
 
 message CollectionConfig {
@@ -622,14 +686,18 @@ enum TokenizerType {
 message KeywordIndexParams {
   // If true - used for tenant optimization.
   optional bool is_tenant = 1;
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 2;
+  optional bool on_disk = 2 [deprecated = true];
   // Enable HNSW graph building for this payload field.
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 3;
   // If set, enable prefix matching (`match: { "prefix": ... }`) on this field.
   optional KeywordPrefixParams prefix = 4;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 5;
 }
 
 // Prefix matching options for the keyword index. Has no options yet:
@@ -646,17 +714,22 @@ message IntegerIndexParams {
   // This option assumes that this key will be used in majority of filtered requests.
   // Default is false.
   optional bool is_principal = 3;
+  // Deprecated: use `memory` instead.
   // If true - store index on disk. Default is false.
-  optional bool on_disk = 4;
+  optional bool on_disk = 4 [deprecated = true];
   // Enable HNSW graph building for this payload field.
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 5;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 6;
 }
 
 message FloatIndexParams {
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 1;
+  optional bool on_disk = 1 [deprecated = true];
   // If true - use this key to organize storage of the collection data.
   // This option assumes that this key will be used in majority of filtered requests.
   optional bool is_principal = 2;
@@ -664,15 +737,22 @@ message FloatIndexParams {
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 3;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message GeoIndexParams {
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 1;
+  optional bool on_disk = 1 [deprecated = true];
   // Enable HNSW graph building for this payload field.
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 2;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 3;
 }
 
 message StopwordsSet {
@@ -691,8 +771,9 @@ message TextIndexParams {
   optional uint64 min_token_len = 3;
   // Maximal token length
   optional uint64 max_token_len = 4;
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 5;
+  optional bool on_disk = 5 [deprecated = true];
   // Stopwords for the text index
   optional StopwordsSet stopwords = 6;
   // If true - support phrase matching.
@@ -706,6 +787,9 @@ message TextIndexParams {
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 10;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 11;
 }
 
 message StemmingAlgorithm {
@@ -726,17 +810,22 @@ message SnowballParams {
 message DisabledStemmer {}
 
 message BoolIndexParams {
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 1;
+  optional bool on_disk = 1 [deprecated = true];
   // Enable HNSW graph building for this payload field.
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 2;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 3;
 }
 
 message DatetimeIndexParams {
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 1;
+  optional bool on_disk = 1 [deprecated = true];
   // If true - use this key to organize storage of the collection data.
   // This option assumes that this key will be used in majority of filtered requests.
   optional bool is_principal = 2;
@@ -744,17 +833,24 @@ message DatetimeIndexParams {
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 3;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message UuidIndexParams {
   // If true - used for tenant optimization.
   optional bool is_tenant = 1;
+  // Deprecated: use `memory` instead.
   // If true - store index on disk.
-  optional bool on_disk = 2;
+  optional bool on_disk = 2 [deprecated = true];
   // Enable HNSW graph building for this payload field.
   // If true, builds additional HNSW links (Need payload_m > 0).
   // Default: true.
   optional bool enable_hnsw = 3;
+  // Memory placement of the index.
+  // Overrides the deprecated `on_disk` flag if both are set.
+  optional Memory memory = 4;
 }
 
 message PayloadIndexParams {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -428,8 +428,10 @@ pub struct VectorParams {
     #[prost(message, optional, tag = "4")]
     #[validate(nested)]
     pub quantization_config: ::core::option::Option<QuantizationConfig>,
+    /// Deprecated: use `memory` instead.
     /// If true - serve vectors from disk.
     /// If set to false, the vectors will be loaded in RAM.
+    #[deprecated]
     #[prost(bool, optional, tag = "5")]
     pub on_disk: ::core::option::Option<bool>,
     /// Data type of the vectors
@@ -438,6 +440,11 @@ pub struct VectorParams {
     /// Configuration for multi-vector search
     #[prost(message, optional, tag = "7")]
     pub multivector_config: ::core::option::Option<MultiVectorConfig>,
+    /// Memory placement of the original vector storage.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    /// `Pinned` is not supported for dense vector storage.
+    #[prost(enumeration = "Memory", optional, tag = "8")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -452,10 +459,17 @@ pub struct VectorParamsDiff {
     #[prost(message, optional, tag = "2")]
     #[validate(nested)]
     pub quantization_config: ::core::option::Option<QuantizationConfigDiff>,
+    /// Deprecated: use `memory` instead.
     /// If true - serve vectors from disk.
     /// If set to false, the vectors will be loaded in RAM.
+    #[deprecated]
     #[prost(bool, optional, tag = "3")]
     pub on_disk: ::core::option::Option<bool>,
+    /// Memory placement of the original vector storage.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    /// `Pinned` is not supported for dense vector storage.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -699,7 +713,9 @@ pub struct HnswConfigDiff {
     /// On small CPUs, less threads are used.
     #[prost(uint64, optional, tag = "4")]
     pub max_indexing_threads: ::core::option::Option<u64>,
+    /// Deprecated: use `memory` instead.
     /// Store HNSW index on disk. If set to false, the index will be stored in RAM.
+    #[deprecated]
     #[prost(bool, optional, tag = "5")]
     pub on_disk: ::core::option::Option<bool>,
     /// Number of additional payload-aware links per node in the index graph.
@@ -712,6 +728,10 @@ pub struct HnswConfigDiff {
     /// Requires quantized vectors to be enabled. Multi-vectors are not supported.
     #[prost(bool, optional, tag = "7")]
     pub inline_storage: ::core::option::Option<bool>,
+    /// Memory placement of the HNSW graph.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "8")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -721,13 +741,19 @@ pub struct SparseIndexConfig {
     /// Note: this is number of vectors, not KiloBytes.
     #[prost(uint64, optional, tag = "1")]
     pub full_scan_threshold: ::core::option::Option<u64>,
+    /// Deprecated: use `memory` instead.
     /// Store inverted index on disk. If set to false, the index will be stored in RAM.
+    #[deprecated]
     #[prost(bool, optional, tag = "2")]
     pub on_disk: ::core::option::Option<bool>,
     /// Datatype used to store weights in the index.
     #[prost(enumeration = "Datatype", optional, tag = "3")]
     #[validate(custom(function = "crate::grpc::validate::validate_sparse_datatype"))]
     pub datatype: ::core::option::Option<i32>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -838,9 +864,15 @@ pub struct ScalarQuantization {
     #[prost(float, optional, tag = "2")]
     #[validate(range(min = 0.5, max = 1.0))]
     pub quantile: ::core::option::Option<f32>,
+    /// Deprecated: use `memory` instead.
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[deprecated]
     #[prost(bool, optional, tag = "3")]
     pub always_ram: ::core::option::Option<bool>,
+    /// Memory placement of quantized vectors.
+    /// Overrides the deprecated `always_ram` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -849,9 +881,15 @@ pub struct ProductQuantization {
     /// Compression ratio
     #[prost(enumeration = "CompressionRatio", tag = "1")]
     pub compression: i32,
+    /// Deprecated: use `memory` instead.
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[deprecated]
     #[prost(bool, optional, tag = "2")]
     pub always_ram: ::core::option::Option<bool>,
+    /// Memory placement of quantized vectors.
+    /// Overrides the deprecated `always_ram` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "3")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
@@ -915,7 +953,9 @@ pub mod binary_quantization_query_encoding {
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BinaryQuantization {
+    /// Deprecated: use `memory` instead.
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub always_ram: ::core::option::Option<bool>,
     /// Binary quantization encoding method
@@ -926,15 +966,25 @@ pub struct BinaryQuantization {
     /// It can increase the accuracy of search at the cost of performance.
     #[prost(message, optional, tag = "3")]
     pub query_encoding: ::core::option::Option<BinaryQuantizationQueryEncoding>,
+    /// Memory placement of quantized vectors.
+    /// Overrides the deprecated `always_ram` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TurboQuantization {
+    /// Deprecated: use `memory` instead.
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub always_ram: ::core::option::Option<bool>,
     #[prost(enumeration = "TurboQuantBitSize", optional, tag = "2")]
     pub bits: ::core::option::Option<i32>,
+    /// Memory placement of quantized vectors.
+    /// Overrides the deprecated `always_ram` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "3")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -1110,6 +1160,16 @@ pub struct StrictModeMultivector {
     #[validate(range(min = 1))]
     pub max_vectors: ::core::option::Option<u64>,
 }
+/// Params of the payload storage
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PayloadStorageParams {
+    /// Memory placement of the payload storage.
+    /// Overrides the deprecated `on_disk_payload` flag if both are set.
+    /// `Pinned` is not supported for payload storage.
+    #[prost(enumeration = "Memory", optional, tag = "1")]
+    pub memory: ::core::option::Option<i32>,
+}
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1138,7 +1198,9 @@ pub struct CreateCollection {
     #[prost(uint32, optional, tag = "7")]
     #[validate(range(min = 1))]
     pub shard_number: ::core::option::Option<u32>,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory
+    #[deprecated]
     #[prost(bool, optional, tag = "8")]
     pub on_disk_payload: ::core::option::Option<bool>,
     /// Wait timeout for operation commit in seconds, if not specified - default
@@ -1174,6 +1236,9 @@ pub struct CreateCollection {
     /// Arbitrary JSON metadata for the collection
     #[prost(map = "string, message", tag = "18")]
     pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+    /// Configuration of the payload storage
+    #[prost(message, optional, tag = "19")]
+    pub payload: ::core::option::Option<PayloadStorageParams>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -1259,7 +1324,9 @@ pub struct CollectionParams {
     /// Number of shards in collection
     #[prost(uint32, tag = "3")]
     pub shard_number: u32,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory
+    #[deprecated]
     #[prost(bool, tag = "4")]
     pub on_disk_payload: bool,
     /// Configuration for vectors
@@ -1284,6 +1351,9 @@ pub struct CollectionParams {
     /// Define number of milliseconds to wait before attempting to read from another replica.
     #[prost(uint64, optional, tag = "11")]
     pub read_fan_out_delay_ms: ::core::option::Option<u64>,
+    /// Configuration of the payload storage
+    #[prost(message, optional, tag = "12")]
+    pub payload: ::core::option::Option<PayloadStorageParams>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -1297,7 +1367,9 @@ pub struct CollectionParamsDiff {
     #[prost(uint32, optional, tag = "2")]
     #[validate(range(min = 1))]
     pub write_consistency_factor: ::core::option::Option<u32>,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory
+    #[deprecated]
     #[prost(bool, optional, tag = "3")]
     pub on_disk_payload: ::core::option::Option<bool>,
     /// Fan-out every read request to these many additional remote nodes (and return first available response)
@@ -1306,6 +1378,9 @@ pub struct CollectionParamsDiff {
     /// Define number of milliseconds to wait before attempting to read from another replica.
     #[prost(uint64, optional, tag = "5")]
     pub read_fan_out_delay_ms: ::core::option::Option<u64>,
+    /// Update params of the payload storage
+    #[prost(message, optional, tag = "6")]
+    pub payload: ::core::option::Option<PayloadStorageParams>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1338,7 +1413,9 @@ pub struct KeywordIndexParams {
     /// If true - used for tenant optimization.
     #[prost(bool, optional, tag = "1")]
     pub is_tenant: ::core::option::Option<bool>,
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "2")]
     pub on_disk: ::core::option::Option<bool>,
     /// Enable HNSW graph building for this payload field.
@@ -1349,6 +1426,10 @@ pub struct KeywordIndexParams {
     /// If set, enable prefix matching (`match: { "prefix": ... }`) on this field.
     #[prost(message, optional, tag = "4")]
     pub prefix: ::core::option::Option<KeywordPrefixParams>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "5")]
+    pub memory: ::core::option::Option<i32>,
 }
 /// Prefix matching options for the keyword index. Has no options yet:
 /// presence of this message enables prefix matching.
@@ -1369,7 +1450,9 @@ pub struct IntegerIndexParams {
     /// Default is false.
     #[prost(bool, optional, tag = "3")]
     pub is_principal: ::core::option::Option<bool>,
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk. Default is false.
+    #[deprecated]
     #[prost(bool, optional, tag = "4")]
     pub on_disk: ::core::option::Option<bool>,
     /// Enable HNSW graph building for this payload field.
@@ -1377,11 +1460,17 @@ pub struct IntegerIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "5")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "6")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct FloatIndexParams {
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub on_disk: ::core::option::Option<bool>,
     /// If true - use this key to organize storage of the collection data.
@@ -1393,11 +1482,17 @@ pub struct FloatIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "3")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GeoIndexParams {
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub on_disk: ::core::option::Option<bool>,
     /// Enable HNSW graph building for this payload field.
@@ -1405,6 +1500,10 @@ pub struct GeoIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "2")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "3")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -1431,7 +1530,9 @@ pub struct TextIndexParams {
     /// Maximal token length
     #[prost(uint64, optional, tag = "4")]
     pub max_token_len: ::core::option::Option<u64>,
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "5")]
     pub on_disk: ::core::option::Option<bool>,
     /// Stopwords for the text index
@@ -1452,6 +1553,10 @@ pub struct TextIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "10")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "11")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -1486,7 +1591,9 @@ pub struct DisabledStemmer {}
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BoolIndexParams {
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub on_disk: ::core::option::Option<bool>,
     /// Enable HNSW graph building for this payload field.
@@ -1494,11 +1601,17 @@ pub struct BoolIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "2")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "3")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DatetimeIndexParams {
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "1")]
     pub on_disk: ::core::option::Option<bool>,
     /// If true - use this key to organize storage of the collection data.
@@ -1510,6 +1623,10 @@ pub struct DatetimeIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "3")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
@@ -1517,7 +1634,9 @@ pub struct UuidIndexParams {
     /// If true - used for tenant optimization.
     #[prost(bool, optional, tag = "1")]
     pub is_tenant: ::core::option::Option<bool>,
+    /// Deprecated: use `memory` instead.
     /// If true - store index on disk.
+    #[deprecated]
     #[prost(bool, optional, tag = "2")]
     pub on_disk: ::core::option::Option<bool>,
     /// Enable HNSW graph building for this payload field.
@@ -1525,6 +1644,10 @@ pub struct UuidIndexParams {
     /// Default: true.
     #[prost(bool, optional, tag = "3")]
     pub enable_hnsw: ::core::option::Option<bool>,
+    /// Memory placement of the index.
+    /// Overrides the deprecated `on_disk` flag if both are set.
+    #[prost(enumeration = "Memory", optional, tag = "4")]
+    pub memory: ::core::option::Option<i32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]
@@ -2080,6 +2203,45 @@ impl Datatype {
             "Uint8" => Some(Self::Uint8),
             "Float16" => Some(Self::Float16),
             "Turbo4" => Some(Self::Turbo4),
+            _ => None,
+        }
+    }
+}
+/// Memory placement of a component's data.
+/// Data is always persisted on disk regardless of this setting;
+/// it only controls how the data is held in RAM.
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Memory {
+    Unknown = 0,
+    /// Data is not pre-loaded from disk to RAM; cached with usage.
+    Cold = 1,
+    /// Data is pre-loaded into disk-cache RAM on start, but may be evicted under memory pressure.
+    Cached = 2,
+    /// Data is loaded in RAM and never evicted.
+    Pinned = 3,
+}
+impl Memory {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unknown => "MemoryUnknown",
+            Self::Cold => "Cold",
+            Self::Cached => "Cached",
+            Self::Pinned => "Pinned",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "MemoryUnknown" => Some(Self::Unknown),
+            "Cold" => Some(Self::Cold),
+            "Cached" => Some(Self::Cached),
+            "Pinned" => Some(Self::Pinned),
             _ => None,
         }
     }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -544,6 +548,7 @@ impl Validate for super::qdrant::IntegerIndexParams {
             is_principal: _,
             on_disk: _,
             enable_hnsw: _,
+            memory: _,
         } = &self;
         validate_integer_index_params(lookup, range)
     }

--- a/lib/collection/src/collection/vector_name_schema.rs
+++ b/lib/collection/src/collection/vector_name_schema.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::num::NonZeroU64;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -105,6 +109,7 @@ fn dense_config_to_params(config: &DenseVectorConfig) -> VectorParams {
         hnsw_config: None,
         quantization_config: None,
         on_disk: None,
+        memory: None,
         datatype: datatype.map(storage_datatype_to_collection),
         multivector_config: *multivector_config,
     }
@@ -117,6 +122,7 @@ fn sparse_config_to_params(config: &SparseVectorConfig) -> SparseVectorParams {
         index: datatype.map(|dt| crate::operations::types::SparseIndexParams {
             full_scan_threshold: None,
             on_disk: None,
+            memory: None,
             datatype: Some(storage_datatype_to_collection(dt)),
         }),
         modifier: *modifier,

--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 /// Looks for segments having a mismatch between configured and actual parameters
 ///
 /// For example, a user may change the HNSW parameters for a collection. A segment that was already
@@ -43,6 +47,7 @@ mod tests {
                     .get(name)
                     .cloned()
                     .unwrap_or(DenseVectorOptimizerConfig {
+                        memory: None,
                         on_disk: None,
                         hnsw_config: HnswConfig::default(),
                         quantization_config: None,
@@ -78,7 +83,15 @@ mod tests {
             sparse_vector: segment_config
                 .sparse_vector_data
                 .keys()
-                .map(|name| (name.clone(), SparseVectorOptimizerConfig { on_disk: None }))
+                .map(|name| {
+                    (
+                        name.clone(),
+                        SparseVectorOptimizerConfig {
+                            memory: None,
+                            on_disk: None,
+                        },
+                    )
+                })
                 .collect(),
             live_vector_names: None,
         }
@@ -121,6 +134,7 @@ mod tests {
         let locked_holder = LockedSegmentHolder::new(holder);
 
         let hnsw_config = HnswConfig {
+            memory: None,
             m: 16,
             ef_construct: 100,
             full_scan_threshold: 10,
@@ -134,6 +148,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(DEFAULT_VECTOR_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config,
                 quantization_config: None,
@@ -181,6 +196,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(DEFAULT_VECTOR_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: changed_hnsw_config,
                 quantization_config: None,
@@ -267,6 +283,7 @@ mod tests {
         let locked_holder = LockedSegmentHolder::new(holder);
 
         let hnsw_config_collection = HnswConfig {
+            memory: None,
             m: 16,
             ef_construct: 100,
             full_scan_threshold: 10,
@@ -287,6 +304,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR1_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: Some(true),
                 hnsw_config: hnsw_config_vector1,
                 quantization_config: None,
@@ -295,6 +313,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: hnsw_config_vector2,
                 quantization_config: None,
@@ -341,6 +360,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: hnsw_config_vector2_changed,
                 quantization_config: None,
@@ -416,6 +436,7 @@ mod tests {
         let quantization_config_vector1 =
             QuantizationConfig::Scalar(segment::types::ScalarQuantization {
                 scalar: ScalarQuantizationConfig {
+                    memory: None,
                     r#type: ScalarType::Int8,
                     quantile: Some(0.99),
                     always_ram: Some(true),
@@ -442,6 +463,7 @@ mod tests {
         let quantization_config_collection =
             QuantizationConfig::Scalar(segment::types::ScalarQuantization {
                 scalar: ScalarQuantizationConfig {
+                    memory: None,
                     r#type: ScalarType::Int8,
                     quantile: Some(0.91),
                     always_ram: None,
@@ -452,6 +474,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR1_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: HnswConfig::default(),
                 quantization_config: Some(quantization_config_vector1.clone()),
@@ -460,6 +483,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: HnswConfig::default(),
                 quantization_config: Some(quantization_config_collection.clone()),
@@ -502,6 +526,7 @@ mod tests {
         // Create changed quantization config for vector2, update it in the optimizer
         let quantization_config_vector2 = QuantizationConfig::Product(ProductQuantization {
             product: ProductQuantizationConfig {
+                memory: None,
                 compression: CompressionRatio::X32,
                 always_ram: Some(true),
             },
@@ -509,6 +534,7 @@ mod tests {
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
             DenseVectorOptimizerConfig {
+                memory: None,
                 on_disk: None,
                 hnsw_config: HnswConfig::default(),
                 quantization_config: Some(quantization_config_vector2.clone()),

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 /// Looks for the segments, which require to be indexed.
 ///
 /// If segment is too large, but still does not have indexes - it is time to create some indexes.
@@ -235,6 +239,7 @@ mod tests {
             vectors: VectorsConfig::Multi(BTreeMap::from([(
                 VECTOR_NAME.to_owned(),
                 VectorParams {
+                    memory: None,
                     size: NonZeroU64::new(DIM as u64).unwrap(),
                     distance: Distance::Dot,
                     hnsw_config: None,
@@ -824,6 +829,7 @@ mod tests {
         let locked_holder = LockedSegmentHolder::new(holder);
 
         let hnsw_config = HnswConfig {
+            memory: None,
             m: 16,
             ef_construct: 100,
             full_scan_threshold: 10,

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -58,6 +58,7 @@ mod tests {
             dense_vector.insert(
                 vector_name.clone(),
                 DenseVectorOptimizerConfig {
+                    memory: None,
                     on_disk: None,
                     hnsw_config: HnswConfig::default(),
                     quantization_config: None,

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 /// Optimizer which looks for segments with high amount of soft-deleted points or vectors
 ///
 /// Since the creation of a segment, a lot of points or vectors may have been soft-deleted. This
@@ -312,6 +316,7 @@ mod tests {
         let locked_holder = LockedSegmentHolder::new(holder);
 
         let hnsw_config = HnswConfig {
+            memory: None,
             m: 16,
             ef_construct: 100,
             full_scan_threshold: 10, // Force to build HNSW links for payload

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{Read, Write as _};
 use std::num::{NonZeroU32, NonZeroUsize};
@@ -12,13 +16,13 @@ use segment::common::anonymize::Anonymize;
 use segment::data_types::vectors::DEFAULT_VECTOR_NAME;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::types::{
-    Distance, HnswConfig, Indexes, Payload, PayloadStorageType, QuantizationConfig, SegmentConfig,
-    SparseVectorDataConfig, StrictModeConfig, VectorDataConfig, VectorName, VectorNameBuf,
-    VectorStorageDatatype, VectorStorageType,
+    Distance, HnswConfig, Indexes, Memory, Payload, PayloadStorageType, QuantizationConfig,
+    SegmentConfig, SparseVectorDataConfig, StrictModeConfig, VectorDataConfig, VectorName,
+    VectorNameBuf, VectorStorageDatatype, VectorStorageType,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 use wal::WalOptions;
 
 use crate::operations::config_diff::{DiffConfig, QuantizationConfigDiff};
@@ -125,6 +129,7 @@ pub struct CollectionParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub read_fan_out_delay_ms: Option<u64>,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
@@ -132,16 +137,83 @@ pub struct CollectionParams {
     ///
     /// Default: true
     #[serde(default = "default_on_disk_payload")]
+    #[deprecated(since = "1.19.0", note = "Use `payload.memory` instead")]
     pub on_disk_payload: bool,
+    /// Configuration of the payload storage
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
+    pub payload: Option<PayloadStorageParams>,
     /// Configuration of the sparse vector storage
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub sparse_vectors: Option<BTreeMap<VectorNameBuf, SparseVectorParams>>,
 }
 
+/// Params of the payload storage
+#[derive(
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    Validate,
+    Anonymize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+)]
+#[serde(rename_all = "snake_case")]
+#[anonymize(false)]
+pub struct PayloadStorageParams {
+    /// Memory placement of the payload storage. Overrides the deprecated `on_disk_payload` flag
+    /// if both are set. `pinned` is not supported for payload storage.
+    /// Default: `cold` (`cached` if `on_disk_payload` is set to false).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(custom(function = "validate_payload_storage_memory"))]
+    pub memory: Option<Memory>,
+}
+
+impl PayloadStorageParams {
+    /// Update this config with fields from `diff`; fields specified in `diff` win.
+    pub fn update(&self, diff: &PayloadStorageParams) -> Self {
+        let PayloadStorageParams { memory } = diff;
+        PayloadStorageParams {
+            memory: memory.or(self.memory),
+        }
+    }
+}
+
+/// Reject memory placements not supported by payload storage.
+/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
+fn validate_payload_storage_memory(memory: &Memory) -> Result<(), ValidationError> {
+    match memory {
+        Memory::Cold | Memory::Cached => Ok(()),
+        Memory::Pinned => {
+            let mut error = ValidationError::new("unsupported_memory_placement");
+            error.message = Some(std::borrow::Cow::from(
+                "`pinned` memory placement is not supported for payload storage",
+            ));
+            Err(error)
+        }
+    }
+}
+
 impl CollectionParams {
     pub fn payload_storage_type(&self) -> PayloadStorageType {
-        PayloadStorageType::from_on_disk_payload(self.on_disk_payload)
+        PayloadStorageType::from_memory(self.payload_memory_placement())
+    }
+
+    /// Effective memory placement of the payload storage, resolving the new `payload.memory`
+    /// parameter against the deprecated `on_disk_payload` flag.
+    ///
+    /// No conflict warning is logged here: `on_disk_payload` is a plain bool with a default, so
+    /// an explicitly configured `payload.memory` would always "conflict" with it.
+    pub fn payload_memory_placement(&self) -> Memory {
+        let memory = self.payload.and_then(|payload| payload.memory);
+        Memory::resolve(memory, Some(Memory::from_on_disk(self.on_disk_payload)))
+            .unwrap_or(Memory::Cold)
     }
 
     /// All vector names (dense and sparse) currently present in the collection schema.
@@ -170,6 +242,7 @@ impl CollectionParams {
             read_fan_out_factor: _, // May be changed
             read_fan_out_delay_ms: _, // May be changed,
             on_disk_payload: _, // May be changed
+            payload: _,      // May be changed
             sparse_vectors: _, // Sets may differ via named vector CRUD
         } = other;
 
@@ -358,6 +431,7 @@ impl CollectionParams {
             write_consistency_factor: default_write_consistency_factor(),
             read_fan_out_factor: None,
             read_fan_out_delay_ms: None,
+            payload: None,
             on_disk_payload: default_on_disk_payload(),
             sparse_vectors: None,
         }
@@ -486,6 +560,7 @@ impl CollectionParams {
                 hnsw_config,
                 quantization_config,
                 on_disk,
+                memory,
             } = update_params.clone();
 
             if let Some(hnsw_diff) = hnsw_config {
@@ -514,6 +589,10 @@ impl CollectionParams {
 
             if let Some(on_disk) = on_disk {
                 vector_params.on_disk = Some(on_disk);
+            }
+
+            if let Some(memory) = memory {
+                vector_params.memory = Some(memory);
             }
         }
         Ok(())
@@ -568,9 +647,16 @@ impl CollectionParams {
                     hnsw_config: _,
                     quantization_config,
                     on_disk,
+                    memory,
                     datatype,
                     multivector_config,
                 } = params;
+
+                let memory_placement = Memory::resolve(
+                    *memory,
+                    Some(Memory::from_on_disk(on_disk.unwrap_or_default())),
+                )
+                .unwrap_or(Memory::Cached);
 
                 (
                     name.into(),
@@ -585,11 +671,7 @@ impl CollectionParams {
                             .then(|| quantization_fn(quantization_config.as_ref()))
                             .flatten(),
                         // Default to in memory storage
-                        storage_type: if on_disk.unwrap_or_default() {
-                            VectorStorageType::ChunkedMmap
-                        } else {
-                            VectorStorageType::InRamChunkedMmap
-                        },
+                        storage_type: VectorStorageType::appendable_from_memory(memory_placement),
                         multivector_config: *multivector_config,
                         datatype: datatype.map(VectorStorageDatatype::from),
                     },
@@ -619,6 +701,7 @@ impl CollectionParams {
                                     .index
                                     .and_then(|index| index.datatype)
                                     .map(VectorStorageDatatype::from),
+                                memory: params.index.and_then(|index| index.memory),
                             },
                             storage_type: params.storage_type(),
                             modifier: params.modifier,

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::{BTreeMap, HashSet};
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
@@ -76,6 +80,7 @@ pub(super) async fn fixture(
                                 r#type: ScalarType::Int8,
                                 quantile: None,
                                 always_ram: None,
+                                memory: None,
                             },
                         }))
                         .with_hnsw_config(HnswConfigDiff {
@@ -118,6 +123,7 @@ pub(super) async fn fixture(
         read_fan_out_factor: None,
         read_fan_out_delay_ms: None,
         on_disk_payload: false,
+        payload: None,
     };
 
     // Optimizer config — `max_segment_size_kb` / `indexing_threshold_kb` are caller-supplied

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -7,13 +7,13 @@ use std::num::NonZeroU32;
 use api::rest::MaxOptimizationThreads;
 use schemars::JsonSchema;
 use segment::types::{
-    BinaryQuantization, HnswConfig, ProductQuantization, ScalarQuantization, StrictModeConfig,
-    TurboQuantization,
+    BinaryQuantization, HnswConfig, Memory, ProductQuantization, ScalarQuantization,
+    StrictModeConfig, TurboQuantization,
 };
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationErrors};
 
-use crate::config::{CollectionParams, WalConfig};
+use crate::config::{CollectionParams, PayloadStorageParams, WalConfig};
 use crate::optimizers_builder::OptimizersConfig;
 
 pub trait DiffConfig<Diff>: Clone {
@@ -62,9 +62,15 @@ pub struct HnswConfigDiff {
     /// On small CPUs, less threads are used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_indexing_threads: Option<usize>,
+    /// Deprecated: use `memory` instead.
     /// Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+    /// Memory placement of the HNSW graph. Overrides the deprecated `on_disk` flag if both are
+    /// set. Default: `cached` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
     /// Custom M param for additional payload-aware HNSW links. If not set, default M will be used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payload_m: Option<usize>,
@@ -87,7 +93,7 @@ pub struct WalConfigDiff {
     pub wal_retain_closed: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq, Eq, Hash)]
 pub struct CollectionParamsDiff {
     /// Number of replicas for each shard
     pub replication_factor: Option<NonZeroU32>,
@@ -97,12 +103,18 @@ pub struct CollectionParamsDiff {
     pub read_fan_out_factor: Option<u32>,
     ///  Delay in milliseconds before sending read requests to remote nodes
     pub read_fan_out_delay_ms: Option<u64>,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
     /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
     #[serde(default)]
+    #[deprecated(since = "1.19.0", note = "Use `payload.memory` instead")]
     pub on_disk_payload: Option<bool>,
+    /// Update params of the payload storage. If none - it is left unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
+    pub payload: Option<PayloadStorageParams>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Validate, Clone, PartialEq)]
@@ -212,6 +224,7 @@ impl DiffConfig<HnswConfigDiff> for HnswConfig {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = diff;
@@ -222,6 +235,7 @@ impl DiffConfig<HnswConfigDiff> for HnswConfig {
             full_scan_threshold: full_scan_threshold.unwrap_or(self.full_scan_threshold),
             max_indexing_threads: max_indexing_threads.unwrap_or(self.max_indexing_threads),
             on_disk: on_disk.or(self.on_disk),
+            memory: memory.or(self.memory),
             payload_m: payload_m.or(self.payload_m),
             inline_storage: inline_storage.or(self.inline_storage),
         }
@@ -236,6 +250,7 @@ impl DiffConfig<HnswConfigDiff> for HnswConfigDiff {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = diff;
@@ -246,6 +261,7 @@ impl DiffConfig<HnswConfigDiff> for HnswConfigDiff {
             full_scan_threshold: full_scan_threshold.or(self.full_scan_threshold),
             max_indexing_threads: max_indexing_threads.or(self.max_indexing_threads),
             on_disk: on_disk.or(self.on_disk),
+            memory: memory.or(self.memory),
             payload_m: payload_m.or(self.payload_m),
             inline_storage: inline_storage.or(self.inline_storage),
         }
@@ -306,6 +322,7 @@ impl DiffConfig<CollectionParamsDiff> for CollectionParams {
             read_fan_out_factor,
             read_fan_out_delay_ms,
             on_disk_payload,
+            payload,
         } = diff;
 
         CollectionParams {
@@ -315,6 +332,10 @@ impl DiffConfig<CollectionParamsDiff> for CollectionParams {
             read_fan_out_factor: read_fan_out_factor.or(self.read_fan_out_factor),
             read_fan_out_delay_ms: read_fan_out_delay_ms.or(self.read_fan_out_delay_ms),
             on_disk_payload: on_disk_payload.unwrap_or(self.on_disk_payload),
+            payload: match (self.payload.as_ref(), payload) {
+                (Some(base), Some(diff)) => Some(base.update(diff)),
+                (base, diff) => diff.or(base.copied()),
+            },
             shard_number: self.shard_number,
             sharding_method: self.sharding_method,
             sparse_vectors: self.sparse_vectors.clone(),
@@ -396,6 +417,7 @@ impl From<HnswConfig> for HnswConfigDiff {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = config;
@@ -406,6 +428,7 @@ impl From<HnswConfig> for HnswConfigDiff {
             full_scan_threshold: Some(full_scan_threshold),
             max_indexing_threads: Some(max_indexing_threads),
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         }
@@ -436,6 +459,7 @@ impl From<CollectionParams> for CollectionParamsDiff {
             read_fan_out_factor,
             read_fan_out_delay_ms,
             on_disk_payload,
+            payload,
             shard_number: _,
             sharding_method: _,
             sparse_vectors: _,
@@ -448,6 +472,7 @@ impl From<CollectionParams> for CollectionParamsDiff {
             read_fan_out_factor,
             read_fan_out_delay_ms,
             on_disk_payload: Some(on_disk_payload),
+            payload,
         }
     }
 }
@@ -540,6 +565,7 @@ mod tests {
             read_fan_out_factor: None,
             read_fan_out_delay_ms: None,
             on_disk_payload: None,
+            payload: None,
         };
 
         let new_params = params.update(&diff);
@@ -547,6 +573,43 @@ mod tests {
         assert_eq!(new_params.replication_factor.get(), 1);
         assert_eq!(new_params.write_consistency_factor.get(), 2);
         assert!(new_params.on_disk_payload);
+    }
+
+    #[test]
+    fn test_update_payload_storage_params() {
+        let params = CollectionParams {
+            vectors: VectorParamsBuilder::new(128, Distance::Cosine)
+                .build()
+                .into(),
+            ..CollectionParams::empty()
+        };
+        // Default `on_disk_payload: true` resolves to cold placement
+        assert_eq!(
+            params.payload_memory_placement(),
+            segment::types::Memory::Cold
+        );
+
+        let diff = CollectionParamsDiff {
+            replication_factor: None,
+            write_consistency_factor: None,
+            read_fan_out_factor: None,
+            read_fan_out_delay_ms: None,
+            on_disk_payload: None,
+            payload: Some(PayloadStorageParams {
+                memory: Some(segment::types::Memory::Cached),
+            }),
+        };
+
+        let new_params = params.update(&diff);
+        // The new `payload.memory` parameter wins over the deprecated `on_disk_payload` flag
+        assert_eq!(
+            new_params.payload_memory_placement(),
+            segment::types::Memory::Cached,
+        );
+        assert_eq!(
+            new_params.payload_storage_type(),
+            segment::types::PayloadStorageType::InRamMmap,
+        );
     }
 
     #[test]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1,9 +1,14 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::BTreeMap;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
 use api::conversions::json::json_path_from_proto;
 use api::grpc::conversions::{
+    convert_memory_from_proto, convert_memory_from_proto_lossy, convert_memory_to_proto,
     convert_shard_key_from_grpc, convert_shard_key_from_grpc_opt, convert_shard_key_to_grpc,
     from_grpc_dist,
 };
@@ -36,7 +41,7 @@ use super::types::{
     VectorsConfigDiff,
 };
 use crate::config::{
-    CollectionParams, ShardingMethod, WalConfig, default_replication_factor,
+    CollectionParams, PayloadStorageParams, ShardingMethod, WalConfig, default_replication_factor,
     default_write_consistency_factor,
 };
 use crate::lookup::WithLookup;
@@ -241,6 +246,7 @@ impl From<api::grpc::qdrant::HnswConfigDiff> for HnswConfigDiff {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = value;
@@ -250,6 +256,7 @@ impl From<api::grpc::qdrant::HnswConfigDiff> for HnswConfigDiff {
             full_scan_threshold: full_scan_threshold.map(|v| v as usize),
             max_indexing_threads: max_indexing_threads.map(|v| v as usize),
             on_disk,
+            memory: convert_memory_from_proto_lossy(memory),
             payload_m: payload_m.map(|v| v as usize),
             inline_storage,
         }
@@ -264,6 +271,7 @@ impl From<HnswConfigDiff> for api::grpc::qdrant::HnswConfigDiff {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = value;
@@ -273,6 +281,7 @@ impl From<HnswConfigDiff> for api::grpc::qdrant::HnswConfigDiff {
             full_scan_threshold: full_scan_threshold.map(|v| v as u64),
             max_indexing_threads: max_indexing_threads.map(|v| v as u64),
             on_disk,
+            memory: convert_memory_to_proto(memory),
             payload_m: payload_m.map(|v| v as u64),
             inline_storage,
         }
@@ -294,6 +303,26 @@ impl From<api::grpc::qdrant::WalConfigDiff> for WalConfigDiff {
     }
 }
 
+impl TryFrom<api::grpc::qdrant::PayloadStorageParams> for PayloadStorageParams {
+    type Error = Status;
+
+    fn try_from(value: api::grpc::qdrant::PayloadStorageParams) -> Result<Self, Self::Error> {
+        let api::grpc::qdrant::PayloadStorageParams { memory } = value;
+        Ok(Self {
+            memory: convert_memory_from_proto(memory)?,
+        })
+    }
+}
+
+impl From<PayloadStorageParams> for api::grpc::qdrant::PayloadStorageParams {
+    fn from(value: PayloadStorageParams) -> Self {
+        let PayloadStorageParams { memory } = value;
+        Self {
+            memory: convert_memory_to_proto(memory),
+        }
+    }
+}
+
 impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
     type Error = Status;
 
@@ -304,6 +333,7 @@ impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
             read_fan_out_factor,
             on_disk_payload,
             read_fan_out_delay_ms,
+            payload,
         } = value;
         Ok(Self {
             replication_factor: replication_factor
@@ -322,6 +352,7 @@ impl TryFrom<api::grpc::qdrant::CollectionParamsDiff> for CollectionParamsDiff {
             read_fan_out_factor,
             read_fan_out_delay_ms,
             on_disk_payload,
+            payload: payload.map(PayloadStorageParams::try_from).transpose()?,
         })
     }
 }
@@ -425,6 +456,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory,
             payload_m,
             inline_storage,
         } = hnsw_config;
@@ -435,6 +467,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
             replication_factor,
             read_fan_out_delay_ms,
             on_disk_payload,
+            payload,
             write_consistency_factor,
             read_fan_out_factor,
             sharding_method,
@@ -502,6 +535,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                         }
                     }),
                     read_fan_out_delay_ms,
+                    payload: payload.map(api::grpc::qdrant::PayloadStorageParams::from),
                 }),
                 hnsw_config: Some(api::grpc::qdrant::HnswConfigDiff {
                     m: Some(m as u64),
@@ -509,6 +543,7 @@ impl From<CollectionInfo> for api::grpc::qdrant::CollectionInfo {
                     full_scan_threshold: Some(full_scan_threshold as u64),
                     max_indexing_threads: Some(max_indexing_threads as u64),
                     on_disk,
+                    memory: convert_memory_to_proto(memory),
                     payload_m: payload_m.map(|v| v as u64),
                     inline_storage,
                 }),
@@ -727,6 +762,7 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
             hnsw_config,
             quantization_config,
             on_disk,
+            memory,
             datatype,
             multivector_config,
         } = vector_params;
@@ -740,6 +776,7 @@ impl TryFrom<api::grpc::qdrant::VectorParams> for VectorParams {
                 .map(grpc_to_segment_quantization_config)
                 .transpose()?,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
             datatype: convert_datatype_from_proto(datatype)?,
             multivector_config: multivector_config
                 .map(MultiVectorConfig::try_from)
@@ -777,11 +814,13 @@ impl TryFrom<api::grpc::qdrant::VectorParamsDiff> for VectorParamsDiff {
             hnsw_config,
             quantization_config,
             on_disk,
+            memory,
         } = vector_params;
         Ok(Self {
             hnsw_config: hnsw_config.map(Into::into),
             quantization_config: quantization_config.map(TryInto::try_into).transpose()?,
             on_disk,
+            memory: convert_memory_from_proto(memory)?,
         })
     }
 }
@@ -799,6 +838,7 @@ impl TryFrom<api::grpc::qdrant::SparseVectorParams> for SparseVectorParams {
                     Ok(SparseIndexParams {
                         full_scan_threshold: index_config.full_scan_threshold.map(|v| v as usize),
                         on_disk: index_config.on_disk,
+                        memory: convert_memory_from_proto(index_config.memory)?,
                         datatype: convert_datatype_from_proto(index_config.datatype)?,
                     })
                 })
@@ -820,11 +860,13 @@ impl From<SparseVectorParams> for api::grpc::qdrant::SparseVectorParams {
                 let SparseIndexParams {
                     full_scan_threshold,
                     on_disk,
+                    memory,
                     datatype,
                 } = index_config;
                 api::grpc::qdrant::SparseIndexConfig {
                     full_scan_threshold: full_scan_threshold.map(|v| v as u64),
                     on_disk,
+                    memory: convert_memory_to_proto(memory),
                     datatype: datatype.map(|dt| api::grpc::qdrant::Datatype::from(dt).into()),
                 }
             }),
@@ -1399,6 +1441,7 @@ impl From<VectorParams> for api::grpc::qdrant::VectorParams {
             hnsw_config,
             quantization_config,
             on_disk,
+            memory,
             datatype,
             multivector_config,
         } = value;
@@ -1414,6 +1457,7 @@ impl From<VectorParams> for api::grpc::qdrant::VectorParams {
             hnsw_config: hnsw_config.map(HnswConfigDiff::into),
             quantization_config: quantization_config.map(QuantizationConfig::into),
             on_disk,
+            memory: convert_memory_to_proto(memory),
             datatype: datatype.map(|dt| api::grpc::qdrant::Datatype::from(dt).into()),
             multivector_config: multivector_config.map(api::grpc::qdrant::MultiVectorConfig::from),
         }
@@ -1869,6 +1913,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                     let api::grpc::qdrant::CollectionParams {
                         shard_number,
                         on_disk_payload,
+                        payload,
                         vectors_config,
                         replication_factor,
                         write_consistency_factor,
@@ -1933,6 +1978,7 @@ impl TryFrom<api::grpc::qdrant::CollectionConfig> for CollectionConfig {
                             .map(sharding_method_from_proto)
                             .transpose()?,
                         read_fan_out_delay_ms,
+                        payload: payload.map(PayloadStorageParams::try_from).transpose()?,
                     }
                 }
             },

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1,4 +1,9 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::backtrace::Backtrace;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as _;
 use std::fmt::{Debug, Write as _};
@@ -25,8 +30,8 @@ use segment::data_types::groups::GroupId;
 use segment::data_types::modifier::Modifier;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, DenseVector};
 use segment::types::{
-    Distance, Filter, HnswConfig, MultiVectorConfig, Payload, PayloadIndexInfo, PayloadKeyType,
-    PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey,
+    Distance, Filter, HnswConfig, Memory, MultiVectorConfig, Payload, PayloadIndexInfo,
+    PayloadKeyType, PointIdType, QuantizationConfig, SearchParams, SeqNumberType, ShardKey,
     SparseVectorStorageType, StrictModeConfigOutput, VectorName, VectorNameBuf,
     VectorStorageDatatype, WithPayloadInterface, WithVector,
 };
@@ -1357,10 +1362,19 @@ pub struct VectorParams {
     )]
     #[validate(nested)]
     pub quantization_config: Option<QuantizationConfig>,
+    /// Deprecated: use `memory` instead.
     /// If true, vectors are served from disk, improving RAM usage at the cost of latency
     /// Default: false
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the original vector storage. Overrides the deprecated `on_disk`
+    /// flag if both are set. `pinned` is not supported for dense vector storage.
+    /// Default: `cached` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(custom(function = "validate_dense_vector_memory"))]
+    pub memory: Option<Memory>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Defines which datatype should be used to represent vectors in the storage.
@@ -1394,6 +1408,21 @@ fn validate_sparse_datatype(datatype: &Datatype) -> Result<(), ValidationError> 
         return Err(common::validation::sparse_turbo4_unsupported_error());
     }
     Ok(())
+}
+
+/// Reject memory placements not supported by dense vector storage.
+/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
+fn validate_dense_vector_memory(memory: &Memory) -> Result<(), ValidationError> {
+    match memory {
+        Memory::Cold | Memory::Cached => Ok(()),
+        Memory::Pinned => {
+            let mut error = ValidationError::new("unsupported_memory_placement");
+            error.message = Some(Cow::from(
+                "`pinned` memory placement is not supported for dense vector storage",
+            ));
+            Err(error)
+        }
+    }
 }
 
 /// Is considered empty if `None` or if diff has no field specified
@@ -1447,9 +1476,15 @@ pub struct SparseIndexParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub full_scan_threshold: Option<usize>,
+    /// Deprecated: use `memory` instead.
     /// Store index on disk. If set to false, the index will be stored in RAM. Default: false
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
     /// Defines which datatype should be used for the index.
     /// Choosing different datatypes allows to optimize memory usage and performance vs accuracy.
     ///
@@ -1470,12 +1505,14 @@ impl SparseIndexParams {
         let SparseIndexParams {
             full_scan_threshold,
             on_disk,
+            memory,
             datatype,
         } = other;
 
         self.full_scan_threshold
             .replace_if_some(full_scan_threshold);
         self.on_disk.replace_if_some(on_disk);
+        self.memory.replace_if_some(memory);
         self.datatype.replace_if_some(datatype);
     }
 }
@@ -1674,6 +1711,7 @@ impl From<&VectorParams> for VectorParamsBase {
             hnsw_config: _,
             quantization_config: _,
             on_disk: _,
+            memory: _,
             datatype: _,
             multivector_config: _,
         } = params;
@@ -1714,9 +1752,16 @@ pub struct VectorParamsDiff {
     )]
     #[validate(nested)]
     pub quantization_config: Option<QuantizationConfigDiff>,
+    /// Deprecated: use `memory` instead.
     /// If true, vectors are served from disk, improving RAM usage at the cost of latency
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+    /// Memory placement of the original vector storage. Overrides the deprecated `on_disk`
+    /// flag if both are set. `pinned` is not supported for dense vector storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[validate(custom(function = "validate_dense_vector_memory"))]
+    pub memory: Option<Memory>,
 }
 
 /// Vector update params for multiple vectors

--- a/lib/collection/src/operations/vector_params_builder.rs
+++ b/lib/collection/src/operations/vector_params_builder.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::num::NonZeroU64;
 
 use segment::types::{Distance, QuantizationConfig};
@@ -18,6 +22,7 @@ impl VectorParamsBuilder {
                 hnsw_config: None,
                 quantization_config: None,
                 on_disk: None,
+                memory: None,
                 datatype: None,
                 multivector_config: None,
             },
@@ -26,6 +31,11 @@ impl VectorParamsBuilder {
 
     pub fn with_on_disk(mut self, on_disk: bool) -> Self {
         self.vector_params.on_disk = Some(on_disk);
+        self
+    }
+
+    pub fn with_memory(mut self, memory: segment::types::Memory) -> Self {
+        self.vector_params.memory = Some(memory);
         self
     }
 

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
@@ -197,6 +201,7 @@ pub fn build_segment_optimizer_config(
                 hnsw_config,
                 quantization_config,
                 on_disk,
+                memory,
                 datatype,
                 multivector_config,
             } = params;
@@ -207,6 +212,7 @@ pub fn build_segment_optimizer_config(
                     size: size.get() as usize,
                     distance: *distance,
                     on_disk: *on_disk,
+                    memory: *memory,
                     hnsw_config: global_hnsw_config.update_opt(hnsw_config.as_ref()),
                     quantization_config: quantization_config
                         .as_ref()
@@ -232,6 +238,7 @@ pub fn build_segment_optimizer_config(
                         name.clone(),
                         SparseVectorOptimizerInput {
                             on_disk: index.and_then(|index| index.on_disk),
+                            memory: index.and_then(|index| index.memory),
                             full_scan_threshold: index.and_then(|index| index.full_scan_threshold),
                             index_datatype: index
                                 .and_then(|index| index.datatype)

--- a/lib/edge/python/src/config/quantization.rs
+++ b/lib/edge/python/src/config/quantization.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::fmt;
 
 use bytemuck::TransparentWrapper;
@@ -100,6 +104,7 @@ impl PyScalarQuantizationConfig {
             r#type: ScalarType::from(r#type),
             quantile,
             always_ram,
+            memory: None,
         })
     }
 
@@ -130,6 +135,7 @@ impl PyScalarQuantizationConfig {
             r#type: _,
             quantile: _,
             always_ram: _,
+            memory: _,
         } = self.0;
     }
 }
@@ -187,6 +193,7 @@ impl PyProductQuantizationConfig {
         Self(ProductQuantizationConfig {
             compression: CompressionRatio::from(compression),
             always_ram,
+            memory: None,
         })
     }
 
@@ -211,6 +218,7 @@ impl PyProductQuantizationConfig {
         let ProductQuantizationConfig {
             compression: _,
             always_ram: _,
+            memory: _,
         } = self.0;
     }
 }
@@ -287,6 +295,7 @@ impl PyBinaryQuantizationConfig {
     ) -> Self {
         Self(BinaryQuantizationConfig {
             always_ram,
+            memory: None,
             encoding: encoding.map(BinaryQuantizationEncoding::from),
             query_encoding: query_encoding.map(BinaryQuantizationQueryEncoding::from),
         })
@@ -319,6 +328,7 @@ impl PyBinaryQuantizationConfig {
         // Every field should have a getter method
         let BinaryQuantizationConfig {
             always_ram: _,
+            memory: _,
             encoding: _,
             query_encoding: _,
         } = self.0;
@@ -448,6 +458,7 @@ impl PyTurboQuantQuantizationConfig {
     pub fn new(always_ram: Option<bool>, bits: Option<PyTurboQuantBitSize>) -> Self {
         Self(TurboQuantQuantizationConfig {
             always_ram,
+            memory: None,
             bits: bits.map(TurboQuantBitSize::from),
         })
     }
@@ -472,6 +483,7 @@ impl PyTurboQuantQuantizationConfig {
         // Every field should have a getter method
         let TurboQuantQuantizationConfig {
             always_ram: _,
+            memory: _,
             bits: _,
         } = self.0;
     }

--- a/lib/edge/python/src/config/vector_data.rs
+++ b/lib/edge/python/src/config/vector_data.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::fmt;
 
@@ -155,6 +159,7 @@ impl PyHnswIndexConfig {
             full_scan_threshold,
             max_indexing_threads,
             on_disk,
+            memory: None,
             payload_m,
             inline_storage,
         })
@@ -209,6 +214,7 @@ impl PyHnswIndexConfig {
             full_scan_threshold: _,
             max_indexing_threads: _, // not relevant for Qdrant Edge
             on_disk: _,
+            memory: _,
             payload_m: _,
             inline_storage: _,
         } = self.0;

--- a/lib/edge/python/src/types/payload_schema/mod.rs
+++ b/lib/edge/python/src/types/payload_schema/mod.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 pub mod text_index;
 
 use std::fmt;
@@ -219,6 +223,7 @@ impl PyKeywordIndexParams {
             r#type: Default::default(),
             is_tenant,
             on_disk,
+            memory: None,
             enable_hnsw,
             prefix,
         })
@@ -252,6 +257,7 @@ impl PyKeywordIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             is_tenant: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
             prefix: _,
         } = self.0;
@@ -281,6 +287,7 @@ impl PyIntegerIndexParams {
             range,
             is_principal,
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -320,6 +327,7 @@ impl PyIntegerIndexParams {
             range: _,
             is_principal: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }
@@ -344,6 +352,7 @@ impl PyFloatIndexParams {
             r#type: Default::default(),
             is_principal,
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -371,6 +380,7 @@ impl PyFloatIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             is_principal: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }
@@ -390,6 +400,7 @@ impl PyGeoIndexParams {
         Self(GeoIndexParams {
             r#type: Default::default(),
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -411,6 +422,7 @@ impl PyGeoIndexParams {
         let GeoIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }
@@ -430,6 +442,7 @@ impl PyBoolIndexParams {
         Self(BoolIndexParams {
             r#type: Default::default(),
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -451,6 +464,7 @@ impl PyBoolIndexParams {
         let BoolIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }
@@ -475,6 +489,7 @@ impl PyDatetimeIndexParams {
             r#type: Default::default(),
             is_principal,
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -502,6 +517,7 @@ impl PyDatetimeIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             is_principal: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }
@@ -522,6 +538,7 @@ impl PyUuidIndexParams {
             r#type: Default::default(),
             is_tenant,
             on_disk,
+            memory: None,
             enable_hnsw,
         })
     }
@@ -549,6 +566,7 @@ impl PyUuidIndexParams {
             r#type: _, // not relevant for Qdrant Edge
             is_tenant: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = self.0;
     }

--- a/lib/edge/python/src/types/payload_schema/text_index.rs
+++ b/lib/edge/python/src/types/payload_schema/text_index.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::BTreeSet;
 use std::fmt;
 
@@ -42,6 +46,7 @@ impl PyTextIndexParams {
             phrase_matching,
             stopwords: stopwords.map(StopwordsInterface::from),
             on_disk,
+            memory: None,
             stemmer: stemmer.map(StemmingAlgorithm::from),
             enable_hnsw,
         })
@@ -109,6 +114,7 @@ impl PyTextIndexParams {
             lowercase: _,
             ascii_folding: _,
             phrase_matching: _,
+            memory: _,
             stopwords: _,
             on_disk: _,
             stemmer: _,

--- a/lib/edge/src/config/vectors.rs
+++ b/lib/edge/src/config/vectors.rs
@@ -88,6 +88,7 @@ impl EdgeVectorParams {
         } = self;
         DenseVectorOptimizerConfig {
             on_disk: *on_disk,
+            memory: None,
             hnsw_config: hnsw_config.unwrap_or(*global_hnsw_config),
             quantization_config: quantization_config
                 .clone()
@@ -155,6 +156,7 @@ impl EdgeSparseVectorParams {
                 full_scan_threshold: *full_scan_threshold,
                 index_type: SparseIndexType::default(),
                 datatype: *datatype,
+                memory: None,
             },
             storage_type: SparseVectorStorageType::Mmap,
             modifier: *modifier,
@@ -170,7 +172,10 @@ impl EdgeSparseVectorParams {
             modifier: _,
             datatype: _,
         } = self;
-        shard::optimizers::config::SparseVectorOptimizerConfig { on_disk: *on_disk }
+        shard::optimizers::config::SparseVectorOptimizerConfig {
+            on_disk: *on_disk,
+            memory: None,
+        }
     }
 
     pub fn from_sparse_vector_data_config(s: &SparseVectorDataConfig) -> Self {
@@ -183,6 +188,7 @@ impl EdgeSparseVectorParams {
             full_scan_threshold,
             index_type,
             datatype,
+            memory: _,
         } = index;
         Self {
             full_scan_threshold: *full_scan_threshold,

--- a/lib/segment/benches/hnsw_incremental_build.rs
+++ b/lib/segment/benches/hnsw_incremental_build.rs
@@ -1,4 +1,7 @@
 #![expect(clippy::wildcard_enum_match_arm, reason = "benchmarks")]
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
 
 use std::collections::BTreeSet;
 use std::fmt::Debug;
@@ -372,6 +375,7 @@ fn build_hnsw_index<R: Rng + ?Sized>(
     ef_construct: usize,
 ) -> HNSWIndex {
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold: 1,

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -103,6 +107,7 @@ fn make_segment_index<R: Rng + ?Sized>(rng: &mut R, distance: Distance) -> HNSWI
 
     // build HNSW index
     let hnsw_config = HnswConfig {
+        memory: None,
         m: 8,
         ef_construct: 16,
         full_scan_threshold: 10, // low value to trigger index usage by default

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -77,6 +77,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
         Some(10_000),
         SparseIndexType::MutableRam,
         Some(VectorStorageDatatype::Float32),
+        None,
     );
 
     let vector_storage = Arc::new(AtomicRefCell::new(vector_storage));

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -103,7 +103,7 @@ fn sparse_vector_index_search_benchmark_impl(
     // mmap inverted index
     let mmap_index_dir = Builder::new().prefix("mmap_index_dir").tempdir().unwrap();
     let sparse_index_config =
-        SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None);
+        SparseIndexConfig::new(Some(FULL_SCAN_THRESHOLD), SparseIndexType::Mmap, None, None);
     let pb = progress("Indexing (2/2)", vectors_len);
     let sparse_vector_index_mmap: SparseVectorIndex<InvertedIndexCompressedMmap<f32, MmapFile>> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {

--- a/lib/segment/src/compat.rs
+++ b/lib/segment/src/compat.rs
@@ -166,6 +166,7 @@ mod tests {
                         size: 10,
                         distance: Distance::Dot,
                         hnsw_config: Some(HnswConfig {
+                            memory: None,
                             m: 20,
                             ef_construct: 100,
                             full_scan_threshold: 10000,
@@ -186,6 +187,7 @@ mod tests {
                         hnsw_config: None,
                         quantization_config: Some(QuantizationConfig::Scalar(ScalarQuantization {
                             scalar: ScalarQuantizationConfig {
+                                memory: None,
                                 r#type: Default::default(),
                                 quantile: Some(0.99),
                                 always_ram: Some(true),
@@ -198,6 +200,7 @@ mod tests {
             .into_iter()
             .collect(),
             index: Indexes::Hnsw(HnswConfig {
+                memory: None,
                 m: 25,
                 ef_construct: 120,
                 full_scan_threshold: 10000,
@@ -262,6 +265,7 @@ mod tests {
                         hnsw_config: None,
                         quantization_config: Some(QuantizationConfig::Scalar(ScalarQuantization {
                             scalar: ScalarQuantizationConfig {
+                                memory: None,
                                 r#type: Default::default(),
                                 quantile: Some(0.99),
                                 always_ram: Some(true),
@@ -274,6 +278,7 @@ mod tests {
             .into_iter()
             .collect(),
             index: Indexes::Hnsw(HnswConfig {
+                memory: None,
                 m: 25,
                 ef_construct: 120,
                 full_scan_threshold: 10000,
@@ -286,6 +291,7 @@ mod tests {
             payload_storage_type: None,
             quantization_config: Some(QuantizationConfig::Scalar(ScalarQuantization {
                 scalar: ScalarQuantizationConfig {
+                    memory: None,
                     r#type: Default::default(),
                     quantile: Some(0.95),
                     always_ram: Some(true),

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
@@ -5,6 +9,8 @@ use std::str::FromStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError, ValidationErrors};
+
+use crate::types::Memory;
 
 // Keyword
 
@@ -25,9 +31,16 @@ pub struct KeywordIndexParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_tenant: Option<bool>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -69,10 +82,16 @@ pub struct IntegerIndexParams {
     /// Default is false.
     pub is_principal: Option<bool>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
-    /// Default is false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -89,6 +108,7 @@ impl Validate for IntegerIndexParams {
             range,
             is_principal: _,
             on_disk: _,
+            memory: _,
             enable_hnsw: _,
         } = &self;
         validate_integer_index_params(lookup, range)
@@ -128,9 +148,16 @@ pub struct UuidIndexParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_tenant: Option<bool>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -158,9 +185,16 @@ pub struct FloatIndexParams {
     /// This option assumes that this key will be used in majority of filtered requests.
     pub is_principal: Option<bool>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -184,9 +218,16 @@ pub struct GeoIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
     pub r#type: GeoIndexType,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -247,9 +288,16 @@ pub struct TextIndexParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stopwords: Option<StopwordsInterface>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Algorithm for stemming. Default: disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -521,9 +569,16 @@ pub struct BoolIndexParams {
     // Required for OpenAPI schema without anonymous types, versus #[serde(tag = "type")]
     pub r#type: BoolIndexType,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).
@@ -551,9 +606,16 @@ pub struct DatetimeIndexParams {
     /// This option assumes that this key will be used in majority of filtered requests.
     pub is_principal: Option<bool>,
 
+    /// Deprecated: use `memory` instead.
     /// If true, store the index on disk. Default: false.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+
+    /// Memory placement of the index. Overrides the deprecated `on_disk` flag if both are set.
+    /// Default: `pinned` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     /// Enable HNSW graph building for this payload field.
     /// If true, builds additional HNSW links (Need payload_m > 0).

--- a/lib/segment/src/fixtures/index_fixtures.rs
+++ b/lib/segment/src/fixtures/index_fixtures.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::atomic::AtomicBool;
 
 use common::bitvec::BitVec;
@@ -50,6 +54,7 @@ impl TestRawScorerProducer {
                     r#type: Default::default(),
                     quantile: None,
                     always_ram: Some(true),
+                    memory: None,
                 }
                 .into(),
                 QuantizedVectorsStorageType::Immutable,

--- a/lib/segment/src/fixtures/sparse_fixtures.rs
+++ b/lib/segment/src/fixtures/sparse_fixtures.rs
@@ -74,7 +74,8 @@ pub fn fixture_sparse_index_from_iter<I: InvertedIndexReadWrite<MmapFile>>(
         num_vectors,
     );
 
-    let sparse_index_config = SparseIndexConfig::new(Some(full_scan_threshold), index_type, None);
+    let sparse_index_config =
+        SparseIndexConfig::new(Some(full_scan_threshold), index_type, None, None);
     let sparse_vector_index: SparseVectorIndex<I> =
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             fs: &MmapFs,

--- a/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
@@ -17,33 +17,33 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::index::TextIndexParams;
 use crate::index::field_index::{FieldIndexBuilderTrait, PayloadFieldIndex, ValueIndexer};
 use crate::index::payload_config::IndexMutability;
+use crate::types::Memory;
 
 impl FullTextIndex {
     pub fn new_mmap(
         path: PathBuf,
         config: TextIndexParams,
-        is_on_disk: bool,
+        memory: Memory,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
-        // pure-mmap variant at load time. Files are shared between variants;
-        // the persisted `is_on_disk` flag in `mmap_index` is untouched.
-        let effective_is_on_disk =
-            is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
+        // Low-memory mode degrades the placement at load time (pinned falls back to the
+        // pure-mmap variant). Files are shared between variants; the persisted
+        // configuration is untouched.
+        let memory = memory.clamp_to_low_memory();
 
-        let populate = Populate::from(!effective_is_on_disk);
+        let populate = Populate::from(memory.populate_on_open());
         let Some(on_disk_index) =
             OnDiskFullTextIndex::open(&MmapFs, path, config, populate, deleted_points)?
         else {
             return Ok(None);
         };
 
-        let index = if effective_is_on_disk {
-            // Use on-disk directly
-            Self::OnDisk(on_disk_index)
-        } else {
+        let index = if memory.is_heap() {
             // Load into RAM, use mmap as backing storage
             Self::Immutable(ImmutableFullTextIndex::load_from_on_disk(on_disk_index)?)
+        } else {
+            // Use on-disk directly
+            Self::OnDisk(on_disk_index)
         };
         Ok(Some(index))
     }

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/tests.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/tests.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use common::types::PointOffsetType;
 use tempfile::Builder;
 
@@ -36,6 +40,7 @@ fn test_full_text_indexing() {
 
     let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config = TextIndexParams {
+        memory: None,
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::Word,
         min_token_len: None,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use common::universal_io::UniversalRead;
 
 use super::mutable_text_index::read_only::ReadOnlyAppendableFullTextIndex;
@@ -57,6 +61,7 @@ mod tests {
 
     fn test_config() -> TextIndexParams {
         TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,

--- a/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/mod.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 mod test_congruence;
 
 use common::bitvec::BitVec;
@@ -159,6 +163,7 @@ fn movie_titles() -> Vec<String> {
 fn test_prefix_search() {
     let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config = TextIndexParams {
+        memory: None,
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::Prefix,
         min_token_len: None,
@@ -218,6 +223,7 @@ fn test_phrase_matching() {
     // Create a text index with phrase matching enabled
     let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config = TextIndexParams {
+        memory: None,
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::default(),
         min_token_len: None,
@@ -351,6 +357,7 @@ fn test_ascii_folding_in_full_text_index_word() {
 
     let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config_enabled = TextIndexParams {
+        memory: None,
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::Word,
         min_token_len: None,
@@ -463,6 +470,7 @@ fn test_special_check_condition_match_text_any() {
 
     let temp_dir = Builder::new().prefix("test_dir").tempdir().unwrap();
     let config = TextIndexParams {
+        memory: None,
         r#type: TextIndexType::Text,
         tokenizer: TokenizerType::Word,
         min_token_len: None,

--- a/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tests/test_congruence.rs
@@ -22,7 +22,7 @@ use crate::index::field_index::full_text_index::on_disk_text_index::FullTextMmap
 use crate::index::field_index::full_text_index::{FullTextGridstoreIndexBuilder, FullTextIndex};
 use crate::index::field_index::{FieldIndexBuilderTrait, ValueIndexer};
 use crate::json_path::JsonPath;
-use crate::types::{FieldCondition, ValuesCount};
+use crate::types::{FieldCondition, Memory, ValuesCount};
 
 type Database = ();
 
@@ -147,16 +147,26 @@ fn reopen_index(
         }
         IndexType::OnDisk => {
             // Reopen with is_on_disk = true (mmap directly)
-            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, true, &deleted)
-                .unwrap()
-                .expect("Failed to reopen ImmMmap index")
+            FullTextIndex::new_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                Memory::Cold,
+                &deleted,
+            )
+            .unwrap()
+            .expect("Failed to reopen ImmMmap index")
         }
         IndexType::Immutable => {
             // Reopen with is_on_disk = false (load into RAM)
             // This is the path that will call ImmutableFullTextIndex::open_mmap
-            FullTextIndex::new_mmap(temp_dir.path().to_path_buf(), config, false, &deleted)
-                .unwrap()
-                .expect("Failed to reopen ImmRamMmap index")
+            FullTextIndex::new_mmap(
+                temp_dir.path().to_path_buf(),
+                config,
+                Memory::Pinned,
+                &deleted,
+            )
+            .unwrap()
+            .expect("Failed to reopen ImmRamMmap index")
         }
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/tokenizers/mod.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 use std::sync::Arc;
 mod ascii_folding;
@@ -175,6 +179,7 @@ impl Tokenizer {
             lowercase,
             ascii_folding,
             on_disk: _,
+            memory: _,
             phrase_matching: _,
             stopwords,
             stemmer,
@@ -414,6 +419,7 @@ mod tests {
         let text = "Hello, Мир!";
         let mut tokens = Vec::new();
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Prefix,
             min_token_len: Some(1),
@@ -447,6 +453,7 @@ mod tests {
         let text = "The quick brown fox jumps over the lazy dog";
         let mut tokens = Vec::new();
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -491,6 +498,7 @@ mod tests {
         for &tokenizer_type in &tokenizer_types {
             let mut tokens = Vec::new();
             let params = TextIndexParams {
+                memory: None,
                 r#type: TextIndexType::Text,
                 tokenizer: tokenizer_type,
                 min_token_len: None,
@@ -525,6 +533,7 @@ mod tests {
         use crate::data_types::index::Language;
 
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -565,6 +574,7 @@ mod tests {
         let text = "The quick brown fox jumps over the lazy dog as a test";
         let mut tokens = Vec::new();
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -605,6 +615,7 @@ mod tests {
         let mut tokens = Vec::new();
         use crate::data_types::index::Language;
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -642,6 +653,7 @@ mod tests {
         let mut tokens = Vec::new();
         use crate::data_types::index::Language;
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -688,6 +700,7 @@ mod tests {
         let text = "The quick brown fox jumps over the lazy dog";
         let mut tokens = Vec::new();
         let params = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -737,6 +750,7 @@ mod tests {
 
         // ascii_folding disabled (default)
         let params_disabled = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,
@@ -756,6 +770,7 @@ mod tests {
 
         // ascii_folding enabled
         let params_enabled = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -25,7 +25,7 @@ pub use self::read_ops::{GeoConditionChecker, GeoIndexRead};
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::geo_hash::GeoHash;
 use crate::index::payload_config::{IndexMutability, StorageType};
-use crate::types::GeoPoint;
+use crate::types::{GeoPoint, Memory};
 
 /// Max number of sub-regions computed for an input geo query
 // TODO discuss value, should it be dynamically computed?
@@ -43,22 +43,24 @@ pub enum GeoIndex {
 impl GeoIndex {
     pub fn new_immutable(
         path: &Path,
-        is_on_disk: bool,
+        memory: Memory,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let effective_is_on_disk =
-            is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
+        // Low-memory mode degrades the placement at load time (pinned falls back to the
+        // pure-mmap variant). Files are shared between variants; the persisted
+        // configuration is untouched.
+        let memory = memory.clamp_to_low_memory();
 
-        let populate = Populate::from(!effective_is_on_disk);
+        let populate = Populate::from(memory.populate_on_open());
         let Some(on_disk_index) = OnDiskGeoIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
             return Ok(None);
         };
 
-        let index = if effective_is_on_disk {
-            GeoIndex::OnDisk(on_disk_index)
-        } else {
+        let index = if memory.is_heap() {
             GeoIndex::Immutable(ImmutableGeoIndex::load_from_on_disk(on_disk_index)?)
+        } else {
+            GeoIndex::OnDisk(on_disk_index)
         };
 
         Ok(Some(index))

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -28,6 +28,7 @@ use crate::json_path::JsonPath;
 use crate::types::test_utils::build_polygon;
 use crate::types::{
     CheckGeoPoint, FieldCondition, GeoBoundingBox, GeoLineString, GeoPoint, GeoPolygon, GeoRadius,
+    Memory,
 };
 
 /// Generous default size for the deleted-points bitslice used in tests.
@@ -667,12 +668,16 @@ fn load_from_disk(#[case] index_type: IndexType) {
         IndexType::Mutable => GeoIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), true, &empty_deleted())
-            .unwrap()
-            .unwrap(),
-        IndexType::Immutable => GeoIndex::new_immutable(temp_dir.path(), false, &empty_deleted())
-            .unwrap()
-            .unwrap(),
+        IndexType::OnDisk => {
+            GeoIndex::new_immutable(temp_dir.path(), Memory::Cold, &empty_deleted())
+                .unwrap()
+                .unwrap()
+        }
+        IndexType::Immutable => {
+            GeoIndex::new_immutable(temp_dir.path(), Memory::Pinned, &empty_deleted())
+                .unwrap()
+                .unwrap()
+        }
     };
 
     let berlin_geo_radius = GeoRadius {
@@ -740,11 +745,13 @@ fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
         IndexType::Mutable => GeoIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), true, &deleted_with(&[1]))
-            .unwrap()
-            .unwrap(),
+        IndexType::OnDisk => {
+            GeoIndex::new_immutable(temp_dir.path(), Memory::Cold, &deleted_with(&[1]))
+                .unwrap()
+                .unwrap()
+        }
         IndexType::Immutable => {
-            GeoIndex::new_immutable(temp_dir.path(), false, &deleted_with(&[1]))
+            GeoIndex::new_immutable(temp_dir.path(), Memory::Pinned, &deleted_with(&[1]))
                 .unwrap()
                 .unwrap()
         }
@@ -1316,10 +1323,10 @@ fn test_geo_index_reload(#[case] index_type: IndexType) {
         IndexType::Mutable => GeoIndex::new_mutable(temp_dir.path().to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), true, &deleted)
+        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), Memory::Cold, &deleted)
             .unwrap()
             .unwrap(),
-        IndexType::Immutable => GeoIndex::new_immutable(temp_dir.path(), false, &deleted)
+        IndexType::Immutable => GeoIndex::new_immutable(temp_dir.path(), Memory::Pinned, &deleted)
             .unwrap()
             .unwrap(),
     };
@@ -1398,12 +1405,14 @@ fn test_geo_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
     let mut short_deleted = BitVec::repeat(false, 2);
     short_deleted.set(1, true);
     let new_index = match index_type {
-        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), true, &short_deleted)
+        IndexType::OnDisk => GeoIndex::new_immutable(temp_dir.path(), Memory::Cold, &short_deleted)
             .unwrap()
             .unwrap(),
-        IndexType::Immutable => GeoIndex::new_immutable(temp_dir.path(), false, &short_deleted)
-            .unwrap()
-            .unwrap(),
+        IndexType::Immutable => {
+            GeoIndex::new_immutable(temp_dir.path(), Memory::Pinned, &short_deleted)
+                .unwrap()
+                .unwrap()
+        }
         IndexType::Mutable => unreachable!(),
     };
 

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -23,13 +23,13 @@ use crate::index::field_index::null_index::MutableNullIndex;
 use crate::index::field_index::numeric_index::{NumericIndex, NumericIndexValue};
 use crate::index::payload_config::{FullPayloadIndexType, IndexMutability, PayloadIndexType};
 use crate::json_path::JsonPath;
-use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
+use crate::types::{Memory, PayloadFieldSchema, PayloadSchemaParams};
 
 /// Selects index and index builder types based on field type.
 #[derive(Copy, Clone)]
 pub enum IndexSelector<'a> {
     /// On disk or in-memory index on mmaps, non-appendable
-    NonAppendable { dir: &'a Path, is_on_disk: bool },
+    NonAppendable { dir: &'a Path, memory: Memory },
     /// In-memory index on gridstore, appendable
     Appendable { dir: &'a Path },
 }
@@ -310,8 +310,8 @@ impl IndexSelector<'_> {
         Ok(match self {
             // The immutable variants detect prefix support from the presence
             // of the prefix index file, written at build time.
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
-                MapIndex::new_immutable(&map_dir(dir, field), *is_on_disk, deleted_points)?
+            IndexSelector::NonAppendable { dir, memory } => {
+                MapIndex::new_immutable(&map_dir(dir, field), *memory, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
                 MapIndex::new_mutable(map_dir(dir, field), create_if_missing, prefix_index)?
@@ -331,14 +331,12 @@ impl IndexSelector<'_> {
         Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
     {
         match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
-                make_mmap(MapIndex::builder_immutable(
-                    &map_dir(dir, field),
-                    *is_on_disk,
-                    deleted_points,
-                    prefix_index,
-                ))
-            }
+            IndexSelector::NonAppendable { dir, memory } => make_mmap(MapIndex::builder_immutable(
+                &map_dir(dir, field),
+                !memory.is_heap(),
+                deleted_points,
+                prefix_index,
+            )),
             IndexSelector::Appendable { dir } => {
                 make_gridstore(MapIndex::builder_mutable(map_dir(dir, field), prefix_index))
             }
@@ -355,8 +353,8 @@ impl IndexSelector<'_> {
         Vec<T>: Blob,
     {
         Ok(match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
-                NumericIndex::new_immutable(&numeric_dir(dir, field), *is_on_disk, deleted_points)?
+            IndexSelector::NonAppendable { dir, memory } => {
+                NumericIndex::new_immutable(&numeric_dir(dir, field), *memory, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
                 NumericIndex::new_mutable(numeric_dir(dir, field), create_if_missing)?
@@ -376,9 +374,11 @@ impl IndexSelector<'_> {
         Vec<T>: Blob,
     {
         match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => make_mmap(
-                NumericIndex::builder_mmap(&numeric_dir(dir, field), *is_on_disk, deleted_points),
-            ),
+            IndexSelector::NonAppendable { dir, memory } => make_mmap(NumericIndex::builder_mmap(
+                &numeric_dir(dir, field),
+                !memory.is_heap(),
+                deleted_points,
+            )),
             IndexSelector::Appendable { dir } => {
                 make_gridstore(NumericIndex::builder_gridstore(numeric_dir(dir, field)))
             }
@@ -392,8 +392,8 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<GeoIndex>> {
         Ok(match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
-                GeoIndex::new_immutable(&map_dir(dir, field), *is_on_disk, deleted_points)?
+            IndexSelector::NonAppendable { dir, memory } => {
+                GeoIndex::new_immutable(&map_dir(dir, field), *memory, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
                 GeoIndex::new_mutable(map_dir(dir, field), create_if_missing)?
@@ -409,9 +409,9 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> FieldIndexBuilder {
         match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => make_mmap(GeoIndex::builder_mmap(
+            IndexSelector::NonAppendable { dir, memory } => make_mmap(GeoIndex::builder_mmap(
                 &map_dir(dir, field),
-                *is_on_disk,
+                !memory.is_heap(),
                 deleted_points,
             )),
             IndexSelector::Appendable { dir } => {
@@ -425,10 +425,7 @@ impl IndexSelector<'_> {
     /// Gridstore segments are appendable/mutable.
     pub fn default_mutability(&self) -> IndexMutability {
         match self {
-            IndexSelector::NonAppendable {
-                dir: _,
-                is_on_disk: _,
-            } => IndexMutability::Immutable,
+            IndexSelector::NonAppendable { dir: _, memory: _ } => IndexMutability::Immutable,
             IndexSelector::Appendable { dir: _ } => IndexMutability::Mutable,
         }
     }
@@ -439,7 +436,7 @@ impl IndexSelector<'_> {
         total_point_count: usize,
     ) -> OperationResult<FieldIndexBuilder> {
         let builder = match self {
-            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
+            IndexSelector::NonAppendable { dir, memory: _ } => {
                 FieldIndexBuilder::ImmutableNullIndex(ImmutableNullIndex::builder(
                     &null_dir(dir, field),
                     total_point_count,
@@ -465,7 +462,7 @@ impl IndexSelector<'_> {
         // Gridstore segments are always appendable, so the null index is
         // always mutable regardless of the stored mutability marker.
         match (self, mutability) {
-            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Immutable) => {
+            (IndexSelector::NonAppendable { dir, memory: _ }, IndexMutability::Immutable) => {
                 Ok(ImmutableNullIndex::open(
                     &null_dir(dir, field),
                     total_point_count,
@@ -474,7 +471,7 @@ impl IndexSelector<'_> {
                 .map(NullIndex::Immutable)
                 .map(FieldIndex::NullIndex))
             }
-            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Mutable)
+            (IndexSelector::NonAppendable { dir, memory: _ }, IndexMutability::Mutable)
             | (IndexSelector::Appendable { dir }, IndexMutability::Mutable)
             | (IndexSelector::Appendable { dir }, IndexMutability::Immutable) => {
                 Ok(MutableNullIndex::open(
@@ -496,8 +493,8 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<FullTextIndex>> {
         Ok(match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
-                FullTextIndex::new_mmap(text_dir(dir, field), config, *is_on_disk, deleted_points)?
+            IndexSelector::NonAppendable { dir, memory } => {
+                FullTextIndex::new_mmap(text_dir(dir, field), config, *memory, deleted_points)?
             }
             IndexSelector::Appendable { dir } => {
                 FullTextIndex::new_gridstore(text_dir(dir, field), config, create_if_missing)?
@@ -512,11 +509,11 @@ impl IndexSelector<'_> {
         deleted_points: &BitSlice,
     ) -> FieldIndexBuilder {
         match self {
-            IndexSelector::NonAppendable { dir, is_on_disk } => {
+            IndexSelector::NonAppendable { dir, memory } => {
                 FieldIndexBuilder::FullTextMmapIndex(FullTextIndex::builder_mmap(
                     text_dir(dir, field),
                     config,
-                    *is_on_disk,
+                    !memory.is_heap(),
                     deleted_points,
                 ))
             }
@@ -528,7 +525,7 @@ impl IndexSelector<'_> {
 
     fn bool_builder(&self, field: &JsonPath) -> OperationResult<FieldIndexBuilder> {
         match self {
-            IndexSelector::NonAppendable { dir, is_on_disk: _ } => {
+            IndexSelector::NonAppendable { dir, memory: _ } => {
                 let dir = bool_dir(dir, field);
                 Ok(FieldIndexBuilder::BoolMmapIndex(
                     ImmutableBoolIndex::builder(&dir)?,
@@ -554,11 +551,11 @@ impl IndexSelector<'_> {
         // `MutableBoolIndex` and `ImmutableBoolIndex` share the same on-disk
         // format; stored mutability picks which in-memory wrapper to build.
         Ok(match (self, mutability) {
-            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Immutable) => {
+            (IndexSelector::NonAppendable { dir, memory: _ }, IndexMutability::Immutable) => {
                 let dir = bool_dir(dir, field);
                 ImmutableBoolIndex::open(&dir, deleted_points)?.map(BoolIndex::Immutable)
             }
-            (IndexSelector::NonAppendable { dir, is_on_disk: _ }, IndexMutability::Mutable)
+            (IndexSelector::NonAppendable { dir, memory: _ }, IndexMutability::Mutable)
             | (IndexSelector::Appendable { dir }, _) => {
                 let dir = bool_dir(dir, field);
                 MutableBoolIndex::open(&dir, create_if_missing)?.map(BoolIndex::Mutable)

--- a/lib/segment/src/index/field_index/map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/lifecycle.rs
@@ -13,6 +13,7 @@ use super::mutable_map_index::MutableMapIndex;
 use super::on_disk_map_index::OnDiskMapIndex;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
+use crate::types::Memory;
 
 impl<N: MapIndexKey + ?Sized> MapIndex<N>
 where
@@ -21,27 +22,25 @@ where
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_immutable(
         path: &Path,
-        is_on_disk: bool,
+        memory: Memory,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
-        // pure-mmap `Storage` variant at load time. Files are shared between
-        // variants; the persisted `is_on_disk` flag in `mmap_index` is
-        // untouched.
-        let effective_is_on_disk =
-            is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
+        // Low-memory mode degrades the placement at load time (pinned falls back to the
+        // pure-mmap variant). Files are shared between variants; the persisted
+        // configuration is untouched.
+        let memory = memory.clamp_to_low_memory();
 
-        let populate = Populate::from(!effective_is_on_disk);
+        let populate = Populate::from(memory.populate_on_open());
         let Some(on_disk_index) = OnDiskMapIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
             return Ok(None);
         };
 
-        let index = if effective_is_on_disk {
-            MapIndex::OnDisk(on_disk_index)
-        } else {
+        let index = if memory.is_heap() {
             // Load into RAM, use mmap as backing storage
             MapIndex::Immutable(ImmutableMapIndex::load_from_on_disk(on_disk_index)?)
+        } else {
+            MapIndex::OnDisk(on_disk_index)
         };
         Ok(Some(index))
     }

--- a/lib/segment/src/index/field_index/map_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/tests.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
 };
-use crate::types::{FieldCondition, IntPayloadType, PayloadKeyType, UuidIntType};
+use crate::types::{FieldCondition, IntPayloadType, Memory, PayloadKeyType, UuidIntType};
 
 /// Generous default size for the deleted-points bitslice used in tests.
 ///
@@ -102,10 +102,10 @@ where
         IndexType::MutableGridstore => MapIndex::<N>::new_mutable(path.to_path_buf(), true, true)
             .unwrap()
             .unwrap(),
-        IndexType::Mmap => MapIndex::<N>::new_immutable(path, true, &empty_deleted())
+        IndexType::Mmap => MapIndex::<N>::new_immutable(path, Memory::Cold, &empty_deleted())
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => MapIndex::<N>::new_immutable(path, false, &empty_deleted())
+        IndexType::RamMmap => MapIndex::<N>::new_immutable(path, Memory::Pinned, &empty_deleted())
             .unwrap()
             .unwrap(),
     };
@@ -361,12 +361,12 @@ fn test_map_index_reload(#[case] index_type: IndexType) {
                 .unwrap()
         }
         IndexType::Mmap => {
-            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), true, &deleted)
+            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Cold, &deleted)
                 .unwrap()
                 .unwrap()
         }
         IndexType::RamMmap => {
-            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), false, &deleted)
+            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Pinned, &deleted)
                 .unwrap()
                 .unwrap()
         }
@@ -428,15 +428,17 @@ fn test_map_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
 
     let new_index = match index_type {
         IndexType::Mmap => {
-            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), true, &short_deleted)
+            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Cold, &short_deleted)
                 .unwrap()
                 .unwrap()
         }
-        IndexType::RamMmap => {
-            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), false, &short_deleted)
-                .unwrap()
-                .unwrap()
-        }
+        IndexType::RamMmap => MapIndex::<IntPayloadType>::new_immutable(
+            temp_dir.path(),
+            Memory::Pinned,
+            &short_deleted,
+        )
+        .unwrap()
+        .unwrap(),
         IndexType::MutableGridstore => unreachable!(),
     };
 
@@ -538,7 +540,7 @@ fn test_for_values_map_on_disk_deleted() {
 
     // Load the on-disk variant with points 0 and 2 marked deleted.
     let deleted = deleted_with(&[0, 2]);
-    let index = MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), true, &deleted)
+    let index = MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Cold, &deleted)
         .unwrap()
         .unwrap();
     assert!(matches!(index, MapIndex::OnDisk(_)));

--- a/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
@@ -19,6 +19,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::field_index::{PayloadFieldIndex, ValueIndexer};
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::telemetry::PayloadIndexTelemetry;
+use crate::types::Memory;
 
 pub(super) const HISTOGRAM_MAX_BUCKET_SIZE: usize = 10_000;
 pub(super) const HISTOGRAM_PRECISION: f64 = 0.01;
@@ -30,10 +31,10 @@ where
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_immutable(
         path: &Path,
-        is_on_disk: bool,
+        memory: Memory,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let index = NumericIndexInner::new_mmap(path, is_on_disk, deleted_points)?;
+        let index = NumericIndexInner::new_mmap(path, memory, deleted_points)?;
 
         Ok(index.map(|inner| Self {
             inner,

--- a/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
@@ -17,6 +17,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::numeric_point::Numericable;
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
+use crate::types::Memory;
 
 impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default> NumericIndexInner<T>
 where
@@ -25,17 +26,15 @@ where
     /// Load immutable mmap based index, either in RAM or on disk
     pub fn new_mmap(
         path: &Path,
-        is_on_disk: bool,
+        memory: Memory,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        // Low-memory mode downgrades the in-RAM `Immutable` wrapper to the
-        // pure-mmap `Storage` variant at load time. Files are shared between
-        // variants; the persisted `is_on_disk` flag in `mmap_index` is
-        // untouched.
-        let effective_is_on_disk =
-            is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
+        // Low-memory mode degrades the placement at load time (pinned falls back to the
+        // pure-mmap `Storage` variant). Files are shared between variants; the persisted
+        // configuration is untouched.
+        let memory = memory.clamp_to_low_memory();
 
-        let populate = Populate::from(!effective_is_on_disk);
+        let populate = Populate::from(memory.populate_on_open());
         let Some(on_disk_index) =
             OnDiskNumericIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
@@ -43,14 +42,14 @@ where
             return Ok(None);
         };
 
-        if effective_is_on_disk {
-            // Use on-disk directly
-            Ok(Some(NumericIndexInner::OnDisk(on_disk_index)))
-        } else {
+        if memory.is_heap() {
             // Load into RAM, use on-disk as backing storage
             Ok(Some(NumericIndexInner::Immutable(
                 ImmutableNumericIndex::load_from_on_disk(on_disk_index),
             )))
+        } else {
+            // Use on-disk directly
+            Ok(Some(NumericIndexInner::OnDisk(on_disk_index)))
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -19,7 +19,7 @@ use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndexRead, ValueIndexer,
 };
 use crate::json_path::JsonPath;
-use crate::types::{FieldCondition, FloatPayloadType, Range, RangeInterface};
+use crate::types::{FieldCondition, FloatPayloadType, Memory, Range, RangeInterface};
 
 /// Generous default size for the deleted-points bitslice used in tests.
 ///
@@ -112,10 +112,10 @@ fn open_index_from_disk(
         IndexType::MutableGridstore => NumericIndex::new_mutable(temp_dir.to_path_buf(), true)
             .unwrap()
             .unwrap(),
-        IndexType::Mmap => NumericIndex::new_immutable(temp_dir, true, deleted)
+        IndexType::Mmap => NumericIndex::new_immutable(temp_dir, Memory::Cold, deleted)
             .unwrap()
             .unwrap(),
-        IndexType::RamMmap => NumericIndex::new_immutable(temp_dir, false, deleted)
+        IndexType::RamMmap => NumericIndex::new_immutable(temp_dir, Memory::Pinned, deleted)
             .unwrap()
             .unwrap(),
     }
@@ -399,15 +399,17 @@ fn test_numeric_index_load_from_disk(#[case] index_type: IndexType) {
         .unwrap()
         .unwrap(),
         IndexType::Mmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), true, &deleted)
+            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), Memory::Cold, &deleted)
                 .unwrap()
                 .unwrap()
         }
-        IndexType::RamMmap => {
-            NumericIndexInner::<FloatPayloadType>::new_mmap(temp_dir.path(), false, &deleted)
-                .unwrap()
-                .unwrap()
-        }
+        IndexType::RamMmap => NumericIndexInner::<FloatPayloadType>::new_mmap(
+            temp_dir.path(),
+            Memory::Pinned,
+            &deleted,
+        )
+        .unwrap()
+        .unwrap(),
     };
 
     test_cond(

--- a/lib/segment/src/index/field_index/schema_transition.rs
+++ b/lib/segment/src/index/field_index/schema_transition.rs
@@ -10,6 +10,10 @@
 //! via the derived `PartialEq`, so a newly added field is accounted for
 //! automatically: any difference outside `on_disk` yields `Incompatible`.
 
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use crate::types::{PayloadFieldSchema, PayloadSchemaParams};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,6 +107,7 @@ mod tests {
 
     fn keyword(on_disk: Option<bool>, is_tenant: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Keyword(KeywordIndexParams {
+            memory: None,
             r#type: KeywordIndexType::Keyword,
             is_tenant,
             on_disk,
@@ -113,6 +118,7 @@ mod tests {
 
     fn integer(on_disk: Option<bool>, lookup: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Integer(IntegerIndexParams {
+            memory: None,
             r#type: IntegerIndexType::Integer,
             lookup,
             range: Some(true),
@@ -124,6 +130,7 @@ mod tests {
 
     fn float(on_disk: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Float(FloatIndexParams {
+            memory: None,
             r#type: FloatIndexType::Float,
             is_principal: None,
             on_disk,
@@ -133,6 +140,7 @@ mod tests {
 
     fn geo(on_disk: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Geo(GeoIndexParams {
+            memory: None,
             r#type: GeoIndexType::Geo,
             on_disk,
             enable_hnsw: None,
@@ -141,6 +149,7 @@ mod tests {
 
     fn text(on_disk: Option<bool>, tokenizer: TokenizerType) -> PayloadSchemaParams {
         PayloadSchemaParams::Text(TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer,
             min_token_len: None,
@@ -157,6 +166,7 @@ mod tests {
 
     fn bool_p(on_disk: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Bool(BoolIndexParams {
+            memory: None,
             r#type: BoolIndexType::Bool,
             on_disk,
             enable_hnsw: None,
@@ -165,6 +175,7 @@ mod tests {
 
     fn datetime(on_disk: Option<bool>, is_principal: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Datetime(DatetimeIndexParams {
+            memory: None,
             r#type: DatetimeIndexType::Datetime,
             is_principal,
             on_disk,
@@ -174,6 +185,7 @@ mod tests {
 
     fn uuid(on_disk: Option<bool>, is_tenant: Option<bool>) -> PayloadSchemaParams {
         PayloadSchemaParams::Uuid(UuidIndexParams {
+            memory: None,
             r#type: UuidIndexType::Uuid,
             is_tenant,
             on_disk,
@@ -216,6 +228,7 @@ mod tests {
         // the sorted key dictionary — a full rebuild, never an in-place swap.
         let plain = wrap(keyword(Some(false), None));
         let with_prefix = wrap(PayloadSchemaParams::Keyword(KeywordIndexParams {
+            memory: None,
             r#type: KeywordIndexType::Keyword,
             is_tenant: None,
             on_disk: Some(false),

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/tests.rs
@@ -1,5 +1,9 @@
 //! Unit tests for GPU vector storage, covering f32, f16, u8 dense/multivectors with SQ, BQ, PQ.
 
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -119,6 +123,7 @@ fn test_gpu_vector_storage_sq(
     let quantization_config = QuantizationConfig::Scalar(ScalarQuantization {
         scalar: ScalarQuantizationConfig {
             always_ram: Some(true),
+            memory: None,
             r#type: crate::types::ScalarType::Int8,
             quantile: Some(0.99),
         },
@@ -219,6 +224,7 @@ fn test_gpu_vector_storage_bq(
     let quantization_config = QuantizationConfig::Binary(BinaryQuantization {
         binary: BinaryQuantizationConfig {
             always_ram: Some(true),
+            memory: None,
             encoding: Some(encoding),
             query_encoding: None,
         },
@@ -309,6 +315,7 @@ fn test_gpu_vector_storage_pq(
     let quantization_config = QuantizationConfig::Product(ProductQuantization {
         product: ProductQuantizationConfig {
             always_ram: Some(true),
+            memory: None,
             compression: crate::types::CompressionRatio::X8,
         },
     });
@@ -555,6 +562,7 @@ fn test_gpu_vector_storage_tq_falls_back_to_half_precision(
     let tq_config = QuantizationConfig::Turbo(TurboQuantization {
         turbo: TurboQuantQuantizationConfig {
             always_ram: Some(true),
+            memory: None,
             bits: Some(TurboQuantBitSize::Bits4),
         },
     });

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -12,7 +12,7 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndex;
-use crate::types::HnswConfig;
+use crate::types::{HnswConfig, Memory};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
@@ -103,14 +103,18 @@ impl HNSWIndex {
 
         let do_convert = LINK_COMPRESSION_CONVERT_EXISTING;
 
-        let is_on_disk = hnsw_config.on_disk.unwrap_or(false);
+        // Effective placement of the graph links: the `memory` parameter (falling back to the
+        // deprecated `on_disk` flag), degraded at load time by the node-wide low-memory mode.
+        let memory = hnsw_config.memory_placement().clamp_to_low_memory();
+        let is_on_disk = memory.is_on_disk();
 
-        // Keep the links cold (lazily on disk) when configured so; otherwise
-        // pre-populate them into the page cache on load.
-        let residency = if is_on_disk {
-            GraphLinksResidency::Cold
-        } else {
-            GraphLinksResidency::Cached
+        let residency = match memory {
+            // Keep the links cold: lazily loaded from disk, cached with usage
+            Memory::Cold => GraphLinksResidency::Cold,
+            // Pre-populate the links into the page cache on load
+            Memory::Cached => GraphLinksResidency::Cached,
+            // Materialize the links on heap, so they are never evicted by cache pressure
+            Memory::Pinned => GraphLinksResidency::Pinned,
         };
 
         let graph = GraphLayers::load(path, residency, do_convert)?;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 mod read;
 
 use std::path::{Path, PathBuf};

--- a/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_graph_connectivity.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -54,6 +58,7 @@ fn test_graph_connectivity() {
     let payload_index_ptr = segment.payload_index.clone();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::anonymize::Anonymize;
 use crate::common::operation_error::OperationResult;
-use crate::types::VectorStorageDatatype;
+use crate::types::{Memory, VectorStorageDatatype};
 
 pub const SPARSE_INDEX_CONFIG_FILE: &str = "sparse_index_config.json";
 
@@ -68,6 +68,13 @@ pub struct SparseIndexConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datatype: Option<VectorStorageDatatype>,
+    /// Requested memory placement of the index.
+    ///
+    /// The structural decision is carried by `index_type`; this field additionally
+    /// distinguishes `cold` from `cached` for the mmap index variant.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 }
 
 impl SparseIndexConfig {
@@ -75,11 +82,27 @@ impl SparseIndexConfig {
         full_scan_threshold: Option<usize>,
         index_type: SparseIndexType,
         datatype: Option<VectorStorageDatatype>,
+        memory: Option<Memory>,
     ) -> Self {
         SparseIndexConfig {
             full_scan_threshold,
             index_type,
             datatype,
+            memory,
+        }
+    }
+
+    /// Effective memory placement of the index, derived from the structural `index_type` and
+    /// refined by the requested `memory` placement.
+    pub fn memory_placement(&self) -> Memory {
+        match self.index_type {
+            // Mutable and immutable RAM indexes are heap structures: pinned by construction
+            SparseIndexType::MutableRam | SparseIndexType::ImmutableRam => Memory::Pinned,
+            // Mmap index is cold by default, but may be requested to be cached
+            SparseIndexType::Mmap => match self.memory {
+                Some(Memory::Cached) => Memory::Cached,
+                Some(Memory::Cold) | Some(Memory::Pinned) | None => Memory::Cold,
+            },
         }
     }
 
@@ -98,5 +121,34 @@ impl SparseIndexConfig {
 
     pub fn save(&self, path: &Path) -> OperationResult<()> {
         Ok(atomic_save_json(path, self)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sparse_index_memory_placement() {
+        // RAM index variants are heap structures: pinned by construction
+        let mutable = SparseIndexConfig::new(None, SparseIndexType::MutableRam, None, None);
+        assert_eq!(mutable.memory_placement(), Memory::Pinned);
+        let immutable = SparseIndexConfig::new(None, SparseIndexType::ImmutableRam, None, None);
+        assert_eq!(immutable.memory_placement(), Memory::Pinned);
+
+        // Mmap index is cold by default and may be requested to be cached
+        let mmap = SparseIndexConfig::new(None, SparseIndexType::Mmap, None, None);
+        assert_eq!(mmap.memory_placement(), Memory::Cold);
+        let cached =
+            SparseIndexConfig::new(None, SparseIndexType::Mmap, None, Some(Memory::Cached));
+        assert_eq!(cached.memory_placement(), Memory::Cached);
+
+        // The `memory` field survives a serde round-trip, and is omitted when unset
+        // for backward compatibility
+        let json = serde_json::to_string(&cached).unwrap();
+        let restored: SparseIndexConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, cached);
+        let json = serde_json::to_string(&mmap).unwrap();
+        assert!(!json.contains("memory"));
     }
 }

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -27,7 +27,7 @@ use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::payload_config::{self, PayloadConfig};
 use crate::index::visited_pool::VisitedPool;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
-use crate::types::{PayloadFieldSchema, PayloadKeyType, VectorNameBuf};
+use crate::types::{Memory, PayloadFieldSchema, PayloadKeyType, VectorNameBuf};
 use crate::vector_storage::VectorStorageEnum;
 
 #[derive(Debug)]
@@ -146,7 +146,7 @@ impl StructPayloadIndex {
                 .iter()
                 // Load each index
                 .map(|index| {
-                    let selector = self.selector_with_type(index);
+                    let selector = self.selector_with_type(index, &payload_schema.schema);
                     selector.new_index_with_type(
                         field,
                         &payload_schema.schema,
@@ -272,24 +272,41 @@ impl StructPayloadIndex {
 
     /// Select which type of PayloadIndex to use for the field
     pub(super) fn selector(&self, payload_schema: &PayloadFieldSchema) -> IndexSelector<'_> {
-        let is_on_disk = payload_schema.is_on_disk();
+        let memory = payload_schema.memory_placement();
 
         match &self.storage_type {
             StorageType::Appendable => IndexSelector::Appendable { dir: &self.path },
             StorageType::NonAppendable => IndexSelector::NonAppendable {
                 dir: &self.path,
-                is_on_disk,
+                memory,
             },
         }
     }
 
-    fn selector_with_type(&self, index_type: &FullPayloadIndexType) -> IndexSelector<'_> {
+    fn selector_with_type(
+        &self,
+        index_type: &FullPayloadIndexType,
+        payload_schema: &PayloadFieldSchema,
+    ) -> IndexSelector<'_> {
         match index_type.storage_type {
             payload_config::StorageType::Gridstore => IndexSelector::Appendable { dir: &self.path },
-            payload_config::StorageType::Mmap { is_on_disk } => IndexSelector::NonAppendable {
-                dir: &self.path,
-                is_on_disk,
-            },
+            payload_config::StorageType::Mmap { is_on_disk } => {
+                // The persisted flag records the structural variant (heap wrapper vs mmap) the
+                // index was built with; the schema's requested placement refines cold vs cached
+                // for the mmap variant.
+                let memory = if is_on_disk {
+                    match payload_schema.memory_placement() {
+                        Memory::Cached => Memory::Cached,
+                        Memory::Cold | Memory::Pinned => Memory::Cold,
+                    }
+                } else {
+                    Memory::Pinned
+                };
+                IndexSelector::NonAppendable {
+                    dir: &self.path,
+                    memory,
+                }
+            }
         }
     }
 

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(not(feature = "testing"), allow(unused_imports))]
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -686,6 +689,7 @@ mod tests {
             .tempdir()
             .unwrap();
         let config = TextIndexParams {
+            memory: None,
             r#type: TextIndexType::Text,
             tokenizer: TokenizerType::Word,
             min_token_len: None,

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -796,7 +796,12 @@ fn create_deferred_segment(
                     "sparse".to_string(),
                     SparseVectorDataConfig {
                         // Don't do full scan unless explicitly enabled so we cover more parts with our tests.
-                        index: SparseIndexConfig::new(Some(1), SparseIndexType::MutableRam, None),
+                        index: SparseIndexConfig::new(
+                            Some(1),
+                            SparseIndexType::MutableRam,
+                            None,
+                            None,
+                        ),
                         storage_type: SparseVectorStorageType::Mmap,
                         modifier: None,
                     },
@@ -807,6 +812,7 @@ fn create_deferred_segment(
                         index: SparseIndexConfig::new(
                             Some(usize::MAX),
                             SparseIndexType::MutableRam,
+                            None,
                             None,
                         ),
                         storage_type: SparseVectorStorageType::Mmap,

--- a/lib/segment/src/segment_constructor/segment_constructor_base/sparse_vector_index.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/sparse_vector_index.rs
@@ -6,7 +6,7 @@ use crate::index::sparse_index::sparse_index_config::SparseIndexType;
 use crate::index::sparse_index::sparse_vector_index::{
     SparseVectorIndex, SparseVectorIndexOpenArgs,
 };
-use crate::types::VectorStorageDatatype;
+use crate::types::{Memory, VectorStorageDatatype};
 
 #[cfg(feature = "testing")]
 pub fn create_sparse_vector_index_test(
@@ -18,6 +18,11 @@ pub fn create_sparse_vector_index_test(
 pub(crate) fn open_or_create_sparse_vector_index(
     args: SparseVectorIndexOpenArgs<MmapFs, impl FnMut()>,
 ) -> OperationResult<VectorIndexEnum> {
+    // Effective placement of the mmap index at load time, degraded by low-memory mode.
+    // Cold and cached share the mmap index variant; cached additionally primes the page
+    // cache after opening.
+    let memory_placement = args.config.memory_placement().clamp_to_low_memory();
+
     let effective_index_type = match args.config.index_type {
         SparseIndexType::ImmutableRam => {
             // Low-memory mode downgrades `ImmutableRam` (which copies the inverted
@@ -68,6 +73,10 @@ pub(crate) fn open_or_create_sparse_vector_index(
             unreachable!("Sparse index incompatible with turbo. Validated at API level.")
         }
     };
+
+    if memory_placement == Memory::Cached {
+        vector_index.populate()?;
+    }
 
     Ok(vector_index)
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -664,7 +668,7 @@ impl Indexes {
     pub fn is_on_disk(&self) -> bool {
         match self {
             Indexes::Plain {} => false,
-            Indexes::Hnsw(config) => config.on_disk.unwrap_or_default(),
+            Indexes::Hnsw(config) => config.memory_placement().is_on_disk(),
         }
     }
 }
@@ -695,9 +699,15 @@ pub struct HnswConfig {
     /// On small CPUs, less threads are used.
     #[serde(default = "default_max_indexing_threads")]
     pub max_indexing_threads: usize,
+    /// Deprecated: use `memory` instead.
     /// Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false
     #[serde(default, skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub on_disk: Option<bool>,
+    /// Memory placement of the HNSW graph. Overrides the deprecated `on_disk` flag if both are
+    /// set. Default: `cached` (`cold` if `on_disk` is set to true).
+    #[serde(default, skip_serializing_if = "Option::is_none")] // Better backward compatibility
+    pub memory: Option<Memory>,
     /// Custom M param for hnsw graph built for payload index. If not set, default M will be used.
     #[serde(default, skip_serializing_if = "Option::is_none")] // Better backward compatibility
     pub payload_m: Option<usize>,
@@ -725,7 +735,10 @@ impl HnswConfig {
             full_scan_threshold,
             max_indexing_threads: _,
             payload_m,
-            on_disk,
+            // Compared through the effective placement below, so that expressing the same
+            // placement through the new `memory` parameter does not trigger a rebuild
+            on_disk: _,
+            memory: _,
             inline_storage,
         } = *self;
 
@@ -736,8 +749,15 @@ impl HnswConfig {
             // Data on disk is the same, we have a unit test for that. We can eventually optimize
             // this to just reload the collection rather than optimizing it again as a whole just
             // to flip this flag
-            || on_disk != other.on_disk
+            || self.memory_placement() != other.memory_placement()
             || inline_storage != other.inline_storage
+    }
+
+    /// Effective memory placement of the HNSW graph, resolving the new `memory` parameter
+    /// against the deprecated `on_disk` flag. Defaults to [`Memory::Cached`].
+    pub fn memory_placement(&self) -> Memory {
+        Memory::resolve(self.memory, self.on_disk.map(Memory::from_on_disk))
+            .unwrap_or(Memory::Cached)
     }
 }
 
@@ -790,9 +810,15 @@ pub struct ScalarQuantizationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.5, max = 1.0))]
     pub quantile: Option<f32>,
+    /// Deprecated: use `memory` instead.
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub always_ram: Option<bool>,
+    /// Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if
+    /// both are set. Default: follow the memory placement of the original vector storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 }
 
 impl ScalarQuantizationConfig {
@@ -804,6 +830,18 @@ impl ScalarQuantizationConfig {
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self != other
     }
+
+    /// Requested memory placement, resolving the new `memory` parameter against the deprecated
+    /// `always_ram` flag. `None` means following the original vector storage placement.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, legacy_always_ram_placement(self.always_ram))
+    }
+}
+
+/// `always_ram=true` used to force quantized vectors into RAM, never evicted by placement
+/// config: the pinned placement. `always_ram=false` means "follow storage", same as unset.
+fn legacy_always_ram_placement(always_ram: Option<bool>) -> Option<Memory> {
+    always_ram.and_then(|always_ram| always_ram.then_some(Memory::Pinned))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
@@ -817,8 +855,15 @@ pub struct ScalarQuantization {
 pub struct ProductQuantizationConfig {
     pub compression: CompressionRatio,
 
+    /// Deprecated: use `memory` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub always_ram: Option<bool>,
+
+    /// Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if
+    /// both are set. Default: follow the memory placement of the original vector storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 }
 
 impl ProductQuantizationConfig {
@@ -829,6 +874,12 @@ impl ProductQuantizationConfig {
     /// - to effectively change the configuration, a quantization rebuild is required
     pub fn mismatch_requires_rebuild(&self, other: &Self) -> bool {
         self != other
+    }
+
+    /// Requested memory placement, resolving the new `memory` parameter against the deprecated
+    /// `always_ram` flag. `None` means following the original vector storage placement.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, legacy_always_ram_placement(self.always_ram))
     }
 }
 
@@ -841,6 +892,7 @@ pub struct ProductQuantization {
 impl Hash for ScalarQuantizationConfig {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.always_ram.hash(state);
+        self.memory.hash(state);
         self.r#type.hash(state);
     }
 }
@@ -859,8 +911,14 @@ pub enum BinaryQuantizationEncoding {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct BinaryQuantizationConfig {
+    /// Deprecated: use `memory` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub always_ram: Option<bool>,
+    /// Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if
+    /// both are set. Default: follow the memory placement of the original vector storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<BinaryQuantizationEncoding>,
@@ -870,6 +928,14 @@ pub struct BinaryQuantizationConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query_encoding: Option<BinaryQuantizationQueryEncoding>,
+}
+
+impl BinaryQuantizationConfig {
+    /// Requested memory placement, resolving the new `memory` parameter against the deprecated
+    /// `always_ram` flag. `None` means following the original vector storage placement.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, legacy_always_ram_placement(self.always_ram))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
@@ -891,12 +957,26 @@ pub enum TurboQuantBitSize {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
 #[serde(rename_all = "snake_case")]
 pub struct TurboQuantQuantizationConfig {
+    /// Deprecated: use `memory` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "1.19.0", note = "Use `memory` instead")]
     pub always_ram: Option<bool>,
+    /// Memory placement of quantized vectors. Overrides the deprecated `always_ram` flag if
+    /// both are set. Default: follow the memory placement of the original vector storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Memory>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bits: Option<TurboQuantBitSize>,
+}
+
+impl TurboQuantQuantizationConfig {
+    /// Requested memory placement, resolving the new `memory` parameter against the deprecated
+    /// `always_ram` flag. `None` means following the original vector storage placement.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, legacy_always_ram_placement(self.always_ram))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize, JsonSchema, Validate)]
@@ -946,6 +1026,19 @@ impl QuantizationConfig {
             QuantizationConfig::Product(p) => p.product.always_ram == Some(true),
             QuantizationConfig::Binary(b) => b.binary.always_ram == Some(true),
             QuantizationConfig::Turbo(t) => t.turbo.always_ram == Some(true),
+        }
+    }
+
+    /// Requested memory placement of quantized vectors, resolving the new `memory` parameter
+    /// against the deprecated `always_ram` flag.
+    ///
+    /// `None` means the placement follows the original vector storage.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        match self {
+            QuantizationConfig::Scalar(s) => s.scalar.memory_placement(),
+            QuantizationConfig::Product(p) => p.product.memory_placement(),
+            QuantizationConfig::Binary(b) => b.binary.memory_placement(),
+            QuantizationConfig::Turbo(t) => t.turbo.memory_placement(),
         }
     }
 }
@@ -1433,6 +1526,7 @@ impl Default for HnswConfig {
             full_scan_threshold: DEFAULT_FULL_SCAN_THRESHOLD,
             max_indexing_threads: 0,
             on_disk: Some(false),
+            memory: None,
             payload_m: None,
             inline_storage: None,
         }
@@ -1468,6 +1562,25 @@ impl PayloadStorageType {
     /// Returns `Mmap` or `InRamMmap`; for RocksDB-backed variants use collection config.
     pub fn from_on_disk_payload(on_disk: bool) -> Self {
         if on_disk { Self::Mmap } else { Self::InRamMmap }
+    }
+
+    /// Convert memory placement to payload storage type.
+    ///
+    /// `Pinned` is not supported for payload storage and is rejected by API validation;
+    /// it defensively maps to the closest supported placement.
+    pub fn from_memory(memory: Memory) -> Self {
+        match memory {
+            Memory::Cold => Self::Mmap,
+            Memory::Cached | Memory::Pinned => Self::InRamMmap,
+        }
+    }
+
+    /// Memory placement this storage type provides.
+    pub fn memory(&self) -> Memory {
+        match self {
+            PayloadStorageType::Mmap => Memory::Cold,
+            PayloadStorageType::InRamMmap => Memory::Cached,
+        }
     }
 
     pub fn is_on_disk(&self) -> bool {
@@ -1597,6 +1710,117 @@ where
     Ok(())
 }
 
+/// Memory placement of a component's data.
+///
+/// Data is always persisted on disk regardless of this setting; it only controls
+/// how the data is held in RAM.
+#[derive(
+    Debug, Deserialize, Serialize, JsonSchema, Anonymize, Eq, PartialEq, Copy, Clone, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Memory {
+    /// Data is not pre-loaded from disk to RAM. Preferred for rarely queried components or
+    /// components larger than RAM size. First request might be slow, but data is cached with
+    /// usage.
+    Cold,
+    /// Data is pre-loaded into disk-cache RAM on start. First request is fast, but data may be
+    /// evicted if there is not enough memory and some other component's data is used more
+    /// frequently.
+    Cached,
+    /// Data is loaded in RAM and never evicted. First request is fast, but the component must
+    /// fit in RAM at all times. Recommended for frequently queried small components like
+    /// quantized vectors or primary indexes.
+    Pinned,
+}
+
+impl Memory {
+    /// Convert legacy `on_disk`-style flag (true = store on disk) into the memory placement it
+    /// used to mean: on-disk data is loaded lazily, in-RAM data is populated but evictable.
+    pub fn from_on_disk(on_disk: bool) -> Self {
+        if on_disk { Self::Cold } else { Self::Cached }
+    }
+
+    /// Convert legacy `on_disk`-style flag for components whose in-RAM variant is a heap
+    /// structure (payload field indexes, sparse vector index): on-disk data is loaded lazily,
+    /// in-RAM data is fully materialized on heap and never evicted.
+    pub fn from_on_disk_heap(on_disk: bool) -> Self {
+        if on_disk { Self::Cold } else { Self::Pinned }
+    }
+
+    /// Whether this placement corresponds to `on_disk = true` in the legacy options.
+    pub fn is_on_disk(self) -> bool {
+        match self {
+            Self::Cold => true,
+            Self::Cached | Self::Pinned => false,
+        }
+    }
+
+    /// Whether this placement is backed by a heap structure rather than an mmap file, for
+    /// components that have both heap and mmap variants (payload field indexes, sparse index).
+    pub fn is_heap(self) -> bool {
+        match self {
+            Self::Pinned => true,
+            Self::Cold | Self::Cached => false,
+        }
+    }
+
+    /// Whether the backing mmap should be populated on open: the cached placement primes the
+    /// page cache, and the pinned placement reads the whole file into heap right after anyway.
+    pub fn populate_on_open(self) -> bool {
+        match self {
+            Self::Cold => false,
+            Self::Cached | Self::Pinned => true,
+        }
+    }
+
+    /// Resolve the effective memory placement from the new explicit `memory` parameter and a
+    /// legacy parameter translated into placement terms. The explicit parameter always wins.
+    pub fn resolve(memory: Option<Self>, legacy: Option<Self>) -> Option<Self> {
+        memory.or(legacy)
+    }
+
+    /// Same as [`Memory::resolve`], but logs a warning if both parameters are set and disagree.
+    ///
+    /// Use at configuration resolution points (e.g. the optimizer); use the silent
+    /// [`Memory::resolve`] in repeatedly called accessors.
+    pub fn resolve_or_warn(
+        memory: Option<Self>,
+        legacy: Option<Self>,
+        component: &dyn std::fmt::Display,
+    ) -> Option<Self> {
+        if let (Some(memory), Some(legacy)) = (memory, legacy)
+            && memory != legacy
+        {
+            log::warn!(
+                "Component {component} has both `memory={memory:?}` and a deprecated storage \
+                 placement parameter implying {legacy:?} configured; using `memory={memory:?}`"
+            );
+        }
+        Self::resolve(memory, legacy)
+    }
+
+    /// Apply the node-wide low-memory mode to this placement at load time.
+    ///
+    /// Mirrors the legacy behavior: `NoResident` downgrades pinned components to their on-disk
+    /// variants (`prefer_disk`), `NoPopulate` additionally skips cache population, so every
+    /// placement degrades to [`Memory::Cold`].
+    ///
+    /// Never affects the persisted configuration.
+    pub fn clamp_to_low_memory(self) -> Self {
+        let mode = common::low_memory::low_memory_mode();
+        if mode.skip_populate() {
+            return Self::Cold;
+        }
+        if mode.prefer_disk() {
+            return match self {
+                Self::Pinned => Self::Cold,
+                Self::Cold | Self::Cached => self,
+            };
+        }
+        self
+    }
+}
+
 /// Storage types for vectors
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Anonymize, Eq, PartialEq, Copy, Clone)]
 pub enum VectorStorageType {
@@ -1693,6 +1917,41 @@ impl VectorStorageType {
             Self::ChunkedMmap
         } else {
             Self::InRamChunkedMmap
+        }
+    }
+
+    /// Convert memory placement to appendable vector storage type.
+    ///
+    /// `Pinned` is not supported for dense vector storage and is rejected by API validation;
+    /// it defensively maps to the closest supported placement.
+    pub fn appendable_from_memory(memory: Memory) -> Self {
+        match memory {
+            Memory::Cold => Self::ChunkedMmap,
+            Memory::Cached | Memory::Pinned => Self::InRamChunkedMmap,
+        }
+    }
+
+    /// Convert memory placement to non-appendable single-file vector storage type.
+    ///
+    /// `Pinned` is not supported for dense vector storage and is rejected by API validation;
+    /// it defensively maps to the closest supported placement.
+    pub fn immutable_from_memory(memory: Memory) -> Self {
+        match memory {
+            Memory::Cold => Self::Mmap,
+            Memory::Cached | Memory::Pinned => Self::InRamMmap,
+        }
+    }
+
+    /// Memory placement this storage type provides.
+    pub fn memory(&self) -> Memory {
+        match self {
+            // Legacy true-heap storage: pinned by construction
+            Self::Memory => Memory::Pinned,
+            Self::Mmap | Self::ChunkedMmap => Memory::Cold,
+            Self::InRamChunkedMmap | Self::InRamMmap => Memory::Cached,
+            // Empty storage has no data; report the safe placement, consistent with
+            // `is_on_disk`
+            Self::Empty => Memory::Cold,
         }
     }
 
@@ -2270,16 +2529,25 @@ impl PayloadSchemaParams {
     }
 
     pub fn is_on_disk(&self) -> bool {
-        match self {
-            PayloadSchemaParams::Keyword(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Integer(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Float(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Datetime(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Uuid(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Text(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Geo(i) => i.on_disk.unwrap_or_default(),
-            PayloadSchemaParams::Bool(i) => i.on_disk.unwrap_or_default(),
-        }
+        self.memory_placement().is_on_disk()
+    }
+
+    /// Effective memory placement of the field index, resolving the new `memory` parameter
+    /// against the deprecated `on_disk` flag.
+    ///
+    /// Defaults to [`Memory::Pinned`]: the legacy in-RAM field indexes are heap structures.
+    pub fn memory_placement(&self) -> Memory {
+        let (memory, on_disk) = match self {
+            PayloadSchemaParams::Keyword(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Integer(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Float(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Datetime(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Uuid(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Text(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Geo(i) => (i.memory, i.on_disk),
+            PayloadSchemaParams::Bool(i) => (i.memory, i.on_disk),
+        };
+        Memory::resolve(memory, on_disk.map(Memory::from_on_disk_heap)).unwrap_or(Memory::Pinned)
     }
 
     pub fn enable_hnsw(&self) -> bool {
@@ -2432,6 +2700,15 @@ impl PayloadFieldSchema {
         match self {
             PayloadFieldSchema::FieldType(_) => false,
             PayloadFieldSchema::FieldParams(params) => params.is_on_disk(),
+        }
+    }
+
+    /// Effective memory placement of the field index, resolving the new `memory` parameter
+    /// against the deprecated `on_disk` flag. Defaults to [`Memory::Pinned`].
+    pub fn memory_placement(&self) -> Memory {
+        match self {
+            PayloadFieldSchema::FieldType(_) => Memory::Pinned,
+            PayloadFieldSchema::FieldParams(params) => params.memory_placement(),
         }
     }
 
@@ -4205,6 +4482,156 @@ mod tests {
 
     use super::test_utils::build_polygon_with_interiors;
     use super::*;
+
+    #[test]
+    fn test_memory_legacy_mapping() {
+        // Mmap-backed components: on-disk data loads lazily, in-RAM data is populated mmap
+        assert_eq!(Memory::from_on_disk(true), Memory::Cold);
+        assert_eq!(Memory::from_on_disk(false), Memory::Cached);
+        // Heap-backed components: in-RAM data is a heap structure, never evicted
+        assert_eq!(Memory::from_on_disk_heap(true), Memory::Cold);
+        assert_eq!(Memory::from_on_disk_heap(false), Memory::Pinned);
+
+        assert!(Memory::Cold.is_on_disk());
+        assert!(!Memory::Cached.is_on_disk());
+        assert!(!Memory::Pinned.is_on_disk());
+
+        assert!(!Memory::Cold.is_heap());
+        assert!(!Memory::Cached.is_heap());
+        assert!(Memory::Pinned.is_heap());
+
+        assert!(!Memory::Cold.populate_on_open());
+        assert!(Memory::Cached.populate_on_open());
+        assert!(Memory::Pinned.populate_on_open());
+    }
+
+    #[test]
+    fn test_memory_resolve_precedence() {
+        // Explicit `memory` always wins over the legacy parameter
+        assert_eq!(
+            Memory::resolve(Some(Memory::Cached), Some(Memory::Cold)),
+            Some(Memory::Cached),
+        );
+        // Legacy parameter is used when `memory` is not set
+        assert_eq!(
+            Memory::resolve(None, Some(Memory::Cold)),
+            Some(Memory::Cold),
+        );
+        assert_eq!(
+            Memory::resolve(Some(Memory::Pinned), None),
+            Some(Memory::Pinned)
+        );
+        assert_eq!(Memory::resolve(None, None), None);
+    }
+
+    #[test]
+    fn test_hnsw_memory_placement() {
+        let mut config = HnswConfig::default();
+        assert_eq!(config.memory_placement(), Memory::Cached);
+
+        config.on_disk = Some(true);
+        assert_eq!(config.memory_placement(), Memory::Cold);
+
+        // Explicit `memory` overrides the deprecated `on_disk` flag
+        config.memory = Some(Memory::Pinned);
+        assert_eq!(config.memory_placement(), Memory::Pinned);
+    }
+
+    #[test]
+    fn test_hnsw_memory_mismatch_no_rebuild_for_same_placement() {
+        // Expressing the same effective placement through `memory` instead of the deprecated
+        // `on_disk` flag must not trigger a rebuild
+        let legacy = HnswConfig {
+            on_disk: Some(true),
+            ..HnswConfig::default()
+        };
+        let explicit = HnswConfig {
+            on_disk: Some(true),
+            memory: Some(Memory::Cold),
+            ..HnswConfig::default()
+        };
+        assert!(!legacy.mismatch_requires_rebuild(&explicit));
+
+        // Changing the effective placement does require a rebuild
+        let cached = HnswConfig {
+            memory: Some(Memory::Cached),
+            ..legacy
+        };
+        assert!(legacy.mismatch_requires_rebuild(&cached));
+    }
+
+    #[test]
+    fn test_quantization_memory_placement() {
+        let mut scalar = ScalarQuantizationConfig {
+            r#type: ScalarType::Int8,
+            quantile: None,
+            always_ram: None,
+            memory: None,
+        };
+        // Unset: follow the original vector storage placement
+        assert_eq!(scalar.memory_placement(), None);
+        // Legacy `always_ram=false` also means "follow storage"
+        scalar.always_ram = Some(false);
+        assert_eq!(scalar.memory_placement(), None);
+        // Legacy `always_ram=true` means pinned in RAM
+        scalar.always_ram = Some(true);
+        assert_eq!(scalar.memory_placement(), Some(Memory::Pinned));
+        // Explicit `memory` overrides the deprecated flag
+        scalar.memory = Some(Memory::Cached);
+        assert_eq!(scalar.memory_placement(), Some(Memory::Cached));
+    }
+
+    #[test]
+    fn test_storage_type_memory_mapping() {
+        assert_eq!(
+            VectorStorageType::appendable_from_memory(Memory::Cold),
+            VectorStorageType::ChunkedMmap,
+        );
+        assert_eq!(
+            VectorStorageType::appendable_from_memory(Memory::Cached),
+            VectorStorageType::InRamChunkedMmap,
+        );
+        assert_eq!(
+            VectorStorageType::immutable_from_memory(Memory::Cold),
+            VectorStorageType::Mmap,
+        );
+        assert_eq!(
+            VectorStorageType::immutable_from_memory(Memory::Cached),
+            VectorStorageType::InRamMmap,
+        );
+
+        assert_eq!(
+            PayloadStorageType::from_memory(Memory::Cold),
+            PayloadStorageType::Mmap
+        );
+        assert_eq!(
+            PayloadStorageType::from_memory(Memory::Cached),
+            PayloadStorageType::InRamMmap,
+        );
+        assert_eq!(PayloadStorageType::Mmap.memory(), Memory::Cold);
+        assert_eq!(PayloadStorageType::InRamMmap.memory(), Memory::Cached);
+    }
+
+    #[test]
+    fn test_payload_field_index_memory_placement() {
+        let mut params = KeywordIndexParams::default();
+        // Legacy in-RAM field indexes are heap structures: pinned by default
+        assert_eq!(
+            PayloadSchemaParams::Keyword(params.clone()).memory_placement(),
+            Memory::Pinned,
+        );
+        params.on_disk = Some(true);
+        assert_eq!(
+            PayloadSchemaParams::Keyword(params.clone()).memory_placement(),
+            Memory::Cold,
+        );
+        // Explicit `memory` overrides the deprecated `on_disk` flag
+        params.memory = Some(Memory::Cached);
+        assert_eq!(
+            PayloadSchemaParams::Keyword(params).memory_placement(),
+            Memory::Cached,
+        );
+    }
 
     #[test]
     fn test_search_params_rejects_zero_hnsw_ef() {

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 use std::io::{self, BufWriter, Write};
 use std::ops::Range;
@@ -844,6 +848,7 @@ mod tests {
         }
 
         let config: QuantizationConfig = ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors.rs
@@ -39,7 +39,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::QueryVector;
 use crate::types::{
     BinaryQuantization, BinaryQuantizationEncoding, BinaryQuantizationQueryEncoding,
-    CompressionRatio, Distance, ProductQuantization, QuantizationConfig, ScalarType,
+    CompressionRatio, Distance, Memory, ProductQuantization, QuantizationConfig, ScalarType,
     TurboQuantBitSize, TurboQuantization, VectorStorageDatatype,
 };
 use crate::vector_storage::RawScorer;
@@ -117,17 +117,30 @@ impl QuantizedVectors {
         }
     }
 
+    /// Effective memory placement of quantized vectors at load time.
+    ///
+    /// `requested` is the placement from the quantization config (the new `memory` parameter
+    /// resolved against the deprecated `always_ram` flag); when unset, the placement follows
+    /// the original vector storage: pinned in RAM alongside an in-RAM storage, cold alongside
+    /// an on-disk storage. The node-wide low-memory mode degrades the result; the on-disk byte
+    /// layout is identical for all placements, so flipping back later works without rebuild.
+    pub(in crate::vector_storage::quantized) fn memory_placement(
+        requested: Option<Memory>,
+        on_disk_vector_storage: bool,
+    ) -> Memory {
+        let follow_storage = if on_disk_vector_storage {
+            Memory::Cold
+        } else {
+            Memory::Pinned
+        };
+        requested.unwrap_or(follow_storage).clamp_to_low_memory()
+    }
+
     pub(in crate::vector_storage::quantized) fn is_ram(
-        always_ram: Option<bool>,
+        requested: Option<Memory>,
         on_disk_vector_storage: bool,
     ) -> bool {
-        // Low-memory mode forces the mmap (on-disk) backend regardless of the
-        // persisted `always_ram` flag. The on-disk byte layout is identical,
-        // so flipping back later still works without rebuild.
-        if common::low_memory::low_memory_mode().prefer_disk() {
-            return false;
-        }
-        !on_disk_vector_storage || always_ram == Some(true)
+        Self::memory_placement(requested, on_disk_vector_storage) == Memory::Pinned
     }
 
     pub(in crate::vector_storage::quantized) fn convert_binary_encoding(

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/binary/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/binary/create.rs
@@ -37,7 +37,7 @@ impl QuantizedVectors {
         >(vector_parameters.dim, encoding);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
-        let in_ram = Self::is_ram(binary_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(binary_config.memory_placement(), on_disk_vector_storage);
 
         match (in_ram, storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
@@ -120,7 +120,7 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
-        let in_ram = Self::is_ram(binary_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(binary_config.memory_placement(), on_disk_vector_storage);
 
         match (in_ram, storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/config.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/config.rs
@@ -3,10 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::types::{
-    BinaryQuantization, ProductQuantization, QuantizationConfig, ScalarQuantization,
-    TurboQuantization,
-};
+use crate::types::{Memory, QuantizationConfig};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 
 pub const QUANTIZED_CONFIG_PATH: &str = "quantized.config.json";
@@ -85,19 +82,25 @@ impl QuantizedVectorsConfig {
         )
     }
 
+    /// Effective memory placement of this config, given whether the source vector storage is
+    /// on disk.
+    pub(in crate::vector_storage::quantized) fn memory_placement(
+        &self,
+        on_disk_vector_storage: bool,
+    ) -> Memory {
+        QuantizedVectors::memory_placement(
+            self.quantization_config.memory_placement(),
+            on_disk_vector_storage,
+        )
+    }
+
     /// Whether this config should be materialized in RAM (vs. kept as a read-only mmap),
     /// given whether the source vector storage is on disk.
     pub(in crate::vector_storage::quantized) fn is_ram(
         &self,
         on_disk_vector_storage: bool,
     ) -> bool {
-        let always_ram = match &self.quantization_config {
-            QuantizationConfig::Scalar(ScalarQuantization { scalar }) => scalar.always_ram,
-            QuantizationConfig::Product(ProductQuantization { product }) => product.always_ram,
-            QuantizationConfig::Binary(BinaryQuantization { binary }) => binary.always_ram,
-            QuantizationConfig::Turbo(TurboQuantization { turbo }) => turbo.always_ram,
-        };
-        QuantizedVectors::is_ram(always_ram, on_disk_vector_storage)
+        self.memory_placement(on_disk_vector_storage) == Memory::Pinned
     }
 
     /// Resolve which storage variant this config selects, given whether the source

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/load.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/load.rs
@@ -12,7 +12,7 @@ use super::{
     QuantizedVectorsStorageType, READ_FS, ReadFile,
 };
 use crate::common::operation_error::OperationResult;
-use crate::types::{MultiVectorConfig, QuantizationConfig};
+use crate::types::{Memory, MultiVectorConfig, QuantizationConfig};
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorage;
 use crate::vector_storage::quantized::quantized_multivector_storage::{
     MultivectorOffsetsStorageChunked, MultivectorOffsetsStorageMmap, MultivectorOffsetsStorageRam,
@@ -80,13 +80,25 @@ impl QuantizedVectors {
 
         let distance = vector_storage.distance();
         let datatype = vector_storage.datatype();
-        Ok(QuantizedVectors {
+        let quantized_vectors = QuantizedVectors {
             storage_impl: quantized_store,
             config,
             path: path.to_path_buf(),
             distance,
             datatype,
-        })
+        };
+
+        // For the cached placement quantized vectors stay mmap-backed, but the page cache is
+        // primed on load
+        if quantized_vectors
+            .config
+            .memory_placement(on_disk_vector_storage)
+            == Memory::Cached
+        {
+            quantized_vectors.populate()?;
+        }
+
+        Ok(quantized_vectors)
     }
 
     fn load_single(

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/pq/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/pq/create.rs
@@ -38,7 +38,7 @@ impl QuantizedVectors {
             encoded_vectors_pq::get_quantized_vector_size(vector_parameters, bucket_size);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
-        let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(pq_config.memory_placement(), on_disk_vector_storage);
         if in_ram {
             let storage_builder = QuantizedRamStorageBuilder::new(
                 data_path.as_path(),
@@ -101,7 +101,7 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
-        let in_ram = Self::is_ram(pq_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(pq_config.memory_placement(), on_disk_vector_storage);
         if in_ram {
             let storage_builder = QuantizedRamStorageBuilder::new(
                 data_path.as_path(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -48,6 +52,7 @@ fn build_on_disk_storage(dir: &std::path::Path, rng: &mut StdRng) -> VectorStora
 
 fn scalar_config(always_ram: bool) -> QuantizationConfig {
     ScalarQuantizationConfig {
+        memory: None,
         r#type: crate::types::ScalarType::Int8,
         quantile: Some(0.99),
         always_ram: Some(always_ram),
@@ -57,6 +62,7 @@ fn scalar_config(always_ram: bool) -> QuantizationConfig {
 
 fn binary_config(always_ram: bool) -> QuantizationConfig {
     BinaryQuantizationConfig {
+        memory: None,
         always_ram: Some(always_ram),
         encoding: None,
         query_encoding: None,
@@ -66,6 +72,7 @@ fn binary_config(always_ram: bool) -> QuantizationConfig {
 
 fn product_config(always_ram: bool) -> QuantizationConfig {
     ProductQuantizationConfig {
+        memory: None,
         compression: crate::types::CompressionRatio::X4,
         always_ram: Some(always_ram),
     }
@@ -75,6 +82,7 @@ fn product_config(always_ram: bool) -> QuantizationConfig {
 fn turbo_config(always_ram: bool) -> QuantizationConfig {
     QuantizationConfig::Turbo(crate::types::TurboQuantization {
         turbo: TurboQuantQuantizationConfig {
+            memory: None,
             always_ram: Some(always_ram),
             bits: None,
         },

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/scalar/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/scalar/create.rs
@@ -38,7 +38,7 @@ impl QuantizedVectors {
             encoded_vectors_u8::get_quantized_vector_size(vector_parameters);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
-        let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(scalar_config.memory_placement(), on_disk_vector_storage);
         if in_ram {
             let storage_builder = QuantizedRamStorageBuilder::new(
                 data_path.as_path(),
@@ -102,7 +102,7 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
-        let in_ram = Self::is_ram(scalar_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(scalar_config.memory_placement(), on_disk_vector_storage);
         if in_ram {
             let storage_builder = QuantizedRamStorageBuilder::new(
                 data_path.as_path(),

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/turbo/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/turbo/create.rs
@@ -40,7 +40,7 @@ impl QuantizedVectors {
             encoded_vectors_tq::get_quantized_vector_size(vector_parameters, bits, mode);
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
-        let in_ram = Self::is_ram(turbo_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(turbo_config.memory_placement(), on_disk_vector_storage);
 
         match (in_ram, storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {
@@ -133,7 +133,7 @@ impl QuantizedVectors {
         let meta_path = Self::get_meta_path(path);
         let data_path = Self::get_data_path(path, storage_type);
         let offsets_path = Self::get_offsets_path(path, storage_type);
-        let in_ram = Self::is_ram(turbo_config.always_ram, on_disk_vector_storage);
+        let in_ram = Self::is_ram(turbo_config.memory_placement(), on_disk_vector_storage);
 
         match (in_ram, storage_type) {
             (_, QuantizedVectorsStorageType::Mutable) => {

--- a/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
+++ b/lib/segment/src/vector_storage/tests/custom_query_scorer_equivalency.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
@@ -67,6 +71,7 @@ fn async_memmap_storage(dir: &std::path::Path) -> VectorStorageEnum {
 
 fn scalar_u8() -> WithQuantization {
     let config = ScalarQuantizationConfig {
+        memory: None,
         r#type: crate::types::ScalarType::Int8,
         quantile: Some(0.5),
         always_ram: Some(true),
@@ -82,6 +87,7 @@ fn scalar_u8() -> WithQuantization {
 
 fn product_x4() -> WithQuantization {
     let config = ProductQuantizationConfig {
+        memory: None,
         compression: crate::types::CompressionRatio::X4,
         always_ram: Some(true),
     }
@@ -95,6 +101,7 @@ fn product_x4() -> WithQuantization {
 
 fn binary() -> WithQuantization {
     let config = BinaryQuantizationConfig {
+        memory: None,
         always_ram: Some(true),
         encoding: None,
         query_encoding: None,

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -316,6 +320,7 @@ fn test_score_quantized_points(storage: &mut VectorStorageEnum) {
     }
 
     let config: QuantizationConfig = ScalarQuantizationConfig {
+        memory: None,
         r#type: Default::default(),
         quantile: None,
         always_ram: None,

--- a/lib/segment/tests/integration/batch_search_test.rs
+++ b/lib/segment/tests/integration/batch_search_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -137,6 +141,7 @@ fn test_batch_and_single_request_equivalency() {
     let full_scan_threshold = 10000;
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/byte_storage_hnsw_test.rs
+++ b/lib/segment/tests/integration/byte_storage_hnsw_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::assert_matches;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -169,6 +173,7 @@ fn test_byte_storage_hnsw(
         .unwrap();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::assert_matches;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
@@ -348,17 +352,20 @@ fn test_quantization_over_typed_storage_hnsw(
 
     let quantization_config = match quantization_variant {
         QuantizationVariant::Scalar => ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,
         }
         .into(),
         QuantizationVariant::PQ => ProductQuantizationConfig {
+            memory: None,
             compression: CompressionRatio::X8,
             always_ram: None,
         }
         .into(),
         QuantizationVariant::Binary => BinaryQuantizationConfig {
+            memory: None,
             always_ram: None,
             encoding: None,
             query_encoding: None,
@@ -366,12 +373,14 @@ fn test_quantization_over_typed_storage_hnsw(
         .into(),
         QuantizationVariant::Turbo => QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: None,
                 bits: None,
             },
         }),
         QuantizationVariant::TurboBits1_5 => QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: None,
                 bits: Some(TurboQuantBitSize::Bits1_5),
             },
@@ -396,6 +405,7 @@ fn test_quantization_over_typed_storage_hnsw(
         });
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/exact_search_test.rs
+++ b/lib/segment/tests/integration/exact_search_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -74,6 +78,7 @@ fn exact_search_test() {
     let payload_index_ptr = segment.payload_index.clone();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/filtrable_hnsw_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -94,6 +98,7 @@ fn _test_filterable_hnsw(
     let payload_index_ptr = segment.payload_index.clone();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,
@@ -286,6 +291,7 @@ fn test_hnsw_search_top_zero(#[case] num_vectors: u64, #[case] full_scan_thresho
     let payload_index_ptr = segment.payload_index.clone();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold: full_scan_threshold_kb,

--- a/lib/segment/tests/integration/fixtures/segment.rs
+++ b/lib/segment/tests/integration/fixtures/segment.rs
@@ -262,7 +262,7 @@ pub fn build_segment_sparse_1(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 SPARSE_VECTOR_NAME.to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None, None),
                     storage_type: SparseVectorStorageType::default(),
                     modifier: None,
                 },
@@ -356,7 +356,7 @@ pub fn build_segment_sparse_2(path: &Path) -> Segment {
             sparse_vector_data: HashMap::from([(
                 SPARSE_VECTOR_NAME.to_owned(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None),
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None, None),
                     storage_type: SparseVectorStorageType::default(),
                     modifier: None,
                 },

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -174,6 +178,7 @@ fn test_gpu_filterable_hnsw() {
         full_scan_threshold,
         max_indexing_threads: 2,
         on_disk: Some(false),
+        memory: None,
         payload_m: None,
         inline_storage: None,
     };

--- a/lib/segment/tests/integration/hnsw_discover_test.rs
+++ b/lib/segment/tests/integration/hnsw_discover_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -89,6 +93,7 @@ fn hnsw_discover_precision() {
     let payload_index_ptr = segment.payload_index.clone();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,
@@ -217,6 +222,7 @@ fn filtered_hnsw_discover_precision() {
         .unwrap();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/hnsw_incremental_build.rs
+++ b/lib/segment/tests/integration/hnsw_incremental_build.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -126,6 +130,7 @@ fn build_hnsw_index<R: Rng + ?Sized>(
     log::info!("Building HNSW index for {:?}", path.file_name().unwrap());
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m: M,
         ef_construct: EF_CONSTRUCT,
         full_scan_threshold: 1,

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -140,6 +144,7 @@ fn hnsw_quantized_search_test(
     });
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold: 2 * payloads_count as usize,
@@ -360,6 +365,7 @@ fn hnsw_quantized_search_cosine_test() {
         5003,
         131,
         ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,
@@ -378,6 +384,7 @@ fn hnsw_quantized_search_euclid_test() {
         5003,
         131,
         ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,
@@ -396,6 +403,7 @@ fn hnsw_quantized_search_manhattan_test() {
         5003,
         131,
         ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,
@@ -414,6 +422,7 @@ fn hnsw_product_quantization_cosine_test() {
         1003,
         64,
         ProductQuantizationConfig {
+            memory: None,
             compression: CompressionRatio::X4,
             always_ram: Some(true),
         }
@@ -431,6 +440,7 @@ fn hnsw_product_quantization_euclid_test() {
         1003,
         64,
         ProductQuantizationConfig {
+            memory: None,
             compression: CompressionRatio::X4,
             always_ram: Some(true),
         }
@@ -448,6 +458,7 @@ fn hnsw_product_quantization_manhattan_test() {
         1003,
         64,
         ProductQuantizationConfig {
+            memory: None,
             compression: CompressionRatio::X4,
             always_ram: Some(true),
         }
@@ -469,6 +480,7 @@ fn hnsw_turbo_quantization_cosine_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits4),
             },
@@ -488,6 +500,7 @@ fn hnsw_turbo_quantization_dot_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits4),
             },
@@ -507,6 +520,7 @@ fn hnsw_turbo_quantization_cosine_larger_test() {
         256,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits4),
             },
@@ -528,6 +542,7 @@ fn hnsw_turbo_quantization_cosine_bits2_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits2),
             },
@@ -547,6 +562,7 @@ fn hnsw_turbo_quantization_dot_bits2_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits2),
             },
@@ -566,6 +582,7 @@ fn hnsw_turbo_quantization_cosine_larger_bits2_test() {
         131,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits2),
             },
@@ -589,6 +606,7 @@ fn hnsw_turbo_quantization_euclid_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits4),
             },
@@ -607,6 +625,7 @@ fn hnsw_turbo_quantization_manhattan_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits4),
             },
@@ -626,6 +645,7 @@ fn hnsw_turbo_quantization_euclid_bits2_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits2),
             },
@@ -645,6 +665,7 @@ fn hnsw_turbo_quantization_manhattan_bits2_test() {
         64,
         QuantizationConfig::Turbo(TurboQuantization {
             turbo: TurboQuantQuantizationConfig {
+                memory: None,
                 always_ram: Some(true),
                 bits: Some(TurboQuantBitSize::Bits2),
             },
@@ -684,11 +705,13 @@ fn hnsw_quantized_low_bit_compare_test(
 
     let tq_config = QuantizationConfig::Turbo(TurboQuantization {
         turbo: TurboQuantQuantizationConfig {
+            memory: None,
             always_ram: Some(true),
             bits: Some(tq_bits),
         },
     });
     let bq_config: QuantizationConfig = BinaryQuantizationConfig {
+        memory: None,
         always_ram: Some(true),
         encoding: Some(bq_encoding),
         query_encoding: None,
@@ -864,6 +887,7 @@ fn build_quantized_hnsw_for_compare(
     });
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold: 2 * payloads_count as usize,
@@ -1013,6 +1037,7 @@ fn test_build_hnsw_using_quantization() {
     let vector_data_config = config.vector_data.get_mut(DEFAULT_VECTOR_NAME).unwrap();
     vector_data_config.quantization_config = Some(
         ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: None,
@@ -1020,6 +1045,7 @@ fn test_build_hnsw_using_quantization() {
         .into(),
     );
     vector_data_config.index = Indexes::Hnsw(HnswConfig {
+        memory: None,
         m: 16,
         ef_construct: 64,
         full_scan_threshold: 16,

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -121,6 +125,7 @@ fn test_multi_filterable_hnsw(
         .unwrap();
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/multivector_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_hnsw_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -112,6 +116,7 @@ fn test_single_multi_and_dense_hnsw_equivalency() {
     let full_scan_threshold = 10000;
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/multivector_quantization_test.rs
+++ b/lib/segment/tests/integration/multivector_quantization_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -260,17 +264,20 @@ fn test_multivector_quantization_hnsw(
 
     let quantization_config = match quantization_variant {
         QuantizationVariant::Scalar => ScalarQuantizationConfig {
+            memory: None,
             r#type: Default::default(),
             quantile: None,
             always_ram: Some(false),
         }
         .into(),
         QuantizationVariant::PQ => ProductQuantizationConfig {
+            memory: None,
             compression: CompressionRatio::X8,
             always_ram: Some(false),
         }
         .into(),
         QuantizationVariant::Binary => BinaryQuantizationConfig {
+            memory: None,
             always_ram: Some(false),
             encoding: None,
             query_encoding: None,
@@ -304,6 +311,7 @@ fn test_multivector_quantization_hnsw(
     });
 
     let hnsw_config = HnswConfig {
+        memory: None,
         m,
         ef_construct,
         full_scan_threshold,

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -136,6 +140,7 @@ impl TestSegments {
                 &JsonPath::new(STR_KEY),
                 Some(&FieldParams(PayloadSchemaParams::Keyword(
                     KeywordIndexParams {
+                        memory: None,
                         r#type: KeywordIndexType::Keyword,
                         is_tenant: None,
                         on_disk: None,
@@ -161,6 +166,7 @@ impl TestSegments {
                 &JsonPath::new(INT_KEY_2),
                 Some(&FieldParams(PayloadSchemaParams::Integer(
                     IntegerIndexParams {
+                        memory: None,
                         r#type: IntegerIndexType::Integer,
                         lookup: Some(true),
                         range: Some(false),
@@ -178,6 +184,7 @@ impl TestSegments {
                 &JsonPath::new(INT_KEY_3),
                 Some(&FieldParams(PayloadSchemaParams::Integer(
                     IntegerIndexParams {
+                        memory: None,
                         r#type: IntegerIndexType::Integer,
                         lookup: Some(false),
                         range: Some(true),
@@ -316,6 +323,7 @@ impl TestSegments {
                 &JsonPath::new(STR_KEY),
                 Some(&FieldParams(PayloadSchemaParams::Keyword(
                     KeywordIndexParams {
+                        memory: None,
                         r#type: KeywordIndexType::Keyword,
                         is_tenant: None,
                         on_disk: Some(true),
@@ -332,6 +340,7 @@ impl TestSegments {
                 &JsonPath::new(INT_KEY),
                 Some(&FieldParams(PayloadSchemaParams::Integer(
                     IntegerIndexParams {
+                        memory: None,
                         r#type: IntegerIndexType::Integer,
                         lookup: Some(true),
                         range: Some(true),
@@ -349,6 +358,7 @@ impl TestSegments {
                 &JsonPath::new(INT_KEY_2),
                 Some(&FieldParams(PayloadSchemaParams::Integer(
                     IntegerIndexParams {
+                        memory: None,
                         r#type: IntegerIndexType::Integer,
                         lookup: Some(true),
                         range: Some(false),
@@ -366,6 +376,7 @@ impl TestSegments {
                 &JsonPath::new(INT_KEY_3),
                 Some(&FieldParams(PayloadSchemaParams::Integer(
                     IntegerIndexParams {
+                        memory: None,
                         r#type: IntegerIndexType::Integer,
                         lookup: Some(false),
                         range: Some(true),
@@ -382,6 +393,7 @@ impl TestSegments {
                 opnum,
                 &JsonPath::new(FLT_KEY),
                 Some(&FieldParams(PayloadSchemaParams::Float(FloatIndexParams {
+                    memory: None,
                     r#type: FloatIndexType::Float,
                     is_principal: None,
                     on_disk: Some(true),

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 
@@ -78,6 +82,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
             &JsonPath::new("names"),
             Some(&PayloadFieldSchema::FieldParams(
                 PayloadSchemaParams::Keyword(KeywordIndexParams {
+                    memory: None,
                     r#type: segment::data_types::index::KeywordIndexType::Keyword,
                     is_tenant: None,
                     on_disk: Some(true),
@@ -94,6 +99,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
             &JsonPath::new("ages"),
             Some(&PayloadFieldSchema::FieldParams(
                 PayloadSchemaParams::Integer(IntegerIndexParams {
+                    memory: None,
                     r#type: segment::data_types::index::IntegerIndexType::Integer,
                     lookup: Some(true),
                     range: Some(true),
@@ -114,6 +120,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
                 distance: Distance::Dot,
                 storage_type: VectorStorageType::Mmap, // mmap vectors
                 index: Indexes::Hnsw(HnswConfig {
+                    memory: None,
                     m: 4,
                     ef_construct: 16,
                     full_scan_threshold: 8,

--- a/lib/segment/tests/integration/sparse_discover_test.rs
+++ b/lib/segment/tests/integration/sparse_discover_test.rs
@@ -126,6 +126,7 @@ fn sparse_index_discover_test() {
             SPARSE_VECTOR_NAME.to_owned(),
             SparseVectorDataConfig {
                 index: SparseIndexConfig {
+                    memory: None,
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
@@ -176,6 +177,7 @@ fn sparse_index_discover_test() {
     let sparse_index = create_sparse_vector_index_test(SparseVectorIndexOpenArgs {
         fs: &MmapFs,
         config: SparseIndexConfig {
+            memory: None,
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,
             datatype: Some(VectorStorageDatatype::Float32),
@@ -265,6 +267,7 @@ fn sparse_index_hardware_measurement_test() {
             SPARSE_VECTOR_NAME.to_owned(),
             SparseVectorDataConfig {
                 index: SparseIndexConfig {
+                    memory: None,
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
@@ -294,6 +297,7 @@ fn sparse_index_hardware_measurement_test() {
     let sparse_index = create_sparse_vector_index_test(SparseVectorIndexOpenArgs {
         fs: &MmapFs,
         config: SparseIndexConfig {
+            memory: None,
             full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
             index_type: SparseIndexType::ImmutableRam,
             datatype: Some(VectorStorageDatatype::Float32),

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -599,6 +599,7 @@ fn sparse_vector_index_persistence_test() {
             SPARSE_VECTOR_NAME.to_owned(),
             SparseVectorDataConfig {
                 index: SparseIndexConfig {
+                    memory: None,
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),
@@ -687,6 +688,7 @@ fn check_persistence<TInvertedIndex: InvertedIndexReadWrite<MmapFile>>(
         SparseVectorIndex::open(SparseVectorIndexOpenArgs {
             fs: &MmapFs,
             config: SparseIndexConfig {
+                memory: None,
                 full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                 index_type: SparseIndexType::Mmap,
                 datatype: Some(VectorStorageDatatype::Float32),
@@ -775,6 +777,7 @@ fn sparse_vector_test_large_index() {
             SPARSE_VECTOR_NAME.to_owned(),
             SparseVectorDataConfig {
                 index: SparseIndexConfig {
+                    memory: None,
                     full_scan_threshold: Some(DEFAULT_SPARSE_FULL_SCAN_THRESHOLD),
                     index_type: SparseIndexType::MutableRam,
                     datatype: Some(VectorStorageDatatype::Float32),

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -7,9 +7,9 @@ use segment::common::BYTES_IN_KB;
 use segment::data_types::modifier::Modifier;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::types::{
-    Distance, HnswConfig, Indexes, MultiVectorConfig, PayloadStorageType, QuantizationConfig,
-    SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType, VectorDataConfig,
-    VectorNameBuf, VectorStorageDatatype, VectorStorageType,
+    Distance, HnswConfig, Indexes, Memory, MultiVectorConfig, PayloadStorageType,
+    QuantizationConfig, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
+    VectorDataConfig, VectorNameBuf, VectorStorageDatatype, VectorStorageType,
 };
 
 pub const TEMP_SEGMENTS_PATH: &str = "temp_segments";
@@ -22,14 +22,32 @@ pub const DEFAULT_VACUUM_MIN_VECTOR_NUMBER: usize = 1000;
 #[derive(Debug, Clone, PartialEq)]
 pub struct DenseVectorOptimizerConfig {
     pub on_disk: Option<bool>,
+    pub memory: Option<Memory>,
     pub hnsw_config: HnswConfig,
     pub quantization_config: Option<QuantizationConfig>,
+}
+
+impl DenseVectorOptimizerConfig {
+    /// Requested memory placement of the original vector storage, resolving the new `memory`
+    /// parameter against the deprecated `on_disk` flag. `None` if neither is configured.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, self.on_disk.map(Memory::from_on_disk))
+    }
 }
 
 /// Extra configuration for sparse vectors, applied on top of the plain config during optimization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SparseVectorOptimizerConfig {
     pub on_disk: Option<bool>,
+    pub memory: Option<Memory>,
+}
+
+impl SparseVectorOptimizerConfig {
+    /// Requested memory placement of the sparse index, resolving the new `memory` parameter
+    /// against the deprecated `on_disk` flag. `None` if neither is configured.
+    pub fn memory_placement(&self) -> Option<Memory> {
+        Memory::resolve(self.memory, self.on_disk.map(Memory::from_on_disk_heap))
+    }
 }
 
 /// Live read of the vector names currently present in the collection schema.
@@ -99,18 +117,24 @@ impl SegmentOptimizerConfig {
                 size,
                 distance,
                 on_disk,
+                memory,
                 hnsw_config,
                 quantization_config,
                 multivector_config,
                 datatype,
             } = input;
+            let plain_memory = Memory::resolve(
+                memory,
+                Some(Memory::from_on_disk(on_disk.unwrap_or_default())),
+            )
+            .unwrap_or(Memory::Cached);
             plain_dense_vector_config.insert(
                 name.clone(),
                 VectorDataConfig {
                     size,
                     distance,
                     index: Indexes::Plain {},
-                    storage_type: VectorStorageType::from_on_disk(on_disk.unwrap_or_default()),
+                    storage_type: VectorStorageType::appendable_from_memory(plain_memory),
                     quantization_config: QuantizationConfig::for_appendable_segment(
                         quantization_config.as_ref(),
                     ),
@@ -122,6 +146,7 @@ impl SegmentOptimizerConfig {
                 name,
                 DenseVectorOptimizerConfig {
                     on_disk,
+                    memory,
                     hnsw_config,
                     quantization_config,
                 },
@@ -132,6 +157,7 @@ impl SegmentOptimizerConfig {
         for (name, input) in sparse_vectors {
             let SparseVectorOptimizerInput {
                 on_disk,
+                memory,
                 full_scan_threshold,
                 index_datatype,
                 storage_type,
@@ -144,12 +170,13 @@ impl SegmentOptimizerConfig {
                         full_scan_threshold,
                         index_type: SparseIndexType::MutableRam,
                         datatype: index_datatype,
+                        memory,
                     },
                     storage_type,
                     modifier,
                 },
             );
-            sparse_vector.insert(name, SparseVectorOptimizerConfig { on_disk });
+            sparse_vector.insert(name, SparseVectorOptimizerConfig { on_disk, memory });
         }
 
         SegmentOptimizerConfig {
@@ -183,6 +210,7 @@ pub struct DenseVectorOptimizerInput {
     pub size: usize,
     pub distance: Distance,
     pub on_disk: Option<bool>,
+    pub memory: Option<Memory>,
     pub hnsw_config: HnswConfig,
     pub quantization_config: Option<QuantizationConfig>,
     pub multivector_config: Option<MultiVectorConfig>,
@@ -193,6 +221,7 @@ pub struct DenseVectorOptimizerInput {
 #[derive(Debug, Clone)]
 pub struct SparseVectorOptimizerInput {
     pub on_disk: Option<bool>,
+    pub memory: Option<Memory>,
     pub full_scan_threshold: Option<usize>,
     pub index_datatype: Option<VectorStorageDatatype>,
     pub storage_type: SparseVectorStorageType,

--- a/lib/shard/src/optimizers/config_mismatch_optimizer.rs
+++ b/lib/shard/src/optimizers/config_mismatch_optimizer.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use segment::common::operation_time_statistics::OperationDurationsAggregator;
 use segment::entry::ReadSegmentEntry;
 use segment::index::sparse_index::sparse_index_config::SparseIndexType;
-use segment::types::{HnswConfig, HnswGlobalConfig, Indexes, VectorName};
+use segment::types::{HnswConfig, HnswGlobalConfig, Indexes, Memory, VectorName};
 
 use super::config::SegmentOptimizerConfig;
 use super::segment_optimizer::{OptimizationPlanner, SegmentOptimizer};
@@ -48,20 +48,21 @@ impl ConfigMismatchOptimizer {
         }
     }
 
-    /// Check if current configuration requires vectors to be stored on disk
-    fn check_if_vectors_on_disk(&self, vector_name: &VectorName) -> Option<bool> {
+    /// Memory placement the current configuration requests for original vectors, if configured
+    fn requested_vectors_memory(&self, vector_name: &VectorName) -> Option<Memory> {
         self.segment_optimizer_config
             .dense_vector
             .get(vector_name)
-            .and_then(|cfg| cfg.on_disk)
+            .and_then(|cfg| cfg.memory_placement())
     }
 
-    /// Check if current configuration requires sparse vectors index to be stored on disk
-    fn check_if_sparse_vectors_index_on_disk(&self, vector_name: &VectorName) -> Option<bool> {
+    /// Memory placement the current configuration requests for the sparse vector index,
+    /// if configured
+    fn requested_sparse_index_memory(&self, vector_name: &VectorName) -> Option<Memory> {
         self.segment_optimizer_config
             .sparse_vector
             .get(vector_name)
-            .and_then(|cfg| cfg.on_disk)
+            .and_then(|cfg| cfg.memory_placement())
     }
 
     fn has_config_mismatch(&self, segment: &dyn ReadSegmentEntry) -> bool {
@@ -100,9 +101,8 @@ impl ConfigMismatchOptimizer {
                     }
 
                     if !vector_data.storage_type.is_empty()
-                        && let Some(is_required_on_disk) =
-                            self.check_if_vectors_on_disk(vector_name)
-                        && is_required_on_disk != vector_data.storage_type.is_on_disk()
+                        && let Some(required_memory) = self.requested_vectors_memory(vector_name)
+                        && required_memory.is_on_disk() != vector_data.storage_type.is_on_disk()
                     {
                         return true;
                     }
@@ -148,16 +148,20 @@ impl ConfigMismatchOptimizer {
                 .sparse_vector_data
                 .iter()
                 .any(|(vector_name, vector_data)| {
-                    let Some(is_required_on_disk) =
-                        self.check_if_sparse_vectors_index_on_disk(vector_name)
+                    let Some(required_memory) = self.requested_sparse_index_memory(vector_name)
                     else {
                         return false; // Do nothing if not specified
                     };
 
                     match vector_data.index.index_type {
-                        SparseIndexType::MutableRam => false, // Do nothing for mutable RAM
-                        SparseIndexType::ImmutableRam => is_required_on_disk, // Rebuild if we require on disk
-                        SparseIndexType::Mmap => !is_required_on_disk, // Rebuild if we require in RAM
+                        // Do nothing for mutable RAM
+                        SparseIndexType::MutableRam => false,
+                        // Rebuild if the effective placement differs from the requested one
+                        // (e.g. pinned segment while cold/cached is required, or a cold/cached
+                        // mmap segment while another placement is required)
+                        SparseIndexType::ImmutableRam | SparseIndexType::Mmap => {
+                            required_memory != vector_data.index.memory_placement()
+                        }
                     }
                 });
 

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -16,7 +16,7 @@ use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{HnswGlobalConfig, Indexes, VectorNameBuf, VectorStorageType};
+use segment::types::{HnswGlobalConfig, Indexes, Memory, VectorNameBuf, VectorStorageType};
 use uuid::Uuid;
 
 use super::config::SegmentOptimizerConfig;
@@ -242,22 +242,32 @@ pub trait SegmentOptimizer: Sync {
 
         // We want to use single-file mmap in the following cases:
         // - It is explicitly configured by `mmap_threshold` -> threshold_is_on_disk=true
-        // - The segment is indexed and configured on disk -> threshold_is_indexed=true && config_on_disk=Some(true)
+        // - The segment is indexed and configured on disk
+        //   -> threshold_is_indexed=true && requested placement is cold
         if threshold_is_on_disk || threshold_is_indexed {
             vector_data.iter_mut().for_each(|(vector_name, config)| {
-                // Check whether on_disk is explicitly configured, if not, set it to true
-                let config_on_disk = segment_optimizer_config
+                // Requested memory placement: explicit `memory`, or the deprecated `on_disk`
+                let config_memory = segment_optimizer_config
                     .dense_vector
                     .get(vector_name)
-                    .and_then(|cfg| cfg.on_disk);
+                    .and_then(|cfg| {
+                        Memory::resolve_or_warn(
+                            cfg.memory,
+                            cfg.on_disk.map(Memory::from_on_disk),
+                            &format_args!("dense vector `{vector_name}`"),
+                        )
+                    });
 
-                match config_on_disk {
-                    Some(true) => config.storage_type = VectorStorageType::Mmap, // Both agree, but prefer mmap storage type
-                    Some(false) => {
+                match config_memory {
+                    // Both agree, but prefer mmap storage type
+                    Some(Memory::Cold) => config.storage_type = VectorStorageType::Mmap,
+                    // `pinned` is not supported for dense vector storage (rejected by API
+                    // validation); defensively treated as the closest supported placement
+                    Some(Memory::Cached) | Some(Memory::Pinned) => {
                         if common::flags::feature_flags().single_file_mmap_vector_storage {
                             config.storage_type = VectorStorageType::InRamMmap;
                         }
-                        // on_disk=false wins, do nothing
+                        // requested in-RAM placement wins, do nothing
                     }
                     None => {
                         if threshold_is_on_disk {
@@ -269,13 +279,13 @@ pub trait SegmentOptimizer: Sync {
                     }
                 }
 
-                // If we explicitly configure on_disk, but the segment storage type uses something
-                // that doesn't match, warn about it
-                if let Some(config_on_disk) = config_on_disk
-                    && config_on_disk != config.storage_type.is_on_disk()
+                // If we explicitly configure the placement, but the segment storage type uses
+                // something that doesn't match, warn about it
+                if let Some(config_memory) = config_memory
+                    && config_memory.is_on_disk() != config.storage_type.is_on_disk()
                 {
                     log::warn!(
-                        "Collection config for vector {vector_name} has on_disk={config_on_disk:?} configured, but storage type for segment doesn't match it"
+                        "Collection config for vector {vector_name} has memory placement {config_memory:?} configured, but storage type for segment doesn't match it"
                     );
                 }
             });
@@ -284,23 +294,37 @@ pub trait SegmentOptimizer: Sync {
         sparse_vector_data
             .iter_mut()
             .for_each(|(vector_name, config)| {
-                // Assign sparse index on disk
-                let config_on_disk = segment_optimizer_config
+                // Requested memory placement: explicit `memory`, or the deprecated `on_disk`
+                let config_memory = segment_optimizer_config
                     .sparse_vector
                     .get(vector_name)
-                    .and_then(|cfg| cfg.on_disk)
-                    .unwrap_or(threshold_is_on_disk);
+                    .and_then(|cfg| {
+                        Memory::resolve_or_warn(
+                            cfg.memory,
+                            cfg.on_disk.map(Memory::from_on_disk_heap),
+                            &format_args!("sparse vector `{vector_name}`"),
+                        )
+                    });
+
+                let requested_memory = config_memory
+                    .unwrap_or_else(|| Memory::from_on_disk_heap(threshold_is_on_disk));
 
                 // If mmap OR index is exceeded
                 let is_big = threshold_is_on_disk || threshold_is_indexed;
 
-                let index_type = match (is_big, config_on_disk) {
-                    (true, true) => SparseIndexType::Mmap,
-                    (true, false) => SparseIndexType::ImmutableRam,
-                    (false, _) => SparseIndexType::MutableRam,
+                let index_type = if is_big {
+                    match requested_memory {
+                        // Both cold and cached are backed by the mmap index; the requested
+                        // placement is kept in the index config to drive cache population
+                        Memory::Cold | Memory::Cached => SparseIndexType::Mmap,
+                        Memory::Pinned => SparseIndexType::ImmutableRam,
+                    }
+                } else {
+                    SparseIndexType::MutableRam
                 };
 
                 config.index.index_type = index_type;
+                config.index.memory = config_memory;
             });
 
         let optimized_config = segment::types::SegmentConfig {

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -324,7 +324,15 @@ pub trait SegmentOptimizer: Sync {
                 };
 
                 config.index.index_type = index_type;
-                config.index.memory = config_memory;
+                // Persist only the explicitly requested `memory` parameter: the structural
+                // decision is carried by `index_type`, and only the cold/cached distinction
+                // (reachable solely through the explicit parameter) needs the extra field.
+                // Legacy-only configurations thus keep a byte-identical index config,
+                // which older Qdrant versions can load without any unknown fields.
+                config.index.memory = segment_optimizer_config
+                    .sparse_vector
+                    .get(vector_name)
+                    .and_then(|cfg| cfg.memory);
             });
 
         let optimized_config = segment::types::SegmentConfig {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -14,6 +14,7 @@ use collection::operations::config_diff::{
 use collection::operations::types::{
     SparseVectorParams, SparseVectorsConfig, VectorsConfig, VectorsConfigDiff,
 };
+use collection::operations::validation;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::resharding::ReshardKey;
 use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
@@ -206,6 +207,17 @@ impl CreateCollectionOperation {
         collection_name: String,
         create_collection: CreateCollection,
     ) -> StorageResult<Self> {
+        // Run the derived `Validate` checks here instead of relying on the API
+        // layer: only the REST extractor validates the deserialized request,
+        // while gRPC validates the proto message, whose constraints can lag
+        // behind the internal ones (e.g. rejecting `memory: pinned` for dense
+        // vectors and payload storage). Constructing the operation is the
+        // common chokepoint for all API paths, before the operation is
+        // proposed to consensus.
+        create_collection.validate().map_err(|errs| {
+            StorageError::bad_input(validation::label_errors("Validation error in body", &errs))
+        })?;
+
         // Apply the same vector-name validation that the
         // `PUT /collections/{name}/vectors/{vector_name}` endpoint enforces
         // (length 0..=200, no filesystem-unsafe characters), so both creation
@@ -335,12 +347,20 @@ impl UpdateCollectionOperation {
         }
     }
 
-    pub fn new(collection_name: String, update_collection: UpdateCollection) -> Self {
-        Self {
+    pub fn new(
+        collection_name: String,
+        update_collection: UpdateCollection,
+    ) -> StorageResult<Self> {
+        // API-layer-independent validation, see `CreateCollectionOperation::new`.
+        update_collection.validate().map_err(|errs| {
+            StorageError::bad_input(validation::label_errors("Validation error in body", &errs))
+        })?;
+
+        Ok(Self {
             collection_name,
             update_collection,
             shard_replica_changes: None,
-        }
+        })
     }
 
     pub fn take_shard_replica_changes(&mut self) -> Option<Vec<replica_set::Change>> {

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -1,6 +1,12 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::BTreeMap;
 
-use collection::config::{CollectionConfigInternal, CollectionParams, ShardingMethod};
+use collection::config::{
+    CollectionConfigInternal, CollectionParams, PayloadStorageParams, ShardingMethod,
+};
 use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
     WalConfigDiff,
@@ -142,6 +148,7 @@ pub struct CreateCollection {
     #[serde(default)]
     #[validate(range(min = 1))]
     pub write_consistency_factor: Option<u32>,
+    /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory.
     /// It will be read from the disk every time it is requested.
     /// This setting saves RAM by (slightly) increasing the response time.
@@ -149,7 +156,12 @@ pub struct CreateCollection {
     ///
     /// Default: true
     #[serde(default)]
+    #[deprecated(since = "1.19.0", note = "Use `payload.memory` instead")]
     pub on_disk_payload: Option<bool>,
+    /// Configuration of the payload storage
+    #[serde(default)]
+    #[validate(nested)]
+    pub payload: Option<PayloadStorageParams>,
     /// Custom params for HNSW index. If none - values from service configuration file are used.
     #[validate(nested)]
     pub hnsw_config: Option<HnswConfigDiff>,
@@ -276,6 +288,7 @@ pub struct UpdateCollection {
     #[validate(nested)]
     pub optimizers_config: Option<OptimizersConfigDiff>, // TODO: Allow updates for other configuration params as well
     /// Collection base params. If none - it is left unchanged.
+    #[validate(nested)]
     pub params: Option<CollectionParamsDiff>,
     /// HNSW parameters to update for the collection index. If none - it is left unchanged.
     #[validate(nested)]
@@ -501,6 +514,7 @@ impl From<CollectionConfigInternal> for CreateCollection {
             read_fan_out_factor: _,
             read_fan_out_delay_ms: _,
             on_disk_payload,
+            payload,
             sparse_vectors,
         } = params;
 
@@ -511,6 +525,7 @@ impl From<CollectionConfigInternal> for CreateCollection {
             replication_factor: Some(replication_factor.get()),
             write_consistency_factor: Some(write_consistency_factor.get()),
             on_disk_payload: Some(on_disk_payload),
+            payload,
             hnsw_config: Some(hnsw_config.into()),
             wal_config: Some(wal_config.into()),
             optimizers_config: Some(optimizer_config.into()),

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -222,7 +222,7 @@ impl TryFrom<grpc::UpdateCollection> for CollectionMetaOperations {
                     Some(json::proto_to_payloads(metadata)?)
                 },
             },
-        )))
+        )?))
     }
 }
 
@@ -383,6 +383,87 @@ impl From<ConsensusThreadStatus> for grpc::ConsensusThreadStatus {
                     grpc::consensus_thread_status::StoppedWithErr { err },
                 )),
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_request(
+        vector_memory: Option<grpc::Memory>,
+        payload_memory: Option<grpc::Memory>,
+    ) -> grpc::CreateCollection {
+        grpc::CreateCollection {
+            collection_name: "test".to_string(),
+            vectors_config: Some(grpc::VectorsConfig {
+                config: Some(grpc::vectors_config::Config::Params(grpc::VectorParams {
+                    size: 4,
+                    distance: grpc::Distance::Cosine as i32,
+                    memory: vector_memory.map(|memory| memory as i32),
+                    ..Default::default()
+                })),
+            }),
+            payload: payload_memory.map(|memory| grpc::PayloadStorageParams {
+                memory: Some(memory as i32),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn update_request(
+        vector_memory: Option<grpc::Memory>,
+        payload_memory: Option<grpc::Memory>,
+    ) -> grpc::UpdateCollection {
+        grpc::UpdateCollection {
+            collection_name: "test".to_string(),
+            vectors_config: vector_memory.map(|memory| grpc::VectorsConfigDiff {
+                config: Some(grpc::vectors_config_diff::Config::Params(
+                    grpc::VectorParamsDiff {
+                        memory: Some(memory as i32),
+                        ..Default::default()
+                    },
+                )),
+            }),
+            params: payload_memory.map(|memory| grpc::CollectionParamsDiff {
+                payload: Some(grpc::PayloadStorageParams {
+                    memory: Some(memory as i32),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn assert_rejected(result: Result<CollectionMetaOperations, Status>) {
+        let status = result.expect_err("`pinned` placement must be rejected");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("pinned"), "{}", status.message());
+    }
+
+    /// `pinned` placement is invalid for dense vector and payload storage. The
+    /// gRPC layer only validates the proto request, so the rejection must not
+    /// depend on it: constructing the meta operation itself has to fail.
+    #[test]
+    fn test_grpc_create_collection_rejects_pinned_memory() {
+        assert_rejected(create_request(Some(grpc::Memory::Pinned), None).try_into());
+        assert_rejected(create_request(None, Some(grpc::Memory::Pinned)).try_into());
+    }
+
+    #[test]
+    fn test_grpc_update_collection_rejects_pinned_memory() {
+        assert_rejected(update_request(Some(grpc::Memory::Pinned), None).try_into());
+        assert_rejected(update_request(None, Some(grpc::Memory::Pinned)).try_into());
+    }
+
+    #[test]
+    fn test_grpc_create_update_collection_accept_valid_memory() {
+        for memory in [grpc::Memory::Cold, grpc::Memory::Cached] {
+            CollectionMetaOperations::try_from(create_request(Some(memory), Some(memory)))
+                .expect("valid placement must be accepted on create");
+            CollectionMetaOperations::try_from(update_request(Some(memory), Some(memory)))
+                .expect("valid placement must be accepted on update");
         }
     }
 }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -77,6 +81,7 @@ impl TryFrom<grpc::CreateCollection> for CollectionMetaOperations {
             optimizers_config,
             shard_number,
             on_disk_payload,
+            payload,
             timeout: _,
             vectors_config,
             replication_factor,
@@ -103,6 +108,9 @@ impl TryFrom<grpc::CreateCollection> for CollectionMetaOperations {
                 optimizers_config: optimizers_config.map(TryFrom::try_from).transpose()?,
                 shard_number,
                 on_disk_payload,
+                payload: payload
+                    .map(collection::config::PayloadStorageParams::try_from)
+                    .transpose()?,
                 replication_factor,
                 write_consistency_factor,
                 quantization_config: quantization_config.map(TryInto::try_into).transpose()?,

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -31,7 +31,7 @@ pub mod consensus_ops {
 
     use super::collection_meta_ops::ReshardingOperation;
     use crate::content_manager::collection_meta_ops::{
-        CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations, UpdateCollection,
+        CollectionMetaOperations, SetShardReplicaState, ShardTransferOperations,
         UpdateCollectionOperation,
     };
 
@@ -127,19 +127,7 @@ pub mod consensus_ops {
             shard_id: u32,
             peer_id: PeerId,
         ) -> Self {
-            let mut operation = UpdateCollectionOperation::new(
-                collection_name,
-                UpdateCollection {
-                    vectors: None,
-                    optimizers_config: None,
-                    params: None,
-                    hnsw_config: None,
-                    quantization_config: None,
-                    sparse_vectors: None,
-                    strict_mode_config: None,
-                    metadata: None,
-                },
-            );
+            let mut operation = UpdateCollectionOperation::new_empty(collection_name);
             operation
                 .set_shard_replica_changes(vec![replica_set::Change::Remove(shard_id, peer_id)]);
 

--- a/lib/storage/src/content_manager/toc/create_collection.rs
+++ b/lib/storage/src/content_manager/toc/create_collection.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
@@ -33,6 +37,7 @@ impl TableOfContent {
             shard_number,
             sharding_method,
             on_disk_payload,
+            payload,
             hnsw_config: hnsw_config_diff,
             wal_config: wal_config_diff,
             optimizers_config: optimizers_config_diff,
@@ -136,6 +141,7 @@ impl TableOfContent {
                 .ok_or_else(|| StorageError::bad_input("`shard_number` cannot be 0"))?,
             sharding_method,
             on_disk_payload: on_disk_payload.unwrap_or(self.storage_config.on_disk_payload),
+            payload,
             replication_factor: NonZeroU32::new(replication_factor).ok_or_else(|| {
                 StorageError::bad_input("`replication_factor` cannot be 0".to_string())
             })?,

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -105,6 +109,7 @@ fn test_alias_operation() {
                             optimizers_config: None,
                             shard_number: Some(1),
                             on_disk_payload: None,
+                            payload: None,
                             replication_factor: None,
                             write_consistency_factor: None,
                             quantization_config: None,

--- a/src/actix/api/collections_api.rs
+++ b/src/actix/api/collections_api.rs
@@ -144,12 +144,15 @@ async fn update_collection(
 ) -> impl Responder {
     let timing = Instant::now();
     let name = collection.collection_name.clone();
+    let update_collection_op = UpdateCollectionOperation::new(name, operation.into_inner());
+
+    let Ok(update_collection_op) = update_collection_op else {
+        return process_response(update_collection_op, timing, None);
+    };
+
     let response = dispatcher
         .submit_collection_meta_op(
-            CollectionMetaOperations::UpdateCollection(UpdateCollectionOperation::new(
-                name,
-                operation.into_inner(),
-            )),
+            CollectionMetaOperations::UpdateCollection(update_collection_op),
             auth,
             query.timeout(),
         )

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, mpsc};
@@ -1694,6 +1698,7 @@ mod tests {
                                 optimizers_config: None,
                                 shard_number: Some(2),
                                 on_disk_payload: None,
+                                payload: None,
                                 replication_factor: None,
                                 write_consistency_factor: None,
                                 quantization_config: None,

--- a/src/migrations/single_to_cluster.rs
+++ b/src/migrations/single_to_cluster.rs
@@ -1,3 +1,7 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
 use std::sync::Arc;
 
 use collection::collection_state::State;
@@ -72,6 +76,7 @@ pub async fn handle_existing_collections(
                 replication_factor: Some(params.replication_factor.get()),
                 write_consistency_factor: Some(params.write_consistency_factor.get()),
                 on_disk_payload: Some(params.on_disk_payload),
+                payload: params.payload,
                 hnsw_config: Some(hnsw_config.into()),
                 wal_config: Some(wal_config.into()),
                 optimizers_config: Some(optimizer_config.into()),

--- a/tests/openapi/test_memory_placement.py
+++ b/tests/openapi/test_memory_placement.py
@@ -1,0 +1,172 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+collection_name = "test_memory_placement"
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    drop_collection(collection_name)
+    yield
+    drop_collection(collection_name)
+
+
+def test_create_collection_with_memory_placement():
+    # Every component configured through the new `memory` parameter
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot",
+                "memory": "cached",
+                "hnsw_config": {"memory": "cold"},
+                "quantization_config": {
+                    "scalar": {"type": "int8", "memory": "pinned"},
+                },
+            },
+            "sparse_vectors": {
+                "sparse": {"index": {"memory": "cold"}},
+            },
+            "payload": {"memory": "cached"},
+        },
+    )
+    assert response.ok, response.text
+
+    # The new parameters must be echoed back in the collection info
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="GET",
+        path_params={"collection_name": collection_name},
+    )
+    assert response.ok, response.text
+    params = response.json()["result"]["config"]["params"]
+    assert params["vectors"]["memory"] == "cached"
+    assert params["vectors"]["hnsw_config"]["memory"] == "cold"
+    assert params["vectors"]["quantization_config"]["scalar"]["memory"] == "pinned"
+    assert params["sparse_vectors"]["sparse"]["index"]["memory"] == "cold"
+    assert params["payload"]["memory"] == "cached"
+
+    # Payload field index with the new parameter
+    response = request_with_validation(
+        api="/collections/{collection_name}/index",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "field_name": "keyword_field",
+            "field_schema": {"type": "keyword", "memory": "cold"},
+        },
+    )
+    assert response.ok, response.text
+
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="GET",
+        path_params={"collection_name": collection_name},
+    )
+    assert response.ok, response.text
+    schema = response.json()["result"]["payload_schema"]
+    assert schema["keyword_field"]["params"]["memory"] == "cold"
+
+
+def test_create_collection_without_memory_placement_has_no_new_fields():
+    # A collection created without the new parameters must not expose them in
+    # the collection info, so clients of older SDKs see an unchanged response
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"size": 4, "distance": "Dot", "on_disk": True},
+        },
+    )
+    assert response.ok, response.text
+
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="GET",
+        path_params={"collection_name": collection_name},
+    )
+    assert response.ok, response.text
+    params = response.json()["result"]["config"]["params"]
+    assert "memory" not in params["vectors"]
+    assert "payload" not in params
+
+
+def test_pinned_dense_vector_storage_is_rejected():
+    # Dense vector storage has no heap variant: `pinned` must be rejected
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"size": 4, "distance": "Dot", "memory": "pinned"},
+        },
+    )
+    assert response.status_code == 422, response.text
+    assert "pinned" in response.json()["status"]["error"]
+
+
+def test_pinned_payload_storage_is_rejected():
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"size": 4, "distance": "Dot"},
+            "payload": {"memory": "pinned"},
+        },
+    )
+    assert response.status_code == 422, response.text
+    assert "pinned" in response.json()["status"]["error"]
+
+
+def test_update_collection_memory_placement():
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"size": 4, "distance": "Dot"},
+        },
+    )
+    assert response.ok, response.text
+
+    # Vector storage placement and payload storage placement are mutable
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PATCH",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"": {"memory": "cold"}},
+            "params": {"payload": {"memory": "cached"}},
+        },
+    )
+    assert response.ok, response.text
+
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="GET",
+        path_params={"collection_name": collection_name},
+    )
+    assert response.ok, response.text
+    params = response.json()["result"]["config"]["params"]
+    assert params["vectors"]["memory"] == "cold"
+    assert params["payload"]["memory"] == "cached"
+
+    # `pinned` is rejected on update as well
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="PATCH",
+        path_params={"collection_name": collection_name},
+        body={
+            "vectors": {"": {"memory": "pinned"}},
+        },
+    )
+    assert response.status_code == 422, response.text
+    assert "pinned" in response.json()["status"]["error"]


### PR DESCRIPTION
## What

Introduces a single optional `memory` parameter controlling how each collection component's data is held in RAM, unifying the inconsistent `on_disk` / `always_ram` / `on_disk_payload` options:

- **`cold`** — not pre-loaded from disk to RAM; first request may be slow, cached with usage
- **`cached`** — pre-populated into disk-cache RAM on load; fast first request, evictable under memory pressure
- **`pinned`** — materialized on heap, never evicted by cache pressure; component must fit in RAM

Available on: dense vectors (`VectorParams.memory` + diff), HNSW (`hnsw_config.memory`), all quantization configs (replacing the polarity-inverted `always_ram`), sparse index (`SparseIndexParams.memory`), all 8 payload field index types, and payload storage via a new `payload: { memory }` sub-object on collection params (replacing `on_disk_payload`).

## Semantics

- `memory` set → overrides the deprecated legacy flag (disagreement logged as warning at optimizer-time resolution, consistent with the existing `on_disk` mismatch warning)
- `memory` unset → exact legacy behavior; no behavior change for existing configs (hence no feature flag)
- Legacy params deprecated: `#[deprecated(since = "1.19.0")]` + proto `[deprecated = true]`, still fully functional
- `pinned` is rejected by API validation for components without a heap variant (dense vector storage, payload storage)
- Low-memory mode degrades placements at load time via `Memory::clamp_to_low_memory()`, mirroring existing `prefer_disk`/`skip_populate` behavior (`no_resident`: pinned→cold; `no_populate`: everything→cold); persisted config is never modified
- Config-mismatch optimizer compares *effective placements*, so expressing the same placement through `memory` instead of `on_disk` does not trigger a spurious rebuild (incl. `HnswConfig::mismatch_requires_rebuild`)

## New capabilities

- HNSW graph links can be **pinned** — first production caller of `GraphLinksResidency::Pinned`
- **`cached`** tier for the sparse mmap index and quantized vectors (mmap + populate after open; requested placement persisted in `SparseIndexConfig.memory` to distinguish cold/cached for the mmap variant)
- **`cached`** tier for on-disk payload field indexes (mmap variant opened with `Populate::Blocking`)

## Notes for review

- `Memory::from_on_disk` (mmap components: `false`→`cached`) vs `Memory::from_on_disk_heap` (heap components: `false`→`pinned`) encode the differing legacy semantics per component family
- `CollectionParamsDiff` now derives `Validate` (previously the update path had no nested validation), wired via `#[validate(nested)]` on the update operation
- The bulk of the diff is mechanical: `memory: None` in test/bench struct literals and file-level `#![allow(deprecated)]` (per the `memmap_threshold` precedent) in files that still handle legacy flags
- Qdrant Edge keeps its legacy params for now (`memory: None` at its conversion boundary)

## Testing

- New unit tests: legacy→placement mapping, resolve precedence, per-component `memory_placement()` resolution (HNSW, quantization, field indexes, sparse), storage-type mapping, no-spurious-rebuild property, payload diff-update path, sparse config serde round-trip/backward compat
- `cargo test --lib` green for segment (830), collection (235), shard (80), storage (46), api (19); workspace compiles warning-free, clippy clean
- OpenAPI regenerated and validated; `Memory`, `PayloadStorageParams` and all `memory` fields present in the schema

Design discussion and decision log: `plan/memory-placement-investigation.md` (kept local, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)