### PR TITLE
fix: resolve AWS S3 default credentials from env (IRSA); object_store 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc32c"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +1948,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "indicatif",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
 ]
@@ -3414,7 +3424,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4309,12 +4318,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4759,14 +4768,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -4776,14 +4787,14 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "md-5",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.2",
+ "quick-xml 0.40.1",
  "rand 0.10.1",
- "reqwest 0.12.28",
- "ring",
+ "reqwest",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4795,6 +4806,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5783,7 +5795,7 @@ dependencies = [
  "object 0.39.1",
  "once_cell",
  "prost 0.14.4",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "smallvec",
  "spin 0.12.0",
@@ -5839,7 +5851,7 @@ dependencies = [
  "raft",
  "raft-proto",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "rstack-self",
  "rustls",
  "rustls-pemfile",
@@ -5952,9 +5964,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -6343,48 +6355,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.4.14",
- "http 1.4.2",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -6422,7 +6392,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7628,7 +7598,7 @@ dependencies = [
  "prost 0.11.9",
  "raft",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "schemars 0.8.22",
  "segment",
  "semver",
@@ -8856,19 +8826,6 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,7 @@ murmur3_32 = "0.1"
 nix = { version = "0.31", features = ["fs", "feature"] }
 num-traits = "0.2.19"
 num_cpus = "1.17"
-object_store = { version = "0.13.2", features = ["aws", "gcp", "azure"] }
+object_store = { version = "0.14.0", features = ["aws", "gcp", "azure"] }
 ordered-float = { version = "5.3.0", features = ["serde", "schemars", "bytemuck"] }
 rayon = "1.12.0"
 parking_lot = { version = "0.12.5", features = ["arc_lock", "deadlock_detection", "serde"] }

--- a/lib/common/io_bridge_object_store/src/backends/aws.rs
+++ b/lib/common/io_bridge_object_store/src/backends/aws.rs
@@ -24,8 +24,7 @@ pub struct AwsConfig {
 /// Authentication mode for AWS S3.
 #[derive(Clone, Debug)]
 pub enum AwsCredentials {
-    /// AWS default credential chain: env vars, shared config files, IMDS,
-    /// ECS task role, etc. (Delegates to whatever the AWS SDK auto-detects.)
+    /// AWS default credential chain, resolved from the environment by `object_store`.
     Default,
     /// Hard-coded access key + secret + optional session token. Useful for
     /// tests and for short-lived credentials provided out-of-band.
@@ -40,21 +39,14 @@ impl BlobBackend for AmazonS3 {
     type Config = AwsConfig;
 
     fn build_store(config: &Self::Config) -> Result<Self> {
-        let mut builder = AmazonS3Builder::new().with_bucket_name(&config.bucket);
-        if let Some(region) = &config.region {
-            builder = builder.with_region(region);
-        }
-        if let Some(endpoint) = &config.endpoint {
-            builder = builder.with_endpoint(endpoint).with_allow_http(true);
-        }
-        builder = match &config.credentials {
-            AwsCredentials::Default => builder,
+        let mut builder = match &config.credentials {
+            AwsCredentials::Default => AmazonS3Builder::from_env(),
             AwsCredentials::Static {
                 access_key_id,
                 secret_access_key,
                 session_token,
             } => {
-                let mut b = builder
+                let mut b = AmazonS3Builder::new()
                     .with_access_key_id(access_key_id)
                     .with_secret_access_key(secret_access_key);
                 if let Some(t) = session_token {
@@ -63,6 +55,13 @@ impl BlobBackend for AmazonS3 {
                 b
             }
         };
+        builder = builder.with_bucket_name(&config.bucket);
+        if let Some(region) = &config.region {
+            builder = builder.with_region(region);
+        }
+        if let Some(endpoint) = &config.endpoint {
+            builder = builder.with_endpoint(endpoint).with_allow_http(true);
+        }
         builder.build().map_err(|err| UniversalIoError::S3Config {
             description: format!("AmazonS3Builder: {err}"),
         })


### PR DESCRIPTION
## Fix: resolve AWS S3 default credentials from the environment

The default credential path built the S3 client with `AmazonS3Builder::new()`, which reads nothing from the environment. So `object_store`'s credential resolver always fell through its chain to **EC2 IMDS (the node instance role)** — `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN` (**EKS IRSA**), ECS task credentials, and EKS Pod Identity were all silently ignored even when their env vars were injected into the pod.

### Change

- `AwsCredentials::Default` now seeds the builder with **`from_env()`**, so web identity (IRSA), container credentials and `AWS_*` keys are honoured. Explicit `bucket` / `region` / `endpoint` from config are applied afterwards and still override anything `from_env()` picks up.
- `AwsCredentials::Static` keeps using `new()` with the explicitly-provided keys.
- Corrects the misleading `Default` doc comment — it is `object_store`, not the AWS SDK, that resolves the chain.

### Also

- Bumps `object_store` 0.13.2 → **0.14.0** (drop-in for the AWS read path; also brings `EKSPodCredentialProvider`).

Base: `dev`.
