### PR TITLE
feat: read-only edge grouping/matrix search + object-storage read path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7296,6 +7296,7 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "fnv",
  "fs-err",
  "fs4 1.1.0",
  "indexmap 2.14.0",

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -6,8 +6,8 @@ use ahash::AHashMap;
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::json_path::JsonPath;
-use segment::types::{Condition, Filter, ScoredPoint, WithVector};
-use shard::grouping::{GroupsAggregator, except_on, match_on, shape_candidates_query};
+use segment::types::WithVector;
+use shard::grouping::{GroupByDriver, RequestBudget};
 
 use super::types::QueryGroupRequest;
 use crate::collection::Collection;
@@ -25,9 +25,6 @@ use crate::operations::universal_query::collection_query::{
 };
 use crate::operations::universal_query::shard_query::{self, ShardQueryRequest};
 use crate::recommendations::recommend_into_core_search;
-
-const MAX_GET_GROUPS_REQUESTS: usize = 5;
-const MAX_GROUP_FILLING_REQUESTS: usize = 5;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SourceRequest {
@@ -131,38 +128,6 @@ impl GroupRequest {
             group_size: self.group_size,
             groups: self.limit,
         })
-    }
-}
-
-impl QueryGroupRequest {
-    async fn r#do(
-        &self,
-        collection: &Collection,
-        read_consistency: Option<ReadConsistency>,
-        routing_token: Option<RoutingToken>,
-        shard_selection: ShardSelectorInternal,
-        timeout: Option<Duration>,
-        hw_measurement_acc: HwMeasurementAcc,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
-        let mut request = self.source.clone();
-
-        // Fetch enough points to fill groups
-        let limit = self.groups * self.group_size;
-        shape_candidates_query(&mut request, &self.group_by, limit, self.group_size);
-
-        // We're enriching the final results at the end, so we'll keep this minimal
-        request.with_vector = WithVector::Bool(false);
-
-        collection
-            .query(
-                request,
-                read_consistency,
-                routing_token,
-                shard_selection,
-                timeout,
-                hw_measurement_acc,
-            )
-            .await
     }
 }
 
