### PR TITLE
Fix test build: missing memory arg in SparseIndexConfig::new

### DIFF
--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -680,7 +680,7 @@ fn test_retrieve_raw_sparse_bytes() {
             sparse_vector_data: HashMap::from_iter([(
                 sparse_name.to_string(),
                 SparseVectorDataConfig {
-                    index: SparseIndexConfig::new(Some(1), SparseIndexType::MutableRam, None),
+                    index: SparseIndexConfig::new(Some(1), SparseIndexType::MutableRam, None, None),
                     storage_type: SparseVectorStorageType::Mmap,
                     modifier: None,
                 },


### PR DESCRIPTION
## Summary

`cargo check --workspace --all-targets` fails on `dev`: one call site in `lib/segment/src/segment/tests/mod.rs` was not updated when `SparseIndexConfig::new` gained the `Option<Memory>` parameter in #9684. This adds the missing trailing `None`.

Verified with `cargo check --workspace --all-targets`, now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)