### PR TITLE
[TQDT] Segment entry raw upsert

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -459,6 +459,23 @@ pub trait SegmentEntry: NonAppendableSegmentEntry {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
+    /// Byte-blob analogue of [`SegmentEntry::upsert_point`]: vector values are
+    /// storage-native bytes in the exact form returned by
+    /// [`ReadSegmentEntry::retrieve_raw`], so requantized (e.g. TurboQuant)
+    /// vectors relocate without a lossy decode/re-encode round-trip.
+    ///
+    /// The bytes carry no encoding/version tag: the target segment must have
+    /// the same vector configuration (kind, datatype, dim) as the source. The
+    /// bytes are inserted as-is, without preprocessing — they were already
+    /// preprocessed (e.g. cosine-normalized) when first ingested.
+    fn upsert_point_raw(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool>;
+
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/vector_index_impl.rs
@@ -92,4 +92,13 @@ impl VectorIndex for HNSWIndex {
     ) -> OperationResult<()> {
         Err(OperationError::service_error("Cannot update HNSW index"))
     }
+
+    fn update_vector_raw(
+        &mut self,
+        _id: PointOffsetType,
+        _vector: Option<&[u8]>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Err(OperationError::service_error("Cannot update HNSW index"))
+    }
 }

--- a/lib/segment/src/index/plain_vector_index/lifecycle.rs
+++ b/lib/segment/src/index/plain_vector_index/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
 use common::types::PointOffsetType;
 
 use super::PlainVectorIndex;
@@ -38,6 +39,31 @@ impl VectorIndex for PlainVectorIndex {
                 vector_storage.insert_vector(id, VectorRef::from(&default_vector), hw_counter)?;
             }
             vector_storage.delete_vector(id)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_vector_raw(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<&[u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let Some(bytes) = vector else {
+            // Removal doesn't touch the vector value; reuse the decoded path.
+            return self.update_vector(id, None, hw_counter);
+        };
+
+        let mut vector_storage = self.vector_storage.borrow_mut();
+        vector_storage.insert_vector_bytes(id, bytes, hw_counter)?;
+
+        let mut quantized_vectors = self.quantized_vectors.borrow_mut();
+        if let Some(quantized_vectors) = quantized_vectors.as_mut() {
+            // Build-time quantized copies can't ingest storage-native bytes;
+            // feed them the decoded vector read back from the storage.
+            let vector = vector_storage.get_vector::<Random>(id).to_owned();
+            quantized_vectors.upsert_vector(id, VectorRef::from(&vector), hw_counter)?;
         }
 
         Ok(())

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
@@ -20,6 +20,7 @@ use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseI
 use crate::index::{VectorIndex, VectorIndexRead};
 use crate::telemetry::VectorIndexSearchesTelemetry;
 use crate::types::{Filter, SearchParams};
+use crate::vector_storage::sparse::StoredSparseVector;
 use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
@@ -186,5 +187,20 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         }
 
         Ok(())
+    }
+
+    fn update_vector_raw(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<&[u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // The raw form is the lossless `StoredSparseVector` encoding; the
+        // inverted index needs the decoded values anyway, so decode and
+        // delegate to the regular path.
+        let sparse = vector
+            .map(|bytes| SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes)?))
+            .transpose()?;
+        self.update_vector(id, sparse.as_ref().map(VectorRef::from), hw_counter)
     }
 }