@@ -309,58 +274,35 @@ pub async fn group_by(
     let score_ordering =
         shard_query::query_result_order(request.source.query.as_ref(), &collection_params)?;
 
-    let mut aggregator = GroupsAggregator::new(
-        request.groups,
-        request.group_size,
-        request.group_by.clone(),
+    let QueryGroupRequest {
+        mut source,
+        group_by,
+        group_size,
+        groups,
+    } = request;
+
+    // Groups are enriched with the user-requested payload and vectors at the end,
+    // so candidates are fetched bare.
+    let with_payload = source.with_payload.clone();
+    let with_vector = source.with_vector.clone();
+    source.with_vector = WithVector::Bool(false);
+
+    let mut driver = GroupByDriver::new(
+        source,
+        group_by,
+        groups,
+        group_size,
         score_ordering,
+        RequestBudget::default(),
     );
 
-    // Try to complete amount of groups
-    let mut needs_filling = true;
-    for _ in 0..MAX_GET_GROUPS_REQUESTS {
+    while let Some(query) = driver.next_request() {
         // update timeout
         let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
-        let mut request = request.clone();
 
-        let source = &mut request.source;
-
-        // Construct filter to exclude already found groups
-        let full_groups = aggregator.keys_of_filled_groups();
-        if !full_groups.is_empty() {
-            let except_any = except_on(&request.group_by, &full_groups);
-            if !except_any.is_empty() {
-                let exclude_groups = Filter {
-                    must: Some(except_any),
-                    ..Default::default()
-                };
-                source.filter = Some(
-                    source
-                        .filter
-                        .as_ref()
-                        .map(|filter| filter.merge(&exclude_groups))
-                        .unwrap_or(exclude_groups),
-                );
-            }
-        }
-
-        // Exclude already aggregated points
-        let ids = aggregator.ids().clone();
-        if !ids.is_empty() {
-            let exclude_ids = Filter::new_must_not(Condition::HasId(ids.into()));
-            source.filter = Some(
-                source
-                    .filter
-                    .as_ref()
-                    .map(|filter| filter.merge(&exclude_ids))
-                    .unwrap_or(exclude_ids),
-            );
-        }
-
-        // Make request
-        let points = request
-            .r#do(
-                collection,
+        let points = collection
+            .query(
+                query,
                 read_consistency,
                 routing_token,
                 shard_selection.clone(),
@@ -369,84 +311,11 @@ pub async fn group_by(
             )
             .await?;
 
-        if points.is_empty() {
-            break;
-        }
-
-        aggregator.add_points(&points);
-
-        // TODO: should we break early if we have some amount of "enough" groups?
-        if aggregator.len_of_filled_best_groups() >= request.groups {
-            needs_filling = false;
-            break;
-        }
-    }
-
-    // Try to fill up groups
-    if needs_filling {
-        for _ in 0..MAX_GROUP_FILLING_REQUESTS {
-            // update timeout
-            let timeout = timeout.map(|t| t.saturating_sub(start.elapsed()));
-            let mut request = request.clone();
-
-            let source = &mut request.source;
-
-            // Construct filter to only include unsatisfied groups
-            let unsatisfied_groups = aggregator.keys_of_unfilled_best_groups();
-            let match_any = match_on(&request.group_by, &unsatisfied_groups);
-            if !match_any.is_empty() {
-                let include_groups = Filter {
-                    must: Some(match_any),
-                    ..Default::default()
-                };
-                source.filter = Some(
-                    source
-                        .filter
-                        .as_ref()
-                        .map(|filter| filter.merge(&include_groups))
-                        .unwrap_or(include_groups),
-                );
-            }
-
-            // Exclude already aggregated points
-            let ids = aggregator.ids().clone();
-            if !ids.is_empty() {
-                let exclude_ids = Filter::new_must_not(Condition::HasId(ids.into()));
-                source.filter = Some(
-                    source
-                        .filter
-                        .as_ref()
-                        .map(|filter| filter.merge(&exclude_ids))
-                        .unwrap_or(exclude_ids),
-                );
-            }
-
-            // Make request
-            let points = request
-                .r#do(
-                    collection,
-                    read_consistency,
-                    routing_token,
-                    shard_selection.clone(),
-                    timeout,
-                    hw_measurement_acc.clone(),
-                )
-                .await?;
-
-            if points.is_empty() {
-                break;
-            }
-
-            aggregator.add_points(&points);
-
-            if aggregator.len_of_filled_best_groups() >= request.groups {
-                break;
-            }
-        }
+        driver.add_points(&points);
     }
 
     // extract best results
-    let mut groups = aggregator.distill();
+    let mut groups = driver.distill();
 
     // flatten results
     let bare_points = groups
@@ -462,8 +331,8 @@ pub async fn group_by(
     let enriched_points: AHashMap<_, _> = collection
         .fill_search_result_with_payload(
             bare_points,
-            Some(request.source.with_payload),
-            request.source.with_vector,
+            Some(with_payload),
+            with_vector,
             read_consistency,
             routing_token,
             &shard_selection,

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -5,16 +5,10 @@ use std::time::Duration;
 use ahash::AHashMap;
 use api::rest::{BaseGroupRequest, SearchGroupsRequestInternal, SearchRequestInternal};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use fnv::FnvBuildHasher;
-use indexmap::IndexSet;
 use segment::json_path::JsonPath;
-use segment::types::{
-    AnyVariants, Condition, FieldCondition, Filter, Match, ScoredPoint, WithPayloadInterface,
-    WithVector,
-};
-use serde_json::Value;
+use segment::types::{Condition, Filter, ScoredPoint, WithVector};
+use shard::grouping::{GroupsAggregator, except_on, match_on, shape_candidates_query};
 
-use super::aggregator::GroupsAggregator;
 use super::types::QueryGroupRequest;
 use crate::collection::Collection;
 use crate::common::fetch_vectors;
@@ -29,7 +23,7 @@ use crate::operations::types::{
 use crate::operations::universal_query::collection_query::{
     CollectionQueryGroupsRequest, CollectionQueryRequest,
 };
-use crate::operations::universal_query::shard_query::{self, ShardPrefetch, ShardQueryRequest};
+use crate::operations::universal_query::shard_query::{self, ShardQueryRequest};
 use crate::recommendations::recommend_into_core_search;
 
 const MAX_GET_GROUPS_REQUESTS: usize = 5;
@@ -141,11 +135,6 @@ impl GroupRequest {
 }
 
 impl QueryGroupRequest {
-    /// Make `group_by` field selector work with as `with_payload`.
-    fn group_by_to_payload_selector(group_by: &JsonPath) -> WithPayloadInterface {
-        WithPayloadInterface::Fields(vec![group_by.strip_wildcard_suffix()])
-    }
-
     async fn r#do(
         &self,
         collection: &Collection,
@@ -157,19 +146,11 @@ impl QueryGroupRequest {
     ) -> CollectionResult<Vec<ScoredPoint>> {
         let mut request = self.source.clone();
 
-        // Adjust limit to fetch enough points to fill groups
-        request.limit = self.groups * self.group_size;
-        request.prefetches.iter_mut().for_each(|prefetch| {
-            increase_limit_for_group(prefetch, self.group_size);
-        });
-
-        let key_not_empty = Filter::new_must_not(Condition::IsEmpty(self.group_by.clone().into()));
-        request.filter = Some(request.filter.unwrap_or_default().merge(&key_not_empty));
-
-        let with_group_by_payload = Self::group_by_to_payload_selector(&self.group_by);
+        // Fetch enough points to fill groups
+        let limit = self.groups * self.group_size;
+        shape_candidates_query(&mut request, &self.group_by, limit, self.group_size);
 
         // We're enriching the final results at the end, so we'll keep this minimal
-        request.with_payload = with_group_by_payload;
         request.with_vector = WithVector::Bool(false);
 
         collection
@@ -505,70 +486,13 @@ pub async fn group_by(
     Ok(groups)
 }
 
-/// Uses the set of values to create Match::Except's, if possible
-fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
-    values_to_any_variants(values)
-        .into_iter()
-        .map(|v| {
-            Condition::Field(FieldCondition::new_match(
-                path.clone(),
-                Match::new_except(v),
-            ))
-        })
-        .collect()
-}
-
-/// Uses the set of values to create Match::Any's, if possible
-fn match_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
-    values_to_any_variants(values)
-        .into_iter()
-        .map(|any_variants| {
-            Condition::Field(FieldCondition::new_match(
-                path.clone(),
-                Match::new_any(any_variants),
-            ))
-        })
-        .collect()
-}
-
-fn values_to_any_variants(values: &[Value]) -> Vec<AnyVariants> {
-    let mut any_variants = Vec::new();
-
-    // gather int values
-    let ints: IndexSet<_, FnvBuildHasher> = values.iter().filter_map(|v| v.as_i64()).collect();
-
-    if !ints.is_empty() {
-        any_variants.push(AnyVariants::Integers(ints));
-    }
-
-    // gather string values
-    let strs: IndexSet<_, FnvBuildHasher> = values
-        .iter()
-        .filter_map(|v| v.as_str().map(Into::into))
-        .collect();
-
-    if !strs.is_empty() {
-        any_variants.push(AnyVariants::Strings(strs));
-    }
-
-    any_variants
-}
-
-fn increase_limit_for_group(shard_prefetch: &mut ShardPrefetch, group_size: usize) {
-    shard_prefetch.limit *= group_size;
-    shard_prefetch.prefetches.iter_mut().for_each(|prefetch| {
-        increase_limit_for_group(prefetch, group_size);
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use ahash::AHashMap;
     use segment::data_types::groups::GroupId;
     use segment::payload_json;
     use segment::types::{Payload, ScoredPoint};
-
-    use crate::grouping::types::Group;
+    use shard::grouping::Group;
 
     fn make_scored_point(id: u64, score: f32, payload: Option<Payload>) -> ScoredPoint {
         ScoredPoint {

--- a/lib/collection/src/grouping/mod.rs
+++ b/lib/collection/src/grouping/mod.rs
@@ -1,4 +1,3 @@
-mod aggregator;
 mod builder;
 pub mod group_by;
 mod types;

--- a/lib/collection/src/grouping/types.rs
+++ b/lib/collection/src/grouping/types.rs
@@ -1,32 +1,8 @@
-use ahash::AHashMap;
-use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
-use segment::types::{PointIdType, ScoredPoint};
+use shard::grouping::Group;
 
 use crate::operations::types::PointGroup;
 use crate::operations::universal_query::shard_query::ShardQueryRequest;
-
-#[derive(PartialEq, Debug)]
-pub(super) enum AggregatorError {
-    BadKeyType,
-    KeyNotFound,
-}
-#[derive(Debug, Clone)]
-pub(super) struct Group {
-    pub hits: Vec<ScoredPoint>,
-    pub key: GroupId,
-}
-
-impl Group {
-    pub(super) fn hydrate_from(&mut self, map: &AHashMap<PointIdType, ScoredPoint>) {
-        self.hits.iter_mut().for_each(|hit| {
-            if let Some(point) = map.get(&hit.id) {
-                hit.payload.clone_from(&point.payload);
-                hit.vector.clone_from(&point.vector);
-            }
-        });
-    }
-}
 
 impl From<Group> for PointGroup {
     fn from(group: Group) -> Self {

--- a/lib/collection/src/operations/universal_query/shard_query.rs
+++ b/lib/collection/src/operations/universal_query/shard_query.rs
@@ -9,37 +9,8 @@ pub fn query_result_order(
     query: Option<&ScoringQuery>,
     collection_params: &CollectionParams,
 ) -> CollectionResult<Option<Order>> {
-    let order = match query {
-        Some(scoring_query) => match scoring_query {
-            ScoringQuery::Vector(query_enum) => {
-                if query_enum.is_distance_scored() {
-                    Some(
-                        collection_params
-                            .get_distance(query_enum.get_vector_name())?
-                            .distance_order(),
-                    )
-                } else {
-                    Some(Order::LargeBetter)
-                }
-            }
-            ScoringQuery::Fusion(fusion) => match fusion {
-                FusionInternal::Rrf { k: _, weights: _ } | FusionInternal::Dbsf => {
-                    Some(Order::LargeBetter)
-                }
-            },
-            // Score boosting formulas are always have descending order,
-            // Euclidean scores can be negated within the formula
-            ScoringQuery::Formula(_formula) => Some(Order::LargeBetter),
-            ScoringQuery::OrderBy(order_by) => Some(Order::from(order_by.direction())),
-            // Random sample does not require ordering
-            ScoringQuery::Sample(SampleInternal::Random) => None,
-            // MMR cannot be reordered
-            ScoringQuery::Mmr(_) => None,
-        },
-        None => {
-            // Order by ID
-            Some(Order::SmallBetter)
-        }
-    };
+    let order = shard::query::query_result_order(query, |vector_name| {
+        collection_params.get_distance(vector_name)
+    })?;
     Ok(order)
 }

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -197,6 +197,13 @@ def main() -> None:
         # otherwise cargo fmt will fail to resolve deleted module
         (r"^#\[cfg\(feature = \"gpu\"\)]\npub mod gpu;\n", ""),
     )
+    # io_bridge_object_store is a path dependency excluded from the amalgamation
+    # (the embedded edge build has no object storage), so drop the BlobFile
+    # UniversalReadExt impl that references it.
+    substitute(
+        AMALGAMATION / "src/segment/index/universal_io.rs",
+        (r"(?s)^#\[rustfmt::skip]\nimpl<A: io_bridge_object_store.*?\n\}\n", ""),
+    )
 
     # Ast-grep-based fixups.
     RULES_TEMPLATE = (Path(__file__).parent / "ast-grep-rules.yaml").read_text(

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 use common::fs::{atomic_save_json, read_json};
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::{
-    HnswConfig, PayloadStorageType, QuantizationConfig, SegmentConfig, VectorNameBuf,
+    Distance, HnswConfig, PayloadStorageType, QuantizationConfig, SegmentConfig, VectorName,
+    VectorNameBuf,
 };
 use serde::{Deserialize, Serialize};
 use shard::operations::optimization::OptimizerThresholds;
@@ -301,6 +302,18 @@ impl EdgeConfig {
         self.vectors
             .get(name)
             .map(|p| p.to_plain_vector_data_config(self.quantization_config.as_ref()))
+    }
+
+    /// Distance of a named vector, mirroring `CollectionParams::get_distance`:
+    /// sparse vectors always score with `Dot`.
+    pub fn get_distance(&self, vector_name: &VectorName) -> OperationResult<Distance> {
+        if let Some(params) = self.vectors.get(vector_name) {
+            Ok(params.distance)
+        } else if self.sparse_vectors.contains_key(vector_name) {
+            Ok(Distance::Dot)
+        } else {
+            Err(OperationError::vector_name_not_exists(vector_name))
+        }
     }
 
     pub fn optimizer_thresholds(&self, num_indexing_threads: usize) -> OptimizerThresholds {

--- a/lib/edge/src/grouping.rs
+++ b/lib/edge/src/grouping.rs
@@ -1,14 +1,10 @@
 use segment::common::operation_error::OperationResult;
 use segment::json_path::JsonPath;
 pub use shard::grouping::Group;
-use shard::grouping::{GroupsAggregator, shape_candidates_query};
+use shard::grouping::{GroupByDriver, RequestBudget};
 use shard::query::{self, ShardQueryRequest};
 
 use crate::read_view::{EdgeReadView, ReadSegmentHandle};
-
-/// Extra candidates fetched per requested `groups * group_size` slot so groups can
-/// fill even when top hits cluster into few distinct group values.
-const OVERFETCH_FACTOR: usize = 4;
 
 /// Group the results of a base query by a payload field.
 pub struct GroupRequest {
@@ -23,29 +19,31 @@ pub struct GroupRequest {
 impl<H: ReadSegmentHandle> EdgeReadView<H> {
     pub(crate) fn query_groups(&self, request: GroupRequest) -> OperationResult<Vec<Group>> {
         let GroupRequest {
-            mut query,
+            query,
             group_by,
             groups,
             group_size,
         } = request;
-        if groups == 0 || group_size == 0 {
-            return Ok(vec![]);
-        }
 
         let order = query::query_result_order(query.query.as_ref(), |vector_name| {
             self.config.get_distance(vector_name)
         })?;
 
-        let limit = groups
-            .saturating_mul(group_size)
-            .saturating_mul(OVERFETCH_FACTOR);
-        shape_candidates_query(&mut query, &group_by, limit, group_size);
+        let mut driver = GroupByDriver::new(
+            query,
+            group_by,
+            groups,
+            group_size,
+            order,
+            RequestBudget::default(),
+        );
 
-        let points = self.query(query)?;
+        while let Some(request) = driver.next_request() {
+            let points = self.query(request)?;
+            driver.add_points(&points);
+        }
 
-        let mut aggregator = GroupsAggregator::new(groups, group_size, group_by, order);
-        aggregator.add_points(&points);
-        Ok(aggregator.distill())
+        Ok(driver.distill())
     }
 }
 

--- a/lib/edge/src/grouping.rs
+++ b/lib/edge/src/grouping.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+
+use segment::common::operation_error::OperationResult;
+use segment::json_path::JsonPath;
+use segment::types::{Condition, Filter, PayloadContainer, ScoredPoint, WithPayloadInterface};
+use serde_json::Value;
+use shard::query::ShardQueryRequest;
+
+use crate::read_view::{EdgeReadView, ReadSegmentHandle};
+
+/// Extra candidates fetched per requested `groups * group_size` slot so groups can
+/// fill even when top hits cluster into few distinct group values.
+const OVERFETCH_FACTOR: usize = 4;
+
+/// Group the results of a base query by a payload field.
+pub struct GroupRequest {
+    /// Base scoring query. Its `limit`/`offset`/`with_payload`/`filter` are adjusted
+    /// here; the query vector, params, prefetch and score_threshold are honoured.
+    pub query: ShardQueryRequest,
+    pub group_by: JsonPath,
+    pub groups: usize,
+    pub group_size: usize,
+}
+
+/// Hashable, scalar group key derived from a payload value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GroupKey {
+    Keyword(String),
+    Integer(i64),
+}
+
+impl GroupKey {
+    fn from_value(value: &Value) -> Option<Self> {
+        match value {
+            Value::String(s) => Some(GroupKey::Keyword(s.clone())),
+            Value::Number(n) => n.as_i64().map(GroupKey::Integer),
+            Value::Null | Value::Bool(_) | Value::Array(_) | Value::Object(_) => None,
+        }
+    }
+}
+
+pub struct PointGroup {
+    pub key: GroupKey,
+    pub hits: Vec<ScoredPoint>,
+}
+
+impl<H: ReadSegmentHandle> EdgeReadView<H> {
+    pub(crate) fn query_groups(&self, request: GroupRequest) -> OperationResult<Vec<PointGroup>> {
+        let GroupRequest {
+            mut query,
+            group_by,
+            groups,
+            group_size,
+        } = request;
+        if groups == 0 || group_size == 0 {
+            return Ok(vec![]);
+        }
+
+        // Only points that carry the group field can be grouped.
+        let present = Filter::new_must_not(Condition::IsEmpty(group_by.clone().into()));
+        query.filter = Some(match query.filter.take() {
+            Some(f) => f.merge(&present),
+            None => present,
+        });
+        // The group value has to come back in the payload to bucket on it.
+        query.with_payload = WithPayloadInterface::Fields(vec![group_by.clone()]);
+        query.limit = groups
+            .saturating_mul(group_size)
+            .saturating_mul(OVERFETCH_FACTOR);
+        query.offset = 0;
+
+        let points = self.query(query)?;
+
+        // Bucket points by group key, preserving first-seen (best-score) order.
+        let mut order: Vec<GroupKey> = Vec::new();
+        let mut buckets: HashMap<GroupKey, Vec<ScoredPoint>> = HashMap::new();
+        for point in points {
+            let Some(payload) = point.payload.as_ref() else {
+                continue;
+            };
+            let keys: Vec<GroupKey> = payload
+                .get_value_cloned(&group_by)
+                .into_iter()
+                .filter_map(|v| GroupKey::from_value(&v))
+                .collect();
+            for key in keys {
+                let bucket = buckets.entry(key.clone()).or_insert_with(|| {
+                    order.push(key.clone());
+                    Vec::new()
+                });
+                if bucket.len() < group_size {
+                    bucket.push(point.clone());
+                }
+            }
+        }
+
+        let result = order
+            .into_iter()
+            .take(groups)
+            .map(|key| {
+                let hits = buckets.remove(&key).unwrap_or_default();
+                PointGroup { key, hits }
+            })
+            .collect();
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use segment::data_types::vectors::{NamedQuery, VectorInternal};
+    use segment::types::WithVector;
+    use shard::query::ScoringQuery;
+    use shard::query::query_enum::QueryEnum;
+
+    use super::*;
+    use crate::EdgeShardRead;
+    use crate::test_helpers::{VECTOR_NAME, point_with_group, test_config, upsert};
+
+    #[test]
+    fn groups_by_payload_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let shard = crate::EdgeShard::new(dir.path(), test_config()).unwrap();
+        upsert(
+            &shard,
+            vec![
+                point_with_group(1, "a"),
+                point_with_group(2, "b"),
+                point_with_group(3, "a"),
+                point_with_group(4, "b"),
+            ],
+        );
+
+        let base = ShardQueryRequest {
+            prefetches: vec![],
+            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
+                VectorInternal::from(vec![1.0]),
+                VECTOR_NAME.to_string(),
+            )))),
+            filter: None,
+            score_threshold: None,
+            limit: 0,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        };
+
+        let groups = shard
+            .query_groups(GroupRequest {
+                query: base,
+                group_by: "group".parse().unwrap(),
+                groups: 2,
+                group_size: 5,
+            })
+            .unwrap();
+
+        assert_eq!(groups.len(), 2);
+        for g in &groups {
+            assert_eq!(g.hits.len(), 2);
+        }
+    }
+}

--- a/lib/edge/src/grouping.rs
+++ b/lib/edge/src/grouping.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use segment::common::operation_error::OperationResult;
 use segment::json_path::JsonPath;
-use segment::types::{Condition, Filter, PayloadContainer, ScoredPoint, WithPayloadInterface};
-use serde_json::Value;
-use shard::query::ShardQueryRequest;
+pub use shard::grouping::Group;
+use shard::grouping::{GroupsAggregator, shape_candidates_query};
+use shard::query::{self, ShardQueryRequest};
 
 use crate::read_view::{EdgeReadView, ReadSegmentHandle};
 
@@ -22,30 +20,8 @@ pub struct GroupRequest {
     pub group_size: usize,
 }
 
-/// Hashable, scalar group key derived from a payload value.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum GroupKey {
-    Keyword(String),
-    Integer(i64),
-}
-
-impl GroupKey {
-    fn from_value(value: &Value) -> Option<Self> {
-        match value {
-            Value::String(s) => Some(GroupKey::Keyword(s.clone())),
-            Value::Number(n) => n.as_i64().map(GroupKey::Integer),
-            Value::Null | Value::Bool(_) | Value::Array(_) | Value::Object(_) => None,
-        }
-    }
-}
-
-pub struct PointGroup {
-    pub key: GroupKey,
-    pub hits: Vec<ScoredPoint>,
-}
-
 impl<H: ReadSegmentHandle> EdgeReadView<H> {
-    pub(crate) fn query_groups(&self, request: GroupRequest) -> OperationResult<Vec<PointGroup>> {
+    pub(crate) fn query_groups(&self, request: GroupRequest) -> OperationResult<Vec<Group>> {
         let GroupRequest {
             mut query,
             group_by,
@@ -56,66 +32,53 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             return Ok(vec![]);
         }
 
-        // Only points that carry the group field can be grouped.
-        let present = Filter::new_must_not(Condition::IsEmpty(group_by.clone().into()));
-        query.filter = Some(match query.filter.take() {
-            Some(f) => f.merge(&present),
-            None => present,
-        });
-        // The group value has to come back in the payload to bucket on it.
-        query.with_payload = WithPayloadInterface::Fields(vec![group_by.clone()]);
-        query.limit = groups
+        let order = query::query_result_order(query.query.as_ref(), |vector_name| {
+            self.config.get_distance(vector_name)
+        })?;
+
+        let limit = groups
             .saturating_mul(group_size)
             .saturating_mul(OVERFETCH_FACTOR);
-        query.offset = 0;
+        shape_candidates_query(&mut query, &group_by, limit, group_size);
 
         let points = self.query(query)?;
 
-        // Bucket points by group key, preserving first-seen (best-score) order.
-        let mut order: Vec<GroupKey> = Vec::new();
-        let mut buckets: HashMap<GroupKey, Vec<ScoredPoint>> = HashMap::new();
-        for point in points {
-            let Some(payload) = point.payload.as_ref() else {
-                continue;
-            };
-            let keys: Vec<GroupKey> = payload
-                .get_value_cloned(&group_by)
-                .into_iter()
-                .filter_map(|v| GroupKey::from_value(&v))
-                .collect();
-            for key in keys {
-                let bucket = buckets.entry(key.clone()).or_insert_with(|| {
-                    order.push(key.clone());
-                    Vec::new()
-                });
-                if bucket.len() < group_size {
-                    bucket.push(point.clone());
-                }
-            }
-        }
-
-        let result = order
-            .into_iter()
-            .take(groups)
-            .map(|key| {
-                let hits = buckets.remove(&key).unwrap_or_default();
-                PointGroup { key, hits }
-            })
-            .collect();
-        Ok(result)
+        let mut aggregator = GroupsAggregator::new(groups, group_size, group_by, order);
+        aggregator.add_points(&points);
+        Ok(aggregator.distill())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use segment::data_types::groups::GroupId;
     use segment::data_types::vectors::{NamedQuery, VectorInternal};
-    use segment::types::WithVector;
+    use segment::types::{WithPayloadInterface, WithVector};
     use shard::query::ScoringQuery;
     use shard::query::query_enum::QueryEnum;
 
     use super::*;
     use crate::EdgeShardRead;
-    use crate::test_helpers::{VECTOR_NAME, point_with_group, test_config, upsert};
+    use crate::test_helpers::{
+        VECTOR_NAME, point_with_group, point_with_group_values, test_config, upsert,
+    };
+
+    fn base_query() -> ShardQueryRequest {
+        ShardQueryRequest {
+            prefetches: vec![],
+            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
+                VectorInternal::from(vec![1.0]),
+                VECTOR_NAME.to_string(),
+            )))),
+            filter: None,
+            score_threshold: None,
+            limit: 0,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        }
+    }
 
     #[test]
     fn groups_by_payload_field() {
@@ -131,24 +94,9 @@ mod tests {
             ],
         );
 
-        let base = ShardQueryRequest {
-            prefetches: vec![],
-            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
-                VectorInternal::from(vec![1.0]),
-                VECTOR_NAME.to_string(),
-            )))),
-            filter: None,
-            score_threshold: None,
-            limit: 0,
-            offset: 0,
-            params: None,
-            with_vector: WithVector::Bool(false),
-            with_payload: WithPayloadInterface::Bool(false),
-        };
-
         let groups = shard
             .query_groups(GroupRequest {
-                query: base,
+                query: base_query(),
                 group_by: "group".parse().unwrap(),
                 groups: 2,
                 group_size: 5,
@@ -156,8 +104,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(groups.len(), 2);
+        // Test vectors score by dot product with [1.0], so the group holding the
+        // highest-id point comes first.
+        assert_eq!(groups[0].key, GroupId::from("b"));
+        assert_eq!(groups[1].key, GroupId::from("a"));
         for g in &groups {
             assert_eq!(g.hits.len(), 2);
+        }
+    }
+
+    #[test]
+    fn groups_by_multi_valued_payload_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let shard = crate::EdgeShard::new(dir.path(), test_config()).unwrap();
+        upsert(
+            &shard,
+            vec![
+                point_with_group_values(1, serde_json::json!(["a", "b"])),
+                point_with_group(2, "a"),
+                point_with_group(3, "b"),
+            ],
+        );
+
+        let groups = shard
+            .query_groups(GroupRequest {
+                query: base_query(),
+                group_by: "group".parse().unwrap(),
+                groups: 2,
+                group_size: 2,
+            })
+            .unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].key, GroupId::from("b"));
+        assert_eq!(groups[1].key, GroupId::from("a"));
+        // Point 1 carries both group values, so it must land in both groups.
+        for g in &groups {
+            assert_eq!(g.hits.len(), 2);
+            assert!(g.hits.iter().any(|hit| hit.id == 1.into()));
         }
     }
 }

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -35,7 +35,7 @@ pub use config::optimizers::EdgeOptimizersConfig;
 pub use config::shard::EdgeConfig;
 pub use config::vectors::{EdgeSparseVectorParams, EdgeVectorParams};
 use fs_err as fs;
-pub use grouping::{GroupKey, GroupRequest, PointGroup};
+pub use grouping::{Group, GroupRequest};
 pub use info::ShardInfo;
 pub use matrix::{SearchMatrixRequest, SearchMatrixResponse};
 use parking_lot::Mutex;

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -3,7 +3,9 @@ mod builders;
 pub mod config;
 mod count;
 mod facet;
+mod grouping;
 mod info;
+mod matrix;
 mod optimize;
 mod pool;
 mod query;
@@ -19,6 +21,9 @@ mod types;
 pub use types::*;
 mod update;
 
+#[cfg(test)]
+mod test_helpers;
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,7 +35,9 @@ pub use config::optimizers::EdgeOptimizersConfig;
 pub use config::shard::EdgeConfig;
 pub use config::vectors::{EdgeSparseVectorParams, EdgeVectorParams};
 use fs_err as fs;
+pub use grouping::{GroupKey, GroupRequest, PointGroup};
 pub use info::ShardInfo;
+pub use matrix::{SearchMatrixRequest, SearchMatrixResponse};
 use parking_lot::Mutex;
 pub use read_only::{
     LocalSegmentEnumerator, ManifestSegmentEnumerator, ReadOnlyEdgeShard, SegmentEnumerator,

--- a/lib/edge/src/matrix.rs
+++ b/lib/edge/src/matrix.rs
@@ -1,0 +1,160 @@
+use ahash::AHashSet;
+use segment::common::operation_error::{OperationError, OperationResult};
+use segment::data_types::vectors::NamedQuery;
+use segment::types::{
+    Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, VectorNameBuf,
+    WithPayloadInterface, WithVector,
+};
+use shard::query::query_enum::QueryEnum;
+use shard::query::{SampleInternal, ScoringQuery, ShardQueryRequest};
+
+use crate::read_view::{EdgeReadView, ReadSegmentHandle};
+
+/// A single-shard distance-matrix request: sample `sample_size` random points that
+/// carry the `using` vector, then find each sample's `limit_per_sample` nearest
+/// neighbours restricted to the sampled set.
+pub struct SearchMatrixRequest {
+    pub sample_size: usize,
+    pub limit_per_sample: usize,
+    pub filter: Option<Filter>,
+    pub using: VectorNameBuf,
+}
+
+#[derive(Debug, Default)]
+pub struct SearchMatrixResponse {
+    pub sample_ids: Vec<PointIdType>,
+    pub nearests: Vec<Vec<ScoredPoint>>,
+}
+
+impl<H: ReadSegmentHandle> EdgeReadView<H> {
+    pub(crate) fn search_matrix(
+        &self,
+        request: SearchMatrixRequest,
+    ) -> OperationResult<SearchMatrixResponse> {
+        let SearchMatrixRequest {
+            sample_size,
+            limit_per_sample,
+            filter,
+            using,
+        } = request;
+        if sample_size == 0 || limit_per_sample == 0 {
+            return Ok(SearchMatrixResponse::default());
+        }
+
+        // Only sample points that actually carry the `using` vector.
+        let has_vector = Filter::new_must(Condition::HasVector(HasVectorCondition::from(
+            using.clone(),
+        )));
+        let sample_filter = Some(filter.map(|f| f.merge(&has_vector)).unwrap_or(has_vector));
+
+        let sampling = ShardQueryRequest {
+            prefetches: vec![],
+            query: Some(ScoringQuery::Sample(SampleInternal::Random)),
+            filter: sample_filter,
+            score_threshold: None,
+            limit: sample_size,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Selector(vec![using.clone()]),
+            with_payload: WithPayloadInterface::Bool(false),
+        };
+        let mut sampled = self.query(sampling)?;
+        if sampled.len() < 2 {
+            return Ok(SearchMatrixResponse::default());
+        }
+        sampled.truncate(sample_size);
+        sampled.sort_unstable_by_key(|p| p.id);
+        let sample_ids: Vec<PointIdType> = sampled.iter().map(|p| p.id).collect();
+
+        // Restrict each nearest search to the sampled set.
+        let id_filter = Filter::new_must(Condition::HasId(HasIdCondition::from(
+            sample_ids.iter().copied().collect::<AHashSet<_>>(),
+        )));
+
+        let mut nearests = Vec::with_capacity(sampled.len());
+        for point in &sampled {
+            let vector = point
+                .vector
+                .as_ref()
+                .and_then(|v| v.get(&using))
+                .map(|v| v.to_owned())
+                .ok_or_else(|| {
+                    OperationError::service_error("sampled point is missing its vector")
+                })?;
+            let nearest = ShardQueryRequest {
+                prefetches: vec![],
+                query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
+                    vector,
+                    using.clone(),
+                )))),
+                filter: Some(id_filter.clone()),
+                score_threshold: None,
+                limit: limit_per_sample.saturating_add(1), // +1 to drop the point itself afterwards
+                offset: 0,
+                params: None,
+                with_vector: WithVector::Bool(false),
+                with_payload: WithPayloadInterface::Bool(false),
+            };
+            let mut scores = self.query(nearest)?;
+            if let Some(pos) = scores.iter().position(|p| p.id == point.id) {
+                scores.remove(pos);
+            } else if scores.len() == limit_per_sample.saturating_add(1) {
+                scores.pop();
+            }
+            nearests.push(scores);
+        }
+
+        Ok(SearchMatrixResponse {
+            sample_ids,
+            nearests,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EdgeShardRead;
+    use crate::test_helpers::{VECTOR_NAME, point, test_config, upsert};
+
+    #[test]
+    fn matrix_returns_sample_and_nearests() {
+        let dir = tempfile::tempdir().unwrap();
+        let shard = crate::EdgeShard::new(dir.path(), test_config()).unwrap();
+        upsert(&shard, (1..=4).map(point).collect());
+
+        let resp = shard
+            .search_matrix(SearchMatrixRequest {
+                sample_size: 4,
+                limit_per_sample: 2,
+                filter: None,
+                using: VECTOR_NAME.to_string(),
+            })
+            .unwrap();
+
+        assert_eq!(resp.sample_ids.len(), 4);
+        assert_eq!(resp.nearests.len(), 4);
+        for (id, row) in resp.sample_ids.iter().zip(&resp.nearests) {
+            assert!(row.iter().all(|p| &p.id != id));
+            assert!(row.len() <= 2);
+        }
+    }
+
+    #[test]
+    fn matrix_empty_when_fewer_than_two_points() {
+        let dir = tempfile::tempdir().unwrap();
+        let shard = crate::EdgeShard::new(dir.path(), test_config()).unwrap();
+        upsert(&shard, vec![point(1)]);
+
+        let resp = shard
+            .search_matrix(SearchMatrixRequest {
+                sample_size: 10,
+                limit_per_sample: 3,
+                filter: None,
+                using: VECTOR_NAME.to_string(),
+            })
+            .unwrap();
+
+        assert!(resp.sample_ids.is_empty());
+    }
+}

--- a/lib/edge/src/read_view.rs
+++ b/lib/edge/src/read_view.rs
@@ -189,6 +189,20 @@ pub trait EdgeShardRead {
         view(self).facet(request)
     }
 
+    fn search_matrix(
+        &self,
+        request: crate::matrix::SearchMatrixRequest,
+    ) -> OperationResult<crate::matrix::SearchMatrixResponse> {
+        view(self).search_matrix(request)
+    }
+
+    fn query_groups(
+        &self,
+        request: crate::grouping::GroupRequest,
+    ) -> OperationResult<Vec<crate::grouping::PointGroup>> {
+        view(self).query_groups(request)
+    }
+
     fn info(&self) -> OperationResult<ShardInfo> {
         view(self).info()
     }

--- a/lib/edge/src/read_view.rs
+++ b/lib/edge/src/read_view.rs
@@ -199,7 +199,7 @@ pub trait EdgeShardRead {
     fn query_groups(
         &self,
         request: crate::grouping::GroupRequest,
-    ) -> OperationResult<Vec<crate::grouping::PointGroup>> {
+    ) -> OperationResult<Vec<crate::grouping::Group>> {
         view(self).query_groups(request)
     }
 

--- a/lib/edge/src/test_helpers.rs
+++ b/lib/edge/src/test_helpers.rs
@@ -52,6 +52,10 @@ pub(crate) fn point(id: u64) -> PointStructPersisted {
 }
 
 pub(crate) fn point_with_group(id: u64, group: &str) -> PointStructPersisted {
+    point_with_group_values(id, serde_json::json!(group))
+}
+
+pub(crate) fn point_with_group_values(id: u64, group: serde_json::Value) -> PointStructPersisted {
     let payload = serde_json::json!({ "group": group });
     PointStructPersisted {
         id: ExtendedPointId::NumId(id),

--- a/lib/edge/src/test_helpers.rs
+++ b/lib/edge/src/test_helpers.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
+use segment::types::{Distance, ExtendedPointId, Payload};
+use shard::operations::CollectionUpdateOperations::PointOperation;
+use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+use shard::operations::point_ops::PointOperations::UpsertPoints;
+use shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
+
+use crate::config::vectors::EdgeVectorParams;
+use crate::{EdgeConfig, EdgeShard};
+
+pub(crate) const VECTOR_NAME: &str = "edge-test-vector";
+
+pub(crate) fn test_config() -> EdgeConfig {
+    EdgeConfig {
+        on_disk_payload: Some(false),
+        vectors: HashMap::from([(
+            VECTOR_NAME.to_string(),
+            EdgeVectorParams {
+                size: 1,
+                distance: Distance::Dot,
+                quantization_config: None,
+                multivector_config: None,
+                datatype: None,
+                on_disk: None,
+                hnsw_config: None,
+            },
+        )]),
+        sparse_vectors: HashMap::new(),
+        hnsw_config: Default::default(),
+        quantization_config: None,
+        optimizers: Default::default(),
+        wal_options: None,
+        max_search_threads: None,
+    }
+}
+
+fn named_vector(id: u64) -> VectorStructPersisted {
+    VectorStructPersisted::from(VectorStructInternal::Named(HashMap::from([(
+        VECTOR_NAME.to_string(),
+        VectorInternal::from(vec![id as f32]),
+    )])))
+}
+
+pub(crate) fn point(id: u64) -> PointStructPersisted {
+    PointStructPersisted {
+        id: ExtendedPointId::NumId(id),
+        vector: named_vector(id),
+        payload: None,
+    }
+}
+
+pub(crate) fn point_with_group(id: u64, group: &str) -> PointStructPersisted {
+    let payload = serde_json::json!({ "group": group });
+    PointStructPersisted {
+        id: ExtendedPointId::NumId(id),
+        vector: named_vector(id),
+        payload: Some(Payload::from(payload.as_object().unwrap().clone())),
+    }
+}
+
+pub(crate) fn upsert(shard: &EdgeShard, points: Vec<PointStructPersisted>) {
+    shard
+        .update(PointOperation(UpsertPoints(PointsList(points))))
+        .unwrap();
+}

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -36,7 +36,6 @@ rstest = { workspace = true }
 segment = { path = ".", default-features = false, features = ["testing"] }
 proptest = { workspace = true }
 anyhow = { workspace = true }
-io_bridge_object_store = { path = "../common/io_bridge_object_store" }
 object_store = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true }
@@ -45,6 +44,7 @@ tokio = { workspace = true }
 pprof = { workspace = true }
 
 [dependencies]
+io_bridge_object_store = { path = "../common/io_bridge_object_store" }
 blink-alloc = { workspace = true }
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }

--- a/lib/segment/src/index/universal_io.rs
+++ b/lib/segment/src/index/universal_io.rs
@@ -115,7 +115,6 @@ impl UniversalReadExt for ReadOnly<MmapFile> {
     fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
 }
 
-#[cfg(test)]
 #[rustfmt::skip]
 impl<A: io_bridge_object_store::AsyncRead + Clone> UniversalReadExt for io_bridge_object_store::BlobFile<A> {
     fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }

--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -25,6 +25,7 @@ wal = { path = "../wal" }
 
 ahash = { workspace = true }
 chrono = { workspace = true }
+fnv = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/lib/shard/src/grouping/aggregator.rs
+++ b/lib/shard/src/grouping/aggregator.rs
@@ -9,7 +9,7 @@ use segment::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterab
 use segment::types::{ExtendedPointId, Order, PayloadContainer, PointIdType, ScoredPoint};
 use serde_json::Value;
 
-use super::types::{AggregatorError, Group};
+use super::{AggregatorError, Group};
 
 /// Avoid excessive memory allocation and allocation failures when a client supplies a huge
 /// `limit` (number of groups) or `group_size`. Mirrors `SearchResultAggregator` and
@@ -17,7 +17,7 @@ use super::types::{AggregatorError, Group};
 const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
 
 type Hits = AHashMap<PointIdType, ScoredPoint>;
-pub(super) struct GroupsAggregator {
+pub struct GroupsAggregator {
     groups: AHashMap<GroupId, Hits>,
     max_group_size: usize,
     grouped_by: JsonPath,
@@ -29,7 +29,7 @@ pub(super) struct GroupsAggregator {
 }
 
 impl GroupsAggregator {
-    pub(super) fn new(
+    pub fn new(
         groups: usize,
         group_size: usize,
         grouped_by: JsonPath,
@@ -127,7 +127,7 @@ impl GroupsAggregator {
     }
 
     /// Adds multiple points to the group that they correspond to based on the group_by field, assumes that the points always have the grouped_by field, else it just ignores them
-    pub(super) fn add_points(&mut self, points: &[ScoredPoint]) {
+    pub fn add_points(&mut self, points: &[ScoredPoint]) {
         for point in points {
             match self.add_point(point) {
                 Ok(()) | Err(AggregatorError::KeyNotFound | AggregatorError::BadKeyType) => {
@@ -160,7 +160,7 @@ impl GroupsAggregator {
     }
 
     /// Gets the keys of the groups that have less than the max group size
-    pub(super) fn keys_of_unfilled_best_groups(&self) -> Vec<Value> {
+    pub fn keys_of_unfilled_best_groups(&self) -> Vec<Value> {
         let best_group_keys: AHashSet<_> = self.best_group_keys().into_iter().collect();
         best_group_keys
             .difference(&self.full_groups)
@@ -170,23 +170,23 @@ impl GroupsAggregator {
     }
 
     /// Gets the keys of the groups that have reached the max group size
-    pub(super) fn keys_of_filled_groups(&self) -> Vec<Value> {
+    pub fn keys_of_filled_groups(&self) -> Vec<Value> {
         self.full_groups.iter().cloned().map_into().collect()
     }
 
     /// Gets the amount of best groups that have reached the max group size
-    pub(super) fn len_of_filled_best_groups(&self) -> usize {
+    pub fn len_of_filled_best_groups(&self) -> usize {
         let best_group_keys: AHashSet<_> = self.best_group_keys().into_iter().collect();
         best_group_keys.intersection(&self.full_groups).count()
     }
 
     /// Gets the ids of the already present points across all the groups
-    pub(super) fn ids(&self) -> &AHashSet<ExtendedPointId> {
+    pub fn ids(&self) -> &AHashSet<ExtendedPointId> {
         &self.all_ids
     }
 
     /// Returns the best groups sorted by their best hit. The hits are sorted too.
-    pub(super) fn distill(mut self) -> Vec<Group> {
+    pub fn distill(mut self) -> Vec<Group> {
         let best_groups = self.best_group_keys();
         let mut groups = Vec::with_capacity(best_groups.len());
 

--- a/lib/shard/src/grouping/driver.rs
+++ b/lib/shard/src/grouping/driver.rs
@@ -1,0 +1,362 @@
+use segment::json_path::JsonPath;
+use segment::types::{Condition, Filter, Order, ScoredPoint};
+
+use super::{Group, GroupsAggregator, except_on, match_on, merge_filter, shape_candidates_query};
+use crate::query::ShardQueryRequest;
+
+const MAX_GET_GROUPS_REQUESTS: usize = 5;
+const MAX_GROUP_FILLING_REQUESTS: usize = 5;
+
+/// How many backend requests a group-by run may spend in each phase.
+#[derive(Copy, Clone, Debug)]
+pub struct RequestBudget {
+    /// Requests used to discover enough groups.
+    pub collect: usize,
+    /// Requests used afterwards to fill up the best groups which are not full yet.
+    pub fill: usize,
+}
+
+impl Default for RequestBudget {
+    fn default() -> Self {
+        Self {
+            collect: MAX_GET_GROUPS_REQUESTS,
+            fill: MAX_GROUP_FILLING_REQUESTS,
+        }
+    }
+}
+
+/// Sans-IO state machine for a group-by run, shared between the server and edge so the
+/// request shaping and stop conditions cannot diverge between them.
+///
+/// Drive it in a loop: [`next_request`](Self::next_request) yields the next backend query,
+/// the caller executes it, feeds the results back with [`add_points`](Self::add_points), and
+/// takes the groups with [`distill`](Self::distill) once no request is yielded. Query
+/// execution stays with the caller, so the same driver serves both the async server path and
+/// the sync edge path; the [`RequestBudget`] makes the effort policy explicit.
+pub struct GroupByDriver {
+    base_query: ShardQueryRequest,
+    group_by: JsonPath,
+    groups: usize,
+    group_size: usize,
+    /// Number of candidate points fetched per request.
+    candidates_limit: usize,
+    aggregator: GroupsAggregator,
+    state: State,
+}
+
+#[derive(Copy, Clone)]
+enum State {
+    /// Discover new groups until enough of the best ones are full.
+    Collecting {
+        requests_left: usize,
+        fill_budget: usize,
+    },
+    /// Fill up the best groups which are not full yet.
+    Filling {
+        requests_left: usize,
+    },
+    Done,
+}
+
+impl GroupByDriver {
+    pub fn new(
+        base_query: ShardQueryRequest,
+        group_by: JsonPath,
+        groups: usize,
+        group_size: usize,
+        order: Option<Order>,
+        budget: RequestBudget,
+    ) -> Self {
+        let state = if groups == 0 || group_size == 0 {
+            State::Done
+        } else {
+            State::Collecting {
+                requests_left: budget.collect,
+                fill_budget: budget.fill,
+            }
+        };
+        Self {
+            aggregator: GroupsAggregator::new(groups, group_size, group_by.clone(), order),
+            base_query,
+            group_by,
+            groups,
+            group_size,
+            // Fetch enough points per request to fill all groups
+            candidates_limit: groups.saturating_mul(group_size),
+            state,
+        }
+    }
+
+    /// The next backend query to execute, or `None` once the run is complete.
+    ///
+    /// Feed the response of each yielded request into [`add_points`](Self::add_points) before
+    /// asking for the next one; without new results the driver yields the same request again
+    /// until its budget runs out.
+    pub fn next_request(&mut self) -> Option<ShardQueryRequest> {
+        loop {
+            match &mut self.state {
+                State::Collecting {
+                    requests_left,
+                    fill_budget,
+                } => {
+                    if *requests_left == 0 {
+                        self.state = State::Filling {
+                            requests_left: *fill_budget,
+                        };
+                        continue;
+                    }
+                    *requests_left -= 1;
+
+                    let mut request = self.base_query.clone();
+
+                    // Construct filter to exclude already found groups
+                    let full_groups = self.aggregator.keys_of_filled_groups();
+                    if !full_groups.is_empty() {
+                        let except_any = except_on(&self.group_by, &full_groups);
+                        if !except_any.is_empty() {
+                            merge_filter(
+                                &mut request.filter,
+                                Filter {
+                                    must: Some(except_any),
+                                    ..Default::default()
+                                },
+                            );
+                        }
+                    }
+
+                    self.exclude_aggregated_points(&mut request);
+                    shape_candidates_query(
+                        &mut request,
+                        &self.group_by,
+                        self.candidates_limit,
+                        self.group_size,
+                    );
+                    return Some(request);
+                }
+                State::Filling { requests_left } => {
+                    if *requests_left == 0 {
+                        self.state = State::Done;
+                        continue;
+                    }
+                    *requests_left -= 1;
+
+                    let mut request = self.base_query.clone();
+
+                    // Construct filter to only include unsatisfied groups
+                    let unsatisfied_groups = self.aggregator.keys_of_unfilled_best_groups();
+                    let match_any = match_on(&self.group_by, &unsatisfied_groups);
+                    if !match_any.is_empty() {
+                        merge_filter(
+                            &mut request.filter,
+                            Filter {
+                                must: Some(match_any),
+                                ..Default::default()
+                            },
+                        );
+                    }
+
+                    self.exclude_aggregated_points(&mut request);
+                    shape_candidates_query(
+                        &mut request,
+                        &self.group_by,
+                        self.candidates_limit,
+                        self.group_size,
+                    );
+                    return Some(request);
+                }
+                State::Done => return None,
+            }
+        }
+    }
+
+    /// Ingest the response of the last yielded request and advance the state machine.
+    pub fn add_points(&mut self, points: &[ScoredPoint]) {
+        self.aggregator.add_points(points);
+
+        let enough_groups = self.aggregator.len_of_filled_best_groups() >= self.groups;
+        match self.state {
+            State::Collecting { fill_budget, .. } => {
+                if enough_groups {
+                    self.state = State::Done;
+                } else if points.is_empty() {
+                    // No more matching points; collecting again is pointless, try filling.
+                    self.state = State::Filling {
+                        requests_left: fill_budget,
+                    };
+                }
+            }
+            State::Filling { .. } => {
+                if enough_groups || points.is_empty() {
+                    self.state = State::Done;
+                }
+            }
+            State::Done => {}
+        }
+    }
+
+    /// Exclude already aggregated points
+    fn exclude_aggregated_points(&self, request: &mut ShardQueryRequest) {
+        let ids = self.aggregator.ids().clone();
+        if !ids.is_empty() {
+            merge_filter(
+                &mut request.filter,
+                Filter::new_must_not(Condition::HasId(ids.into())),
+            );
+        }
+    }
+
+    /// Consume the driver and return the best groups, sorted by their best hit.
+    pub fn distill(self) -> Vec<Group> {
+        self.aggregator.distill()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::types::ScoreType;
+    use segment::data_types::groups::GroupId;
+    use segment::payload_json;
+    use segment::types::{WithPayloadInterface, WithVector};
+
+    use super::*;
+
+    const GROUPS: usize = 2;
+    const GROUP_SIZE: usize = 2;
+
+    fn base_query() -> ShardQueryRequest {
+        ShardQueryRequest {
+            prefetches: vec![],
+            query: None,
+            filter: None,
+            score_threshold: None,
+            limit: 0,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        }
+    }
+
+    fn driver(budget: RequestBudget) -> GroupByDriver {
+        GroupByDriver::new(
+            base_query(),
+            "g".parse().unwrap(),
+            GROUPS,
+            GROUP_SIZE,
+            Some(Order::LargeBetter),
+            budget,
+        )
+    }
+
+    fn point(id: u64, score: ScoreType, group: &str) -> ScoredPoint {
+        ScoredPoint {
+            id: id.into(),
+            version: 0,
+            score,
+            payload: Some(payload_json! { "g": group }),
+            vector: None,
+            shard_key: None,
+            order_value: None,
+        }
+    }
+
+    #[test]
+    fn single_request_budget_yields_one_shaped_request() {
+        let mut driver = driver(RequestBudget {
+            collect: 1,
+            fill: 0,
+        });
+
+        let request = driver.next_request().unwrap();
+        assert_eq!(request.limit, GROUPS * GROUP_SIZE);
+        assert_eq!(request.offset, 0);
+        // The is-empty restriction on the group_by field must be in place.
+        assert!(request.filter.is_some());
+        assert_eq!(
+            request.with_payload,
+            WithPayloadInterface::Fields(vec!["g".parse().unwrap()])
+        );
+
+        // One incomplete group left after the response, but the budget is spent.
+        driver.add_points(&[point(1, 1.0, "a")]);
+        assert!(driver.next_request().is_none());
+
+        let groups = driver.distill();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].key, GroupId::from("a"));
+    }
+
+    #[test]
+    fn stops_early_when_enough_groups_are_filled() {
+        let mut driver = driver(RequestBudget {
+            collect: 5,
+            fill: 5,
+        });
+
+        assert!(driver.next_request().is_some());
+        driver.add_points(&[
+            point(1, 4.0, "a"),
+            point(2, 3.0, "a"),
+            point(3, 2.0, "b"),
+            point(4, 1.0, "b"),
+        ]);
+
+        // Both requested groups are full; no further requests are spent.
+        assert!(driver.next_request().is_none());
+
+        let groups = driver.distill();
+        assert_eq!(groups.len(), GROUPS);
+        assert_eq!(groups[0].key, GroupId::from("a"));
+        assert_eq!(groups[1].key, GroupId::from("b"));
+        for group in &groups {
+            assert_eq!(group.hits.len(), GROUP_SIZE);
+        }
+    }
+
+    #[test]
+    fn moves_to_filling_and_finishes_on_empty_responses() {
+        let mut driver = driver(RequestBudget {
+            collect: 5,
+            fill: 5,
+        });
+
+        // Collect round: one hit per group, none full.
+        let collect_request = driver.next_request().unwrap();
+        driver.add_points(&[point(1, 2.0, "a"), point(2, 1.0, "b")]);
+
+        // Next collect round excludes the aggregated points, so its filter grows.
+        let second_request = driver.next_request().unwrap();
+        assert_ne!(collect_request.filter, second_request.filter);
+
+        // Nothing new to collect: the driver switches to filling.
+        driver.add_points(&[]);
+        assert!(driver.next_request().is_some());
+
+        // Filling also comes up empty: the run is over.
+        driver.add_points(&[]);
+        assert!(driver.next_request().is_none());
+
+        let groups = driver.distill();
+        assert_eq!(groups.len(), 2);
+    }
+
+    #[test]
+    fn zero_groups_or_group_size_finishes_immediately() {
+        let budget = RequestBudget {
+            collect: 5,
+            fill: 5,
+        };
+        for (groups, group_size) in [(0, GROUP_SIZE), (GROUPS, 0)] {
+            let mut driver = GroupByDriver::new(
+                base_query(),
+                "g".parse().unwrap(),
+                groups,
+                group_size,
+                Some(Order::LargeBetter),
+                budget,
+            );
+            assert!(driver.next_request().is_none());
+            assert!(driver.distill().is_empty());
+        }
+    }
+}

--- a/lib/shard/src/grouping/mod.rs
+++ b/lib/shard/src/grouping/mod.rs
@@ -1,0 +1,130 @@
+//! Building blocks for group-by queries, shared between the full server implementation
+//! (multi-request group filling in `collection`) and the single-request edge implementation,
+//! so both interpret group keys and shape candidate queries identically.
+
+pub mod aggregator;
+
+use ahash::AHashMap;
+use fnv::FnvBuildHasher;
+use indexmap::IndexSet;
+use segment::data_types::groups::GroupId;
+use segment::json_path::JsonPath;
+use segment::types::{
+    AnyVariants, Condition, FieldCondition, Filter, Match, PointIdType, ScoredPoint,
+    WithPayloadInterface,
+};
+use serde_json::Value;
+
+pub use self::aggregator::GroupsAggregator;
+use crate::query::{ShardPrefetch, ShardQueryRequest};
+
+#[derive(PartialEq, Debug)]
+pub enum AggregatorError {
+    BadKeyType,
+    KeyNotFound,
+}
+
+/// A group of points that share the same value of the `group_by` field.
+#[derive(Debug, Clone)]
+pub struct Group {
+    pub hits: Vec<ScoredPoint>,
+    pub key: GroupId,
+}
+
+impl Group {
+    pub fn hydrate_from(&mut self, map: &AHashMap<PointIdType, ScoredPoint>) {
+        self.hits.iter_mut().for_each(|hit| {
+            if let Some(point) = map.get(&hit.id) {
+                hit.payload.clone_from(&point.payload);
+                hit.vector.clone_from(&point.vector);
+            }
+        });
+    }
+}
+
+/// Make `group_by` field selector work with as `with_payload`.
+pub fn group_by_to_payload_selector(group_by: &JsonPath) -> WithPayloadInterface {
+    WithPayloadInterface::Fields(vec![group_by.strip_wildcard_suffix()])
+}
+
+/// Rewrite a base scoring query into the query used to fetch group candidates: restrict it to
+/// points that carry the `group_by` field, fetch `limit` candidates with only the `group_by`
+/// payload, and scale nested prefetch limits by `group_size` so enough candidates survive
+/// every rescoring stage.
+pub fn shape_candidates_query(
+    query: &mut ShardQueryRequest,
+    group_by: &JsonPath,
+    limit: usize,
+    group_size: usize,
+) {
+    query.limit = limit;
+    query.offset = 0;
+    query
+        .prefetches
+        .iter_mut()
+        .for_each(|prefetch| increase_limit_for_group(prefetch, group_size));
+
+    let key_not_empty = Filter::new_must_not(Condition::IsEmpty(group_by.clone().into()));
+    query.filter = Some(match query.filter.take() {
+        Some(filter) => filter.merge_owned(key_not_empty),
+        None => key_not_empty,
+    });
+
+    query.with_payload = group_by_to_payload_selector(group_by);
+}
+
+fn increase_limit_for_group(shard_prefetch: &mut ShardPrefetch, group_size: usize) {
+    shard_prefetch.limit *= group_size;
+    shard_prefetch.prefetches.iter_mut().for_each(|prefetch| {
+        increase_limit_for_group(prefetch, group_size);
+    });
+}
+
+/// Uses the set of values to create Match::Except's, if possible
+pub fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
+    values_to_any_variants(values)
+        .into_iter()
+        .map(|v| {
+            Condition::Field(FieldCondition::new_match(
+                path.clone(),
+                Match::new_except(v),
+            ))
+        })
+        .collect()
+}
+
+/// Uses the set of values to create Match::Any's, if possible
+pub fn match_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
+    values_to_any_variants(values)
+        .into_iter()
+        .map(|any_variants| {
+            Condition::Field(FieldCondition::new_match(
+                path.clone(),
+                Match::new_any(any_variants),
+            ))
+        })
+        .collect()
+}
+
+fn values_to_any_variants(values: &[Value]) -> Vec<AnyVariants> {
+    let mut any_variants = Vec::new();
+
+    // gather int values
+    let ints: IndexSet<_, FnvBuildHasher> = values.iter().filter_map(|v| v.as_i64()).collect();
+
+    if !ints.is_empty() {
+        any_variants.push(AnyVariants::Integers(ints));
+    }
+
+    // gather string values
+    let strs: IndexSet<_, FnvBuildHasher> = values
+        .iter()
+        .filter_map(|v| v.as_str().map(Into::into))
+        .collect();
+
+    if !strs.is_empty() {
+        any_variants.push(AnyVariants::Strings(strs));
+    }
+
+    any_variants
+}

--- a/lib/shard/src/grouping/mod.rs
+++ b/lib/shard/src/grouping/mod.rs
@@ -3,6 +3,7 @@
 //! so both interpret group keys and shape candidate queries identically.
 
 pub mod aggregator;
+mod driver;
 
 use ahash::AHashMap;
 use fnv::FnvBuildHasher;
@@ -16,6 +17,7 @@ use segment::types::{
 use serde_json::Value;
 
 pub use self::aggregator::GroupsAggregator;
+pub use self::driver::{GroupByDriver, RequestBudget};
 use crate::query::{ShardPrefetch, ShardQueryRequest};
 
 #[derive(PartialEq, Debug)]
@@ -43,15 +45,23 @@ impl Group {
 }
 
 /// Make `group_by` field selector work with as `with_payload`.
-pub fn group_by_to_payload_selector(group_by: &JsonPath) -> WithPayloadInterface {
+fn group_by_to_payload_selector(group_by: &JsonPath) -> WithPayloadInterface {
     WithPayloadInterface::Fields(vec![group_by.strip_wildcard_suffix()])
+}
+
+/// Merge an extra filter into an optional existing one.
+fn merge_filter(target: &mut Option<Filter>, extra: Filter) {
+    *target = Some(match target.take() {
+        Some(filter) => filter.merge_owned(extra),
+        None => extra,
+    });
 }
 
 /// Rewrite a base scoring query into the query used to fetch group candidates: restrict it to
 /// points that carry the `group_by` field, fetch `limit` candidates with only the `group_by`
 /// payload, and scale nested prefetch limits by `group_size` so enough candidates survive
 /// every rescoring stage.
-pub fn shape_candidates_query(
+fn shape_candidates_query(
     query: &mut ShardQueryRequest,
     group_by: &JsonPath,
     limit: usize,
@@ -65,10 +75,7 @@ pub fn shape_candidates_query(
         .for_each(|prefetch| increase_limit_for_group(prefetch, group_size));
 
     let key_not_empty = Filter::new_must_not(Condition::IsEmpty(group_by.clone().into()));
-    query.filter = Some(match query.filter.take() {
-        Some(filter) => filter.merge_owned(key_not_empty),
-        None => key_not_empty,
-    });
+    merge_filter(&mut query.filter, key_not_empty);
 
     query.with_payload = group_by_to_payload_selector(group_by);
 }
@@ -81,7 +88,7 @@ fn increase_limit_for_group(shard_prefetch: &mut ShardPrefetch, group_size: usiz
 }
 
 /// Uses the set of values to create Match::Except's, if possible
-pub fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
+fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
     values_to_any_variants(values)
         .into_iter()
         .map(|v| {
@@ -94,7 +101,7 @@ pub fn except_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
 }
 
 /// Uses the set of values to create Match::Any's, if possible
-pub fn match_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
+fn match_on(path: &JsonPath, values: &[Value]) -> Vec<Condition> {
     values_to_any_variants(values)
         .into_iter()
         .map(|any_variants| {

--- a/lib/shard/src/lib.rs
+++ b/lib/shard/src/lib.rs
@@ -2,6 +2,7 @@ pub mod common;
 pub mod count;
 pub mod facet;
 pub mod files;
+pub mod grouping;
 pub mod locked_segment;
 pub mod operation_rate_cost;
 pub mod operations;

--- a/lib/shard/src/query/mod.rs
+++ b/lib/shard/src/query/mod.rs
@@ -150,6 +150,45 @@ impl ScoringQuery {
     }
 }
 
+/// Returns the expected order of results, depending on the type of query.
+///
+/// `get_distance` resolves the distance of a named vector, for queries scored by raw vector
+/// distance.
+pub fn query_result_order<E>(
+    query: Option<&ScoringQuery>,
+    get_distance: impl FnOnce(&VectorName) -> Result<Distance, E>,
+) -> Result<Option<Order>, E> {
+    let order = match query {
+        Some(scoring_query) => match scoring_query {
+            ScoringQuery::Vector(query_enum) => {
+                if query_enum.is_distance_scored() {
+                    Some(get_distance(query_enum.get_vector_name())?.distance_order())
+                } else {
+                    Some(Order::LargeBetter)
+                }
+            }
+            ScoringQuery::Fusion(fusion) => match fusion {
+                FusionInternal::Rrf { k: _, weights: _ } | FusionInternal::Dbsf => {
+                    Some(Order::LargeBetter)
+                }
+            },
+            // Score boosting formulas are always have descending order,
+            // Euclidean scores can be negated within the formula
+            ScoringQuery::Formula(_formula) => Some(Order::LargeBetter),
+            ScoringQuery::OrderBy(order_by) => Some(Order::from(order_by.direction())),
+            // Random sample does not require ordering
+            ScoringQuery::Sample(SampleInternal::Random) => None,
+            // MMR cannot be reordered
+            ScoringQuery::Mmr(_) => None,
+        },
+        None => {
+            // Order by ID
+            Some(Order::SmallBetter)
+        }
+    };
+    Ok(order)
+}
+
 #[derive(Clone, Debug, PartialEq, Hash, Serialize)]
 pub enum FusionInternal {
     /// Reciprocal Rank Fusion with optional weights per prefetch


### PR DESCRIPTION
## What

Adds two read-only search methods to the edge shard's `EdgeShardRead` API and makes the object-storage read path usable outside of tests.

- **`query_groups`** — group a base query's results by a payload field (new `grouping` module), over-fetching candidates so groups still fill when top hits cluster into few distinct group values.
- **`search_matrix`** — single-shard distance matrix (new `matrix` module): sample points that carry a given vector, then find each sample's nearest neighbours restricted to the sampled set.
- Wires both into the `EdgeShardRead` trait; adds edge test helpers.

## Object-storage read path

Drops the `#[cfg(test)]` gate on the `BlobFile` `UniversalReadExt` impl and moves `io_bridge_object_store` / `object_store` into `segment`'s normal dependencies, so a `ReadOnlyEdgeShard` can serve segments read from object storage (S3) in non-test builds.

Base: `dev`.
