### PR TITLE
Rename ambiguous build_multivec_segment test fixture

### DIFF
--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -11,7 +11,7 @@ use segment::entry::entry_point::SegmentEntry;
 use segment::payload_json;
 use segment::segment::Segment;
 use segment::segment_constructor::simple_segment_constructor::{
-    VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment, build_simple_segment,
+    VECTOR1_NAME, VECTOR2_NAME, build_segment_with_two_named_vecs, build_simple_segment,
 };
 use segment::types::{Distance, HnswGlobalConfig, Payload, PointIdType, SeqNumberType};
 use shard::operations::optimization::OptimizerThresholds;
@@ -66,7 +66,7 @@ pub fn random_multi_vec_segment(
     dim2: usize,
 ) -> Segment {
     let mut id_gen = PointIdGenerator::default();
-    let mut segment = build_multivec_segment(path, dim1, dim2, Distance::Dot).unwrap();
+    let mut segment = build_segment_with_two_named_vecs(path, dim1, dim2, Distance::Dot).unwrap();
     let mut rnd = rand::rng();
     let payload_key = "number";
     let keyword_key = "keyword";

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -39,7 +39,7 @@ use crate::id_tracker::{IdTracker, IdTrackerRead};
 use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use crate::json_path::JsonPath;
 use crate::segment_constructor::simple_segment_constructor::{
-    VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment, build_simple_segment,
+    VECTOR1_NAME, VECTOR2_NAME, build_segment_with_two_named_vecs, build_simple_segment,
 };
 use crate::segment_constructor::{build_segment, load_segment};
 use crate::types::{
@@ -557,7 +557,8 @@ fn test_point_vector_count_multivec() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let dim = 1;
 
-    let mut segment = build_multivec_segment(dir.path(), dim, dim, Distance::Dot).unwrap();
+    let mut segment =
+        build_segment_with_two_named_vecs(dir.path(), dim, dim, Distance::Dot).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 
@@ -1280,7 +1281,7 @@ fn test_vector_compatibility_checks() {
     init_logger();
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut segment = build_multivec_segment(dir.path(), 4, 2, Distance::Dot).unwrap();
+    let mut segment = build_segment_with_two_named_vecs(dir.path(), 4, 2, Distance::Dot).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/segment/src/segment_constructor/simple_segment_constructor.rs
+++ b/lib/segment/src/segment_constructor/simple_segment_constructor.rs
@@ -78,7 +78,9 @@ pub fn build_simple_segment_with_payload_storage(
     .map(|(segment, _token)| segment)
 }
 
-pub fn build_multivec_segment(
+/// Builds a new segment with plain index and two named dense vectors:
+/// [`VECTOR1_NAME`] with `dim1` and [`VECTOR2_NAME`] with `dim2`.
+pub fn build_segment_with_two_named_vecs(
     path: &Path,
     dim1: usize,
     dim2: usize,

--- a/lib/segment/tests/integration/disbalanced_vectors_test.rs
+++ b/lib/segment/tests/integration/disbalanced_vectors_test.rs
@@ -8,7 +8,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::{NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry};
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::{
-    VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment,
+    VECTOR1_NAME, VECTOR2_NAME, build_segment_with_two_named_vecs,
 };
 use segment::types::{Distance, HnswGlobalConfig};
 use segment::vector_storage::VectorStorageRead;
@@ -21,8 +21,8 @@ fn test_rebuild_with_removed_vectors() {
 
     let stopped = AtomicBool::new(false);
 
-    let mut segment1 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
-    let mut segment2 = build_multivec_segment(dir.path(), 4, 6, Distance::Dot).unwrap();
+    let mut segment1 = build_segment_with_two_named_vecs(dir.path(), 4, 6, Distance::Dot).unwrap();
+    let mut segment2 = build_segment_with_two_named_vecs(dir.path(), 4, 6, Distance::Dot).unwrap();
 
     let hw_counter = HardwareCounterCell::new();
 

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -563,7 +563,7 @@ fn test_point_vector_count() {
 #[test]
 fn test_point_vector_count_multivec() {
     use segment::segment_constructor::simple_segment_constructor::{
-        VECTOR1_NAME, VECTOR2_NAME, build_multivec_segment,
+        VECTOR1_NAME, VECTOR2_NAME, build_segment_with_two_named_vecs,
     };
     use segment::types::Distance;
 
@@ -571,7 +571,8 @@ fn test_point_vector_count_multivec() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let dim = 1;
 
-    let mut original_segment = build_multivec_segment(dir.path(), dim, dim, Distance::Dot).unwrap();
+    let mut original_segment =
+        build_segment_with_two_named_vecs(dir.path(), dim, dim, Distance::Dot).unwrap();
 
     let hw_cell = HardwareCounterCell::new();
 


### PR DESCRIPTION
The test fixture `build_multivec_segment` was highly ambiguous: the name suggests multi-dense (ColBERT-style) _multivectors_, but it actually builds _two single-dense named vectors_ (vector1/vector2, both [without multivector_config](https://github.com/qdrant/qdrant/blob/5e81d1fe6098115c7c4c9a29c17e68a79b9bcec6/lib/segment/src/segment_constructor/simple_segment_constructor.rs#L98))

This caused confusion in [#9690](https://github.com/qdrant/qdrant/pull/9690/changes#diff-524a2f40e5b5dc77e7acd5330dc5e3298a87cc96e0327a9478200c0fa3c3a4aeR598), where we assumed it builds a segment with ColBERT multivectors.

**Solution**: Renamed the fixture to `build_segment_with_two_named_vecs`. No behavior change.