--- a/lib/segment/src/index/vector_index_base.rs
+++ b/lib/segment/src/index/vector_index_base.rs
@@ -84,6 +84,20 @@ pub trait VectorIndex: VectorIndexRead {
         vector: Option<VectorRef>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
+
+    /// Byte-blob analogue of [`VectorIndex::update_vector`]: `vector` is the
+    /// storage-native serialized form (the [`retrieve_raw`] format), letting
+    /// requantized storages ingest bytes verbatim instead of a lossy
+    /// decode/re-encode round-trip. `None` behaves exactly like
+    /// `update_vector(id, None, _)`.
+    ///
+    /// [`retrieve_raw`]: crate::entry::entry_point::ReadSegmentEntry::retrieve_raw
+    fn update_vector_raw(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<&[u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
 }
 
 #[derive(Debug)]
@@ -346,6 +360,31 @@ impl VectorIndex for VectorIndexEnum {
             Self::SparseCompressedMmapF32(index) => index.update_vector(id, vector, hw_counter),
             Self::SparseCompressedMmapF16(index) => index.update_vector(id, vector, hw_counter),
             Self::SparseCompressedMmapU8(index) => index.update_vector(id, vector, hw_counter),
+        }
+    }
+
+    fn update_vector_raw(
+        &mut self,
+        id: PointOffsetType,
+        vector: Option<&[u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            Self::Plain(index) => index.update_vector_raw(id, vector, hw_counter),
+            Self::Hnsw(index) => index.update_vector_raw(id, vector, hw_counter),
+            Self::SparseRam(index) => index.update_vector_raw(id, vector, hw_counter),
+            Self::SparseCompressedImmutableRamF32(index) => {
+                index.update_vector_raw(id, vector, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamF16(index) => {
+                index.update_vector_raw(id, vector, hw_counter)
+            }
+            Self::SparseCompressedImmutableRamU8(index) => {
+                index.update_vector_raw(id, vector, hw_counter)
+            }
+            Self::SparseCompressedMmapF32(index) => index.update_vector_raw(id, vector, hw_counter),
+            Self::SparseCompressedMmapF16(index) => index.update_vector_raw(id, vector, hw_counter),
+            Self::SparseCompressedMmapU8(index) => index.update_vector_raw(id, vector, hw_counter),
         }
     }
 }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -768,6 +768,65 @@ impl SegmentEntry for Segment {
         }
     }
 
+    fn upsert_point_raw(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        debug_assert!(self.is_appendable());
+        for (vector_name, _) in vectors {
+            check_vector_name(vector_name, &self.segment_config)?;
+        }
+        // No `preprocess` here on purpose: raw bytes are the stored form,
+        // already preprocessed (e.g. cosine-normalized) on first ingestion.
+        let stored_internal_point = self
+            .id_tracker
+            .borrow()
+            .internal_id_with_behavior(point_id, DeferredBehavior::WithDeferred);
+        match stored_internal_point {
+            // Not `handle_point_mutate`: its append-only arm snapshots the old
+            // vectors into decoded `NamedVectors`, which cannot carry
+            // storage-native bytes (and would be a lossy read for TurboQuant).
+            // The raw clone path skips the vector snapshot entirely — upsert
+            // discards all old vectors anyway.
+            Some(existing_internal_id) => {
+                let append_only = self.is_append_only();
+                self.handle_point_version_and_failure(
+                    op_num,
+                    point_id,
+                    Some(existing_internal_id),
+                    |segment| {
+                        if append_only {
+                            let new_id = segment.clone_and_replace_point_raw(
+                                op_num,
+                                point_id,
+                                existing_internal_id,
+                                vectors,
+                                hw_counter,
+                            )?;
+                            Ok((true, Some(new_id)))
+                        } else {
+                            segment.replace_all_vectors_raw(
+                                existing_internal_id,
+                                op_num,
+                                vectors,
+                                hw_counter,
+                            )?;
+                            Ok((true, Some(existing_internal_id)))
+                        }
+                    },
+                )
+            }
+            None => self.handle_point_version_and_failure(op_num, point_id, None, |segment| {
+                let new_index =
+                    segment.insert_new_vectors_raw(point_id, op_num, vectors, hw_counter)?;
+                Ok((false, Some(new_index)))
+            }),
+        }
+    }
+
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -25,10 +25,21 @@ use crate::id_tracker::{IdTracker, IdTrackerRead};
 use crate::index::{PayloadIndex, PayloadIndexRead, VectorIndex};
 use crate::types::{
     Payload, PayloadFieldSchema, PayloadKeyType, PointIdType, SegmentState, SeqNumberType,
-    SnapshotFormat, VectorName,
+    SnapshotFormat, VectorName, VectorNameBuf,
 };
 use crate::utils;
 use crate::vector_storage::VectorStorageRead;
+
+/// Look up a named vector in the `retrieve_raw`-shaped `(name, bytes)` list.
+fn find_raw_vector<'a>(
+    vectors: &'a [(VectorNameBuf, Vec<u8>)],
+    vector_name: &VectorName,
+) -> Option<&'a [u8]> {
+    vectors
+        .iter()
+        .find(|(name, _)| name == vector_name)
+        .map(|(_, bytes)| bytes.as_slice())
+}
 
 impl Segment {
     /// Replace vectors in-place
@@ -116,6 +127,94 @@ impl Segment {
         }
         self.id_tracker.borrow_mut().set_link(point_id, new_index)?;
         Ok(new_index)
+    }
+
+    /// Byte-blob analogue of [`Segment::replace_all_vectors`]: vector values
+    /// are storage-native bytes (the `retrieve_raw` form). Semantics are the
+    /// same — named vectors not present in `vectors` are deleted.
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    pub(super) fn replace_all_vectors_raw(
+        &mut self,
+        internal_id: PointOffsetType,
+        op_num: SeqNumberType,
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        debug_assert!(self.is_appendable());
+        for (vector_name, vector_data) in self.vector_data.iter_mut() {
+            let bytes = find_raw_vector(vectors, vector_name);
+            let mut vector_index = vector_data.vector_index.borrow_mut();
+            vector_index.update_vector_raw(internal_id, bytes, hw_counter)?;
+            self.version_tracker.set_vector(vector_name, Some(op_num));
+        }
+        Ok(())
+    }
+
+    /// Byte-blob analogue of [`Segment::insert_new_vectors`]: vector values
+    /// are storage-native bytes (the `retrieve_raw` form).
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    pub(super) fn insert_new_vectors_raw(
+        &mut self,
+        point_id: PointIdType,
+        op_num: SeqNumberType,
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<PointOffsetType> {
+        debug_assert!(self.is_appendable());
+        let new_index = self.id_tracker.borrow().total_point_count() as PointOffsetType;
+        for (vector_name, vector_data) in self.vector_data.iter_mut() {
+            let bytes = find_raw_vector(vectors, vector_name);
+            let mut vector_index = vector_data.vector_index.borrow_mut();
+            vector_index.update_vector_raw(new_index, bytes, hw_counter)?;
+            self.version_tracker.set_vector(vector_name, Some(op_num));
+        }
+        self.id_tracker.borrow_mut().set_link(point_id, new_index)?;
+        Ok(new_index)
+    }
+
+    /// Append-only counterpart of [`Segment::replace_all_vectors_raw`]: write
+    /// the raw vectors at a fresh internal id and repoint the id tracker,
+    /// tombstoning `old_id` — the raw twin of [`Segment::clone_and_mutate_point`]
+    /// specialized to full-vector replacement.
+    ///
+    /// Unlike `clone_and_mutate_point`, no vector snapshot is taken: upsert
+    /// discards every old named vector anyway, so reading them (a lossy
+    /// decode for TurboQuant storages) is unnecessary. Only the payload
+    /// survives the move; it is rewritten at the new id — always, even when
+    /// empty, for the same null-index `total_point_count` bump reason.
+    ///
+    /// The payload lands after `set_link`, unlike `clone_and_mutate_point`'s
+    /// order. Not observable: callers hold exclusive segment access, and on a
+    /// mid-way failure the wrapping version handler parks the segment in a
+    /// failed state for replay either way.
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    pub(super) fn clone_and_replace_point_raw(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        old_id: PointOffsetType,
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<PointOffsetType> {
+        debug_assert!(self.is_appendable());
+        let payload = self
+            .payload_index
+            .borrow()
+            .with_view(|view| view.get_payload(old_id, hw_counter))?;
+        let new_id = self.insert_new_vectors_raw(point_id, op_num, vectors, hw_counter)?;
+        self.payload_index
+            .borrow_mut()
+            .overwrite_payload(new_id, &payload, hw_counter)?;
+        Ok(new_id)
     }
 
     /// Append-only update: snapshot the point at `old_id` into owned vectors

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -133,6 +133,10 @@ impl Segment {
     /// are storage-native bytes (the `retrieve_raw` form). Semantics are the
     /// same — named vectors not present in `vectors` are deleted.
     ///
+    /// Unlike its decoded twin, `internal_id` may also be a fresh id one past
+    /// the current end: the raw insert paths reuse this loop and the storages
+    /// grow as needed.
+    ///
     /// # Warning
     ///
     /// Available for appendable segments only.
@@ -168,12 +172,7 @@ impl Segment {
     ) -> OperationResult<PointOffsetType> {
         debug_assert!(self.is_appendable());
         let new_index = self.id_tracker.borrow().total_point_count() as PointOffsetType;
-        for (vector_name, vector_data) in self.vector_data.iter_mut() {
-            let bytes = find_raw_vector(vectors, vector_name);
-            let mut vector_index = vector_data.vector_index.borrow_mut();
-            vector_index.update_vector_raw(new_index, bytes, hw_counter)?;
-            self.version_tracker.set_vector(vector_name, Some(op_num));
-        }
+        self.replace_all_vectors_raw(new_index, op_num, vectors, hw_counter)?;
         self.id_tracker.borrow_mut().set_link(point_id, new_index)?;
         Ok(new_index)
     }
@@ -189,10 +188,9 @@ impl Segment {
     /// survives the move; it is rewritten at the new id — always, even when
     /// empty, for the same null-index `total_point_count` bump reason.
     ///
-    /// The payload lands after `set_link`, unlike `clone_and_mutate_point`'s
-    /// order. Not observable: callers hold exclusive segment access, and on a
-    /// mid-way failure the wrapping version handler parks the segment in a
-    /// failed state for replay either way.
+    /// Step order matches `clone_and_mutate_point`: vectors, then payload,
+    /// then `set_link` last — so a mid-way failure leaves the id tracker
+    /// still pointing at the intact `old_id`.
     ///
     /// # Warning
     ///
@@ -210,10 +208,12 @@ impl Segment {
             .payload_index
             .borrow()
             .with_view(|view| view.get_payload(old_id, hw_counter))?;
-        let new_id = self.insert_new_vectors_raw(point_id, op_num, vectors, hw_counter)?;
+        let new_id = self.id_tracker.borrow().total_point_count() as PointOffsetType;
+        self.replace_all_vectors_raw(new_id, op_num, vectors, hw_counter)?;
         self.payload_index
             .borrow_mut()
             .overwrite_payload(new_id, &payload, hw_counter)?;
+        self.id_tracker.borrow_mut().set_link(point_id, new_id)?;
         Ok(new_id)
     }
 

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -46,7 +46,8 @@ use crate::types::{
     Condition, Distance, ExtendedPointId, FieldCondition, Filter, HasIdCondition, Indexes, Match,
     MultiVectorConfig, Payload, PayloadContainer, PayloadFieldSchema, PayloadSchemaType,
     PointIdType, SearchParams, SnapshotFormat, SparseVectorDataConfig, SparseVectorStorageType,
-    ValueVariants, VectorDataConfig, VectorStorageType, WithPayload, WithVector,
+    ValueVariants, VectorDataConfig, VectorStorageDatatype, VectorStorageType, WithPayload,
+    WithVector,
 };
 use crate::utils::maybe_arc::MaybeArc;
 use crate::vector_storage::query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery};
@@ -724,6 +725,368 @@ fn test_retrieve_raw_sparse_bytes() {
 
     let decoded = SparseVector::try_from(StoredSparseVector::from_bytes(bytes)).unwrap();
     assert_eq!(decoded, sparse);
+}
+
+/// Fetch one named vector of one point via `retrieve_raw`.
+fn retrieve_raw_vector(segment: &Segment, point_id: PointIdType, name: &str) -> Vec<u8> {
+    let hw_counter = HardwareCounterCell::new();
+    let is_stopped = AtomicBool::new(false);
+    let raw = segment
+        .retrieve_raw(
+            &[point_id],
+            &WithPayload::default(),
+            &true.into(),
+            &hw_counter,
+            &is_stopped,
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+    let record = raw.get(&point_id).expect("point must be retrieved");
+    let vectors = record.vectors.as_ref().expect("vectors requested");
+    vectors
+        .iter()
+        .find(|(n, _)| n == name)
+        .map(|(_, bytes)| bytes.clone())
+        .expect("vector must be present")
+}
+
+/// `upsert_point_raw` with `retrieve_raw` bytes must reproduce the point: the
+/// destination decodes to the original vector and re-serializes to identical
+/// bytes. Also covers the replace path (raw upsert over an existing point).
+#[test]
+fn test_upsert_raw_dense_roundtrip() {
+    init_logger();
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let dim = 4;
+
+    let mut src = build_simple_segment(src_dir.path(), dim, Distance::Dot).unwrap();
+    let mut dst = build_simple_segment(dst_dir.path(), dim, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec = vec![0.1_f32, 0.2, 0.3, 0.4];
+    src.upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+
+    // Insert path: the point does not exist in the destination yet.
+    dst.upsert_point_raw(
+        100,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(vec)),
+    );
+    assert_eq!(
+        retrieve_raw_vector(&dst, 7.into(), DEFAULT_VECTOR_NAME),
+        bytes
+    );
+
+    // Replace path: raw upsert over the existing point with different bytes.
+    let vec2 = vec![1.0_f32, 2.0, 3.0, 4.0];
+    src.upsert_point(101, 8.into(), only_default_vector(&vec2), &hw_counter)
+        .unwrap();
+    let bytes2 = retrieve_raw_vector(&src, 8.into(), DEFAULT_VECTOR_NAME);
+    dst.upsert_point_raw(
+        101,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes2)],
+        &hw_counter,
+    )
+    .unwrap();
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(vec2)),
+    );
+}
+
+/// Raw upsert over an existing point on an append-only segment must go
+/// through the clone-and-tombstone path: vectors are replaced from the raw
+/// bytes at a fresh internal id, the payload survives the move.
+#[test]
+fn test_upsert_raw_append_only_replace() {
+    init_logger();
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let dim = 4;
+
+    let mut src = build_simple_segment(src_dir.path(), dim, Distance::Dot).unwrap();
+    let mut dst = build_simple_segment(dst_dir.path(), dim, Distance::Dot).unwrap();
+    dst.append_only_mutations = true;
+    let hw_counter = HardwareCounterCell::new();
+
+    let old_vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    dst.upsert_point(100, 7.into(), only_default_vector(&old_vec), &hw_counter)
+        .unwrap();
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+    dst.set_full_payload(101, 7.into(), &payload, &hw_counter)
+        .unwrap();
+    let old_internal_id = dst
+        .with_view(|v| v.lookup_internal_id(7.into(), DeferredBehavior::VisibleOnly))
+        .unwrap();
+
+    let new_vec = vec![0.1_f32, 0.2, 0.3, 0.4];
+    src.upsert_point(100, 7.into(), only_default_vector(&new_vec), &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+
+    dst.upsert_point_raw(
+        102,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    // The point moved to a fresh internal id (old slot tombstoned)...
+    let new_internal_id = dst
+        .with_view(|v| v.lookup_internal_id(7.into(), DeferredBehavior::VisibleOnly))
+        .unwrap();
+    assert_ne!(old_internal_id, new_internal_id);
+    // ...carrying the replaced vector (byte-identical) and the old payload.
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(new_vec)),
+    );
+    assert_eq!(
+        retrieve_raw_vector(&dst, 7.into(), DEFAULT_VECTOR_NAME),
+        bytes
+    );
+    assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload);
+}
+
+/// Multi-dense raw round-trip: the flattened inner-vector blob must survive
+/// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
+/// original multivector.
+#[test]
+fn test_upsert_raw_multivec_roundtrip() {
+    init_logger();
+    let dim = 3;
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance: Distance::Dot,
+                storage_type: VectorStorageType::default(),
+                index: Indexes::Plain {},
+                quantization_config: None,
+                multivector_config: Some(MultiVectorConfig::default()),
+                datatype: None,
+            },
+        )]),
+        sparse_vector_data: Default::default(),
+        payload_storage_type: Default::default(),
+    };
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let (mut src, _) = build_segment(src_dir.path(), &config, None, true).unwrap();
+    let (mut dst, _) = build_segment(dst_dir.path(), &config, None, true).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // Two inner vectors of `dim` elements each, flattened.
+    let flattened = vec![0.1_f32, 0.2, 0.3, 0.4, 0.5, 0.6];
+    let multi_vec = MultiDenseVectorInternal::new(flattened, dim);
+    src.upsert_point(
+        100,
+        4.into(),
+        only_default_multi_vector(&multi_vec),
+        &hw_counter,
+    )
+    .unwrap();
+    let bytes = retrieve_raw_vector(&src, 4.into(), DEFAULT_VECTOR_NAME);
+
+    dst.upsert_point_raw(
+        100,
+        4.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 4.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::MultiDense(multi_vec)),
+    );
+    assert_eq!(
+        retrieve_raw_vector(&dst, 4.into(), DEFAULT_VECTOR_NAME),
+        bytes
+    );
+}
+
+/// Sparse raw round-trip: the `StoredSparseVector` bincode blob must insert
+/// back and decode to the original sparse vector.
+#[test]
+fn test_upsert_raw_sparse_roundtrip() {
+    init_logger();
+    let sparse_name = "sparse";
+    let config = SegmentConfig {
+        vector_data: HashMap::new(),
+        sparse_vector_data: HashMap::from_iter([(
+            sparse_name.to_string(),
+            SparseVectorDataConfig {
+                index: SparseIndexConfig::new(Some(1), SparseIndexType::MutableRam, None, None),
+                storage_type: SparseVectorStorageType::Mmap,
+                modifier: None,
+            },
+        )]),
+        payload_storage_type: Default::default(),
+    };
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let (mut src, _) = build_segment(src_dir.path(), &config, None, true).unwrap();
+    let (mut dst, _) = build_segment(dst_dir.path(), &config, None, true).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let sparse = SparseVector::new(vec![1, 5, 42], vec![0.5, 1.5, 2.5]).unwrap();
+    let mut vectors = NamedVectors::default();
+    vectors.insert(
+        sparse_name.to_string(),
+        VectorInternal::Sparse(sparse.clone()),
+    );
+    src.upsert_point(100, 7.into(), vectors, &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), sparse_name);
+
+    dst.upsert_point_raw(
+        100,
+        7.into(),
+        &[(sparse_name.to_string(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dst.vector(sparse_name, 7.into(), &hw_counter).unwrap(),
+        Some(VectorInternal::Sparse(sparse)),
+    );
+    assert_eq!(retrieve_raw_vector(&dst, 7.into(), sparse_name), bytes);
+}
+
+/// TurboQuant dense raw round-trip: the encoded TQ blob must be ingested
+/// verbatim — byte-identical after `upsert_point_raw` → `retrieve_raw`, with
+/// no dequantize/requantize drift (destination decodes exactly like the
+/// source).
+#[test]
+fn test_upsert_raw_dense_turbo_bytes() {
+    init_logger();
+    let dim = 64;
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance: Distance::Dot,
+                storage_type: VectorStorageType::ChunkedMmap,
+                index: Indexes::Plain {},
+                quantization_config: None,
+                multivector_config: None,
+                datatype: Some(VectorStorageDatatype::Turbo4),
+            },
+        )]),
+        sparse_vector_data: Default::default(),
+        payload_storage_type: Default::default(),
+    };
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let (mut src, _) = build_segment(src_dir.path(), &config, None, true).unwrap();
+    let (mut dst, _) = build_segment(dst_dir.path(), &config, None, true).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec: Vec<f32> = (0..dim).map(|i| (i as f32).sin()).collect();
+    src.upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+
+    dst.upsert_point_raw(
+        100,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    // Encoded bytes survive verbatim — no requantization round-trip.
+    assert_eq!(
+        retrieve_raw_vector(&dst, 7.into(), DEFAULT_VECTOR_NAME),
+        bytes
+    );
+    // And both segments dequantize to exactly the same vector.
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        src.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+    );
+}
+
+/// TurboQuant multivector raw round-trip: the concatenated encoded inner
+/// records must be ingested verbatim.
+#[test]
+fn test_upsert_raw_multivec_turbo_bytes() {
+    init_logger();
+    let dim = 64;
+    let config = SegmentConfig {
+        vector_data: HashMap::from([(
+            DEFAULT_VECTOR_NAME.to_owned(),
+            VectorDataConfig {
+                size: dim,
+                distance: Distance::Dot,
+                storage_type: VectorStorageType::ChunkedMmap,
+                index: Indexes::Plain {},
+                quantization_config: None,
+                multivector_config: Some(MultiVectorConfig::default()),
+                datatype: Some(VectorStorageDatatype::Turbo4),
+            },
+        )]),
+        sparse_vector_data: Default::default(),
+        payload_storage_type: Default::default(),
+    };
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let (mut src, _) = build_segment(src_dir.path(), &config, None, true).unwrap();
+    let (mut dst, _) = build_segment(dst_dir.path(), &config, None, true).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // Three inner vectors of `dim` elements each, flattened.
+    let flattened: Vec<f32> = (0..3 * dim).map(|i| (i as f32).cos()).collect();
+    let multi_vec = MultiDenseVectorInternal::new(flattened, dim);
+    src.upsert_point(
+        100,
+        4.into(),
+        only_default_multi_vector(&multi_vec),
+        &hw_counter,
+    )
+    .unwrap();
+    let bytes = retrieve_raw_vector(&src, 4.into(), DEFAULT_VECTOR_NAME);
+
+    dst.upsert_point_raw(
+        100,
+        4.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        &hw_counter,
+    )
+    .unwrap();
+
+    assert_eq!(
+        retrieve_raw_vector(&dst, 4.into(), DEFAULT_VECTOR_NAME),
+        bytes
+    );
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 4.into(), &hw_counter)
+            .unwrap(),
+        src.vector(DEFAULT_VECTOR_NAME, 4.into(), &hw_counter)
+            .unwrap(),
+    );
 }
 
 /// Tests segment functions to ensure invalid requests do error

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -972,6 +972,85 @@ fn test_upsert_raw_sparse_roundtrip() {
     assert_eq!(retrieve_raw_vector(&dst, 7.into(), sparse_name), bytes);
 }
 
