### PR TITLE
Fix /readyz of reinitialized peer waiting on a foreign consensus

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -17,6 +17,7 @@ use itertools::Itertools;
 use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::toc::TableOfContent;
 use storage::rbac::Access;
+use storage::types::PeerAddressById;
 use tokio::{runtime, sync, time};
 
 const READY_CHECK_TIMEOUT: Duration = Duration::from_millis(500);
@@ -166,7 +167,7 @@ impl Task {
                 self.check_ready_signal.notified().await;
 
                 // Ensure we're not the only peer left
-                if self.consensus_state.peer_count() <= 1 {
+                if self.member_peer_addresses().len() <= 1 {
                     self.set_ready();
                     return;
                 }
@@ -210,13 +211,14 @@ impl Task {
         // Wait for `/readyz` signal
         self.check_ready_signal.notified().await;
 
+        let peer_address_by_id = self.member_peer_addresses();
+
         // Check if there is only 1 node in the cluster
-        if self.consensus_state.peer_count() <= 1 {
+        if peer_address_by_id.len() <= 1 {
             return None;
         }
 
         // Get *cluster* commit index
-        let peer_address_by_id = self.consensus_state.peer_address_by_id();
         let transport_channel_pool = &self.toc.get_channel_service().channel_pool;
         let this_peer_id = self.toc.this_peer_id;
         let this_peer_uri = peer_address_by_id.get(&this_peer_id);
@@ -299,6 +301,39 @@ impl Task {
             .read()
             .last_applied_entry()
             .unwrap_or(0)
+    }
+
+    /// Addresses of the peers that are members of the current consensus configuration.
+    ///
+    /// `peer_address_by_id` can also hold peers that are no longer part of the cluster. Most
+    /// notably, after `--reinit` of a previously removed peer, it still lists the peers of the
+    /// old cluster, while `conf_state` is reset to this peer only. Waiting to reach the commit
+    /// index of such peers means waiting for the commit index of a foreign consensus, which this
+    /// peer may never reach.
+    ///
+    /// An empty `conf_state` means this peer doesn't know the cluster configuration yet (e.g. it
+    /// bootstraps and didn't apply any configuration change so far). In this case all known peer
+    /// addresses are considered members.
+    fn member_peer_addresses(&self) -> PeerAddressById {
+        let persistent = self.consensus_state.persistent.read();
+        let conf_state = &persistent.state().conf_state;
+
+        let members: HashSet<_> = conf_state
+            .voters
+            .iter()
+            .chain(&conf_state.voters_outgoing)
+            .chain(&conf_state.learners)
+            .chain(&conf_state.learners_next)
+            .copied()
+            .collect();
+
+        let mut peer_address_by_id = persistent.peer_address_by_id();
+
+        if !members.is_empty() {
+            peer_address_by_id.retain(|peer_id, _| members.contains(peer_id));
+        }
+
+        peer_address_by_id
     }
 
     /// List shards that are unhealthy, which may undergo automatic recovery.

--- a/tests/consensus_tests/test_reinit_removed_peer.py
+++ b/tests/consensus_tests/test_reinit_removed_peer.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 
 from .utils import *
@@ -64,3 +65,73 @@ def test_reinit_removed_peer(tmp_path: pathlib.Path):
     new_peer_uri = start_peer(new_peer_dir, "new_peer.log", reinit_bootstrap_uri)
     wait_for_peer_online(new_peer_uri)
     wait_for(check_leader, new_peer_uri, leader)
+
+
+def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
+    """
+    Regression test for `/readyz` of a reinitialized peer racing against the
+    old cluster.
+
+    Applying `RemoveNode(self)` prunes all other peers from the removed peer's
+    persisted address book. But the peer may be killed after the removal is
+    committed and *before it applied the entry* - then the old first peer's
+    address survives in `raft_state.json`. After `--reinit` the health checker
+    used to treat every address-book entry as a cluster member and would wait
+    for the reinitialized peer to reach the *old* cluster's commit index - a
+    foreign consensus it can never catch up with, so `/readyz` never passed.
+
+    The kill-before-apply race is simulated by putting the old first peer's
+    address back into the killed peer's persisted state, and the old cluster's
+    commit index is pushed ahead so the reinitialized single-voter consensus
+    stays behind it. `/readyz` must rely on `conf_state` (reset to a single
+    voter by `--reinit`) and ignore the old peer.
+    """
+    assert_project_root()
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS)
+
+    removed_peer_uri = peer_api_uris[1]
+    removed_peer_dir = peer_dirs[1]
+    removed_peer_id = get_cluster_info(removed_peer_uri)["peer_id"]
+    first_peer_id = get_cluster_info(peer_api_uris[0])["peer_id"]
+
+    res = requests.delete(f"{peer_api_uris[0]}/cluster/peer/{removed_peer_id}?timeout=60")
+    assert_http_ok(res)
+    wait_for(check_cluster_size, peer_api_uris[0], 1)
+
+    removed_peer_process = processes[1]
+    removed_peer_process.kill()
+    processes.remove(removed_peer_process)
+
+    # Simulate the killed peer not having applied `RemoveNode(self)` yet: the
+    # old first peer's address is still in its persisted address book.
+    raft_state_path = removed_peer_dir / "storage" / "raft_state.json"
+    raft_state = json.loads(raft_state_path.read_text())
+    raft_state["peer_address_by_id"][str(first_peer_id)] = bootstrap_uri
+    raft_state_path.write_text(json.dumps(raft_state))
+
+    # Push the old cluster's commit index well ahead of anything the removed
+    # peer has in its WAL. Each collection creation commits several consensus
+    # entries on the (now single-node) old cluster.
+    for i in range(3):
+        res = requests.put(
+            f"{peer_api_uris[0]}/collections/ahead_{i}?timeout=60",
+            json={"vectors": {"size": 4, "distance": "Dot"}},
+        )
+        assert_http_ok(res)
+
+    old_commit = get_cluster_info(peer_api_uris[0])["raft_info"]["commit"]
+
+    # Reinitialize the removed peer as a fresh first peer, with the old first
+    # peer still alive and reachable. Its own single-voter consensus can never
+    # reach `old_commit`, so `/readyz` must not depend on it.
+    reinit_api_uri, _reinit_bootstrap_uri = start_first_peer(
+        removed_peer_dir, "removed_peer_reinit.log", reinit=True,
+    )
+
+    wait_for_peer_online(reinit_api_uri)
+
+    # The readiness race is only exercised while the reinitialized peer's own
+    # commit index stays behind the old cluster's.
+    reinit_commit = get_cluster_info(reinit_api_uri)["raft_info"]["commit"]
+    assert reinit_commit < old_commit


### PR DESCRIPTION
## Problem

`test_reinit_removed_peer` is flaky on CI ([failing run](https://github.com/qdrant/qdrant/actions/runs/28715612774/attempts/1), job `integration-tests-consensus`):

```
FAILED tests/consensus_tests/test_reinit_removed_peer.py::test_reinit_removed_peer - Exception: Timeout waiting for condition peer_is_online to be satisfied in 30 seconds
```

The captured cluster info at timeout shows the reinitialized peer perfectly healthy — leader of its single-voter consensus, consensus thread working — yet `/readyz` never returns 200.

## Root cause

Applying `RemoveNode(self)` prunes all other peers from the removed peer's persisted address book (`TableOfContent::remove_peer`). But the peer may be stopped after the removal is *committed* and before it *applied* the entry — the test only waits for the remaining peer to observe the removal, so this is a race. In that case the old first peer's address survives in `raft_state.json` across `--reinit`.

The `/readyz` health checker treated every `peer_address_by_id` entry as a cluster member: it queried the old first peer (still alive) via `GetConsensusCommit` and waited for the reinitialized peer to reach the *old* cluster's commit index — a foreign consensus it can never catch up with, since its own single-voter log only grows by its few startup entries (and `clear_unapplied_entries_on_reinit` drops the unapplied tail, widening the gap). `/readyz` then never passes, not just within the test's 30s.

This is not test-only: an operator recovering a cluster via `--reinit` while old peers are still reachable hits the same stuck `/readyz`.

## Fix

Filter the address book by current `conf_state` membership (voters, outgoing voters, learners, next learners) in the health checker, falling back to all known addresses while `conf_state` is still empty (a bootstrapping node that hasn't applied any configuration change yet — filtering there would report ready prematurely). After `--reinit` the `conf_state` is reset to a single voter, so the readiness check correctly ignores peers of the old cluster. The `wait_for_bootstrap` loop intentionally stays address-based: addresses arriving early is its join signal.

## Verification

- New regression test `test_reinit_removed_peer_readyz_ignores_old_cluster` simulates the kill-before-apply state (re-adds the old peer's address to the killed peer's `raft_state.json`) and pushes the old cluster's commit index ahead. It reproduces the exact CI failure deterministically without the fix, and passes with it.
- Readiness-sensitive suites pass locally: `test_reinit_removed_peer.py`, `test_cluster_rejoin.py`, `test_consensus_compaction.py`, `test_remove_node.py` (15 passed, 1 pre-existing conditional skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)