### PR TITLE
Fix consensus operations idempotency issues

### DIFF
--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -292,6 +292,43 @@ impl Collection {
         drop(shard_holder); // drop the read lock before acquiring write lock
         let mut shard_holder = self.shards_holder.write().await;
 
+        // Decrement and persist shard count *before* aborting resharding, so crash
+        // doesn't leave `shard_number` pointing at deleted dir, which would panic on startup
+        if resharding_key.direction == ReshardingDirection::Up {
+            let mut config = self.collection_config.write().await;
+
+            match config.params.sharding_method.unwrap_or_default() {
+                // Custom shards don't use persisted count, no need to change it
+                ShardingMethod::Custom => {}
+
+                // Set shard count to ID of shard being aborted, instead of decrementing current
+                // shard count.
+                //
+                // Shard IDs are contiguous, from 0 to N-1.
+                // During scale-up resharding, we add shard N.
+                // Once shard N is aborted, there will be N shards left, from 0 to N-1.
+                //
+                // If operation is replayed after crash, we select same count every time,
+                // instead of decrementing it twice.
+                ShardingMethod::Auto => {
+                    resharding_key
+                        .debug_assert_targets_last_shard(config.params.shard_number.get());
+
+                    let new_shard_number = NonZeroU32::new(resharding_key.shard_id)
+                        .expect("cannot have zero shards after aborting resharding up");
+
+                    if config.params.shard_number != new_shard_number {
+                        config.params.shard_number = new_shard_number;
+                        if let Err(err) = config.save(&self.path) {
+                            log::error!(
+                                "Failed to update and save collection config during resharding: {err}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         // Abort resharding before the related transfers to keep this
         // idempotent on replay: if we aborted a transfer first and crashed,
         // on restart the transfer would be gone and we'd no longer detect
@@ -319,33 +356,6 @@ impl Collection {
             self.abort_shard_transfer(transfer, &shard_holder).await?;
         }
         drop(shard_holder);
-
-        // Decrease the persisted shard count, ensures we don't load dropped shard on restart
-        if resharding_key.direction == ReshardingDirection::Up {
-            let mut config = self.collection_config.write().await;
-            match config.params.sharding_method.unwrap_or_default() {
-                // Idempotent: set the shard count to the aborted shard's id
-                // (shard ids are contiguous from zero, so this is the count
-                // after removing the shard). A replay converges to the same
-                // value instead of decrementing again.
-                ShardingMethod::Auto => {
-                    resharding_key
-                        .debug_assert_targets_last_shard(config.params.shard_number.get());
-                    let new_shard_number = NonZeroU32::new(resharding_key.shard_id)
-                        .expect("cannot have zero shards after aborting resharding up");
-                    if config.params.shard_number != new_shard_number {
-                        config.params.shard_number = new_shard_number;
-                        if let Err(err) = config.save(&self.path) {
-                            log::error!(
-                                "Failed to update and save collection config during resharding: {err}"
-                            );
-                        }
-                    }
-                }
-                // Custom shards don't use the persisted count, we don't change it
-                ShardingMethod::Custom => {}
-            }
-        }
 
         Ok(())
     }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -203,23 +203,31 @@ impl Collection {
                 shard_holder.remove_shard_from_key_mapping(resharding_key.shard_id, shard_key)?;
             }
 
-            shard_holder
-                .drop_and_remove_shard(resharding_key.shard_id)
-                .await?;
-
+            // Decrement and persist shard count *before* dropping shard directory, so crash
+            // doesn't leave `shard_number` pointing at deleted dir, which would panic on startup
             {
                 let mut config = self.collection_config.write().await;
+
                 match config.params.sharding_method.unwrap_or_default() {
-                    // Idempotent: set the shard count to the id of the just
-                    // removed shard (which equals the new count, since shard
-                    // ids are contiguous and this was the highest one). A
-                    // replay converges to the same value instead of
-                    // decrementing again.
+                    // Custom shards don't use persisted count, no need to change it
+                    ShardingMethod::Custom => {}
+
+                    // Set shard count to ID of shard being removed, instead of decrementing current
+                    // shard count.
+                    //
+                    // Shard IDs are contiguous, from 0 to N.
+                    // During scale-down resharding, we remove shard N.
+                    // Once shard N is removed, there will be N shards left, from 0 to N-1.
+                    //
+                    // If operation is replayed after crash, we select same count every time,
+                    // instead of decrementing it twice.
                     ShardingMethod::Auto => {
                         resharding_key
                             .debug_assert_targets_last_shard(config.params.shard_number.get());
+
                         let new_shard_number = NonZeroU32::new(resharding_key.shard_id)
                             .expect("cannot have zero shards after finishing resharding down");
+
                         if config.params.shard_number != new_shard_number {
                             config.params.shard_number = new_shard_number;
                             if let Err(err) = config.save(&self.path) {
@@ -229,10 +237,12 @@ impl Collection {
                             }
                         }
                     }
-                    // Custom shards don't use the persisted count, we don't change it
-                    ShardingMethod::Custom => {}
                 }
             }
+
+            shard_holder
+                .drop_and_remove_shard(resharding_key.shard_id)
+                .await?;
         }
 
         Ok(())

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -89,11 +89,7 @@ impl Collection {
                             .expect("cannot have more than u32::MAX shards after resharding");
                         if config.params.shard_number != new_shard_number {
                             config.params.shard_number = new_shard_number;
-                            if let Err(err) = config.save(&self.path) {
-                                log::error!(
-                                    "Failed to update and save collection config during resharding: {err}",
-                                );
-                            }
+                            config.save(&self.path)?;
                         }
                     }
                     // Custom shards don't use the persisted count, we don't change it
@@ -230,11 +226,7 @@ impl Collection {
 
                         if config.params.shard_number != new_shard_number {
                             config.params.shard_number = new_shard_number;
-                            if let Err(err) = config.save(&self.path) {
-                                log::error!(
-                                    "Failed to update and save collection config during resharding: {err}"
-                                );
-                            }
+                            config.save(&self.path)?;
                         }
                     }
                 }
@@ -319,11 +311,7 @@ impl Collection {
 
                     if config.params.shard_number != new_shard_number {
                         config.params.shard_number = new_shard_number;
-                        if let Err(err) = config.save(&self.path) {
-                            log::error!(
-                                "Failed to update and save collection config during resharding: {err}"
-                            );
-                        }
+                        config.save(&self.path)?;
                     }
                 }
             }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -143,17 +143,17 @@ impl Collection {
                 }
 
                 ShardTransferMethod::ReshardingStreamRecords => {
-                    let resharding_direction =
-                        self.resharding_state().await.map(|state| state.direction);
+                    let direction = self.resharding_state().await.map(|state| state.direction);
 
-                    match resharding_direction {
-                        Some(ReshardingDirection::Up) => ReplicaState::Resharding,
-                        Some(ReshardingDirection::Down) => ReplicaState::ReshardingScaleDown,
-                        None => {
-                            return Err(CollectionError::bad_input(
-                                "can't start resharding transfer, because resharding is not in progress",
-                            ));
-                        }
+                    let Some(direction) = direction else {
+                        return Err(CollectionError::bad_input(
+                            "can't start resharding transfer, because resharding is not in progress",
+                        ));
+                    };
+
+                    match direction {
+                        ReshardingDirection::Up => ReplicaState::Resharding,
+                        ReshardingDirection::Down => ReplicaState::ReshardingScaleDown,
                     }
                 }
             };

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -117,12 +117,15 @@ impl Collection {
                 .unwrap_or(shard_transfer.shard_id);
 
             let shards_holder = self.shards_holder.read().await;
+
             let from_replica_set = shards_holder.get_shard(from_shard_id).ok_or_else(|| {
-                CollectionError::service_error(format!("Shard {from_shard_id} doesn't exist"))
+                CollectionError::bad_request(format!("shard {from_shard_id} doesn't exist"))
             })?;
+
             let to_replica_set = shards_holder.get_shard(to_shard_id).ok_or_else(|| {
-                CollectionError::service_error(format!("Shard {to_shard_id} doesn't exist"))
+                CollectionError::bad_request(format!("shard {to_shard_id} doesn't exist"))
             })?;
+
             let _was_not_transferred =
                 shards_holder.register_start_shard_transfer(shard_transfer.clone())?;
 

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -150,12 +150,12 @@ impl Collection {
         let state = self.state().await;
 
         match state.config.params.sharding_method.unwrap_or_default() {
+            ShardingMethod::Custom => {}
             ShardingMethod::Auto => {
                 return Err(CollectionError::bad_request(format!(
-                    "Shard Key {shard_key} cannot be removed with Auto sharding method"
+                    "shard key {shard_key} cannot be removed with Auto sharding method"
                 )));
             }
-            ShardingMethod::Custom => {}
         }
 
         // Abort resharding and propagate abort error, so we don't leave active resharding
@@ -169,19 +169,21 @@ impl Collection {
             self.abort_resharding(state.key(), true).await?;
         }
 
-        // Invalidate local shard cleaning tasks
-        match self
+        // Invalidate local shard cleanup tasks
+        let shard_ids = self
             .shards_holder
             .read()
             .await
-            .get_shard_ids_by_key(&shard_key)
-        {
+            .get_shard_ids_by_key(&shard_key);
+
+        match shard_ids {
             Ok(shard_ids) => self.invalidate_clean_local_shards(shard_ids).await,
             Err(err) => {
-                log::warn!("Failed to invalidate local shard cleaning task, ignoring: {err}");
+                log::warn!("Failed to invalidate local shard cleanup task, ignoring: {err}");
             }
         }
 
+        // Remove shard key
         self.shards_holder
             .write()
             .await

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -158,18 +158,15 @@ impl Collection {
             ShardingMethod::Custom => {}
         }
 
+        // Abort resharding and propagate abort error, so we don't leave active resharding
+        // referencing deleted shard key
         let resharding_state = self
             .resharding_state()
             .await
             .filter(|state| state.shard_key.as_ref() == Some(&shard_key));
 
-        if let Some(state) = resharding_state
-            && let Err(err) = self.abort_resharding(state.key(), true).await
-        {
-            log::error!(
-                "failed to abort resharding {} while deleting shard key {shard_key}: {err}",
-                state.key(),
-            );
+        if let Some(state) = resharding_state {
+            self.abort_resharding(state.key(), true).await?;
         }
 
         // Invalidate local shard cleaning tasks

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -192,7 +192,15 @@ impl ShardReplicaSet {
                     if err.is_transient() {
                         // Deactivate the peer if forwarding failed with transient error
                         let replica_state = self.replica_state.read();
-                        let from_state = replica_state.get_peer_state(leader_peer);
+
+                        // Note, we explicitly *don't* want to use `from_state` for `ReshardingScaleDown`,
+                        // because it interacts poorly with how abort resharding currently works. 😔
+                        //
+                        // See https://github.com/qdrant/qdrant/pull/7849#issuecomment-4720894619
+                        let from_state = replica_state
+                            .get_peer_state(leader_peer)
+                            .filter(|state| !state.is_partial_or_recovery());
+
                         self.add_locally_disabled(Some(&replica_state), leader_peer, from_state);
 
                         // Return service error

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -91,7 +91,7 @@ pub fn validate_transfer(
     shards_key_mapping: &ShardKeyMapping,
 ) -> CollectionResult<()> {
     let Some(source_replicas) = source_replicas else {
-        return Err(CollectionError::service_error(format!(
+        return Err(CollectionError::bad_request(format!(
             "Shard {} does not exist",
             transfer.shard_id,
         )));
@@ -165,7 +165,7 @@ pub fn validate_transfer(
 
     if transfer.method == Some(ShardTransferMethod::ReshardingStreamRecords) {
         let Some(destination_replicas) = destination_replicas else {
-            return Err(CollectionError::service_error(format!(
+            return Err(CollectionError::bad_request(format!(
                 "Destination shard {} does not exist",
                 transfer.shard_id,
             )));
@@ -207,7 +207,7 @@ pub fn validate_transfer(
         }
     } else if transfer.filter.is_some() {
         let Some(destination_replicas) = destination_replicas else {
-            return Err(CollectionError::service_error(format!(
+            return Err(CollectionError::bad_request(format!(
                 "Destination shard {} does not exist",
                 transfer.shard_id,
             )));

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -79,7 +79,7 @@ where
 ///
 /// For resharding transfers this also checks:
 /// 1. If the source and target shards are different
-/// 2. If the source and target shardsd share the same shard key
+/// 2. If the source and target shards share the same shard key
 ///
 /// If validation fails, return `BadRequest` error.
 pub fn validate_transfer(

--- a/lib/collection/src/shards/transfer/helpers.rs
+++ b/lib/collection/src/shards/transfer/helpers.rs
@@ -125,7 +125,38 @@ pub fn validate_transfer(
         )));
     }
 
-    if let Some(existing_transfer) = check_transfer_conflicts(transfer, current_transfers.iter()) {
+    // If transfer with this key already exist, there are two possible cases:
+    // - either we apply identical, but *conflicting* operation
+    // - or we re-apply *the same* operation after a crash
+    //
+    // We can distinguish between the two, because *last step* of `start_resharding`
+    // sets destination replica state to `Partial`.
+    //
+    // If destination replica *is* in `Partial` state, we should reject conflicting operation.
+    // If destination replica is *not* in `Partial` state, we should re-apply existing operation.
+    if get_transfer(&transfer.key(), current_transfers).is_some() {
+        // Resharding/filtered transfers have separate destination shard
+        let destination_replicas = destination_replicas.unwrap_or(source_replicas);
+
+        let is_applied = destination_replicas
+            .get(&transfer.to)
+            .is_some_and(|state| state.is_partial_or_recovery());
+
+        if is_applied {
+            return Err(CollectionError::bad_request(format!(
+                "Shard {} is already involved in transfer {} -> {}",
+                transfer.shard_id, transfer.from, transfer.to,
+            )));
+        }
+    }
+
+    // Exclude this key from conflict check, because we already checked for identical transfer
+    // conflict above
+    let other_transfers = current_transfers
+        .iter()
+        .filter(|other| transfer.key() != other.key());
+
+    if let Some(existing_transfer) = check_transfer_conflicts(transfer, other_transfers) {
         return Err(CollectionError::bad_request(format!(
             "Shard {} is already involved in transfer {} -> {}",
             transfer.shard_id, existing_transfer.from, existing_transfer.to,


### PR DESCRIPTION
I've run Fable on our consensus code, and it found a bunch of places where our operations are non-idempotent or not partial-failure safe.

This PR implements first batch of fixes, that were the most trivial to implement. Each fix is local to a single operation and relatively easy to understand.

(The audit had more issue than this PR includes, so `audit-A`/`audit-H` labels are a bit weird, sorry about that. 🤷‍♀️)

- **Replica deactivation** (`[audit-A]`): the forward-update failure path proposed `Dead` with an unfiltered `from_state`. If the replica was in a `Resharding*` state, applying `Dead` triggers abort-resharding, whose early writes change the replica state — so a peer that crashes mid-abort fails the `from_state` check on re-apply, dismisses the entry, and keeps the half-aborted state forever. Now filtered like the sibling site (PR #7849), so such proposals carry no `from_state` and re-apply converges.
- **Crash-loop on restart** (`[audit-H]` ×2): `finish_resharding` (down) and `abort_resharding` (up) deleted the shard directory *before* persisting the decremented `shard_number`, so a crash in between made the loader panic on the missing dir at every restart. The config is now saved before the drop. A crash in the new order leaves an extra shard dir that the loader simply doesn't load, and the re-applied operation deletes it.
- **Swallowed config saves** (`[audit-J]`): resharding logged-and-ignored `config.save` failures, letting the operation "succeed" with a stale shard count on disk. Errors now propagate (halt-and-retry, safe because the saves are value-idempotent).
- **Transfer Start replay** (`[audit-D]`): re-apply of a half-applied Start hit its *own* registered transfer in the conflict check and was dismissed, permanently missing the destination replica. The transfer's own key is now excluded, so replay re-runs the idempotent start.
- **Cluster-wide stalls** (`[audit-F]`): pre-write transfer validations (missing source/destination shard) returned `service_error`, deterministically halting consensus on every peer. They run before any durable write, so they are now dismissable `bad_request`.
- **DropShardKey** (`[audit-M]`): a failed force-abort of resharding was swallowed and the shards dropped anyway, potentially leaving `resharding_state.json` referencing a dropped key. The error now propagates.

Each commit message details the exact crash window and why the new behavior converges on replay.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