+/// Byte/half dense raw round-trip: the packed `[T]` blob must survive
+/// `retrieve_raw` → `upsert_point_raw` byte-identically for the narrow
+/// element types too — the `T` → `f32` → `T` hop through the regular insert
+/// path is lossless.
+#[test]
+fn test_upsert_raw_dense_narrow_datatypes_roundtrip() {
+    init_logger();
+    let dim = 4;
+    for datatype in [VectorStorageDatatype::Uint8, VectorStorageDatatype::Float16] {
+        let config = SegmentConfig {
+            vector_data: HashMap::from([(
+                DEFAULT_VECTOR_NAME.to_owned(),
+                VectorDataConfig {
+                    size: dim,
+                    distance: Distance::Dot,
+                    storage_type: VectorStorageType::ChunkedMmap,
+                    index: Indexes::Plain {},
+                    quantization_config: None,
+                    multivector_config: None,
+                    datatype: Some(datatype),
+                },
+            )]),
+            sparse_vector_data: Default::default(),
+            payload_storage_type: Default::default(),
+        };
+        let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+        let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+        let (mut src, _) = build_segment(src_dir.path(), &config, None, true).unwrap();
+        let (mut dst, _) = build_segment(dst_dir.path(), &config, None, true).unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Values exactly representable in both u8 and f16.
+        let vec = vec![0.0_f32, 1.0, 128.0, 255.0];
+        src.upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+            .unwrap();
+        let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+
+        dst.upsert_point_raw(
+            100,
+            7.into(),
+            &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+            &hw_counter,
+        )
+        .unwrap();
+
+        assert_eq!(
+            retrieve_raw_vector(&dst, 7.into(), DEFAULT_VECTOR_NAME),
+            bytes,
+            "raw bytes must round-trip for {datatype:?}",
+        );
+        assert_eq!(
+            dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+                .unwrap(),
+            src.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+                .unwrap(),
+            "decoded vector must round-trip for {datatype:?}",
+        );
+    }
+}
+
+/// A raw blob whose size doesn't match the storage layout must be rejected
+/// with an error, not silently mis-written.
+#[test]
+fn test_upsert_raw_malformed_blob_rejected() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // 3 bytes is not a valid packed-[f32; 4] blob.
+    let result = segment.upsert_point_raw(
+        100,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), vec![0_u8, 1, 2])],
+        &hw_counter,
+    );
+    assert!(result.is_err(), "malformed blob must be rejected");
+}
+
 /// TurboQuant dense raw round-trip: the encoded TQ blob must be ingested
 /// verbatim — byte-identical after `upsert_point_raw` → `retrieve_raw`, with
 /// no dequantize/requantize drift (destination decodes exactly like the

