### PR TITLE
[TQDT] Segment retrieves a serialized vector

### DIFF
--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -3,17 +3,30 @@ use crate::types::{Payload, PointIdType, VectorNameBuf};
 
 pub type NamedVectorsOwned = Vec<(VectorNameBuf, VectorInternal)>;
 
-pub struct SegmentRecord {
+/// Like [`NamedVectorsOwned`], but vectors are kept as storage-native bytes
+/// instead of decoded [`VectorInternal`]s (avoids a lossy round-trip).
+pub type NamedVectorsOwnedRaw = Vec<(VectorNameBuf, Vec<u8>)>;
+
+/// A retrieved point: id, optional vectors, optional payload.
+///
+/// `V` is the vector representation: [`VectorInternal`] for [`SegmentRecord`],
+/// storage-native bytes for [`SegmentRecordRaw`].
+pub struct SegmentRecordGeneric<V> {
     pub id: PointIdType,
-    pub vectors: Option<NamedVectorsOwned>,
+    pub vectors: Option<Vec<(VectorNameBuf, V)>>,
     pub payload: Option<Payload>,
 }
 
-impl SegmentRecord {
+pub type SegmentRecord = SegmentRecordGeneric<VectorInternal>;
+
+/// Byte-blob analogue of [`SegmentRecord`].
+pub type SegmentRecordRaw = SegmentRecordGeneric<Vec<u8>>;
+
+impl<V> SegmentRecordGeneric<V> {
     pub fn empty(id: PointIdType) -> Self {
         Self {
             id,
-            vectors: Some(NamedVectorsOwned::default()),
+            vectors: Some(Vec::new()),
             payload: None,
         }
     }

--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -3,10 +3,6 @@ use crate::types::{Payload, PointIdType, VectorNameBuf};
 
 pub type NamedVectorsOwned = Vec<(VectorNameBuf, VectorInternal)>;
 
-/// Like [`NamedVectorsOwned`], but vectors are kept as storage-native bytes
-/// instead of decoded [`VectorInternal`]s (avoids a lossy round-trip).
-pub type NamedVectorsOwnedRaw = Vec<(VectorNameBuf, Vec<u8>)>;
-
 /// A retrieved point: id, optional vectors, optional payload.
 ///
 /// `V` is the vector representation: [`VectorInternal`] for [`SegmentRecord`],
@@ -21,13 +17,3 @@ pub type SegmentRecord = SegmentRecordGeneric<VectorInternal>;
 
 /// Byte-blob analogue of [`SegmentRecord`].
 pub type SegmentRecordRaw = SegmentRecordGeneric<Vec<u8>>;
-
-impl<V> SegmentRecordGeneric<V> {
-    pub fn empty(id: PointIdType) -> Self {
-        Self {
-            id,
-            vectors: Some(Vec::new()),
-            payload: None,
-        }
-    }
-}

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -15,7 +15,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::SegmentRecord;
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::snapshot_entry::SnapshotEntry;
@@ -114,6 +114,21 @@ pub trait ReadSegmentEntry {
         is_stopped: &AtomicBool,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>>;
+
+    /// Byte-blob analogue of [`ReadSegmentEntry::retrieve`]: returns vectors as
+    /// storage-native bytes ([`SegmentRecordRaw`]) to avoid a lossy round-trip
+    /// when relocating points (copy-on-write moves, shard transfer).
+    ///
+    /// Like `retrieve`, may return fewer records than requested and in any order.
+    fn retrieve_raw(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>>;
 
     /// Retrieve payload for the point
     /// If not found, return empty payload

--- a/lib/segment/src/index/hnsw_index/graph_links/vectors.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/vectors.rs
@@ -81,7 +81,7 @@ impl<'a> GraphLinksVectors for StorageGraphLinksVectors<'a> {
         f: &mut dyn FnMut(&[u8]) -> OperationResult<()>,
     ) -> OperationResult<()> {
         self.vector_storage
-            .with_vector_bytes_opt::<Sequential, _>(point_id, f)
+            .with_vector_bytes_opt::<Sequential, _>(point_id, f)?
             .unwrap_or_else(|| {
                 Err(OperationError::service_error(format!(
                     "Point {point_id} not found in vector storage"

--- a/lib/segment/src/index/hnsw_index/graph_links/vectors.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/vectors.rs
@@ -14,8 +14,8 @@ use common::generic_consts::Sequential;
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::vector_storage::VectorStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
+use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 /// This trait lets the [`serialize_graph_links`] to access vector values.
 ///

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -17,7 +17,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::SegmentRecord;
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::{
@@ -155,6 +155,27 @@ impl ReadSegmentEntry for Segment {
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
         self.with_view(|view| {
             view.retrieve(
+                point_ids,
+                with_payload,
+                with_vector,
+                hw_counter,
+                is_stopped,
+                deferred_behavior,
+            )
+        })
+    }
+
+    fn retrieve_raw(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>> {
+        self.with_view(|view| {
+            view.retrieve_raw(
                 point_ids,
                 with_payload,
                 with_vector,

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -13,7 +13,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::SegmentRecord;
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::ReadSegmentEntry;
 use crate::id_tracker::IdTrackerRead;
@@ -151,6 +151,27 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
         self.with_view(|view| {
             view.retrieve(
+                point_ids,
+                with_payload,
+                with_vector,
+                hw_counter,
+                is_stopped,
+                deferred_behavior,
+            )
+        })
+    }
+
+    fn retrieve_raw(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>> {
+        self.with_view(|view| {
+            view.retrieve_raw(
                 point_ids,
                 with_payload,
                 with_vector,

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -4,12 +4,12 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::iterator_ext::IteratorExt;
-use common::types::{DeferredBehavior, ScoredPointOffset};
+use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::{check_query_vectors, check_stopped};
 use crate::data_types::query_context::{QueryContext, QueryIdfStats, SegmentQueryContext};
-use crate::data_types::segment_record::{NamedVectorsOwned, SegmentRecord};
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordGeneric, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorStructInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::{PayloadIndexRead, VectorIndexRead};
@@ -39,54 +39,118 @@ where
         is_stopped: &AtomicBool,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
-        // Stage 1: resolve external → internal once, into two parallel vectors.
-        // The id tracker owns this: deferred filtering happens inline (no
-        // `point_is_deferred` lookup). The parallel-vector shape lets
-        // a future batched payload / vector fetcher consume `&offsets`
-        // straight without unzipping first.
+        self.retrieve_generic(
+            point_ids,
+            with_payload,
+            with_vector,
+            is_stopped,
+            deferred_behavior,
+            hw_counter,
+            |vector_name, ids, offsets, push| {
+                let keys = ids
+                    .iter()
+                    .zip(offsets)
+                    .map(|(&id, &offset)| (id, offset))
+                    .stop_if(is_stopped);
+                self.vectors_by_offsets(vector_name, keys, hw_counter, |id, _offset, vec| {
+                    push(id, vec)
+                })
+            },
+        )
+    }
+
+    /// Byte-blob analogue of [`Self::retrieve`]: vectors are read as
+    /// storage-native bytes (`Vec<u8>`) to avoid a lossy round-trip.
+    pub fn retrieve_raw(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>> {
+        self.retrieve_generic(
+            point_ids,
+            with_payload,
+            with_vector,
+            is_stopped,
+            deferred_behavior,
+            hw_counter,
+            |vector_name, ids, offsets, push| {
+                let keys = ids
+                    .iter()
+                    .zip(offsets)
+                    .map(|(&id, &offset)| (id, offset))
+                    .stop_if(is_stopped);
+                self.vector_bytes_by_offsets(vector_name, keys, hw_counter, |id, _offset, bytes| {
+                    push(id, bytes)
+                })
+            },
+        )
+    }
+
+    /// Shared body of [`Self::retrieve`] and [`Self::retrieve_raw`]; only the
+    /// vector representation `V` and the storage read differ. `read_name` gets
+    /// each vector name, the resolved (id, offset) slices and a `push` sink for
+    /// the `(id, value)`s it reads — it owns the storage reader choice.
+    #[allow(clippy::too_many_arguments)]
+    fn retrieve_generic<V>(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+        hw_counter: &HardwareCounterCell,
+        mut read_name: impl FnMut(
+            &VectorNameBuf,
+            &[ExtendedPointId],
+            &[PointOffsetType],
+            &mut dyn FnMut(ExtendedPointId, V),
+        ) -> OperationResult<()>,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordGeneric<V>>> {
+        // Stage 1: resolve external → internal ids once, with deferred filtering.
         let (resolved_ids, resolved_offsets) = self
             .id_tracker
             .resolve_external_ids(point_ids, deferred_behavior);
         debug_assert_eq!(resolved_ids.len(), resolved_offsets.len());
 
-        // Stage 2: pre-allocate one record per resolved point. The `vectors`
-        // slot is initialised here according to `with_vector`, so the
-        // `WithVector::Bool(false)` path needs no separate clearing pass.
+        // Stage 2: pre-allocate one record per point; `vectors` is `Some` only
+        // when requested, so the `WithVector::Bool(false)` path needs no cleanup.
         let needs_vectors = match with_vector {
             WithVector::Bool(true) | WithVector::Selector(_) => true,
             WithVector::Bool(false) => false,
         };
-        let mut records: AHashMap<ExtendedPointId, SegmentRecord> = resolved_ids
+        let mut records: AHashMap<ExtendedPointId, SegmentRecordGeneric<V>> = resolved_ids
             .iter()
             .map(|&id| {
-                let record = SegmentRecord {
+                let record = SegmentRecordGeneric {
                     id,
-                    vectors: needs_vectors.then(NamedVectorsOwned::default),
+                    vectors: needs_vectors.then(Vec::new),
                     payload: None,
                 };
                 (id, record)
             })
             .collect();
 
-        // Stage 3: vectors. The external id rides along as the read's user
-        // data — it comes back unchanged in the callback, so no extra
-        // `offset → id` lookup is needed.
+        // Stage 3: vectors, delegated to `read_name` per requested vector name.
         if needs_vectors {
             let mut process_vectors = |vector_name: &VectorNameBuf| -> OperationResult<()> {
-                let keys = resolved_ids
-                    .iter()
-                    .zip(&resolved_offsets)
-                    .map(|(&id, &offset)| (id, offset))
-                    .stop_if(is_stopped);
-                self.vectors_by_offsets(vector_name, keys, hw_counter, |id, _offset, vec| {
-                    if let Some(record) = records.get_mut(&id) {
-                        record
-                            .vectors
-                            .as_mut()
-                            .expect("needs_vectors path keeps vectors as Some")
-                            .push((vector_name.clone(), vec));
-                    }
-                })
+                read_name(
+                    vector_name,
+                    &resolved_ids,
+                    &resolved_offsets,
+                    &mut |id, value| {
+                        if let Some(record) = records.get_mut(&id) {
+                            record
+                                .vectors
+                                .as_mut()
+                                .expect("needs_vectors path keeps vectors as Some")
+                                .push((vector_name.clone(), value));
+                        }
+                    },
+                )
             };
 
             match with_vector {
@@ -104,10 +168,7 @@ where
             }
         }
 
-        // Stage 4: payload. Use the already-resolved offsets to skip another
-        // external→internal lookup per point. The per-iteration shape here
-        // mirrors what a future batched payload fetcher would consume —
-        // `&resolved_offsets` becomes its input directly.
+        // Stage 4: payload, reusing the already-resolved offsets.
         if with_payload.enable {
             let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
 

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -46,12 +46,7 @@ where
             is_stopped,
             deferred_behavior,
             hw_counter,
-            |vector_name, ids, offsets, push| {
-                let keys = ids
-                    .iter()
-                    .zip(offsets)
-                    .map(|(&id, &offset)| (id, offset))
-                    .stop_if(is_stopped);
+            |vector_name, keys, push| {
                 self.vectors_by_offsets(vector_name, keys, hw_counter, |id, _offset, vec| {
                     push(id, vec)
                 })
@@ -77,12 +72,7 @@ where
             is_stopped,
             deferred_behavior,
             hw_counter,
-            |vector_name, ids, offsets, push| {
-                let keys = ids
-                    .iter()
-                    .zip(offsets)
-                    .map(|(&id, &offset)| (id, offset))
-                    .stop_if(is_stopped);
+            |vector_name, keys, push| {
                 self.vector_bytes_by_offsets(vector_name, keys, hw_counter, |id, _offset, bytes| {
                     push(id, bytes)
                 })
@@ -92,8 +82,9 @@ where
 
     /// Shared body of [`Self::retrieve`] and [`Self::retrieve_raw`]; only the
     /// vector representation `V` and the storage read differ. `read_name` gets
-    /// each vector name, the resolved (id, offset) slices and a `push` sink for
-    /// the `(id, value)`s it reads — it owns the storage reader choice.
+    /// each vector name, the resolved `(id, offset)` keys (already wired to the
+    /// stop signal) and a `push` sink for the `(id, value)`s it reads — it owns
+    /// the storage reader choice.
     #[allow(clippy::too_many_arguments)]
     fn retrieve_generic<V>(
         &self,
@@ -105,8 +96,7 @@ where
         hw_counter: &HardwareCounterCell,
         mut read_name: impl FnMut(
             &VectorNameBuf,
-            &[ExtendedPointId],
-            &[PointOffsetType],
+            &mut dyn Iterator<Item = (ExtendedPointId, PointOffsetType)>,
             &mut dyn FnMut(ExtendedPointId, V),
         ) -> OperationResult<()>,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordGeneric<V>>> {
@@ -137,20 +127,20 @@ where
         // Stage 3: vectors, delegated to `read_name` per requested vector name.
         if needs_vectors {
             let mut process_vectors = |vector_name: &VectorNameBuf| -> OperationResult<()> {
-                read_name(
-                    vector_name,
-                    &resolved_ids,
-                    &resolved_offsets,
-                    &mut |id, value| {
-                        if let Some(record) = records.get_mut(&id) {
-                            record
-                                .vectors
-                                .as_mut()
-                                .expect("needs_vectors path keeps vectors as Some")
-                                .push((vector_name.clone(), value));
-                        }
-                    },
-                )
+                let mut keys = resolved_ids
+                    .iter()
+                    .zip(&resolved_offsets)
+                    .map(|(&id, &offset)| (id, offset))
+                    .stop_if(is_stopped);
+                read_name(vector_name, &mut keys, &mut |id, value| {
+                    if let Some(record) = records.get_mut(&id) {
+                        record
+                            .vectors
+                            .as_mut()
+                            .expect("needs_vectors path keeps vectors as Some")
+                            .push((vector_name.clone(), value));
+                    }
+                })
             };
 
             match with_vector {

--- a/lib/segment/src/segment/read_view/vectors.rs
+++ b/lib/segment/src/segment/read_view/vectors.rs
@@ -96,6 +96,56 @@ where
         Ok(())
     }
 
+    /// Byte-blob analogue of [`Self::vectors_by_offsets`]: yields each vector as
+    /// storage-native bytes (`Vec<u8>`) instead of a decoded [`VectorInternal`],
+    /// avoiding a lossy round-trip. Deleted vectors/points are skipped lazily.
+    pub fn vector_bytes_by_offsets<U: Copy + common::universal_io::UserData>(
+        &self,
+        vector_name: &VectorName,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        hw_counter: &HardwareCounterCell,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        check_vector_name(vector_name, self.segment_config)?;
+        let vector_data = self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
+        let vector_storage = vector_data.vector_storage();
+        let total_vectors = vector_storage.total_vector_count();
+        let id_tracker = self.id_tracker;
+
+        for (user_data, point_offset) in keys {
+            if total_vectors <= point_offset as usize {
+                debug_assert!(
+                    false,
+                    "Vector storage is inconsistent, total_vector_count: {total_vectors}, point_offset: {point_offset}, external_id: {:?}",
+                    id_tracker.external_id(point_offset),
+                );
+                continue;
+            }
+            if vector_storage.is_deleted_vector(point_offset)
+                || id_tracker.is_deleted_point(point_offset)
+            {
+                continue;
+            }
+
+            let bytes = vector_storage
+                .vector_bytes_opt::<Random>(point_offset)
+                .ok_or_else(|| {
+                    OperationError::service_error(format!(
+                        "Raw bytes are not available for vector {vector_name:?} at offset {point_offset}",
+                    ))
+                })?;
+            if vector_storage.is_on_disk() {
+                hw_counter.vector_io_read().incr_delta(bytes.len());
+            }
+            callback(user_data, point_offset, bytes);
+        }
+
+        Ok(())
+    }
+
     /// Retrieve a named vector for an external point ID.
     pub fn vector(
         &self,

--- a/lib/segment/src/segment/read_view/vectors.rs
+++ b/lib/segment/src/segment/read_view/vectors.rs
@@ -56,30 +56,8 @@ where
         hw_counter: &HardwareCounterCell,
         mut callback: impl FnMut(U, PointOffsetType, VectorInternal),
     ) -> OperationResult<()> {
-        check_vector_name(vector_name, self.segment_config)?;
-        let vector_data = self
-            .vector_data
-            .get(vector_name)
-            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
-        let vector_storage = vector_data.vector_storage();
-        let total_vectors = vector_storage.total_vector_count();
-
-        let id_tracker = self.id_tracker;
-        // The user-data tag rides alongside each offset, so the deletion
-        // filter stays lazy — no parallel `Vec<(orig_idx, offset)>` needed.
-        let live_keys = keys.into_iter().filter(|&(_, point_offset)| {
-            if total_vectors <= point_offset as usize {
-                debug_assert!(
-                    false,
-                    "Vector storage is inconsistent, total_vector_count: {total_vectors}, point_offset: {point_offset}, external_id: {:?}",
-                    id_tracker.external_id(point_offset),
-                );
-                return false;
-            }
-            let is_vector_deleted = vector_storage.is_deleted_vector(point_offset);
-            let is_point_deleted = id_tracker.is_deleted_point(point_offset);
-            !is_vector_deleted && !is_point_deleted
-        });
+        let vector_storage = self.vector_storage_for(vector_name)?;
+        let live_keys = self.filter_live_keys(&*vector_storage, keys);
 
         vector_storage.read_vectors::<Random, U>(
             live_keys,
@@ -98,7 +76,9 @@ where
 
     /// Byte-blob analogue of [`Self::vectors_by_offsets`]: yields each vector as
     /// storage-native bytes (`Vec<u8>`) instead of a decoded [`VectorInternal`],
-    /// avoiding a lossy round-trip. Deleted vectors/points are skipped lazily.
+    /// avoiding a lossy round-trip. Deleted vectors/points and offsets without
+    /// a stored value are skipped lazily, like in the decoded twin; storage
+    /// read failures propagate as errors.
     pub fn vector_bytes_by_offsets<U: Copy + common::universal_io::UserData>(
         &self,
         vector_name: &VectorName,
@@ -106,37 +86,17 @@ where
         hw_counter: &HardwareCounterCell,
         mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
     ) -> OperationResult<()> {
-        check_vector_name(vector_name, self.segment_config)?;
-        let vector_data = self
-            .vector_data
-            .get(vector_name)
-            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
-        let vector_storage = vector_data.vector_storage();
-        let total_vectors = vector_storage.total_vector_count();
-        let id_tracker = self.id_tracker;
+        let vector_storage = self.vector_storage_for(vector_name)?;
 
-        for (user_data, point_offset) in keys {
-            if total_vectors <= point_offset as usize {
-                debug_assert!(
-                    false,
-                    "Vector storage is inconsistent, total_vector_count: {total_vectors}, point_offset: {point_offset}, external_id: {:?}",
-                    id_tracker.external_id(point_offset),
-                );
+        // TODO(tqdt): this issues one blocking read per offset, unlike the
+        // decoded path which pipelines reads (io_uring) via `read_vectors`.
+        // Batch the raw reads too before relying on this for bulk relocation.
+        for (user_data, point_offset) in self.filter_live_keys(&*vector_storage, keys) {
+            let Some(bytes) = vector_storage.vector_bytes_opt::<Random>(point_offset)? else {
+                // No stored value for a live offset (e.g. empty placeholder
+                // storage) — skip it, mirroring `vectors_by_offsets`.
                 continue;
-            }
-            if vector_storage.is_deleted_vector(point_offset)
-                || id_tracker.is_deleted_point(point_offset)
-            {
-                continue;
-            }
-
-            let bytes = vector_storage
-                .vector_bytes_opt::<Random>(point_offset)
-                .ok_or_else(|| {
-                    OperationError::service_error(format!(
-                        "Raw bytes are not available for vector {vector_name:?} at offset {point_offset}",
-                    ))
-                })?;
+            };
             if vector_storage.is_on_disk() {
                 hw_counter.vector_io_read().incr_delta(bytes.len());
             }
@@ -144,6 +104,43 @@ where
         }
 
         Ok(())
+    }
+
+    /// Resolve the vector storage for a named vector, validating the name.
+    fn vector_storage_for(&self, vector_name: &VectorName) -> OperationResult<TVD::StorageRef<'_>> {
+        check_vector_name(vector_name, self.segment_config)?;
+        let vector_data = self
+            .vector_data
+            .get(vector_name)
+            .ok_or_else(|| OperationError::vector_name_not_exists(vector_name))?;
+        Ok(vector_data.vector_storage())
+    }
+
+    /// Shared liveness filter of [`Self::vectors_by_offsets`] and
+    /// [`Self::vector_bytes_by_offsets`]: lazily drops out-of-bounds offsets
+    /// (with a debug assert) and offsets whose vector or point is deleted.
+    /// The user-data tag rides alongside each offset, so no parallel
+    /// `Vec<(orig_idx, offset)>` is needed.
+    fn filter_live_keys<'a, U: Copy, S: VectorStorageRead + ?Sized>(
+        &'a self,
+        vector_storage: &'a S,
+        keys: impl IntoIterator<Item = (U, PointOffsetType), IntoIter: 'a>,
+    ) -> impl Iterator<Item = (U, PointOffsetType)> + 'a {
+        let total_vectors = vector_storage.total_vector_count();
+        let id_tracker = self.id_tracker;
+        keys.into_iter().filter(move |&(_, point_offset)| {
+            if total_vectors <= point_offset as usize {
+                debug_assert!(
+                    false,
+                    "Vector storage is inconsistent, total_vector_count: {total_vectors}, point_offset: {point_offset}, external_id: {:?}",
+                    id_tracker.external_id(point_offset),
+                );
+                return false;
+            }
+            let is_vector_deleted = vector_storage.is_deleted_vector(point_offset);
+            let is_point_deleted = id_tracker.is_deleted_point(point_offset);
+            !is_vector_deleted && !is_point_deleted
+        })
     }
 
     /// Retrieve a named vector for an external point ID.

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -28,7 +28,8 @@ use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::OrderBy;
 use crate::data_types::query_context::QueryContext;
 use crate::data_types::vectors::{
-    DEFAULT_VECTOR_NAME, QueryVector, VectorInternal, VectorRef, only_default_vector,
+    DEFAULT_VECTOR_NAME, MultiDenseVectorInternal, QueryVector, VectorInternal, VectorRef,
+    only_default_multi_vector, only_default_vector,
 };
 use crate::entry::entry_point::{
     NonAppendableSegmentEntry as _, ReadSegmentEntry as _, SegmentEntry as _,
@@ -43,9 +44,9 @@ use crate::segment_constructor::simple_segment_constructor::{
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{
     Condition, Distance, ExtendedPointId, FieldCondition, Filter, HasIdCondition, Indexes, Match,
-    Payload, PayloadContainer, PayloadFieldSchema, PayloadSchemaType, PointIdType, SearchParams,
-    SnapshotFormat, SparseVectorDataConfig, SparseVectorStorageType, ValueVariants,
-    VectorDataConfig, VectorStorageType, WithPayload, WithVector,
+    MultiVectorConfig, Payload, PayloadContainer, PayloadFieldSchema, PayloadSchemaType,
+    PointIdType, SearchParams, SnapshotFormat, SparseVectorDataConfig, SparseVectorStorageType,
+    ValueVariants, VectorDataConfig, VectorStorageType, WithPayload, WithVector,
 };
 use crate::utils::maybe_arc::MaybeArc;
 use crate::vector_storage::query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery};
@@ -592,27 +593,47 @@ fn test_retrieve_raw_dense_bytes() {
     assert_eq!(bytes.as_slice(), expected);
 }
 
-/// `retrieve_raw` over a multi-dense storage must return the flattened inner
-/// vectors as raw bytes for each named vector.
+/// `retrieve_raw` over a multi-dense (ColBERT-style) storage must return the
+/// flattened inner vectors as raw bytes; the inner count is derived from the
+/// byte length, so the blob must cover all inner vectors, not just the first.
 #[test]
 fn test_retrieve_raw_multivec_bytes() {
     init_logger();
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let dim = 1;
+    let dim = 3;
 
-    let mut segment = build_multivec_segment(dir.path(), dim, dim, Distance::Dot).unwrap();
+    let (mut segment, _) = build_segment(
+        dir.path(),
+        &SegmentConfig {
+            vector_data: HashMap::from([(
+                DEFAULT_VECTOR_NAME.to_owned(),
+                VectorDataConfig {
+                    size: dim,
+                    distance: Distance::Dot,
+                    storage_type: VectorStorageType::default(),
+                    index: Indexes::Plain {},
+                    quantization_config: None,
+                    multivector_config: Some(MultiVectorConfig::default()),
+                    datatype: None,
+                },
+            )]),
+            sparse_vector_data: Default::default(),
+            payload_storage_type: Default::default(),
+        },
+        None,
+        true,
+    )
+    .unwrap();
     let hw_counter = HardwareCounterCell::new();
 
-    let v1 = vec![0.4_f32];
-    let v2 = vec![0.5_f32];
+    // Two inner vectors of `dim` elements each, flattened.
+    let flattened = vec![0.1_f32, 0.2, 0.3, 0.4, 0.5, 0.6];
+    let multi_vec = MultiDenseVectorInternal::new(flattened.clone(), dim);
     segment
         .upsert_point(
             100,
             4.into(),
-            NamedVectors::from_pairs([
-                (VECTOR1_NAME.into(), v1.clone()),
-                (VECTOR2_NAME.into(), v2.clone()),
-            ]),
+            only_default_multi_vector(&multi_vec),
             &hw_counter,
         )
         .unwrap();
@@ -631,15 +652,13 @@ fn test_retrieve_raw_multivec_bytes() {
 
     let record = raw.get(&4.into()).expect("point 4 must be retrieved");
     let vectors = record.vectors.as_ref().expect("vectors requested");
+    let (_, bytes) = vectors
+        .iter()
+        .find(|(name, _)| name == DEFAULT_VECTOR_NAME)
+        .expect("default vector must be present");
 
-    for (name, expected) in [(VECTOR1_NAME, &v1), (VECTOR2_NAME, &v2)] {
-        let (_, bytes) = vectors
-            .iter()
-            .find(|(n, _)| n == name)
-            .unwrap_or_else(|| panic!("vector {name} must be present"));
-        let expected_bytes: &[u8] = bytemuck::cast_slice(expected);
-        assert_eq!(bytes.as_slice(), expected_bytes, "mismatch for {name}");
-    }
+    let expected: &[u8] = bytemuck::cast_slice(&flattened);
+    assert_eq!(bytes.as_slice(), expected);
 }
 
 /// `retrieve_raw` over a sparse storage must return the on-disk

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -553,6 +553,160 @@ fn test_point_vector_count_multivec() {
     assert_eq!(segment_info.num_vectors, 6);
 }
 
+/// `retrieve_raw` on a plain dense segment must return the verbatim f32 bytes
+/// of the stored vector (zero-copy `bytemuck` cast), with payload untouched.
+#[test]
+fn test_retrieve_raw_dense_bytes() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dim = 4;
+
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec = vec![0.1_f32, 0.2, 0.3, 0.4];
+    segment
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+
+    let is_stopped = AtomicBool::new(false);
+    let raw = segment
+        .retrieve_raw(
+            &[7.into()],
+            &WithPayload::default(),
+            &true.into(),
+            &hw_counter,
+            &is_stopped,
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+
+    let record = raw.get(&7.into()).expect("point 7 must be retrieved");
+    let vectors = record.vectors.as_ref().expect("vectors requested");
+    let (_, bytes) = vectors
+        .iter()
+        .find(|(name, _)| name == DEFAULT_VECTOR_NAME)
+        .expect("default vector must be present");
+
+    let expected: &[u8] = bytemuck::cast_slice(&vec);
+    assert_eq!(bytes.as_slice(), expected);
+}
+
+/// `retrieve_raw` over a multi-dense storage must return the flattened inner
+/// vectors as raw bytes for each named vector.
+#[test]
+fn test_retrieve_raw_multivec_bytes() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dim = 1;
+
+    let mut segment = build_multivec_segment(dir.path(), dim, dim, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let v1 = vec![0.4_f32];
+    let v2 = vec![0.5_f32];
+    segment
+        .upsert_point(
+            100,
+            4.into(),
+            NamedVectors::from_pairs([
+                (VECTOR1_NAME.into(), v1.clone()),
+                (VECTOR2_NAME.into(), v2.clone()),
+            ]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let is_stopped = AtomicBool::new(false);
+    let raw = segment
+        .retrieve_raw(
+            &[4.into()],
+            &WithPayload::default(),
+            &true.into(),
+            &hw_counter,
+            &is_stopped,
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+
+    let record = raw.get(&4.into()).expect("point 4 must be retrieved");
+    let vectors = record.vectors.as_ref().expect("vectors requested");
+
+    for (name, expected) in [(VECTOR1_NAME, &v1), (VECTOR2_NAME, &v2)] {
+        let (_, bytes) = vectors
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("vector {name} must be present"));
+        let expected_bytes: &[u8] = bytemuck::cast_slice(expected);
+        assert_eq!(bytes.as_slice(), expected_bytes, "mismatch for {name}");
+    }
+}
+
+/// `retrieve_raw` over a sparse storage must return the on-disk
+/// `StoredSparseVector` bincode form, which decodes back to the original vector.
+#[test]
+fn test_retrieve_raw_sparse_bytes() {
+    use gridstore::Blob;
+
+    use crate::vector_storage::sparse::StoredSparseVector;
+
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let sparse_name = "sparse";
+    let (mut segment, _) = build_segment(
+        dir.path(),
+        &SegmentConfig {
+            vector_data: HashMap::new(),
+            sparse_vector_data: HashMap::from_iter([(
+                sparse_name.to_string(),
+                SparseVectorDataConfig {
+                    index: SparseIndexConfig::new(Some(1), SparseIndexType::MutableRam, None),
+                    storage_type: SparseVectorStorageType::Mmap,
+                    modifier: None,
+                },
+            )]),
+            payload_storage_type: Default::default(),
+        },
+        None,
+        true,
+    )
+    .unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    let sparse = SparseVector::new(vec![1, 5, 42], vec![0.5, 1.5, 2.5]).unwrap();
+    let mut vectors = NamedVectors::default();
+    vectors.insert(
+        sparse_name.to_string(),
+        VectorInternal::Sparse(sparse.clone()),
+    );
+    segment
+        .upsert_point(100, 7.into(), vectors, &hw_counter)
+        .unwrap();
+
+    let is_stopped = AtomicBool::new(false);
+    let raw = segment
+        .retrieve_raw(
+            &[7.into()],
+            &WithPayload::default(),
+            &true.into(),
+            &hw_counter,
+            &is_stopped,
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+
+    let record = raw.get(&7.into()).expect("point 7 must be retrieved");
+    let vectors = record.vectors.as_ref().expect("vectors requested");
+    let (_, bytes) = vectors
+        .iter()
+        .find(|(name, _)| name == sparse_name)
+        .expect("sparse vector must be present");
+
+    let decoded = SparseVector::try_from(StoredSparseVector::from_bytes(bytes)).unwrap();
+    assert_eq!(decoded, sparse);
+}
+
 /// Tests segment functions to ensure invalid requests do error
 #[test]
 fn test_vector_compatibility_checks() {

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -4,9 +4,12 @@ use common::types::PointOffsetType;
 use common::universal_io::{UniversalRead, UserData};
 
 use super::VectorStorageReadEnum;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::VectorStorageRead;
+use crate::vector_storage::{
+    DenseVectorStorageRead, MultiVectorStorageRead, SparseVectorStorageRead, VectorStorageRead,
+};
 
 impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
@@ -183,6 +186,57 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_bitslice(),
+        }
+    }
+
+    fn with_vector_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> OperationResult<Option<R>> {
+        match self {
+            VectorStorageReadEnum::Dense(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseByte(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseHalf(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseChunked(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseChunkedByte(s) => {
+                Ok(s.with_dense_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::DenseChunkedHalf(s) => {
+                Ok(s.with_dense_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::MultiDenseChunked(s) => {
+                Ok(s.with_multi_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                Ok(s.with_multi_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                Ok(s.with_multi_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::Sparse(s) => s.with_sparse_bytes_opt::<P, R>(key, f),
+        }
+    }
+
+    fn vector_bytes_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> OperationResult<Option<Vec<u8>>> {
+        match self {
+            // Sparse already allocates on serialize — return it without a copy.
+            VectorStorageReadEnum::Sparse(s) => s.sparse_bytes_opt::<P>(key),
+            // Others expose borrowed bytes; one copy out is unavoidable.
+            VectorStorageReadEnum::Dense(_)
+            | VectorStorageReadEnum::DenseByte(_)
+            | VectorStorageReadEnum::DenseHalf(_)
+            | VectorStorageReadEnum::DenseChunked(_)
+            | VectorStorageReadEnum::DenseChunkedByte(_)
+            | VectorStorageReadEnum::DenseChunkedHalf(_)
+            | VectorStorageReadEnum::MultiDenseChunked(_)
+            | VectorStorageReadEnum::MultiDenseChunkedByte(_)
+            | VectorStorageReadEnum::MultiDenseChunkedHalf(_) => {
+                self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
+            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/sparse/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/mod.rs
@@ -4,6 +4,8 @@ pub mod read_only;
 mod stored_sparse_vectors;
 pub mod volatile_sparse_vector_storage;
 
+pub(crate) use stored_sparse_vectors::StoredSparseVector;
+
 use crate::types::Distance;
 
 pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -776,9 +776,6 @@ impl VectorStorageRead for VectorStorageEnum {
             | VectorStorageEnum::DenseMemmap(_)
             | VectorStorageEnum::DenseMemmapByte(_)
             | VectorStorageEnum::DenseMemmapHalf(_)
-            | VectorStorageEnum::DenseUring(_)
-            | VectorStorageEnum::DenseUringByte(_)
-            | VectorStorageEnum::DenseUringHalf(_)
             | VectorStorageEnum::DenseAppendableMemmap(_)
             | VectorStorageEnum::DenseAppendableMemmapByte(_)
             | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -797,6 +794,12 @@ impl VectorStorageRead for VectorStorageEnum {
             | VectorStorageEnum::DenseVolatileHalf(_)
             | VectorStorageEnum::MultiDenseVolatileByte(_)
             | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+                self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
+            }
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(_)
+            | VectorStorageEnum::DenseUringByte(_)
+            | VectorStorageEnum::DenseUringHalf(_) => {
                 self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
             }
         }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -143,19 +143,27 @@ pub trait VectorStorageRead {
     /// Size of all available (non-deleted) vectors in bytes.
     fn size_of_available_vectors_in_bytes(&self) -> usize;
 
-    /// Call `f` with the storage-native serialized bytes of the vector, if any.
+    /// Call `f` with the storage-native serialized bytes of the vector.
+    /// `Ok(None)` means the storage has no value for this key.
     ///
-    /// Default returns `None`; [`VectorStorageEnum`] dispatches to the concrete
-    /// dense / sparse / multi byte readers. The format is storage-native (raw
-    /// elements, TurboQuant bytes, or bincoded sparse) and carries no
+    /// Only [`VectorStorageEnum`] implements this, dispatching to the concrete
+    /// dense / sparse / multi byte readers; calling it on any other storage
+    /// type is a bug and returns a service error. The format is storage-native
+    /// (raw elements, TurboQuant bytes, or bincoded sparse) and carries no
     /// encoding/version tag, so it round-trips only into a matching storage.
     fn with_vector_bytes_opt<P: AccessPattern, R>(
         &self,
         key: PointOffsetType,
         f: impl FnOnce(&[u8]) -> R,
-    ) -> Option<R> {
+    ) -> OperationResult<Option<R>> {
         let _ = (key, f);
-        None
+        debug_assert!(
+            false,
+            "with_vector_bytes_opt is only dispatched by VectorStorageEnum",
+        );
+        Err(OperationError::service_error(
+            "Raw vector bytes are not implemented for this storage",
+        ))
     }
 
     /// Owned counterpart of [`VectorStorageRead::with_vector_bytes_opt`], for
@@ -163,7 +171,10 @@ pub trait VectorStorageRead {
     ///
     /// Default copies the borrowed bytes once; [`VectorStorageEnum`] returns the
     /// already-owned sparse buffer directly to skip a redundant copy.
-    fn vector_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
+    fn vector_bytes_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> OperationResult<Option<Vec<u8>>> {
         self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
     }
 }
@@ -275,9 +286,14 @@ pub trait SparseVectorStorageRead: VectorStorageRead {
     /// [`StoredSparseVector`] form. Never zero-copy: re-encoding allocates the
     /// returned buffer. Prefer this over [`Self::with_sparse_bytes_opt`] when an
     /// owned `Vec<u8>` is needed, to skip an extra copy.
-    fn sparse_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
-        let sparse = self.get_sparse_opt::<P>(key).ok().flatten()?;
-        Some(StoredSparseVector::from(&sparse).to_bytes())
+    fn sparse_bytes_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> OperationResult<Option<Vec<u8>>> {
+        let Some(sparse) = self.get_sparse_opt::<P>(key)? else {
+            return Ok(None);
+        };
+        Ok(Some(StoredSparseVector::from(&sparse).to_bytes()))
     }
 
     /// Borrow-based form of [`Self::sparse_bytes_opt`].
@@ -285,8 +301,8 @@ pub trait SparseVectorStorageRead: VectorStorageRead {
         &self,
         key: PointOffsetType,
         f: impl FnOnce(&[u8]) -> R,
-    ) -> Option<R> {
-        self.sparse_bytes_opt::<P>(key).map(|bytes| f(&bytes))
+    ) -> OperationResult<Option<R>> {
+        Ok(self.sparse_bytes_opt::<P>(key)?.map(|bytes| f(&bytes)))
     }
 }
 
@@ -718,55 +734,64 @@ impl VectorStorageRead for VectorStorageEnum {
         &self,
         key: PointOffsetType,
         f: impl FnOnce(&[u8]) -> R,
-    ) -> Option<R> {
+    ) -> OperationResult<Option<R>> {
         match self {
-            VectorStorageEnum::DenseVolatile(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseVolatile(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseVolatileByte(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmapByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseVolatileHalf(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseMemmap(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseMemmapByte(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseMemmapHalf(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
 
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseUring(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseUringByte(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseUringHalf(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
 
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseAppendableMemmap(v) => {
+                Ok(v.with_dense_bytes_opt::<P, R>(key, f))
+            }
             VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.with_dense_bytes_opt::<P, R>(key, f)
+                Ok(v.with_dense_bytes_opt::<P, R>(key, f))
             }
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.with_dense_bytes_opt::<P, R>(key, f)
+                Ok(v.with_dense_bytes_opt::<P, R>(key, f))
             }
-            VectorStorageEnum::DenseTurbo(v) => v.with_dense_tq_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseTurbo(v) => Ok(v.with_dense_tq_bytes_opt::<P, R>(key, f)),
             VectorStorageEnum::SparseVolatile(v) => v.with_sparse_bytes_opt::<P, R>(key, f),
             VectorStorageEnum::SparseMmap(v) => v.with_sparse_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::MultiDenseVolatile(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::MultiDenseVolatile(v) => Ok(v.with_multi_bytes_opt::<P, R>(key, f)),
             #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::MultiDenseVolatileByte(v) => {
+                Ok(v.with_multi_bytes_opt::<P, R>(key, f))
+            }
             #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => {
+                Ok(v.with_multi_bytes_opt::<P, R>(key, f))
+            }
             VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
-                v.with_multi_bytes_opt::<P, R>(key, f)
+                Ok(v.with_multi_bytes_opt::<P, R>(key, f))
             }
             VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
-                v.with_multi_bytes_opt::<P, R>(key, f)
+                Ok(v.with_multi_bytes_opt::<P, R>(key, f))
             }
             VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
-                v.with_multi_bytes_opt::<P, R>(key, f)
+                Ok(v.with_multi_bytes_opt::<P, R>(key, f))
             }
-            VectorStorageEnum::MultiDenseTurbo(v) => v.with_multi_tq_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::EmptyDense(_) => None,
-            VectorStorageEnum::EmptySparse(_) => None,
+            VectorStorageEnum::MultiDenseTurbo(v) => Ok(v.with_multi_tq_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::EmptyDense(_) => Ok(None),
+            VectorStorageEnum::EmptySparse(_) => Ok(None),
         }
     }
 
-    fn vector_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
+    fn vector_bytes_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> OperationResult<Option<Vec<u8>>> {
         match self {
             // Sparse already allocates on serialize — return it without a copy.
             VectorStorageEnum::SparseVolatile(v) => v.sparse_bytes_opt::<P>(key),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -12,6 +12,7 @@ use common::types::PointOffsetType;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
 use common::universal_io::UserData;
+use gridstore::Blob;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::dense::dense_vector_storage::DenseVectorStorageImpl;
@@ -19,6 +20,7 @@ use super::dense::empty_dense_vector_storage::EmptyDenseVectorStorage;
 use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::AppendableMmapMultiDenseVectorStorage;
 use super::multi_dense::volatile_multi_dense_vector_storage::VolatileMultiDenseVectorStorage;
+use super::sparse::StoredSparseVector;
 use super::sparse::empty_sparse_vector_storage::EmptySparseVectorStorage;
 use super::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use super::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
@@ -140,6 +142,30 @@ pub trait VectorStorageRead {
 
     /// Size of all available (non-deleted) vectors in bytes.
     fn size_of_available_vectors_in_bytes(&self) -> usize;
+
+    /// Call `f` with the storage-native serialized bytes of the vector, if any.
+    ///
+    /// Default returns `None`; [`VectorStorageEnum`] dispatches to the concrete
+    /// dense / sparse / multi byte readers. The format is storage-native (raw
+    /// elements, TurboQuant bytes, or bincoded sparse) and carries no
+    /// encoding/version tag, so it round-trips only into a matching storage.
+    fn with_vector_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        let _ = (key, f);
+        None
+    }
+
+    /// Owned counterpart of [`VectorStorageRead::with_vector_bytes_opt`], for
+    /// callers that need a `Vec<u8>` (e.g. `retrieve_raw`).
+    ///
+    /// Default copies the borrowed bytes once; [`VectorStorageEnum`] returns the
+    /// already-owned sparse buffer directly to skip a redundant copy.
+    fn vector_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
+        self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
+    }
 }
 
 /// Trait for vector storage with mutating operations.
@@ -244,6 +270,24 @@ pub trait SparseVectorStorageRead: VectorStorageRead {
     ) -> OperationResult<()>
     where
         F: FnMut(usize, SparseVector);
+
+    /// Serialized sparse vector bytes, in the lossless on-disk
+    /// [`StoredSparseVector`] form. Never zero-copy: re-encoding allocates the
+    /// returned buffer. Prefer this over [`Self::with_sparse_bytes_opt`] when an
+    /// owned `Vec<u8>` is needed, to skip an extra copy.
+    fn sparse_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
+        let sparse = self.get_sparse_opt::<P>(key).ok().flatten()?;
+        Some(StoredSparseVector::from(&sparse).to_bytes())
+    }
+
+    /// Borrow-based form of [`Self::sparse_bytes_opt`].
+    fn with_sparse_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        self.sparse_bytes_opt::<P>(key).map(|bytes| f(&bytes))
+    }
 }
 
 pub trait SparseVectorStorage: SparseVectorStorageRead {
@@ -278,6 +322,17 @@ pub trait MultiVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
 
     fn iterate_inner_vectors(&self) -> impl Iterator<Item = Cow<'_, [T]>> + Clone + Send;
     fn multi_vector_config(&self) -> &MultiVectorConfig;
+
+    /// Call `f` with the raw bytes of the flattened inner vectors, if any.
+    /// Inner-vector count = `len() / (vector_dim() * size_of::<T>())`.
+    fn with_multi_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        let multi = self.get_multi_opt::<P>(key)?;
+        Some(f(bytemuck::cast_slice(multi.as_ref().flattened_vectors)))
+    }
 }
 
 pub trait MultiVectorStorage<T: PrimitiveVectorElement>: MultiVectorStorageRead<T> {
@@ -375,6 +430,19 @@ pub trait MultiTQVectorStorage: VectorStorageRead {
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>>;
+
+    /// Call `f` with the concatenated encoded inner vectors, if any.
+    /// Inner-vector count = `len() / quantized_vector_size()`.
+    fn with_multi_tq_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        ((key as usize) < self.total_vector_count()).then(|| {
+            let multi_tq = self.get_multi_tq::<P>(key);
+            f(&multi_tq)
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -602,53 +670,6 @@ impl VectorStorageEnum {
         Ok(())
     }
 
-    /// Call `f` with the raw bytes of the vector if it exists.
-    pub fn with_vector_bytes_opt<P: AccessPattern, R>(
-        &self,
-        key: PointOffsetType,
-        f: impl FnOnce(&[u8]) -> R,
-    ) -> Option<R> {
-        match self {
-            VectorStorageEnum::DenseVolatile(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmapByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-
-            VectorStorageEnum::DenseAppendableMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.with_dense_bytes_opt::<P, R>(key, f)
-            }
-            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.with_dense_bytes_opt::<P, R>(key, f)
-            }
-            VectorStorageEnum::DenseTurbo(v) => v.with_dense_tq_bytes_opt::<P, R>(key, f),
-            VectorStorageEnum::SparseVolatile(_) => None,
-            VectorStorageEnum::SparseMmap(_) => None,
-            VectorStorageEnum::MultiDenseVolatile(_) => None,
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(_) => None,
-            #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileHalf(_) => None,
-            VectorStorageEnum::MultiDenseAppendableMemmap(_) => None,
-            VectorStorageEnum::MultiDenseAppendableMemmapByte(_) => None,
-            VectorStorageEnum::MultiDenseAppendableMemmapHalf(_) => None,
-            VectorStorageEnum::MultiDenseTurbo(_) => None,
-            VectorStorageEnum::EmptyDense(_) => None,
-            VectorStorageEnum::EmptySparse(_) => None,
-        }
-    }
-
     /// Get layout for a single vector
     pub fn get_vector_layout(&self) -> OperationResult<Layout> {
         match self {
@@ -693,6 +714,94 @@ impl VectorStorageEnum {
 }
 
 impl VectorStorageRead for VectorStorageEnum {
+    fn with_vector_bytes_opt<P: AccessPattern, R>(
+        &self,
+        key: PointOffsetType,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmapByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.with_dense_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                v.with_dense_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                v.with_dense_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::DenseTurbo(v) => v.with_dense_tq_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::SparseVolatile(v) => v.with_sparse_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::SparseMmap(v) => v.with_sparse_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.with_multi_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.with_multi_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.with_multi_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.with_multi_bytes_opt::<P, R>(key, f)
+            }
+            VectorStorageEnum::MultiDenseTurbo(v) => v.with_multi_tq_bytes_opt::<P, R>(key, f),
+            VectorStorageEnum::EmptyDense(_) => None,
+            VectorStorageEnum::EmptySparse(_) => None,
+        }
+    }
+
+    fn vector_bytes_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Vec<u8>> {
+        match self {
+            // Sparse already allocates on serialize — return it without a copy.
+            VectorStorageEnum::SparseVolatile(v) => v.sparse_bytes_opt::<P>(key),
+            VectorStorageEnum::SparseMmap(v) => v.sparse_bytes_opt::<P>(key),
+            // Others expose borrowed bytes; one copy out is unavoidable.
+            VectorStorageEnum::DenseVolatile(_)
+            | VectorStorageEnum::DenseMemmap(_)
+            | VectorStorageEnum::DenseMemmapByte(_)
+            | VectorStorageEnum::DenseMemmapHalf(_)
+            | VectorStorageEnum::DenseUring(_)
+            | VectorStorageEnum::DenseUringByte(_)
+            | VectorStorageEnum::DenseUringHalf(_)
+            | VectorStorageEnum::DenseAppendableMemmap(_)
+            | VectorStorageEnum::DenseAppendableMemmapByte(_)
+            | VectorStorageEnum::DenseAppendableMemmapHalf(_)
+            | VectorStorageEnum::DenseTurbo(_)
+            | VectorStorageEnum::MultiDenseVolatile(_)
+            | VectorStorageEnum::MultiDenseAppendableMemmap(_)
+            | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
+            | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
+            | VectorStorageEnum::MultiDenseTurbo(_)
+            | VectorStorageEnum::EmptyDense(_)
+            | VectorStorageEnum::EmptySparse(_) => {
+                self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(_)
+            | VectorStorageEnum::DenseVolatileHalf(_)
+            | VectorStorageEnum::MultiDenseVolatileByte(_)
+            | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
+                self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
+            }
+        }
+    }
+
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         match self {
             VectorStorageEnum::DenseVolatile(v) => v.size_of_available_vectors_in_bytes(),

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -28,6 +28,28 @@ use uuid::Uuid;
 use super::{ProxyDeletedPoint, ProxyIndexChange, ProxySegment};
 use crate::locked_segment::LockedSegment;
 
+impl ProxySegment {
+    /// Shared preamble of `retrieve` and `retrieve_raw`: strip any vector
+    /// names that the proxy intends to delete or replace with a different
+    /// schema, and drop proxy-deleted points, before delegating to the
+    /// wrapped segment.
+    fn redact_and_filter_for_retrieve<'a>(
+        &self,
+        with_vector: &'a WithVector,
+        point_ids: &[PointIdType],
+    ) -> (std::borrow::Cow<'a, WithVector>, Vec<PointIdType>) {
+        let with_vector = self
+            .changed_vector_names
+            .redact_with_vector(with_vector, &self.wrapped_config);
+        let filtered_point_ids = point_ids
+            .iter()
+            .copied()
+            .filter(|id| !self.deleted_points.contains_key(id))
+            .collect();
+        (with_vector, filtered_point_ids)
+    }
+}
+
 impl ReadSegmentEntry for ProxySegment {
     fn is_proxy(&self) -> bool {
         true
@@ -279,22 +301,12 @@ impl ReadSegmentEntry for ProxySegment {
         is_stopped: &AtomicBool,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
-        // Strip any vector names that the proxy intends to delete or replace
-        // with a different schema before delegating to the wrapped segment.
-        let with_vector = self
-            .changed_vector_names
-            .redact_with_vector(with_vector, &self.wrapped_config);
-        let with_vector = with_vector.as_ref();
-
-        let filtered_point_ids: Vec<PointIdType> = point_ids
-            .iter()
-            .copied()
-            .filter(|id| !self.deleted_points.contains_key(id))
-            .collect();
+        let (with_vector, filtered_point_ids) =
+            self.redact_and_filter_for_retrieve(with_vector, point_ids);
         self.wrapped_segment.get().read().retrieve(
             &filtered_point_ids,
             with_payload,
-            with_vector,
+            with_vector.as_ref(),
             hw_counter,
             is_stopped,
             deferred_behavior,
@@ -310,22 +322,12 @@ impl ReadSegmentEntry for ProxySegment {
         is_stopped: &AtomicBool,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>> {
-        // Mirrors `retrieve`: strip redacted vector names, drop proxy-deleted
-        // points, then delegate to the wrapped segment.
-        let with_vector = self
-            .changed_vector_names
-            .redact_with_vector(with_vector, &self.wrapped_config);
-        let with_vector = with_vector.as_ref();
-
-        let filtered_point_ids: Vec<PointIdType> = point_ids
-            .iter()
-            .copied()
-            .filter(|id| !self.deleted_points.contains_key(id))
-            .collect();
+        let (with_vector, filtered_point_ids) =
+            self.redact_and_filter_for_retrieve(with_vector, point_ids);
         self.wrapped_segment.get().read().retrieve_raw(
             &filtered_point_ids,
             with_payload,
-            with_vector,
+            with_vector.as_ref(),
             hw_counter,
             is_stopped,
             deferred_behavior,

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -14,7 +14,7 @@ use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_record::SegmentRecord;
+use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use segment::data_types::vector_name_config::VectorNameConfig;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::StorageSegmentEntry;
@@ -292,6 +292,37 @@ impl ReadSegmentEntry for ProxySegment {
             .filter(|id| !self.deleted_points.contains_key(id))
             .collect();
         self.wrapped_segment.get().read().retrieve(
+            &filtered_point_ids,
+            with_payload,
+            with_vector,
+            hw_counter,
+            is_stopped,
+            deferred_behavior,
+        )
+    }
+
+    fn retrieve_raw(
+        &self,
+        point_ids: &[PointIdType],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+        deferred_behavior: DeferredBehavior,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>> {
+        // Mirrors `retrieve`: strip redacted vector names, drop proxy-deleted
+        // points, then delegate to the wrapped segment.
+        let with_vector = self
+            .changed_vector_names
+            .redact_with_vector(with_vector, &self.wrapped_config);
+        let with_vector = with_vector.as_ref();
+
+        let filtered_point_ids: Vec<PointIdType> = point_ids
+            .iter()
+            .copied()
+            .filter(|id| !self.deleted_points.contains_key(id))
+            .collect();
+        self.wrapped_segment.get().read().retrieve_raw(
             &filtered_point_ids,
             with_payload,
             with_vector,


### PR DESCRIPTION
This PR is a starting point of the roundtrip problem milestone: https://app.notion.com/p/qdrant/TQDT-round-trip-bug-design-doc-383674779d3380d5aee1df8ac1fe9a88

As a first step of the milestone, this PR adds a new method in `SegmentEntry` which is a full analogue of `SegmentEntry::retrieve`, but returns a serialized vector:

```
    // EXISTING METHOD
    fn retrieve(
        &self,
        point_ids: &[PointIdType],
        with_payload: &WithPayload,
        with_vector: &WithVector,
        hw_counter: &HardwareCounterCell,
        is_stopped: &AtomicBool,
        deferred_behavior: DeferredBehavior,
    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>;

    // RAW VARIANT
    fn retrieve_raw(
        &self,
        point_ids: &[PointIdType],
        with_payload: &WithPayload,
        with_vector: &WithVector,
        hw_counter: &HardwareCounterCell,
        is_stopped: &AtomicBool,
        deferred_behavior: DeferredBehavior,
    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecordRaw>>;
```

It works the same as retrieve, common logic is moved into `SegmentReadView::retrieve_generic` which is vector-type agnostic.

Unit tests cover dense, sparse, and multivector variants.
