### PR TITLE
Update pyroscope to 2.1.0 and tikv-jemalloc crates to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,9 +3929,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+checksum = "0bb2dfa20a68824f4c8c1aa271617d0ee0d9b707a866d56b7d7ee39c60c235a8"
 dependencies = [
  "anyhow",
  "libc",
@@ -5512,7 +5512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5532,7 +5532,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5634,7 +5634,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "prost 0.14.4",
  "prost-build 0.14.4",
  "prost-types 0.14.4",
@@ -5776,21 +5776,20 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "2.0.6"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6869e0f2cae5cef10281c57d5a260f91372d7f190a7f717eb1a54f643d92151"
+checksum = "7b9adfbc87341b5976c0bbab196ed2e2c188e2acf9f4d434d46eb9433f0f529c"
 dependencies = [
  "aligned-vec",
  "backtrace",
  "findshlibs",
  "framehop",
  "jemalloc_pprof",
- "lazy_static",
  "libc",
  "libflate",
  "log",
  "memmap2",
- "nix 0.26.4",
+ "nix 0.31.3",
  "object 0.39.1",
  "once_cell",
  "prost 0.14.4",
@@ -7846,7 +7845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -7917,9 +7916,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -7928,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -7938,9 +7937,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,19 +151,19 @@ actix-web-extras = "0.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18.0", default-features = false }
-pyroscope = { version = "2.0.0", features = ["backend-pprof-rs", "backend-jemalloc"] }
+pyroscope = { version = "2.1.0", features = ["backend-pprof-rs", "backend-jemalloc"] }
 # Backtrace
 rstack-self = { version = "0.3.0", optional = true }
 
 # Jemalloc
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-tikv-jemallocator = { version = "0.6.1", features = [
+tikv-jemallocator = { version = "0.7.0", features = [
     "stats",
     "unprefixed_malloc_on_supported_platforms",
     "background_threads",
     "profiling",
 ] }
-tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats"] }
+tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"


### PR DESCRIPTION
Updates the profiling/allocator dependency stack:

| Crate | Old | New |
|---|---|---|
| `pyroscope` | 2.0.6 | 2.1.0 |
| `tikv-jemallocator` | 0.6.1 | 0.7.0 |
| `tikv-jemalloc-ctl` | 0.6.1 | 0.7.0 |
| `tikv-jemalloc-sys` (transitive) | 0.6.1 (jemalloc 5.3.0) | 0.7.1 (jemalloc 5.3.1) |
| `jemalloc_pprof` (transitive) | 0.8.2 | 0.9.0 |

### Highlights

**pyroscope 2.1.0** ([release notes](https://github.com/grafana/pyroscope-rs/releases/tag/lib-2.1.0))
- Adds `otel.scope.name`, `otel.scope.version`, `process.runtime.name`, `process.runtime.version` labels to profiles
- Security bump of `memmap2` to 0.9.11
- New method to set the timer's ticker in `PyroscopeAgent`

**tikv jemalloc crates 0.7.0** ([release notes](https://github.com/tikv/jemallocator/releases/tag/0.7.0))
- Bundled jemalloc updated 5.3.0 -> 5.3.1
- jemalloc-ctl: fix invalid update implementation (we use the `stats` feature)
- New `free` FFI and `profiling_libunwind` feature; assorted build-system and cross-compile fixes

**jemalloc_pprof 0.9.0** (pulled in by pyroscope's jemalloc backend; no published changelog)
- Adds `JemallocProfCtl::dump_profile`, dependency updates

### Verification

- `cargo check --workspace` passes on Linux, which type-checks the pyroscope integration (`src/common/pyroscope_state.rs`, `cfg(target_os = "linux")`) including the `backend-jemalloc` API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)