--- a/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
+++ b/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
@@ -15,6 +15,14 @@ pub struct StoredSparseVector {
 }
 
 impl StoredSparseVector {
+    /// Fallible counterpart of [`Blob::from_bytes`], for deserializing bytes
+    /// that arrive from outside this storage (e.g. raw point relocation).
+    pub(crate) fn try_from_bytes(data: &[u8]) -> Result<Self, OperationError> {
+        bincode::deserialize(data).map_err(|err| {
+            OperationError::service_error(format!("Failed to decode sparse vector bytes: {err}"))
+        })
+    }
+
     /// Convert indices into a byte array
     /// Use bitpacking and delta-encoding for additional compression
     fn serialize_indices(indices: &[DimId64]) -> Vec<u8> {

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -30,7 +30,7 @@ use self::turbo_encoded_vectors::TurboEncodedVectorStorage;
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
 use crate::spaces::metric::Metric;
@@ -86,6 +86,27 @@ impl TurboVectorStorage {
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.storage.clear_cache()?;
         self.deleted.clear_cache()?;
+        Ok(())
+    }
+
+    /// Upsert one vector from its already-encoded TurboQuant bytes, verbatim —
+    /// no dequantize/requantize round-trip. The bytes must come from a storage
+    /// with the same quantizer configuration (dim, distance).
+    pub(crate) fn insert_tq_bytes(
+        &mut self,
+        key: PointOffsetType,
+        bytes: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let expected_size = self.quantizer.quantized_size();
+        if bytes.len() != expected_size {
+            return Err(OperationError::service_error(format!(
+                "Malformed dense TQ blob of {} bytes, expected {expected_size}",
+                bytes.len(),
+            )));
+        }
+        self.storage.upsert_vector(key, bytes, hw_counter)?;
+        self.set_deleted(key, false);
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -258,17 +258,14 @@ impl TurboMultiVectorStorage {
         Ok(next_chunk)
     }
 
-    /// Encode and upsert one multivector at `key`: reuse the existing record range
-    /// in place when the new count fits its capacity, else append a fresh range.
-    fn insert_multi(
-        &mut self,
+    /// Record range for upserting `count` records at `key`: reuse the existing
+    /// range in place when the new count fits its capacity, else allocate a
+    /// fresh range at the end.
+    fn record_range_for_upsert(
+        &self,
         key: PointOffsetType,
-        multi_vector: TypedMultiDenseVectorRef<'_, VectorElementType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        assert_eq!(multi_vector.dim, self.dim);
-
-        let count = multi_vector.vectors_count() as PointOffsetType;
+        count: PointOffsetType,
+    ) -> OperationResult<MultivectorMmapOffset> {
         let mut offset = self
             .offsets
             .get::<Random>(key as VectorOffsetType)
@@ -284,6 +281,20 @@ impl TurboMultiVectorStorage {
         } else {
             offset.count = count;
         }
+        Ok(offset)
+    }
+
+    /// Encode and upsert one multivector at `key`.
+    fn insert_multi(
+        &mut self,
+        key: PointOffsetType,
+        multi_vector: TypedMultiDenseVectorRef<'_, VectorElementType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        assert_eq!(multi_vector.dim, self.dim);
+
+        let count = multi_vector.vectors_count() as PointOffsetType;
+        let offset = self.record_range_for_upsert(key, count)?;
 
         for (i, inner) in multi_vector
             .flattened_vectors
@@ -296,6 +307,41 @@ impl TurboMultiVectorStorage {
             self.storage.upsert_vector(
                 offset.offset + i as PointOffsetType,
                 &quantized,
+                hw_counter,
+            )?;
+        }
+        self.offsets
+            .insert(key as VectorOffsetType, &[offset], hw_counter)?;
+        self.set_deleted(key, false);
+
+        Ok(())
+    }
+
+    /// Upsert one multivector from its already-encoded concatenated inner
+    /// records (the [`MultiTQVectorStorage::get_multi_tq`] form), verbatim —
+    /// no dequantize/requantize round-trip. The bytes must come from a storage
+    /// with the same quantizer configuration (dim, distance).
+    pub(crate) fn insert_multi_tq_bytes(
+        &mut self,
+        key: PointOffsetType,
+        bytes: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let record_size = self.quantizer.quantized_size();
+        if bytes.is_empty() || !bytes.len().is_multiple_of(record_size) {
+            return Err(OperationError::service_error(format!(
+                "Malformed multi TQ blob of {} bytes, expected a positive multiple of {record_size}",
+                bytes.len(),
+            )));
+        }
+
+        let count = (bytes.len() / record_size) as PointOffsetType;
+        let offset = self.record_range_for_upsert(key, count)?;
+
+        for (i, encoded) in bytes.chunks_exact(record_size).enumerate() {
+            self.storage.upsert_vector(
+                offset.offset + i as PointOffsetType,
+                encoded,
                 hw_counter,
             )?;
         }

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -31,8 +31,8 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::{
-    MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorElementTypeByte,
-    VectorElementTypeHalf, VectorInternal, VectorRef,
+    MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef, VectorElementType,
+    VectorElementTypeByte, VectorElementTypeHalf, VectorInternal, VectorRef,
 };
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
@@ -768,6 +768,155 @@ impl VectorStorageEnum {
             "Vector layout is not implemented for this storage",
         ))
     }
+
+    /// Write-side counterpart of [`VectorStorageRead::with_vector_bytes_opt`]:
+    /// insert a vector given in the storage-native serialized form.
+    ///
+    /// The bytes carry no encoding/version tag, so they must come from a
+    /// storage with the same configuration (kind, datatype, dim) — in
+    /// practice, from `retrieve_raw` on a segment with a matching config.
+    /// TurboQuant storages ingest the encoded bytes verbatim, avoiding the
+    /// lossy dequantize/requantize round-trip; all other storages decode
+    /// losslessly and reuse their regular insert path.
+    pub fn insert_vector_bytes(
+        &mut self,
+        key: PointOffsetType,
+        bytes: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => insert_dense_bytes(v, key, bytes, hw_counter),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => {
+                insert_dense_bytes(v, key, bytes, hw_counter)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => {
+                insert_dense_bytes(v, key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseMemmap(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseMemmapByte(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseMemmapHalf(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseTurbo(v) => v.insert_tq_bytes(key, bytes, hw_counter),
+            VectorStorageEnum::SparseVolatile(v) => insert_sparse_bytes(v, key, bytes, hw_counter),
+            VectorStorageEnum::SparseMmap(v) => insert_sparse_bytes(v, key, bytes, hw_counter),
+            VectorStorageEnum::MultiDenseVolatile(v) => {
+                insert_multi_bytes(v, key, bytes, hw_counter)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => {
+                insert_multi_bytes(v, key, bytes, hw_counter)
+            }
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => {
+                insert_multi_bytes(v, key, bytes, hw_counter)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                insert_multi_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                insert_multi_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                insert_multi_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::MultiDenseTurbo(v) => {
+                v.insert_multi_tq_bytes(key, bytes, hw_counter)
+            }
+            VectorStorageEnum::EmptyDense(_) | VectorStorageEnum::EmptySparse(_) => Err(
+                OperationError::service_error("Cannot insert into empty vector storage"),
+            ),
+        }
+    }
+}
+
+/// Insert a dense vector from its storage-native bytes (packed `[T]`, as
+/// returned by [`DenseVectorStorageRead::with_dense_bytes_opt`]). The `T` →
+/// `f32` → `T` round-trip through the regular insert path is lossless for
+/// every supported element type.
+fn insert_dense_bytes<T: PrimitiveVectorElement, S: DenseVectorStorageRead<T> + VectorStorage>(
+    storage: &mut S,
+    key: PointOffsetType,
+    bytes: &[u8],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<()> {
+    let expected_size = storage.vector_dim() * size_of::<T>();
+    if bytes.len() != expected_size {
+        return Err(OperationError::service_error(format!(
+            "Malformed dense vector blob of {} bytes, expected {expected_size}",
+            bytes.len(),
+        )));
+    }
+    // `pod_collect_to_vec` instead of `cast_slice`: incoming bytes may not be
+    // aligned for `T`.
+    let elements: Vec<T> = bytemuck::allocation::pod_collect_to_vec(bytes);
+    let vector = T::slice_to_float_cow(Cow::Owned(elements));
+    storage.insert_vector(key, VectorRef::from(vector.as_ref()), hw_counter)
+}
+
+/// Insert a multi-dense vector from its storage-native bytes (flattened inner
+/// vectors, as returned by [`MultiVectorStorageRead::with_multi_bytes_opt`]).
+fn insert_multi_bytes<T: PrimitiveVectorElement, S: MultiVectorStorageRead<T> + VectorStorage>(
+    storage: &mut S,
+    key: PointOffsetType,
+    bytes: &[u8],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<()> {
+    let inner_size = storage.vector_dim() * size_of::<T>();
+    if bytes.is_empty() || !bytes.len().is_multiple_of(inner_size) {
+        return Err(OperationError::service_error(format!(
+            "Malformed multi vector blob of {} bytes, expected a positive multiple of {inner_size}",
+            bytes.len(),
+        )));
+    }
+    let elements: Vec<T> = bytemuck::allocation::pod_collect_to_vec(bytes);
+    let dim = storage.vector_dim();
+    let multi = T::into_float_multivector(CowMultiVector::Owned(TypedMultiDenseVector::new(
+        elements, dim,
+    )));
+    storage.insert_vector(key, VectorRef::MultiDense(multi.as_vec_ref()), hw_counter)
+}
+
+/// Insert a sparse vector from its storage-native bytes (the lossless
+/// [`StoredSparseVector`] bincode form returned by
+/// [`SparseVectorStorageRead::sparse_bytes_opt`]).
+fn insert_sparse_bytes<S: VectorStorage>(
+    storage: &mut S,
+    key: PointOffsetType,
+    bytes: &[u8],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<()> {
+    let sparse = SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes)?)?;
+    storage.insert_vector(key, VectorRef::from(&sparse), hw_counter)
 }
 
 /// Per-key fallback for [`VectorStorageRead::read_vector_bytes`], for storages

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -830,6 +830,18 @@ impl SegmentEntry for ProxySegment {
         )))
     }
 
+    fn upsert_point_raw(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        _vectors: &[(VectorNameBuf, Vec<u8>)],
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        Err(OperationError::service_error(format!(
+            "Upsert is disabled for proxy segments: operation {op_num} on point {point_id}",
+        )))
+    }
+
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,


### PR DESCRIPTION
Follow-up of #9690, write side of the same idea.

New SegmentEntry::upsert_point_raw takes vectors as storage-native bytes, same format which retrieve_raw returns. TQ storages insert encoded blob as is, no dequantize/requantize round trip, so no requantization drift. All other storages decode bytes (lossless for them) and go through regular insert path.

Same contract as retrieve_raw: bytes have no type tag, source and destination segments must have same vector config.

No callers yet. will be used by CoW and points transfer in the next PRs